### PR TITLE
Add OpenAI factuality and closed-QA graders

### DIFF
--- a/examples/openai-eval-factuality/README.md
+++ b/examples/openai-eval-factuality/README.md
@@ -1,0 +1,7 @@
+This example uses the factuality and closed QA evaluation method from OpenAI.
+
+It is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+
+```
+promptfoo eval
+```

--- a/examples/openai-eval-factuality/promptfooconfig.yaml
+++ b/examples/openai-eval-factuality/promptfooconfig.yaml
@@ -1,0 +1,14 @@
+providers: [openai:gpt-3.5-turbo]
+prompts: [prompts/name_capitals_concise.txt, prompts/name_capitals_verbose.txt]
+tests:
+  - vars:
+      location: Sacramento
+
+    assert:
+      # Ensure the answer agrees with the provided facts
+      - type: model-graded-factuality
+        value: The capital of California is Sacramento
+
+      # Ensure the answer meets the criteria
+      - type: model-graded-closedqa
+        value: Does not include any extra information or facts about Sacramento

--- a/examples/openai-eval-factuality/prompts/name_capitals_concise.txt
+++ b/examples/openai-eval-factuality/prompts/name_capitals_concise.txt
@@ -1,0 +1,1 @@
+Output the capital of {{location}}

--- a/examples/openai-eval-factuality/prompts/name_capitals_verbose.txt
+++ b/examples/openai-eval-factuality/prompts/name_capitals_verbose.txt
@@ -1,0 +1,1 @@
+Tell me about the capital of {{location}}

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -163,7 +163,7 @@ class Evaluator {
         }
 
         invariant(processedResponse.output != null, 'Response output should not be null');
