### PR TITLE
Support for custom functions as prompts

### DIFF
--- a/examples/custom-prompt-function/README.md
+++ b/examples/custom-prompt-function/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, have a look at the various prompt .js files. These prompts are constructed programmatically, and you can include custom logic in them.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/custom-prompt-function/prompt_chat.js
+++ b/examples/custom-prompt-function/prompt_chat.js
@@ -1,0 +1,13 @@
+// An example prompt function that returns a JSON OpenAI-like "chat" object.
+module.exports = async function ({ vars }) {
+  return [
+    {
+      role: 'system',
+      content: `You're an angry pirate. Be concise and stay in character.`,
+    },
+    {
+      role: 'user',
+      content: `Tell me about ${vars.topic}`,
+    },
+  ];
+};

--- a/examples/custom-prompt-function/prompt_multiple.js
+++ b/examples/custom-prompt-function/prompt_multiple.js
@@ -1,0 +1,26 @@
+// An example prompt function that returns a JSON OpenAI-like "chat" object.
+module.exports.prompt1 = async function ({ vars }) {
+  return [
+    {
+      role: 'system',
+      content: `You're an angry pirate. Be concise and stay in character.`,
+    },
+    {
+      role: 'user',
+      content: `Tell me about ${vars.topic}`,
+    },
+  ];
+};
+
+module.exports.prompt2 = async function ({ vars }) {
+  return [
+    {
+      role: 'system',
+      content: `You're an angry gnome. Be concise and stay in character.`,
+    },
+    {
+      role: 'user',
+      content: `Tell me about ${vars.topic}`,
+    },
+  ];
+};

--- a/examples/custom-prompt-function/prompt_python.py
+++ b/examples/custom-prompt-function/prompt_python.py
@@ -1,0 +1,8 @@
+import sys
+import json
+
+def generate_prompt(context):
+    return f'Describe {context["vars"]["topic"]} concisely, comparing it to the Python programming language.'
+
+if __name__ == '__main__':
+    print(generate_prompt(json.loads(sys.argv[1])))

--- a/examples/custom-prompt-function/prompt_string.js
+++ b/examples/custom-prompt-function/prompt_string.js
@@ -1,0 +1,4 @@
+// An example prompt function that returns a simple string.
+module.exports = async function ({ vars }) {
+  return `Imagine you're an angry pirate. Be concise and stay in character. Tell me about ${vars.topic}`;
+};

--- a/examples/custom-prompt-function/promptfooconfig.yaml
+++ b/examples/custom-prompt-function/promptfooconfig.yaml
@@ -1,0 +1,9 @@
+prompts: [prompt_chat.js, prompt_string.js]
+providers: [openai:gpt-3.5-turbo-0613]
+tests:
+  - vars:
+      topic: the weather
+  - vars:
+      topic: bob dylan
+  - vars:
+      topic: the Roman Empire

--- a/examples/custom-prompt-function/promptfooconfig.yaml
+++ b/examples/custom-prompt-function/promptfooconfig.yaml
@@ -1,4 +1,4 @@
-prompts: [prompt_chat.js, prompt_string.js]
+prompts: ['prompt_chat.js', 'prompt_string.js', 'prompt_multiple.js:prompt2', 'prompt_python.py:generate_prompt']
 providers: [openai:gpt-3.5-turbo-0613]
 tests:
   - vars:

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -71,13 +71,15 @@ function generateVarCombinations(
   return combinations;
 }
 
