### PR TITLE
Fix README link to providers docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you're looking to customize your usage, you have a wide set of parameters at 
 | Option                              | Description                                                                                                                                                                                                            |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-p, --prompts <paths...>`          | Paths to [prompt files](https://promptfoo.dev/docs/configuration/parameters#prompt-files), directory, or glob                                                                                                          |
-| `-r, --providers <name or path...>` | One of: openai:chat, openai:completion, openai:model-name, localai:chat:model-name, localai:completion:model-name. See [API providers](https://promptfoo.dev/docs/configuration/providers)                             |
+| `-r, --providers <name or path...>` | One of: openai:chat, openai:completion, openai:model-name, localai:chat:model-name, localai:completion:model-name. See [API providers][providers-docs]                             |
 | `-o, --output <path>`               | Path to [output file](https://promptfoo.dev/docs/configuration/parameters#output-file) (csv, json, yaml, html)                                                                                                         |
 | `--tests <path>`                    | Path to [external test file](https://promptfoo.dev/docs/configurationexpected-outputsassertions#load-an-external-tests-file)                                                                                           |
 | `-c, --config <path>`               | Path to [configuration file](https://promptfoo.dev/docs/configuration/guide). `promptfooconfig.js/json/yaml` is automatically loaded if present                                                                        |
@@ -140,7 +140,7 @@ If you're looking to customize your usage, you have a wide set of parameters at 
 | `--table-cell-max-length <number>`  | Truncate console table cells to this length                                                                                                                                                                            |
 | `--prompt-prefix <path>`            | This prefix is prepended to every prompt                                                                                                                                                                               |
 | `--prompt-suffix <path>`            | This suffix is append to every prompt                                                                                                                                                                                  |
-| `--grader`                          | [Provider](https://promptfoo.dev/docs/configuration/providers) that will conduct the evaluation, if you are [using LLM to grade your output](https://promptfoo.dev/docs/configuration/expected-outputs#llm-evaluation) |
+| `--grader`                          | [Provider][providers-docs] that will conduct the evaluation, if you are [using LLM to grade your output](https://promptfoo.dev/docs/configuration/expected-outputs#llm-evaluation) |
 
 After running an eval, you may optionally use the `view` command to open the web viewer:
 
@@ -274,7 +274,7 @@ See **[installation docs](https://promptfoo.dev/docs/installation)**
 
 ## API Providers
 
-We support OpenAI's API as well as a number of open-source models. It's also to set up your own custom API provider. **[See Provider documentation](https://promptfoo.dev/docs/configuration/providers)** for more details.
+We support OpenAI's API as well as a number of open-source models. It's also to set up your own custom API provider. **[See Provider documentation][providers-docs]** for more details.
 
 ## Development
 
@@ -290,3 +290,5 @@ Here are some of the available scripts:
 - `test:watch`: Continuously run test suite on changes
 
 # [» View full documentation «](https://promptfoo.dev/docs/intro)
+
+[providers-docs]: https://promptfoo.dev/docs/providers


### PR DESCRIPTION
Just trying our promptfoo - thanks for creating it!

The existing providers docs link was outdated/broken, so I've fixed it up. I switched to using a reference, too, to make it easier to maintain.

:octocat: 