### PR TITLE
feat: support standalone assertions on CLI

### DIFF
--- a/examples/standalone-assertions/README.md
+++ b/examples/standalone-assertions/README.md
@@ -4,7 +4,7 @@ If you use a model-graded eval, you must set your OPENAI_API_KEY environment var
 
 Then run:
 ```
-promptfoo eval --assertions asserts.yaml --llm-outputs outputs.json
+promptfoo eval --assertions asserts.yaml --model-outputs outputs.json
 ```
 
 Afterwards, you can view the results by running `promptfoo view`

--- a/examples/standalone-assertions/README.md
+++ b/examples/standalone-assertions/README.md
@@ -1,0 +1,10 @@
+To get started, have a look at `asserts.yaml`
+
+If you use a model-graded eval, you must set your OPENAI_API_KEY environment variable or override the provider (see https://promptfoo.dev/docs/configuration/expected-outputs/model-graded/#overriding-the-llm-grader).
+
+Then run:
+```
+promptfoo eval --assertions asserts.yaml --llm-outputs outputs.json
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/standalone-assertions/asserts.yaml
+++ b/examples/standalone-assertions/asserts.yaml
@@ -1,0 +1,9 @@
+# For more information on assertions, see https://promptfoo.dev/docs/configuration/expected-outputs
+- type: icontains
+  value: hello
+- type: javascript
+  value: 1 / (output.length + 1)  # prefer shorter outputs
+
+# For more information on model-graded evals, see https://promptfoo.dev/docs/configuration/expected-outputs/model-graded
+- type: model-graded-closedqa
+  value: ensure that the output contains a greeting

--- a/examples/standalone-assertions/outputs.json
+++ b/examples/standalone-assertions/outputs.json
@@ -1,0 +1,5 @@
+[
+  "Hello world",
+  "Greetings, planet",
+  "Salutations, Earth"
+]

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -463,9 +463,9 @@ class Evaluator {
       testCase.options = { ...testSuite.defaultTest?.options, ...testCase.options };
 
       const prependToPrompt =
-        testCase.options?.prefix || testSuite.defaultTest?.options?.prefix || '';
+        row.__prefix || testCase.options?.prefix || testSuite.defaultTest?.options?.prefix || '';
       const appendToPrompt =
-        testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
+        row.__suffix || testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
 
       // Finalize test case eval
       const varCombinations = generateVarCombinations(testCase.vars || {});

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -463,9 +463,9 @@ class Evaluator {
       testCase.options = { ...testSuite.defaultTest?.options, ...testCase.options };
 
       const prependToPrompt =
-        row.__prefix || testCase.options?.prefix || testSuite.defaultTest?.options?.prefix || '';
+        testCase.options?.prefix || testSuite.defaultTest?.options?.prefix || '';
       const appendToPrompt =
-        row.__suffix || testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
+        testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
 
       // Finalize test case eval
       const varCombinations = generateVarCombinations(testCase.vars || {});

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,7 +235,8 @@ async function main() {
       'Path to CSV with test cases',
       defaultConfig?.commandLineOptions?.vars,
     )
-    .option('-a', '--assertions <path>', 'Path to assertions file')
+    .option('-a, --assertions <path>', 'Path to assertions file')
+    .option('--llm-outputs <path>', 'Path to JSON with LLM outputs')
     .option('-t, --tests <path>', 'Path to CSV with test cases')
     .option('-o, --output <paths...>', 'Path to output file (csv, txt, json, yaml, yml, html)')
     .option(
@@ -317,7 +318,13 @@ async function main() {
 
       // Standalone assertion mode
       if (cmdObj.assertions) {
-        const llmOutputs: string[] = ['hello world', 'salutations, earth', 'greetings, planet'];
+        if (!cmdObj.llmOutputs) {
+          logger.error(chalk.red('You must provide --llm-outputs when using --assertions'));
+          process.exit(1);
+        }
+        const llmOutputs = JSON.parse(
+          readFileSync(pathJoin(process.cwd(), cmdObj.llmOutputs), 'utf8'),
+        ) as string[];
         const assertions = await readAssertions(cmdObj.assertions);
         fileConfig.prompts = ['{{output}}'];
         fileConfig.providers = ['echo'];

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,7 +236,7 @@ async function main() {
       defaultConfig?.commandLineOptions?.vars,
     )
     .option('-a, --assertions <path>', 'Path to assertions file')
-    .option('--llm-outputs <path>', 'Path to JSON with LLM outputs')
+    .option('--model-outputs <path>', 'Path to JSON containing list of LLM output strings')
     .option('-t, --tests <path>', 'Path to CSV with test cases')
     .option('-o, --output <paths...>', 'Path to output file (csv, txt, json, yaml, yml, html)')
     .option(
@@ -318,17 +318,17 @@ async function main() {
 
       // Standalone assertion mode
       if (cmdObj.assertions) {
-        if (!cmdObj.llmOutputs) {
-          logger.error(chalk.red('You must provide --llm-outputs when using --assertions'));
+        if (!cmdObj.modelOutputs) {
+          logger.error(chalk.red('You must provide --model-outputs when using --assertions'));
           process.exit(1);
         }
-        const llmOutputs = JSON.parse(
-          readFileSync(pathJoin(process.cwd(), cmdObj.llmOutputs), 'utf8'),
+        const modelOutputs = JSON.parse(
+          readFileSync(pathJoin(process.cwd(), cmdObj.modelOutputs), 'utf8'),
         ) as string[];
         const assertions = await readAssertions(cmdObj.assertions);
         fileConfig.prompts = ['{{output}}'];
         fileConfig.providers = ['echo'];
-        fileConfig.tests = llmOutputs.map((output) => ({
+        fileConfig.tests = modelOutputs.map((output) => ({
           vars: {
             output,
           },

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -116,6 +116,11 @@ export async function loadApiProvider(
     invariant(yamlContent.id, `Provider config ${filePath} must have an id`);
     logger.info(`Loaded provider ${yamlContent.id} from ${filePath}`);
     return loadApiProvider(yamlContent.id, { ...context, options: yamlContent });
+  } else if (providerPath === 'echo') {
+    return {
+      id: () => 'echo',
+      callApi: async (input) => ({output: input}),
+    };
   } else if (providerPath?.startsWith('exec:')) {
     // Load script module
     const scriptPath = providerPath.split(':')[1];

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface CommandLineOptions {
   tests?: FilePath;
   config?: FilePath[];
   assertions?: FilePath;
-  llmOutputs?: FilePath;
+  modelOutputs?: FilePath;
   verbose?: boolean;
   grader?: string;
   view?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface CommandLineOptions {
   tests?: FilePath;
   config?: FilePath[];
   assertions?: FilePath;
+  llmOutputs?: FilePath;
   verbose?: boolean;
   grader?: string;
   view?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface CommandLineOptions {
   vars?: FilePath;
   tests?: FilePath;
   config?: FilePath[];
+  assertions?: FilePath;
   verbose?: boolean;
   grader?: string;
   view?: string;


### PR DESCRIPTION
Allows devs to supply a list of LLM outputs and run assertions on them.

For example:
```
promptfoo eval --assertions asserts.yaml --model-outputs outputs.json
```

asserts.yaml:
```yaml
# For more information on assertions, see https://promptfoo.dev/docs/configuration/expected-outputs
- type: icontains
  value: hello
- type: javascript
  value: 1 / (output.length + 1)  # prefer shorter outputs

# For more information on model-graded evals, see https://promptfoo.dev/docs/configuration/expected-outputs/model-graded
- type: model-graded-closedqa
  value: ensure that the output contains a greeting
```
outputs.json:
```json
[
  "Hello world",
  "Greetings, planet",
  "Salutations, Earth"
]
```

<img width="995" alt="image" src="https://github.com/promptfoo/promptfoo/assets/310310/5fb278e9-7be3-4cd8-a02e-c8c72fd04936">
