### PR TITLE
Promptfoo Theories

### DIFF
--- a/examples/multiple-translations-theory/README.md
+++ b/examples/multiple-translations-theory/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/multiple-translations-theory/promptfooconfig.yaml
+++ b/examples/multiple-translations-theory/promptfooconfig.yaml
@@ -1,0 +1,46 @@
+prompts: prompts.txt
+providers: [openai:gpt-3.5-turbo, openai:gpt-4]
+theories:
+  - dataSet:
+      -vars:
+        language: Spanish
+        expectedHelloWorld: 'Hola Mundo'
+        expectedGoodMorning: 'Buenos Dias'
+        expectedHowAreYou: '¿Cómo estás?'
+
+      -vars:
+        language: French
+        expectedHelloWorld: 'Bonjour le monde'
+        expectedGoodMorning: 'Bonjour'
+        expectedHowAreYou: 'Comment allez-vous?'
+
+      -vars:
+        language: German
+        expectedHelloWorld: 'Hallo Welt'
+        expectedGoodMorning: 'Guten Morgen'
+        expectedHowAreYou: 'Wie geht es dir?'
+
+    tests:
+      - description: Translated Hello World
+        vars:
+          input: 'Hello world'
+        assert:
+        - type: similar
+          value: '{{expectedHelloWorld}}'
+          threshold: 0.95
+      
+      - description: Translated Good Morning
+        vars:
+          input: 'Good morning'
+        assert:
+        - type: similar
+          value: '{{expectedGoodMorning}}'
+          threshold: 0.95
+      
+      - description: Translated How are you?
+        vars:
+          input: 'How are you?'
+        assert:
+        - type: similar
+          value: '{{expectedHowAreYou}}'
+          threshold: 0.95

--- a/examples/multiple-translations-theory/promptfooconfig.yaml
+++ b/examples/multiple-translations-theory/promptfooconfig.yaml
@@ -2,23 +2,21 @@ prompts: prompts.txt
 providers: [openai:gpt-3.5-turbo, openai:gpt-4]
 theories:
   - dataSet:
-      -vars:
-        language: Spanish
-        expectedHelloWorld: 'Hola Mundo'
-        expectedGoodMorning: 'Buenos Dias'
-        expectedHowAreYou: '¿Cómo estás?'
-
-      -vars:
-        language: French
-        expectedHelloWorld: 'Bonjour le monde'
-        expectedGoodMorning: 'Bonjour'
-        expectedHowAreYou: 'Comment allez-vous?'
-
-      -vars:
-        language: German
-        expectedHelloWorld: 'Hallo Welt'
-        expectedGoodMorning: 'Guten Morgen'
-        expectedHowAreYou: 'Wie geht es dir?'
+      - vars:
+          language: Spanish
+          expectedHelloWorld: 'Hola mundo'
+          expectedGoodMorning: 'Buenos días'
+          expectedHowAreYou: '¿Cómo estás?'
+      - vars:
+          language: French
+          expectedHelloWorld: 'Bonjour le monde'
+          expectedGoodMorning: 'Bonjour'
+          expectedHowAreYou: 'Comment ça va?'
+      - vars:
+          language: German
+          expectedHelloWorld: 'Hallo Welt'
+          expectedGoodMorning: 'Guten Morgen'
+          expectedHowAreYou: 'Wie geht es dir?'
 
     tests:
       - description: Translated Hello World
@@ -27,7 +25,7 @@ theories:
         assert:
         - type: similar
           value: '{{expectedHelloWorld}}'
-          threshold: 0.95
+          threshold: 0.90
       
       - description: Translated Good Morning
         vars:
@@ -35,7 +33,7 @@ theories:
         assert:
         - type: similar
           value: '{{expectedGoodMorning}}'
-          threshold: 0.95
+          threshold: 0.90
       
       - description: Translated How are you?
         vars:
@@ -43,4 +41,4 @@ theories:
         assert:
         - type: similar
           value: '{{expectedHowAreYou}}'
