### PR TITLE
Add _conversation variable for testing multiple-turn chat conversations

### DIFF
--- a/examples/multiple-turn-conversation/README.md
+++ b/examples/multiple-turn-conversation/README.md
@@ -14,7 +14,7 @@ type Conversation = Completion[];
 
 When looping through `_conversation`, use `completion.prompt` in the Nunjucks prompt template to use the previous outputs. For example, `completion.prompt[completion.prompt.length - 1].content` is the last user message sent in a chat-formatted prompt.
 
-`completion.input` is the last part of the prompt. In a chat-formatted conversation, it will be equal to `completion.prompt[completion.prompt.length - 1].content`.  In other conversations, it will be equal to `completion.prompt[completion.prompt.length - 1]`.
+`completion.input` is the last part of the prompt. In a chat-formatted conversation, it will be equal to `completion.prompt[completion.prompt.length - 1].content`. In other conversations, it will be equal to `completion.prompt[completion.prompt.length - 1]`.
 
 Use `completion.output` to get the assistant's response to that message.
 

--- a/examples/multiple-turn-conversation/README.md
+++ b/examples/multiple-turn-conversation/README.md
@@ -5,6 +5,7 @@ Next, have a look at prompt.json and edit promptfooconfig.yaml. The prompt uses 
 ```ts
 type Completion = {
   prompt: string | object;
+  input: string;
   output: string;
 };
 
@@ -12,6 +13,8 @@ type Conversation = Completion[];
 ```
 
 When looping through `_conversation`, use `completion.prompt` in the Nunjucks prompt template to use the previous outputs. For example, `completion.prompt[completion.prompt.length - 1].content` is the last user message sent in a chat-formatted prompt.
+
+`completion.input` is the last part of the prompt. In a chat-formatted conversation, it will be equal to `completion.prompt[completion.prompt.length - 1].content`.  In other conversations, it will be equal to `completion.prompt[completion.prompt.length - 1]`.
 
 Use `completion.output` to get the assistant's response to that message.
 

