### PR TITLE
fix: properly escape arguments for external python assertions

### DIFF
--- a/examples/external-python-assert/README.md
+++ b/examples/external-python-assert/README.md
@@ -1,0 +1,10 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, edit assert.py and promptfooconfig.yaml.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/external-python-assert/assert.py
+++ b/examples/external-python-assert/assert.py
@@ -1,0 +1,17 @@
+import json
+import sys
+
+def main():
+    if len(sys.argv) >= 3:
+        output = sys.argv[1]
+        context = json.loads(sys.argv[2])
+    else:
+        raise ValueError("Model output and context are expected from promptfoo.")
+
+    # Do whatever you want with `output` and `context` here.
+    # ...
+
+    return 'bananas' in output.lower()
+
+# Any output from this script will interpreted as the result of the assertion.
+print(main())

--- a/examples/external-python-assert/promptfooconfig.yaml
+++ b/examples/external-python-assert/promptfooconfig.yaml
@@ -1,0 +1,20 @@
+prompts:
+  - 'Tell me about {{topic}} in three words'
+providers:
+  - openai:gpt-4-1106-preview
+tests:
+  - vars:
+      topic: yellow fruits
+    assert:
+      - type: python
+        value: file://assert.py
+  - vars:
+      topic: fruits high in potassium
+    assert:
+      - type: python
+        value: file://assert.py
+  - vars:
+      topic: fruits that are long and skinny
+    assert:
+      - type: python
+        value: file://assert.py

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1494,7 +1494,7 @@ describe('runAssertion', () => {
       };
 
       const result: GradingResult = await runAssertion({
-        prompt: 'Some prompt',
+        prompt: 'Some prompt that includes "double quotes" and \'single quotes\'',
         provider: new OpenAiChatCompletionProvider('foo'),
         assertion: fileAssertion,
         test: {} as AtomicTestCase,
@@ -1502,7 +1502,7 @@ describe('runAssertion', () => {
       });
 
       expect(execSyncMock).toHaveBeenCalledWith(
-        `python /path/to/assert.py \"Expected output\" \"{\\\"prompt\\\":\\\"Some prompt\\\",\\\"vars\\\":{}}\"`,
+        `python /path/to/assert.py "Expected output" "{\\"prompt\\":\\"Some prompt that includes \\\\\\"double quotes\\\\\\" and 'single quotes'\\",\\"vars\\":{}}"`,
       );
       expect(result.pass).toBe(expectedPass);
       expect(result.reason).toContain(expectedReason);


### PR DESCRIPTION
Related to #337 