### PR TITLE
feat: add perplexity assertion type

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Deterministic eval metrics
 | `webhook`                       | provided webhook returns `{pass: true}`                          |
 | `rouge-n`                       | Rouge-N score is above a given threshold                         |
 | `levenshtein`                   | Levenshtein distance is below a threshold                        |
-| `latency``                      | Latency is below a threshold (milliseconds)                      |
+| `latency`                      | Latency is below a threshold (milliseconds)                      |
+| `perplexity`                   | Perplexity is below a threshold                                  |
 | `is-valid-openai-function-call` | Ensure that the function call matches the function's JSON schema |
 
 Model-assisted eval metrics

--- a/examples/gpt-3.5-vs-4/promptfooconfig.yaml
+++ b/examples/gpt-3.5-vs-4/promptfooconfig.yaml
@@ -1,9 +1,9 @@
 prompts:
   - prompts.txt
 providers:
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  #- openai:gpt-3.5-turbo
+  - openai:gpt-4-1106-preview
 defaultTest:
   assert:
-    - type: latency
-      threshold: 3000
+    - type: perplexity
+      threshold: 0.5

--- a/examples/gpt-3.5-vs-4/promptfooconfig.yaml
+++ b/examples/gpt-3.5-vs-4/promptfooconfig.yaml
@@ -1,9 +1,11 @@
 prompts:
   - prompts.txt
 providers:
-  #- openai:gpt-3.5-turbo
-  - openai:gpt-4-1106-preview
+  - openai:gpt-3.5-turbo
+  - openai:gpt-4
 defaultTest:
   assert:
+    - type: latency
+      threshold: 3000
     - type: perplexity
-      threshold: 0.5
+      threshold: 5

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -349,6 +349,10 @@ assert:
     threshold: 1.5
 ```
 
