### PR TITLE
Add webhook provider

### DIFF
--- a/examples/simple-cli/promptfooconfig.yaml
+++ b/examples/simple-cli/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 description: A translator built with LLM
 prompts: [prompts.txt]
-providers: [webhook:https://webhook.site/6b8cecd1-28b4-4e25-a0d5-2dde9f45275b]
+providers: [openai:gpt-3.5-turbo]
 tests:
   - vars:
       language: French

--- a/examples/simple-cli/promptfooconfig.yaml
+++ b/examples/simple-cli/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 description: A translator built with LLM
 prompts: [prompts.txt]
-providers: [openai:gpt-3.5-turbo]
+providers: [webhook:https://webhook.site/6b8cecd1-28b4-4e25-a0d5-2dde9f45275b]
 tests:
   - vars:
       language: French

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -6,6 +6,7 @@ import { ReplicateProvider } from './providers/replicate';
 import { LocalAiCompletionProvider, LocalAiChatProvider } from './providers/localai';
 import { LlamaProvider } from './providers/llama';
 import { OllamaProvider } from './providers/ollama';
+import { WebhookProvider } from './providers/webhook';
 import { ScriptCompletionProvider } from './providers/scriptCompletion';
 import {
   AzureOpenAiChatCompletionProvider,
@@ -157,7 +158,7 @@ export async function loadApiProvider(
   }
 
   if (providerPath.startsWith('webhook:')) {
-    const webhookUrl = providerPath.split(':')[1];
+    const webhookUrl = providerPath.substring('webhook:'.length);
     return new WebhookProvider(webhookUrl);
   } else if (providerPath === 'llama' || providerPath.startsWith('llama:')) {
     const modelName = providerPath.split(':')[1];

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -156,7 +156,10 @@ export async function loadApiProvider(
     return new ReplicateProvider(modelName, undefined, context.config);
   }
 
-  if (providerPath === 'llama' || providerPath.startsWith('llama:')) {
+  if (providerPath.startsWith('webhook:')) {
+    const webhookUrl = providerPath.split(':')[1];
+    return new WebhookProvider(webhookUrl);
+  } else if (providerPath === 'llama' || providerPath.startsWith('llama:')) {
     const modelName = providerPath.split(':')[1];
     return new LlamaProvider(modelName, context.config);
   } else if (providerPath.startsWith('ollama:')) {

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -1,0 +1,59 @@
+import logger from '../logger';
+import { fetchWithCache } from '../cache';
+
+import type { ApiProvider, ProviderResponse } from '../types.js';
+import { REQUEST_TIMEOUT_MS } from './shared';
+
+export class WebhookProvider implements ApiProvider {
+  webhookUrl: string;
+
+  constructor(webhookUrl: string) {
+    this.webhookUrl = webhookUrl;
+  }
+
+  id(): string {
+    return `webhook:${this.webhookUrl}`;
+  }
+
+  toString(): string {
+    return `[Webhook Provider ${this.webhookUrl}]`;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    const params = {
+      prompt,
+    };
+
+    logger.debug(`Calling Webhook: ${this.webhookUrl} with params: ${JSON.stringify(params)}`);
+    let response;
+    try {
+      response = await fetchWithCache(
+        this.webhookUrl,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(params),
+        },
+        REQUEST_TIMEOUT_MS,
+        'json',
+      );
+    } catch (err) {
+      return {
+        error: `Webhook call error: ${String(err)}`,
+      };
+    }
+    logger.debug(`\tWebhook response: ${JSON.stringify(response.data)}`);
+
+    if (response.data && typeof response.data.output === 'string') {
+      return {
+        output: response.data.output,
+      };
+    } else {
+      return {
+        error: `Webhook response error: Unexpected response format: ${JSON.stringify(response.data)}`,
+      };
+    }
+  }
+}

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -52,7 +52,9 @@ export class WebhookProvider implements ApiProvider {
       };
     } else {
       return {
-        error: `Webhook response error: Unexpected response format: ${JSON.stringify(response.data)}`,
+        error: `Webhook response error: Unexpected response format: ${JSON.stringify(
+          response.data,
+        )}`,
       };
     }
   }

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -286,3 +286,17 @@ describe('providers', () => {
     expect(providers[2]).toBeInstanceOf(AnthropicCompletionProvider);
   });
 });
+  test('WebhookProvider callApi', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({
+        output: 'Test output',
+      }),
+    };
+    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+
+    const provider = new WebhookProvider('http://example.com/webhook');
+    const result = await provider.callApi('Test prompt');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.output).toBe('Test output');
+  });


### PR DESCRIPTION
The provider can be specified like:

```
providers: [webhook:http://example.com/webhook]
```

It sends an HTTP POST request with the following JSON payload:
```json
{
  "prompt": "..."
}
```

And expects a JSON response:
```json
{
  "output": "..."
}
```

This type of provider can be useful for triggering more complex flows or prompt chains end to end in your app.