### PR TITLE
Consistent envars and configs across providers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
+import invariant from 'tiny-invariant';
+
 import assertions from './assertions';
 import providers, { loadApiProvider } from './providers';
 import telemetry from './telemetry';
 import { evaluate as doEvaluate } from './evaluator';
 import { loadApiProviders } from './providers';
 import { readTests, writeLatestResults, writeOutput } from './util';
-import type { EvaluateOptions, TestSuite, EvaluateTestSuite, TestCase, Assertion } from './types';
+import type { EvaluateOptions, TestSuite, EvaluateTestSuite, ProviderOptions } from './types';
 
 export * from './types';
 
@@ -24,20 +26,30 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
       display: promptContent,
     })),
   };
-  telemetry.maybeShowNotice();
 
-  for (const test of constructedTestSuite.tests) {
-    if ((test as TestCase).options?.provider) {
-      (test as TestCase).options.provider = await loadApiProvider((test as TestCase).options.provider);
+  // Resolve nested providers
+  for (const test of constructedTestSuite.tests || []) {
+    if (test.options?.provider && typeof test.options.provider === 'function') {
+      test.options.provider = await loadApiProvider(test.options.provider);
     }
-    if ((test as TestCase).assert) {
-      for (const assertion of (test as TestCase).assert) {
-        if ((assertion as Assertion).provider) {
-          (assertion as Assertion).provider = await loadApiProvider((assertion as Assertion).provider);
+    if (test.assert) {
+      for (const assertion of test.assert) {
+        if (assertion.provider) {
+          if (typeof assertion.provider === 'object') {
+            const casted = assertion.provider as ProviderOptions;
+            invariant(casted.id, 'Provider object must have an id');
+            assertion.provider = await loadApiProvider(casted.id, { options: casted });
+          } else if (typeof assertion.provider === 'string') {
+            assertion.provider = await loadApiProvider(assertion.provider);
+          } else {
+            // It's a function, no need to do anything
+          }
         }
       }
     }
   }
+
+  telemetry.maybeShowNotice();
 
   const ret = await doEvaluate(constructedTestSuite, options);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ export { generateTable } from './table';
 async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions = {}) {
   const constructedTestSuite: TestSuite = {
     ...testSuite,
-    providers: await loadApiProviders(testSuite.providers),
+    providers: await loadApiProviders(testSuite.providers, {
+      env: testSuite.env,
+    }),
     tests: await readTests(testSuite.tests),
 
     // Full prompts expected (not filepaths)

--- a/src/main.ts
+++ b/src/main.ts
@@ -310,7 +310,7 @@ async function main() {
       // Use basepath in cases where path was supplied in the config file
       const basePath = configPath ? dirname(configPath) : '';
       const parsedPrompts = readPrompts(config.prompts, cmdObj.prompts ? undefined : basePath);
-      const parsedProviders = await loadApiProviders(config.providers, basePath);
+      const parsedProviders = await loadApiProviders(config.providers, { basePath });
       const parsedTests: TestCase[] = await readTests(
         config.tests,
         cmdObj.tests ? undefined : basePath,

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -26,7 +26,7 @@ export async function getGradingProvider(
     const providerId = typeof provider.id === 'string' ? provider.id : provider.id?.();
     invariant(providerId, 'Provider supplied to llm-rubric must have an id');
     // TODO(ian): set basepath if invoked from filesystem config
-    finalProvider = await loadApiProvider(providerId, provider as ProviderOptions);
+    finalProvider = await loadApiProvider(providerId, { options: provider as ProviderOptions });
   } else {
     finalProvider = defaultProvider;
   }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -19,6 +19,7 @@ import {
 
 import type {
   ApiProvider,
+  EnvOverrides,
   ProviderOptions,
   ProviderFunction,
   ProviderId,
@@ -34,6 +35,7 @@ export async function loadApiProviders(
     | ProviderFunction,
   options: {
     basePath?: string;
+    env?: EnvOverrides;
   } = {},
 ): Promise<ApiProvider[]> {
   if (typeof providerPaths === 'string') {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -38,8 +38,9 @@ export async function loadApiProviders(
     env?: EnvOverrides;
   } = {},
 ): Promise<ApiProvider[]> {
+  const { basePath, env } = options;
   if (typeof providerPaths === 'string') {
-    return [await loadApiProvider({ providerPath: providerPaths, basePath: options.basePath })];
+    return [await loadApiProvider(providerPaths, { basePath, env })];
   } else if (typeof providerPaths === 'function') {
     return [
       {
@@ -51,7 +52,7 @@ export async function loadApiProviders(
     return Promise.all(
       providerPaths.map((provider, idx) => {
         if (typeof provider === 'string') {
-          return loadApiProvider({ providerPath: provider, basePath: options.basePath });
+          return loadApiProvider(provider, { basePath, env });
         } else if (typeof provider === 'function') {
           return {
             id: () => `custom-function-${idx}`,
@@ -59,13 +60,17 @@ export async function loadApiProviders(
           };
         } else if (provider.id) {
           // List of ProviderConfig objects
-          return loadApiProvider({ providerPath: (provider as ProviderOptions).id!, options: provider, basePath: options.basePath });
+          return loadApiProvider((provider as ProviderOptions).id!, {
+            options: provider,
+            basePath,
+            env,
+          });
         } else {
           // List of { id: string, config: ProviderConfig } objects
           const id = Object.keys(provider)[0];
           const providerObject = (provider as ProviderOptionsMap)[id];
           const context = { ...providerObject, id: providerObject.id || id };
-          return loadApiProvider({ providerPath: id, options: context, basePath: options.basePath });
+          return loadApiProvider(id, { options: context, basePath, env });
         }
       }),
     );
@@ -73,15 +78,20 @@ export async function loadApiProviders(
   throw new Error('Invalid providers list');
 }
 
-export async function loadApiProvider({
-  providerPath,
-  options = {},
-  basePath,
-}: {
-  providerPath: string;
-  options?: ProviderOptions;
-  basePath?: string;
-}): Promise<ApiProvider> {
+export async function loadApiProvider(
+  providerPath: string,
+  context: {
+    options?: ProviderOptions;
+    basePath?: string;
+    env?: EnvOverrides;
+  } = {},
+): Promise<ApiProvider> {
+  const { options = {}, basePath, env } = context;
+  const providerOptions = {
+    id: options.id,
+    config: options.config,
+    env,
+  };
   if (providerPath?.startsWith('exec:')) {
     // Load script module
     const scriptPath = providerPath.split(':')[1];
@@ -96,27 +106,19 @@ export async function loadApiProvider({
     const modelName = splits[2];
 
     if (modelType === 'chat') {
-      return new OpenAiChatCompletionProvider(
-        modelName || 'gpt-3.5-turbo',
-        options.config,
-        options.id,
-      );
+      return new OpenAiChatCompletionProvider(modelName || 'gpt-3.5-turbo', providerOptions);
     } else if (modelType === 'embedding') {
-      return new OpenAiEmbeddingProvider(
-        modelName || 'text-embedding-ada-002',
-        options.config,
-        options.id,
-      );
+      return new OpenAiEmbeddingProvider(modelName || 'text-embedding-ada-002', {
+        id: options.id,
+        config: options.config,
+        env,
+      });
     } else if (modelType === 'completion') {
-      return new OpenAiCompletionProvider(
-        modelName || 'text-davinci-003',
-        options.config,
-        options.id,
-      );
+      return new OpenAiCompletionProvider(modelName || 'text-davinci-003', providerOptions);
     } else if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODELS.includes(modelType)) {
-      return new OpenAiChatCompletionProvider(modelType, options.config, options.id);
+      return new OpenAiChatCompletionProvider(modelType, providerOptions);
     } else if (OpenAiCompletionProvider.OPENAI_COMPLETION_MODELS.includes(modelType)) {
-      return new OpenAiCompletionProvider(modelType, options.config, options.id);
+      return new OpenAiCompletionProvider(modelType, providerOptions);
     } else {
       throw new Error(
         `Unknown OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>`,
@@ -129,9 +131,9 @@ export async function loadApiProvider({
     const deploymentName = splits[2];
 
     if (modelType === 'chat') {
-      return new AzureOpenAiChatCompletionProvider(deploymentName, options.config, options.id);
+      return new AzureOpenAiChatCompletionProvider(deploymentName, providerOptions);
     } else if (modelType === 'completion') {
-      return new AzureOpenAiCompletionProvider(deploymentName, options.config, options.id);
+      return new AzureOpenAiCompletionProvider(deploymentName, providerOptions);
     } else {
       throw new Error(
         `Unknown Azure OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>`,
@@ -144,9 +146,9 @@ export async function loadApiProvider({
     const modelName = splits[2];
 
     if (modelType === 'completion') {
-      return new AnthropicCompletionProvider(modelName || 'claude-instant-1', options.config);
+      return new AnthropicCompletionProvider(modelName || 'claude-instant-1', providerOptions);
     } else if (AnthropicCompletionProvider.ANTHROPIC_COMPLETION_MODELS.includes(modelType)) {
-      return new AnthropicCompletionProvider(modelType, options.config);
+      return new AnthropicCompletionProvider(modelType, providerOptions);
     } else {
       throw new Error(
         `Unknown Anthropic model type: ${modelType}. Use one of the following providers: anthropic:completion:<model name>`,
@@ -157,29 +159,29 @@ export async function loadApiProvider({
     const splits = providerPath.split(':');
     const modelName = splits.slice(1).join(':');
 
-    return new ReplicateProvider(modelName, options.config);
+    return new ReplicateProvider(modelName, providerOptions);
   }
 
   if (providerPath.startsWith('webhook:')) {
     const webhookUrl = providerPath.substring('webhook:'.length);
-    return new WebhookProvider(webhookUrl);
+    return new WebhookProvider(webhookUrl, providerOptions);
   } else if (providerPath === 'llama' || providerPath.startsWith('llama:')) {
     const modelName = providerPath.split(':')[1];
-    return new LlamaProvider(modelName, options.config);
+    return new LlamaProvider(modelName, providerOptions);
   } else if (providerPath.startsWith('ollama:')) {
     const modelName = providerPath.split(':')[1];
-    return new OllamaProvider(modelName);
+    return new OllamaProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('localai:')) {
     const splits = providerPath.split(':');
     const modelType = splits[1];
     const modelName = splits[2];
 
     if (modelType === 'chat') {
-      return new LocalAiChatProvider(modelName);
+      return new LocalAiChatProvider(modelName, providerOptions);
     } else if (modelType === 'completion') {
-      return new LocalAiCompletionProvider(modelName);
+      return new LocalAiCompletionProvider(modelName, providerOptions);
     } else {
-      return new LocalAiChatProvider(modelType);
+      return new LocalAiChatProvider(modelType, providerOptions);
     }
   }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -32,10 +32,12 @@ export async function loadApiProviders(
     | ProviderOptionsMap[]
     | ProviderOptions[]
     | ProviderFunction,
-  basePath?: string,
+  options: {
+    basePath?: string;
+  } = {},
 ): Promise<ApiProvider[]> {
   if (typeof providerPaths === 'string') {
-    return [await loadApiProvider(providerPaths, undefined, basePath)];
+    return [await loadApiProvider(providerPaths, undefined, options.basePath)];
   } else if (typeof providerPaths === 'function') {
     return [
       {
@@ -47,7 +49,7 @@ export async function loadApiProviders(
     return Promise.all(
       providerPaths.map((provider, idx) => {
         if (typeof provider === 'string') {
-          return loadApiProvider(provider, undefined, basePath);
+          return loadApiProvider(provider, undefined, options.basePath);
         } else if (typeof provider === 'function') {
           return {
             id: () => `custom-function-${idx}`,
@@ -55,13 +57,13 @@ export async function loadApiProviders(
           };
         } else if (provider.id) {
           // List of ProviderConfig objects
-          return loadApiProvider((provider as ProviderOptions).id!, provider, basePath);
+          return loadApiProvider((provider as ProviderOptions).id!, provider, options.basePath);
         } else {
           // List of { id: string, config: ProviderConfig } objects
           const id = Object.keys(provider)[0];
           const providerObject = (provider as ProviderOptionsMap)[id];
           const context = { ...providerObject, id: providerObject.id || id };
-          return loadApiProvider(id, context, basePath);
+          return loadApiProvider(id, context, options.basePath);
         }
       }),
     );

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import logger from '../logger';
 
-import type { ApiProvider, ProviderResponse } from '../types.js';
+import type { ApiProvider, EnvOverrides, ProviderResponse } from '../types.js';
 
 interface AnthropicCompletionOptions {
   apiKey?: string;
@@ -24,11 +24,16 @@ export class AnthropicCompletionProvider implements ApiProvider {
   anthropic: Anthropic;
   config: AnthropicCompletionOptions;
 
-  constructor(modelName: string, config?: AnthropicCompletionOptions) {
+  constructor(
+    modelName: string,
+    options: { config?: AnthropicCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    const { config, id, env } = options;
     this.modelName = modelName;
-    this.apiKey = config?.apiKey || process.env.ANTHROPIC_API_KEY;
+    this.apiKey = config?.apiKey || env?.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY;
     this.anthropic = new Anthropic({ apiKey: this.apiKey });
     this.config = config || {};
+    this.id = id ? () => id : this.id;
   }
 
   id(): string {

--- a/src/providers/llama.ts
+++ b/src/providers/llama.ts
@@ -25,11 +25,13 @@ interface LlamaCompletionOptions {
 
 export class LlamaProvider implements ApiProvider {
   modelName: string;
-  options?: LlamaCompletionOptions;
+  config?: LlamaCompletionOptions;
 
-  constructor(modelName: string, options?: LlamaCompletionOptions) {
+  constructor(modelName: string, options: { config?: LlamaCompletionOptions; id?: string } = {}) {
+    const { config, id } = options;
     this.modelName = modelName;
-    this.options = options;
+    this.config = config;
+    this.id = id ? () => id : this.id;
   }
 
   id(): string {
@@ -41,7 +43,7 @@ export class LlamaProvider implements ApiProvider {
   }
 
   async callApi(prompt: string, options?: LlamaCompletionOptions): Promise<ProviderResponse> {
-    options = Object.assign({}, this.options, options);
+    options = Object.assign({}, this.config, options);
     const body = {
       prompt,
       n_predict: options?.n_predict || 512,

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,8 +1,8 @@
 import logger from '../logger';
 import { fetchWithCache } from '../cache';
+import { REQUEST_TIMEOUT_MS } from './shared';
 
 import type { ApiProvider, ProviderResponse } from '../types.js';
-import { REQUEST_TIMEOUT_MS } from './shared';
 
 interface OllamaJsonL {
   model: string;

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -23,8 +23,10 @@ interface OllamaJsonL {
 export class OllamaProvider implements ApiProvider {
   modelName: string;
 
-  constructor(modelName: string) {
+  constructor(modelName: string, options: { id?: string } = {}) {
+    const { id } = options;
     this.modelName = modelName;
+    this.id = id ? () => id : this.id;
   }
 
   id(): string {

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import logger from '../logger';
 import { getCache, isCacheEnabled } from '../cache';
 
-import type { ApiProvider, ProviderResponse } from '../types.js';
+import type { ApiProvider, EnvOverrides, ProviderResponse } from '../types.js';
 
 interface ReplicateCompletionOptions {
   apiKey?: string;
@@ -22,11 +22,20 @@ export class ReplicateProvider implements ApiProvider {
   replicate: any;
   config: ReplicateCompletionOptions;
 
-  constructor(modelName: string, config?: ReplicateCompletionOptions) {
+  constructor(
+    modelName: string,
+    options: { config?: ReplicateCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    const { config, id, env } = options;
     this.modelName = modelName;
     this.apiKey =
-      config?.apiKey || process.env.REPLICATE_API_TOKEN || process.env.REPLICATE_API_KEY;
+      config?.apiKey ||
+      env?.REPLICATE_API_KEY ||
+      env?.REPLICATE_API_TOKEN ||
+      process.env.REPLICATE_API_TOKEN ||
+      process.env.REPLICATE_API_KEY;
     this.config = config || {};
+    this.id = id ? () => id : this.id;
   }
 
   id(): string {

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -7,8 +7,10 @@ import { REQUEST_TIMEOUT_MS } from './shared';
 export class WebhookProvider implements ApiProvider {
   webhookUrl: string;
 
-  constructor(webhookUrl: string) {
+  constructor(webhookUrl: string, options: { id?: string } = {}) {
+    const { id } = options;
     this.webhookUrl = webhookUrl;
+    this.id = id ? () => id : this.id;
   }
 
   id(): string {

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -1,8 +1,9 @@
 import logger from '../logger';
 import { fetchWithCache } from '../cache';
 
-import type { ApiProvider, ProviderResponse } from '../types.js';
 import { REQUEST_TIMEOUT_MS } from './shared';
+
+import type { ApiProvider, ProviderResponse } from '../types.js';
 
 export class WebhookProvider implements ApiProvider {
   webhookUrl: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,15 @@ export interface CommandLineOptions {
   promptSuffix?: string;
 }
 
+interface EnvOverrides {
+  ANTHROPIC_API_KEY?: string;
+  AZURE_OPENAI_API_HOST?: string;
+  AZURE_OPENAI_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+  REPLICATE_API_KEY?: string;
+  REPLICATE_API_TOKEN?: string;
+}
+
 export interface ProviderOptions {
   id?: ProviderId;
   config?: any;
@@ -248,6 +257,9 @@ export interface TestSuite {
 
   // Default test case config
   defaultTest?: Partial<TestCase>;
+
+  // Envar overrides
+  env?: EnvOverrides;
 }
 
 export type ProviderId = string;
@@ -286,6 +298,9 @@ export interface TestSuiteConfig {
 
   // Determines whether or not sharing is enabled.
   sharing?: boolean;
+
+  // Envar overrides
+  env?: EnvOverrides;
 }
 
 export type UnifiedConfig = TestSuiteConfig & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface CommandLineOptions {
   promptSuffix?: string;
 }
 
-interface EnvOverrides {
+export interface EnvOverrides {
   ANTHROPIC_API_KEY?: string;
   AZURE_OPENAI_API_HOST?: string;
   AZURE_OPENAI_API_KEY?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,11 @@ export interface EnvOverrides {
   AZURE_OPENAI_API_HOST?: string;
   AZURE_OPENAI_API_KEY?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_API_HOST?: string;
+  OPENAI_ORGANIZATION?: string;
   REPLICATE_API_KEY?: string;
   REPLICATE_API_TOKEN?: string;
+  LOCALAI_BASE_URL?: string;
 }
 
 export interface ProviderOptions {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -6,13 +6,14 @@ import { LlamaProvider } from '../src/providers/llama';
 
 import { disableCache, enableCache } from '../src/cache.js';
 import { loadApiProvider, loadApiProviders } from '../src/providers.js';
-import type { ProviderOptionsMap, ProviderFunction } from '../src/types';
 import {
   AzureOpenAiChatCompletionProvider,
   AzureOpenAiCompletionProvider,
 } from '../src/providers/azureopenai';
 import { OllamaProvider } from '../src/providers/ollama';
 import { WebhookProvider } from '../src/providers/webhook';
+
+import type { ProviderOptionsMap, ProviderFunction } from '../src/types';
 
 jest.mock('node-fetch', () => jest.fn());
 
@@ -87,7 +88,7 @@ describe('providers', () => {
       temperature: 3.1415926,
       max_tokens: 201,
     };
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo', {config});
+    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo', { config });
     const prompt = 'Test prompt';
     await provider.callApi(prompt);
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -87,7 +87,7 @@ describe('providers', () => {
       temperature: 3.1415926,
       max_tokens: 201,
     };
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo', config);
+    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo', {config});
     const prompt = 'Test prompt';
     await provider.callApi(prompt);
 
@@ -281,7 +281,9 @@ describe('providers', () => {
         config: { foo: 'bar' },
       },
     };
-    const provider = await loadApiProvider('openai:chat', rawProviderConfig['openai:chat']);
+    const provider = await loadApiProvider('openai:chat', {
+      options: rawProviderConfig['openai:chat'],
+    });
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
   });
 


### PR DESCRIPTION
- Add an `env` mapping to `TestSuite` that allows users to set `OPENAI_API_KEY` and similar envars in YAML
- Make it easier to set inference parameters like `temperature` across all providers (some were missing support for various parameters)
- Add support for custom provider IDs to non-OpenAI providers (allows comparison of the same model with different parameters)