### PR TITLE
cli: Add support for raw text prompts

### DIFF
--- a/examples/assistant-cli/promptfooconfig.yaml
+++ b/examples/assistant-cli/promptfooconfig.yaml
@@ -1,3 +1,3 @@
-prompts: prompts.txt
+prompts: file://prompts.txt
 providers: openai:gpt-3.5-turbo
 tests: tests.csv

--- a/examples/simple-cli/promptfooconfig.yaml
+++ b/examples/simple-cli/promptfooconfig.yaml
@@ -1,5 +1,7 @@
 description: A translator built with LLM
-prompts: [prompts.txt]
+prompts:
+  - prompts.txt
+  - :) hehe hi
 providers: [openai:gpt-3.5-turbo]
 tests:
   - vars:

--- a/examples/simple-cli/promptfooconfig.yaml
+++ b/examples/simple-cli/promptfooconfig.yaml
@@ -1,7 +1,6 @@
-description: A translator built with LLM
 prompts:
-  - prompts.txt
-  - :) hehe hi
+  - "Rephrase this in {{language}}: {{body}}"
+  - "Translate this to conversational {{language}}: {{body}}"
 providers: [openai:gpt-3.5-turbo]
 tests:
   - vars:

--- a/examples/simple-cli/prompts.txt
+++ b/examples/simple-cli/prompts.txt
@@ -1,3 +1,0 @@
-Rephrase this in {{language}}: {{body}}
----
-Translate this to conversational {{language}}: {{body}}

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -19,6 +19,7 @@ If you prefer, you can break prompts into multiple files (make sure to edit prom
 `;
 
 export const DEFAULT_YAML_CONFIG = `# This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
+# Learn more: https://promptfoo.dev/docs/configuration/guide
 
 prompts:
   - "Example prompt 1"
@@ -26,7 +27,8 @@ prompts:
   - |-
     Example prompt 3
     This is a multi-line prompt
-  # You can also import prompts from file:
+  # You may also import prompts from file. This path is relative to the config file.
+  # For more information on prompts, see https://promptfoo.dev/docs/configuration/parameters.
   - file://prompts.txt
 providers: [openai:gpt-3.5-turbo-0613]
 tests:
@@ -35,6 +37,7 @@ tests:
       var1: first variable's value
       var2: another value
       var3: some other value
+    # For more information on assertions, see https://promptfoo.dev/docs/configuration/expected-outputs
     assert:
       - type: equals
         value: expected LLM output goes here
@@ -59,13 +62,13 @@ tests:
       - type: contains-json
       - type: similar
         value: ensures that output is semantically similar to this text
-      - type: llm-rubric
+      - type: model-graded-closedqa
         value: ensure that output contains a reference to X
 `;
 
 export const DEFAULT_README = `To get started, set your OPENAI_API_KEY environment variable.
 
-Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
+Next, edit promptfooconfig.yaml.
 
 Then run:
 \`\`\`

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -23,6 +23,9 @@ export const DEFAULT_YAML_CONFIG = `# This configuration runs each prompt throug
 prompts:
   - "Example prompt 1"
   - "Example prompt 2"
+  - |-
+    Example prompt 3
+    This is a multi-line prompt
   # You can also import prompts from file:
   - file://prompts.txt
 providers: [openai:gpt-3.5-turbo-0613]

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -20,7 +20,11 @@ If you prefer, you can break prompts into multiple files (make sure to edit prom
 
 export const DEFAULT_YAML_CONFIG = `# This configuration runs each prompt through a series of example inputs and checks if they meet requirements.
 
-prompts: [prompts.txt]
+prompts:
+  - "Example prompt 1"
+  - "Example prompt 2"
+  # You can also import prompts from file:
+  - file://prompts.txt
 providers: [openai:gpt-3.5-turbo-0613]
 tests:
   - description: First test case - automatic review

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -84,10 +84,13 @@ export function readPrompts(
     resolvedPathToDisplay.set(resolvedPath, promptPathOrGlobs);
     inputType = PromptInputType.STRING;
   } else if (Array.isArray(promptPathOrGlobs)) {
-    // List of paths to prompt files
+    // List of paths to prompt files or raw prompts
     promptPaths = promptPathOrGlobs.flatMap((pathOrGlob) => {
-      // Could be a raw prompt
-      // TODO: implement
+      // Check if it's a raw prompt
+      if (!pathOrGlob.includes('/') && !pathOrGlob.includes('\\')) {
+        promptContents.push({ raw: pathOrGlob, display: pathOrGlob });
+        return [];
+      }
 
       resolvedPath = path.resolve(basePath, pathOrGlob);
       resolvedPathToDisplay.set(resolvedPath, pathOrGlob);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -64,6 +64,7 @@ enum PromptInputType {
   STRING = 1,
   ARRAY = 2,
   NAMED = 3,
+  RAW = 4,
 }
 
 export function readPrompts(
@@ -77,6 +78,9 @@ export function readPrompts(
   let resolvedPath: string | undefined;
   const resolvedPathToDisplay = new Map<string, string>();
   if (typeof promptPathOrGlobs === 'string') {
+    // Could be a raw prompt
+    // TODO: implement
+
     // Path to a prompt file
     resolvedPath = path.resolve(basePath, promptPathOrGlobs);
     promptPaths = [resolvedPath];

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -78,9 +78,6 @@ export function readPrompts(
   let resolvedPath: string | undefined;
   const resolvedPathToDisplay = new Map<string, string>();
   if (typeof promptPathOrGlobs === 'string') {
-    // Could be a raw prompt
-    // TODO: implement
-
     // Path to a prompt file
     resolvedPath = path.resolve(basePath, promptPathOrGlobs);
     promptPaths = [resolvedPath];
@@ -89,6 +86,9 @@ export function readPrompts(
   } else if (Array.isArray(promptPathOrGlobs)) {
     // List of paths to prompt files
     promptPaths = promptPathOrGlobs.flatMap((pathOrGlob) => {
+      // Could be a raw prompt
+      // TODO: implement
+
       resolvedPath = path.resolve(basePath, pathOrGlob);
       resolvedPathToDisplay.set(resolvedPath, pathOrGlob);
       const globbedPaths = globSync(resolvedPath);


### PR DESCRIPTION
Adds support for configs like this:

```yaml
prompts:
  - "Rephrase this in {{language}}: {{body}}"
  - "Translate this to conversational {{language}}: {{body}}"
providers: [openai:gpt-3.5-turbo]
tests:
  - vars:
      language: French
      body: Hello world
  # ...
```

Also supports the `file://` syntax, which is consistent with behavior elsewhere (such as external asserts):  
```yaml
prompts: 
  - file://prompts.txt
 ```

Supporting raw text prompts will hopefully make the initial setup easier to understand and easier to get running.

For backwards compatibility, it will try loading `prompts` as a file first, then fall back to the raw prompt.  If I could go back in time, I'd make the raw text behavior the default and require the use of `file://` to load files!