### PR TITLE
testing providers w/ same model diff params

### DIFF
--- a/examples/gpt-3.5-temperature-comparison/README.md
+++ b/examples/gpt-3.5-temperature-comparison/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY and REPLICATE_API_TOKEN environment variables.
+
+Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/gpt-3.5-temperature-comparison/promptfooconfig.yaml
+++ b/examples/gpt-3.5-temperature-comparison/promptfooconfig.yaml
@@ -15,12 +15,12 @@ providers:
       config:
         temperature: 1
         max_tokens: 128
-  - replicate:replicate/llama70b-v2-chat:e951f18578850b652510200860fc4ea62b3b16fac280f83ff32282f87bbd2e48:
-      prompts: completion_prompt
+  - openai:gpt-4-0613:
+      prompts: chat_prompt
       config:
-        temperature: 0.01 # minimum temperature
-        max_length: 128
-
+        temperature: 0
+        max_tokens: 128
+        
 tests:
   - vars:
       message: hello world

--- a/examples/gpt-3.5-temperature-comparison/prompts.txt
+++ b/examples/gpt-3.5-temperature-comparison/prompts.txt
@@ -1,0 +1,18 @@
+Your first prompt goes here
+---
+Next prompt goes here. You can substitute variables like this: {{var1}} {{var2}} {{var3}}
+---
+This is the next prompt.
+
+These prompts are nunjucks templates, so you can use logic like this:
+{% if var1 %}
+  {{ var1 }}
+{% endif %}
+---
+[
+  {"role": "system", "content": "This is another prompt. JSON is supported."},
+  {"role": "user", "content": "Using this format, you may construct multi-shot OpenAI prompts"}
+  {"role": "user", "content": "Variable substitution still works: {{ var3 }}"}
+]
+---
+If you prefer, you can break prompts into multiple files (make sure to edit promptfooconfig.yaml accordingly)

--- a/examples/gpt-3.5-temperature-comparison/prompts/chat_prompt.json
+++ b/examples/gpt-3.5-temperature-comparison/prompts/chat_prompt.json
@@ -1,0 +1,6 @@
+[
+  {
+    "role": "user",
+    "content": "{{message}}"
+  }
+]

--- a/examples/gpt-3.5-temperature-comparison/prompts/completion_prompt.txt
+++ b/examples/gpt-3.5-temperature-comparison/prompts/completion_prompt.txt
@@ -1,0 +1,2 @@
+User: {{message}}
+Assistant:

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -42,12 +42,9 @@ export async function loadApiProviders(
             callApi: provider,
           };
         } else {
-          let id = Object.keys(provider)[0];
+          const id = Object.keys(provider)[0];
           const providerObject = provider[id];
-          const context = { ...provider[id], id };
-          if (providerObject.id) {
-            context.id = providerObject.id;
-          }
+          const context = { ...providerObject, id: providerObject.id || id };
           return loadApiProvider(id, context, basePath);
         }
       }),

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -24,8 +24,12 @@ export async function loadApiProviders(
         if (typeof provider === 'string') {
           return loadApiProvider(provider, undefined, basePath);
         } else {
-          const id = Object.keys(provider)[0];
+          let id = Object.keys(provider)[0];
+          const providerObject = provider[id];
           const context = { ...provider[id], id };
+          if (providerObject.id) {
+            context.id = providerObject.id;
+          }
           return loadApiProvider(id, context, basePath);
         }
       }),
