### PR TITLE
Add support for HuggingFace Inference API (text generation)

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -2,3 +2,4 @@ process.env.OPENAI_API_KEY = 'foo';
 process.env.AZURE_OPENAI_API_KEY = 'foo';
 process.env.AZURE_OPENAI_API_HOST = 'azure.openai.host';
 process.env.ANTHROPIC_API_KEY = 'foo';
+process.env.HF_API_TOKEN = 'foo';

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -162,6 +162,10 @@ export async function loadApiProvider(
         `Unknown Anthropic model type: ${modelType}. Use one of the following providers: anthropic:completion:<model name>`,
       );
     }
+  } else if (providerPath?.startsWith('huggingface:')) {
+    // Load Huggingface module
+    const modelName = providerPath.split(':')[1];
+    return new HuggingfaceProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('replicate:')) {
     // Load Replicate module
     const splits = providerPath.split(':');

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -23,7 +23,7 @@ import {
   AzureOpenAiCompletionProvider,
   AzureOpenAiEmbeddingProvider,
 } from './providers/azureopenai';
-import { HuggingfaceTextGenerationProvider } from './providers/huggingface';
+import { HuggingfaceFeatureExtractionProvider, HuggingfaceTextGenerationProvider } from './providers/huggingface';
 
 import type {
   ApiProvider,
@@ -164,8 +164,22 @@ export async function loadApiProvider(
       );
     }
   } else if (providerPath?.startsWith('huggingface:')) {
-    const modelName = providerPath.split(':')[1];
-    return new HuggingfaceTextGenerationProvider(modelName, providerOptions);
+    const splits = providerPath.split(':');
+    if (splits.length < 3) {
+      throw new Error(
+        `Invalid Huggingface provider path: ${providerPath}. Use one of the following providers: huggingface:feature-extraction:<model name>, huggingface:text-generation:<model name>`,
+      );
+    }
+    const modelName = splits.slice(2).join(':');
+    if (splits[1] === 'feature-extraction') {
+      return new HuggingfaceFeatureExtractionProvider(modelName, providerOptions);
+    } else if (splits[1] === 'text-generation') {
+      return new HuggingfaceTextGenerationProvider(modelName, providerOptions);
+    } else {
+      throw new Error(
+        `Invalid Huggingface provider path: ${providerPath}. Use one of the following providers: huggingface:feature-extraction:<model name>, huggingface:text-generation:<model name>`,
+      );
+    }
   } else if (providerPath?.startsWith('replicate:')) {
     const splits = providerPath.split(':');
     const modelName = splits.slice(1).join(':');

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -23,6 +23,7 @@ import {
   AzureOpenAiCompletionProvider,
   AzureOpenAiEmbeddingProvider,
 } from './providers/azureopenai';
+import { HuggingfaceTextGenerationProvider } from './providers/huggingface';
 
 import type {
   ApiProvider,
@@ -163,14 +164,11 @@ export async function loadApiProvider(
       );
     }
   } else if (providerPath?.startsWith('huggingface:')) {
-    // Load Huggingface module
     const modelName = providerPath.split(':')[1];
-    return new HuggingfaceProvider(modelName, providerOptions);
+    return new HuggingfaceTextGenerationProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('replicate:')) {
-    // Load Replicate module
     const splits = providerPath.split(':');
     const modelName = splits.slice(1).join(':');
-
     return new ReplicateProvider(modelName, providerOptions);
   }
 

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -52,7 +52,7 @@ export class HuggingfaceTextGenerationProvider implements ApiProvider {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${process.env.HF_API_TOKEN}`,
+          ...(process.env.HF_API_TOKEN ? { 'Authorization': `Bearer ${process.env.HF_API_TOKEN}` } : {}),
         },
         body: JSON.stringify(params),
       }, REQUEST_TIMEOUT_MS);
@@ -118,7 +118,7 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
          method: 'POST',
          headers: {
            'Content-Type': 'application/json',
-           'Authorization': `Bearer ${process.env.HF_API_TOKEN}`,
+           ...(process.env.HF_API_TOKEN ? { 'Authorization': `Bearer ${process.env.HF_API_TOKEN}` } : {}),
          },
          body: JSON.stringify(params),
        }, REQUEST_TIMEOUT_MS);

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -1,0 +1,63 @@
+import fetch from 'node-fetch';
+import { ApiProvider, ProviderResponse } from '../types.js';
+
+interface HuggingfaceCompletionOptions {
+  top_k?: number;
+  top_p?: number;
+  temperature?: number;
+  repetition_penalty?: number;
+  max_new_tokens?: number;
+  max_time?: number;
+  return_full_text?: boolean;
+  num_return_sequences?: number;
+  do_sample?: boolean;
+  use_cache?: boolean;
+  wait_for_model?: boolean;
+}
+
+export class HuggingfaceProvider implements ApiProvider {
+  modelName: string;
+  config: HuggingfaceCompletionOptions;
+
+  constructor(modelName: string, options: { id?: string, config?: HuggingfaceCompletionOptions } = {}) {
+    const { id, config } = options;
+    this.modelName = modelName;
+    this.id = id ? () => id : this.id;
+    this.config = config || {};
+  }
+
+  id(): string {
+    return `huggingface:${this.modelName}`;
+  }
+
+  toString(): string {
+    return `[Huggingface Provider ${this.modelName}]`;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    const params = {
+      inputs: prompt,
+      parameters: this.config,
+    };
+
+    const response = await fetch(`https://api-inference.huggingface.co/models/${this.modelName}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.HF_API_TOKEN}`,
+      },
+      body: JSON.stringify(params),
+    });
+
+    if (!response.ok) {
+      return {
+        error: `API call error: ${response.statusText}`,
+      };
+    }
+
+    const data = await response.json();
+    return {
+      output: data[0]?.generated_text,
+    };
+  }
+}

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -128,14 +128,14 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
            error: `API call error: ${response.data.error}`,
          };
        }
