### PR TITLE
Add support for custom config directory

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
   writeLatestResults,
   writeOutput,
   writeMultipleOutputs,
+  setConfigDirectoryPath,
 } from './util';
 import { DEFAULT_README, DEFAULT_YAML_CONFIG, DEFAULT_PROMPTS } from './onboarding';
 import { disableCache, clearCache } from './cache';
@@ -123,16 +124,21 @@ async function main() {
     });
 
   program
-    .command('view')
+    .command('view [directory]')
     .description('Start browser ui')
     .option('-p, --port <number>', 'Port number', '15500')
     .option('-y, --yes', 'Skip confirmation and auto-open the URL')
-    .action(async (cmdObj: { port: number; yes: boolean } & Command) => {
+    .action(async (directory: string | undefined, cmdObj: { port: number; yes: boolean } & Command) => {
       telemetry.maybeShowNotice();
       telemetry.record('command_used', {
         name: 'view',
       });
       await telemetry.send();
+
+      console.log(directory);
+      if (directory) {
+        setConfigDirectoryPath(directory);
+      }
       startServer(cmdObj.port, cmdObj.yes);
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -146,10 +146,14 @@ export function writeOutput(
   }
 }
 
-const RESULT_HISTORY_LENGTH = parseInt(process.env.RESULT_HISTORY_LENGTH || '', 10) || 50;
+let configDirectoryPath: string | undefined = process.env.PROMPTFOO_CONFIG_DIR;
 
 export function getConfigDirectoryPath(): string {
-  return path.join(os.homedir(), '.promptfoo');
+  return configDirectoryPath || path.join(os.homedir(), '.promptfoo');
+}
+
+export function setConfigDirectoryPath(newPath: string): void {
+  configDirectoryPath = newPath;
 }
 
 export function getLatestResultsPath(): string {
@@ -198,6 +202,8 @@ export function listPreviousResults(): string[] {
   });
   return sortedFiles;
 }
+
+const RESULT_HISTORY_LENGTH = parseInt(process.env.RESULT_HISTORY_LENGTH || '', 10) || 50;
 
 export function cleanupOldResults(remaining = RESULT_HISTORY_LENGTH) {
   const sortedFiles = listPreviousResults();


### PR DESCRIPTION
Adds support for environment variable `PROMPTFOO_CONFIG_DIR`, which determines where promptfoo will store eval results.

Also adds a directory param to `promptfoo view`:
```
promptfoo view /path/to/directory
```

Note that this expects `/path/to/directory/output/latest.json` to exist.

Related to #256 