### PR TITLE
feat: add `cost` assertion type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,28 +104,29 @@ See [Test assertions](https://promptfoo.dev/docs/configuration/expected-outputs)
 
 Deterministic eval metrics
 
-| Assertion Type                  | Returns true if...                                               |
-| ------------------------------- | ---------------------------------------------------------------- |
-| `equals`                        | output matches exactly                                           |
-| `contains`                      | output contains substring                                        |
-| `icontains`                     | output contains substring, case insensitive                      |
-| `regex`                         | output matches regex                                             |
-| `starts-with`                   | output starts with string                                        |
-| `contains-any`                  | output contains any of the listed substrings                     |
-| `contains-all`                  | output contains all list of substrings                           |
-| `icontains-any`                 | output contains any of the listed substrings, case insensitive   |
-| `icontains-all`                 | output contains all list of substrings, case insensitive         |
-| `is-json`                       | output is valid json (optional json schema validation)           |
-| `contains-json`                 | output contains valid json (optional json schema validation)     |
-| `javascript`                    | provided Javascript function validates the output                |
-| `python`                        | provided Python function validates the output                    |
-| `webhook`                       | provided webhook returns `{pass: true}`                          |
-| `rouge-n`                       | Rouge-N score is above a given threshold                         |
-| `levenshtein`                   | Levenshtein distance is below a threshold                        |
-| `latency`                       | Latency is below a threshold (milliseconds)                      |
-| `perplexity`                    | Perplexity is below a threshold                                  |
-| `is-valid-openai-function-call` | Ensure that the function call matches the function's JSON schema |
-| `is-valid-openai-tools-call`    | Ensure that all tool calls match the tools JSON schema           |
+| Assertion Type                  | Returns true if...                                                |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `equals`                        | output matches exactly                                            |
+| `contains`                      | output contains substring                                         |
+| `icontains`                     | output contains substring, case insensitive                       |
+| `regex`                         | output matches regex                                              |
+| `starts-with`                   | output starts with string                                         |
+| `contains-any`                  | output contains any of the listed substrings                      |
+| `contains-all`                  | output contains all list of substrings                            |
+| `icontains-any`                 | output contains any of the listed substrings, case insensitive    |
+| `icontains-all`                 | output contains all list of substrings, case insensitive          |
+| `is-json`                       | output is valid json (optional json schema validation)            |
+| `contains-json`                 | output contains valid json (optional json schema validation)      |
+| `javascript`                    | provided Javascript function validates the output                 |
+| `python`                        | provided Python function validates the output                     |
+| `webhook`                       | provided webhook returns `{pass: true}`                           |
+| `rouge-n`                       | Rouge-N score is above a given threshold                          |
+| `levenshtein`                   | Levenshtein distance is below a threshold                         |
+| `latency`                       | Latency is below a threshold (milliseconds)                       |
+| `perplexity`                    | Perplexity is below a threshold                                   |
+| `cost`                          | Cost is below a threshold (for models with cost info such as GPT) |
+| `is-valid-openai-function-call` | Ensure that the function call matches the function's JSON schema  |
+| `is-valid-openai-tools-call`    | Ensure that all tool calls match the tools JSON schema            |
 
 Model-assisted eval metrics
 

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -48,13 +48,14 @@ Deterministic eval metrics
 | [contains-any](#contains-any)                                   | output contains any of the listed substrings                     |
 | [contains-json](#contains-json)                                 | output contains valid json (optional json schema validation)     |
 | [contains](#contains)                                           | output contains substring                                        |
+| [cost](#cost)                                                   | Inference cost is below a threshold                              |
 | [equals](#equality)                                             | output matches exactly                                           |
 | [icontains-all](#contains-all)                                  | output contains all list of substrings, case insensitive         |
 | [icontains-any](#contains-any)                                  | output contains any of the listed substrings, case insensitive   |
 | [icontains](#contains)                                          | output contains substring, case insensitive                      |
 | [is-json](#is-json)                                             | output is valid json (optional json schema validation)           |
 | [is-valid-openai-function-call](#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema |
-| [is-valid-openai-tools-call](#is-valid-openai-tools-call) | Ensure all tool calls match the tools JSON schema |
+| [is-valid-openai-tools-call](#is-valid-openai-tools-call)       | Ensure all tool calls match the tools JSON schema                |
 | [javascript](/docs/configuration/expected-outputs/javascript)   | provided Javascript function validates the output                |
 | [latency](#latency)                                             | Latency is below a threshold (milliseconds)                      |
 | [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                        |
@@ -353,6 +354,24 @@ assert:
 :::warning
 Perplexity requires the LLM API to output `logprobs`. Currently only more recent versions of OpenAI GPT support this.
 :::
+
+### Cost
+
+The `cost` assertion checks if the cost of the LLM call is below a specified threshold. 
+
+This requires LLM providers to return cost information. Currently this is only supported by OpenAI GPT models and custom providers.
+
+Example:
+
+```yaml
+providers:
+  - openai:gpt-3.5-turbo
+  - openai:gpt-4
+assert:
+  # Pass if the LLM call costs less than $0.001
+  - type: cost
+    threshold: 0.001
+```
 
 #### Comparing different outputs from the same LLM
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -260,6 +260,7 @@ class Evaluator {
           output: processedResponse.output,
           latencyMs: response.cached ? undefined : latencyMs,
           logProbs: response.logProbs,
+          cost: processedResponse.cost,
         });
         if (!checkResult.pass) {
           ret.error = checkResult.reason;

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,7 +300,8 @@ type BaseAssertionTypes =
   | 'is-valid-openai-function-call'
   | 'is-valid-openai-tools-call'
   | 'latency'
-  | 'perplexity';
+  | 'perplexity'
+  | 'cost';
 
 type NotPrefixed<T extends string> = `not-${T}`;
 

--- a/src/web/nextui/src/app/setup/AssertsForm.tsx
+++ b/src/web/nextui/src/app/setup/AssertsForm.tsx
@@ -56,6 +56,7 @@ const assertTypes: AssertionType[] = [
   'is-valid-openai-tools-call',
   'latency',
   'perplexity',
+  'cost',
   'answer-relevance',
   'context-faithfulness',
   'context-recall',


### PR DESCRIPTION
For example:

```yaml
providers:
  - openai:gpt-3.5-turbo
  - openai:gpt-4
assert:
  # Pass if the LLM call costs less than $0.001
  - type: cost
    threshold: 0.001
```