### PR TITLE
allow Python in tests.csv

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -734,9 +734,13 @@ function containsJSON(str: string): any {
 
 export function assertionFromString(expected: string): Assertion {
   // Legacy options
-  if (expected.startsWith('fn:') || expected.startsWith('eval:')) {
+  if (expected.startsWith('javascript:') || expected.startsWith('fn:') || expected.startsWith('eval:')) {
     // TODO(1.0): delete eval: legacy option
-    const sliceLength = expected.startsWith('fn:') ? 'fn:'.length : 'eval:'.length;
+    let sliceLength;
+    if (expected.startsWith('javascript:')) { sliceLength = 'javascript:'.length; }
+    if (expected.startsWith('fn:')) { sliceLength = 'fn:'.length; }
+    if (expected.startsWith('eval:')) { sliceLength = 'eval:'.length; }
+
     const functionBody = expected.slice(sliceLength);
     return {
       type: 'javascript',
@@ -747,6 +751,14 @@ export function assertionFromString(expected: string): Assertion {
     return {
       type: 'llm-rubric',
       value: expected.slice(6),
+    };
+  }
+  if (expected.startsWith('python:')) {
+    const sliceLength = 'python:'.length;
+    const functionBody = expected.slice(sliceLength);
+    return {
+      type: 'python',
+      value: functionBody,
     };
   }
 


### PR DESCRIPTION
Additionally I added the option to call inline JS with `javascript:`

This PR addresses part of https://github.com/promptfoo/promptfoo/issues/238