### PR TITLE
Add support for YAML-formatted OpenAI prompts

### DIFF
--- a/examples/openai-multiline-yaml/README.md
+++ b/examples/openai-multiline-yaml/README.md
@@ -1,0 +1,5 @@
+This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+
+```
+promptfoo eval
+```

--- a/examples/openai-multiline-yaml/prompt.yaml
+++ b/examples/openai-multiline-yaml/prompt.yaml
@@ -1,0 +1,11 @@
+- role: system
+  content: |
+    Respond to the user while keeping the following in mind
+      - You are a travel agent
+      - You can help with logistics
+      - You do not refer to yourself as an AI unless asked
+
+    Be extremely conise.
+
+- role: user
+  content: {{content}}

--- a/examples/openai-multiline-yaml/promptfooconfig.yaml
+++ b/examples/openai-multiline-yaml/promptfooconfig.yaml
@@ -1,0 +1,11 @@
+# prettier-ignore
+prompts: [prompt.yaml]
+providers: ['openai:chat:gpt-3.5-turbo-0613']
+
+tests:
+  - vars:
+      content: hey
+  - vars:
+      content: what can you help with?
+  - vars:
+      content: tell me about hawaii

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,6 @@ async function main() {
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
         defaultTest: fileConfig.defaultTest,
       };
-      console.log(defaultConfig.commandLineOptions);
 
       // Validation
       if (!config.prompts || config.prompts.length === 0) {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,3 +1,5 @@
+import yaml from 'js-yaml';
+
 import logger from '../logger';
 import { fetchJsonWithCache } from '../cache';
 import { REQUEST_TIMEOUT_MS } from './shared';
@@ -227,6 +229,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     let messages: { role: string; content: string; name?: string }[];
     try {
+      // Try JSON
       messages = JSON.parse(prompt) as { role: string; content: string }[];
     } catch (err) {
       const trimmedPrompt = prompt.trim();


### PR DESCRIPTION
Closes #65 

For example:
```yaml
- role: system
  content: |
    This is a multiline prompt.
    It has multiple lines in it.
    Today, it doesn't work.
- role: user
  content: |
    Another prompt,
    which has several lines in it.
```