### PR TITLE
feat: add `promptfoo generate dataset`

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -122,3 +122,28 @@ These general-purpose environment variables are supported:
 | `PROMPTFOO_DISABLE_JSON_AUTOESCAPE`  | If set, disables smart variable substitution within JSON prompts |                |
 | `PROMPTFOO_DISABLE_CONVERSATION_VAR` | Prevents the `_conversation` variable from being set             |                |
 | `PROMPTFOO_DISABLE_REF_PARSER`       | Prevents JSON schema dereferencing                               |                |
+
+## `promptfoo generate dataset`
+
+BETA: Generate synthetic test cases based on existing prompts and variables.
+
+| Option                              | Description                                                | Default              |
+| ----------------------------------- | ---------------------------------------------------------- | -------------------- |
+| `-c, --config <path>`               | Path to the configuration file                             | promptfooconfig.yaml |
+| `-w, --write`                       | Write the generated test cases directly to the config file | false                |
+| `-i, --instructions <text>`         | Custom instructions for test case generation               |                      |
+| `-o, --output <path>`               | Path to write the generated test cases                     | stdout               |
+| `--numPersonas <number>`            | Number of personas to generate                             | 5                    |
+| `--numTestCasesPerPersona <number>` | Number of test cases per persona                           | 3                    |
+
+For example, this command will modify your default config file (usually `promptfooconfig.yaml`) with new test cases:
+
+```
+promptfoo generate dataset -w
+```
+
+This command will generate test cases for a specific config and write them to a file, while following special instructions:
+
+```
+promptfoo generate dataset -c my_config.yaml -o new_tests.yaml -i 'All test cases for {{location}} must be European cities'
+```

--- a/src/main.ts
+++ b/src/main.ts
@@ -392,9 +392,17 @@ async function main() {
         const yamlString = yaml.dump(configAddition);
         if (options.output) {
           writeFileSync(options.output, yamlString);
+          printBorder();
+          logger.info(`Wrote ${results.length} new test cases to ${options.output}`);
+          printBorder();
         } else {
+          printBorder();
+          logger.info('New test Cases');
+          printBorder();
           logger.info(yamlString);
         }
+
+        printBorder();
         const configPath = options.config;
         if (options.write && configPath) {
           const existingConfig = yaml.load(
@@ -403,6 +411,12 @@ async function main() {
           existingConfig.tests = [...(existingConfig.tests || []), ...configAddition.tests];
           writeFileSync(configPath, yaml.dump(existingConfig));
           logger.info(`Wrote ${results.length} new test cases to ${configPath}`);
+        } else {
+          logger.info(
+            `Copy the above test cases or run ${chalk.greenBright(
+              'promptfoo generate dataset --write',
+            )} to write directly to the config`,
+          );
         }
       },
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -418,6 +418,11 @@ async function main() {
             )} to write directly to the config`,
           );
         }
+
+        telemetry.record('command_used', {
+          name: 'generate_dataset',
+        });
+        await telemetry.send();
       },
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { readAssertions } from './assertions';
 import { loadApiProvider, loadApiProviders } from './providers';
 import { evaluate, DEFAULT_MAX_CONCURRENCY } from './evaluator';
 import { readPrompts, readProviderPromptMap } from './prompts';
-import { readTest, readTests } from './testCases';
+import { readTest, readTests, synthesize } from './testCases';
 import {
   cleanupOldResults,
   maybeReadConfig,
@@ -219,6 +219,25 @@ async function main() {
     .description('Send feedback to the promptfoo developers')
     .action((message?: string) => {
       gatherFeedback(message);
+    });
+
+  program
+    .command('generate dataset')
+    .description('Generate test cases for a given prompt')
+    .option('-p, --prompt <path>', 'Prompt to generate test dataset for')
+    .option(
+      '-i, --instructions [instructions]',
+      'Any additional instructions for generating test cases',
+    )
+    .option('-t, --tests [path]', 'Path to any existing tests')
+    .action(async (_, options: { prompt: string; instructions: string; tests: string }) => {
+      const prompts = readPrompts([options.prompt]);
+      const tests = options.tests ? readTests([options.tests]) : [];
+      const results = await synthesize({
+        prompt: prompts[0].raw,
+        instructions: options.instructions,
+        tests,
+      });
     });
 
   program

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -248,6 +248,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
       best_of: this.config.best_of ?? parseInt(process.env.OPENAI_BEST_OF || '1'),
       ...(callApiOptions?.includeLogProbs ? { logprobs: callApiOptions.includeLogProbs } : {}),
       ...(stop ? { stop } : {}),
+      ...(this.config.passthrough || {}),
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
     let data,
@@ -388,6 +389,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       ...(this.config.response_format ? { response_format: this.config.response_format } : {}),
       ...(callApiOptions?.includeLogProbs ? { logprobs: callApiOptions.includeLogProbs } : {}),
       ...(this.config.stop ? { stop: this.config.stop } : {}),
+      ...(this.config.passthrough || {}),
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -248,7 +248,6 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
       best_of: this.config.best_of ?? parseInt(process.env.OPENAI_BEST_OF || '1'),
       ...(callApiOptions?.includeLogProbs ? { logprobs: callApiOptions.includeLogProbs } : {}),
       ...(stop ? { stop } : {}),
-      ...(this.config.passthrough || {}),
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
     let data,
@@ -389,7 +388,6 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       ...(this.config.response_format ? { response_format: this.config.response_format } : {}),
       ...(callApiOptions?.includeLogProbs ? { logprobs: callApiOptions.includeLogProbs } : {}),
       ...(this.config.stop ? { stop: this.config.stop } : {}),
-      ...(this.config.passthrough || {}),
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
 

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -212,7 +212,10 @@ interface SynthesizeOptions {
   numTestCasesPerPersona?: number;
 }
 
-export async function synthesizeFromTestSuite(testSuite: TestSuite, options: Partial<SynthesizeOptions>) {
+export async function synthesizeFromTestSuite(
+  testSuite: TestSuite,
+  options: Partial<SynthesizeOptions>,
+) {
   return synthesize({
     ...options,
     prompts: testSuite.prompts.map((prompt) => prompt.raw),
@@ -231,8 +234,15 @@ export async function synthesize({
     throw new Error('Dataset synthesis requires at least one prompt.');
   }
 
+  numPersonas = numPersonas || 5;
+  numTestCasesPerPersona = numTestCasesPerPersona || 3;
+
+  logger.info(
+    `Starting dataset synthesis. We'll begin by generating up to ${numPersonas} personas. Each persona will be used to generate ${numTestCasesPerPersona} test cases.`,
+  );
+
   // Consider the following prompt for an LLM application: {{prompt}}. List up to 5 user personas that would send this prompt.
