### PR TITLE
feat: add perplexity-score metric

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -60,6 +60,7 @@ tests:
 | [latency](#latency)                                             | Latency is below a threshold (milliseconds)                      |
 | [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                        |
 | [perplexity](#perplexity)                                       | Perplexity is below a threshold                                  |
+| [perplexity-score](#perplexity-score)                           | Normalized perplexity                                            |
 | [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                    |
 | [regex](#regex)                                                 | output matches regex                                             |
 | [starts-with](#starts-with)                                     | output starts with string                                        |
@@ -356,6 +357,21 @@ assert:
 :::warning
 Perplexity requires the LLM API to output `logprobs`. Currently only more recent versions of OpenAI GPT support this.
 :::
+
+#### perplexity-score
+
+`perplexity-score` is a supported metric similar to `perplexity`, except it is normalized between 0 and 1 and inverted, meaning larger numbers are better.
+
+This makes it easier to include in an aggregate promptfoo score, as higher scores are usually better. In this example, we compare perplexity across multiple GPTs:
+
+```yaml
+providers: [gpt-4-1106-preview, gpt-3.5-turbo-1106]
+tests:
+  - assert:
+      - type: perplexity-score
+        threshold: 0.5 # optional
+  # ...
+```
 
 ### Cost
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,6 +301,7 @@ type BaseAssertionTypes =
   | 'is-valid-openai-tools-call'
   | 'latency'
   | 'perplexity'
+  | 'perplexity-score'
   | 'cost';
 
 type NotPrefixed<T extends string> = `not-${T}`;

--- a/src/web/nextui/src/app/setup/AssertsForm.tsx
+++ b/src/web/nextui/src/app/setup/AssertsForm.tsx
@@ -56,6 +56,7 @@ const assertTypes: AssertionType[] = [
   'is-valid-openai-tools-call',
   'latency',
   'perplexity',
+  'perplexity-score',
   'cost',
   'answer-relevance',
   'context-faithfulness',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1748,6 +1748,51 @@ print(json.dumps(eval(value)))`,
     });
   });
 
+  describe('perplexity-score assertion', () => {
+    it('should pass when the perplexity-score assertion passes', async () => {
+      const logProbs = [-0.2, -0.4, -0.1, -0.3]; 
+      const provider = {
+        callApi: jest.fn().mockResolvedValue({ logProbs }),
+      } as unknown as ApiProvider;
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider,
+        assertion: {
+          type: 'perplexity-score',
+          threshold: 0.25,
+        },
+        test: {} as AtomicTestCase,
+        output: 'Some output',
+        logProbs,
+      });
+      expect(result.pass).toBeTruthy();
+      expect(result.reason).toBe('Assertion passed');
+    });
+
+    it('should fail when the perplexity-score assertion fails', async () => {
+      const logProbs = [-0.2, -0.4, -0.1, -0.3];
+      const provider = {
+        callApi: jest.fn().mockResolvedValue({ logProbs }),
+      } as unknown as ApiProvider;
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider,
+        assertion: {
+          type: 'perplexity-score',
+          threshold: 0.5,
+        },
+        test: {} as AtomicTestCase,
+        output: 'Some output',
+        logProbs,
+      });
+      console.log(result)
+      expect(result.pass).toBeFalsy();
+      expect(result.reason).toBe('Perplexity score 0.44 is less than threshold 0.5');
+    });
+  });
+
   describe('cost assertion', () => {
     it('should pass when the cost is below the threshold', async () => {
       const cost = 0.0005;
@@ -2117,6 +2162,14 @@ describe('assertionFromString', () => {
     const result: Assertion = assertionFromString(expected);
     expect(result.type).toBe('perplexity');
     expect(result.threshold).toBe(1.5);
+  });
+
+  it('should create a perplexity-score assertion', () => {
+    const expected = 'perplexity-score(0.5)';
+
+    const result: Assertion = assertionFromString(expected);
+    expect(result.type).toBe('perplexity-score');
+    expect(result.threshold).toBe(0.5);
   });
 
   it('should create a cost assertion', () => {


### PR DESCRIPTION
`perplexity-score` is an assertion type similar to `perplexity`, except it is normalized between 0 and 1 and inverted, meaning larger numbers are better.  This makes it easier to include perplexity in an aggregate promptfoo score.