### PR TITLE
Broken custom api host for OpenAI.

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -64,7 +64,7 @@ class OpenAiGenericProvider implements ApiProvider {
   getApiUrl(): string {
     const apiHost = this.config.apiHost || this.env?.OPENAI_API_HOST || process.env.OPENAI_API_HOST;
     if (apiHost) {
-      return `https://${apiHost}}`;
+      return `https://${apiHost}`;
     }
     return (
       this.config.apiBaseUrl ||


### PR DESCRIPTION
When providing an API host to the open ai provider an extra curly brace is injected causing the feature to break. 