### PR TITLE
Fix escaping in python asserts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         node: ['16.x', '18.x', '20.x']
+        python: ['3.7']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -22,6 +23,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/examples/simple-test/promptfooconfig.yaml
+++ b/examples/simple-test/promptfooconfig.yaml
@@ -28,6 +28,8 @@ tests:
       # Look for substring
       - type: javascript
         value: output.startsWith('Ahoy')
+      - type: python
+        value: max(0, len(output) - 300)
 
       # Check for semantic similarity
       - type: similar

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -377,11 +377,12 @@ import sys
 data = json.load(sys.stdin)
 output = data["output"]
 context = data["context"]
+value = data["value"]
 
-${isMultiline ? escapedRenderedValue : `print(json.dumps(${escapedRenderedValue}))`}
+${isMultiline ? 'exec(value)': 'print(json.dumps(eval(value)))'}
 `;
-      const pythonProcessInput = JSON.stringify({ output, context });
-      const result = execSync(`python -c '${pythonScript.replace(/\n/g, ';')}'`, {
+      const pythonProcessInput = JSON.stringify({ output, context, value: renderedValue });
+      const result = execSync(`python -c '${pythonScript}'`, {
         input: pythonProcessInput,
       })
         .toString()

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -363,8 +363,10 @@ ${renderedValue}`,
   }
 
   if (baseType === 'python') {
+    invariant(typeof renderedValue === 'string', 'python assertion must have a string value');
     try {
       const { execSync } = require('child_process');
+      const isMultiline = renderedValue.includes('\n');
       const pythonScript = `
 import json
 import sys
@@ -373,8 +375,8 @@ data = json.load(sys.stdin)
 output = data['output']
 context = data['context']
 
-${assertion.value}
-      `;
+${isMultiline ? renderedValue : `print(json.dumps(${renderedValue}))`}
+`;
       const pythonProcessInput = JSON.stringify({ output, context });
       const result = execSync('python -c "' + pythonScript + '"', {
         input: pythonProcessInput,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -373,7 +373,7 @@ data = json.load(sys.stdin)
 output = data['output']
 context = data['context']
 
-print(json.dumps(${assertion.value}))
+${assertion.value}
       `;
       const pythonProcessInput = JSON.stringify({ output, context });
       const result = execSync('python -c "' + pythonScript + '"', {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -380,11 +380,8 @@ context = data["context"]
 
 ${isMultiline ? escapedRenderedValue : `print(json.dumps(${escapedRenderedValue}))`}
 `;
-      if (os.platform() === 'win32') {
-        pythonScript = pythonScript.split('\n').map(line => line.trim()).join('^' + '\n');
-      }
       const pythonProcessInput = JSON.stringify({ output, context });
-      const result = execSync(`python -c '${pythonScript}'`, {
+      const result = execSync(`python -c '${pythonScript.replace(/\n/g, ';')}'`, {
         input: pythonProcessInput,
       })
         .toString()

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+
 import rouge from 'rouge';
 import invariant from 'tiny-invariant';
 import Ajv from 'ajv';
@@ -368,7 +370,7 @@ ${renderedValue}`,
       const { execSync } = require('child_process');
       const isMultiline = renderedValue.includes('\n');
       const escapedRenderedValue = renderedValue.replace(/'/g, "\\\\'");
-      const pythonScript = `
+      let pythonScript = `
 import json
 import sys
 
@@ -378,7 +380,9 @@ context = data["context"]
 
 ${isMultiline ? escapedRenderedValue : `print(json.dumps(${escapedRenderedValue}))`}
 `;
-      console.log(pythonScript);
+      if (os.platform() === 'win32') {
+        pythonScript = pythonScript.replace(/\n/g, "^\n");
+      }
       const pythonProcessInput = JSON.stringify({ output, context });
       const result = execSync(`python -c '${pythonScript}'`, {
         input: pythonProcessInput,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -381,7 +381,7 @@ context = data["context"]
 ${isMultiline ? escapedRenderedValue : `print(json.dumps(${escapedRenderedValue}))`}
 `;
       if (os.platform() === 'win32') {
-        pythonScript = pythonScript.replace(/\n/g, "^\n");
+        pythonScript = pythonScript.split('\n').map(line => line.trim()).join('^' + '\n');
       }
       const pythonProcessInput = JSON.stringify({ output, context });
       const result = execSync(`python -c '${pythonScript}'`, {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -372,13 +372,13 @@ import json
 import sys
 
 data = json.load(sys.stdin)
-output = data['output']
-context = data['context']
+output = data["output"]
+context = data["context"]
 
 ${isMultiline ? renderedValue : `print(json.dumps(${renderedValue}))`}
 `;
       const pythonProcessInput = JSON.stringify({ output, context });
-      const result = execSync('python -c "' + pythonScript + '"', {
+      const result = execSync(`python -c '${pythonScript}'`, {
         input: pythonProcessInput,
       })
         .toString()

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -370,19 +370,15 @@ ${renderedValue}`,
       const { execSync } = require('child_process');
       const isMultiline = renderedValue.includes('\n');
       const escapedRenderedValue = renderedValue.replace(/'/g, "\\\\'");
-      let pythonScript = `
-import json
+      let pythonScript = `import json
 import sys
-
 data = json.load(sys.stdin)
 output = data["output"]
 context = data["context"]
 value = data["value"]
-
-${isMultiline ? 'exec(value)': 'print(json.dumps(eval(value)))'}
-`;
+${isMultiline ? 'exec(value)': 'print(json.dumps(eval(value)))'}`;
       const pythonProcessInput = JSON.stringify({ output, context, value: renderedValue });
-      const result = execSync(`python -c '${pythonScript}'`, {
+      const result = execSync(`python -c '${pythonScript.replace(/\n/g, ";")}'`, {
         input: pythonProcessInput,
       })
         .toString()

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -367,6 +367,7 @@ ${renderedValue}`,
     try {
       const { execSync } = require('child_process');
       const isMultiline = renderedValue.includes('\n');
+      const escapedRenderedValue = renderedValue.replace(/'/g, "\\\\'");
       const pythonScript = `
 import json
 import sys
@@ -375,8 +376,9 @@ data = json.load(sys.stdin)
 output = data["output"]
 context = data["context"]
 
-${isMultiline ? renderedValue : `print(json.dumps(${renderedValue}))`}
+${isMultiline ? escapedRenderedValue : `print(json.dumps(${escapedRenderedValue}))`}
 `;
+      console.log(pythonScript);
       const pythonProcessInput = JSON.stringify({ output, context });
       const result = execSync(`python -c '${pythonScript}'`, {
         input: pythonProcessInput,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -369,16 +369,16 @@ ${renderedValue}`,
     try {
       const { execSync } = require('child_process');
       const isMultiline = renderedValue.includes('\n');
-      const escapedRenderedValue = renderedValue.replace(/'/g, "\\\\'");
+      const escapedRenderedValue = renderedValue.replace(/"/g, '\\\\"');
       let pythonScript = `import json
 import sys
 data = json.load(sys.stdin)
-output = data["output"]
-context = data["context"]
-value = data["value"]
+output = data['output']
+context = data['context']
+value = data['value']
 ${isMultiline ? 'exec(value)': 'print(json.dumps(eval(value)))'}`;
       const pythonProcessInput = JSON.stringify({ output, context, value: renderedValue });
-      const result = execSync(`python -c '${pythonScript.replace(/\n/g, ";")}'`, {
+      const result = execSync(`python -c "${pythonScript.replace(/\n/g, ";")}"`, {
         input: pythonProcessInput,
       })
         .toString()

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -83,7 +83,9 @@ export async function readTest(
         if (typeof value === 'string' && value.startsWith('file://')) {
           // Load file from disk.
           if (value.endsWith('.yaml') || value.endsWith('.yml')) {
-            vars[key] = yaml.load(fs.readFileSync(value.slice('file://'.length), 'utf-8')) as string;
+            vars[key] = yaml.load(
+              fs.readFileSync(value.slice('file://'.length), 'utf-8'),
+            ) as string;
           } else {
             vars[key] = fs.readFileSync(value.slice('file://'.length), 'utf-8');
           }

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -915,6 +915,27 @@ describe('runAssertion', () => {
     expect(result.pass).toBeFalsy();
     expect(result.reason).toBe('Levenshtein distance 8 is greater than threshold 5');
   });
+
+  it('should handle output strings with both single and double quotes correctly in python assertion', async () => {
+    const output =
+      'This is a string with "double quotes"\n and \'single quotes\' \n\n and some \n\t newlines.';
+
+    const pythonAssertion: Assertion = {
+      type: 'python',
+      value: '0.5',
+    };
+
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      pythonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
+
+    expect(result.pass).toBeTruthy();
+    expect(result.reason).toBe('Assertion passed');
+    expect(result.score).toBe(0.5);
+  });
 });
 
 describe('assertionFromString', () => {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -932,9 +932,9 @@ describe('runAssertion', () => {
       output,
     );
 
-    expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
     expect(result.score).toBe(0.5);
+    expect(result.pass).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Depending on the quotes used in output and vars, Python asserts could fail

Related to issue #155 