### PR TITLE
Provide the prompt in the context to external assertion scripts

### DIFF
--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1285,6 +1285,7 @@ describe('runAssertion', () => {
         output,
       );
 
+      expect(mockFn).toHaveBeenCalledWith("Expected output", {"prompt": "Some prompt", "vars": {}})
       expect(result.pass).toBe(expectedPass);
       expect(result.reason).toContain(expectedReason);
     },
@@ -1335,9 +1336,10 @@ describe('runAssertion', () => {
     async (type, pythonOutput, expectedPass, expectedReason) => {
       const output = 'Expected output';
 
+      const execSyncMock = jest.fn(() => Buffer.from(pythonOutput));
       jest.doMock('child_process', () => {
         return {
-          execSync: jest.fn(() => Buffer.from(pythonOutput)),
+          execSync: execSyncMock,
         };
       });
 
@@ -1353,6 +1355,9 @@ describe('runAssertion', () => {
         output,
       );
 
+      expect(execSyncMock).toHaveBeenCalledWith(
+          `python /path/to/assert.py \"Expected output\" \"{\\\"prompt\\\":\\\"Some prompt\\\",\\\"vars\\\":{}}\"`
+      )
       expect(result.pass).toBe(expectedPass);
       expect(result.reason).toContain(expectedReason);
     },


### PR DESCRIPTION
When using an inline script the prompt is available in the provided `context`. This is not currently the case with external scripts.

By pulling the creation of the `context` up a few blocks we can use it in place of the manually created objects and this will provide a more consistent interface.