-       if (!Array.isArray(response.data) || response.data.length < 1) {
+       if (!Array.isArray(response.data)) {
          return {
            error: `Malformed response data: ${response.data}`,
          };
        }
 
        return {
-         embedding: response.data[0],
+         embedding: response.data,
        };
      } catch(err) {
        return {

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -128,14 +128,14 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
            error: `API call error: ${response.data.error}`,
          };
        }
-       if (!response.data[0]) {
+       if (!Array.isArray(response.data) || response.data.length < 1) {
          return {
            error: `Malformed response data: ${response.data}`,
          };
        }
 
        return {
-         embedding: response.data,
+         embedding: response.data[0],
        };
      } catch(err) {
        return {

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -1,6 +1,8 @@
 import fetch from 'node-fetch';
+import {fetchWithCache} from '../cache';
 
-import type { ApiProvider, ProviderEmbeddingResponse, ProviderResponse } from '../types.js';
+import type { ApiProvider, ProviderEmbeddingResponse, ProviderResponse } from '../types';
+import {REQUEST_TIMEOUT_MS} from './shared';
 
 interface HuggingfaceTextGenerationOptions {
   top_k?: number;
@@ -44,32 +46,36 @@ export class HuggingfaceTextGenerationProvider implements ApiProvider {
       },
     };
 
-    const response = await fetch(`https://api-inference.huggingface.co/models/${this.modelName}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.HF_API_TOKEN}`,
-      },
-      body: JSON.stringify(params),
-    });
+    let response;
+    try {
+      response = await fetchWithCache(`https://api-inference.huggingface.co/models/${this.modelName}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.HF_API_TOKEN}`,
+        },
+        body: JSON.stringify(params),
+      }, REQUEST_TIMEOUT_MS);
 
