### PR TITLE
Add support for loading test cases from file/directory path

### DIFF
--- a/examples/separate-test-configs/README.md
+++ b/examples/separate-test-configs/README.md
@@ -1,0 +1,7 @@
+This example shows how you can use paths and wildcards to simplify for `promptfooconfig.yaml`.
+
+Run:
+
+```
+promptfoo eval
+```

--- a/examples/separate-test-configs/promptfooconfig.yaml
+++ b/examples/separate-test-configs/promptfooconfig.yaml
@@ -1,0 +1,20 @@
+prompts: prompts.txt
+providers: openai:gpt-3.5-turbo
+
+# The defaultTest configuration is applied to every test case in this config.
+defaultTest:
+  options:
+    suffix: Be extremely concise
+
+# Loads & runs all test cases matching these filepaths
+tests:
+  # You can supply an exact filepath
+  - tests/tests2.yaml
+
+  # Or a glob (wildcard)
+  - tests/*
+
+  # Mix and match with actual test cases
+  - vars:
+      topic: the internet
+      content_type: witty tweets

--- a/examples/separate-test-configs/prompts.txt
+++ b/examples/separate-test-configs/prompts.txt
@@ -1,0 +1,3 @@
+Generate a list of creative {{content_type}} about {{topic}}.
+---
+Imagine you are an expert in {{topic}}. What {{content_type}} would you recommend writing about?

--- a/examples/separate-test-configs/tests/tests1.yaml
+++ b/examples/separate-test-configs/tests/tests1.yaml
@@ -1,0 +1,24 @@
+# This file contains a list of test cases. They're added alongside test cases
+# from tests2.yaml in the example promptfooconfig.yaml.
+
+- vars:
+    topic: artificial intelligence
+    content_type: blog post ideas
+  assert:
+    - type: javascript
+      value: output.length > 100
+- vars:
+    topic: climate change
+    content_type: policy proposals
+- vars:
+    topic: vegetarian cooking
+    content_type: recipe ideas
+- vars:
+    topic: cybersecurity
+    content_type: educational topics
+- vars:
+    topic: remote work
+    content_type: challenges
+- vars:
+    topic: quantum computing
+    content_type: use cases

--- a/examples/separate-test-configs/tests/tests2.yaml
+++ b/examples/separate-test-configs/tests/tests2.yaml
@@ -1,0 +1,24 @@
+# This file contains a list of test cases. They're added alongside test cases
+# from tests1.yaml in the example promptfooconfig.yaml.
+
+- vars:
+    topic: alien invasions
+    content_type: survival tips
+  assert:
+    - type: javascript
+      value: output.length > 100
+- vars:
+    topic: time travel
+    content_type: tourist attractions
+- vars:
+    topic: zombie apocalypse
+    content_type: home renovation ideas
+- vars:
+    topic: unicorn breeding
+    content_type: best practices
+- vars:
+    topic: telepathy for beginners
+    content_type: etiquette rules
+- vars:
+    topic: fairy dust
+    content_type: cleaning hacks

--- a/examples/separate-test-configs/tests/tests2.yaml
+++ b/examples/separate-test-configs/tests/tests2.yaml
@@ -22,3 +22,4 @@
 - vars:
     topic: fairy dust
     content_type: cleaning hacks
+- vars: ../vars/vars_*.yaml

--- a/examples/separate-test-configs/vars/vars_extra.yaml
+++ b/examples/separate-test-configs/vars/vars_extra.yaml
@@ -1,0 +1,2 @@
+topic: bananas
+content_type: musings of an evil genius

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,7 +281,6 @@ async function main() {
         prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts,
         providers: cmdObj.providers || fileConfig.providers || defaultConfig.providers,
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
-        loadTests: fileConfig.loadTests ?? defaultConfig.loadTests,
         sharing:
           process.env.PROMPTFOO_DISABLE_SHARING === '1'
             ? false
@@ -309,7 +308,6 @@ async function main() {
       const parsedProviders = await loadApiProviders(config.providers, basePath);
       const parsedTests: TestCase[] = await readTests(
         config.tests,
-        config.loadTests,
         cmdObj.tests ? undefined : basePath,
       );
       const parsedProviderPromptMap = readProviderPromptMap(config, parsedPrompts);

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,7 @@ async function main() {
         prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts,
         providers: cmdObj.providers || fileConfig.providers || defaultConfig.providers,
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
+        loadTests: fileConfig.loadTests ?? defaultConfig.loadTests,
         sharing:
           process.env.PROMPTFOO_DISABLE_SHARING === '1'
             ? false
@@ -308,6 +309,7 @@ async function main() {
       const parsedProviders = await loadApiProviders(config.providers, basePath);
       const parsedTests: TestCase[] = await readTests(
         config.tests,
+        config.loadTests,
         cmdObj.tests ? undefined : basePath,
       );
       const parsedProviderPromptMap = readProviderPromptMap(config, parsedPrompts);

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,9 @@ export interface TestCase {
   // Key-value pairs to substitute in the prompt
   vars?: Record<string, string | string[] | object>;
 
+  // Optional filepath or glob pattern to load vars from
+  varsFile?: string;
+
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,7 +189,7 @@ export interface TestCase {
   vars?: Record<string, string | string[] | object>;
 
   // Optional filepath or glob pattern to load vars from
-  varsFile?: string;
+  loadVars?: string | string[];
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];
@@ -221,6 +221,9 @@ export interface TestSuite {
   // Test cases
   tests?: TestCase[];
 
+  // File paths to load tests from
+  loadTests?: string | string[];
+
   // Default test case config
   defaultTest?: Partial<TestCase>;
 }
@@ -242,6 +245,9 @@ export interface TestSuiteConfig {
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
   tests: string | TestCase[];
+
+  // File paths to load tests from
+  loadTests?: string | string[];
 
   // Sets the default properties for each test case. Useful for setting an assertion, on all test cases, for example.
   defaultTest?: Omit<TestCase, 'description'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,9 +221,6 @@ export interface TestSuite {
   // Test cases
   tests?: TestCase[];
 
-  // File paths to load tests from
-  loadTests?: string | string[];
-
   // Default test case config
   defaultTest?: Partial<TestCase>;
 }
@@ -244,10 +241,7 @@ export interface TestSuiteConfig {
   prompts: string | string[];
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
-  tests: string | TestCase[];
-
-  // File paths to load tests from
-  loadTests?: string | string[];
+  tests: string | string[] | TestCase[];
 
   // Sets the default properties for each test case. Useful for setting an assertion, on all test cases, for example.
   defaultTest?: Omit<TestCase, 'description'>;

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 import { globSync } from 'glob';
 
 import {
-  readVars,
+  readTestsFile,
   readPrompts,
   writeOutput,
   readTests,
@@ -137,7 +137,7 @@ describe('util', () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2\nvalue1,value2');
     const varsPath = 'vars.csv';
 
-    const result = await readVars(varsPath);
+    const result = await readTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);
@@ -147,7 +147,7 @@ describe('util', () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('[{"var1": "value1", "var2": "value2"}]');
     const varsPath = 'vars.json';
 
-    const result = await readVars(varsPath);
+    const result = await readTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);
@@ -157,7 +157,7 @@ describe('util', () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('- var1: value1\n  var2: value2');
     const varsPath = 'vars.yaml';
 
-    const result = await readVars(varsPath);
+    const result = await readTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -447,4 +447,31 @@ describe('readTests', () => {
 
     expect(result).toEqual(input);
   });
+
+  test('readTests with string array input (paths to test configs)', async () => {
+    const testsPaths = ['test1.yaml', 'test2.yaml'];
+    const test1Content = [
+      {
+        description: 'Test 1',
+        vars: { var1: 'value1', var2: 'value2' },
+        assert: [{ type: 'equals', value: 'value1' }],
+      },
+    ];
+    const test2Content = [
+      {
+        description: 'Test 2',
+        vars: { var1: 'value3', var2: 'value4' },
+        assert: [{ type: 'contains-json', value: 'value3' }],
+      },
+    ];
+    (fs.readFileSync as jest.Mock)
+      .mockReturnValueOnce(yaml.dump(test1Content))
+      .mockReturnValueOnce(yaml.dump(test2Content));
+    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+
+    const result = await readTests(testsPaths);
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([...test1Content, ...test2Content]);
+  });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -474,4 +474,28 @@ describe('readTests', () => {
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(result).toEqual([...test1Content, ...test2Content]);
   });
+
+  test('readTests with vars glob input (paths to vars configs)', async () => {
+    const testsPaths = ['test1.yaml'];
+    const test1Content = [
+      {
+        description: 'Test 1',
+        vars: 'vars1.yaml',
+        assert: [{ type: 'equals', value: 'value1' }],
+      },
+    ];
+    const vars1Content = {
+      var1: 'value1',
+      var2: 'value2',
+    };
+    (fs.readFileSync as jest.Mock)
+      .mockReturnValueOnce(yaml.dump(test1Content))
+      .mockReturnValueOnce(yaml.dump(vars1Content));
+    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+
+    const result = await readTests(testsPaths);
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([Object.assign({}, test1Content[0], {vars: vars1Content})]);
+  });
 });


### PR DESCRIPTION
Lets you do things like this:

```yaml
prompts: prompts.txt
providers: openai:gpt-3.5-turbo

# Loads & runs all test cases matching these filepaths
tests:
  # You can supply an exact filepath
  - tests/tests2.yaml

  # Or a glob (wildcard)
  - tests/*

  # Mix and match with actual test cases
  - vars:
      var1: foo
      var2: bar
```

This is also valid:
```yaml
tests: tests/*
```

Or this:
```yaml
tests: ['tests/accuracy', 'tests/creativity']
```

----------------

Also adds support for importing vars, like this:

```yaml
tests:
  - vars: path/to/vars*.yaml
``` 

----------------

Closes #86 
Relevant to #73 