### PR TITLE
Increase request backoff and add optional delay between API calls

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -27,7 +27,7 @@ import type {
 interface RunEvalOptions {
   provider: ApiProvider;
   prompt: Prompt;
-  delayMs: number;
+  delay: number;
 
   test: AtomicTestCase;
 
@@ -96,7 +96,7 @@ class Evaluator {
     prompt,
     test,
     includeProviderId,
-    delayMs,
+    delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
     const renderedPrompt = nunjucks.renderString(prompt.raw, vars);
@@ -123,8 +123,8 @@ class Evaluator {
       latencyMs = endTime - startTime;
 
       if (!response.cached) {
-        let sleep = delayMs;
-        if (!delayMs && process.env.PROMPTFOO_DELAY_MS) {
+        let sleep = delay;
+        if (!delay && process.env.PROMPTFOO_DELAY_MS) {
           sleep = parseInt(process.env.PROMPTFOO_DELAY_MS, 10) || 0;
         }
         if (sleep) {
@@ -368,7 +368,7 @@ class Evaluator {
                 }
               }
               runEvalOptions.push({
-                delayMs: options.delayMs || 0,
+                delay: options.delay || 0,
                 provider,
                 prompt: {
                   ...prompt,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -120,6 +120,14 @@ class Evaluator {
       const endTime = Date.now();
       latencyMs = endTime - startTime;
 
+      if (!response.cached && process.env.PROMPTFOO_SLEEP_MS) {
+        const sleep = parseInt(process.env.PROMPTFOO_SLEEP_MS, 10) || 0;
+        if (sleep) {
+          logger.debug(`Sleeping for ${sleep}ms`);
+          await new Promise((resolve) => setTimeout(resolve, sleep));
+        }
+      }
+
       const ret: EvaluateResult = {
         ...setup,
         response,

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,10 +236,10 @@ async function main() {
         : undefined,
     )
     .option(
-      '--delayMs <number>',
+      '--delay <number>',
       'Delay between each test (in milliseconds)',
-      defaultConfig.evaluateOptions?.delayMs
-        ? String(defaultConfig.evaluateOptions.delayMs)
+      defaultConfig.evaluateOptions?.delay
+        ? String(defaultConfig.evaluateOptions.delay)
         : undefined,
     )
     .option(
@@ -372,11 +372,11 @@ async function main() {
 
       let maxConcurrency = parseInt(cmdObj.maxConcurrency || '', 10);
       const iterations = parseInt(cmdObj.repeat || '', 10);
-      const delayMs = parseInt(cmdObj.delayMs || '', 0);
+      const delay = parseInt(cmdObj.delay || '', 0);
 
-      if (delayMs > 0) {
+      if (delay > 0) {
         maxConcurrency = 1;
-        logger.info(`Running at concurrency=1 because ${delayMs}ms delay was requested between API calls`);
+        logger.info(`Running at concurrency=1 because ${delay}ms delay was requested between API calls`);
       }
 
       const options: EvaluateOptions = {
@@ -386,7 +386,7 @@ async function main() {
             : cmdObj.progressBar,
         maxConcurrency: !isNaN(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : undefined,
         repeat: !isNaN(iterations) && iterations > 0 ? iterations : 1,
-        delayMs: !isNaN(delayMs) && delayMs > 0 ? delayMs : undefined,
+        delay: !isNaN(delay) && delay > 0 ? delay : undefined,
         ...evaluateOptions,
       };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,6 +236,13 @@ async function main() {
         : undefined,
     )
     .option(
+      '--delayMs <number>',
+      'Delay between each test (in milliseconds)',
+      defaultConfig.evaluateOptions?.delayMs
+        ? String(defaultConfig.evaluateOptions.delayMs)
+        : undefined,
+    )
+    .option(
       '--table-cell-max-length <number>',
       'Truncate console table cells to this length',
       '250',
@@ -363,8 +370,15 @@ async function main() {
         defaultTest,
       };
 
-      const maxConcurrency = parseInt(cmdObj.maxConcurrency || '', 10);
+      let maxConcurrency = parseInt(cmdObj.maxConcurrency || '', 10);
       const iterations = parseInt(cmdObj.repeat || '', 10);
+      const delayMs = parseInt(cmdObj.delayMs || '', 0);
+
+      if (delayMs > 0) {
+        maxConcurrency = 1;
+        logger.info(`Running at concurrency=1 because ${delayMs}ms delay was requested between API calls`);
+      }
+
       const options: EvaluateOptions = {
         showProgressBar:
           typeof cmdObj.progressBar === 'undefined'
@@ -372,6 +386,7 @@ async function main() {
             : cmdObj.progressBar,
         maxConcurrency: !isNaN(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : undefined,
         repeat: !isNaN(iterations) && iterations > 0 ? iterations : 1,
+        delayMs: !isNaN(delayMs) && delayMs > 0 ? delayMs : undefined,
         ...evaluateOptions,
       };
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -316,16 +316,6 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       };
     }
 
-    if (!cached) {
-      const sleep =
-        this.config.sleepBetweenCallsMs ??
-        (process.env.PROMPTFOO_SLEEP_MS ? parseInt(process.env.PROMPTFOO_SLEEP_MS, 10) : 0);
-      if (sleep) {
-        logger.debug(`Sleeping for ${sleep}ms`);
-        await new Promise((resolve) => setTimeout(resolve, sleep));
-      }
-    }
-
     logger.debug(`\tOpenAI API response: ${JSON.stringify(data)}`);
     try {
       const message = data.choices[0].message;
@@ -339,6 +329,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
               prompt: data.usage.prompt_tokens,
               completion: data.usage.completion_tokens,
             },
+        cached,
       };
     } catch (err) {
       return {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -25,10 +25,10 @@ interface OpenAiCompletionOptions {
   }[];
   function_call?: 'none' | 'auto';
   stop?: string[];
+
   apiKey?: string;
   apiHost?: string;
   organization?: string;
-  sleepBetweenCallsMs?: number;
 }
 
 class OpenAiGenericProvider implements ApiProvider {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -28,6 +28,7 @@ interface OpenAiCompletionOptions {
   apiKey?: string;
   apiHost?: string;
   organization?: string;
+  sleepBetweenCallsMs?: number;
 }
 
 class OpenAiGenericProvider implements ApiProvider {
@@ -313,6 +314,16 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       return {
         error: `API call error: ${String(err)}`,
       };
+    }
+
+    if (!cached) {
+      const sleep =
+        this.config.sleepBetweenCallsMs ??
+        (process.env.PROMPTFOO_SLEEP_MS ? parseInt(process.env.PROMPTFOO_SLEEP_MS, 10) : 0);
+      if (sleep) {
+        logger.debug(`Sleeping for ${sleep}ms`);
+        await new Promise((resolve) => setTimeout(resolve, sleep));
+      }
     }
 
     logger.debug(`\tOpenAI API response: ${JSON.stringify(data)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface CommandLineOptions {
   // Shared with EvaluateOptions
   maxConcurrency: string;
   repeat: string;
-  delayMs: string;
+  delay: string;
 
   // Command line only
   vars?: string;
@@ -98,7 +98,7 @@ export interface EvaluateOptions {
   progressCallback?: (progress: number, total: number) => void;
   generateSuggestions?: boolean;
   repeat?: number;
-  delayMs?: number;
+  delay?: number;
 }
 
 export interface Prompt {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface ProviderResponse {
   error?: string;
   output?: string;
   tokenUsage?: Partial<TokenUsage>;
+  cached?: boolean;
 }
 
 export interface ProviderEmbeddingResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface CommandLineOptions {
   // Shared with EvaluateOptions
   maxConcurrency: string;
   repeat: string;
+  delayMs: string;
 
   // Command line only
   vars?: string;
@@ -97,6 +98,7 @@ export interface EvaluateOptions {
   progressCallback?: (progress: number, total: number) => void;
   generateSuggestions?: boolean;
   repeat?: number;
+  delayMs?: number;
 }
 
 export interface Prompt {

--- a/src/util.ts
+++ b/src/util.ts
@@ -420,15 +420,18 @@ export async function fetchWithRetries(
   url: RequestInfo,
   options: RequestInit = {},
   timeout: number,
-  retries: number = 3,
+  retries: number = 4,
 ): Promise<Response> {
   let lastError;
+  const backoff = process.env.PROMPTFOO_REQUEST_BACKOFF_MS
+    ? parseInt(process.env.PROMPTFOO_REQUEST_BACKOFF_MS, 10)
+    : 5000;
   for (let i = 0; i < retries; i++) {
     try {
       return await fetchWithTimeout(url, options, timeout);
     } catch (error) {
       lastError = error;
-      const waitTime = Math.pow(2, i) * 1000; // Exponential backoff
+      const waitTime = Math.pow(2, i) * backoff;
       await new Promise((resolve) => setTimeout(resolve, waitTime));
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -431,7 +431,7 @@ export async function fetchWithRetries(
       return await fetchWithTimeout(url, options, timeout);
     } catch (error) {
       lastError = error;
-      const waitTime = Math.pow(2, i) * backoff;
+      const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());
       await new Promise((resolve) => setTimeout(resolve, waitTime));
     }
   }


### PR DESCRIPTION
Backoff is set by envar `PROMPTFOO_REQUEST_BACKOFF_MS` and defaults to 5000 ms, increasing exponentially.

You can also set a delay after each API call:
- Using the `--delay` CLI argument
- Or by setting the `PROMPTFOO_DELAY_MS` environment variable

Note that when setting the environment variable, you probably also want to set `--max-concurrency` to 1 - otherwise you'll still have calls running in parallel.

#121 