### PR TITLE
feat: Support for OpenAI assistants API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
+        "openai": "^4.19.0",
         "opener": "^1.5.2",
         "replicate": "^0.12.3",
         "rouge": "^1.0.3",
@@ -4992,6 +4993,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.19.0.tgz",
+      "integrity": "sha512-cJbl0noZyAaXVKBTMMq6X5BAvP1pm2rWYDBnZes99NL+Zh5/4NmlAwyuhTZEru5SqGGZIoiYKeMPXy4bm9DI0w==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.10.tgz",
+      "integrity": "sha512-luANqZxPmjTll8bduz4ACs/lNTCLuWssCyjqTY9yLdsv1xnViQp3ISKwsEWOIecO13JWUqjVdig/Vjjc09o8uA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -6251,6 +6287,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
+    "openai": "^4.19.0",
     "opener": "^1.5.2",
     "replicate": "^0.12.3",
     "rouge": "^1.0.3",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -50,8 +50,9 @@ export async function fetchWithCache(
   options: RequestInit = {},
   timeout: number,
   format: 'json' | 'text' = 'json',
+  bust: boolean = false,
 ): Promise<{ data: any; cached: boolean }> {
-  if (!enabled) {
+  if (!enabled || bust) {
     const resp = await fetchWithRetries(url, options, timeout);
     return {
       cached: false,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import {
+  OpenAiAssistantProvider,
   OpenAiCompletionProvider,
   OpenAiChatCompletionProvider,
   OpenAiEmbeddingProvider,
@@ -127,6 +128,8 @@ export async function loadApiProvider(
       return new OpenAiChatCompletionProvider(modelType, providerOptions);
     } else if (OpenAiCompletionProvider.OPENAI_COMPLETION_MODELS.includes(modelType)) {
       return new OpenAiCompletionProvider(modelType, providerOptions);
+    } else if (modelType === 'assistant') {
+      return new OpenAiAssistantProvider(modelName, providerOptions);
     } else {
       throw new Error(
         `Unknown OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>`,
@@ -237,6 +240,7 @@ export async function loadApiProvider(
 export default {
   OpenAiCompletionProvider,
   OpenAiChatCompletionProvider,
+  OpenAiAssistantProvider,
   AnthropicCompletionProvider,
   ReplicateProvider,
   LocalAiCompletionProvider,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -342,7 +342,18 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
   }
 }
 
-interface AssistantMessagesResponseData { data: {content?: {type: string, text?: {value: string}}[]}[] }
+interface Content {
+  type: string;
+  text?: {
+    value: string;
+  };
+}
+
+interface AssistantMessagesResponseData { 
+  data: {
+    content?: Content[];
+  }[] 
+}
 
 export class OpenAIAssistantProvider extends OpenAiGenericProvider {
   assistantId: string;

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -235,22 +235,21 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
   }
 }
 
-export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
-  static OPENAI_CHAT_MODELS = [
-    'gpt-4',
-    'gpt-4-0314',
-    'gpt-4-0613',
-    'gpt-4-1106-preview',
-    'gpt-4-1106-vision-preview',
-    'gpt-4-32k',
-    'gpt-4-32k-0314',
-    'gpt-3.5-turbo',
-    'gpt-3.5-turbo-0301',
-    'gpt-3.5-turbo-0613',
-    'gpt-3.5-turbo-1106',
-    'gpt-3.5-turbo-16k',
-    'gpt-3.5-turbo-16k-0613',
-  ];
+export class OpenAIAssistantProvider extends OpenAiGenericProvider {
+  assistantId: string;
+
+  constructor(
+    assistantId: string,
+    options: { config?: OpenAiCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    super(assistantId, options);
+    this.assistantId = assistantId;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    // TODO: Implement the API calls to create a thread and run it, wait for the run to reach "status: completed", and list messages for the thread.
+    throw new Error('Not implemented');
+  }
 
   constructor(
     modelName: string,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -235,21 +235,22 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
   }
 }
 
-export class OpenAIAssistantProvider extends OpenAiGenericProvider {
-  assistantId: string;
-
-  constructor(
-    assistantId: string,
-    options: { config?: OpenAiCompletionOptions; id?: string; env?: EnvOverrides } = {},
-  ) {
-    super(assistantId, options);
-    this.assistantId = assistantId;
-  }
-
-  async callApi(prompt: string): Promise<ProviderResponse> {
-    // TODO: Implement the API calls to create a thread and run it, wait for the run to reach "status: completed", and list messages for the thread.
-    throw new Error('Not implemented');
-  }
+ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
+   static OPENAI_CHAT_MODELS = [
+     'gpt-4',
+     'gpt-4-0314',
+     'gpt-4-0613',
+     'gpt-4-1106-preview',
+     'gpt-4-1106-vision-preview',
+     'gpt-4-32k',
+     'gpt-4-32k-0314',
+     'gpt-3.5-turbo',
+     'gpt-3.5-turbo-0301',
+     'gpt-3.5-turbo-0613',
+     'gpt-3.5-turbo-1106',
+     'gpt-3.5-turbo-16k',
+     'gpt-3.5-turbo-16k-0613',
+   ];
 
   constructor(
     modelName: string,
@@ -338,6 +339,23 @@ export class OpenAIAssistantProvider extends OpenAiGenericProvider {
         error: `API response error: ${String(err)}: ${JSON.stringify(data)}`,
       };
     }
+  }
+}
+
+export class OpenAIAssistantProvider extends OpenAiGenericProvider {
+  assistantId: string;
+
+  constructor(
+    assistantId: string,
+    options: { config?: OpenAiCompletionOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    super(assistantId, options);
+    this.assistantId = assistantId;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    // TODO: Implement the API calls to create a thread and run it, wait for the run to reach "status: completed", and list messages for the thread.
+    throw new Error('Not implemented');
   }
 }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -342,17 +342,17 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
   }
 }
 
-interface Content {
+interface AssistantMessagesResponseDataContent {
   type: string;
   text?: {
     value: string;
   };
 }
 
-interface AssistantMessagesResponseData { 
+interface AssistantMessagesResponseData {
   data: {
-    content?: Content[];
-  }[] 
+    content?: AssistantMessagesResponseDataContent[];
+  }[]
 }
 
 export class OpenAIAssistantProvider extends OpenAiGenericProvider {
@@ -458,7 +458,7 @@ export class OpenAIAssistantProvider extends OpenAiGenericProvider {
     const data = await messagesResp.json() as AssistantMessagesResponseData;
 
     return {
-      output: data.map(datum => datum.content?.map(content => content.type === 'text' ? content.text?.value : '').join('')).join('\n'),
+      output: data.map(datum => datum.content?.map((content: AssistantMessagesResponseDataContent) => content.type === 'text' ? content.text?.value : '').join('')).join('\n'),
       tokenUsage: {
         total: data.usage.total_tokens,
         prompt: data.usage.prompt_tokens,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -429,7 +429,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
 
     logger.debug(`\tOpenAI thread run API response: ${JSON.stringify(run)}`);
 
-    while (run.status === 'in_progress') {
+    while (run.status === 'in_progress' || run.status === 'queued') {
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       logger.debug(`Calling OpenAI API, getting thread run ${run.id} status`);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -34,11 +34,6 @@ interface OpenAiCompletionOptions {
   organization?: string;
 }
 
-const openai = new OpenAI({
-  maxRetries: 3,
-  timeout: REQUEST_TIMEOUT_MS,
-});
-
 function failApiCall(err: any) {
   if (err instanceof OpenAI.APIError) {
     return {
@@ -404,6 +399,11 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );
     }
+
+    const openai = new OpenAI({
+      maxRetries: 3,
+      timeout: REQUEST_TIMEOUT_MS,
+    });
 
     const messages = parseChatPrompt(prompt, [
       { role: 'user', content: prompt },

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -455,10 +455,10 @@ export class OpenAIAssistantProvider extends OpenAiGenericProvider {
       };
     }
 
-    const data = await messagesResp.json() as AssistantMessagesResponseData;
+    const {data} = await messagesResp.json() as AssistantMessagesResponseData;
 
     return {
-      output: data.map(datum => datum.content?.map((content: AssistantMessagesResponseDataContent) => content.type === 'text' ? content.text?.value : '').join('')).join('\n'),
+      output: data.map((datum: { content?: AssistantMessagesResponseDataContent[] }) => datum.content?.map((content: AssistantMessagesResponseDataContent) => content.type === 'text' ? content.text?.value : '').join('')).join('\n'),
       tokenUsage: {
         total: data.usage.total_tokens,
         prompt: data.usage.prompt_tokens,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -363,6 +363,10 @@ interface OpenAiAssistantOptions {
   metadata?: object[];
 }
 
+function toTitleCase(str: string) {
+  return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+}
+
 export class OpenAiAssistantProvider extends OpenAiGenericProvider {
   assistantId: string;
   assistantConfig: OpenAiAssistantOptions;
@@ -501,13 +505,13 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
 
     const outputBlocks = [];
     if (runObject.tools) {
-      outputBlocks.push(`Tools used: ${runObject.tools.map((tool) => tool.type).join(', ')}`);
+      outputBlocks.push(`[Tools used: ${runObject.tools.map((tool) => tool.type).join(', ')}]`);
     }
     for (const message of json.data) {
       const content = message.content
         ?.map((content) => (content.type === 'text' ? content.text?.value : ''))
         .join('');
-      const line = message.role + ': ' + content;
+      const line = `[${toTitleCase(message.role)}] ${content}`;
       outputBlocks.push(line);
     }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -106,6 +106,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.getApiKey()}`,
+            'OpenAI-Beta': 'assistants=v1',
             ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
           },
           body: JSON.stringify(body),

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1,6 +1,10 @@
 import fetch from 'node-fetch';
 
-import { OpenAiCompletionProvider, OpenAiChatCompletionProvider } from '../src/providers/openai';
+import {
+  OpenAiAssistantProvider,
+  OpenAiCompletionProvider,
+  OpenAiChatCompletionProvider,
+} from '../src/providers/openai';
 import { AnthropicCompletionProvider } from '../src/providers/anthropic';
 import { LlamaProvider } from '../src/providers/llama';
 
@@ -372,6 +376,11 @@ describe('providers', () => {
   test('loadApiProvider with openai:completion', async () => {
     const provider = await loadApiProvider('openai:completion');
     expect(provider).toBeInstanceOf(OpenAiCompletionProvider);
+  });
+
+  test('loadApiProvider with openai:assistant', async () => {
+    const provider = await loadApiProvider('openai:assistant:foobar');
+    expect(provider).toBeInstanceOf(OpenAiAssistantProvider);
   });
 
   test('loadApiProvider with openai:chat:modelName', async () => {


### PR DESCRIPTION
Handles code interpreter, retrieval, function calls, etc.

Example promptfooconfig.yaml:
```yaml
prompts:
  - '{{message}}'
providers:
  - openai:assistant:asst_fEhNN3MClMamLfKLkIaoIpgB
tests:
  - vars:
      message: write a tweet about bananas
  - vars:
      message: what is the sum of 38.293 and the square root of 30300300
  - vars:
      message: reverse the string "all dogs go to heaven"
```

<img width="785" alt="image" src="https://github.com/promptfoo/promptfoo/assets/310310/d6c52841-af6f-4ddd-b88f-4d58bf0d4ca2">
