### PR TITLE
feat: add support for self-hosted huggingface text generation inference

### DIFF
--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -10,6 +10,7 @@ import type {
 import { REQUEST_TIMEOUT_MS } from './shared';
 
 interface HuggingfaceTextGenerationOptions {
+  apiEndpoint?: string;
   top_k?: number;
   top_p?: number;
   temperature?: number;
@@ -54,7 +55,9 @@ export class HuggingfaceTextGenerationProvider implements ApiProvider {
       },
     };
 
-    const url = `https://api-inference.huggingface.co/models/${this.modelName}`;
+    const url = this.config.apiEndpoint
+      ? this.config.apiEndpoint
+      : `https://api-inference.huggingface.co/models/${this.modelName}`;
     logger.debug(`Huggingface API request: ${url} ${JSON.stringify(params)}`);
 
     let response;


### PR DESCRIPTION
If you're using running the [Huggingface Text Generation Inference](https://github.com/huggingface/text-generation-inference) server locally, this PR enables you to do this:
```yaml
providers:
  - id: huggingface:text-generation:my-local-model
    config:
      apiEndpoint: http://127.0.0.1:8080/generate
```

Related to #133.
