### PR TITLE
Auto-escape vars when prompt is a JSON object

### DIFF
--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -1,4 +1,4 @@
-import { evaluate } from '../src/evaluator.js';
+import { evaluate, renderPrompt } from '../src/evaluator.js';
 
 import type { ApiProvider, TestSuite, Prompt } from '../src/types.js';
 
@@ -575,4 +575,32 @@ it('should use the options from the test if they exist', async () => {
   expect(summary.stats.successes).toBe(1);
   expect(summary.stats.failures).toBe(0);
   expect(summary.results[0].response?.output).toBe('Test output postprocessed');
+});
+
+describe('renderPrompt', () => {
+  it('should render a prompt with a single variable', () => {
+    const prompt = 'Test prompt {{ var1 }}';
+    const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
+    expect(renderedPrompt).toBe('Test prompt value1');
+  });
+
+  it('should render a JSON prompt', () => {
+    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
+    expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"value1"}]');
+  });
+
+  it('should render a JSON prompt and escape the var string', () => {
+    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const renderedPrompt = renderPrompt(prompt, { var1: 'He said "hello world!"' });
+    expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"He said \\"hello world!\\""}]');
+  });
+
+  it('should render a JSON prompt with nested JSON', () => {
+    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const renderedPrompt = renderPrompt(prompt, { var1: '{"nested": "value1"}' });
+    expect(renderedPrompt).toBe(
+      '[{"text":"Test prompt "},{"text":"{\\"nested\\": \\"value1\\"}"}]',
+    );
+  });
 });


### PR DESCRIPTION
This resolves a common footgun where you'd have something like the following:

prompt
```json
[{
  "role": "user",
  "content": "Write a character description for the following person: {{name}}"
}]
```

config
```yaml
prompts: ['naming.json']
tests:
  - vars:
      name: James "Jimmy" Carter
```

Before: fails because the quotation marks in the var are blindly substituted into the JSON.  Requires the user to manually escape with {{ name | replace('"', '\\"') }}

After: behaves as expected, escaping the quotation marks within the JSON string.