### PR TITLE
feat(bedrock): introduce amazon titan models as another option for Bedrock

### DIFF
--- a/examples/amazon-bedrock/promptfooconfig.claude.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.claude.yaml
@@ -1,0 +1,16 @@
+prompts:
+  - 'Convert this English to {{language}}: {{input}}'
+  - 'Translate to {{language}}: {{input}}'
+providers:
+  - id: bedrock:completion:anthropic.claude-instant-v1
+    config:
+      region: 'us-west-2'
+      temperature: 0.7
+      max_tokens_to_sample: 256
+tests:
+  - vars:
+      language: French
+      input: Hello world
+  - vars:
+      language: Spanish
+      input: Where is the library?

--- a/examples/amazon-bedrock/promptfooconfig.titan-text.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.titan-text.yaml
@@ -1,0 +1,19 @@
+prompts:
+  - 'Convert this English to {{language}}: {{input}}'
+  - 'Translate to {{language}}: {{input}}'
+providers:
+  - id: bedrock:completion:amazon.titan-text-lite-v1
+    config:
+      region: 'us-west-2'
+      textGenerationConfig:
+        maxTokenCount: 400
+        temperature: 0.3
+        stopSequences: []
+        topP: 0.9
+tests:
+  - vars:
+      language: French
+      input: Hello world
+  - vars:
+      language: Spanish
+      input: Where is the library?

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -30,13 +30,13 @@ interface BedrockClaudeCompletionOptions extends BedrockOptions {
 }
 
 interface IBedrockModel {
-  params: (config: BedrockOptions, prompt: string) => any,
+  params: (config: BedrockOptions, prompt: string, stop: string[]) => any,
   output: (responseJson: any) => any,
 }
 
 const BEDROCK_MODEL = {
   CLAUDE: {
-    params: (config: BedrockClaudeCompletionOptions, prompt: string) => ({
+    params: (config: BedrockClaudeCompletionOptions, prompt: string, stop: string[]) => ({
       prompt: `${Anthropic.HUMAN_PROMPT} ${prompt} ${Anthropic.AI_PROMPT}`,
       max_tokens_to_sample:
         config?.max_tokens_to_sample || parseInt(process.env.AWS_BEDROCK_MAX_TOKENS || '1024'),
@@ -49,7 +49,7 @@ const BEDROCK_MODEL = {
     },
   },
   TITAN_TEXT: {
-    params: (config: BedrockTextGenerationOptions, prompt: string) => ({
+    params: (config: BedrockTextGenerationOptions, prompt: string, stop: string[]) => ({
       inputText: prompt,
       textGenerationConfig: {
         maxTokenCount: config?.textGenerationConfig?.maxTokenCount || parseInt(process.env.AWS_BEDROCK_MAX_TOKENS || '1024'),
@@ -133,7 +133,7 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
     }
 
     const model = AWS_BEDROCK_MODELS[this.modelName];
-    const params = model.params(this.config, prompt);
+    const params = model.params(this.config, prompt, stop);
 
     logger.debug(`Calling Amazon Bedrock API: ${JSON.stringify(params)}`);
 


### PR DESCRIPTION
This pull request (PR) aims to introduce _"Amazon Titan Foundation Models"_ as another option for the Bedrock feature. The Bedrock option in this library is currently limited to _"Anthropic Claude Family of Large Language Models."_

This change aims to make the API request function more flexible, allowing for the integration of additional Bedrock options that may have different API requests.

Here's a comparison of how the API request is for both Bedrock options based on their respective AWS documentation:
- [Amazon Titan text models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html)
  - <details><summary><i>request body</i></summary>
    
    ```sh
    {
        "inputText": string,
        "textGenerationConfig": {
            "temperature": float,  
            "topP": float,
            "maxTokenCount": int,
            "stopSequences": [string]
        }
    }
    ```
    </details>
  - <details><summary><i>response body</i></summary>
    
    ```sh
    {
        'inputTextTokenCount': int,
        'results': [{
            'tokenCount': int,
            'outputText': '\n<response>\n',
            'completionReason': string
        }]
    }
    ```
    </details>
- [Anthropic Claude models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html)
  - <details><summary><i>request body</i></summary>
    
    ```sh
    {
        "prompt": "\n\nHuman:<prompt>\n\nAssistant:",
        "temperature": float,
        "top_p": float,
        "top_k": int,
        "max_tokens_to_sample": int,
        "stop_sequences": ["\n\nHuman:"]
    }
    ```
    </details>
  - [_response body_](https://docs.anthropic.com/claude/reference/complete_post)


In sum, below is a table comparing the API requests for both Bedrock options:
<details><summary>see table <strong>summary</strong>...</summary>

| Bedrock option | API request | API response |
|:---:|:---:|:---:|
| Amazon Titan Foundation Models | ![image](https://github.com/promptfoo/promptfoo/assets/1886786/ffb57cc5-d499-4e86-bd9c-c963674fcce2) | ![img](https://github.com/promptfoo/promptfoo/assets/1886786/e7188e69-320f-481a-b9e3-9700f985559e) |
| Anthropic Claude Family of Large Language Models |  ![image](https://github.com/promptfoo/promptfoo/assets/1886786/c9347a6a-4184-41b9-8553-84cc58f0d27f) | ![img](https://github.com/promptfoo/promptfoo/assets/1886786/32d9c8f9-cc3a-48fd-9514-75cdc17b9368) |
</details>


To test the API requests for both Bedrock options, you can use the following commands:
- for _"Amazon Titan Foundation Models"_, use the following command:
  - ```sh
     (AWS_ACCESS_KEY_ID="xxxxx" AWS_SECRET_ACCESS_KEY="xxxxx" \
        node ./dist/src/main.js eval \
        --config examples/amazon-bedrock/promptfooconfig.titan-text.yaml --no-cache)
     ```
  - ![img](https://github.com/promptfoo/promptfoo/assets/1886786/adf7e65c-34f8-4253-8e51-160001073dd7)

- for _"Anthropic Claude Family of Large Language Models"_, use the following command:
  - ```sh
     (AWS_ACCESS_KEY_ID="xxxxx" AWS_SECRET_ACCESS_KEY="xxxxx" \
         node ./dist/src/main.js eval \
         --config examples/amazon-bedrock/promptfooconfig.claude.yaml --no-cache)
     ```
  - ![img](https://github.com/promptfoo/promptfoo/assets/1886786/42c3ac2b-5103-4893-8e1f-9769287598bc)


With this change, we're making it possible to utilize different Bedrock options with varying API requests, giving users more flexibility and choice.

Let me know if you have any questions or feedback.