### PR TITLE
feat: retry when getting internal server error with PROMPTFOO_RETRY_5XX envar

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -60,7 +60,12 @@ export async function fetchWithRetries(
     : 5000;
   for (let i = 0; i < retries; i++) {
     try {
-      return await fetchWithTimeout(url, options, timeout);
+        const response = await fetchWithTimeout(url, options, timeout);
+        // Retry 5xx error
+        if (response.status/100 === 5) {
+            throw new Error(`Get Internal Server Error: ${response.status}`);        
+        }
+        return response
     } catch (error) {
       lastError = error;
       const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -60,12 +60,11 @@ export async function fetchWithRetries(
     : 5000;
   for (let i = 0; i < retries; i++) {
     try {
-        const response = await fetchWithTimeout(url, options, timeout);
-        // Retry 5xx error
-        if (response.status/100 === 5) {
-            throw new Error(`Get Internal Server Error: ${response.status}`);        
-        }
-        return response
+      const response = await fetchWithTimeout(url, options, timeout);
+      if (process.env.PROMPTFOO_RETRY_5XX && response.status / 100 === 5) {
+        throw new Error(`Internal Server Error: ${response.status} ${response.statusText}`);
+      }
+      return response;
     } catch (error) {
       lastError = error;
       const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());


### PR DESCRIPTION
Hi teams, 
I would like to make promptfoo able to retry sending requests when getting an internal server error.
This is useful when the LLM server is too busy or other temporary errors (ex: connection errors).
Any suggestions and inputs would be highly appreciated!
