### PR TITLE
`OPENAI_API_HOST` to `OPENAI_API_BASE_URL`

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -9,8 +9,6 @@ import type {
   ProviderResponse,
 } from '../types.js';
 
-const DEFAULT_OPENAI_HOST = 'api.openai.com';
-
 interface OpenAiCompletionOptions {
   temperature?: number;
   max_tokens?: number;
@@ -27,7 +25,7 @@ interface OpenAiCompletionOptions {
   stop?: string[];
 
   apiKey?: string;
-  apiHost?: string;
+  apiBaseUrl?: string;
   organization?: string;
 }
 
@@ -62,12 +60,12 @@ class OpenAiGenericProvider implements ApiProvider {
     );
   }
 
-  getApiHost(): string | undefined {
+  getApiUrl(): string | undefined {
     return (
-      this.config.apiHost ||
-      this.env?.OPENAI_API_HOST ||
-      process.env.OPENAI_API_HOST ||
-      DEFAULT_OPENAI_HOST
+      this.config.apiBaseUrl ||
+      this.env?.OPENAI_API_BASE_URL ||
+      process.env.OPENAI_API_BASE_URL ||
+      'https://api.openai.com'
     );
   }
 
@@ -95,7 +93,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `https://${this.getApiHost()}/v1/embeddings`,
+        `${this.getApiUrl()}/v1/embeddings`,
         {
           method: 'POST',
           headers: {
@@ -202,7 +200,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `https://${this.getApiHost()}/v1/completions`,
+        `${this.getApiUrl()}/v1/completions`,
         {
           method: 'POST',
           headers: {
@@ -300,7 +298,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `https://${this.getApiHost()}/v1/chat/completions`,
+        `${this.getApiUrl()}/v1/chat/completions`,
         {
           method: 'POST',
           headers: {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -25,6 +25,7 @@ interface OpenAiCompletionOptions {
   stop?: string[];
 
   apiKey?: string;
+  apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;
 }
@@ -60,7 +61,11 @@ class OpenAiGenericProvider implements ApiProvider {
     );
   }
 
-  getApiUrl(): string | undefined {
+  getApiUrl(): string {
+    let apiHost;
+    if ((apiHost = this.config.apiHost || this.env?.OPENAI_API_HOST || process.env.OPENAI_API_HOST)) {
+     return `https://${apiHost}}`;
+    }
     return (
       this.config.apiBaseUrl ||
       this.env?.OPENAI_API_BASE_URL ||

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -62,8 +62,8 @@ class OpenAiGenericProvider implements ApiProvider {
   }
 
   getApiUrl(): string {
-    let apiHost;
-    if ((apiHost = this.config.apiHost || this.env?.OPENAI_API_HOST || process.env.OPENAI_API_HOST)) {
+    const apiHost = this.config.apiHost || this.env?.OPENAI_API_HOST || process.env.OPENAI_API_HOST;
+    if (apiHost) {
      return `https://${apiHost}}`;
     }
     return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface EnvOverrides {
   AZURE_OPENAI_API_HOST?: string;
   AZURE_OPENAI_API_KEY?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_API_HOST?: string;
   OPENAI_API_BASE_URL?: string;
   OPENAI_ORGANIZATION?: string;
   REPLICATE_API_KEY?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface EnvOverrides {
   AZURE_OPENAI_API_HOST?: string;
   AZURE_OPENAI_API_KEY?: string;
   OPENAI_API_KEY?: string;
-  OPENAI_API_HOST?: string;
+  OPENAI_API_BASE_URL?: string;
   OPENAI_ORGANIZATION?: string;
   REPLICATE_API_KEY?: string;
   REPLICATE_API_TOKEN?: string;


### PR DESCRIPTION
Closes https://github.com/promptfoo/promptfoo/issues/177 by matching LocalAI, Llama.cpp, and Ollama convention of `_BASE_URL` and `getApiUrl`

If accepted, I will open a sister PR in the `promptfoo-docs` to mention `OPENAI_API_BASE_URL`/`getApiUrl`