### PR TITLE
Adding YAML document start

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 github: [typpo]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 on: [push]
 env:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,4 @@
+---
 trailingComma: 'all'
 singleQuote: true
 printWidth: 100

--- a/examples/assistant-cli/promptfooconfig.yaml
+++ b/examples/assistant-cli/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: openai:gpt-3.5-turbo
 tests: tests.csv

--- a/examples/custom-grading-prompt/promptfooconfig.yaml
+++ b/examples/custom-grading-prompt/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo]
 defaultTest:

--- a/examples/custom-provider/promptfooconfig.yaml
+++ b/examples/custom-provider/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: customProvider.js
 tests: vars.csv

--- a/examples/google-vertex/promptfooconfig.yaml
+++ b/examples/google-vertex/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 # This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
 
 prompts: [prompts.txt]

--- a/examples/gpt-3.5-temperature-comparison/promptfooconfig.yaml
+++ b/examples/gpt-3.5-temperature-comparison/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts:
   prompts/chat_prompt.json: chat_prompt
 

--- a/examples/gpt-3.5-vs-4/promptfooconfig.yaml
+++ b/examples/gpt-3.5-vs-4/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers:
   - openai:gpt-3.5-turbo

--- a/examples/langchain-python/promptfooconfig.yaml
+++ b/examples/langchain-python/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompt.txt
 providers:
   - openai:chat:gpt-4-0613

--- a/examples/llama-gpt-comparison/promptfooconfig.yaml
+++ b/examples/llama-gpt-comparison/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts:
   prompts/chat_prompt.json: chat_prompt
   prompts/completion_prompt.txt: completion_prompt

--- a/examples/multiple-translations-scenarios/promptfooconfig.yaml
+++ b/examples/multiple-translations-scenarios/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: [openai:gpt-3.5-turbo, openai:gpt-4]
 scenarios:

--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: [openai:gpt-3.5-turbo, openai:gpt-4]
 tests:

--- a/examples/multishot/promptfooconfig.yaml
+++ b/examples/multishot/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: [prompt1.json, prompt2.json]
 providers: [openai:gpt-3.5-turbo]
 tests:

--- a/examples/openai-chat-history/promptfooconfig.yaml
+++ b/examples/openai-chat-history/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: [prompt.json]
 providers: [openai:gpt-3.5-turbo]
 

--- a/examples/openai-eval-factuality/promptfooconfig.yaml
+++ b/examples/openai-eval-factuality/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 providers: [openai:gpt-3.5-turbo]
 prompts: [prompts/name_capitals_concise.txt, prompts/name_capitals_verbose.txt]
 tests:

--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 # prettier-ignore
 prompts: [prompt.txt]
 providers:

--- a/examples/openai-multiline-yaml/prompt.yaml
+++ b/examples/openai-multiline-yaml/prompt.yaml
@@ -1,3 +1,4 @@
+---
 - role: system
   content: |
     Respond to the user while keeping the following in mind

--- a/examples/openai-multiline-yaml/promptfooconfig.yaml
+++ b/examples/openai-multiline-yaml/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 # prettier-ignore
 prompts: [prompt.yaml]
 providers: ['openai:chat:gpt-3.5-turbo-0613']

--- a/examples/replicate-llama2/promptfooconfig.yaml
+++ b/examples/replicate-llama2/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: [prompts.txt]
 providers:
   - replicate:replicate/llama70b-v2-chat:e951f18578850b652510200860fc4ea62b3b16fac280f83ff32282f87bbd2e48

--- a/examples/self-grading/promptfooconfig.yaml
+++ b/examples/self-grading/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: openai:gpt-4-0613
 defaultTest:

--- a/examples/separate-test-configs/promptfooconfig.yaml
+++ b/examples/separate-test-configs/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: prompts.txt
 providers: openai:gpt-3.5-turbo
 

--- a/examples/separate-test-configs/tests/tests1.yaml
+++ b/examples/separate-test-configs/tests/tests1.yaml
@@ -1,3 +1,4 @@
+---
 # This file contains a list of test cases. They're added alongside test cases
 # from tests2.yaml in the example promptfooconfig.yaml.
 

--- a/examples/separate-test-configs/tests/tests2.yaml
+++ b/examples/separate-test-configs/tests/tests2.yaml
@@ -1,3 +1,4 @@
+---
 # This file contains a list of test cases. They're added alongside test cases
 # from tests1.yaml in the example promptfooconfig.yaml.
 

--- a/examples/separate-test-configs/vars/var_content_type.yaml
+++ b/examples/separate-test-configs/vars/var_content_type.yaml
@@ -1,1 +1,2 @@
+---
 UN resolution title

--- a/examples/separate-test-configs/vars/var_topic.yaml
+++ b/examples/separate-test-configs/vars/var_topic.yaml
@@ -1,1 +1,2 @@
+---
 world peace

--- a/examples/separate-test-configs/vars/vars_extra.yaml
+++ b/examples/separate-test-configs/vars/vars_extra.yaml
@@ -1,2 +1,3 @@
+---
 topic: bananas
 content_type: musings of an evil genius

--- a/examples/simple-cli/promptfooconfig.yaml
+++ b/examples/simple-cli/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 description: A translator built with LLM
 prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo]

--- a/examples/simple-csv/promptfooconfig.yaml
+++ b/examples/simple-csv/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 description: A translator built with LLM
 prompts: prompts.txt
 providers: openai:gpt-3.5-turbo

--- a/examples/simple-test/promptfooconfig.yaml
+++ b/examples/simple-test/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+---
 prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo]
 tests:

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -18,7 +18,8 @@ These prompts are nunjucks templates, so you can use logic like this:
 If you prefer, you can break prompts into multiple files (make sure to edit promptfooconfig.yaml accordingly)
 `;
 
-export const DEFAULT_YAML_CONFIG = `# This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
+export const DEFAULT_YAML_CONFIG = `---
+# This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
 
 prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo-0613]


### PR DESCRIPTION
- Adds YAML document start to all YAML files and default `promptfoodefaultconfig.yaml`
- ~Fixes `--config` option to have proper casing in `promptfoodefaultconfig.yaml`~ (fixed upstream in https://github.com/promptfoo/promptfoo/commit/72d426e366d491a667cee4c2173197c844b46748)