+:::warning
+Perplexity requires the LLM API to output `logprobs`. Currently only more recent versions of OpenAI GPT support this.
+:::
+
 #### Comparing different outputs from the same LLM
 
 You can compare perplexity scores across different outputs from the same model to get a sense of which output the model finds more likely (or less surprising). This is a good way to tune your prompts and hyperparameters (like temperature) to be more accurate.

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -57,6 +57,7 @@ Deterministic eval metrics
 | [javascript](/docs/configuration/expected-outputs/javascript)   | provided Javascript function validates the output                |
 | [latency](#latency)                                             | Latency is below a threshold (milliseconds)                      |
 | [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                        |
+| [perplexity](#perplexity)                                       | Perplexity is below a threshold                                  |
 | [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                    |
 | [regex](#regex)                                                 | output matches regex                                             |
 | [starts-with](#starts-with)                                     | output starts with string                                        |
@@ -330,6 +331,31 @@ assert:
 ```
 
 Note that `latency` requires that the [cache is disabled](/docs/configuration/caching) with `promptfoo eval --no-cache` or an equivalent option.
+
+### Perplexity
+
+Perplexity is a measurement used in natural language processing to quantify how well a language model predicts a sample of text. It's essentially a measure of the model's uncertainty.
+
+**High perplexity** suggests it is less certain about its predictions, often because the text is very diverse or the model is not well-tuned to the task at hand.
+
+**Low perplexity** means the model predicts the text with greater confidence, implying it's better at understanding and generating text similar to its training data.
+
+To specify a perplexity threshold, use the `perplexity` assertion type:
+
+```yaml
+assert:
+  # Fail if the LLM is below perplexity threshold
+  - type: perplexity
+    threshold: 1.5
+```
+
+#### Comparing different outputs from the same LLM
+
+You can compare perplexity scores across different outputs from the same model to get a sense of which output the model finds more likely (or less surprising). This is a good way to tune your prompts and hyperparameters (like temperature) to be more accurate.
+
+#### Comparing outputs from different LLMs
+
+Comparing scores across models may not be meaningful, unless the models have been trained on similar datasets, the tokenization process is consistent between models, and the vocabulary of the models is roughly the same.
 
 ### is-valid-openai-function-call
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -193,9 +193,15 @@ class Evaluator {
     let latencyMs = 0;
     try {
       const startTime = Date.now();
-      const response = await provider.callApi(renderedPrompt, {
-        vars,
-      });
+      const response = await provider.callApi(
+        renderedPrompt,
+        {
+          vars,
+        },
+        {
+          includeLogProbs: test.assert?.some((a) => a.type === 'perplexity'),
+        },
+      );
       const endTime = Date.now();
       latencyMs = endTime - startTime;
 
@@ -258,6 +264,7 @@ class Evaluator {
           test,
           output: processedResponse.output,
           latencyMs: response.cached ? undefined : latencyMs,
+          logProbs: response.logProbs,
         });
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
@@ -664,7 +671,7 @@ class Evaluator {
           process.env.TRAVIS ||
           process.env.CIRCLECI ||
           process.env.JENKINS ||
-          process.env.GITLAB_CI
+          process.env.GITLAB_CI,
       ),
     });
 

--- a/src/providers/scriptCompletion.ts
+++ b/src/providers/scriptCompletion.ts
@@ -3,7 +3,7 @@ import { execFile } from 'child_process';
 import invariant from 'tiny-invariant';
 
 import logger from '../logger';
-import type { ApiProvider, ProviderOptions, ProviderResponse } from '../types';
+import type { ApiProvider, CallApiContextParams, ProviderOptions, ProviderResponse } from '../types';
 
 const ANSI_ESCAPE = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 
@@ -18,7 +18,7 @@ export class ScriptCompletionProvider implements ApiProvider {
     return `exec:${this.scriptPath}`;
   }
 
-  async callApi(prompt: string, vars?: Record<string, string | object>) {
+  async callApi(prompt: string, context?: CallApiContextParams) {
     return new Promise<ProviderResponse>((resolve, reject) => {
       // This regex handles quoted arguments, which are passed to the execFile call as a single argument
       const scriptPartsRegex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
@@ -43,7 +43,7 @@ export class ScriptCompletionProvider implements ApiProvider {
       const scriptArgs = scriptParts.concat([
         prompt,
         JSON.stringify(this.options || {}),
-        JSON.stringify(vars || {}),
+        JSON.stringify(context || {}),
       ]);
       const options = this.options?.config.basePath ? { cwd: this.options.config.basePath } : {};
 

--- a/src/providers/scriptCompletion.ts
+++ b/src/providers/scriptCompletion.ts
@@ -3,7 +3,12 @@ import { execFile } from 'child_process';
 import invariant from 'tiny-invariant';
 
 import logger from '../logger';
-import type { ApiProvider, CallApiContextParams, ProviderOptions, ProviderResponse } from '../types';
+import type {
+  ApiProvider,
+  CallApiContextParams,
+  ProviderOptions,
+  ProviderResponse,
+} from '../types';
 
 const ANSI_ESCAPE = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,13 +57,20 @@ export interface ProviderOptions {
   prompts?: string[]; // List of prompt display strings
 }
 
+export interface CallApiContextParams {
+  vars: Record<string, string | object>;
+}
+
+export interface CallApiOptionsParams {
+  includeLogProbs?: boolean;
+}
+
 export interface ApiProvider {
   id: () => string;
   callApi: (
     prompt: string,
-    context?: {
-      vars: Record<string, string | object>;
-    },
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
   ) => Promise<ProviderResponse>;
   callEmbeddingApi?: (prompt: string) => Promise<ProviderEmbeddingResponse>;
   callClassificationApi?: (prompt: string) => Promise<ProviderClassificationResponse>;
@@ -89,6 +96,7 @@ export interface ProviderResponse {
   output?: string | object;
   tokenUsage?: Partial<TokenUsage>;
   cached?: boolean;
+  logProbs?: number[];
 }
 
 export interface ProviderEmbeddingResponse {
@@ -268,7 +276,8 @@ type BaseAssertionTypes =
   | 'rouge-l'
   | 'levenshtein'
   | 'is-valid-openai-function-call'
-  | 'latency';
+  | 'latency'
+  | 'perplexity';
 
 type NotPrefixed<T extends string> = `not-${T}`;
 

--- a/src/web/nextui/src/app/setup/AssertsForm.tsx
+++ b/src/web/nextui/src/app/setup/AssertsForm.tsx
@@ -54,6 +54,7 @@ const assertTypes: AssertionType[] = [
   'not-rouge-l',
   'is-valid-openai-function-call',
   'latency',
+  'perplexity',
   'answer-relevance',
   'context-faithfulness',
   'context-recall',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1655,6 +1655,50 @@ describe('runAssertion', () => {
     });
   });
 
+  describe('perplexity assertion', () => {
+    it('should pass when the perplexity assertion passes', async () => {
+      const logProbs = [-0.2, -0.4, -0.1, -0.3]; // Dummy logProbs for testing
+      const provider = {
+        callApi: jest.fn().mockResolvedValue({ logProbs }),
+      } as unknown as ApiProvider;
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider,
+        assertion: {
+          type: 'perplexity',
+          threshold: 2,
+        },
+        test: {} as AtomicTestCase,
+        output: 'Some output',
+        logProbs,
+      });
+      expect(result.pass).toBeTruthy();
+      expect(result.reason).toBe('Assertion passed');
+    });
+
+    it('should fail when the perplexity assertion fails', async () => {
+      const logProbs = [-0.2, -0.4, -0.1, -0.3]; // Dummy logProbs for testing
+      const provider = {
+        callApi: jest.fn().mockResolvedValue({ logProbs }),
+      } as unknown as ApiProvider;
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider,
+        assertion: {
+          type: 'perplexity',
+          threshold: 0.2,
+        },
+        test: {} as AtomicTestCase,
+        output: 'Some output',
+        logProbs,
+      });
+      expect(result.pass).toBeFalsy();
+      expect(result.reason).toBe('Perplexity 1.28 is greater than threshold 0.2');
+    });
+  });
+
   describe('is-valid-openai-function-call assertion', () => {
     it('should pass for a valid function call with correct arguments', async () => {
       const output = { arguments: '{"x": 10, "y": 20}', name: 'add' };

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1940,6 +1940,14 @@ describe('assertionFromString', () => {
     expect(result.threshold).toBe(1000);
   });
 
+  it('should create a latency assertion', () => {
+    const expected = 'perplexity(1.5)';
+
+    const result: Assertion = assertionFromString(expected);
+    expect(result.type).toBe('perplexity');
+    expect(result.threshold).toBe(1.5);
+  });
+
   it('should create an openai function call assertion', () => {
     const expected = 'is-valid-openai-function-call';
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -453,7 +453,11 @@ describe('call provider apis', () => {
               expect(file).toContain(inputFile);
               expect(args).toEqual(
                 expect.arrayContaining(
-                  inputArgs.concat(["Test prompt", "{\"config\":{\"some_config_val\":42}}", "{\"vars\":{\"var1\":\"value 1\",\"var2\":\"value 2 \\\"with some double \\\"quotes\\\"\\\"\"}}"]),
+                  inputArgs.concat([
+                    'Test prompt',
+                    '{"config":{"some_config_val":42}}',
+                    '{"vars":{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""}}',
+                  ]),
                 ),
               );
               process.nextTick(() => callback(null, Buffer.from(mockResponse), Buffer.from('')));

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -453,11 +453,7 @@ describe('call provider apis', () => {
               expect(file).toContain(inputFile);
               expect(args).toEqual(
                 expect.arrayContaining(
-                  inputArgs.concat([
-                    'Test prompt',
-                    '{"config":{"some_config_val":42}}',
-                    '{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""}',
-                  ]),
+                  inputArgs.concat(["Test prompt", "{\"config\":{\"some_config_val\":42}}", "{\"vars\":{\"var1\":\"value 1\",\"var2\":\"value 2 \\\"with some double \\\"quotes\\\"\\\"\"}}"]),
                 ),
               );
               process.nextTick(() => callback(null, Buffer.from(mockResponse), Buffer.from('')));
@@ -472,8 +468,10 @@ describe('call provider apis', () => {
         },
       });
       const result = await provider.callApi('Test prompt', {
-        var1: 'value 1',
-        var2: 'value 2 "with some double "quotes""',
+        vars: {
+          var1: 'value 1',
+          var2: 'value 2 "with some double "quotes""',
+        },
       });
 
       expect(result.output).toBe(mockResponse);


### PR DESCRIPTION
Perplexity is a measurement of the model's uncertainty.  Low perplexity = more confident, high perplexity = less confident

```yaml
assert:
  # Fail if the LLM is below perplexity threshold
  - type: perplexity
    threshold: 1.5
```

Added support for any provider with logprobs, currently just OpenAI