### PR TITLE
feat: Add support for external provider configs via file://

### DIFF
--- a/examples/external-provider-config/README.md
+++ b/examples/external-provider-config/README.md
@@ -1,0 +1,5 @@
+This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+
+```
+promptfoo eval
+```

--- a/examples/external-provider-config/gpt-3.5.yaml
+++ b/examples/external-provider-config/gpt-3.5.yaml
@@ -1,0 +1,20 @@
+id: 'openai:chat:gpt-3.5-turbo-0613'
+config:
+  functions:
+    [
+      {
+        'name': 'get_current_weather',
+        'description': 'Get the current weather in a given location',
+        'parameters':
+          {
+            'type': 'object',
+            'properties':
+              {
+                'location':
+                  { 'type': 'string', 'description': 'The city and state, e.g. San Francisco, CA' },
+                'unit': { 'type': 'string', 'enum': ['celsius', 'fahrenheit'] },
+              },
+            'required': ['location'],
+          },
+      },
+    ]

--- a/examples/external-provider-config/promptfooconfig.yaml
+++ b/examples/external-provider-config/promptfooconfig.yaml
@@ -1,0 +1,12 @@
+prompts: 'Tell me about the weather in {{city}}.'
+providers:
+  - file://./gpt-3.5.yaml
+tests:
+  - vars:
+      city: Boston
+  - vars:
+      city: New York
+  - vars:
+      city: Paris
+  - vars:
+      city: Mars

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -109,7 +109,6 @@ export async function loadApiProvider(
   if (providerPath.startsWith('file://')) {
     const filePath = providerPath.slice('file://'.length);
     const yamlContent = yaml.load(fs.readFileSync(filePath, 'utf8')) as ProviderOptions;
-    console.log('got yaml content', yamlContent);
     invariant(yamlContent, `Provider config ${filePath} is undefined`);
     invariant(yamlContent.id, `Provider config ${filePath} must have an id`)
     logger.info(`Loaded provider ${yamlContent.id} from ${filePath}`);


### PR DESCRIPTION
This enables `file://` provider imports like so:

```yaml
prompts: 'Tell me about the weather in {{city}}.'
providers:
  - file://./gpt-3.5.yaml
tests:
  - vars:
      city: Boston
  # ...
```