### PR TITLE
fix: check whether telemetry is disabled

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -35,7 +35,7 @@ export class Telemetry {
   }
 
   maybeShowNotice(): void {
-    if (maybeRecordFirstRun()) {
+    if (maybeRecordFirstRun() && !this.disabled) {
       logger.info(
         chalk.gray(
           'Anonymous telemetry is enabled. For more info, see https://www.promptfoo.dev/docs/configuration/telemetry',


### PR DESCRIPTION
Instead of  `PROMPTFOO_DISABLE_TELEMETRY=1` , "telemetry is enabled" is logged.

Maybe it would be logged not only FirstRun but every run?