### PR TITLE
Add support for loading vars directly from file

### DIFF
--- a/examples/openai-chat-history/README.md
+++ b/examples/openai-chat-history/README.md
@@ -3,6 +3,7 @@ To get started, set your OPENAI_API_KEY environment variable.
 Next, have a look at prompt.json and edit promptfooconfig.yaml.
 
 Then run:
+
 ```
 promptfoo eval
 ```

--- a/examples/separate-test-configs/promptfooconfig.yaml
+++ b/examples/separate-test-configs/promptfooconfig.yaml
@@ -18,3 +18,8 @@ tests:
   - vars:
       topic: the internet
       content_type: witty tweets
+
+  # Use the file:// prefix to load entire files as vars
+  - vars:
+      topic: file://vars/var_topic.yaml
+      content_type: file://vars/var_content_type.yaml

--- a/examples/separate-test-configs/vars/var_content_type.yaml
+++ b/examples/separate-test-configs/vars/var_content_type.yaml
@@ -1,0 +1,1 @@
+UN resolution title

--- a/examples/separate-test-configs/vars/var_topic.yaml
+++ b/examples/separate-test-configs/vars/var_topic.yaml
@@ -1,0 +1,1 @@
+world peace

--- a/src/util.ts
+++ b/src/util.ts
@@ -304,8 +304,17 @@ export async function readTest(
     const ret: TestCase = { ...testCase, vars: undefined };
     if (typeof testCase.vars === 'string' || Array.isArray(testCase.vars)) {
       ret.vars = await readVarsFiles(testCase.vars, testBasePath);
-    } else {
-      ret.vars = testCase.vars;
+    } else if (typeof testCase.vars === 'object') {
+      // Try treating the values of the object as filepaths, and load from disk
+      const vars: Record<string, string | string[] | object> = {};
+      for (const [key, value] of Object.entries(testCase.vars)) {
+        if (typeof value === 'string' && value.startsWith('file://')) {
+          vars[key] = yaml.load(fs.readFileSync(value.slice('file://'.length), 'utf-8')) as string;
+        } else {
+          vars[key] = value;
+        }
+      }
+      ret.vars = vars;
     }
     return ret;
   };

--- a/src/util.ts
+++ b/src/util.ts
@@ -305,12 +305,13 @@ export async function readTest(
     if (typeof testCase.vars === 'string' || Array.isArray(testCase.vars)) {
       ret.vars = await readVarsFiles(testCase.vars, testBasePath);
     } else if (typeof testCase.vars === 'object') {
-      // Try treating the values of the object as filepaths, and load from disk
       const vars: Record<string, string | string[] | object> = {};
       for (const [key, value] of Object.entries(testCase.vars)) {
         if (typeof value === 'string' && value.startsWith('file://')) {
+          // Load file from disk.
           vars[key] = yaml.load(fs.readFileSync(value.slice('file://'.length), 'utf-8')) as string;
         } else {
+          // This is a normal key:value.
           vars[key] = value;
         }
       }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -467,6 +467,25 @@ describe('readTest', () => {
       assert: [{ type: 'equals', value: 'value1' }],
     });
   });
+
+  test('readTest with TestCase that contains a var with file:// prefix', async () => {
+    const input = {
+      description: 'Test 1',
+      vars: { var1: 'file://vars/var1.yaml' },
+      assert: [{ type: 'equals' as AssertionType, value: 'value1' }],
+    };
+    const varsContent1 = { var1: 'value1' };
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(yaml.dump(varsContent1));
+
+    const result = await readTest(input);
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      description: 'Test 1',
+      vars: { var1: 'value1' },
+      assert: [{ type: 'equals', value: 'value1' }],
+    });
+  });
 });
 
 describe('readTests', () => {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -471,18 +471,17 @@ describe('readTest', () => {
   test('readTest with TestCase that contains a var with file:// prefix', async () => {
     const input = {
       description: 'Test 1',
-      vars: { var1: 'file://vars/var1.yaml' },
+      vars: { var1: 'file://vars/var1.yaml', var2: 'a normal var' },
       assert: [{ type: 'equals' as AssertionType, value: 'value1' }],
     };
-    const varsContent1 = { var1: 'value1' };
-    (fs.readFileSync as jest.Mock).mockReturnValueOnce(yaml.dump(varsContent1));
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce('value1');
 
     const result = await readTest(input);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       description: 'Test 1',
-      vars: { var1: 'value1' },
+      vars: { var1: 'value1', var2: 'a normal var' },
       assert: [{ type: 'equals', value: 'value1' }],
     });
   });


### PR DESCRIPTION
The `vars` object now accepts a `file://` prefix, which can be used to directly import from disk:

```yaml
  - vars:
      topic: file://vars/var_topic.yaml
      content_type: file://vars/var_content_type.yaml
```

This addresses requests in #136 and #128 