### PR TITLE
feat: throw error correctly when invalid api key is passed for OpenAI

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -111,14 +111,8 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
         REQUEST_TIMEOUT_MS,
       )) as unknown as any);
     } catch (err) {
-      return {
-        error: `API call error: ${String(err)}`,
-        tokenUsage: {
-          total: 0,
-          prompt: 0,
-          completion: 0,
-        },
-      };
+      logger.error(`API call error: ${err}`);
+      throw err;
     }
     logger.debug(`\tOpenAI embeddings API response: ${JSON.stringify(data)}`);
 
@@ -141,17 +135,12 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
             },
       };
     } catch (err) {
-      return {
-        error: `API response error: ${String(err)}: ${JSON.stringify(data)}`,
-        tokenUsage: {
-          total: data?.usage?.total_tokens,
-          prompt: data?.usage?.prompt_tokens,
-          completion: data?.usage?.completion_tokens,
-        },
-      };
+      logger.error(data.error.message);
+      throw err;
     }
   }
 }
+
 
 export class OpenAiCompletionProvider extends OpenAiGenericProvider {
   static OPENAI_COMPLETION_MODELS = [

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -113,6 +113,29 @@ describe('matchesSimilarity', () => {
 
     mockCallApi.mockRestore();
   });
+
+  it('should throw an error when API call fails', async () => {
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const threshold = 0.5;
+    const grading: GradingConfig = {
+      provider: {
+        id: 'openai:embedding:text-embedding-ada-9999999',
+        config: {
+          apiKey: 'abc123',
+          temperature: 3.1415926,
+        },
+      },
+    };
+
+    jest.spyOn(OpenAiEmbeddingProvider.prototype, 'callEmbeddingApi').mockRejectedValueOnce(
+      new Error('API call failed'),
+    );
+  
+    await expect(async () => {
+      await matchesSimilarity(expected, output, threshold, false, grading);
+    }).rejects.toThrow('API call failed');
+  });
 });
 
 describe('matchesLlmRubric', () => {


### PR DESCRIPTION
Failing tests like the ones in the examples would pass as a false positive due to the API not being called and the so the strings would never truely be compared