-export function renderPrompt(rawPrompt: string, vars: Record<string, string | object>): string {
+export function renderPrompt(prompt: Prompt, vars: Record<string, string | object>): string {
+  console.log('function', prompt.function);
+  const basePrompt = prompt.function ? prompt.function({ vars }) : prompt.raw;
   try {
     if (process.env.PROMPTFOO_DISABLE_JSON_AUTOESCAPE) {
-      return nunjucks.renderString(rawPrompt, vars);
+      return nunjucks.renderString(basePrompt, vars);
     }
 
-    const parsed = JSON.parse(rawPrompt);
+    const parsed = JSON.parse(basePrompt);
 
     // Remove any trailing newlines from vars
     for (const key of Object.keys(vars)) {
@@ -100,7 +102,7 @@ export function renderPrompt(rawPrompt: string, vars: Record<string, string | ob
     };
     return JSON.stringify(walk(parsed));
   } catch (err) {
-    return nunjucks.renderString(rawPrompt, vars);
+    return nunjucks.renderString(basePrompt, vars);
   }
 }
 
@@ -132,7 +134,7 @@ class Evaluator {
     delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
-    const renderedPrompt = renderPrompt(prompt.raw, vars);
+    const renderedPrompt = renderPrompt(prompt, vars);
 
     // Note that we're using original prompt, not renderedPrompt
     let promptDisplay = prompt.display;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -71,10 +71,13 @@ function generateVarCombinations(
   return combinations;
 }
 
-export function renderPrompt(prompt: Prompt, vars: Record<string, string | object>): string {
+export async function renderPrompt(
+  prompt: Prompt,
+  vars: Record<string, string | object>,
+): Promise<string> {
   let basePrompt = prompt.raw;
   if (prompt.function) {
-    const result = prompt.function({ vars });
+    const result = await prompt.function({ vars });
     if (typeof result === 'string') {
       basePrompt = result;
     } else if (typeof result === 'object') {
@@ -145,7 +148,7 @@ class Evaluator {
     delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
-    const renderedPrompt = renderPrompt(prompt, vars);
+    const renderedPrompt = await renderPrompt(prompt, vars);
 
     // Note that we're using original prompt, not renderedPrompt
     let promptDisplay = prompt.display;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -72,8 +72,19 @@ function generateVarCombinations(
 }
 
 export function renderPrompt(prompt: Prompt, vars: Record<string, string | object>): string {
-  console.log('function', prompt.function);
-  const basePrompt = prompt.function ? prompt.function({ vars }) : prompt.raw;
+  let basePrompt = prompt.raw;
+  if (prompt.function) {
+    const result = prompt.function({ vars });
+    if (typeof result === 'string') {
+      basePrompt = result;
+    } else if (typeof result === 'object') {
+      basePrompt = JSON.stringify(result);
+    } else {
+      throw new Error(`Prompt function must return a string or object, got ${typeof result}`);
+    }
+    // TODO(ian): Handle promise
+  }
+
   try {
     if (process.env.PROMPTFOO_DISABLE_JSON_AUTOESCAPE) {
       return nunjucks.renderString(basePrompt, vars);

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,7 +365,6 @@ async function main() {
         ...config.defaultTest,
       };
 
-      console.log('parsedPrompts', parsedPrompts);
       const testSuite: TestSuite = {
         description: config.description,
         prompts: parsedPrompts,

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,6 +365,7 @@ async function main() {
         ...config.defaultTest,
       };
 
+      console.log('parsedPrompts', parsedPrompts);
       const testSuite: TestSuite = {
         description: config.description,
         prompts: parsedPrompts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,7 @@ export interface EvaluateOptions {
 export interface Prompt {
   raw: string;
   display: string;
-  function?: (context: { vars: Record<string, string | object> }) => string;
+  function?: (context: { vars: Record<string, string | object> }) => string | object;
 }
 
 export interface EvaluateResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,7 @@ export interface EvaluateOptions {
 export interface Prompt {
   raw: string;
   display: string;
-  function?: (context: { vars: Record<string, string | object> }) => string | object;
+  function?: (context: { vars: Record<string, string | object> }) => Promise<string | object>;
 }
 
 export interface EvaluateResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface EvaluateOptions {
 export interface Prompt {
   raw: string;
   display: string;
+  function?: (context: { vars: Record<string, string | object> }) => string;
 }
 
 export interface EvaluateResult {

--- a/src/util.ts
+++ b/src/util.ts
@@ -204,30 +204,30 @@ export function readPrompts(
       });
       promptContents.push(...fileContents.map((content) => ({ raw: content, display: content })));
     } else {
-      const fileContent = fs.readFileSync(promptPath, 'utf-8');
       const ext = path.parse(promptPath).ext;
       if (ext === '.js') {
         const promptFunction = require(promptPath);
-        promptContents.push({ raw: fileContent, display: fileContent, function: promptFunction });
+        promptContents.push({ raw: String(promptFunction), display: String(promptFunction), function: promptFunction });
       } else {
+        const fileContent = fs.readFileSync(promptPath, 'utf-8');
+        let display: string | undefined;
+        if (inputType === PromptInputType.NAMED) {
+          display = resolvedPathToDisplay.get(promptPath) || promptPath;
+        } else {
+          display = fileContent.length > 200 ? promptPath : fileContent;
 
-      let display: string | undefined;
-      if (inputType === PromptInputType.NAMED) {
-        display = resolvedPathToDisplay.get(promptPath) || promptPath;
-      } else {
-        display = fileContent.length > 200 ? promptPath : fileContent;
-
-        const ext = path.parse(promptPath).ext;
-        if (ext === '.jsonl') {
-          // Special case for JSONL file
-          const jsonLines = fileContent.split(/\r?\n/).filter((line) => line.length > 0);
-          for (const json of jsonLines) {
-            promptContents.push({ raw: json, display: json });
+          const ext = path.parse(promptPath).ext;
+          if (ext === '.jsonl') {
+            // Special case for JSONL file
+            const jsonLines = fileContent.split(/\r?\n/).filter((line) => line.length > 0);
+            for (const json of jsonLines) {
+              promptContents.push({ raw: json, display: json });
+            }
+            continue;
           }
-          continue;
         }
+        promptContents.push({ raw: fileContent, display });
       }
-      promptContents.push({ raw: fileContent, display });
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -205,6 +205,11 @@ export function readPrompts(
       promptContents.push(...fileContents.map((content) => ({ raw: content, display: content })));
     } else {
       const fileContent = fs.readFileSync(promptPath, 'utf-8');
+      const ext = path.parse(promptPath).ext;
+      if (ext === '.js') {
+        const promptFunction = require(promptPath);
+        promptContents.push({ raw: fileContent, display: fileContent, function: promptFunction });
+      } else {
 
       let display: string | undefined;
       if (inputType === PromptInputType.NAMED) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -168,11 +168,13 @@ export function readPrompts(
   let resolvedPath: string | undefined;
   const resolvedPathToDisplay = new Map<string, string>();
   if (typeof promptPathOrGlobs === 'string') {
+    // Path to a prompt file
     resolvedPath = path.resolve(basePath, promptPathOrGlobs);
     promptPaths = [resolvedPath];
     resolvedPathToDisplay.set(resolvedPath, promptPathOrGlobs);
     inputType = PromptInputType.STRING;
   } else if (Array.isArray(promptPathOrGlobs)) {
+    // List of paths to prompt files
     promptPaths = promptPathOrGlobs.flatMap((pathOrGlob) => {
       resolvedPath = path.resolve(basePath, pathOrGlob);
       resolvedPathToDisplay.set(resolvedPath, pathOrGlob);
@@ -180,6 +182,7 @@ export function readPrompts(
     });
     inputType = PromptInputType.ARRAY;
   } else if (typeof promptPathOrGlobs === 'object') {
+    // Display/contents mapping
     promptPaths = Object.keys(promptPathOrGlobs).map((key) => {
       resolvedPath = path.resolve(basePath, key);
       resolvedPathToDisplay.set(resolvedPath, promptPathOrGlobs[key]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -207,7 +207,11 @@ export function readPrompts(
       const ext = path.parse(promptPath).ext;
       if (ext === '.js') {
         const promptFunction = require(promptPath);
-        promptContents.push({ raw: String(promptFunction), display: String(promptFunction), function: promptFunction });
+        promptContents.push({
+          raw: String(promptFunction),
+          display: String(promptFunction),
+          function: promptFunction,
+        });
       } else {
         const fileContent = fs.readFileSync(promptPath, 'utf-8');
         let display: string | undefined;
@@ -231,7 +235,11 @@ export function readPrompts(
     }
   }
 
-  if (promptContents.length === 1 && inputType !== PromptInputType.NAMED && !promptContents[0]['function']) {
+  if (
+    promptContents.length === 1 &&
+    inputType !== PromptInputType.NAMED &&
+    !promptContents[0]['function']
+  ) {
     // Split raw text file into multiple prompts
     const content = promptContents[0].raw;
     promptContents = content

--- a/src/util.ts
+++ b/src/util.ts
@@ -231,7 +231,8 @@ export function readPrompts(
     }
   }
 
-  if (promptContents.length === 1 && inputType !== PromptInputType.NAMED) {
+  if (promptContents.length === 1 && inputType !== PromptInputType.NAMED && !promptContents[0]['function']) {
+    // Split raw text file into multiple prompts
     const content = promptContents[0].raw;
     promptContents = content
       .split(PROMPT_DELIMITER)

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -578,27 +578,27 @@ it('should use the options from the test if they exist', async () => {
 });
 
 describe('renderPrompt', () => {
-  it('should render a prompt with a single variable', () => {
+  it('should render a prompt with a single variable', async () => {
     const prompt = toPrompt('Test prompt {{ var1 }}');
-    const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
+    const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' });
     expect(renderedPrompt).toBe('Test prompt value1');
   });
 
-  it('should render a JSON prompt', () => {
+  it('should render a JSON prompt', async () => {
     const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
-    const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
+    const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' });
     expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"value1"}]');
   });
 
-  it('should render a JSON prompt and escape the var string', () => {
+  it('should render a JSON prompt and escape the var string', async () => {
     const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
-    const renderedPrompt = renderPrompt(prompt, { var1: 'He said "hello world!"' });
+    const renderedPrompt = await renderPrompt(prompt, { var1: 'He said "hello world!"' });
     expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"He said \\"hello world!\\""}]');
   });
 
-  it('should render a JSON prompt with nested JSON', () => {
+  it('should render a JSON prompt with nested JSON', async () => {
     const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
-    const renderedPrompt = renderPrompt(prompt, { var1: '{"nested": "value1"}' });
+    const renderedPrompt = await renderPrompt(prompt, { var1: '{"nested": "value1"}' });
     expect(renderedPrompt).toBe(
       '[{"text":"Test prompt "},{"text":"{\\"nested\\": \\"value1\\"}"}]',
     );

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -579,25 +579,25 @@ it('should use the options from the test if they exist', async () => {
 
 describe('renderPrompt', () => {
   it('should render a prompt with a single variable', () => {
-    const prompt = 'Test prompt {{ var1 }}';
+    const prompt = toPrompt('Test prompt {{ var1 }}');
     const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
     expect(renderedPrompt).toBe('Test prompt value1');
   });
 
   it('should render a JSON prompt', () => {
-    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
     const renderedPrompt = renderPrompt(prompt, { var1: 'value1' });
     expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"value1"}]');
   });
 
   it('should render a JSON prompt and escape the var string', () => {
-    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
     const renderedPrompt = renderPrompt(prompt, { var1: 'He said "hello world!"' });
     expect(renderedPrompt).toBe('[{"text":"Test prompt "},{"text":"He said \\"hello world!\\""}]');
   });
 
   it('should render a JSON prompt with nested JSON', () => {
-    const prompt = '[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]';
+    const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
     const renderedPrompt = renderPrompt(prompt, { var1: '{"nested": "value1"}' });
     expect(renderedPrompt).toBe(
       '[{"text":"Test prompt "},{"text":"{\\"nested\\": \\"value1\\"}"}]',


### PR DESCRIPTION
Prompt files with `.js` extensions are imported and dynamically evaluated:

```yaml
prompts: [prompt.js]
```

Here's an example prompt function that returns a JSON OpenAI-like "chat" object:
```js
module.exports = async function ({ vars }) {
  return [
    {
      role: 'system',
      content: vars.system_message,
    },
    {
      role: 'user',
      content: `Tell me about ${vars.topic}`,
    },
  ];
};
```

This feature can make it easier to integrate promptfoo with existing application logic.

#134 