### PR TITLE
feat: add support for custom metrics

### DIFF
--- a/examples/named-metrics/README.md
+++ b/examples/named-metrics/README.md
@@ -1,0 +1,7 @@
+This example shows how to label metrics and surface them in the webview.
+
+Run the test suite with:
+
+```
+promptfoo eval
+``````

--- a/examples/named-metrics/promptfooconfig.yaml
+++ b/examples/named-metrics/promptfooconfig.yaml
@@ -1,0 +1,53 @@
+prompts:
+  - 'Say this as though you are a pirate: {{body}}'
+  - 'Say this as though you are a seafarer from the 17th century: {{body}}'
+providers:
+  - openai:gpt-3.5-turbo
+tests:
+  - description: Check for exact match
+    vars:
+      body: Yes
+    assert:
+      - type: equals
+        value: Yarr
+        metric: Pirateness
+
+  - description: Another basic substring check
+    vars:
+      body: I'm hungry
+    assert:
+      - type: icontains
+        value: grub
+        metric: Pirateness
+
+  - description: Check if output is JSON
+    vars:
+      body: Output the story of your life in JSON
+    assert:
+      - type: is-json
+        metric: Consistency
+
+  - description: Check for semantic similarity
+    vars:
+      body: Hello world
+    assert:
+      # Look for substring
+      - type: javascript
+        value: output.startsWith('Ahoy')
+      - type: python
+        value: max(0, len(output) - 300)
+        metric: Consistency
+
+      # Check for semantic similarity
+      - type: similar
+        value: Ahoy, world
+        metric: Pirateness
+
+  - description: Use LLM to evaluate output
+    vars:
+      body: The quick brown fox jumps over the lazy dog
+    assert:
+      # Ask the LLM to check if it spoke like a pirate
+      - type: llm-rubric
+        value: Is spoken like a pirate
+        metric: Pirateness

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -93,7 +93,7 @@ export async function runAssertions(
   let allPass = true;
   let failedReason = '';
   const componentResults: GradingResult[] = [];
-
+  const customScores: Record<string, number> = {};
   for (const assertion of test.assert) {
     const weight = assertion.weight || 1;
     totalWeight += weight;
@@ -101,6 +101,10 @@ export async function runAssertions(
     const result = await runAssertion(prompt, assertion, test, output);
     totalScore += result.score * weight;
     componentResults.push(result);
+
+    if (assertion.metric) {
+      customScores[assertion.metric] = (customScores[assertion.metric] || 0) + result.score;
+    }
 
     if (result.tokensUsed) {
       tokensUsed.total += result.tokensUsed.total;
@@ -132,6 +136,7 @@ export async function runAssertions(
   return {
     pass: allPass,
     score: finalScore,
+    custom: customScores,
     reason: finalReason,
     tokensUsed,
     componentResults,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -93,7 +93,7 @@ export async function runAssertions(
   let allPass = true;
   let failedReason = '';
   const componentResults: GradingResult[] = [];
-  const customScores: Record<string, number> = {};
+  const namedScores: Record<string, number> = {};
   for (const assertion of test.assert) {
     const weight = assertion.weight || 1;
     totalWeight += weight;
@@ -103,7 +103,7 @@ export async function runAssertions(
     componentResults.push(result);
 
     if (assertion.metric) {
-      customScores[assertion.metric] = (customScores[assertion.metric] || 0) + result.score;
+      namedScores[assertion.metric] = (namedScores[assertion.metric] || 0) + result.score;
     }
 
     if (result.tokensUsed) {
@@ -136,7 +136,7 @@ export async function runAssertions(
   return {
     pass: allPass,
     score: finalScore,
-    custom: customScores,
+    namedScores: namedScores,
     reason: finalReason,
     tokensUsed,
     componentResults,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -228,7 +228,7 @@ class Evaluator {
         response,
         success: false,
         score: 0,
-        custom: {},
+        namedScores: {},
         latencyMs,
       };
       if (response.error) {
@@ -258,7 +258,7 @@ class Evaluator {
         }
         ret.success = checkResult.pass;
         ret.score = checkResult.score;
-        ret.custom = checkResult.custom || {};
+        ret.namedScores = checkResult.namedScores || {};
         if (checkResult.tokensUsed) {
           this.stats.tokenUsage.total += checkResult.tokensUsed.total;
           this.stats.tokenUsage.prompt += checkResult.tokensUsed.prompt;
@@ -293,7 +293,7 @@ class Evaluator {
         error: String(err) + '\n\n' + (err as Error).stack,
         success: false,
         score: 0,
-        custom: {},
+        namedScores: {},
         latencyMs,
       };
     }
@@ -375,7 +375,7 @@ class Evaluator {
               completion: 0,
               cached: 0,
             },
-            custom: {},
+            namedScores: {},
           },
         });
       }
@@ -608,7 +608,7 @@ class Evaluator {
         table.body[rowIndex].outputs[colIndex] = {
           pass: row.success,
           score: row.score,
-          custom: row.custom,
+          namedScores: row.namedScores,
           text: resultText,
           prompt: row.prompt.raw,
           provider: row.provider.id,
@@ -620,8 +620,8 @@ class Evaluator {
         const metrics = table.head.prompts[colIndex].metrics;
         invariant(metrics, 'Expected prompt.metrics to be set');
         metrics.score += row.score;
-        for (const [key, value] of Object.entries(row.custom)) {
-          metrics.custom[key] = (metrics.custom[key] || 0) + value;
+        for (const [key, value] of Object.entries(row.namedScores)) {
+          metrics.namedScores[key] = (metrics.namedScores[key] || 0) + value;
         }
         metrics.testPassCount += row.success ? 1 : 0;
         metrics.testFailCount += row.success ? 0 : 1;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -228,6 +228,7 @@ class Evaluator {
         response,
         success: false,
         score: 0,
+        custom: {},
         latencyMs,
       };
       if (response.error) {
@@ -257,6 +258,7 @@ class Evaluator {
         }
         ret.success = checkResult.pass;
         ret.score = checkResult.score;
+        ret.custom = checkResult.custom || {};
         if (checkResult.tokensUsed) {
           this.stats.tokenUsage.total += checkResult.tokensUsed.total;
           this.stats.tokenUsage.prompt += checkResult.tokensUsed.prompt;
@@ -291,6 +293,7 @@ class Evaluator {
         error: String(err) + '\n\n' + (err as Error).stack,
         success: false,
         score: 0,
+        custom: {},
         latencyMs,
       };
     }
@@ -372,6 +375,7 @@ class Evaluator {
               completion: 0,
               cached: 0,
             },
+            custom: {},
           },
         });
       }
@@ -604,6 +608,7 @@ class Evaluator {
         table.body[rowIndex].outputs[colIndex] = {
           pass: row.success,
           score: row.score,
+          custom: row.custom,
           text: resultText,
           prompt: row.prompt.raw,
           provider: row.provider.id,
@@ -615,6 +620,9 @@ class Evaluator {
         const metrics = table.head.prompts[colIndex].metrics;
         invariant(metrics, 'Expected prompt.metrics to be set');
         metrics.score += row.score;
+        for (const [key, value] of Object.entries(row.custom)) {
+          metrics.custom[key] = (metrics.custom[key] || 0) + value;
+        }
         metrics.testPassCount += row.success ? 1 : 0;
         metrics.testFailCount += row.success ? 0 : 1;
         metrics.assertPassCount +=

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,7 +156,7 @@ export interface Prompt {
     assertFailCount: number;
     totalLatencyMs: number;
     tokenUsage: TokenUsage;
-    custom: Record<string, number>;
+    namedScores: Record<string, number>;
   };
 }
 
@@ -186,13 +186,13 @@ export interface EvaluateResult {
   score: number;
   latencyMs: number;
   gradingResult?: GradingResult;
-  custom: Record<string, number>;
+  namedScores: Record<string, number>;
 }
 
 export interface EvaluateTableOutput {
   pass: boolean;
   score: number;
-  custom: Record<string, number>;
+  namedScores: Record<string, number>;
   text: string;
   prompt: string;
   latencyMs: number;
@@ -231,7 +231,7 @@ export interface EvaluateSummary {
 export interface GradingResult {
   pass: boolean;
   score: number;
-  custom?: Record<string, number>;
+  namedScores?: Record<string, number>;
   reason: string;
   tokensUsed?: TokenUsage;
   componentResults?: GradingResult[];
@@ -299,7 +299,7 @@ export interface Assertion {
   // Override the grading rubric
   rubricPrompt?: GradingConfig['rubricPrompt'];
 
-  // Tag this as a custom metric
+  // Tag this as a named metric
   metric?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,7 @@ export interface Prompt {
     assertFailCount: number;
     totalLatencyMs: number;
     tokenUsage: TokenUsage;
+    custom: Record<string, number>;
   };
 }
 
@@ -185,11 +186,13 @@ export interface EvaluateResult {
   score: number;
   latencyMs: number;
   gradingResult?: GradingResult;
+  custom: Record<string, number>;
 }
 
 export interface EvaluateTableOutput {
   pass: boolean;
   score: number;
+  custom: Record<string, number>;
   text: string;
   prompt: string;
   latencyMs: number;
@@ -228,6 +231,7 @@ export interface EvaluateSummary {
 export interface GradingResult {
   pass: boolean;
   score: number;
+  custom?: Record<string, number>;
   reason: string;
   tokensUsed?: TokenUsage;
   componentResults?: GradingResult[];
@@ -292,7 +296,11 @@ export interface Assertion {
   // Some assertions (similarity, llm-rubric) require an LLM provider
   provider?: GradingConfig['provider'];
 
+  // Override the grading rubric
   rubricPrompt?: GradingConfig['rubricPrompt'];
+
+  // Tag this as a custom metric
+  metric?: string;
 }
 
 // Used when building prompts index from files.

--- a/src/web/nextui/src/app/eval/CustomMetrics.css
+++ b/src/web/nextui/src/app/eval/CustomMetrics.css
@@ -1,0 +1,14 @@
+.custom-metric-container {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: normal;
+}
+
+.custom-metric-container div {
+  padding: 0.25rem;
+  border-radius: 4px;
+  color: var(--text-color);
+  border: 1px solid var(--text-color);
+}

--- a/src/web/nextui/src/app/eval/CustomMetrics.tsx
+++ b/src/web/nextui/src/app/eval/CustomMetrics.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import './CustomMetrics.css';
+
+interface CustomMetricsProps {
+  lookup: Record<string, number>;
+}
+
+const CustomMetrics: React.FC<CustomMetricsProps> = ({ lookup }) => {
+  return (
+    <div className="custom-metric-container">
+      {Object.entries(lookup).map(([metric, score]) => (
+        <div key={metric}>
+          {metric}: {score.toFixed(2)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CustomMetrics;

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -188,14 +188,14 @@ function EvalOutputCell({
         {output.pass && (
           <div className="status pass">
             PASS <span className="score">{scoreToString(output.score)}</span>
-            {output.custom ? <CustomMetrics lookup={output.custom} /> : null}
+            {output.namedScores ? <CustomMetrics lookup={output.namedScores} /> : null}
           </div>
         )}
         {!output.pass && (
           <div className="status fail">
             [FAIL <span className="score">{scoreToString(output.score)}</span>]{' '}
             <span dangerouslySetInnerHTML={{ __html: chunks[0].replace(/\n/g, '<br>') }} />
-            {output.custom ? <CustomMetrics lookup={output.custom} /> : null}
+            {output.namedScores ? <CustomMetrics lookup={output.namedScores} /> : null}
           </div>
         )}{' '}
         <TruncatedText text={text} maxLength={maxTextLength} />

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -16,11 +16,11 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Link from 'next/link';
 
+import CustomMetrics from './CustomMetrics';
+import EvalOutputPromptDialog from './EvalOutputPromptDialog';
 import { useStore } from './store';
 
 import type { CellContext, VisibilityState } from '@tanstack/table-core';
-
-import EvalOutputPromptDialog from './EvalOutputPromptDialog';
 
 import type { EvaluateTableRow, EvaluateTableOutput, FilterMode, GradingResult } from './types';
 
@@ -188,12 +188,14 @@ function EvalOutputCell({
         {output.pass && (
           <div className="status pass">
             PASS <span className="score">{scoreToString(output.score)}</span>
+            {output.custom ? <CustomMetrics lookup={output.custom} /> : null}
           </div>
         )}
         {!output.pass && (
           <div className="status fail">
-            [FAIL<span className="score">{scoreToString(output.score)}</span>]{' '}
+            [FAIL <span className="score">{scoreToString(output.score)}</span>]{' '}
             <span dangerouslySetInnerHTML={{ __html: chunks[0].replace(/\n/g, '<br>') }} />
+            {output.custom ? <CustomMetrics lookup={output.custom} /> : null}
           </div>
         )}{' '}
         <TruncatedText text={text} maxLength={maxTextLength} />

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -47,6 +47,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
+        custom: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -72,7 +73,14 @@ describe('util', () => {
       body: [
         {
           outputs: [
-            { pass: true, score: 1.0, text: 'Test output', prompt: 'Test prompt', latencyMs: 1000 },
+            {
+              pass: true,
+              score: 1.0,
+              custom: {},
+              text: 'Test output',
+              prompt: 'Test prompt',
+              latencyMs: 1000,
+            },
           ],
           vars: ['value1', 'value2'],
         },
@@ -108,6 +116,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
+        custom: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -133,7 +142,14 @@ describe('util', () => {
       body: [
         {
           outputs: [
-            { pass: true, score: 1.0, text: 'Test output', prompt: 'Test prompt', latencyMs: 1000 },
+            {
+              pass: true,
+              score: 1.0,
+              custom: {},
+              text: 'Test output',
+              prompt: 'Test prompt',
+              latencyMs: 1000,
+            },
           ],
           vars: ['value1', 'value2'],
         },
@@ -169,6 +185,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
+        custom: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -194,7 +211,14 @@ describe('util', () => {
       body: [
         {
           outputs: [
-            { pass: true, score: 1.0, text: 'Test output', prompt: 'Test prompt', latencyMs: 1000 },
+            {
+              pass: true,
+              score: 1.0,
+              custom: {},
+              text: 'Test output',
+              prompt: 'Test prompt',
+              latencyMs: 1000,
+            },
           ],
           vars: ['value1', 'value2'],
         },
@@ -230,6 +254,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
+        custom: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -255,7 +280,14 @@ describe('util', () => {
       body: [
         {
           outputs: [
-            { pass: true, score: 1.0, text: 'Test output', prompt: 'Test prompt', latencyMs: 1000 },
+            {
+              pass: true,
+              score: 1.0,
+              custom: {},
+              text: 'Test output',
+              prompt: 'Test prompt',
+              latencyMs: 1000,
+            },
           ],
           vars: ['value1', 'value2'],
         },

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -47,7 +47,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
-        custom: {},
+        namedScores: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -76,7 +76,7 @@ describe('util', () => {
             {
               pass: true,
               score: 1.0,
-              custom: {},
+              namedScores: {},
               text: 'Test output',
               prompt: 'Test prompt',
               latencyMs: 1000,
@@ -116,7 +116,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
-        custom: {},
+        namedScores: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -145,7 +145,7 @@ describe('util', () => {
             {
               pass: true,
               score: 1.0,
-              custom: {},
+              namedScores: {},
               text: 'Test output',
               prompt: 'Test prompt',
               latencyMs: 1000,
@@ -185,7 +185,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
-        custom: {},
+        namedScores: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -214,7 +214,7 @@ describe('util', () => {
             {
               pass: true,
               score: 1.0,
-              custom: {},
+              namedScores: {},
               text: 'Test output',
               prompt: 'Test prompt',
               latencyMs: 1000,
@@ -254,7 +254,7 @@ describe('util', () => {
       {
         success: true,
         score: 1.0,
-        custom: {},
+        namedScores: {},
         latencyMs: 1000,
         provider: {
           id: 'foo',
@@ -283,7 +283,7 @@ describe('util', () => {
             {
               pass: true,
               score: 1.0,
-              custom: {},
+              namedScores: {},
               text: 'Test output',
               prompt: 'Test prompt',
               latencyMs: 1000,


### PR DESCRIPTION
Adds the ability to label assertions with metric names that appear in the webview.

For example:

```yaml
  - # ...
    assert:
      - type: icontains
        value: arrr
        metric: Pirateness

  - # ...
    assert:
      - type: is-json
        metric: Consistency
```

<img width="811" alt="image" src="https://github.com/promptfoo/promptfoo/assets/310310/1b936a7e-798b-4036-ac53-7e725c9d86c0">
