### PR TITLE
feat: latency assertion type

### DIFF
--- a/examples/gpt-3.5-vs-4/promptfooconfig.yaml
+++ b/examples/gpt-3.5-vs-4/promptfooconfig.yaml
@@ -3,3 +3,7 @@ prompts:
 providers:
   - openai:gpt-3.5-turbo
   - openai:gpt-4
+defaultTest:
+  assert:
+    - type: latency
+      threshold: 800

--- a/examples/gpt-3.5-vs-4/promptfooconfig.yaml
+++ b/examples/gpt-3.5-vs-4/promptfooconfig.yaml
@@ -6,4 +6,4 @@ providers:
 defaultTest:
   assert:
     - type: latency
-      threshold: 800
+      threshold: 3000

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -329,6 +329,8 @@ assert:
     threshold: 5000
 ```
 
+Note that `latency` requires that the [cache is disabled](/docs/configuration/caching) with `promptfoo eval --no-cache` or an equivalent option.
+
 ### is-valid-openai-function-call
 
 This ensures that any JSON LLM output adheres to the schema specified in the `functions` configuration of the provider. Learn more about the [OpenAI provider](/docs/providers/openai/#Using-functions).

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -44,37 +44,38 @@ Deterministic eval metrics
 
 | Assertion Type                                                  | Returns true if...                                               |
 | --------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [equals](#equality)                                             | output matches exactly                                           |
+| [contains-all](#contains-all)                                   | output contains all list of substrings                           |
+| [contains-any](#contains-any)                                   | output contains any of the listed substrings                     |
+| [contains-json](#contains-json)                                 | output contains valid json (optional json schema validation)     |
 | [contains](#contains)                                           | output contains substring                                        |
+| [equals](#equality)                                             | output matches exactly                                           |
+| [icontains-all](#contains-all)                                  | output contains all list of substrings, case insensitive         |
+| [icontains-any](#contains-any)                                  | output contains any of the listed substrings, case insensitive   |
 | [icontains](#contains)                                          | output contains substring, case insensitive                      |
+| [is-json](#is-json)                                             | output is valid json (optional json schema validation)           |
+| [is-valid-openai-function-call](#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema |
+| [javascript](/docs/configuration/expected-outputs/javascript)   | provided Javascript function validates the output                |
+| [latency](#latency)                                             | Latency is below a threshold (milliseconds)                      |
+| [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                        |
+| [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                    |
 | [regex](#regex)                                                 | output matches regex                                             |
 | [starts-with](#starts-with)                                     | output starts with string                                        |
-| [contains-any](#contains-any)                                   | output contains any of the listed substrings                     |
-| [contains-all](#contains-all)                                   | output contains all list of substrings                           |
-| [icontains-any](#contains-any)                                  | output contains any of the listed substrings, case insensitive   |
-| [icontains-all](#contains-all)                                  | output contains all list of substrings, case insensitive         |
-| [is-json](#is-json)                                             | output is valid json (optional json schema validation)           |
-| [contains-json](#contains-json)                                 | output contains valid json (optional json schema validation)     |
-| [javascript](/docs/configuration/expected-outputs/javascript)   | provided Javascript function validates the output                |
-| [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                    |
 | [webhook](#webhook)                                             | provided webhook returns \{pass: true\}                          |
 | rouge-n                                                         | Rouge-N score is above a given threshold                         |
-| [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                        |
-| [is-valid-openai-function-call](#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema |
 
 Model-assisted eval metrics
 
 | Assertion Type                                                             | Method                                                                          |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [similar](/docs/configuration/expected-outputs/similar)                    | embeddings and cosine similarity are above a threshold                          |
-| [classifier](/docs/configuration/expected-outputs/classifier)              | Run LLM output through a classifier                                             |
-| [llm-rubric](/docs/configuration/expected-outputs/model-graded)            | LLM output matches a given rubric, using a Language Model to grade output       |
-| [factuality](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
-| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded) | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
 | [answer-relevance](/docs/configuration/expected-outputs/model-graded)      | Ensure that LLM output is related to original query                             |
+| [classifier](/docs/configuration/expected-outputs/classifier)              | Run LLM output through a classifier                                             |
+| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)  | Ensure that LLM output uses the context                                         |
 | [context-recall](/docs/configuration/expected-outputs/model-graded)        | Ensure that ground truth appears in context                                     |
 | [context-relevance](/docs/configuration/expected-outputs/model-graded)     | Ensure that context is relevant to original query                               |
-| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)  | Ensure that LLM output uses the context                                         |
+| [factuality](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
+| [llm-rubric](/docs/configuration/expected-outputs/model-graded)            | LLM output matches a given rubric, using a Language Model to grade output       |
+| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded) | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
+| [similar](/docs/configuration/expected-outputs/similar)                    | embeddings and cosine similarity are above a threshold                          |
 
 :::tip
 Every test type can be negated by prepending `not-`. For example, `not-equals` or `not-regex`.
@@ -315,9 +316,22 @@ assert:
     value: hello world
 ```
 
