### PR TITLE
Support for Google Vertex and PaLM chat APIs

### DIFF
--- a/examples/google-vertex/README.md
+++ b/examples/google-vertex/README.md
@@ -1,4 +1,4 @@
-To get started, set your `VERTEX_API_KEY` environment variable from `gcloud auth print-access-token`.  Also set `VERTEX_PROJECT_ID` to your Google Cloud Platform project.
+To get started, set your `VERTEX_API_KEY` environment variable from `gcloud auth print-access-token`. Also set `VERTEX_PROJECT_ID` to your Google Cloud Platform project.
 
 Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
 

--- a/examples/google-vertex/README.md
+++ b/examples/google-vertex/README.md
@@ -1,0 +1,11 @@
+To get started, set your `VERTEX_API_KEY` environment variable from `gcloud auth print-access-token`.  Also set `VERTEX_PROJECT_ID` to your Google Cloud Platform project.
+
+Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/google-vertex/promptfooconfig.yaml
+++ b/examples/google-vertex/promptfooconfig.yaml
@@ -1,0 +1,77 @@
+# This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
+
+prompts: [prompts.txt]
+providers: [vertex:chat-bison]
+tests:
+  - vars:
+      question: What's the weather in New York?
+  - vars:
+      question: Who won the latest football match between the Giants and 49ers?
+  - vars:
+      question: "Which magazine was started first Arthur's Magazine or First for Women?"
+  - vars:
+      question: 'The Oberoi family is part of a hotel company that has a head office in what city?'
+  - vars:
+      question: 'Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, who Matt Groening named after who?'
+  - vars:
+      question: "What nationality was James Henry Miller's wife?"
+  - vars:
+      question: 'Cadmium Chloride is slightly soluble in this chemical, it is also called what?'
+  - vars:
+      question: 'Which tennis player won more Grand Slam titles, Henri Leconte or Jonathan Stark?'
+  - vars:
+      question: "Which genus of moth in the world's seventh-largest country contains only one species?"
+  - vars:
+      question: 'Who was once considered the best kick boxer in the world, however he has been involved in a number of controversies relating to his "unsportsmanlike conducts" in the sport and crimes of violence outside of the ring.'
+  - vars:
+      question: 'The Dutch-Belgian television series that "House of Anubis" was based on first aired in what year?'
+  - vars:
+      question: 'What is the length of the track where the 2013 Liqui Moly Bathurst 12 Hour was staged?'
+  - vars:
+      question: 'Fast Cars, Danger, Fire and Knives includes guest appearances from which hip hop record executive?'
+  - vars:
+      question: 'Gunmen from Laredo starred which narrator of "Frontier"?'
+  - vars:
+      question: 'Where did the form of music played by Die Rhöner Säuwäntzt originate?'
+  - vars:
+      question: 'In which American football game was Malcolm Smith named Most Valuable player?'
+  - vars:
+      question: 'What U.S Highway gives access to Zilpo Road, and is also known as Midland Trail?'
+  - vars:
+      question: 'The 1988 American comedy film, The Great Outdoors, starred a four-time Academy Award nominee, who received a star on the Hollywood Walk of Fame in what year?'
+  - vars:
+      question: 'What are the names of the current members of  American heavy metal band who wrote the music for  Hurt Locker The Musical?'
+  - vars:
+      question: 'Human Error" is the season finale of the third season of a tv show that aired on what network?'
+  - vars:
+      question: 'Dua Lipa, an English singer, songwriter and model, the album spawned the number-one single "New Rules" is a song by English singer Dua Lipa from her eponymous debut studio album, released in what year?'
+  - vars:
+      question: 'American politician Joe Heck ran unsuccessfully against Democrat Catherine Cortez Masto, a woman who previously served as the 32nd Attorney General of where?'
+  - vars:
+      question: 'Which state does the drug stores, of which the CEO is Warren Bryant, are located?'
+  - vars:
+      question: 'Which  American politician did Donahue replaced '
+  - vars:
+      question: 'Which band was founded first, Hole, the rock band that Courtney Love was a frontwoman of, or The Wolfhounds?'
+  - vars:
+      question: 'How old is the female main protagonist of Catching Fire?'
+  - vars:
+      question: 'Chang Ucchin was born in korea during a time that ended with the conclusion of what?'
+  - vars:
+      question: 'Who is the director of the 2003 film which has scenes in it filmed at the Quality Cafe in Los Angeles?'
+  - vars:
+      question: "Which actress played the part of fictitious character Kimberly Ann Hart, in the franchise built around a live action superhero television series taking much of its footage from the Japanese tokusatsu 'Super Sentai'?"
+  - vars:
+      question: 'Who was born first, Pablo Trapero or Aleksander Ford?'
+  - vars:
+      question: "Are Jane and First for Women both women's magazines?"
+  - vars:
+      question: 'What profession does Nicholas Ray and Elia Kazan have in common?'
+  - vars:
+      question: 'Where is the company that purchased Aixam based in?'
+  - vars:
+      question: 'Which documentary is about Finnish rock groups, Adam Clayton Powell or The Saimaa Gesture?'
+  - vars:
+      question: 'Who was inducted into the Rock and Roll Hall of Fame, David Lee Roth or Cia Berg?'
+  - vars:
+      question: "Zimbabwe's Guwe Secondary School has a sister school in what New York county?"

