### PR TITLE
Fix prompt per provider

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -190,9 +190,14 @@ export function readPrompts(
           const output = execSync(`python "${promptPath}" "${contextString}"`);
           return output.toString();
         };
+        let display = fileContent;
+        if (inputType === PromptInputType.NAMED) {
+          display = resolvedPathToDisplay.get(promptPath) || promptPath;
+        }
+
         promptContents.push({
           raw: fileContent,
-          display: fileContent,
+          display,
           function: promptFunction,
         });
       } else {

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -92,11 +92,14 @@ describe('prompts', () => {
     (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
 
     const result = readPrompts({
-      'prompts.txt': 'foo bar',
+      'prompts.txt': 'foo1',
+      'prompts.py': 'foo2',
     });
 
-    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([{ raw: 'some raw text', display: 'foo bar' }]);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ raw: 'some raw text', display: 'foo1' });
+    expect(result[1]).toEqual(expect.objectContaining({ raw: 'some raw text', display: 'foo2' }));
   });
 
   test('readPrompts with JSONL file', () => {


### PR DESCRIPTION
when configuring the YAML as following:
```
prompts:
  llama.py: ml
  gpt.txt: gp
providers:
  - openai:gpt-3.5-turbo-0613:
      prompts: gp
  - huggingface:text-generation:meta-llama/Llama-2-7b-chat-hf:
      prompts: ml
```

the `.py` file is not assigned with the right alias (ml), which means the same configuration file **can't** use multiple models with each model has a different prompting format

I fixed that and updated the relevant test