### PR TITLE
fix: sharing option is degraded 

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -170,6 +170,7 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
       (prev, curr) => ({ ...prev, ...curr.commandLineOptions }),
       {},
     ),
+    sharing: configs.at(-1)?.sharing,
   };
 
   return combinedConfig;

--- a/src/util.ts
+++ b/src/util.ts
@@ -170,7 +170,7 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
       (prev, curr) => ({ ...prev, ...curr.commandLineOptions }),
       {},
     ),
-    sharing: configs.at(-1)?.sharing,
+    sharing: !configs.some(config => config.sharing === false),
   };
 
   return combinedConfig;

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -403,7 +403,7 @@ describe('util', () => {
         env: { envVar1: 'envValue1' },
         evaluateOptions: { maxConcurrency: 1 },
         commandLineOptions: { verbose: true },
-        sharing: true,
+        sharing: false,
       };
       const config2 = {
         description: 'test2',
@@ -420,7 +420,7 @@ describe('util', () => {
         env: { envVar2: 'envValue2' },
         evaluateOptions: { maxConcurrency: 2 },
         commandLineOptions: { verbose: false },
-        sharing: false,
+        sharing: true,
       };
 
       (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
@@ -456,7 +456,7 @@ describe('util', () => {
         env: { envVar1: 'envValue1' },
         evaluateOptions: { maxConcurrency: 1 },
         commandLineOptions: { verbose: true },
-        sharing: true,
+        sharing: false,
       });
 
       const config2Result = await readConfigs(['config2.json']);
@@ -478,7 +478,7 @@ describe('util', () => {
         env: { envVar2: 'envValue2' },
         evaluateOptions: { maxConcurrency: 2 },
         commandLineOptions: { verbose: false },
-        sharing: false,
+        sharing: true,
       });
 
       const result = await readConfigs(['config1.json', 'config2.json']);

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -403,6 +403,7 @@ describe('util', () => {
         env: { envVar1: 'envValue1' },
         evaluateOptions: { maxConcurrency: 1 },
         commandLineOptions: { verbose: true },
+        sharing: true,
       };
       const config2 = {
         description: 'test2',
@@ -419,10 +420,13 @@ describe('util', () => {
         env: { envVar2: 'envValue2' },
         evaluateOptions: { maxConcurrency: 2 },
         commandLineOptions: { verbose: false },
+        sharing: false,
       };
 
       (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
       (fs.readFileSync as jest.Mock)
+        .mockReturnValueOnce(JSON.stringify(config1))
+        .mockReturnValueOnce(JSON.stringify(config2))
         .mockReturnValueOnce(JSON.stringify(config1))
         .mockReturnValueOnce(JSON.stringify(config2))
         .mockReturnValue('you should not see this');
@@ -433,9 +437,53 @@ describe('util', () => {
         throw new Error('File does not exist');
       });
 
+      const config1Result = await readConfigs(['config1.json']);
+      expect(config1Result).toEqual({
+        description: 'test1',
+        providers: ['provider1'],
+        prompts: ['prompt1'],
+        tests: ['test1'],
+        scenarios: ['scenario1'],
+        defaultTest: {
+          description: 'defaultTest1',
+          options: {},
+          vars: { var1: 'value1' },
+          assert: [
+            { type: 'equals', value: 'expected1' },
+          ],
+        },
+        nunjucksFilters: { filter1: 'filter1' },
+        env: { envVar1: 'envValue1' },
+        evaluateOptions: { maxConcurrency: 1 },
+        commandLineOptions: { verbose: true },
+        sharing: true,
+      });
+
+      const config2Result = await readConfigs(['config2.json']);
+      expect(config2Result).toEqual({
+        description: 'test2',
+        providers: ['provider2'],
+        prompts: ['prompt2'],
+        tests: ['test2'],
+        scenarios: ['scenario2'],
+        defaultTest: {
+          description: 'defaultTest2',
+          options: {},
+          vars: { var2: 'value2' },
+          assert: [
+            { type: 'equals', value: 'expected2' },
+          ],
+        },
+        nunjucksFilters: { filter2: 'filter2' },
+        env: { envVar2: 'envValue2' },
+        evaluateOptions: { maxConcurrency: 2 },
+        commandLineOptions: { verbose: false },
+        sharing: false,
+      });
+
       const result = await readConfigs(['config1.json', 'config2.json']);
 
-      expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.readFileSync).toHaveBeenCalledTimes(4);
       expect(result).toEqual({
         description: 'test1, test2',
         providers: ['provider1', 'provider2'],
@@ -455,6 +503,7 @@ describe('util', () => {
         env: { envVar1: 'envValue1', envVar2: 'envValue2' },
         evaluateOptions: { maxConcurrency: 2 },
         commandLineOptions: { verbose: false },
+        sharing: false,
       });
     });
 


### PR DESCRIPTION
Sharing option at config file was degraded at unified config implementation.

Checking `fileConfig.sharing` like below, but it never assign.
https://github.com/promptfoo/promptfoo/blob/71af29f5266a89b446fbc65eea3d6f2a845f562e/src/main.ts#L325-L327