### PR TITLE
fix: do not dereference tools and functions in config

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -162,6 +162,10 @@ assertionTemplates:
 // highlight-end
 ```
 
+:::info
+`tools` and `functions` values in providers config are _not_ dereferenced.  This is because they are standalone JSON schemas that may  contain their own internal references.
+:::
+
 #### Import tests from separate files
 
 The `tests` config attribute takes a list of paths to files or directories. For example:

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -121,3 +121,4 @@ These general-purpose environment variables are supported:
 | `PROMPTFOO_CONFIG_DIR`               | Directory that stores eval history                               | `~/.promptfoo` |
 | `PROMPTFOO_DISABLE_JSON_AUTOESCAPE`  | If set, disables smart variable substitution within JSON prompts |                |
 | `PROMPTFOO_DISABLE_CONVERSATION_VAR` | Prevents the `_conversation` variable from being set             |                |
+| `PROMPTFOO_DISABLE_REF_PARSER`       | Prevents JSON schema dereferencing                               |                |

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,7 +76,7 @@ export async function maybeReadConfig(configPath: string): Promise<UnifiedConfig
   return readConfig(configPath);
 }
 
-async function dereferenceConfig(rawConfig: UnifiedConfig): Promise<UnifiedConfig> {
+export async function dereferenceConfig(rawConfig: UnifiedConfig): Promise<UnifiedConfig> {
   if (process.env.PROMPTFOO_DISABLE_REF_PARSER) {
     return rawConfig;
   }
@@ -138,20 +138,20 @@ async function dereferenceConfig(rawConfig: UnifiedConfig): Promise<UnifiedConfi
         provider = Object.values(provider)[0] as ProviderOptions;
       }
 
-      if (provider.config.functions) {
+      if (provider.config?.functions) {
         functionsParametersList[providerIndex] = extractFunctionParameters(
           provider.config.functions,
         );
       }
 
-      if (provider.config.tools) {
+      if (provider.config?.tools) {
         toolsParametersList[providerIndex] = extractToolParameters(provider.config.tools);
       }
     });
   }
 
   // Dereference JSON
-  const config = (await $RefParser.dereference(rawConfig)) as UnifiedConfig;
+  const config = (await $RefParser.dereference(rawConfig)) as unknown as UnifiedConfig;
 
   // Restore functions and tools parameters
   if (Array.isArray(config.providers)) {


### PR DESCRIPTION
This change prevents `providers[].config.tools[].function.parameters` and `providers[].config.functions[].parameters` from being dereferenced in promptfoo configs.  

This exception is necessary because function calls are self-contained JSON schemas.

Related to #364 