### PR TITLE
feat: save manual edits to test outputs in webview

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,7 @@ import type {
   TestCasesWithMetadataPrompt,
   UnifiedConfig,
   OutputFile,
+  EvaluateTable,
 } from './types';
 
 let globalConfigCache: any = null;
@@ -338,6 +339,26 @@ export function readResult(
     };
   } catch (err) {
     logger.error(`Failed to read results from ${resultsPath}:\n${err}`);
+  }
+}
+
+export function updateResult(filename: string, newTable: EvaluateTable): void {
+  const resultsDirectory = path.join(getConfigDirectoryPath(), 'output');
+  const safeFilename = path.basename(filename);
+  const resultsPath = path.join(resultsDirectory, safeFilename);
+  try {
+    const evalData = JSON.parse(fs.readFileSync(resultsPath, 'utf-8')) as ResultsFile;
+    evalData.results.table = newTable;
+    fs.writeFileSync(resultsPath, JSON.stringify(evalData, null, 2));
+    logger.info(`Updated results in ${resultsPath}`)
+
+    const results = listPreviousResults();
+    if (filename === results[results.length - 1]) {
+      // Overwite latest.json too
+      fs.copyFileSync(resultsPath, getLatestResultsPath());
+    }
+  } catch (err) {
+    logger.error(`Failed to update results in ${resultsPath}:\n${err}`);
   }
 }
 

--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -55,7 +55,7 @@ export default function Eval({
   defaultEvalId: defaultEvalIdProp,
 }: EvalOptions) {
   const router = useRouter();
-  const { table, setTable, setConfig } = useStore();
+  const { table, setTable, setConfig, setFilePath } = useStore();
   const [loaded, setLoaded] = React.useState<boolean>(false);
   const [failed, setFailed] = React.useState<boolean>(false);
   const [recentEvals, setRecentEvals] = React.useState<{ id: string; label: string }[]>(
@@ -75,6 +75,7 @@ export default function Eval({
     const body = await resp.json();
     setTable(body.data.results.table);
     setConfig(body.data.config);
+    setFilePath(id);
   };
 
   const handleRecentEvalSelection = async (id: string) => {
@@ -97,17 +98,17 @@ export default function Eval({
 
   React.useEffect(() => {
     if (file) {
-      const doIt = async () => {
+      const run = async () => {
         await fetchEvalById(file);
         setLoaded(true);
       };
-      doIt();
+      run();
     } else if (preloadedData) {
       setTable(preloadedData.data.results?.table as EvaluateTable);
       setConfig(preloadedData.data.config);
       setLoaded(true);
     } else if (fetchId) {
-      const doIt = async () => {
+      const run = async () => {
         const response = await fetch(`https://api.promptfoo.dev/eval/${fetchId}`);
         if (!response.ok) {
           setFailed(true);
@@ -118,7 +119,7 @@ export default function Eval({
         setConfig(results.data.config);
         setLoaded(true);
       };
-      doIt();
+      run();
     } else if (IS_RUNNING_LOCALLY) {
       getApiBaseUrl().then((apiBaseUrl) => {
         const socket = SocketIOClient(apiBaseUrl);
@@ -130,6 +131,7 @@ export default function Eval({
           setConfig(data.config);
           fetchRecentFileEvals().then((newRecentEvals) => {
             setDefaultEvalId(newRecentEvals[0]?.id);
+            setFilePath(newRecentEvals[0]?.id);
           });
         });
 

--- a/src/web/nextui/src/app/eval/store.ts
+++ b/src/web/nextui/src/app/eval/store.ts
@@ -1,8 +1,11 @@
 import { create } from 'zustand';
 
-import type { EvaluateTable, UnifiedConfig } from './types';
+import type { EvaluateTable, FilePath, UnifiedConfig } from './types';
 
 interface TableState {
+  filePath: FilePath | null,
+  setFilePath: (filename: FilePath) => void;
+
   table: EvaluateTable | null;
   setTable: (table: EvaluateTable | null) => void;
 
@@ -18,6 +21,9 @@ interface TableState {
 }
 
 export const useStore = create<TableState>((set) => ({
+  filePath: null,
+  setFilePath: (filePath: FilePath) => set(() => ({ filePath })),
+
   table: null,
   setTable: (table: EvaluateTable | null) => set(() => ({ table })),
   config: null,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -23,6 +23,7 @@ import {
   readResult,
   filenameToDate,
   getTestCases,
+  updateResult,
 } from '../util';
 
 interface Job {
@@ -134,6 +135,23 @@ export function startServer(port = 15500, apiBaseUrl = '', skipConfirmation = fa
     }
   });
 
+  app.post('/api/eval/:id', (req, res) => {
+    const id = req.params.id;
+    const evalTable = req.body.table;
+    
+    if (!id) {
+      res.status(400).json({ error: 'Missing id' });
+      return;
+    }
+    
+    try {
+      updateResult(id, evalTable);
+      res.json({ message: 'Eval table updated successfully' });
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to update eval table' });
+    }
+  });
+
   app.get('/results/:filename', (req, res) => {
     const filename = req.params.filename;
     const safeFilename = path.basename(filename);
@@ -196,7 +214,7 @@ export function startServer(port = 15500, apiBaseUrl = '', skipConfirmation = fa
         input: process.stdin,
         output: process.stdout,
       });
-      rl.question('Do you want to open the browser to the URL? (y/N): ', async (answer) => {
+      rl.question('Open URL in browser? (y/N): ', async (answer) => {
         if (answer.toLowerCase().startsWith('y')) {
           openUrl();
         }


### PR DESCRIPTION
This change overwrites LLM output grades on disk when thumbsup/thumbsdown/score are updated in the webview.