+### Latency
+
+The `latency` assertion passes if the LLM call takes longer than the specified threshold. Duration is specified in milliseconds.
+
+Example:
+
+```yaml
+assert:
+  # Fail if the LLM call takes longer than 5 seconds
+  - type: latency
+    threshold: 5000
+```
+
 ### is-valid-openai-function-call
 
-This ensures that any JSON LLM output adheres to the schema specified in the `functions` configuration of the provider.  Learn more about the [OpenAI provider](/docs/providers/openai/#Using-functions).
+This ensures that any JSON LLM output adheres to the schema specified in the `functions` configuration of the provider. Learn more about the [OpenAI provider](/docs/providers/openai/#Using-functions).
 
 ### Model-graded evals
 
@@ -503,7 +517,7 @@ In this example, the `containsMentalHealth` assertion template is defined at the
 
 ## Labeling assertions
 
-Each assertion supports a `metrics` field that allows you to tag the result however you like.  Use this feature to combine related assertions into aggregate metrics. 
+Each assertion supports a `metrics` field that allows you to tag the result however you like. Use this feature to combine related assertions into aggregate metrics.
 
 For example, these asserts will aggregate results into two metrics, `Tone` and `Consistency`.
 

--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -26,14 +26,14 @@ Here is the main structure of the promptfoo configuration file:
 A test case represents a single example input that is fed into all prompts and providers.
 
 | Property             | Type                                        | Required | Description                                                                 |
-| -------------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------- |
 | description          | string                                      | No       | Description of what you're testing                                          |
-| vars                 | Record\<string, string \| string[] \| any\> | string   | No                                                                          | Key-value pairs to substitute in the prompt. If `vars` is a plain string, it will be treated as a YAML filepath to load a var mapping from. |
+| vars                 | Record\<string, string \| string[] \| any\>   | No       | Key-value pairs to substitute in the prompt. If `vars` is a plain string, it will be treated as a YAML filepath to load a var mapping from. |
 | assert               | [Assertion](#assertion)[]                   | No       | List of automatic checks to run on the LLM output                           |
 | threshold            | number                                      | No       | Test will fail if the combined score of assertions is less than this number |
 | options              | Object                                      | No       | Additional configuration settings                                           |
 | options.prefix       | string                                      | No       | This is prepended to the prompt                                             |
-| options.suffix       | string                                      | No       | This is append to the prompt                                                |
+| options.suffix       | string                                      | No       | This is appended to the prompt                                              |
 | options.postprocess  | string                                      | No       | A JavaScript snippet that runs on LLM output before any assertions          |
 | options.provider     | string                                      | No       | The API provider to use for LLM rubric grading                              |
 | options.rubricPrompt | string                                      | No       | The prompt to use for LLM rubric grading                                    |
@@ -233,11 +233,12 @@ GradingResult is an object that represents the result of grading a test case. It
 
 ```typescript
 interface GradingResult {
-  pass: boolean;
-  score: number;
-  reason: string;
-  tokensUsed?: TokenUsage;
-  componentResults?: GradingResult[];
-  assertion: Assertion | null;
+  pass: boolean;                        # did test pass?
+  score: number;                        # score between 0 and 1
+  reason: string;                       # plaintext reason for outcome
+  tokensUsed?: TokenUsage;              # tokens consumed by the test
+  componentResults?: GradingResult[];   # if this is a composite score, it can have nested results
+  assertion: Assertion | null;          # source of assertion
+  latencyMs?: number;                   # latency of LLM call
 }
 ```

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -257,6 +257,7 @@ class Evaluator {
           provider,
           test,
           output: processedResponse.output,
+          latencyMs: response.cached ? undefined : latencyMs,
         });
         if (!checkResult.pass) {
           ret.error = checkResult.reason;

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,7 +267,8 @@ type BaseAssertionTypes =
   | 'rouge-s'
   | 'rouge-l'
   | 'levenshtein'
-  | 'is-valid-openai-function-call';
+  | 'is-valid-openai-function-call'
+  | 'latency';
 
 type NotPrefixed<T extends string> = `not-${T}`;
 

--- a/src/web/nextui/src/app/setup/AssertsForm.tsx
+++ b/src/web/nextui/src/app/setup/AssertsForm.tsx
@@ -30,6 +30,7 @@ const assertTypes: AssertionType[] = [
   'similar',
   'llm-rubric',
   'model-graded-closedqa',
+  'factuality',
   'model-graded-factuality',
   'webhook',
   'rouge-n',
@@ -51,6 +52,12 @@ const assertTypes: AssertionType[] = [
   'not-rouge-n',
   'not-rouge-s',
   'not-rouge-l',
+  'is-valid-openai-function-call',
+  'latency',
+  'answer-relevance',
+  'context-faithfulness',
+  'context-recall',
+  'context-relevance',
 ];
 
 const AssertsForm: React.FC<AssertsFormProps> = ({ onAdd, initialValues }) => {


### PR DESCRIPTION
Adds a new latency assertion type.  This is useful, for example, when comparing GPT 3.5 vs 4.

```yaml
assert:
  - type: latency
    threshold: 4000  # anything slower than 4 seconds fails
```

Related to #312 