### PR TITLE
Allow object with function name as a value for function_call

### DIFF
--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -21,7 +21,7 @@ interface AzureOpenAiCompletionOptions {
     description?: string;
     parameters: any;
   }[];
-  function_call?: 'none' | 'auto';
+  function_call?: 'none' | 'auto' | { name: string; };
   stop?: string[];
 }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -23,7 +23,7 @@ interface OpenAiCompletionOptions {
     description?: string;
     parameters: any;
   }[];
-  function_call?: 'none' | 'auto';
+  function_call?: 'none' | 'auto' | { name: string; };
   stop?: string[];
 
   apiKey?: string;


### PR DESCRIPTION
As [documented by OpenAI](https://platform.openai.com/docs/api-reference/chat/create). (Looks like everything just works when passing this through from a config file, too.)