### PR TITLE
Add support for including files in defaultTest

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,7 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   description?: string;
 
   // Key-value pairs to substitute in the prompt
-  vars?: Record<string, string | string[] | object>;
+  vars?: Vars;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];

--- a/src/util.ts
+++ b/src/util.ts
@@ -297,7 +297,7 @@ export async function readTest(
   test: string | TestCaseWithVarsFile,
   basePath: string = '',
 ): Promise<TestCase> {
-  const loadVarsForTest = async (
+  const loadTestWithVars = async (
     testCase: TestCaseWithVarsFile,
     testBasePath: string,
   ): Promise<TestCase> => {
@@ -316,9 +316,9 @@ export async function readTest(
     const testFilePath = path.resolve(basePath, test);
     const testBasePath = path.dirname(testFilePath);
     const rawTestCase = yaml.load(fs.readFileSync(testFilePath, 'utf-8')) as TestCaseWithVarsFile;
-    testCase = await loadVarsForTest(rawTestCase, testBasePath);
+    testCase = await loadTestWithVars(rawTestCase, testBasePath);
   } else {
-    testCase = await loadVarsForTest(test, basePath);
+    testCase = await loadTestWithVars(test, basePath);
   }
 
   // Validation of the shape of test
@@ -348,7 +348,7 @@ export async function readTests(
     for (const testFile of testFiles) {
       const testFileContent = yaml.load(fs.readFileSync(testFile, 'utf-8')) as TestCase[];
       for (const testCase of testFileContent) {
-        ret.push(await readTest(testCase, testFile));
+        ret.push(await readTest(testCase, path.dirname(testFile)));
       }
     }
     return ret;

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -405,6 +405,41 @@ describe('util', () => {
   });
 });
 
+describe('readTest', () => {
+  test('readTest with string input (path to test config)', async () => {
+    const testPath = 'test1.yaml';
+    const testContent = {
+      description: 'Test 1',
+      vars: { var1: 'value1', var2: 'value2' },
+      assert: [{ type: 'equals', value: 'value1' }],
+    };
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(yaml.dump(testContent));
+
+    const result = await readTest(testPath);
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(testContent);
+  });
+
+  test('readTest with TestCase input', async () => {
+    const input: TestCase = {
+      description: 'Test 1',
+      vars: { var1: 'value1', var2: 'value2' },
+      assert: [{ type: 'equals', value: 'value1' }],
+    };
+
+    const result = await readTest(input);
+
+    expect(result).toEqual(input);
+  });
+
+  test('readTest with invalid input', async () => {
+    const input: any = 123;
+
+    await expect(readTest(input)).rejects.toThrow();
+  });
+});
+
 describe('readTests', () => {
   afterEach(() => {
     jest.resetAllMocks();

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -8,6 +8,7 @@ import {
   readTestsFile,
   readPrompts,
   writeOutput,
+  readTest,
   readTests,
   readGlobalConfig,
   maybeRecordFirstRun,

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -15,7 +15,7 @@ import {
   resetGlobalConfig,
 } from '../src/util';
 
-import type { EvaluateResult, EvaluateTable, Prompt, TestCase } from '../src/types';
+import type { AssertionType, EvaluateResult, EvaluateTable, Prompt, TestCase } from '../src/types';
 
 jest.mock('node-fetch', () => jest.fn());
 jest.mock('glob', () => ({
@@ -36,6 +36,10 @@ jest.mock('../src/esm.js');
 function toPrompt(text: string): Prompt {
   return { raw: text, display: text };
 }
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('util', () => {
   afterEach(() => {
@@ -441,10 +445,10 @@ describe('readTest', () => {
   });
 
   test('readTest with TestCase that contains a vars glob input', async () => {
-    const input: TestCase = {
+    const input = {
       description: 'Test 1',
       vars: 'vars/*.yaml',
-      assert: [{ type: 'equals', value: 'value1' }],
+      assert: [{ type: 'equals' as AssertionType, value: 'value1' }],
     };
     const varsContent1 = { var1: 'value1' };
     const varsContent2 = { var2: 'value2' };

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -439,6 +439,30 @@ describe('readTest', () => {
 
     await expect(readTest(input)).rejects.toThrow();
   });
+
+  test('readTest with TestCase that contains a vars glob input', async () => {
+    const input: TestCase = {
+      description: 'Test 1',
+      vars: 'vars/*.yaml',
+      assert: [{ type: 'equals', value: 'value1' }],
+    };
+    const varsContent1 = { var1: 'value1' };
+    const varsContent2 = { var2: 'value2' };
+    (globSync as jest.Mock).mockReturnValueOnce(['vars/vars1.yaml', 'vars/vars2.yaml']);
+    (fs.readFileSync as jest.Mock)
+      .mockReturnValueOnce(yaml.dump(varsContent1))
+      .mockReturnValueOnce(yaml.dump(varsContent2));
+
+    const result = await readTest(input);
+
+    expect(globSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      description: 'Test 1',
+      vars: { var1: 'value1', var2: 'value2' },
+      assert: [{ type: 'equals', value: 'value1' }],
+    });
+  });
 });
 
 describe('readTests', () => {


### PR DESCRIPTION
- Adds basic validation for `defaultTest`, which would have caught the malformed example in #136.
- Refactors `loadTests`, the logic which hydrates test cases from file, into `loadTest` and `loadTests`