--- a/examples/google-vertex/prompts.txt
+++ b/examples/google-vertex/prompts.txt
@@ -1,0 +1,9 @@
+You are a helpful assistant. Reply with a concise answer to this inquiry: "{{question}}"
+---
+You are a helpful assistant. Reply with a concise answer to this inquiry: "{{question}}"
+
+- Think carefully & step-by-step.
+- Only use information available on Wikipedia.
+- You must answer the question directly, without speculation.
+- You cannot access realtime information. Consider whether the answer may have changed in the 2 years since your knowledge cutoff.
+- If you are not confident in your answer, begin your response with "Unsure".

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -8,6 +8,7 @@ import {
 import { AnthropicCompletionProvider } from './providers/anthropic';
 import { ReplicateProvider } from './providers/replicate';
 import { LocalAiCompletionProvider, LocalAiChatProvider } from './providers/localai';
+import { PalmChatProvider } from './providers/palm';
 import { LlamaProvider } from './providers/llama';
 import { OllamaProvider } from './providers/ollama';
 import { WebhookProvider } from './providers/webhook';
@@ -171,6 +172,9 @@ export async function loadApiProvider(
   } else if (providerPath.startsWith('ollama:')) {
     const modelName = providerPath.split(':').slice(1).join(':');
     return new OllamaProvider(modelName, providerOptions);
+  } else if (providerPath.startsWith('palm:')) {
+    const modelName = providerPath.split(':')[1];
+    return new PalmChatProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('localai:')) {
     const splits = providerPath.split(':');
     const modelType = splits[1];

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -11,6 +11,7 @@ import { LocalAiCompletionProvider, LocalAiChatProvider } from './providers/loca
 import { PalmChatProvider } from './providers/palm';
 import { LlamaProvider } from './providers/llama';
 import { OllamaProvider } from './providers/ollama';
+import { VertexChatProvider } from './providers/vertex';
 import { WebhookProvider } from './providers/webhook';
 import { ScriptCompletionProvider } from './providers/scriptCompletion';
 import {
@@ -175,6 +176,9 @@ export async function loadApiProvider(
   } else if (providerPath.startsWith('palm:')) {
     const modelName = providerPath.split(':')[1];
     return new PalmChatProvider(modelName, providerOptions);
+  } else if (providerPath.startsWith('vertex')) {
+    const modelName = providerPath.split(':')[1];
+    return new VertexChatProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('localai:')) {
     const splits = providerPath.split(':');
     const modelType = splits[1];

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -214,7 +214,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
       throw new Error('Azure OpenAI API host must be set');
     }
 
-    const messages = parseChatPrompt(prompt);
+    const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
     let stop: string;
     try {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,0 +1,120 @@
+import logger from '../logger';
+import { fetchWithCache } from '../cache';
+import { REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
+
+import type {
+  ApiProvider,
+  EnvOverrides,
+  ProviderResponse,
+} from '../types.js';
+
+const DEFAULT_GOOGLE_HOST = 'generativelanguage.googleapis.com';
+
+interface GoogleCompletionOptions {
+  apiKey?: string;
+  apiHost?: string;
+}
+
+class GoogleGenericProvider implements ApiProvider {
+  modelName: string;
+
+  config: GoogleCompletionOptions;
+  env?: EnvOverrides;
+
+  constructor(
+    modelName: string,
+    options: { config?: GoogleCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    const { config, id, env } = options;
+    this.env = env;
+    this.modelName = modelName;
+    this.config = config || {};
+    this.id = id ? () => id : this.id;
+  }
+
+  id(): string {
+    return `google:${this.modelName}`;
+  }
+
+  toString(): string {
+    return `[Google Provider ${this.modelName}]`;
+  }
+
+  getApiHost(): string | undefined {
+    return (
+      this.config.apiHost ||
+      this.env?.GOOGLE_API_HOST ||
+      process.env.GOOGLE_API_HOST ||
+      DEFAULT_GOOGLE_HOST
+    );
+  }
+
+  getApiKey(): string | undefined {
+    return this.config.apiKey || this.env?.GOOGLE_API_KEY || process.env.GOOGLE_API_KEY;
+  }
+
+  // @ts-ignore: Prompt is not used in this implementation
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    throw new Error('Not implemented');
+  }
+}
+
+export class GoogleChatProvider extends GoogleGenericProvider {
+  static GOOGLE_CHAT_MODELS = ['text-bison-001'];
+
+  constructor(
+    modelName: string,
+    options: { config?: GoogleCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    if (!GoogleChatProvider.GOOGLE_CHAT_MODELS.includes(modelName)) {
+      logger.warn(`Using unknown Google chat model: ${modelName}`);
+    }
+    super(modelName, options);
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    if (!this.getApiKey()) {
+      throw new Error(
+        'Google API key is not set. Set the GOOGLE_API_KEY environment variable or add `apiKey` to the provider config.',
+      );
+    }
+
+    const messages = parseChatPrompt(prompt);
+
+    const body = {
+      prompt: { messages },
+    };
+    logger.debug(`Calling Google API: ${JSON.stringify(body)}`);
+
+    let data;
+    try {
+      ({ data } = (await fetchWithCache(
+        `https://${this.getApiHost()}/v1beta2/models/${this.modelName}:generateMessage?key=${this.getApiKey()}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        },
+        REQUEST_TIMEOUT_MS,
+      )) as unknown as any);
+    } catch (err) {
+      return {
+        error: `API call error: ${String(err)}`,
+      };
+    }
+
+    logger.debug(`\tGoogle API response: ${JSON.stringify(data)}`);
+    try {
+      const output = data.candidates[0].content;
+      return {
+        output,
+      };
+    } catch (err) {
+      return {
+        error: `API response error: ${String(err)}: ${JSON.stringify(data)}`,
+      };
+    }
+  }
+}

--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -45,7 +45,7 @@ class LocalAiGenericProvider implements ApiProvider {
 
 export class LocalAiChatProvider extends LocalAiGenericProvider {
   async callApi(prompt: string): Promise<ProviderResponse> {
-    const messages = parseChatPrompt(prompt);
+    const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
     const body = {
       model: this.modelName,
       messages: messages,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -268,7 +268,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       );
     }
 
-    const messages = parseChatPrompt(prompt);
+    const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
     let stop: string;
     try {

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -4,21 +4,19 @@ export const REQUEST_TIMEOUT_MS = process.env.REQUEST_TIMEOUT_MS
   ? parseInt(process.env.REQUEST_TIMEOUT_MS, 10)
   : 300_000;
 
-export function parseChatPrompt(
-  prompt: string,
-): { role: string; content: string; name?: string }[] {
+export function parseChatPrompt<T>(prompt: string, defaultValue: T): T {
   const trimmedPrompt = prompt.trim();
   if (trimmedPrompt.startsWith('- role:')) {
     try {
-      // Try YAML
-      return yaml.load(prompt) as { role: string; content: string }[];
+      // Try YAML - some legacy OpenAI prompts are YAML :(
+      return yaml.load(prompt) as T;
     } catch (err) {
       throw new Error(`Chat Completion prompt is not a valid YAML string: ${err}\n\n${prompt}`);
     }
   } else {
     try {
       // Try JSON
-      return JSON.parse(prompt) as { role: string; content: string }[];
+      return JSON.parse(prompt) as T;
     } catch (err) {
       if (
         process.env.PROMPTFOO_REQUIRE_JSON_PROMPTS ||
@@ -27,8 +25,8 @@ export function parseChatPrompt(
       ) {
         throw new Error(`Chat Completion prompt is not a valid JSON string: ${err}\n\n${prompt}`);
       }
-      // Fall back to wrapping the prompt in a user message
-      return [{ role: 'user', content: prompt }];
+      // Fall back to the provided default value
+      return defaultValue;
     }
   }
 }

--- a/src/providers/vertex.ts
+++ b/src/providers/vertex.ts
@@ -1,0 +1,183 @@
+import logger from '../logger';
+import { fetchWithCache } from '../cache';
+import { parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+
+import type { ApiProvider, EnvOverrides, ProviderResponse } from '../types.js';
+
+interface VertexCompletionOptions {
+  apiKey?: string;
+  apiHost?: string;
+  projectId?: string;
+  region?: string;
+  publisher?: string;
+
+  context?: string;
+  examples?: { input: string; output: string }[];
+  safetySettings?: { category: string; probability: string }[];
+  stopSequence?: string[];
+  temperature?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  topK?: number;
+}
+
+class VertexGenericProvider implements ApiProvider {
+  modelName: string;
+
+  config: VertexCompletionOptions;
+  env?: EnvOverrides;
+
+  constructor(
+    modelName: string,
+    options: { config?: VertexCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    const { config, id, env } = options;
+    this.env = env;
+    this.modelName = modelName;
+    this.config = config || {};
+    this.id = id ? () => id : this.id;
+  }
+
+  id(): string {
+    return `vertex:${this.modelName}`;
+  }
+
+  toString(): string {
+    return `[Google Vertex Provider ${this.modelName}]`;
+  }
+
+  getApiHost(): string | undefined {
+    return (
+      this.config.apiHost ||
+      this.env?.VERTEX_API_HOST ||
+      process.env.VERTEX_API_HOST ||
+      `${this.getRegion()}-aiplatform.googleapis.com`
+    );
+  }
+
+  getProjectId(): string | undefined {
+    return this.config.projectId || this.env?.VERTEX_PROJECT_ID || process.env.VERTEX_PROJECT_ID;
+  }
+
+  getApiKey(): string | undefined {
+    return this.config.apiKey || this.env?.VERTEX_API_KEY || process.env.VERTEX_API_KEY;
+  }
+
+  getRegion(): string {
+    return (
+      this.config.region || this.env?.VERTEX_REGION || process.env.VERTEX_REGION || 'us-central1'
+    );
+  }
+
+  getPublisher(): string | undefined {
+    return (
+      this.config.publisher ||
+      this.env?.VERTEX_PUBLISHER ||
+      process.env.VERTEX_PUBLISHER ||
+      'google'
+    );
+  }
+
+  // @ts-ignore: Prompt is not used in this implementation
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    throw new Error('Not implemented');
+  }
+}
+
+export class VertexChatProvider extends VertexGenericProvider {
+  static CHAT_MODELS = [
+    'chat-bison',
+    'chat-bison@001',
+    'chat-bison-32k',
+    'chat-bison-32k@001',
+    'codechat-bison',
+    'codechat-bison@001',
+    'codechat-bison-32k',
+    'codechat-bison-32k@001',
+  ];
+
+  constructor(
+    modelName: string,
+    options: { config?: VertexCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    if (!VertexChatProvider.CHAT_MODELS.includes(modelName)) {
+      logger.warn(`Using unknown Google Vertex chat model: ${modelName}`);
+    }
+    super(modelName, options);
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    if (!this.getApiKey()) {
+      throw new Error(
+        'Google Vertex API key is not set. Set the VERTEX_API_KEY environment variable or add `apiKey` to the provider config. You can get an API token by running `gcloud auth print-access-token`',
+      );
+    }
+    if (!this.getProjectId()) {
+      throw new Error(
+        'Google Vertex project ID is not set. Set the VERTEX_PROJECT_ID environment variable or add `projectId` to the provider config.',
+      );
+    }
+
+    // https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-chat#generative-ai-text-chat-drest
+    const instances = parseChatPrompt(prompt, [
+      {
+        messages: [
+          {
+            author: 'user',
+            content: prompt,
+          },
+        ],
+      },
+    ]);
+
+    const body = {
+      instances,
+      parameters: {
+        context: this.config.context,
+        examples: this.config.examples,
+        safetySettings: this.config.safetySettings,
+        stopSequence: this.config.stopSequence,
+        temperature: this.config.temperature,
+        maxOutputTokens: this.config.maxOutputTokens,
+        topP: this.config.topP,
+        topK: this.config.topK,
+      },
+    };
+    logger.debug(`Calling Google Vertex API: ${JSON.stringify(body)}`);
+
+    let data;
+    try {
+      ({ data } = (await fetchWithCache(
+        // POST https://us-central1-aiplatform.googleapis.com/
+        `https://${this.getApiHost()}/v1/projects/${this.getProjectId()}/locations/${this.getRegion()}/publishers/${this.getPublisher()}/models/${
+          this.modelName
+        }:predict`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.getApiKey()}`,
+          },
+          body: JSON.stringify(body),
+        },
+        REQUEST_TIMEOUT_MS,
+      )) as unknown as any);
+    } catch (err) {
+      return {
+        error: `API call error: ${String(err)}`,
+      };
+    }
+
+    logger.debug(`\tVertex API response: ${JSON.stringify(data)}`);
+    try {
+      const output = data.predictions[0].candidates[0].content;
+      return {
+        output,
+      };
+    } catch (err) {
+      return {
+        error: `API response error: ${String(err)}: ${JSON.stringify(data)}`,
+      };
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface EnvOverrides {
   REPLICATE_API_TOKEN?: string;
   LOCALAI_BASE_URL?: string;
   PALM_API_KEY?: string;
-  GOOGLE_API_HOST?: string;
+  PALM_API_HOST?: string;
 }
 
 export interface ProviderOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export interface EnvOverrides {
   REPLICATE_API_KEY?: string;
   REPLICATE_API_TOKEN?: string;
   LOCALAI_BASE_URL?: string;
+  PALM_API_KEY?: string;
+  GOOGLE_API_HOST?: string;
 }
 
 export interface ProviderOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export interface EnvOverrides {
   LOCALAI_BASE_URL?: string;
   PALM_API_KEY?: string;
   PALM_API_HOST?: string;
+  VERTEX_API_KEY?: string;
+  VERTEX_API_HOST?: string;
+  VERTEX_PROJECT_ID?: string;
+  VERTEX_REGION?: string;
+  VERTEX_PUBLISHER?: string;
 }
 
 export interface ProviderOptions {

--- a/src/web/nextui/src/app/setup/ConfigureEnvButton.tsx
+++ b/src/web/nextui/src/app/setup/ConfigureEnvButton.tsx
@@ -89,6 +89,36 @@ const ConfigureEnvButton: React.FC = () => {
             </AccordionDetails>
           </Accordion>
           <Accordion>
+            <AccordionSummary>Google Vertex AI</AccordionSummary>
+            <AccordionDetails>
+              <TextField
+                label="Vertex API Key"
+                fullWidth
+                margin="normal"
+                value={env.VERTEX_API_KEY}
+                onChange={(e) => setEnv({ ...env, VERTEX_API_KEY: e.target.value })}
+              />
+            </AccordionDetails>
+            <AccordionDetails>
+              <TextField
+                label="Vertex Project ID"
+                fullWidth
+                margin="normal"
+                value={env.VERTEX_PROJECT_ID}
+                onChange={(e) => setEnv({ ...env, VERTEX_PROJECT_ID: e.target.value })}
+              />
+            </AccordionDetails>
+            <AccordionDetails>
+              <TextField
+                label="Vertex Region"
+                fullWidth
+                margin="normal"
+                value={env.VERTEX_REGION}
+                onChange={(e) => setEnv({ ...env, VERTEX_REGION: e.target.value })}
+              />
+            </AccordionDetails>
+          </Accordion>
+          <Accordion>
             <AccordionSummary>Replicate</AccordionSummary>
             <AccordionDetails>
               <TextField

--- a/src/web/nextui/src/app/setup/ProviderSelector.tsx
+++ b/src/web/nextui/src/app/setup/ProviderSelector.tsx
@@ -127,6 +127,26 @@ const defaultProviders: ProviderOptions[] = ([] as (ProviderOptions & { id: stri
       },
     })),
   )
+  .concat(
+    [
+      'vertex:chat-bison@001',
+      'vertex:chat-bison',
+      'vertex:chat-bison-32k',
+      'vertex:chat-bison-32k@001',
+    ].map((id) => ({
+      id,
+      config: {
+        context: undefined,
+        examples: undefined,
+        temperature: 0,
+        maxOutputTokens: 1024,
+        topP: 0.95,
+        topK: 40,
+        safetySettings: undefined,
+        stopSequence: undefined,
+      },
+    })),
+  )
   .sort((a, b) => a.id.localeCompare(b.id));
 
 const PREFIX_TO_PROVIDER: Record<string, string> = {


### PR DESCRIPTION
Can be used by setting `VERTEX_API_KEY` and `VERTEX_PROJECT_ID` envars, then:

```yaml
providers: [vertex:chat-bison]
```

It enables interesting comparisons between GPT 3.5 and Bison.