-          threshold: 0.95
+          threshold: 0.90

--- a/examples/multiple-translations-theory/promptfooconfig.yaml
+++ b/examples/multiple-translations-theory/promptfooconfig.yaml
@@ -23,22 +23,22 @@ theories:
         vars:
           input: 'Hello world'
         assert:
-        - type: similar
-          value: '{{expectedHelloWorld}}'
-          threshold: 0.90
-      
+          - type: similar
+            value: '{{expectedHelloWorld}}'
+            threshold: 0.90
+
       - description: Translated Good Morning
         vars:
           input: 'Good morning'
         assert:
-        - type: similar
-          value: '{{expectedGoodMorning}}'
-          threshold: 0.90
-      
+          - type: similar
+            value: '{{expectedGoodMorning}}'
+            threshold: 0.90
+
       - description: Translated How are you?
         vars:
           input: 'How are you?'
         assert:
-        - type: similar
-          value: '{{expectedHowAreYou}}'
-          threshold: 0.90
+          - type: similar
+            value: '{{expectedHowAreYou}}'
+            threshold: 0.90

--- a/examples/multiple-translations-theory/prompts.txt
+++ b/examples/multiple-translations-theory/prompts.txt
@@ -1,0 +1,3 @@
+You're a translator.  Translate this into {{language}}: {{input}}
+---
+Speak in {{language}}: {{input}}

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -98,15 +98,14 @@ export async function runAssertion(
   telemetry.record('assertion_used', {
     type: baseType,
   });
-  
+
   //render assertion values
   let renderedValue = assertion.value;
   // renderString for assertion values
-  if(renderedValue && typeof renderedValue === 'string'){    
+  if (renderedValue && typeof renderedValue === 'string') {
     renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
-  }
-  else if(renderedValue && Array.isArray(renderedValue)){    
-    renderedValue = renderedValue.map(v => nunjucks.renderString(v, test.vars || {}));
+  } else if (renderedValue && Array.isArray(renderedValue)) {
+    renderedValue = renderedValue.map((v) => nunjucks.renderString(v, test.vars || {}));
   }
 
   if (baseType === 'equals') {
@@ -160,9 +159,7 @@ export async function runAssertion(
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain one of "${renderedValue.join(
-            ', ',
-          )}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}contain one of "${renderedValue.join(', ')}"`,
     };
   }
 
@@ -178,9 +175,7 @@ export async function runAssertion(
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain all of "${renderedValue.join(
-            ', ',
-          )}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}contain all of "${renderedValue.join(', ')}"`,
     };
   }
 
