### PR TITLE
Add support for nunjucks filters

### DIFF
--- a/examples/nunjucks-custom-filters/README.md
+++ b/examples/nunjucks-custom-filters/README.md
@@ -1,0 +1,7 @@
+This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+
+```
+promptfoo eval
+```
+
+`allcaps.js` is a standard [Nunjucks custom filter](https://mozilla.github.io/nunjucks/api.html#custom-filters).

--- a/examples/nunjucks-custom-filters/allcaps.js
+++ b/examples/nunjucks-custom-filters/allcaps.js
@@ -1,0 +1,3 @@
+module.exports = function (str) {
+  return str.toUpperCase();
+};

--- a/examples/nunjucks-custom-filters/promptfooconfig.yaml
+++ b/examples/nunjucks-custom-filters/promptfooconfig.yaml
@@ -1,0 +1,11 @@
+prompts: [prompts.txt]
+providers: [openai:gpt-3.5-turbo]
+filters:
+  allcaps: ./allcaps.js
+tests:
+  - vars:
+      language: French
+      body: Hello world
+  - vars:
+      language: French
+      body: I'm hungry

--- a/examples/nunjucks-custom-filters/promptfooconfig.yaml
+++ b/examples/nunjucks-custom-filters/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 prompts: [prompts.txt]
 providers: [openai:gpt-3.5-turbo]
-filters:
+nunjucksFilters:
   allcaps: ./allcaps.js
 tests:
   - vars:

--- a/examples/nunjucks-custom-filters/prompts.txt
+++ b/examples/nunjucks-custom-filters/prompts.txt
@@ -1,0 +1,3 @@
+Rephrase this in {{language}}: {{body | allcaps}}
+---
+Translate this to conversational {{language}}: {{body | allcaps}}

--- a/examples/simple-cli/README.md
+++ b/examples/simple-cli/README.md
@@ -1,4 +1,4 @@
-This example is pre-configured in `promptfooconfig.yaml` (both identical examples). That means you can just run:
+This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
 
 ```
 promptfoo eval

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -31,7 +31,7 @@ interface RunEvalOptions {
   delay: number;
 
   test: AtomicTestCase;
-  filters?: NunjucksFilterMap;
+  nunjucksFilters?: NunjucksFilterMap;
 
   includeProviderId?: boolean;
 
@@ -150,7 +150,7 @@ class Evaluator {
     test,
     includeProviderId,
     delay,
-    filters,
+    nunjucksFilters: filters,
   }: RunEvalOptions): Promise<EvaluateResult> {
     // Use the original prompt to set the display, not renderedPrompt
     let promptDisplay = prompt.display;
@@ -466,7 +466,7 @@ class Evaluator {
                   raw: prependToPrompt + prompt.raw + appendToPrompt,
                 },
                 test: { ...testCase, vars, options: testCase.options },
-                filters: testSuite.filters,
+                nunjucksFilters: testSuite.nunjucksFilters,
                 includeProviderId: testSuite.providers.length > 1,
                 rowIndex,
                 colIndex,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -13,15 +13,16 @@ import { getNunjucksEngine, sha256 } from './util';
 import type { SingleBar } from 'cli-progress';
 import type {
   ApiProvider,
+  AtomicTestCase,
   EvaluateOptions,
   EvaluateResult,
   EvaluateStats,
   EvaluateSummary,
   EvaluateTable,
-  TestSuite,
+  NunjucksFilterMap,
   Prompt,
   TestCase,
-  AtomicTestCase,
+  TestSuite,
 } from './types';
 
 interface RunEvalOptions {
@@ -30,6 +31,7 @@ interface RunEvalOptions {
   delay: number;
 
   test: AtomicTestCase;
+  filters?: NunjucksFilterMap;
 
   includeProviderId?: boolean;
 
@@ -39,8 +41,6 @@ interface RunEvalOptions {
 }
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
-
-const nunjucks = getNunjucksEngine();
 
 function generateVarCombinations(
   vars: Record<string, string | string[] | any>,
@@ -74,7 +74,9 @@ function generateVarCombinations(
 export async function renderPrompt(
   prompt: Prompt,
   vars: Record<string, string | object>,
+  nunjucksFilters?: NunjucksFilterMap,
 ): Promise<string> {
+  const nunjucks = getNunjucksEngine(nunjucksFilters);
   let basePrompt = prompt.raw;
   if (prompt.function) {
     const result = await prompt.function({ vars });
@@ -148,6 +150,7 @@ class Evaluator {
     test,
     includeProviderId,
     delay,
+    filters,
   }: RunEvalOptions): Promise<EvaluateResult> {
     // Use the original prompt to set the display, not renderedPrompt
     let promptDisplay = prompt.display;
@@ -161,7 +164,7 @@ class Evaluator {
     vars._conversation = this.conversations[conversationKey] || [];
 
     // Render the prompt
-    const renderedPrompt = await renderPrompt(prompt, vars);
+    const renderedPrompt = await renderPrompt(prompt, vars, filters);
 
     let renderedJson = undefined;
     try {
@@ -463,6 +466,7 @@ class Evaluator {
                   raw: prependToPrompt + prompt.raw + appendToPrompt,
                 },
                 test: { ...testCase, vars, options: testCase.options },
+                filters: testSuite.filters,
                 includeProviderId: testSuite.providers.length > 1,
                 rowIndex,
                 colIndex,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     }),
     tests: await readTests(testSuite.tests),
 
-    filters: readFilters(testSuite.filters || {}),
+    nunjucksFilters: readFilters(testSuite.nunjucksFilters || {}),
 
     // Full prompts expected (not filepaths)
     prompts: testSuite.prompts.map((promptContent) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { disableCache } from './cache';
 import { evaluate as doEvaluate } from './evaluator';
 import { loadApiProviders } from './providers';
 import { readTests } from './testCases';
-import { writeLatestResults, writeMultipleOutputs, writeOutput } from './util';
+import { readFilters, writeLatestResults, writeMultipleOutputs, writeOutput } from './util';
 import type { EvaluateOptions, TestSuite, EvaluateTestSuite, ProviderOptions } from './types';
 
 export * from './types';
@@ -21,6 +21,8 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
       env: testSuite.env,
     }),
     tests: await readTests(testSuite.tests),
+
+    filters: readFilters(testSuite.filters || {}),
 
     // Full prompts expected (not filepaths)
     prompts: testSuite.prompts.map((promptContent) => ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   maybeReadConfig,
   printBorder,
   readConfig,
+  readFilters,
   readLatestResults,
   writeLatestResults,
   writeOutput,
@@ -38,7 +39,7 @@ import type {
   TestSuite,
   UnifiedConfig,
 } from './types';
-import { generateTable, wrapTable } from './table';
+import { generateTable } from './table';
 import { createShareableUrl } from './share';
 
 function createDummyFiles(directory: string | null) {
@@ -372,6 +373,7 @@ async function main() {
         tests: parsedTests,
         scenarios: config.scenarios,
         defaultTest,
+        filters: readFilters(fileConfig.filters || defaultConfig.filters || {}, basePath),
       };
 
       let maxConcurrency = parseInt(cmdObj.maxConcurrency || '', 10);

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,7 +373,7 @@ async function main() {
         tests: parsedTests,
         scenarios: config.scenarios,
         defaultTest,
-        filters: readFilters(fileConfig.filters || defaultConfig.filters || {}, basePath),
+        nunjucksFilters: readFilters(fileConfig.nunjucksFilters || defaultConfig.nunjucksFilters || {}, basePath),
       };
 
       let maxConcurrency = parseInt(cmdObj.maxConcurrency || '', 10);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
+export type FilePath = string;
+
 export interface CommandLineOptions {
   // Shared with TestSuite
-  prompts: string[];
-  providers: string[];
-  output: string[];
+  prompts: FilePath[];
+  providers: FilePath[];
+  output: FilePath[];
 
   // Shared with EvaluateOptions
   maxConcurrency: string;
@@ -10,9 +12,9 @@ export interface CommandLineOptions {
   delay: string;
 
   // Command line only
-  vars?: string;
-  tests?: string;
-  config?: string;
+  vars?: FilePath;
+  tests?: FilePath;
+  config?: FilePath;
   verbose?: boolean;
   grader?: string;
   view?: string;
@@ -145,7 +147,7 @@ export interface PromptWithMetadata {
   recentEvalFilepath: string;
   evals: {
     id: string;
-    filePath: string;
+    filePath: FilePath;
     datasetId: string;
     metrics: Prompt['metrics'];
   }[];
@@ -266,15 +268,15 @@ export interface TestCasesWithMetadataPrompt {
   prompt: Prompt;
   id: string;
   evalId: string;
-  evalFilepath: string;
+  evalFilepath: FilePath;
 }
 
 export interface TestCasesWithMetadata {
   id: string;
-  testCases: string | string[] | TestCase[];
+  testCases: FilePath | FilePath[] | TestCase[];
   recentEvalDate: Date;
   recentEvalId: string;
-  recentEvalFilepath: string;
+  recentEvalFilepath: FilePath;
   count: number;
   prompts: TestCasesWithMetadataPrompt[];
 }
@@ -313,6 +315,8 @@ export interface AtomicTestCase<Vars = Record<string, string | object>> extends 
   vars?: Record<string, string | object>;
 }
 
+export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;
+
 // The test suite defines the "knobs" that we are tuning in prompt engineering: providers and prompts
 export interface TestSuite {
   // Optional description of what your LLM is trying to do
@@ -336,6 +340,9 @@ export interface TestSuite {
 
   // Default test case config
   defaultTest?: Partial<TestCase>;
+
+  // Nunjucks filters
+  filters?: NunjucksFilterMap;
 
   // Envar overrides
   env?: EnvOverrides;
@@ -361,10 +368,10 @@ export interface TestSuiteConfig {
     | ProviderFunction;
 
   // One or more prompt files to load
-  prompts: string | string[];
+  prompts: FilePath | FilePath[];
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
-  tests: string | string[] | TestCase[];
+  tests: FilePath | FilePath[] | TestCase[];
 
   // Scenarios, groupings of data and tests to be evaluated
   scenarios?: Scenario[];
@@ -373,10 +380,13 @@ export interface TestSuiteConfig {
   defaultTest?: Omit<TestCase, 'description'>;
 
   // Path to write output. Writes to console/web viewer if not set.
-  outputPath?: string | string[];
+  outputPath?: FilePath | FilePath[];
 
   // Determines whether or not sharing is enabled.
   sharing?: boolean;
+
+  // Nunjucks filters
+  filters?: Record<string, FilePath>;
 
   // Envar overrides
   env?: EnvOverrides;
@@ -389,7 +399,7 @@ export type UnifiedConfig = TestSuiteConfig & {
 
 export interface EvalWithMetadata {
   id: string;
-  filePath: string;
+  filePath: FilePath;
   date: Date;
   config: Partial<UnifiedConfig>;
   results: EvaluateSummary;

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,7 +342,7 @@ export interface TestSuite {
   defaultTest?: Partial<TestCase>;
 
   // Nunjucks filters
-  filters?: NunjucksFilterMap;
+  nunjucksFilters?: NunjucksFilterMap;
 
   // Envar overrides
   env?: EnvOverrides;
@@ -386,7 +386,7 @@ export interface TestSuiteConfig {
   sharing?: boolean;
 
   // Nunjucks filters
-  filters?: Record<string, FilePath>;
+  nunjucksFilters?: Record<string, FilePath>;
 
   // Envar overrides
   env?: EnvOverrides;

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { globSync } from 'glob';
 
 import { readPrompts } from '../src/prompts';

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,4 +1,7 @@
 import * as fs from 'fs';
+import * as path from 'path';
+
+import { globSync } from 'glob';
 
 import yaml from 'js-yaml';
 
@@ -8,9 +11,14 @@ import {
   readGlobalConfig,
   maybeRecordFirstRun,
   resetGlobalConfig,
+  readFilters,
 } from '../src/util';
 
 import type { EvaluateResult, EvaluateTable } from '../src/types';
+
+jest.mock('glob', () => ({
+  globSync: jest.fn(),
+}));
 
 jest.mock('fs', () => ({
   readFileSync: jest.fn(),
@@ -328,5 +336,16 @@ describe('util', () => {
       expect(fs.readFileSync).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
+  });
+
+  test('readFilters', () => {
+    const mockFilter = jest.fn();
+    jest.doMock(path.resolve('filter.js'), () => mockFilter, { virtual: true });
+
+    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+
+    const filters = readFilters({ testFilter: 'filter.js' });
+
+    expect(filters.testFilter).toBe(mockFilter);
   });
 });


### PR DESCRIPTION
Adds support for nunjucks filters.  For example

promptfooconfig.yaml:
```yaml
prompts: [prompts.txt]
providers: [openai:gpt-3.5-turbo]
nunjucksFilters:
  allcaps: ./allcaps.js
tests:
  # ...
```

allcaps.js:
```js
module.exports = function (str) {
  return str.toUpperCase();
};
```

`allcaps` can be used as a filter in `prompts.txt`:
```
Rephrase this in {{language}}: {{body | allcaps}}
```