### PR TITLE
Improvements to custom grading

### DIFF
--- a/examples/custom-grading-prompt/README.md
+++ b/examples/custom-grading-prompt/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, have a look at the custom prompt in promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/custom-grading-prompt/promptfooconfig.yaml
+++ b/examples/custom-grading-prompt/promptfooconfig.yaml
@@ -2,7 +2,6 @@ prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo]
 defaultTest:
   options:
-
     # ---
     # Custom grading prompt:
     # ---

--- a/examples/custom-grading-prompt/promptfooconfig.yaml
+++ b/examples/custom-grading-prompt/promptfooconfig.yaml
@@ -1,0 +1,47 @@
+prompts: [prompts.txt]
+providers: [openai:gpt-3.5-turbo]
+defaultTest:
+  options:
+
+    # ---
+    # Custom grading prompt:
+    # ---
+    rubricPrompt:
+      - role: system
+        content: >-
+          Grade the output by the following specifications, keeping track of the points scored:
+
+          Did the output mention {{x}}? +1 point
+          Did the output describe {{y}}? + 1 point
+          Did the output ask to clarify {{z}}? +1 point
+
+          Calculate the score but always pass the test. Output your response in the following JSON format:
+          {pass: true, score: number, reason: string}
+      - role: user
+        content: 'Output: {{ output }}'
+
+#    ---
+#    You can also provide an OpenAI prompt directly as pure JSON:
+#    ---
+#
+#    rubricPrompt: >-
+#      [
+#        {
+#          "role": "system",
+#          "content": "Grade the output by the following specifications, keeping track of the points scored:\n Did the output mention {{x}}? +1 point\n Did the output describe {{y}}? + 1 point\n Did the output ask to clarify {{z}}? +1 point\n\n Output your response in the following JSON format:\n {pass: bool, score: number, reason: string}"
+#        },
+#        {
+#          "role": "user",
+#          "content": "Output: {{ output }}"
+#        }
+#      ]
+#
+
+tests:
+  - vars:
+      topic: the economy
+      x: the Federal Reserve
+      y: macroeconomics
+      z: the specific question the user wants to ask
+    assert:
+      - type: llm-rubric

--- a/examples/custom-grading-prompt/prompts.txt
+++ b/examples/custom-grading-prompt/prompts.txt
@@ -1,1 +1,3 @@
-Talk about {{topic}}
+Talk about {{topic}}.
+---
+Talk about {{topic}}. Include a brief primer on macroeconomics. Be sure to ask the user for clarification if they have inquired about a broad topic.

--- a/examples/custom-grading-prompt/prompts.txt
+++ b/examples/custom-grading-prompt/prompts.txt
@@ -1,0 +1,1 @@
+Talk about {{topic}}

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -12,6 +12,23 @@ import type { ApiProvider, GradingConfig, GradingResult, ProviderOptions } from 
 
 const nunjucks = getNunjucksEngine();
 
+function fromVars(vars?: Record<string, string | object>) {
+  if (!vars) {
+    return {};
+  }
+
+  const ret: Record<string, string> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    if (typeof value === 'object') {
+      ret[key] = JSON.stringify(value);
+    } else {
+      ret[key] = value;
+    }
+  }
+
+  return ret;
+}
+
 export async function getGradingProvider(
   provider: GradingConfig['provider'],
   defaultProvider: ApiProvider,
@@ -106,6 +123,7 @@ export async function matchesLlmRubric(
   expected: string,
   output: string,
   grading?: GradingConfig,
+  vars?: Record<string, string | object>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -116,6 +134,7 @@ export async function matchesLlmRubric(
   const prompt = nunjucks.renderString(grading.rubricPrompt || DEFAULT_GRADING_PROMPT, {
     output: output.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
     rubric: expected.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
+    ...fromVars(vars),
   });
 
   let provider = grading.provider;
@@ -161,6 +180,7 @@ export async function matchesFactuality(
   expected: string,
   output: string,
   grading?: GradingConfig,
+  vars?: Record<string, string | object>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -172,6 +192,7 @@ export async function matchesFactuality(
     input: input.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
     ideal: expected.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
     completion: output.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
+    ...fromVars(vars),
   });
 
   let provider = grading.provider;
@@ -255,6 +276,7 @@ export async function matchesClosedQa(
   expected: string,
   output: string,
   grading?: GradingConfig,
+  vars?: Record<string, string | object>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -266,6 +288,7 @@ export async function matchesClosedQa(
     input: input.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
     criteria: expected.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
     completion: output.replace(/\n/g, '\\n').replace(/"/g, '\\"'),
+    ...fromVars(vars),
   });
 
   let provider = grading.provider;

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -154,13 +154,13 @@ export async function matchesLlmRubric(
   }
 
   try {
-    const parsed = JSON.parse(resp.output) as Omit<GradingResult, 'score'>;
+    const parsed = JSON.parse(resp.output) as GradingResult;
     parsed.tokensUsed = {
       total: resp.tokenUsage?.total || 0,
       prompt: resp.tokenUsage?.prompt || 0,
       completion: resp.tokenUsage?.completion || 0,
     };
-    return { ...parsed, score: parsed.pass ? 1 : 0 };
+    return { ...parsed };
   } catch (err) {
     return {
       pass: false,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -7,11 +7,11 @@ Examples:
 
 Output: Hello world
 Rubric: Content contains a greeting
-{"pass": true, "reason": "the content contains the word 'world'"}
+{"pass": true, "score": 1.0, "reason": "the content contains the word 'world'"}
 
 Output: Avast ye swabs, repel the invaders!
 Rubric: Does not speak like a pirate
-{"pass": false, "reason": "'avast ye' is a common pirate term"}`,
+{"pass": false, "score": 0.0, "reason": "'avast ye' is a common pirate term"}`,
   },
   {
     role: 'user',


### PR DESCRIPTION
- Add support for `score` to `llm-rubric`
- Remove the `value` requirement from `llm-rubric`
- Substitute `vars` directly in the matcher, instead of in the assertion.  This makes it possible to use built-in vars such as `{{output}}` in your custom prompt.
- Add an example custom grader

#138 