### PR TITLE
Add support for provider-specific prompts in the test suite configuration

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -213,6 +213,10 @@ class Evaluator {
     // Split prompts by provider
     for (const prompt of testSuite.prompts) {
       for (const provider of testSuite.providers) {
+        // Check if providerPromptMap exists and if it contains the current prompt's display
+        if (testSuite.providerPromptMap && !testSuite.providerPromptMap[provider.id()].includes(prompt.display)) {
+          continue;
+        }
         const updatedDisplay =
           testSuite.providers.length > 1 ? `[${provider.id()}] ${prompt.display}` : prompt.display;
         prompts.push({
@@ -274,6 +278,13 @@ class Evaluator {
           let colIndex = 0;
           for (const prompt of testSuite.prompts) {
             for (const provider of testSuite.providers) {
+              if (testSuite.providerPromptMap) {
+                const allowedPrompts = testSuite.providerPromptMap[provider.id()];
+                if (allowedPrompts && !allowedPrompts.includes(prompt.display)) {
+                  // This prompt should not be used with this provider.
+                  continue;
+                }
+              }
               runEvalOptions.push({
                 provider,
                 prompt: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   readConfig,
   readLatestResults,
   readPrompts,
+  readProviderPromptMap,
   readTests,
   writeLatestResults,
   writeOutput,
@@ -307,6 +308,7 @@ async function main() {
         config.tests,
         cmdObj.tests ? undefined : basePath,
       );
+      const parsedProviderPromptMap = readProviderPromptMap(config, parsedPrompts);
 
       if (parsedPrompts.length === 0) {
         logger.error(chalk.red('No prompts found'));
@@ -327,6 +329,7 @@ async function main() {
         description: config.description,
         prompts: parsedPrompts,
         providers: parsedProviders,
+        providerPromptMap: parsedProviderPromptMap,
         tests: parsedTests,
         defaultTest,
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface CommandLineOptions {
 export interface ProviderConfig {
   id: ProviderId;
   config?: any;
+  prompts?: string[]; // List of prompt display strings
 }
 
 export interface ApiProvider {
@@ -202,6 +203,10 @@ export interface TestSuite {
 
   // One or more prompt strings
   prompts: Prompt[];
+
+  // Optional mapping of provider to prompt display strings.  If not provided,
+  // all prompts are used for all providers.
+  providerPromptMap?: Record<string, string[]>;
 
   // Test cases
   tests?: TestCase[];

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,32 @@ import type {
   UnifiedConfig,
   TestCase,
   Prompt,
+  RawProviderConfig,
+  TestSuite,
 } from './types';
+
+export function readProviderPromptMap(config: Partial<UnifiedConfig>, parsedPrompts: Prompt[]): TestSuite["providerPromptMap"] {
+  const ret: Record<string, string[]> = {};
+
+  if (!config.providers) {
+    return ret;
+  }
+
+  const allPrompts = [];
+  for (const prompt of parsedPrompts) {
+    allPrompts.push(prompt.display);
+  }
+
+  for (const provider of config.providers) {
+    if (typeof provider === 'object') {
+      const rawProvider = provider as RawProviderConfig;
+      const id = Object.keys(rawProvider)[0];
+      ret[id] = rawProvider[id].prompts || allPrompts;
+    }
+  }
+
+  return ret;
+}
 
 const PROMPT_DELIMITER = '---';
 

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -344,4 +344,29 @@ describe('evaluator', () => {
     expect(summary.results[0].success).toBe(false);
     expect(summary.results[0].response?.output).toBe('Test output');
   });
+
+  test('evaluate with providerPromptMap', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt 1'), toPrompt('Test prompt 2')],
+      providerPromptMap: {
+        'test-provider': ['Test prompt 1']
+      },
+      tests: [
+        {
+          vars: { var1: 'value1', var2: 'value2' },
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
+    expect(summary.results[0].prompt.raw).toBe('Test prompt 1');
+    expect(summary.results[0].prompt.display).toBe('Test prompt 1');
+    expect(summary.results[0].response?.output).toBe('Test output');
+  });
 });


### PR DESCRIPTION
This makes it easier to mix and match providers and prompts.  A common use case would be comparing `chat`-style prompts with `completion`-style prompts.

Here's an example:

```yaml
prompts:
  prompts/chat_prompt.json: chat_prompt
  prompts/completion_prompt.txt: completion_prompt

providers:
  - openai:gpt-3.5-turbo-0613:
      prompts: chat_prompt
  - openai:gpt-4-0613:
      prompts: chat_prompt
  - replicate:replicate/llama70b-v2-chat:e951f18578850b652510200860fc4ea62b3b16fac280f83ff32282f87bbd2e48:
      prompts: completion_prompt
```