### PR TITLE
Allow multiple output formats simultaneously with `outputPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ You can also use `promptfoo` as a library in your project by importing the `eval
     tests: string | TestCase[]; // Path to a CSV file, or list of test cases
 
     defaultTest?: Omit<TestCase, 'description'>; // Optional: add default vars and assertions on test case
-    outputPath?: string; // Optional: write results to file
+    outputPath?: string | string[]; // Optional: write results to file
   }
 
   interface TestCase {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { disableCache } from './cache';
 import { evaluate as doEvaluate } from './evaluator';
 import { loadApiProviders } from './providers';
 import { readTests } from './testCases';
-import { writeLatestResults, writeOutput } from './util';
+import { writeLatestResults, writeMultipleOutputs, writeOutput } from './util';
 import type { EvaluateOptions, TestSuite, EvaluateTestSuite, ProviderOptions } from './types';
 
 export * from './types';
@@ -61,7 +61,11 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
   const ret = await doEvaluate(constructedTestSuite, options);
 
   if (testSuite.outputPath) {
-    writeOutput(testSuite.outputPath, ret, testSuite, null);
+    if (typeof testSuite.outputPath === 'string') {
+      writeOutput(testSuite.outputPath, ret, testSuite, null);
+    } else if (Array.isArray(testSuite.outputPath)) {
+      writeMultipleOutputs(testSuite.outputPath, ret, testSuite, null);
+    }
   }
 
   if (testSuite.writeLatestResults) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
   readLatestResults,
   writeLatestResults,
   writeOutput,
+  writeMultipleOutputs,
 } from './util';
 import { DEFAULT_README, DEFAULT_YAML_CONFIG, DEFAULT_PROMPTS } from './onboarding';
 import { disableCache, clearCache } from './cache';
@@ -409,8 +410,12 @@ async function main() {
         cmdObj.share && config.sharing ? await createShareableUrl(summary, config) : null;
 
       if (cmdObj.output) {
+        if (typeof cmdObj.output === 'string') {
+          writeOutput(cmdObj.output, summary, config, shareableUrl);
+        } else if (Array.isArray(cmdObj.output)) {
+          writeMultipleOutputs(cmdObj.output, summary, config, shareableUrl);
+        }
         logger.info(chalk.yellow(`Writing output to ${cmdObj.output}`));
-        writeOutput(cmdObj.output, summary, config, shareableUrl);
       } else if (cmdObj.table && getLogLevel() !== 'debug') {
         // Output table by default
         const table = generateTable(summary, parseInt(cmdObj.tableCellMaxLength || '', 10));

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,7 +220,7 @@ async function main() {
     )
     .option('-t, --tests <path>', 'Path to CSV with test cases')
     .option(
-      '-o, --output <path>',
+      '-o, --output <paths...>',
       'Path to output file (csv, txt, json, yaml, yml, html)',
       defaultConfig.outputPath,
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface CommandLineOptions {
   // Shared with TestSuite
   prompts: string[];
   providers: string[];
-  output: string;
+  output: string[];
 
   // Shared with EvaluateOptions
   maxConcurrency: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -373,7 +373,7 @@ export interface TestSuiteConfig {
   defaultTest?: Omit<TestCase, 'description'>;
 
   // Path to write output. Writes to console/web viewer if not set.
-  outputPath?: string;
+  outputPath?: string | string[];
 
   // Determines whether or not sharing is enabled.
   sharing?: boolean;

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,6 +88,17 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
   }
 }
 
+export function writeMultipleOutputs(
+  outputPaths: string[],
+  results: EvaluateSummary,
+  config: Partial<UnifiedConfig>,
+  shareableUrl: string | null,
+): void {
+  for (const outputPath of outputPaths) {
+    writeOutput(outputPath, results, config, shareableUrl);
+  }
+}
+
 export function writeOutput(
   outputPath: string,
   results: EvaluateSummary,

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 import yaml from 'js-yaml';
 
-import { writeOutput, readGlobalConfig, maybeRecordFirstRun, resetGlobalConfig } from '../src/util';
+import { writeOutput, writeMultipleOutputs, readGlobalConfig, maybeRecordFirstRun, resetGlobalConfig } from '../src/util';
 
 import type { EvaluateResult, EvaluateTable } from '../src/types';
 
@@ -203,6 +203,67 @@ describe('util', () => {
     writeOutput(outputPath, summary, config, shareableUrl);
 
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  test('writeOutput with json and txt output', () => {
+    const outputPath = ['output.json', 'output.txt'];
+    const results: EvaluateResult[] = [
+      {
+        success: true,
+        score: 1.0,
+        latencyMs: 1000,
+        provider: {
+          id: 'foo',
+        },
+        prompt: {
+          raw: 'Test prompt',
+          display: '[display] Test prompt',
+        },
+        response: {
+          output: 'Test output',
+        },
+        vars: {
+          var1: 'value1',
+          var2: 'value2',
+        },
+      },
+    ];
+    const table: EvaluateTable = {
+      head: {
+        prompts: [{ raw: 'Test prompt', display: '[display] Test prompt' }],
+        vars: ['var1', 'var2'],
+      },
+      body: [
+        {
+          outputs: [
+            { pass: true, score: 1.0, text: 'Test output', prompt: 'Test prompt', latencyMs: 1000 },
+          ],
+          vars: ['value1', 'value2'],
+        },
+      ],
+    };
+    const summary = {
+      version: 1,
+      stats: {
+        successes: 1,
+        failures: 1,
+        tokenUsage: {
+          total: 10,
+          prompt: 5,
+          completion: 5,
+          cached: 0,
+        },
+      },
+      results,
+      table,
+    };
+    const config = {
+      description: 'test',
+    };
+    const shareableUrl = null;
+    writeMultipleOutputs(outputPath, summary, config, shareableUrl);
+
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
   });
 
   describe('readCliConfig', () => {


### PR DESCRIPTION
Close issue https://github.com/promptfoo/promptfoo/issues/227 to allow multiple outputs.