### PR TITLE
fix: use relative paths consistently and handle object formats

### DIFF
--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -1,4 +1,4 @@
-prompts: [prompts.txt]
+prompts: ['file://prompts.txt']
 providers: [openai:gpt-3.5-turbo, openai:gpt-4]
 tests:
   - vars:

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -80,12 +80,11 @@ export async function readTest(
       for (const [key, value] of Object.entries(testCase.vars)) {
         if (typeof value === 'string' && value.startsWith('file://')) {
           // Load file from disk.
-          if (value.endsWith('.yaml') || value.endsWith('.yml')) {
-            vars[key] = (
-              yaml.load(fs.readFileSync(value.slice('file://'.length), 'utf-8')) as string
-            ).trim();
+          const filePath = path.resolve(testBasePath, value.slice('file://'.length));
+          if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
+            vars[key] = (yaml.load(fs.readFileSync(filePath, 'utf-8')) as string).trim();
           } else {
-            vars[key] = fs.readFileSync(value.slice('file://'.length), 'utf-8').trim();
+            vars[key] = fs.readFileSync(filePath, 'utf-8').trim();
           }
         } else {
           // This is a normal key:value.

--- a/src/types.ts
+++ b/src/types.ts
@@ -439,7 +439,7 @@ export interface TestSuiteConfig {
   providers: ProviderId | ProviderFunction | (ProviderId | ProviderOptionsMap | ProviderOptions)[];
 
   // One or more prompt files to load
-  prompts: FilePath | FilePath[];
+  prompts: FilePath | FilePath[] | Record<FilePath, string>;
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
   tests: FilePath | (FilePath | TestCase)[];

--- a/src/util.ts
+++ b/src/util.ts
@@ -234,13 +234,23 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
     }
   });
 
-  const prompts: UnifiedConfig['prompts'] = [];
-  const seenPrompts = new Set<string>();
+  const configsAreStringOrArray = configs.every(
+    (config) => typeof config.prompts === 'string' || Array.isArray(config.prompts),
+  );
+  const configsAreObjects = configs.every((config) => typeof config.prompts === 'object');
+  let prompts: UnifiedConfig['prompts'] = configsAreStringOrArray ? [] : {};
+
   configs.forEach((config) => {
     if (typeof config.prompts === 'string') {
+      invariant(Array.isArray(prompts), 'Cannot mix string and map-type prompts');
       prompts.push(config.prompts);
-    } else {
+    } else if (Array.isArray(config.prompts)) {
+      invariant(Array.isArray(prompts), 'Cannot mix configs with map and array-type prompts');
       prompts.push(...config.prompts);
+    } else {
+      // Object format such as { 'prompts/prompt1.txt': 'foo', 'prompts/prompt2.txt': 'bar' }
+      invariant(typeof prompts === 'object', 'Cannot mix configs with map and array-type prompts');
+      prompts = { ...prompts, ...config.prompts };
     }
   });
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -515,6 +515,35 @@ describe('util', () => {
         'Unsupported configuration file format: .unsupported',
       );
     });
+
+    test('makeAbsolute should resolve file:// syntax and plaintext prompts', async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
+        if (path === 'config1.json') {
+          return JSON.stringify({
+            description: 'test1',
+            prompts: ['file://prompt1.txt', 'prompt2'],
+          });
+        } else if (path === 'config2.json') {
+          return JSON.stringify({
+            description: 'test2',
+            prompts: ['file://prompt3.txt', 'prompt4'],
+          });
+        }
+        return null;
+      });
+
+      const configPaths = ['config1.json', 'config2.json'];
+      const result = await readConfigs(configPaths);
+
+      expect(result.prompts).toEqual([
+        'file://' + path.resolve(path.dirname(configPaths[0]), 'prompt1.txt'),
+        'prompt2',
+        'file://' + path.resolve(path.dirname(configPaths[1]), 'prompt3.txt'),
+        'prompt4',
+      ]);
+    });
+
   });
 
   describe('dereferenceConfig', () => {


### PR DESCRIPTION
Related to #372 and #359 