### PR TITLE
Add support for OpenAI organization

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -69,8 +69,10 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
-            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
+            Authorization: `Bearer ${this.apiKey}`,
+            ...(process.env.OPENAI_ORGANIZATION
+              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+              : {}),
           },
           body: JSON.stringify(body),
         },
@@ -187,7 +189,11 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
-            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
+            ...(options?.organization
+              ? { 'OpenAI-Organization': options.organization }
+              : process.env.OPENAI_ORGANIZATION
+              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+              : {}),
           },
           body: JSON.stringify(body),
         },
@@ -286,7 +292,11 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
-            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
+            ...(options?.organization
+              ? { 'OpenAI-Organization': options.organization }
+              : process.env.OPENAI_ORGANIZATION
+              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+              : {}),
           },
           body: JSON.stringify(body),
         },

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -19,6 +19,8 @@ interface OpenAiCompletionOptions {
     parameters: any;
   }[];
   function_call?: 'none' | 'auto';
+  apiKey?: string;
+  organization?: string;
 }
 
 class OpenAiGenericProvider implements ApiProvider {
@@ -67,8 +69,8 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.apiKey}`,
-            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
+            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
+            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
           },
           body: JSON.stringify(body),
         },
@@ -184,8 +186,8 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.apiKey}`,
-            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
+            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
+            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
           },
           body: JSON.stringify(body),
         },
@@ -283,8 +285,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.apiKey}`,
-            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
+            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
+            ...(options?.organization ? { 'OpenAI-Organization': options.organization } : (process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {})),
           },
           body: JSON.stringify(body),
         },

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -74,8 +74,8 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
-            ...(this.getOrganization(options)
-              ? { 'OpenAI-Organization': this.getOrganization(options) }
+            ...(this.getOrganization()
+              ? { 'OpenAI-Organization': this.getOrganization() }
               : {}),
           },
           body: JSON.stringify(body),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -44,6 +44,10 @@ class OpenAiGenericProvider implements ApiProvider {
     return `[OpenAI Provider ${this.modelName}]`;
   }
 
+  getOrganization(options?: OpenAiCompletionOptions): string | undefined {
+    return options?.organization || process.env.OPENAI_ORGANIZATION;
+  }
+
   // @ts-ignore: Prompt is not used in this implementation
   async callApi(prompt: string, options?: OpenAiCompletionOptions): Promise<ProviderResponse> {
     throw new Error('Not implemented');
@@ -70,8 +74,8 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
-            ...(process.env.OPENAI_ORGANIZATION
-              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+            ...(this.getOrganization(options)
+              ? { 'OpenAI-Organization': this.getOrganization(options) }
               : {}),
           },
           body: JSON.stringify(body),
@@ -189,10 +193,8 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
-            ...(options?.organization
-              ? { 'OpenAI-Organization': options.organization }
-              : process.env.OPENAI_ORGANIZATION
-              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+            ...(this.getOrganization(options)
+              ? { 'OpenAI-Organization': this.getOrganization(options) }
               : {}),
           },
           body: JSON.stringify(body),
@@ -292,10 +294,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
-            ...(options?.organization
-              ? { 'OpenAI-Organization': options.organization }
-              : process.env.OPENAI_ORGANIZATION
-              ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION }
+            ...(this.getOrganization(options)
+              ? { 'OpenAI-Organization': this.getOrganization(options) }
               : {}),
           },
           body: JSON.stringify(body),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -68,6 +68,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
+            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
           },
           body: JSON.stringify(body),
         },
@@ -184,6 +185,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
+            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
           },
           body: JSON.stringify(body),
         },
@@ -282,6 +284,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
+            ...(process.env.OPENAI_ORGANIZATION ? { 'OpenAI-Organization': process.env.OPENAI_ORGANIZATION } : {}),
           },
           body: JSON.stringify(body),
         },

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -48,6 +48,10 @@ class OpenAiGenericProvider implements ApiProvider {
     return options?.organization || process.env.OPENAI_ORGANIZATION;
   }
 
+  getApiKey(options?: OpenAiCompletionOptions): string | undefined {
+    return options?.apiKey || this.apiKey;
+  }
+
   // @ts-ignore: Prompt is not used in this implementation
   async callApi(prompt: string, options?: OpenAiCompletionOptions): Promise<ProviderResponse> {
     throw new Error('Not implemented');
@@ -73,7 +77,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.apiKey}`,
+            Authorization: `Bearer ${this.getApiKey()}`,
             ...(this.getOrganization()
               ? { 'OpenAI-Organization': this.getOrganization() }
               : {}),
@@ -192,7 +196,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
+            Authorization: `Bearer ${this.getApiKey(options)}`,
             ...(this.getOrganization(options)
               ? { 'OpenAI-Organization': this.getOrganization(options) }
               : {}),
@@ -293,7 +297,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${options?.apiKey || this.apiKey}`,
+            Authorization: `Bearer ${this.getApiKey(options)}`,
             ...(this.getOrganization(options)
               ? { 'OpenAI-Organization': this.getOrganization(options) }
               : {}),


### PR DESCRIPTION
via `OPENAI_ORGANIZATION` envar

also adds `apiKey` and `organization` to provider config

Closes #105 