### PR TITLE
Ability to include files as assertion values

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -349,7 +349,7 @@ export async function runAssertion(
       }
       invariant(typeof renderedValue === 'string', 'javascript assertion must have a string value');
       let result: boolean | number | GradingResult;
-      if (valueFromScript) {
+      if (typeof valueFromScript !== 'undefined') {
         invariant(typeof valueFromScript === 'boolean' || typeof valueFromScript === 'number' || typeof valueFromScript === 'object', `Javascript assertion script must return a boolean, number, or object (${assertion.value})`);
         result = valueFromScript;
       } else {
@@ -361,11 +361,7 @@ export async function runAssertion(
         pass = result !== inverse;
         score = 1.0;
       } else if (typeof result === 'number') {
-        if (typeof assertion.threshold !== 'undefined' && result < assertion.threshold) {
-          pass = false;
-        } else {
-          pass = true;
-        }
+        pass = assertion.threshold ? result >= assertion.threshold : result > 0;
         score = result;
       } else if (typeof result === 'object') {
         return result;
@@ -396,7 +392,7 @@ ${renderedValue}`,
     invariant(typeof renderedValue === 'string', 'python assertion must have a string value');
     try {
       let result: string;
-      if (valueFromScript) {
+      if (typeof valueFromScript !== 'undefined') {
         invariant(typeof valueFromScript === 'string', `Python assertion script must return a string (${assertion.value})`);
         result = valueFromScript;
       } else {
@@ -433,8 +429,8 @@ ${renderedValue}`,
         }
         return parsed;
       } else {
-        pass = true;
         score = parseFloat(result);
+        pass = assertion.threshold ? score >= assertion.threshold : score > 0;
         if (isNaN(score)) {
           throw new Error(
             'Python assertion must return a boolean, number, or {pass, score, reason} object',

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -139,7 +139,8 @@ export async function runAssertion(
     if (renderedValue.startsWith('file://')) {
       const filePath = renderedValue.slice('file://'.length);
       if (filePath.endsWith('.js')) {
-        renderedValue = require(path.resolve(filePath)).default;
+        const requiredModule = require(path.resolve(filePath));
+        renderedValue = requiredModule.default || requiredModule;
       } else {
         throw new Error('Only JavaScript files are supported for file:// syntax in assertion values');
       }

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -151,7 +151,9 @@ export async function runAssertion(
             }
           } else if (filePath.endsWith('.py')) {
             const { execSync } = require('child_process');
-            const pythonScriptOutput = execSync(`python ${filePath} ${output} '${JSON.stringify({ vars: test.vars || {} })}'`).toString();
+            const escapedOutput = output.replace(/"/g, '\\"');
+            const escapedContext = JSON.stringify({ vars: test.vars || {} }).replace(/"/g, '\\"');
+            const pythonScriptOutput = execSync(`python ${filePath} "${escapedOutput}" "${escapedContext}"`).toString();
             renderedValue = pythonScriptOutput.trim();
           } else {
             throw new Error('Only JavaScript and Python files are supported for file:// syntax in assertion values');

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -136,7 +136,16 @@ export async function runAssertion(
   let renderedValue = assertion.value;
   // renderString for assertion values
   if (renderedValue && typeof renderedValue === 'string') {
-    renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
+    if (renderedValue.startsWith('file://')) {
+      const filePath = renderedValue.slice('file://'.length);
+      if (filePath.endsWith('.js')) {
+        renderedValue = require(path.resolve(filePath)).default;
+      } else {
+        throw new Error('Only JavaScript files are supported for file:// syntax in assertion values');
+      }
+    } else {
+      renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
+    }
   } else if (renderedValue && Array.isArray(renderedValue)) {
     renderedValue = renderedValue.map((v) => nunjucks.renderString(String(v), test.vars || {}));
   }

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -151,8 +151,8 @@ export async function runAssertion(
             }
           } else if (filePath.endsWith('.py')) {
             const { execSync } = require('child_process');
-            const escapedOutput = output.replace(/"/g, '\\"');
-            const escapedContext = JSON.stringify({ vars: test.vars || {} }).replace(/"/g, '\\"');
+            const escapedOutput = output.replace(/"/g, '\\"').replace(/\n/g, '\\n');
+            const escapedContext = JSON.stringify({ vars: test.vars || {} }).replace(/"/g, '\\"').replace(/\n/g, '\\n');
             const pythonScriptOutput = execSync(`python ${filePath} "${escapedOutput}" "${escapedContext}"`).toString();
             renderedValue = pythonScriptOutput.trim();
           } else {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -417,10 +417,11 @@ ${renderedValue}`,
           .toString()
           .trim() as string;
       }
-      if (result === 'true') {
+
+      if (result.toLowerCase() === 'true') {
         pass = true;
         score = 1.0;
-      } else if (result === 'false') {
+      } else if (result.toLowerCase() === 'false') {
         pass = false;
         score = 0.0;
       } else if (result.startsWith('{')) {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -136,16 +136,26 @@ export async function runAssertion(
   let renderedValue = assertion.value;
   // renderString for assertion values
   if (renderedValue && typeof renderedValue === 'string') {
-    if (renderedValue.startsWith('file://')) {
-      const filePath = renderedValue.slice('file://'.length);
-      if (filePath.endsWith('.js')) {
-        const requiredModule = require(path.resolve(filePath));
-        renderedValue = requiredModule.default || requiredModule;
+    if (renderedValue && typeof renderedValue === 'string') {
+      if (renderedValue.startsWith('file://')) {
+        const filePath = renderedValue.slice('file://'.length);
+        if (filePath.endsWith('.js')) {
+          const requiredModule = require(path.resolve(filePath));
+          if (typeof requiredModule === 'function') {
+            renderedValue = requiredModule(output, { vars: test.vars || {} });
+          } else if (requiredModule.default && typeof requiredModule.default === 'function') {
+            renderedValue = requiredModule.default(output, { vars: test.vars || {} });
+          } else {
+            throw new Error('The JavaScript file must export a function or have a default export as a function');
+          }
+        } else {
+          throw new Error('Only JavaScript files are supported for file:// syntax in assertion values');
+        }
       } else {
-        throw new Error('Only JavaScript files are supported for file:// syntax in assertion values');
+        renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
       }
-    } else {
-      renderedValue = nunjucks.renderString(renderedValue, test.vars || {});
+    } else if (renderedValue && Array.isArray(renderedValue)) {
+      renderedValue = renderedValue.map((v) => nunjucks.renderString(String(v), test.vars || {}));
     }
   } else if (renderedValue && Array.isArray(renderedValue)) {
     renderedValue = renderedValue.map((v) => nunjucks.renderString(String(v), test.vars || {}));

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import { Response } from 'node-fetch';
 import { runAssertions, runAssertion, assertionFromString } from '../src/assertions';
 import * as fetch from '../src/fetch';
@@ -957,7 +959,7 @@ describe('runAssertion', () => {
   ])('should pass when the file:// assertion with .js file returns a %s', async (type, mockFn, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
-    jest.doMock('/path/to/assert.js', () => mockFn, { virtual: true });
+    jest.doMock(path.resolve('/path/to/assert.js'), () => mockFn, { virtual: true });
 
     const fileAssertion: Assertion = {
       type: 'javascript',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -972,10 +972,33 @@ describe('runAssertion', () => {
     expect(result.reason).toBe(expectedReason);
   });
 
+  it('should handle output strings with both single and double quotes correctly in python assertion', async () => {
+    // Due to terrible sins related to mocking, this test must appear before
+    // the `child_process` mock below.
+    const output =
+      'This is a string with "double quotes"\n and \'single quotes\' \n\n and some \n\t newlines.';
+
+    const pythonAssertion: Assertion = {
+      type: 'python',
+      value: '0.5',
+    };
+
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      pythonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
+
+    expect(result.reason).toBe('Assertion passed');
+    expect(result.score).toBe(0.5);
+    expect(result.pass).toBeTruthy();
+  });
+
   it.each([
     ['boolean', 'True', true, 'Assertion passed'],
-    //['number', '0.5', true, 'Assertion passed'],
-    //['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
+    ['number', '0.5', true, 'Assertion passed'],
+    ['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
@@ -999,27 +1022,6 @@ describe('runAssertion', () => {
 
     expect(result.pass).toBe(expectedPass);
     expect(result.reason).toBe(expectedReason);
-  });
-
-  it('should handle output strings with both single and double quotes correctly in python assertion', async () => {
-    const output =
-      'This is a string with "double quotes"\n and \'single quotes\' \n\n and some \n\t newlines.';
-
-    const pythonAssertion: Assertion = {
-      type: 'python',
-      value: '0.5',
-    };
-
-    const result: GradingResult = await runAssertion(
-      'Some prompt',
-      pythonAssertion,
-      {} as AtomicTestCase,
-      output,
-    );
-
-    expect(result.reason).toBe('Assertion passed');
-    expect(result.score).toBe(0.5);
-    expect(result.pass).toBeTruthy();
   });
 });
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -951,9 +951,9 @@ describe('runAssertion', () => {
     ['boolean', jest.fn((output: string) => output === 'Expected output'), true, 'Assertion passed'],
     ['number', jest.fn((output: string) => output.length), true, 'Assertion passed'],
     ['GradingResult', jest.fn((output: string) => ({ pass: true, score: 1, reason: 'Custom reason' })), true, 'Custom reason'],
-    ['boolean', jest.fn((output: string) => output !== 'Expected output'), false, 'Assertion failed'],
-    ['number', jest.fn((output: string) => output.length * 0), false, 'Assertion failed'],
-    ['GradingResult', jest.fn((output: string) => ({ pass: false, score: 0, reason: 'Custom reason' })), false, 'Custom reason'],
+    ['boolean', jest.fn((output: string) => output !== 'Expected output'), false, 'Custom function returned false'],
+    ['number', jest.fn((output: string) => 0), false, 'Custom function returned false'],
+    ['GradingResult', jest.fn((output: string) => ({ pass: false, score: 0.1, reason: 'Custom reason' })), false, 'Custom reason'],
   ])('should pass when the file:// assertion with .js file returns a %s', async (type, mockFn, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
@@ -972,7 +972,7 @@ describe('runAssertion', () => {
     );
 
     expect(result.pass).toBe(expectedPass);
-    expect(result.reason).toBe(expectedReason);
+    expect(result.reason).toContain(expectedReason);
   });
 
   it('should handle output strings with both single and double quotes correctly in python assertion', async () => {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -943,14 +943,14 @@ describe('runAssertion', () => {
     expect(result.reason).toBe('Levenshtein distance 8 is greater than threshold 5');
   });
 
-  it('should pass when the file:// assertion with .js file returns a boolean', async () => {
+  it.each([
+    ['boolean', jest.fn((output: string) => output === 'Expected output'), true, 'Assertion passed'],
+    ['number', jest.fn((output: string) => output.length), true, 'Assertion passed'],
+    ['GradingResult', jest.fn((output: string) => ({ pass: true, score: 1, reason: 'Custom reason' })), true, 'Custom reason'],
+  ])('should pass when the file:// assertion with .js file returns a %s', async (type, mockFn, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
-    // https://stackoverflow.com/a/47728913
-    // https://stackoverflow.com/a/56052635
-    jest.doMock('/path/to/assert.js', () => {
-      return jest.fn((output: string) => output === 'Expected output');
-    }, { virtual: true });
+    jest.doMock('/path/to/assert.js', () => mockFn, { virtual: true });
 
     const fileAssertion: Assertion = {
       type: 'javascript',
@@ -964,9 +964,8 @@ describe('runAssertion', () => {
       output,
     );
 
-    console.log(result)
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result.pass).toBe(expectedPass);
+    expect(result.reason).toBe(expectedReason);
   });
 
   it('should handle output strings with both single and double quotes correctly in python assertion', async () => {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -953,12 +953,12 @@ describe('runAssertion', () => {
     fs.writeFileSync(
       tempFilePath,
       `module.exports = function(output, context) {
-        return output;
+        return output === 'Expected output';
       };`
     );
 
     const fileAssertion: Assertion = {
-      type: 'equals',
+      type: 'javascript',
       value: `file://${tempFilePath}`,
     };
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -24,6 +24,10 @@ export class TestGrader implements ApiProvider {
 }
 const Grader = new TestGrader();
 
+beforeEach(() => {
+  jest.resetModules();
+});
+
 describe('runAssertions', () => {
   const test: AtomicTestCase = {
     assert: [

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -972,6 +972,31 @@ describe('runAssertion', () => {
     expect(result.reason).toBe(expectedReason);
   });
 
+  it.each([
+    ['boolean', 'True', true, 'Assertion passed'],
+    ['number', '0.5', true, 'Assertion passed'],
+    ['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
+  ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
+    const output = 'Expected output';
+
+    jest.spyOn(child_process, 'execSync').mockImplementation(() => Buffer.from(pythonOutput));
+
+    const fileAssertion: Assertion = {
+      type: 'python',
+      value: 'file:///path/to/assert.py',
+    };
+
+    const result: GradingResult = await runAssertion(
+      'Some prompt',
+      fileAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
+
+    expect(result.pass).toBe(expectedPass);
+    expect(result.reason).toBe(expectedReason);
+  });
+
   it('should handle output strings with both single and double quotes correctly in python assertion', async () => {
     const output =
       'This is a string with "double quotes"\n and \'single quotes\' \n\n and some \n\t newlines.';

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -943,7 +943,7 @@ describe('runAssertion', () => {
     expect(result.reason).toBe('Levenshtein distance 8 is greater than threshold 5');
   });
 
-  it('should pass when the file:// assertion with .js file passes', async () => {
+  it('should pass when the file:// assertion with .js file returns a boolean', async () => {
     const output = 'Expected output';
 
     // https://stackoverflow.com/a/47728913

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,3 +1,5 @@
+import * as child_process from 'child_process';
+
 import { Response } from 'node-fetch';
 import { runAssertions, runAssertion, assertionFromString } from '../src/assertions';
 import * as fetch from '../src/fetch';
@@ -974,8 +976,8 @@ describe('runAssertion', () => {
 
   it.each([
     ['boolean', 'True', true, 'Assertion passed'],
-    ['number', '0.5', true, 'Assertion passed'],
-    ['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
+    //['number', '0.5', true, 'Assertion passed'],
+    //['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -948,10 +948,10 @@ describe('runAssertion', () => {
   it('should pass when the file:// assertion with .js file passes', async () => {
     const output = 'Expected output';
 
-    // Create a temporary JavaScript file
-    const tempFilePath = path.join(__dirname, 'temp.js');
+    // Create a temporary JavaScript file using the tmp package
+    const tempFile = tmp.fileSync({ postfix: '.js' });
     fs.writeFileSync(
-      tempFilePath,
+      tempFile.name,
       `module.exports = function(output, context) {
         return output === 'Expected output';
       };`
@@ -959,7 +959,7 @@ describe('runAssertion', () => {
 
     const fileAssertion: Assertion = {
       type: 'javascript',
-      value: `file://${tempFilePath}`,
+      value: `file://${tempFile.name}`,
     };
 
     const result: GradingResult = await runAssertion(
@@ -969,8 +969,7 @@ describe('runAssertion', () => {
       output,
     );
 
-    // Delete the temporary JavaScript file
-    fs.unlinkSync(tempFilePath);
+    // The temporary file will be automatically deleted when the process exits
 
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,5 +1,4 @@
-jest.mock('child_process');
-const child_process = require('child_process');
+// Remove the global mock of child_process
 
 import { Response } from 'node-fetch';
 import { runAssertions, runAssertion, assertionFromString } from '../src/assertions';
@@ -982,7 +981,12 @@ describe('runAssertion', () => {
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
-    child_process.execSync.mockImplementation(() => Buffer.from(pythonOutput));
+    // Mock child_process within the test case
+    jest.mock('child_process', () => {
+      return {
+        execSync: jest.fn(() => Buffer.from(pythonOutput)),
+      };
+    });
 
     const fileAssertion: Assertion = {
       type: 'python',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,4 +1,5 @@
-import * as child_process from 'child_process';
+jest.mock('child_process');
+const child_process = require('child_process');
 
 import { Response } from 'node-fetch';
 import { runAssertions, runAssertion, assertionFromString } from '../src/assertions';
@@ -981,7 +982,7 @@ describe('runAssertion', () => {
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
-    jest.spyOn(child_process, 'execSync').mockImplementation(() => Buffer.from(pythonOutput));
+    child_process.execSync.mockImplementation(() => Buffer.from(pythonOutput));
 
     const fileAssertion: Assertion = {
       type: 'python',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,5 +1,3 @@
-// Remove the global mock of child_process
-
 import { Response } from 'node-fetch';
 import { runAssertions, runAssertion, assertionFromString } from '../src/assertions';
 import * as fetch from '../src/fetch';
@@ -981,8 +979,7 @@ describe('runAssertion', () => {
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
-    // Mock child_process within the test case
-    jest.mock('child_process', () => {
+    jest.doMock('child_process', () => {
       return {
         execSync: jest.fn(() => Buffer.from(pythonOutput)),
       };

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -951,6 +951,9 @@ describe('runAssertion', () => {
     ['boolean', jest.fn((output: string) => output === 'Expected output'), true, 'Assertion passed'],
     ['number', jest.fn((output: string) => output.length), true, 'Assertion passed'],
     ['GradingResult', jest.fn((output: string) => ({ pass: true, score: 1, reason: 'Custom reason' })), true, 'Custom reason'],
+    ['boolean', jest.fn((output: string) => output !== 'Expected output'), false, 'Assertion failed'],
+    ['number', jest.fn((output: string) => output.length * 0), false, 'Assertion failed'],
+    ['GradingResult', jest.fn((output: string) => ({ pass: false, score: 0, reason: 'Custom reason' })), false, 'Custom reason'],
   ])('should pass when the file:// assertion with .js file returns a %s', async (type, mockFn, expectedPass, expectedReason) => {
     const output = 'Expected output';
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1002,6 +1002,9 @@ describe('runAssertion', () => {
     ['boolean', 'True', true, 'Assertion passed'],
     ['number', '0.5', true, 'Assertion passed'],
     ['GradingResult', '{"pass": true, "score": 1, "reason": "Custom reason"}', true, 'Custom reason'],
+    ['boolean', 'False', false, 'Python code returned false'],
+    ['number', '0', false, 'Python code returned false'],
+    ['GradingResult', '{"pass": false, "score": 0, "reason": "Custom reason"}', false, 'Custom reason'],
   ])('should pass when the file:// assertion with .py file returns a %s', async (type, pythonOutput, expectedPass, expectedReason) => {
     const output = 'Expected output';
 
@@ -1024,7 +1027,7 @@ describe('runAssertion', () => {
     );
 
     expect(result.pass).toBe(expectedPass);
-    expect(result.reason).toBe(expectedReason);
+    expect(result.reason).toContain(expectedReason);
   });
 });
 


### PR DESCRIPTION
This supports normal files as well as JS/Python scripts.

```yaml
- assert:
    - type: contains
      value: file://gettysburg_address.txt
    - type: contains
      value: file://path/to/assert.js
```

#150 