### PR TITLE
Add support for JSON schema validation for is-json and contains-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ See [Test assertions](https://promptfoo.dev/docs/configuration/expected-outputs)
 | `starts-with`   | output starts with string                                                 |
 | `contains-any ` | output contains any of the listed substrings                              |
 | `contains-all`  | output contains all list of substrings                                    |
-| `is-json`       | output is valid json                                                      |
-| `contains-json` | output contains valid json                                                |
+| `is-json`       | output is valid json (optional json schema validation)                    |
+| `contains-json` | output contains valid json (optional json schema validation)              |
 | `javascript`    | provided Javascript function validates the output                         |
 | `python`        | provided Python function validates the output                             |
 | `webhook`       | provided webhook returns `{pass: true}`                                   |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.5.2",
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "ajv": "^8.12.0",
         "async": "^3.2.4",
         "cache-manager": "^4.1.0",
         "cache-manager-fs-hash": "^1.0.0",
@@ -1686,6 +1687,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2757,6 +2773,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4087,6 +4108,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4764,6 +4790,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
@@ -4851,6 +4885,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5567,6 +5609,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7178,6 +7228,17 @@
         "humanize-ms": "^1.2.1"
       }
     },
+    "ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -8003,6 +8064,11 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -8990,6 +9056,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9468,6 +9539,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+    },
     "pure-rand": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
@@ -9524,6 +9600,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.2",
@@ -10023,6 +10104,14 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.5.2",
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
+    "ajv": "^8.12.0",
     "async": "^3.2.4",
     "cache-manager": "^4.1.0",
     "cache-manager-fs-hash": "^1.0.0",

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,5 +1,6 @@
 import rouge from 'rouge';
 import invariant from 'tiny-invariant';
+import Ajv from 'ajv';
 
 import telemetry from './telemetry';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from './providers/openai';