@@ -65,9 +69,9 @@ export async function loadApiProvider(
         context?.config,
       );
     } else if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODELS.includes(modelType)) {
-      return new OpenAiChatCompletionProvider(modelType, undefined, context?.config);
+      return new OpenAiChatCompletionProvider(modelType, undefined, context?.config, context?.id);
     } else if (OpenAiCompletionProvider.OPENAI_COMPLETION_MODELS.includes(modelType)) {
-      return new OpenAiCompletionProvider(modelType, undefined, context?.config);
+      return new OpenAiCompletionProvider(modelType, undefined, context?.config, context?.id);
     } else {
       throw new Error(
         `Unknown OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>`,
@@ -80,9 +84,9 @@ export async function loadApiProvider(
     const deploymentName = options[2];
 
     if (modelType === 'chat') {
-      return new AzureOpenAiChatCompletionProvider(deploymentName, undefined, context?.config);
+      return new AzureOpenAiChatCompletionProvider(deploymentName, undefined, context?.config, context?.id);
     } else if (modelType === 'completion') {
-      return new AzureOpenAiCompletionProvider(deploymentName, undefined, context?.config);
+      return new AzureOpenAiCompletionProvider(deploymentName, undefined, context?.config, context?.id);
     } else {
       throw new Error(
         `Unknown Azure OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>`,

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -117,9 +117,10 @@ export class AzureOpenAiEmbeddingProvider extends AzureOpenAiGenericProvider {
 export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
   options: AzureOpenAiCompletionOptions;
 
-  constructor(deploymentName: string, apiKey?: string, context?: AzureOpenAiCompletionOptions) {
+  constructor(deploymentName: string, apiKey?: string, context?: AzureOpenAiCompletionOptions, id?: string) {
     super(deploymentName, apiKey);
     this.options = context || {};
+    this.id = id ? () => id : this.id;
   }
 
   async callApi(prompt: string, options?: AzureOpenAiCompletionOptions): Promise<ProviderResponse> {
@@ -205,9 +206,10 @@ export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
 export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvider {
   options: AzureOpenAiCompletionOptions;
 
-  constructor(deploymentName: string, apiKey?: string, context?: AzureOpenAiCompletionOptions) {
+  constructor(deploymentName: string, apiKey?: string, context?: AzureOpenAiCompletionOptions, id?: string) {
     super(deploymentName, apiKey);
     this.options = context || {};
+    this.id = id ? () => id : this.id;
   }
 
   async callApi(prompt: string, options?: AzureOpenAiCompletionOptions): Promise<ProviderResponse> {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -125,12 +125,13 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
 
   options: OpenAiCompletionOptions;
 
-  constructor(modelName: string, apiKey?: string, context?: OpenAiCompletionOptions) {
+  constructor(modelName: string, apiKey?: string, context?: OpenAiCompletionOptions, id?: string) {
     if (!OpenAiCompletionProvider.OPENAI_COMPLETION_MODELS.includes(modelName)) {
       logger.warn(`Using unknown OpenAI completion model: ${modelName}`);
     }
     super(modelName, apiKey);
     this.options = context || {};
+    this.id = id ? () => id : this.id;
   }
 
   async callApi(prompt: string, options?: OpenAiCompletionOptions): Promise<ProviderResponse> {
@@ -229,12 +230,13 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
   options: OpenAiCompletionOptions;
 
-  constructor(modelName: string, apiKey?: string, context?: OpenAiCompletionOptions) {
+  constructor(modelName: string, apiKey?: string, context?: OpenAiCompletionOptions, id?: string) {
     if (!OpenAiChatCompletionProvider.OPENAI_CHAT_MODELS.includes(modelName)) {
       logger.warn(`Using unknown OpenAI chat model: ${modelName}`);
     }
     super(modelName, apiKey);
     this.options = context || {};
+    this.id = id ? () => id : this.id;
   }
 
   async callApi(prompt: string, options?: OpenAiCompletionOptions): Promise<ProviderResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface CommandLineOptions {
 }
 
 export interface ProviderConfig {
-  id: ProviderId;
+  id?: ProviderId;
   config?: any;
   prompts?: string[]; // List of prompt display strings
 }
@@ -217,7 +217,7 @@ export interface TestSuite {
 
 export type ProviderId = string;
 
-export type RawProviderConfig = Record<ProviderId, Omit<ProviderConfig, 'id'>>;
+export type RawProviderConfig = Record<ProviderId, ProviderConfig>;
 
 // TestSuiteConfig = Test Suite, but before everything is parsed and resolved.  Providers are just strings, prompts are filepaths, tests can be filepath or inline.
 export interface TestSuiteConfig {

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,8 +47,13 @@ export function readProviderPromptMap(
   for (const provider of config.providers) {
     if (typeof provider === 'object') {
       const rawProvider = provider as RawProviderConfig;
-      const id = Object.keys(rawProvider)[0];
-      ret[id] = rawProvider[id].prompts || allPrompts;
+      let id = Object.keys(rawProvider)[0];
+      let originalId = id;
+      const providerObject = rawProvider[id];
+      if (providerObject.id) {
+        id = providerObject.id;
+      }
+      ret[id] = rawProvider[originalId].prompts || allPrompts;
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -57,12 +57,9 @@ export function readProviderPromptMap(
   for (const provider of config.providers) {
     if (typeof provider === 'object') {
       const rawProvider = provider as RawProviderConfig;
-      let id = Object.keys(rawProvider)[0];
-      let originalId = id;
-      const providerObject = rawProvider[id];
-      if (providerObject.id) {
-        id = providerObject.id;
-      }
+      const originalId = Object.keys(rawProvider)[0];
+      const providerObject = rawProvider[originalId];
+      const id = providerObject.id || originalId;
       ret[id] = rawProvider[originalId].prompts || allPrompts;
     }
   }


### PR DESCRIPTION
One feature we would like is the ability to compare identical models with different settings (differing temperature, functions, etc).

This PR is a start - potentially needs some work.

- Adds 'id' to constructor for azure and openai chat & completion providers, allowing base function to be overridden with user-provided identifier
- allows id to be specified in the provider object rawconfig
- adds example of temperature comparison w/ identical models

Example:

```yaml
providers:
  - openai:gpt-3.5-turbo-0613:
      id: openai-gpt-3.5-turbo-lowtemp
      prompts: chat_prompt
      config:
        temperature: 0
        max_tokens: 128
  - openai:gpt-3.5-turbo-0613:
      id: openai-gpt-3.5-turbo-hightemp
      prompts: chat_prompt
      config:
        temperature: 1
        max_tokens: 128
  - openai:gpt-4-0613:
      prompts: chat_prompt
      config:
        temperature: 0
        max_tokens: 128
```

NOT in this PR, but just an idea, it may be desirable to refactor the configuration of providers into something like:

```yaml
providers:
  - type: openai:gpt-3.5-turbo-0613
    id: openai-gpt-3.5-turbo-lowtemp
    prompts: chat_prompt
    config:
      temperature: 0
      max_tokens: 128
  - type: openai:gpt-3.5-turbo-0613:
    id: openai-gpt-3.5-turbo-hightemp
    prompts: chat_prompt
    config:
      temperature: 1
      max_tokens: 128
  - type: openai:gpt-4-0613:
    prompts: chat_prompt
    config:
      temperature: 0
      max_tokens: 128
```

That way the name of the provider is inside of the object.

So JSON structure goes from `[{"provider": {...}}]` -> `[{"type": "provider", ...}]`

This might also help with code clarity and remove the need to use `Object.keys(provider)[0]`.
