### PR TITLE
Add support for postprocessing in test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promptfoo",
   "description": "LLM eval & testing toolkit",
   "author": "Ian Webster",
-  "version": "0.17.8",
+  "version": "0.17.7",
   "license": "MIT",
   "type": "commonjs",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promptfoo",
   "description": "LLM eval & testing toolkit",
   "author": "Ian Webster",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "license": "MIT",
   "type": "commonjs",
   "main": "dist/src/index.js",

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -121,7 +121,12 @@ class Evaluator {
       if (response.error) {
         ret.error = response.error;
       } else if (response.output) {
-        const checkResult = await runAssertions(test, response.output);
+        let output = response.output;
+        // Apply postprocess function if it exists
+        if (test.postprocess) {
+          output = test.postprocess(output);
+        }
+        const checkResult = await runAssertions(test, output);
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
         }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -137,7 +137,6 @@ class Evaluator {
           }
         }
 
-        console.log('checking output', processedResponse.output, JSON.stringify(ret));
         invariant(processedResponse.output != null, 'Response output should not be null');
         const checkResult = await runAssertions(test, processedResponse.output);
         if (!checkResult.pass) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -130,12 +130,12 @@ class Evaluator {
           );
           response.output = postprocessFn(response.output);
           if (response.output == null) {
-            throw new Error('Postprocess function must return a value');
+            throw new Error('Postprocess function did not return a value');
           }
         }
 
-        let output = response.output;
-        const checkResult = await runAssertions(test, output);
+        console.log('checking output', response.output, JSON.stringify(ret))
+        const checkResult = await runAssertions(test, response.output);
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
         }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -3,6 +3,7 @@ import readline from 'readline';
 import async from 'async';
 import chalk from 'chalk';
 import nunjucks from 'nunjucks';
+import invariant from 'tiny-invariant';
 
 import logger from './logger';
 import telemetry from './telemetry';
@@ -121,6 +122,8 @@ class Evaluator {
       if (response.error) {
         ret.error = response.error;
       } else if (response.output) {
+        // Create a copy of response so we can potentially mutate it.
+        let processedResponse = { ...response };
         if (test.options?.postprocess) {
           const { postprocess } = test.options;
           const postprocessFn = new Function(
@@ -128,14 +131,15 @@ class Evaluator {
             'context',
             postprocess.includes('\n') ? postprocess : `return ${postprocess}`,
           );
-          response.output = postprocessFn(response.output);
-          if (response.output == null) {
+          processedResponse.output = postprocessFn(processedResponse.output);
+          if (processedResponse.output == null) {
             throw new Error('Postprocess function did not return a value');
           }
         }
 
-        console.log('checking output', response.output, JSON.stringify(ret))
-        const checkResult = await runAssertions(test, response.output);
+        console.log('checking output', processedResponse.output, JSON.stringify(ret));
+        invariant(processedResponse.output != null, 'Response output should not be null');
+        const checkResult = await runAssertions(test, processedResponse.output);
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
         }
@@ -146,6 +150,7 @@ class Evaluator {
           this.stats.tokenUsage.prompt += checkResult.tokensUsed.prompt;
           this.stats.tokenUsage.completion += checkResult.tokensUsed.completion;
         }
+        ret.response = processedResponse;
       } else {
         ret.success = false;
         ret.score = 0;
@@ -286,7 +291,8 @@ class Evaluator {
         testCase.options?.prefix || testSuite.defaultTest?.options?.prefix || '';
       const appendToPrompt =
         testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
-      testCase.options.postprocess = testCase.options.postprocess || testSuite.defaultTest?.options?.postprocess;
+      testCase.options.postprocess =
+        testCase.options.postprocess || testSuite.defaultTest?.options?.postprocess;
 
       // Finalize test case eval
       const varCombinations = generateVarCombinations(testCase.vars || {});

--- a/src/main.ts
+++ b/src/main.ts
@@ -323,6 +323,7 @@ async function main() {
           suffix: cmdObj.promptSuffix,
           provider: cmdObj.grader,
           // rubricPrompt:
+          // postprocess
         },
         ...config.defaultTest,
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,6 +191,9 @@ export interface TestCase {
 
   // Additional configuration settings for the prompt
   options?: PromptConfig & OutputConfig & GradingConfig;
+
+  // Optional postprocessing function to modify the output
+  postprocess?: (output: string) => string;
 }
 
 // Same as a TestCase, except the `vars` object has been flattened into its final form.

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,6 @@ export interface PromptConfig {
 }
 
 export interface OutputConfig {
-  preprocess?: string;
   postprocess?: string;
 }
 
@@ -191,9 +190,6 @@ export interface TestCase {
 
   // Additional configuration settings for the prompt
   options?: PromptConfig & OutputConfig & GradingConfig;
-
-  // Optional postprocessing function to modify the output
-  postprocess?: (output: string) => string;
 }
 
 // Same as a TestCase, except the `vars` object has been flattened into its final form.

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface PromptConfig {
   suffix?: string;
 }
 
+export interface OutputConfig {
+  preprocess?: string;
+  postprocess?: string;
+}
+
 export interface EvaluateOptions {
   maxConcurrency?: number;
   showProgressBar?: boolean;
@@ -185,7 +190,7 @@ export interface TestCase {
   assert?: Assertion[];
 
   // Additional configuration settings for the prompt
-  options?: PromptConfig & GradingConfig;
+  options?: PromptConfig & OutputConfig & GradingConfig;
 }
 
 // Same as a TestCase, except the `vars` object has been flattened into its final form.

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -364,22 +364,23 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
 
-  /*
   test('evaluate with postprocess option - single test', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
-      tests: [{
-        assert: [
-          {
-            type: 'equals',
-            value: 'Test output postprocessed',
+      tests: [
+        {
+          assert: [
+            {
+              type: 'equals',
+              value: 'Test output postprocessed',
+            },
+          ],
+          options: {
+            postprocess: 'output + " postprocessed"',
           },
-        ],
-        options: {
-          postprocess: 'output + " postprocessed"',
         },
-      }],
+      ],
     };
 
     const summary = await evaluate(testSuite, {});
@@ -389,7 +390,6 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
-  */
 
   test('evaluate with providerPromptMap', async () => {
     const testSuite: TestSuite = {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -345,6 +345,52 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
+  test('evaluate with postprocess option - default test', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt')],
+      defaultTest: {
+        options: {
+          postprocess: 'output + " postprocessed"',
+        },
+      },
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].response?.output).toBe('Test output postprocessed');
+  });
+
+  /*
+  test('evaluate with postprocess option - single test', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{
+        assert: [
+          {
+            type: 'equals',
+            value: 'Test output postprocessed',
+          },
+        ],
+        options: {
+          postprocess: 'output + " postprocessed"',
+        },
+      }],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].response?.output).toBe('Test output postprocessed');
+  });
+  */
+
   test('evaluate with providerPromptMap', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],


### PR DESCRIPTION
The `TestCase.options.postprocess` field is a Javascript snippet that modifies the LLM output.  Postprocessing occurs before any assertions are run.

For example:

```yaml
# ...
tests:
  - vars:
      language: French
      body: Hello world
    options:
      postprocess: output.toUpperCase()
    # ...
```

Or multiline:

```yaml
# ...
tests:
  - vars:
      language: French
      body: Hello world
    options:
      postprocess: |
        const words = output.split(' ').filter(x => !!x);
        return JSON.stringify(words);
    # ...
```