### PR TITLE
fix: handle multiple configs that import multiple prompts

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -139,7 +139,7 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
 
   const prompts: UnifiedConfig['prompts'] = [];
   const seenPrompts = new Set<string>();
-  for (const [configIdx, config] of configs.entries()) {
+  configs.forEach((config, configIdx) => {
     // Need to read prompts from the config file just so we can dedupe them. They may reference external files.
     for (const configPrompt of config.prompts) {
       const expandedPrompts = readPrompts([configPrompt], path.dirname(configPaths[configIdx]));
@@ -150,7 +150,7 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
         }
       }
     }
-  }
+  });
 
   // Combine all configs into a single UnifiedConfig
   const combinedConfig: UnifiedConfig = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,16 +139,18 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
 
   const prompts: UnifiedConfig['prompts'] = [];
   const seenPrompts = new Set<string>();
-  configs.forEach((config, idx) => {
+  for (const [configIdx, config] of configs.entries()) {
     // Need to read prompts from the config file just so we can dedupe them. They may reference external files.
-    const ps = readPrompts(config.prompts, path.dirname(configPaths[idx]));
-    ps.forEach((prompt, idx) => {
-      if (!seenPrompts.has(prompt.raw)) {
-        prompts.push(typeof config.prompts === 'string' ? config.prompts : config.prompts[idx]);
-        seenPrompts.add(prompt.raw);
+    for (const configPrompt of config.prompts) {
+      const expandedPrompts = readPrompts([configPrompt], path.dirname(configPaths[configIdx]));
+      for (const expandedPrompt of expandedPrompts) {
+        if (!seenPrompts.has(expandedPrompt.raw)) {
+          prompts.push(expandedPrompt.raw);
+          seenPrompts.add(expandedPrompt.raw);
+        }
       }
-    });
-  });
+    }
+  }
 
   // Combine all configs into a single UnifiedConfig
   const combinedConfig: UnifiedConfig = {


### PR DESCRIPTION
In certain scenarios, configs that imported multiple prompts could not be included in the command line with other configs.

Fixes #302 