-  logger.info(`Synthesizing user personas for prompts:\n${prompts.join('\n')}`);
+  logger.info(`\nGenerating user personas from ${prompts.length} prompts...`);
   const provider = new OpenAiChatCompletionProvider('gpt-4-1106-preview', {
     config: {
       temperature: 1.0,
@@ -248,13 +258,15 @@ ${prompts.map((prompt) => `<Prompt>\n${prompt}\n</Prompt>`).join('\n')}
     `Consider the following prompt${prompts.length > 1 ? 's' : ''} for an LLM application:
 ${promptsString}
 
-List up to ${numPersonas || 5} user personas that would send ${
+List up to ${numPersonas} user personas that would send ${
       prompts.length > 1 ? 'these prompts' : 'this prompt'
     }. Your response should be JSON of the form {personas: string[]}`,
   );
 
-  console.log(resp.output);
   const personas = (JSON.parse(resp.output as string) as { personas: string[] }).personas;
+  logger.info(
+    `\nGenerated ${personas.length} personas:\n${personas.map((p) => `  - ${p}`).join('\n')}`,
+  );
 
   // Extract variable names from the nunjucks template in the prompts
   const variableRegex = /{{\s*(\w+)\s*}}/g;
@@ -265,6 +277,11 @@ List up to ${numPersonas || 5} user personas that would send ${
       variables.add(match[1]);
     }
   }
+  logger.info(
+    `\nExtracted ${variables.size} variables from prompts:\n${Array.from(variables)
+      .map((v) => `  - ${v}`)
+      .join('\n')}`,
+  );
 
   const existingTests =
     `Here are some existing tests:` +
@@ -284,8 +301,9 @@ ${JSON.stringify(test.vars, null, 2)}
 
   // For each user persona, we will generate a map of variable names to values
   const testCaseVars: VarMapping[] = [];
-  for (const persona of personas) {
-    console.log(`Processing persona: ${persona}`);
+  for (let i = 0; i < personas.length; i++) {
+    const persona = personas[i];
+    logger.info(`\nGenerating test cases for persona ${i + 1}...`);
     // Construct the prompt for the LLM to generate variable values
     const personaPrompt = `Consider ${
       prompts.length > 1 ? 'these prompts' : 'this prompt'
@@ -301,9 +319,9 @@ ${existingTests}
 
 Fully embody this persona and determine a value for each variable, such that the prompt would be sent by this persona.
 
-You are a tester, so try to think of ${
-      numTestCasesPerPersona || 3
-    } sets of values that would be interesting or unusual to test. ${instructions || ''}
+You are a tester, so try to think of ${numTestCasesPerPersona} sets of values that would be interesting or unusual to test. ${
+      instructions || ''
+    }
 
 Your response should contain a JSON map of variable names to values, of the form {vars: {${Array.from(
       variables,
@@ -315,10 +333,8 @@ Your response should contain a JSON map of variable names to values, of the form
     const parsed = JSON.parse(personaResponse.output as string) as {
       vars: VarMapping[];
     };
-    console.log('********************************************************');
-    console.log('Persona: ', persona);
     for (const vars of parsed.vars) {
-      console.log(vars);
+      logger.info(`${JSON.stringify(vars, null, 2)}`);
       testCaseVars.push(vars);
     }
   }
@@ -328,9 +344,5 @@ Your response should contain a JSON map of variable names to values, of the form
   const dedupedTestCaseVars: VarMapping[] = Array.from(uniqueTestCaseStrings).map((testCase) =>
     JSON.parse(testCase),
   );
-  console.log('********************************************************');
-  console.log('Test cases:');
-  console.log(dedupedTestCaseVars);
-
   return dedupedTestCaseVars;
 }

--- a/src/web/nextui/src/app/eval/GenerateTestCases.tsx
+++ b/src/web/nextui/src/app/eval/GenerateTestCases.tsx
@@ -60,18 +60,21 @@ function GenerateTestCases() {
         <DialogTitle>Run on Command Line</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            This feature is in beta.  UI coming soon.  Run{' '}
-            <Box
-              component="code"
-              sx={{
-                backgroundColor: theme.palette.mode === 'dark' ? '#424242' : '#f0f0f0',
-                padding: '2px 4px',
-                borderRadius: '4px',
-              }}
-            >
-              promptfoo generate dataset
-            </Box>
-            to generate test cases on the command line.
+            <p>This feature is in beta. UI coming soon.</p>
+            <p>
+              Run{' '}
+              <Box
+                component="code"
+                sx={{
+                  backgroundColor: theme.palette.mode === 'dark' ? '#424242' : '#f0f0f0',
+                  padding: '2px 4px',
+                  borderRadius: '4px',
+                }}
+              >
+                promptfoo generate dataset
+              </Box>
+              to generate test cases on the command line.
+            </p>
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/web/nextui/src/app/eval/GenerateTestCases.tsx
+++ b/src/web/nextui/src/app/eval/GenerateTestCases.tsx
@@ -60,7 +60,7 @@ function GenerateTestCases() {
         <DialogTitle>Run on Command Line</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            UI coming soon. Run{' '}
+            This feature is in beta.  UI coming soon.  Run{' '}
             <Box
               component="code"
               sx={{

--- a/src/web/nextui/src/app/eval/GenerateTestCases.tsx
+++ b/src/web/nextui/src/app/eval/GenerateTestCases.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import AddIcon from '@mui/icons-material/Add';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import useTheme from '@mui/material/styles/useTheme';
+import { useStore } from './store';
+
+function GenerateTestCases() {
+  /*
+  const {config, table} = useStore();
+  const handleGenerateTestCases = async () => {
+    try {
+      const prompts = table?.head.prompts.map((prompt) => prompt.raw);
+      const tests = config?.tests.map((test) => test.raw);
+      const response = await fetch('/api/dataset/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          prompts,
+          tests,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      const data = await response.json();
+      console.log('Test cases generated:', data.results);
+    } catch (error) {
+      console.error('Failed to generate test cases:', error);
+    }
+  };
+  */
+  const theme = useTheme();
+  const [openDialog, setOpenDialog] = React.useState(false);
+
+  const handleOpenDialog = () => {
+    setOpenDialog(true);
+  };
+
+  const handleCloseDialog = () => {
+    setOpenDialog(false);
+  };
+
+  return (
+    <>
+      <div style={{ textAlign: 'center', marginTop: 20, marginBottom: 40 }}>
+        <Button variant="text" color="primary" startIcon={<AddIcon />} onClick={handleOpenDialog}>
+          Generate test cases
+        </Button>
+      </div>
+      <Dialog open={openDialog} onClose={handleCloseDialog}>
+        <DialogTitle>Run on Command Line</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            UI coming soon. Run{' '}
+            <Box
+              component="code"
+              sx={{
+                backgroundColor: theme.palette.mode === 'dark' ? '#424242' : '#f0f0f0',
+                padding: '2px 4px',
+                borderRadius: '4px',
+              }}
+            >
+              promptfoo generate dataset
+            </Box>
+            to generate test cases on the command line.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog} color="primary">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+export default GenerateTestCases;

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -10,10 +10,12 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Tooltip from '@mui/material/Tooltip';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import AddIcon from '@mui/icons-material/Add';
 import Link from 'next/link';
 
 import CustomMetrics from '@/app/eval/CustomMetrics';
@@ -864,6 +866,18 @@ export default function ResultsTable({
             </tr>
           );
         })}
+        <tr>
+          <td colSpan={100} style={{ textAlign: 'center' }}>
+            <Button
+              variant="text"
+              color="primary"
+              startIcon={<AddIcon />}
+              onClick={() => {}}
+            >
+              Generate more test cases
+            </Button>
+          </td>
+        </tr>
       </tbody>
     </table>
   );

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -10,16 +10,15 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Tooltip from '@mui/material/Tooltip';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import AddIcon from '@mui/icons-material/Add';
 import Link from 'next/link';
 
 import CustomMetrics from '@/app/eval/CustomMetrics';
 import EvalOutputPromptDialog from '@/app/eval/EvalOutputPromptDialog';
+import GenerateTestCases from '@/app/eval/GenerateTestCases';
 import { getApiBaseUrl } from '@/api';
 import { useStore } from '@/app/eval/store';
 
@@ -798,87 +797,78 @@ export default function ResultsTable({
   });
 
   return (
-    <table
-      className={`results-table firefox-fix ${maxTextLength <= 25 ? 'compact' : ''}`}
-      style={{
-        wordBreak,
-      }}
-    >
-      <thead>
-        {reactTable.getHeaderGroups().map((headerGroup: any) => (
-          <tr key={headerGroup.id} className="header">
-            {headerGroup.headers.map((header: any) => {
-              return (
-                <th
-                  key={header.id}
-                  {...{
-                    colSpan: header.colSpan,
-                    style: {
-                      width: header.getSize(),
-                    },
-                  }}
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                  <div
-                    {...{
-                      onMouseDown: header.getResizeHandler(),
-                      onTouchStart: header.getResizeHandler(),
-                      className: `resizer ${header.column.getIsResizing() ? 'isResizing' : ''}`,
-                    }}
-                  />
-                </th>
-              );
-            })}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {reactTable.getRowModel().rows.map((row: any, rowIndex: any) => {
-          let colBorderDrawn = false;
-          return (
-            <tr key={row.id}>
-              {row.getVisibleCells().map((cell: any) => {
-                const isMetadataCol =
-                  cell.column.id.startsWith('Variable') || cell.column.id === 'description';
-                const shouldDrawColBorder = !isMetadataCol && !colBorderDrawn;
-                if (shouldDrawColBorder) {
-                  colBorderDrawn = true;
-                }
-                const shouldDrawRowBorder = rowIndex === 0 && !isMetadataCol;
+    <div>
+      <table
+        className={`results-table firefox-fix ${maxTextLength <= 25 ? 'compact' : ''}`}
+        style={{
+          wordBreak,
+        }}
+      >
+        <thead>
+          {reactTable.getHeaderGroups().map((headerGroup: any) => (
+            <tr key={headerGroup.id} className="header">
+              {headerGroup.headers.map((header: any) => {
                 return (
-                  <td
-                    key={cell.id}
+                  <th
+                    key={header.id}
                     {...{
+                      colSpan: header.colSpan,
                       style: {
-                        width: cell.column.getSize(),
+                        width: header.getSize(),
                       },
-                      className: `${isMetadataCol ? 'variable' : ''} ${
-                        shouldDrawRowBorder ? 'first-prompt-row' : ''
-                      } ${shouldDrawColBorder ? 'first-prompt-col' : ''}`,
                     }}
                   >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                    <div
+                      {...{
+                        onMouseDown: header.getResizeHandler(),
+                        onTouchStart: header.getResizeHandler(),
+                        className: `resizer ${header.column.getIsResizing() ? 'isResizing' : ''}`,
+                      }}
+                    />
+                  </th>
                 );
               })}
             </tr>
-          );
-        })}
-        <tr>
-          <td colSpan={100} style={{ textAlign: 'center' }}>
-            <Button
-              variant="text"
-              color="primary"
-              startIcon={<AddIcon />}
-              onClick={() => {}}
-            >
-              Generate more test cases
-            </Button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          ))}
+        </thead>
+        <tbody>
+          {reactTable.getRowModel().rows.map((row: any, rowIndex: any) => {
+            let colBorderDrawn = false;
+            return (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell: any) => {
+                  const isMetadataCol =
+                    cell.column.id.startsWith('Variable') || cell.column.id === 'description';
+                  const shouldDrawColBorder = !isMetadataCol && !colBorderDrawn;
+                  if (shouldDrawColBorder) {
+                    colBorderDrawn = true;
+                  }
+                  const shouldDrawRowBorder = rowIndex === 0 && !isMetadataCol;
+                  return (
+                    <td
+                      key={cell.id}
+                      {...{
+                        style: {
+                          width: cell.column.getSize(),
+                        },
+                        className: `${isMetadataCol ? 'variable' : ''} ${
+                          shouldDrawRowBorder ? 'first-prompt-row' : ''
+                        } ${shouldDrawColBorder ? 'first-prompt-col' : ''}`,
+                      }}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <GenerateTestCases />
+    </div>
   );
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -11,7 +11,14 @@ import cors from 'cors';
 import compression from 'compression';
 import opener from 'opener';
 import { Server as SocketIOServer } from 'socket.io';
-import promptfoo, { EvaluateSummary, EvaluateTestSuite, PromptWithMetadata } from '../index';
+import promptfoo, {
+  EvaluateSummary,
+  EvaluateTestSuite,
+  Prompt,
+  PromptWithMetadata,
+  TestCase,
+  TestSuite,
+} from '../index';
 
 import logger from '../logger';
 import { getDirectory } from '../esm';
@@ -25,6 +32,7 @@ import {
   getTestCases,
   updateResult,
 } from '../util';
+import { synthesizeFromTestSuite } from '../testCases';
 
 interface Job {
   status: 'in-progress' | 'complete';
@@ -200,6 +208,19 @@ export function startServer(port = 15500, apiBaseUrl = '', skipConfirmation = fa
     res.json({
       apiBaseUrl: apiBaseUrl || '',
     });
+  });
+
+  app.post('/api/dataset/generate', async (req, res) => {
+    const testSuite: TestSuite = {
+      prompts: req.body.prompts as Prompt[],
+      tests: req.body.tests as TestCase[],
+      providers: [],
+    };
+
+    const results = await synthesizeFromTestSuite(testSuite, {});
+    return {
+      results,
+    };
   });
 
   // Must come after the above routes (particularly /api/config) so it doesn't


### PR DESCRIPTION
BETA: Generate synthetic test cases based on existing prompts and variables.

| Option                              | Description                                                | Default              |
| ----------------------------------- | ---------------------------------------------------------- | -------------------- |
| `-c, --config <path>`               | Path to the configuration file                             | promptfooconfig.yaml |
| `-w, --write`                       | Write the generated test cases directly to the config file | false                |
| `-i, --instructions <text>`         | Custom instructions for test case generation               |                      |
| `-o, --output <path>`               | Path to write the generated test cases                     | stdout               |
| `--numPersonas <number>`            | Number of personas to generate                             | 5                    |
| `--numTestCasesPerPersona <number>` | Number of test cases per persona                           | 3                    |

For example, this command will modify your default config file (usually `promptfooconfig.yaml`) with new test cases:

```
promptfoo generate dataset -w
```

This command will generate test cases for a specific config and write them to a file, while following special instructions:

```
promptfoo generate dataset -c my_config.yaml -o new_tests.yaml -i 'All test cases for {{location}} must be European cities'
```