### PR TITLE
Add support for var objects that can be manipulated in nunjucks templates

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface Prompt {
 
 export interface EvaluateResult {
   prompt: Prompt;
-  vars: Record<string, string>;
+  vars: Record<string, string | object>;
   response?: ProviderResponse;
   error?: string;
   success: boolean;
@@ -174,7 +174,7 @@ export interface TestCase {
   description?: string;
 
   // Key-value pairs to substitute in the prompt
-  vars?: Record<string, string | string[]>;
+  vars?: Record<string, string | string[] | object>;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];
@@ -185,7 +185,7 @@ export interface TestCase {
 
 // Same as a TestCase, except the `vars` object has been flattened into its final form.
 export interface AtomicTestCase extends TestCase {
-  vars?: Record<string, string>;
+  vars?: Record<string, string | object>;
 }
 
 // The test suite defines the "knobs" that we are tuning in prompt engineering: providers and prompts

--- a/src/web/client/src/types.ts
+++ b/src/web/client/src/types.ts
@@ -6,7 +6,7 @@ export type EvalHead = {
 export type EvalRowOutput = {
   pass: boolean;
   score: number;
-  text: string;
+  text: string | object;
 };
 
 export type EvalRow = {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -61,6 +61,28 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
+  test('evaluate with vars as object', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt {{ var1.prop1 }} {{ var2 }}')],
+      tests: [
+        {
+          vars: { var1: { prop1: 'value1' }, var2: 'value2' },
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
+    expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
+    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1.prop1 }} {{ var2 }}');
+    expect(summary.results[0].response?.output).toBe('Test output');
+  });
+
   test('evaluate with named prompt', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],


### PR DESCRIPTION
For example:

template - 
```nunjucks
{% for message in previous_messages %}
{
  "role": "{{message|first}}",
  "content": "{{ message[message|first] }}"
}{% if not loop.last %},{% endif %}
{% endfor %}
```

config -
```yaml
tests:
  - vars:
    previous_messages:
      - user: hello world
      - assistant: how are you?
      - user: great, thanks
```