@@ -298,10 +293,7 @@ ${renderedValue}`,
 
   if (baseType === 'webhook') {
     invariant(renderedValue, '"webhook" assertion type must have a URL value');
-    invariant(
-      typeof renderedValue === 'string',
-      '"webhook" assertion type must have a URL value',
-    );
+    invariant(typeof renderedValue === 'string', '"webhook" assertion type must have a URL value');
 
     try {
       const context = {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -98,13 +98,23 @@ export async function runAssertion(
   telemetry.record('assertion_used', {
     type: baseType,
   });
+  
+  //render assertion values
+  let renderedValue = assertion.value;
+  // renderString for assertion values
+  if(renderedValue && typeof renderedValue === 'string'){    
+    renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
+  }
+  else if(renderedValue && Array.isArray(renderedValue)){    
+    renderedValue = renderedValue.map(v => nunjucks.renderString(v, test.vars || {}));
+  }
 
   if (baseType === 'equals') {
-    pass = assertion.value === output;
+    pass = renderedValue === output;
     return {
       pass,
       score: pass ? 1 : 0,
-      reason: pass ? 'Assertion passed' : `Expected output "${assertion.value}"`,
+      reason: pass ? 'Assertion passed' : `Expected output "${renderedValue}"`,
     };
   }
 
@@ -123,103 +133,103 @@ export async function runAssertion(
   }
 
   if (baseType === 'contains') {
-    invariant(assertion.value, '"contains" assertion type must have a string or number value');
+    invariant(renderedValue, '"contains" assertion type must have a string or number value');
     invariant(
-      typeof assertion.value === 'string' || typeof assertion.value === 'number',
+      typeof renderedValue === 'string' || typeof renderedValue === 'number',
       '"contains" assertion type must have a string or number value',
     );
-    pass = output.includes(String(assertion.value)) !== inverse;
+    pass = output.includes(String(renderedValue)) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain "${assertion.value}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}contain "${renderedValue}"`,
     };
   }
 
   if (baseType === 'contains-any') {
-    invariant(assertion.value, '"contains-any" assertion type must have a value');
+    invariant(renderedValue, '"contains-any" assertion type must have a value');
     invariant(
-      Array.isArray(assertion.value),
+      Array.isArray(renderedValue),
       '"contains-any" assertion type must have an array value',
     );
-    pass = assertion.value.some((value) => output.includes(value)) !== inverse;
+    pass = renderedValue.some((value) => output.includes(value)) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain one of "${assertion.value.join(
+        : `Expected output to ${inverse ? 'not ' : ''}contain one of "${renderedValue.join(
             ', ',
           )}"`,
     };
   }
 
   if (baseType === 'contains-all') {
-    invariant(assertion.value, '"contains-all" assertion type must have a value');
+    invariant(renderedValue, '"contains-all" assertion type must have a value');
     invariant(
-      Array.isArray(assertion.value),
+      Array.isArray(renderedValue),
       '"contains-all" assertion type must have an array value',
     );
-    pass = assertion.value.every((value) => output.includes(value)) !== inverse;
+    pass = renderedValue.every((value) => output.includes(value)) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain all of "${assertion.value.join(
+        : `Expected output to ${inverse ? 'not ' : ''}contain all of "${renderedValue.join(
             ', ',
           )}"`,
     };
   }
 
   if (baseType === 'regex') {
-    invariant(assertion.value, '"regex" assertion type must have a string value');
+    invariant(renderedValue, '"regex" assertion type must have a string value');
     invariant(
-      typeof assertion.value === 'string',
+      typeof renderedValue === 'string',
       '"contains" assertion type must have a string value',
     );
-    const regex = new RegExp(assertion.value);
+    const regex = new RegExp(renderedValue);
     pass = regex.test(output) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}match regex "${assertion.value}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}match regex "${renderedValue}"`,
     };
   }
 
   if (baseType === 'icontains') {
-    invariant(assertion.value, '"icontains" assertion type must have a string or number value');
+    invariant(renderedValue, '"icontains" assertion type must have a string or number value');
     invariant(
-      typeof assertion.value === 'string' || typeof assertion.value === 'number',
+      typeof renderedValue === 'string' || typeof renderedValue === 'number',
       '"icontains" assertion type must have a string or number value',
     );
-    pass = output.toLowerCase().includes(String(assertion.value).toLowerCase()) !== inverse;
+    pass = output.toLowerCase().includes(String(renderedValue).toLowerCase()) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}contain "${assertion.value}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}contain "${renderedValue}"`,
     };
   }
 
   if (baseType === 'starts-with') {
-    invariant(assertion.value, '"starts-with" assertion type must have a string value');
+    invariant(renderedValue, '"starts-with" assertion type must have a string value');
     invariant(
-      typeof assertion.value === 'string',
+      typeof renderedValue === 'string',
       '"starts-with" assertion type must have a string value',
     );
-    pass = output.startsWith(String(assertion.value)) !== inverse;
+    pass = output.startsWith(String(renderedValue)) !== inverse;
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
-        : `Expected output to ${inverse ? 'not ' : ''}start with "${assertion.value}"`,
+        : `Expected output to ${inverse ? 'not ' : ''}start with "${renderedValue}"`,
     };
   }
 