-    if (!response.ok) {
-      try {
-        const json = await response.json();
+      if (response.data.error) {
         return {
-          error: `API call error: ${json.error}\nHTTP ${response.status} ${response.statusText}`,
-        };
-      } catch {
-        return {
-          error: `API call error: ${response.status} ${response.statusText}`,
+          error: `API call error: ${response.data.error}`,
         };
       }
-    }
+      if (!response.data[0]) {
+        return {
+          error: `Malformed response data: ${response.data}`,
+        };
+      }
 
-    const data = await response.json();
-    return {
-      output: data[0]?.generated_text,
-    };
+      return {
+        output: response.data[0]?.generated_text,
+      };
+    } catch(err) {
+      return {
+        error: `API call error: ${String(err)}. Output:\n${response?.data}`,
+      };
+    }
   }
 }
 

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -136,10 +136,10 @@ export class OllamaProvider implements ApiProvider {
 }
 
 export class OllamaEmbeddingProvider extends OllamaProvider {
-  async callEmbeddingApi(prompt: string): Promise<ProviderEmbeddingResponse> {
+  async callEmbeddingApi(text: string): Promise<ProviderEmbeddingResponse> {
     const params = {
       model: this.modelName,
-      prompt,
+      prompt: text,
     };
 
     logger.debug(`Calling Ollama API: ${JSON.stringify(params)}`);

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/providers/azureopenai';
 import { OllamaProvider } from '../src/providers/ollama';
 import { WebhookProvider } from '../src/providers/webhook';
+import { HuggingfaceTextGenerationProvider, HuggingfaceFeatureExtractionProvider } from '../src/providers/huggingface';
 
 import type { ProviderOptionsMap, ProviderFunction } from '../src/types';
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -243,9 +243,9 @@ describe('providers', () => {
 
   test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue([
+      json: jest.fn().mockResolvedValue(
         [0.1, 0.2, 0.3, 0.4, 0.5],
-      ]),
+      ),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -226,6 +226,37 @@ describe('providers', () => {
     expect(result.output).toBe('Test output');
   });
 
+  test('HuggingfaceTextGenerationProvider callApi', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue([
+        { generated_text: 'Test output' },
+      ]),
+    };
+    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+
+    const provider = new HuggingfaceTextGenerationProvider('gpt2');
+    const result = await provider.callApi('Test prompt');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.output).toBe('Test output');
+  });
+
+  test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue([
+        [0.1, 0.2, 0.3, 0.4, 0.5],
+      ]),
+    };
+    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+
+    const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
+    const result = await provider.callEmbeddingApi('Test text');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
+  });
+
+
   test('loadApiProvider with openai:chat', async () => {
     const provider = await loadApiProvider('openai:chat');
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
@@ -266,36 +297,6 @@ describe('providers', () => {
     expect(provider).toBeInstanceOf(AnthropicCompletionProvider);
   });
 
-  test('HuggingfaceTextGenerationProvider callApi', async () => {
-    const mockResponse = {
-      json: jest.fn().mockResolvedValue([
-        { generated_text: 'Test output' },
-      ]),
-    };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
-
-    const provider = new HuggingfaceTextGenerationProvider('gpt2');
-    const result = await provider.callApi('Test prompt');
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(result.output).toBe('Test output');
-  });
-
-  test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
-    const mockResponse = {
-      json: jest.fn().mockResolvedValue([
-        [0.1, 0.2, 0.3, 0.4, 0.5],
-      ]),
-    };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
-
-    const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
-    const result = await provider.callEmbeddingApi('Test text');
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
-  });
-
   test('loadApiProvider with ollama:modelName', async () => {
     const provider = await loadApiProvider('ollama:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaProvider);
@@ -310,6 +311,16 @@ describe('providers', () => {
   test('loadApiProvider with webhook', async () => {
     const provider = await loadApiProvider('webhook:http://example.com/webhook');
     expect(provider).toBeInstanceOf(WebhookProvider);
+  });
+
+  test('loadApiProvider with huggingface:text-generation', async () => {
+    const provider = await loadApiProvider('huggingface:text-generation:foobar/baz');
+    expect(provider).toBeInstanceOf(HuggingfaceTextGenerationProvider);
+  });
+
+  test('loadApiProvider with huggingface:feature-extraction', async () => {
+    const provider = await loadApiProvider('huggingface:feature-extraction:foobar/baz');
+    expect(provider).toBeInstanceOf(HuggingfaceFeatureExtractionProvider);
   });
 
   test('loadApiProvider with RawProviderConfig', async () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -265,6 +265,36 @@ describe('providers', () => {
     expect(provider).toBeInstanceOf(AnthropicCompletionProvider);
   });
 
+  test('HuggingfaceTextGenerationProvider callApi', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue([
+        { generated_text: 'Test output' },
+      ]),
+    };
+    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+
+    const provider = new HuggingfaceTextGenerationProvider('gpt2');
+    const result = await provider.callApi('Test prompt');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.output).toBe('Test output');
+  });
+
+  test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue([
+        [0.1, 0.2, 0.3, 0.4, 0.5],
+      ]),
+    };
+    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+
+    const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
+    const result = await provider.callEmbeddingApi('Test text');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
+  });
+
   test('loadApiProvider with ollama:modelName', async () => {
     const provider = await loadApiProvider('ollama:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaProvider);


### PR DESCRIPTION
Adds support for HuggingFace text generation models.

Example
```yaml
providers:
  - id: huggingface:text-generation:mistralai/Mistral-7B-v0.1
    config:
      temperature: 0.1
```

Related to #133 