--- a/examples/multiple-turn-conversation/README.md
+++ b/examples/multiple-turn-conversation/README.md
@@ -1,0 +1,24 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, have a look at prompt.json and edit promptfooconfig.yaml. The prompt uses a special built-in variable `_conversation` that has the following signature:
+
+```ts
+type Completion = {
+  prompt: string | object;
+  output: string;
+};
+
+type Conversation = Completion[];
+```
+
+When looping through `_conversation`, use `completion.prompt` in the Nunjucks prompt template to use the previous outputs. For example, `completion.prompt[completion.prompt.length - 1].content` is the last user message sent in a chat-formatted prompt.
+
+Use `completion.output` to get the assistant's response to that message.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/multiple-turn-conversation/prompt.json
+++ b/examples/multiple-turn-conversation/prompt.json
@@ -6,7 +6,7 @@
   {% for completion in _conversation %}
     {
       "role": "user",
-      "content": "{{ completion.input[completion.input.length - 1].content }}"
+      "content": "{{ completion.prompt[completion.prompt.length - 1].content }}"
     },
     {
       "role": "assistant",

--- a/examples/multiple-turn-conversation/prompt.json
+++ b/examples/multiple-turn-conversation/prompt.json
@@ -1,0 +1,20 @@
+[
+  {
+    "role": "system",
+    "content": "{{ system_message }}"
+  },
+  {% for completion in _conversation %}
+    {
+      "role": "user",
+      "content": "{{ completion.input[completion.input.length - 1].content }}"
+    },
+    {
+      "role": "assistant",
+      "content": "{{ completion.output }}"
+    },
+  {% endfor %}
+  {
+    "role": "user",
+    "content": "{{ question }}"
+  }
+]

--- a/examples/multiple-turn-conversation/promptfooconfig.yaml
+++ b/examples/multiple-turn-conversation/promptfooconfig.yaml
@@ -1,0 +1,16 @@
+prompts: [prompt.json]
+providers: [openai:gpt-3.5-turbo]
+
+# Set up the system message for all tests
+defaultTest:
+  vars:
+    system_message: You are a helpful assistant
+
+# Test out a conversation with multiple turns
+tests:
+  - vars:
+      question: Who founded Facebook?
+  - vars:
+      question: What's his favorite food?
+  - vars:
+      question: Will he let me borrow $5?

--- a/examples/multiple-turn-conversation/promptfooconfig.yaml
+++ b/examples/multiple-turn-conversation/promptfooconfig.yaml
@@ -11,6 +11,6 @@ tests:
   - vars:
       question: Who founded Facebook?
   - vars:
-      question: What's his favorite food?
+      question: Where does he live?
   - vars:
-      question: Will he let me borrow $5?
+      question: Which state is that in?

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -124,6 +124,7 @@ class Evaluator {
   testSuite: TestSuite;
   options: EvaluateOptions;
   stats: EvaluateStats;
+  previousOutput: string | undefined;
 
   constructor(testSuite: TestSuite, options: EvaluateOptions) {
     this.testSuite = testSuite;
@@ -138,6 +139,7 @@ class Evaluator {
         cached: 0,
       },
     };
+    this.previousOutput = undefined;
   }
 
   async runEval({
@@ -148,7 +150,7 @@ class Evaluator {
     delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
-    vars._lastOutput = 'TODO';
+    vars._lastOutput = this.previousOutput || 'No previous output';
     const renderedPrompt = await renderPrompt(prompt, vars);
 
     // Note that we're using original prompt, not renderedPrompt
@@ -176,6 +178,8 @@ class Evaluator {
       });
       const endTime = Date.now();
       latencyMs = endTime - startTime;
+
+      this.previousOutput = response.output;
 
       if (!response.cached) {
         let sleep = delay;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -124,7 +124,7 @@ class Evaluator {
   testSuite: TestSuite;
   options: EvaluateOptions;
   stats: EvaluateStats;
-  conversations: Record<string, { prompt: string | object; input: string, output: string }[]>;
+  conversations: Record<string, { prompt: string | object; input: string; output: string }[]>;
 
   constructor(testSuite: TestSuite, options: EvaluateOptions) {
     this.testSuite = testSuite;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -148,6 +148,7 @@ class Evaluator {
     delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
+    vars._lastOutput = 'TODO';
     const renderedPrompt = await renderPrompt(prompt, vars);
 
     // Note that we're using original prompt, not renderedPrompt

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -150,7 +150,7 @@ class Evaluator {
     delay,
   }: RunEvalOptions): Promise<EvaluateResult> {
     const vars = test.vars || {};
-    vars._lastOutput = this.previousOutput || 'No previous output';
+    vars._lastOutput = this.previousOutput || 'undefined';
     const renderedPrompt = await renderPrompt(prompt, vars);
 
     // Note that we're using original prompt, not renderedPrompt


### PR DESCRIPTION
This change adds a built-in `_conversation` variable that contains the prompt and output of previous turns of a conversation.  This is makes it easier to test an ongoing chat conversation, a request that I've received a few times.

The `_conversation` variable has the following type signature:
```ts
type Completion = {
  prompt: string | object;
  input: string;
  output: string;
};

type Conversation = Completion[];
```

When looping through `_conversation`, use `completion.prompt` in the Nunjucks prompt template to reference the previous conversation. For example, `completion.prompt.length` will get the number of messages in a chat-formatted prompt.

Use `completion.input` as a shortcut to get the last user message.  It is set to the last user message - `completion.prompt[completion.prompt.length - 1].content` - in a chat-formatted prompt.  If the prompt is not chat-formatted, its value will be `completion.prompt[completion.prompt.length - 1]` or the full prompt itself.

Here's an example test config.  Note how each question assumes context from the previous output:
```yaml
tests:
  - vars:
      question: Who founded Facebook?
  - vars:
      question: Where does he live?
  - vars:
      question: Which state is that in?
```

And an example prompt:
```
[
  {% for completion in _conversation %}
    {
      "role": "user",
      "content": "{{ completion.input }}"
    },
    {
      "role": "assistant",
      "content": "{{ completion.output }}"
    },
  {% endfor %}
  {
    "role": "user",
    "content": "{{ question }}"
  }
]
```

![multiple turn conversation eval](https://github.com/promptfoo/promptfoo/assets/310310/70048ae5-34ce-46f0-bd28-42d3aa96f03e)

Previously, to do this sort of test you'd have to create a stateful custom `ApiProvider`.  With this change, you can access the full history of a conversation within each prompt.

Note that when the `_conversation` variable is present, the eval is run single-threaded (concurrency of 1).