@@ -17,6 +18,7 @@ import type {
 
 const DEFAULT_SEMANTIC_SIMILARITY_THRESHOLD = 0.8;
 
+const ajv = new Ajv();
 const nunjucks = getNunjucksEngine();
 
 function handleRougeScore(
@@ -132,12 +134,28 @@ export async function runAssertion(
   }
 
   if (baseType === 'is-json') {
+    let parsedJson;
     try {
-      JSON.parse(output);
+      parsedJson = JSON.parse(output);
       pass = !inverse;
     } catch (err) {
       pass = inverse;
     }
+
+    if (pass && renderedValue) {
+      invariant(typeof renderedValue === 'object', 'is-json assertion must have an object value');
+      const validate = ajv.compile(renderedValue);
+      pass = validate(parsedJson);
+      if (!pass) {
+        return {
+          pass,
+          score: 0,
+          reason: `JSON does not conform to the provided schema. Errors: ${ajv.errorsText(validate.errors)}`,
+          assertion,
+        };
+      }
+    }
+
     return {
       pass,
       score: pass ? 1 : 0,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -150,7 +150,9 @@ export async function runAssertion(
         return {
           pass,
           score: 0,
-          reason: `JSON does not conform to the provided schema. Errors: ${ajv.errorsText(validate.errors)}`,
+          reason: `JSON does not conform to the provided schema. Errors: ${ajv.errorsText(
+            validate.errors,
+          )}`,
           assertion,
         };
       }
@@ -272,14 +274,19 @@ export async function runAssertion(
     pass = jsonMatch !== inverse;
 
     if (pass && renderedValue) {
-      invariant(typeof renderedValue === 'object', 'contains-json assertion must have an object value');
+      invariant(
+        typeof renderedValue === 'object',
+        'contains-json assertion must have an object value',
+      );
       const validate = ajv.compile(renderedValue);
       pass = validate(jsonMatch);
       if (!pass) {
         return {
           pass,
           score: 0,
-          reason: `JSON does not conform to the provided schema. Errors: ${ajv.errorsText(validate.errors)}`,
+          reason: `JSON does not conform to the provided schema. Errors: ${ajv.errorsText(
+            validate.errors,
+          )}`,
           assertion,
         };
       }
@@ -476,8 +483,7 @@ function containsJSON(str: string): boolean {
   }
 
   try {
-    JSON.parse(match[0]);
-    return true;
+    return JSON.parse(match[0]);
   } catch (error) {
     return false;
   }

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -279,8 +279,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
     logger.debug(`\tAzure OpenAI API response: ${JSON.stringify(data)}`);
     try {
       const message = data.choices[0].message;
-      const output =
-        message.content == null ? message.function_call : message.content;
+      const output = message.content == null ? message.function_call : message.content;
       return {
         output,
         tokenUsage: cached

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -78,9 +78,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.getApiKey()}`,
-            ...(this.getOrganization()
-              ? { 'OpenAI-Organization': this.getOrganization() }
-              : {}),
+            ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
           },
           body: JSON.stringify(body),
         },
@@ -315,8 +313,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     logger.debug(`\tOpenAI API response: ${JSON.stringify(data)}`);
     try {
       const message = data.choices[0].message;
-      const output =
-        message.content === null ? message.function_call : message.content;
+      const output = message.content === null ? message.function_call : message.content;
       return {
         output,
         tokenUsage: cached

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,7 @@ export interface Assertion {
   value?:
     | string
     | string[]
+    | object
     | ((output: string, testCase: AtomicTestCase, assertion: Assertion) => Promise<GradingResult>);
 
   // The threshold value, only applicable for similarity (cosine distance)

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -54,8 +54,48 @@ describe('runAssertion', () => {
     type: 'is-json',
   };
 
+  const isJsonAssertionWithSchema: Assertion = {
+    type: 'is-json',
+    value: {
+      required: ['latitude', 'longitude'],
+      type: 'object',
+      properties: {
+        latitude: {
+          type: 'number',
+          minimum: -90,
+          maximum: 90,
+        },
+        longitude: {
+          type: 'number',
+          minimum: -180,
+          maximum: 180,
+        },
+      },
+    },
+  };
+
   const containsJsonAssertion: Assertion = {
     type: 'contains-json',
+  };
+
+  const containsJsonAssertionWithSchema: Assertion = {
+    type: 'contains-json',
+    value: {
+      required: ['latitude', 'longitude'],
+      type: 'object',
+      properties: {
+        latitude: {
+          type: 'number',
+          minimum: -90,
+          maximum: 90,
+        },
+        longitude: {
+          type: 'number',
+          minimum: -180,
+          maximum: 180,
+        },
+      },
+    },
   };
 
   const javascriptStringAssertion: Assertion = {
@@ -128,6 +168,32 @@ describe('runAssertion', () => {
     expect(result.reason).toContain('Expected output to be valid JSON');
   });
 
+  it('should pass when the is-json assertion passes with schema', async () => {
+    const output = '{"latitude": 80.123, "longitude": -1}';
+
+    const result: GradingResult = await runAssertion(
+      isJsonAssertionWithSchema,
+      {} as AtomicTestCase,
+      output,
+    );
+    expect(result.pass).toBeTruthy();
+    expect(result.reason).toBe('Assertion passed');
+  });
+
+  it('should fail when the is-json assertion fails with schema', async () => {
+    const output = '{"latitude": "high", "longitude": [-1]}';
+
+    const result: GradingResult = await runAssertion(
+      isJsonAssertionWithSchema,
+      {} as AtomicTestCase,
+      output,
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.reason).toBe(
+      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    );
+  });
+
   it('should pass when the contains-json assertion passes', async () => {
     const output =
       'this is some other stuff \n\n {"key": "value", "key2": {"key3": "value2", "key4": ["value3", "value4"]}} \n\n blah blah';
@@ -151,6 +217,32 @@ describe('runAssertion', () => {
     );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toContain('Expected output to contain valid JSON');
+  });
+
+  it('should pass when the contains-json assertion passes with schema', async () => {
+    const output = 'here is the answer\n\n```{"latitude": 80.123, "longitude": -1}```';
+
+    const result: GradingResult = await runAssertion(
+      containsJsonAssertionWithSchema,
+      {} as AtomicTestCase,
+      output,
+    );
+    expect(result.pass).toBeTruthy();
+    expect(result.reason).toBe('Assertion passed');
+  });
+
+  it('should fail when the contains-json assertion fails with schema', async () => {
+    const output = 'here is the answer\n\n```{"latitude": "medium", "longitude": -1}```';
+
+    const result: GradingResult = await runAssertion(
+      containsJsonAssertionWithSchema,
+      {} as AtomicTestCase,
+      output,
+    );
+    expect(result.pass).toBeFalsy();
+    expect(result.reason).toBe(
+      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    );
   });
 
   it('should pass when the javascript assertion passes', async () => {


### PR DESCRIPTION
`is-json` and `contains-json` assertions support JSON schema `value`s

Example validation:

```yaml
tests:
  - vars:
      location: Paris
  - assert:
      - type: is-json
        value: {
          required: ['latitude', 'longitude'],
          type: 'object',
          properties: {
            latitude: {
              type: 'number',
              minimum: -90,
              maximum: 90,
            },
            longitude: {
              type: 'number',
              minimum: -180,
              maximum: 180,
            }
          }
        }
```

YAML equivalent of JSON schema also works:
```yaml
tests:
- vars:
    location: Paris
- assert:
  - type: is-json
    value:
      required: [latitude, longitude]
      type: object
      properties:
        latitude:
          minimum: -90
          type: number
          maximum: 90
        longitude:
          minimum: -180
          type: number
          maximum: 180
```