@@ -236,7 +246,7 @@ export async function runAssertion(
 
   if (baseType === 'javascript') {
     try {
-      const customFunction = new Function('output', 'context', `return ${assertion.value}`);
+      const customFunction = new Function('output', 'context', `return ${renderedValue}`);
       const context = {
         vars: test.vars || {},
       };
@@ -255,7 +265,7 @@ export async function runAssertion(
         pass: false,
         score: 0,
         reason: `Custom function threw error: ${(err as Error).message}
-${assertion.value}`,
+${renderedValue}`,
       };
     }
     return {
@@ -264,32 +274,32 @@ ${assertion.value}`,
       reason: pass
         ? 'Assertion passed'
         : `Custom function returned ${inverse ? 'true' : 'false'}
-${assertion.value}`,
+${renderedValue}`,
     };
   }
 
   if (baseType === 'similar') {
-    invariant(assertion.value, 'Similarity assertion must have a string value');
+    invariant(renderedValue, 'Similarity assertion must have a string value');
     invariant(
-      typeof assertion.value === 'string',
+      typeof renderedValue === 'string',
       '"contains" assertion type must have a string value',
     );
-    return matchesSimilarity(assertion.value, output, assertion.threshold || 0.75, inverse);
+    return matchesSimilarity(renderedValue, output, assertion.threshold || 0.75, inverse);
   }
 
   if (baseType === 'llm-rubric') {
-    invariant(assertion.value, 'Similarity assertion must have a string value');
+    invariant(renderedValue, 'Similarity assertion must have a string value');
     invariant(
-      typeof assertion.value === 'string',
+      typeof renderedValue === 'string',
       '"contains" assertion type must have a string value',
     );
-    return matchesLlmRubric(assertion.value, output, test.options);
+    return matchesLlmRubric(renderedValue, output, test.options);
   }
 
   if (baseType === 'webhook') {
-    invariant(assertion.value, '"webhook" assertion type must have a URL value');
+    invariant(renderedValue, '"webhook" assertion type must have a URL value');
     invariant(
-      typeof assertion.value === 'string',
+      typeof renderedValue === 'string',
       '"webhook" assertion type must have a URL value',
     );
 
@@ -298,7 +308,7 @@ ${assertion.value}`,
         vars: test.vars || {},
       };
       const response = await fetchWithRetries(
-        assertion.value,
+        renderedValue,
         {
           method: 'POST',
           headers: {
@@ -339,8 +349,8 @@ ${assertion.value}`,
   }
 
   if (baseType === 'rouge-n') {
-    invariant(assertion.value, '"rouge" assertion type must a value (string or string array)');
-    return handleRougeScore(baseType, assertion, assertion.value, output, inverse);
+    invariant(renderedValue, '"rouge" assertion type must a value (string or string array)');
+    return handleRougeScore(baseType, assertion, renderedValue, output, inverse);
   }
 
   throw new Error('Unknown assertion type: ' + assertion.type);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -258,6 +258,8 @@ class Evaluator {
     let tests = (
       testSuite.tests && testSuite.tests.length > 0
         ? testSuite.tests
+        : testSuite.theories
+        ? []
         : [
             {
               // Dummy test for cases when we're only comparing raw prompts.

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -280,16 +280,16 @@ class Evaluator {
               },
             ]
           ).map((test) => {
-            return{
+            return {
               ...testSuite.defaultTest,
               ...data,
               ...test,
-              vars:{
+              vars: {
                 ...testSuite.defaultTest?.vars,
                 ...data.vars,
-                ...test.vars
-              }
-            }
+                ...test.vars,
+              },
+            };
           });
           //add theory tests to tests
           tests = tests.concat(theoryTests);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -255,8 +255,7 @@ class Evaluator {
     }
 
     // Aggregate all vars across test cases
-
-    const tests = (
+    let tests = (
       testSuite.tests && testSuite.tests.length > 0
         ? testSuite.tests
         : [
@@ -268,6 +267,35 @@ class Evaluator {
       const finalTestCase: TestCase = Object.assign({}, testSuite.defaultTest);
       return Object.assign(finalTestCase, test);
     });
+
+    //build theories and add to tests
+    if (testSuite.theories && testSuite.theories.length > 0) {
+      for (const theory of testSuite.theories) {
+        for (const data of theory.dataSet) {
+          //merge defaultTest with TheoryData
+          const theoryTests = (
+            theory.tests || [
+              {
+                // Dummy test for cases when we're only comparing raw prompts.
+              },
+            ]
+          ).map((test) => {
+            return{
+              ...testSuite.defaultTest,
+              ...data,
+              ...test,
+              vars:{
+                ...testSuite.defaultTest?.vars,
+                ...data.vars,
+                ...test.vars
+              }
+            }
+          });
+          //add theory tests to tests
+          tests = tests.concat(theoryTests);
+        }
+      }
+    }
 
     const varNames: Set<string> = new Set();
     const varsWithSpecialColsRemoved: Record<string, string | string[] | object>[] = [];
@@ -352,8 +380,7 @@ class Evaluator {
     // Set up progress bar...
     let progressbar: SingleBar | undefined;
     if (options.showProgressBar) {
-      const totalNumRuns =
-        testSuite.prompts.length * testSuite.providers.length * (totalVarCombinations || 1);
+      const totalNumRuns = runEvalOptions.length;
       const cliProgress = await import('cli-progress');
       progressbar = new cliProgress.SingleBar(
         {

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,7 @@ async function main() {
         prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts,
         providers: cmdObj.providers || fileConfig.providers || defaultConfig.providers,
         tests: cmdObj.tests || cmdObj.vars || fileConfig.tests || defaultConfig.tests,
+        theories: fileConfig.theories,
         sharing:
           process.env.PROMPTFOO_DISABLE_SHARING === '1'
             ? false
@@ -310,6 +311,18 @@ async function main() {
         config.tests,
         cmdObj.tests ? undefined : basePath,
       );
+
+      //parse testCases for each theory
+      if (fileConfig.theories) {
+        for (const theory of fileConfig.theories) {
+          const parsedTheoryTests: TestCase[] = await readTests(
+            theory.tests,
+            cmdObj.tests ? undefined : basePath,
+          );
+          theory.tests = parsedTheoryTests;
+        }
+      }
+
       const parsedProviderPromptMap = readProviderPromptMap(config, parsedPrompts);
 
       if (parsedPrompts.length === 0) {
@@ -334,6 +347,7 @@ async function main() {
         providers: parsedProviders,
         providerPromptMap: parsedProviderPromptMap,
         tests: parsedTests,
+        theories:config.theories,
         defaultTest,
       };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,7 +347,7 @@ async function main() {
         providers: parsedProviders,
         providerPromptMap: parsedProviderPromptMap,
         tests: parsedTests,
-        theories:config.theories,
+        theories: config.theories,
         defaultTest,
       };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,17 @@ export interface TestCase {
   options?: PromptConfig & OutputConfig & GradingConfig;
 }
 
+export interface Theory { 
+  // Optional description of what you're testing
+  description?: string;
+
+  // Default test case config
+  dataSet: Partial<TestCase>[];
+
+  // Optional list of automatic checks to run on the LLM output
+  tests: TestCase[];
+}
+
 // Same as a TestCase, except the `vars` object has been flattened into its final form.
 export interface AtomicTestCase extends TestCase {
   vars?: Record<string, string | object>;
@@ -221,6 +232,9 @@ export interface TestSuite {
   // Test cases
   tests?: TestCase[];
 
+  // Theories
+  theories?: Theory[];
+
   // Default test case config
   defaultTest?: Partial<TestCase>;
 }
@@ -242,6 +256,9 @@ export interface TestSuiteConfig {
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
   tests: string | string[] | TestCase[];
+
+  // Theories, groupings of data and tests to be evaluated
+  theories?: Theory[];
 
   // Sets the default properties for each test case. Useful for setting an assertion, on all test cases, for example.
   defaultTest?: Omit<TestCase, 'description'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,7 +198,7 @@ export interface TestCase {
   options?: PromptConfig & OutputConfig & GradingConfig;
 }
 
-export interface Theory { 
+export interface Theory {
   // Optional description of what you're testing
   description?: string;
 

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -415,4 +415,121 @@ describe('evaluator', () => {
     expect(summary.results[0].prompt.display).toBe('Test prompt 1');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
+
+  test('evaluate with theories', async () => {
+    const mockApiProvider: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider'),
+      callApi: jest
+        .fn()
+        .mockResolvedValueOnce({
+          output: 'Hola mundo',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        })
+        .mockResolvedValueOnce({
+          output: 'Bonjour le monde',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt {{ language }}')],
+      theories: [
+        {
+          dataSet: [
+            {
+              vars: {
+                language: 'Spanish',
+                expectedHelloWorld: 'Hola mundo',
+              },
+            },
+            {
+              vars: {
+                language: 'French',
+                expectedHelloWorld: 'Bonjour le monde',
+              },
+            },
+          ],
+          tests: [
+            {
+              assert: [
+                {
+                  type: 'equals',
+                  value: '{{expectedHelloWorld}}',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(2);
+    expect(summary.stats.successes).toBe(2);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].response?.output).toBe('Hola mundo');
+    expect(summary.results[1].response?.output).toBe('Bonjour le monde');
+  });
+
+  test('evaluate with theories and multiple vars', async () => {
+    const mockApiProvider: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider'),
+      callApi: jest
+        .fn()
+        .mockResolvedValueOnce({
+          output: 'Spanish Hola',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        })
+        .mockResolvedValueOnce({
+          output: 'Spanish Bonjour',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        })
+        .mockResolvedValueOnce({
+          output: 'French Hola',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        })
+        .mockResolvedValueOnce({
+          output: 'French Bonjour',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+        }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt {{ language }} {{ greeting }}')],
+      theories: [
+        {
+          dataSet: [
+            {
+              vars: {
+                language: ['Spanish', 'French'],
+                greeting: ['Hola', 'Bonjour'],
+              },
+            },
+          ],
+          tests: [
+            {
+              assert: [
+                {
+                  type: 'equals',
+                  value: '{{language}} {{greeting}}',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(4);
+    expect(summary.stats.successes).toBe(4);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].response?.output).toBe('Spanish Hola');
+    expect(summary.results[1].response?.output).toBe('Spanish Bonjour');
+    expect(summary.results[2].response?.output).toBe('French Hola');
+    expect(summary.results[3].response?.output).toBe('French Bonjour');
+  });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -496,6 +496,6 @@ describe('readTests', () => {
     const result = await readTests(testsPaths);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([Object.assign({}, test1Content[0], {vars: vars1Content})]);
+    expect(result).toEqual([Object.assign({}, test1Content[0], { vars: vars1Content })]);
   });
 });


### PR DESCRIPTION

Wanted to contribute a new way of configuring tests / scenarios in promptfoo.  Theories will now allow datasets to be associated with specific set of tests allowing the ability to execute many data driven tests without the requirement of copying a test over and over for each data set. 
Related to #73 [Allow separation of 'tests' vs. 'scenarios'](https://github.com/promptfoo/promptfoo/issues/73) 
Example configuration
```
theories:
  - dataSet:
      - vars:
          language: Spanish
          expectedHelloWorld: 'Hola mundo'
      - vars:
          language: French
          expectedHelloWorld: 'Bonjour le monde'
      - vars:
          language: German
          expectedHelloWorld: 'Hallo Welt'

    tests:
      - description: Translated Hello World
        vars:
          input: 'Hello world'
        assert:
        - type: similar
          value: '{{expectedHelloWorld}}'
          threshold: 0.90      
```