-        const checkResult = await runAssertions(test, processedResponse.output);
+        const checkResult = await runAssertions(renderedPrompt, test, processedResponse.output);
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
         }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -281,7 +281,7 @@ export async function matchesClosedQa(
     if (pass) {
       reason = 'The submission meets the criterion';
     } else if (resp.output.endsWith('N')) {
-      reason = 'The submission does not meet the criterion';
+      reason = `The submission does not meet the criterion: ${resp.output}`;
     } else {
       reason = 'Model grader received an ambiguous response';
     }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -194,26 +194,15 @@ export async function matchesFactuality(
     const failing = grading.failChoices || 'D';
 
     let pass = passing.includes(option) && !failing.includes(option);
-    switch (option) {
-      case 'A':
-        reason = `The submitted answer is a subset of the expert answer and is fully consistent with it.`;
-        break;
-      case 'B':
-        reason = `The submitted answer is a superset of the expert answer and is fully consistent with it.`;
-        break;
-      case 'C':
-        reason = `The submitted answer contains all the same details as the expert answer.`;
-        break;
-      case 'D':
-        reason = `There is a disagreement between the submitted answer and the expert answer.`;
-        break;
-      case 'E':
-        reason = `The answers differ, but these differences don't matter from the perspective of factuality.`;
-        break;
-      default:
-        pass = false;
-        reason = `Invalid option: ${option}`;
-    }
+    const optionReasons = {
+      'A': `The submitted answer is a subset of the expert answer and is fully consistent with it.`,
+      'B': `The submitted answer is a superset of the expert answer and is fully consistent with it.`,
+      'C': `The submitted answer contains all the same details as the expert answer.`,
+      'D': `There is a disagreement between the submitted answer and the expert answer.`,
+      'E': `The answers differ, but these differences don't matter from the perspective of factuality.`,
+    };
+    reason = optionReasons[option] || `Invalid option: ${option}`;
+    pass = reason !== `Invalid option: ${option}`;
 
     return {
       pass,

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -187,18 +187,41 @@ export async function matchesFactuality(
   }
 
   try {
-    // TODO: Parse output and create GradingResult.
-    parsed.tokensUsed = {
-      total: resp.tokenUsage?.total || 0,
-      prompt: resp.tokenUsage?.prompt || 0,
-      completion: resp.tokenUsage?.completion || 0,
+    const option = resp.output.trim().charAt(1); // Extract the option character
+    let pass = false;
+    let reason = '';
+
+    switch (option) {
+      case 'A':
+      case 'B':
+      case 'C':
+        pass = true;
+        reason = `The submitted answer is consistent with the expert answer. Option: ${option}`;
+        break;
+      case 'D':
+      case 'E':
+        pass = false;
+        reason = `The submitted answer is not consistent with the expert answer. Option: ${option}`;
+        break;
+      default:
+        reason = `Invalid option: ${option}`;
+    }
+
+    return {
+      pass,
+      score: pass ? 1 : 0,
+      reason,
+      tokensUsed: {
+        total: resp.tokenUsage?.total || 0,
+        prompt: resp.tokenUsage?.prompt || 0,
+        completion: resp.tokenUsage?.completion || 0,
+      },
     };
-    return { ...parsed, score: parsed.pass ? 1 : 0 };
   } catch (err) {
     return {
       pass: false,
       score: 0,
-      reason: `Output is not valid JSON: ${resp.output}`,
+      reason: `Error parsing output: ${err.message}`,
       tokensUsed: {
         total: resp.tokenUsage?.total || 0,
         prompt: resp.tokenUsage?.prompt || 0,

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -194,15 +194,19 @@ export async function matchesFactuality(
     const failing = grading.failChoices || 'D';
 
     let pass = passing.includes(option) && !failing.includes(option);
-    const optionReasons = {
-      'A': `The submitted answer is a subset of the expert answer and is fully consistent with it.`,
-      'B': `The submitted answer is a superset of the expert answer and is fully consistent with it.`,
-      'C': `The submitted answer contains all the same details as the expert answer.`,
-      'D': `There is a disagreement between the submitted answer and the expert answer.`,
-      'E': `The answers differ, but these differences don't matter from the perspective of factuality.`,
+    const optionReasons: Record<string, string> = {
+      A: `The submitted answer is a subset of the expert answer and is fully consistent with it.`,
+      B: `The submitted answer is a superset of the expert answer and is fully consistent with it.`,
+      C: `The submitted answer contains all the same details as the expert answer.`,
+      D: `There is a disagreement between the submitted answer and the expert answer.`,
+      E: `The answers differ, but these differences don't matter from the perspective of factuality.`,
     };
-    reason = optionReasons[option] || `Invalid option: ${option}`;
-    pass = reason !== `Invalid option: ${option}`;
+    if (optionReasons[option]) {
+      reason = optionReasons[option];
+    } else {
+      pass = false;
+      reason = `Invalid option: ${option}`;
+    }
 
     return {
       pass,
@@ -218,7 +222,7 @@ export async function matchesFactuality(
     return {
       pass: false,
       score: 0,
-      reason: `Error parsing output: ${err.message}`,
+      reason: `Error parsing output: ${(err as Error).message}`,
       tokensUsed: {
         total: resp.tokenUsage?.total || 0,
         prompt: resp.tokenUsage?.prompt || 0,

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -193,15 +193,24 @@ export async function matchesFactuality(
 
     switch (option) {
       case 'A':
+        pass = true;
+        reason = `The submitted answer is a subset of the expert answer and is fully consistent with it.`;
+        break;
       case 'B':
+        pass = true;
+        reason = `The submitted answer is a superset of the expert answer and is fully consistent with it.`;
+        break;
       case 'C':
         pass = true;
-        reason = `The submitted answer is consistent with the expert answer. Option: ${option}`;
+        reason = `The submitted answer contains all the same details as the expert answer.`;
         break;
       case 'D':
+        pass = false;
+        reason = `There is a disagreement between the submitted answer and the expert answer.`;
+        break;
       case 'E':
         pass = false;
-        reason = `The submitted answer is not consistent with the expert answer. Option: ${option}`;
+        reason = `The answers differ, but these differences don't matter from the perspective of factuality.`;
         break;
       default:
         reason = `Invalid option: ${option}`;

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -188,31 +188,30 @@ export async function matchesFactuality(
 
   try {
     const option = resp.output.trim().charAt(1); // Extract the option character
-    let pass = false;
     let reason = '';
 
+    const passing = grading.passChoices || 'ABCE';
+    const failing = grading.failChoices || 'D';
+
+    let pass = passing.includes(option) && !failing.includes(option);
     switch (option) {
       case 'A':
-        pass = true;
         reason = `The submitted answer is a subset of the expert answer and is fully consistent with it.`;
         break;
       case 'B':
-        pass = true;
         reason = `The submitted answer is a superset of the expert answer and is fully consistent with it.`;
         break;
       case 'C':
-        pass = true;
         reason = `The submitted answer contains all the same details as the expert answer.`;
         break;
       case 'D':
-        pass = false;
         reason = `There is a disagreement between the submitted answer and the expert answer.`;
         break;
       case 'E':
-        pass = false;
         reason = `The answers differ, but these differences don't matter from the perspective of factuality.`;
         break;
       default:
+        pass = false;
         reason = `Invalid option: ${option}`;
     }
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -44,6 +44,25 @@ The submitted answer may either be a subset or superset of the expert answer, or
   },
 ]);
 
+export const OPENAI_CLOSED_QA_PROMPT = JSON.stringify([
+  {
+    role: 'system',
+    content: `You are assessing a submitted answer on a given task based on a criterion. Here is the data:
+[BEGIN DATA]
+***
+[Task]: {{input}}
+***
+[Submission]: {{completion}}
+***
+[Criterion]: {{criteria}}
+***
+[END DATA]
+Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.
+
+    Reasoning:`,
+  },
+]);
+
 export const SUGGEST_PROMPTS_SYSTEM_MESSAGE = {
   role: 'system',
   content: `You're helping a scientist who is tuning a prompt for a large language model.  You will receive messages, and each message is a full prompt.  Generate a candidate variation of the given prompt.  This variation will be tested for quality in order to select a winner.

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -19,6 +19,31 @@ Rubric: Does not speak like a pirate
   },
 ]);
 
+// https://github.com/openai/evals/blob/main/evals/registry/modelgraded/fact.yaml
+export const OPENAI_FACTUALITY_PROMPT = JSON.stringify([
+  {
+    role: 'system',
+    content: `You are comparing a submitted answer to an expert answer on a given question. Here is the data:
+[BEGIN DATA]
+************
+[Question]: {{input}}
+************
+[Expert]: {{ideal}}
+************
+[Submission]: {{completion}}
+************
+[END DATA]
+
+Compare the factual content of the submitted answer with the expert answer. Ignore any differences in style, grammar, or punctuation.
+The submitted answer may either be a subset or superset of the expert answer, or it may conflict with it. Determine which case applies. Answer the question by selecting one of the following options:
+(A) The submitted answer is a subset of the expert answer and is fully consistent with it.
+(B) The submitted answer is a superset of the expert answer and is fully consistent with it.
+(C) The submitted answer contains all the same details as the expert answer.
+(D) There is a disagreement between the submitted answer and the expert answer.
+(E) The answers differ, but these differences don't matter from the perspective of factuality.`,
+  }
+]);
+
 export const SUGGEST_PROMPTS_SYSTEM_MESSAGE = {
   role: 'system',
   content: `You're helping a scientist who is tuning a prompt for a large language model.  You will receive messages, and each message is a full prompt.  Generate a candidate variation of the given prompt.  This variation will be tested for quality in order to select a winner.

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -41,7 +41,7 @@ The submitted answer may either be a subset or superset of the expert answer, or
 (C) The submitted answer contains all the same details as the expert answer.
 (D) There is a disagreement between the submitted answer and the expert answer.
 (E) The answers differ, but these differences don't matter from the perspective of factuality.`,
-  }
+  },
 ]);
 
 export const SUGGEST_PROMPTS_SYSTEM_MESSAGE = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,11 @@ export type VarMapping = Record<string, string>;
 export interface GradingConfig {
   rubricPrompt?: string;
   provider?: string | ProviderOptions | ApiProvider;
-  passChoices?: string | string[];
-  failChoices?: string | string[];
+  choices?: {
+    pass?: string | string[];
+    fail?: string | string[];
+    scores?: Record<string, number>;
+  };
 }
 
 export interface PromptConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,8 @@ export type VarMapping = Record<string, string>;
 export interface GradingConfig {
   rubricPrompt?: string;
   provider?: string | ProviderOptions | ApiProvider;
+  passChoices?: string | string[];
+  failChoices?: string | string[];
 }
 
 export interface PromptConfig {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -37,7 +37,7 @@ describe('runAssertions', () => {
   it('should pass when all assertions pass', async () => {
     const output = 'Expected output';
 
-    const result: GradingResult = await runAssertions(test, output);
+    const result: GradingResult = await runAssertions('Some prompt', test, output);
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('All assertions passed');
   });
@@ -45,7 +45,7 @@ describe('runAssertions', () => {
   it('should fail when any assertion fails', async () => {
     const output = 'Different output';
 
-    const result: GradingResult = await runAssertions(test, output);
+    const result: GradingResult = await runAssertions('Some prompt', test, output);
     expect(result.pass).toBeFalsy();
     expect(result.reason).toBe('Expected output "Expected output"');
   });
@@ -54,6 +54,7 @@ describe('runAssertions', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertions(
+      'Some prompt',
       {
         threshold: 0.5,
         assert: [
@@ -79,6 +80,7 @@ describe('runAssertions', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertions(
+      'Some prompt',
       {
         threshold: 0.25,
         assert: [
@@ -212,6 +214,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       equalityAssertion,
       {} as AtomicTestCase,
       output,
@@ -224,6 +227,7 @@ describe('runAssertion', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       equalityAssertion,
       {} as AtomicTestCase,
       output,
@@ -235,7 +239,12 @@ describe('runAssertion', () => {
   it('should pass when the is-json assertion passes', async () => {
     const output = '{"key": "value"}';
 
-    const result: GradingResult = await runAssertion(isJsonAssertion, {} as AtomicTestCase, output);
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      isJsonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
   });
@@ -243,7 +252,12 @@ describe('runAssertion', () => {
   it('should fail when the is-json assertion fails', async () => {
     const output = 'Not valid JSON';
 
-    const result: GradingResult = await runAssertion(isJsonAssertion, {} as AtomicTestCase, output);
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      isJsonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toContain('Expected output to be valid JSON');
   });
@@ -252,6 +266,7 @@ describe('runAssertion', () => {
     const output = '{"latitude": 80.123, "longitude": -1}';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       isJsonAssertionWithSchema,
       {} as AtomicTestCase,
       output,
@@ -264,6 +279,7 @@ describe('runAssertion', () => {
     const output = '{"latitude": "high", "longitude": [-1]}';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       isJsonAssertionWithSchema,
       {} as AtomicTestCase,
       output,
@@ -279,6 +295,7 @@ describe('runAssertion', () => {
       'this is some other stuff \n\n {"key": "value", "key2": {"key3": "value2", "key4": ["value3", "value4"]}} \n\n blah blah';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsJsonAssertion,
       {} as AtomicTestCase,
       output,
@@ -291,6 +308,7 @@ describe('runAssertion', () => {
     const output = 'Not valid JSON';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsJsonAssertion,
       {} as AtomicTestCase,
       output,
@@ -303,6 +321,7 @@ describe('runAssertion', () => {
     const output = 'here is the answer\n\n```{"latitude": 80.123, "longitude": -1}```';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsJsonAssertionWithSchema,
       {} as AtomicTestCase,
       output,
@@ -315,6 +334,7 @@ describe('runAssertion', () => {
     const output = 'here is the answer\n\n```{"latitude": "medium", "longitude": -1}```';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsJsonAssertionWithSchema,
       {} as AtomicTestCase,
       output,
@@ -329,6 +349,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertion,
       {} as AtomicTestCase,
       output,
@@ -341,6 +362,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertionWithNumber,
       {} as AtomicTestCase,
       output,
@@ -354,6 +376,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertionWithNumberAndThreshold,
       {} as AtomicTestCase,
       output,
@@ -367,6 +390,7 @@ describe('runAssertion', () => {
     const output = '';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertionWithNumberAndThreshold,
       {} as AtomicTestCase,
       output,
@@ -380,6 +404,7 @@ describe('runAssertion', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertion,
       {} as AtomicTestCase,
       output,
@@ -396,6 +421,7 @@ describe('runAssertion', () => {
       value: 'output === "Expected output" && context.vars.foo === "bar"',
     };
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertionWithVars,
       { vars: { foo: 'bar' } } as AtomicTestCase,
       output,
@@ -412,6 +438,7 @@ describe('runAssertion', () => {
       value: 'output === "Expected output" && context.vars.foo === "something else"',
     };
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptStringAssertionWithVars,
       { vars: { foo: 'bar' } } as AtomicTestCase,
       output,
@@ -426,6 +453,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptFunctionAssertion,
       {} as AtomicTestCase,
       output,
@@ -439,6 +467,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptFunctionFailAssertion,
       {} as AtomicTestCase,
       output,
@@ -452,6 +481,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptMultilineStringAssertion,
       {} as AtomicTestCase,
       output,
@@ -464,6 +494,7 @@ describe('runAssertion', () => {
     const output = 'Not the expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       javascriptMultilineStringAssertion,
       {} as AtomicTestCase,
       output,
@@ -481,6 +512,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsAssertion,
       {} as AtomicTestCase,
       output,
@@ -493,6 +525,7 @@ describe('runAssertion', () => {
     const output = 'Unexpected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsAssertion,
       {} as AtomicTestCase,
       output,
@@ -511,6 +544,7 @@ describe('runAssertion', () => {
     const output = 'EXPECTED OUTPUT';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsLowerAssertion,
       {} as AtomicTestCase,
       output,
@@ -523,6 +557,7 @@ describe('runAssertion', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsLowerAssertion,
       {} as AtomicTestCase,
       output,
@@ -541,6 +576,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsLowerAssertion,
       {} as AtomicTestCase,
       output,
@@ -553,6 +589,7 @@ describe('runAssertion', () => {
     const output = 'UNEXPECTED OUTPUT';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsLowerAssertion,
       {} as AtomicTestCase,
       output,
@@ -571,6 +608,7 @@ describe('runAssertion', () => {
     const output = 'This output contains option1';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsAnyAssertion,
       {} as AtomicTestCase,
       output,
@@ -583,6 +621,7 @@ describe('runAssertion', () => {
     const output = 'This output does not contain any option';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsAnyAssertion,
       {} as AtomicTestCase,
       output,
@@ -601,6 +640,7 @@ describe('runAssertion', () => {
     const output = 'This output contains option1, option2, and option3';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsAllAssertion,
       {} as AtomicTestCase,
       output,
@@ -613,6 +653,7 @@ describe('runAssertion', () => {
     const output = 'This output contains only option1 and option2';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsAllAssertion,
       {} as AtomicTestCase,
       output,
@@ -631,6 +672,7 @@ describe('runAssertion', () => {
     const output = 'This output contains 123-45-6789';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsRegexAssertion,
       {} as AtomicTestCase,
       output,
@@ -643,6 +685,7 @@ describe('runAssertion', () => {
     const output = 'This output does not contain the pattern';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       containsRegexAssertion,
       {} as AtomicTestCase,
       output,
@@ -661,6 +704,7 @@ describe('runAssertion', () => {
     const output = 'This output does not contain the pattern';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsRegexAssertion,
       {} as AtomicTestCase,
       output,
@@ -673,6 +717,7 @@ describe('runAssertion', () => {
     const output = 'This output contains 123-45-6789';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       notContainsRegexAssertion,
       {} as AtomicTestCase,
       output,
@@ -697,6 +742,7 @@ describe('runAssertion', () => {
       );
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       webhookAssertion,
       {} as AtomicTestCase,
       output,
@@ -715,6 +761,7 @@ describe('runAssertion', () => {
       );
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       webhookAssertion,
       {} as AtomicTestCase,
       output,
@@ -731,6 +778,7 @@ describe('runAssertion', () => {
       .mockImplementation(() => Promise.resolve(new Response('', { status: 500 })));
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       webhookAssertion,
       {} as AtomicTestCase,
       output,
@@ -749,7 +797,12 @@ describe('runAssertion', () => {
   it('should pass when the rouge-n assertion passes', async () => {
     const output = 'This is the expected output.';
 
-    const result: GradingResult = await runAssertion(rougeNAssertion, {} as AtomicTestCase, output);
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      rougeNAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('ROUGE-N score 1 is greater than or equal to threshold 0.75');
   });
@@ -757,7 +810,12 @@ describe('runAssertion', () => {
   it('should fail when the rouge-n assertion fails', async () => {
     const output = 'some different output';
 
-    const result: GradingResult = await runAssertion(rougeNAssertion, {} as AtomicTestCase, output);
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      rougeNAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toBe('ROUGE-N score 0.2 is less than threshold 0.75');
   });
@@ -772,6 +830,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       startsWithAssertion,
       {} as AtomicTestCase,
       output,
@@ -784,6 +843,7 @@ describe('runAssertion', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       startsWithAssertion,
       {} as AtomicTestCase,
       output,
@@ -818,7 +878,7 @@ describe('runAssertion', () => {
     };
 
     // Expect test to pass because assertion grader takes priority
-    const result: GradingResult = await runAssertion(assertion, test, output);
+    const result: GradingResult = await runAssertion('Some prompt', assertion, test, output);
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Test grading output');
   });
@@ -834,6 +894,7 @@ describe('runAssertion', () => {
     const output = 'Expected output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       levenshteinAssertion,
       {} as AtomicTestCase,
       output,
@@ -846,6 +907,7 @@ describe('runAssertion', () => {
     const output = 'Different output';
 
     const result: GradingResult = await runAssertion(
+      'Some prompt',
       levenshteinAssertion,
       {} as AtomicTestCase,
       output,

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -170,15 +170,48 @@ describe('matchesLlmRubric', () => {
 
 describe('matchesFactuality', () => {
   it('should pass when the factuality check passes', async () => {
-    // Add your test logic here
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
+      output: JSON.stringify({ pass: true, reason: 'Factuality check passed' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesFactuality(input, expected, output, grading);
+    expect(result.pass).toBeTruthy();
+    expect(result.reason).toBe('Factuality check passed');
   });
 
   it('should fail when the factuality check fails', async () => {
-    // Add your test logic here
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
+      output: JSON.stringify({ pass: false, reason: 'Factuality check failed' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesFactuality(input, expected, output, grading);
+    expect(result.pass).toBeFalsy();
+    expect(result.reason).toBe('Factuality check failed');
   });
 
   it('should throw an error when an error occurs', async () => {
-    // Add your test logic here
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    jest.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(() => {
+      throw new Error('An error occurred');
+    });
+
+    await expect(matchesFactuality(input, expected, output, grading)).rejects.toThrow('An error occurred');
   });
 });
 

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -168,6 +168,20 @@ describe('matchesLlmRubric', () => {
   });
 });
 
+describe('matchesFactuality', () => {
+  it('should pass when the factuality check passes', async () => {
+    // Add your test logic here
+  });
+
+  it('should fail when the factuality check fails', async () => {
+    // Add your test logic here
+  });
+
+  it('should throw an error when an error occurs', async () => {
+    // Add your test logic here
+  });
+});
+
 describe('getGradingProvider', () => {
   it('should return the correct provider when provider is a string', async () => {
     const provider = await getGradingProvider(

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -256,7 +256,7 @@ describe('matchesClosedQa', () => {
 
     const result = await matchesClosedQa(input, expected, output, grading);
     expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('The submission does not meet the criterion');
+    expect(result.reason).toBe('The submission does not meet the criterion: foo bar N');
   });
 
   it('should throw an error when an error occurs', async () => {

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -1,6 +1,6 @@
 import { getGradingProvider } from '../src/matchers';
 import { OpenAiChatCompletionProvider, OpenAiEmbeddingProvider } from '../src/providers/openai';
-import { matchesSimilarity, matchesLlmRubric } from '../src/matchers';
+import { matchesSimilarity, matchesLlmRubric, matchesFactuality, matchesClosedQa } from '../src/matchers';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai';
 
 import { TestGrader } from './assertions.test';
@@ -176,13 +176,13 @@ describe('matchesFactuality', () => {
     const grading = {};
 
     jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
-      output: JSON.stringify({ pass: true, reason: 'Factuality check passed' }),
+      output: '(A) The submitted answer is a subset of the expert answer and is fully consistent with it.',
       tokenUsage: { total: 10, prompt: 5, completion: 5 },
     });
 
     const result = await matchesFactuality(input, expected, output, grading);
     expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Factuality check passed');
+    expect(result.reason).toBe('The submitted answer is a subset of the expert answer and is fully consistent with it.');
   });
 
   it('should fail when the factuality check fails', async () => {
@@ -190,15 +190,14 @@ describe('matchesFactuality', () => {
     const expected = 'Expected output';
     const output = 'Sample output';
     const grading = {};
-
     jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
-      output: JSON.stringify({ pass: false, reason: 'Factuality check failed' }),
+      output: '(D) There is a disagreement between the submitted answer and the expert answer.',
       tokenUsage: { total: 10, prompt: 5, completion: 5 },
     });
 
     const result = await matchesFactuality(input, expected, output, grading);
     expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Factuality check failed');
+    expect(result.reason).toBe('There is a disagreement between the submitted answer and the expert answer.');
   });
 
   it('should throw an error when an error occurs', async () => {


### PR DESCRIPTION
Add the factuality and closed QA model-graded evaluation prompts from OpenAI's eval toolkit.  They work similarly to `llm-rubric`, but presumably are more battle-tested by OpenAI.

Two new assertion types:
- `model-graded-factuality`
- `model-graded-closedqa`

Example usage:

```yaml
prompts: [name_capitals.txt]
tests:
  - vars:
      location: Sacramento

    assert:
      # Ensure the answer agrees with the provided facts
      - type: model-graded-factuality
        value: The capital of California is Sacramento

      # Ensure the answer meets the criteria
      - type: model-graded-closedqa
        value: Does not include any extra information or facts about Sacramento
```