### PR TITLE
Allow option to disable sharing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,11 @@ async function main() {
       });
       await telemetry.send();
 
+      if (!defaultConfig.sharing) {
+        logger.error('Sharing is not enabled. Add `sharing: true` to your promptfooconfig.yaml');
+        process.exit(1);
+      }
+
       const latestResults = readLatestResults();
       if (!latestResults) {
         logger.error('Could not load results. Do you need to run `promptfoo eval` first?');
@@ -246,6 +251,7 @@ async function main() {
         prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts,
         providers: cmdObj.providers || fileConfig.providers || defaultConfig.providers,
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
+        sharing: process.env.DISABLE_SHARING === "1" ? false : defaultConfig.sharing ?? true,
         defaultTest: fileConfig.defaultTest,
       };
 
@@ -314,7 +320,7 @@ async function main() {
 
       const summary = await evaluate(testSuite, options);
 
-      const shareableUrl = cmdObj.share ? await createShareableUrl(summary, config) : null;
+      const shareableUrl = cmdObj.share && config.sharing ? await createShareableUrl(summary, config) : null;
 
       if (cmdObj.output) {
         logger.info(chalk.yellow(`Writing output to ${cmdObj.output}`));

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,7 +251,7 @@ async function main() {
         prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts,
         providers: cmdObj.providers || fileConfig.providers || defaultConfig.providers,
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
-        sharing: process.env.DISABLE_SHARING === "1" ? false : defaultConfig.sharing ?? true,
+        sharing: process.env.PROMPTFOO_DISABLE_SHARING === "1" ? false : (fileConfig.sharing ?? defaultConfig.sharing ?? true),
         defaultTest: fileConfig.defaultTest,
       };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,9 @@ export interface TestSuiteConfig {
 
   // Path to write output. Writes to console/web viewer if not set.
   outputPath?: string;
+
+  // Determines whether or not sharing is enabled.
+  sharing?: boolean;
 }
 
 export type UnifiedConfig = TestSuiteConfig & {

--- a/src/web/client/src/ResultsView.tsx
+++ b/src/web/client/src/ResultsView.tsx
@@ -218,16 +218,18 @@ export default function ResultsView() {
                   </Button>
                 </Tooltip>
               )}
-              <Tooltip title="Generate a unique URL that others can access">
-                <Button
-                  color="primary"
-                  onClick={handleShareButtonClick}
-                  disabled={shareLoading}
-                  startIcon={shareLoading ? <CircularProgress size={16} /> : <ShareIcon />}
-                >
-                  Share
-                </Button>
-              </Tooltip>
+              {config?.sharing && (
+                <Tooltip title="Generate a unique URL that others can access">
+                  <Button
+                    color="primary"
+                    onClick={handleShareButtonClick}
+                    disabled={shareLoading}
+                    startIcon={shareLoading ? <CircularProgress size={16} /> : <ShareIcon />}
+                  >
+                    Share
+                  </Button>
+                </Tooltip>
+              )}
             </ResponsiveStack>
           </Box>
         </ResponsiveStack>


### PR DESCRIPTION
It is not always desirable to have the ability to share results (storing sensitive data on a server), so this PR allows sharing to be disabled.

Disable sharing through DISABLE_SHARING environment variable, or through adding 'sharing: false' to the YAML confinguration.

If sharing is disabled, there will also be no sharing functionality in the browser (the button will be removed).