### PR TITLE
Fix broken default config for OpenAI evals created in web app

### DIFF
--- a/src/web/nextui/src/app/setup/ProviderSelector.tsx
+++ b/src/web/nextui/src/app/setup/ProviderSelector.tsx
@@ -89,7 +89,6 @@ const defaultProviders: ProviderOptions[] = ([] as (ProviderOptions & { id: stri
       id,
       config: {
         organization: '',
-        apiHost: 'api.openai.com',
         temperature: 0.5,
         max_tokens: 1024,
         top_p: 1.0,


### PR DESCRIPTION
When creating a new eval from the web interface using openai, the default option for apiHost is malformed / wrong.
<img width="1238" alt="Pasted Graphic 1" src="https://github.com/promptfoo/promptfoo/assets/6785029/e592a3ee-5f12-4453-9c8d-b4589fdddceb">

It will always cause this error.
<img width="1257" alt="Pasted Graphic" src="https://github.com/promptfoo/promptfoo/assets/6785029/30e6fdab-14f0-4c94-af49-35f33af2c3d4">

If the default attribute is removed, the issue is resolved.

<img width="1238" alt="Pasted Graphic 4" src="https://github.com/promptfoo/promptfoo/assets/6785029/e163a218-7c67-4e75-bbf4-4bedf0e45f15">

The error no longer appears and the evals are created as intended.
<img width="1238" alt="Pasted Graphic 3" src="https://github.com/promptfoo/promptfoo/assets/6785029/4f70d05e-480e-4a05-ab81-ba319322bd2e">
