### PR TITLE
fix: multiple configs handle external test and prompt files correctly

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ import type {
 } from './types';
 import invariant from 'tiny-invariant';
 import { readPrompts } from './prompts';
-import {readTests} from './testCases';
+import { readTests } from './testCases';
 
 let globalConfigCache: any = null;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,14 +139,11 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
   const prompts: UnifiedConfig['prompts'] = [];
   const seenPrompts = new Set<string>();
   configs.forEach((config, idx) => {
+    // Need to read prompts from the config file just so we can dedupe them. They may reference external files.
     const ps = readPrompts(config.prompts, path.dirname(configPaths[idx]));
     ps.forEach((prompt, idx) => {
       if (!seenPrompts.has(prompt.raw)) {
-        if (prompt.function) {
-          prompts.push(typeof config.prompts === 'string' ? config.prompts : config.prompts[idx]);
-        } else {
-          prompts.push(prompt.raw);
-        }
+        prompts.push(typeof config.prompts === 'string' ? config.prompts : config.prompts[idx]);
         seenPrompts.add(prompt.raw);
       }
     });


### PR DESCRIPTION
Fixes handling when loading multiple configs that reference external test or prompt files.

---

For example: `promptfoo -c *.yaml`

prompt.py:
```
import json
import sys

def generate_prompt(context: dict) -> str:
    return (
        f"Describe {context['vars']['topic']} concisely in a single sentence"
    )

if __name__ == "__main__":
    print(generate_prompt(json.loads(sys.argv[1])))
```
promptfooconfig.yaml:
```
description: description
providers: openai:gpt-4-1106-preview
prompts: prompt.py
tests: tests.csv
```
tests.csv:
```
topic
bananas
pomegranates
fruit loops
```

Related to #288 