### PR TITLE
fix: Only open previous results when necessary (uses lots of memory)

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -26,6 +26,7 @@ import {
   getLatestResultsPath,
   getPrompts,
   getPromptsForTestCasesHash,
+  listPreviousResultFilenames,
   listPreviousResults,
   readResult,
   filenameToDate,
@@ -172,8 +173,7 @@ export function startServer(port = 15500, apiBaseUrl = '', skipConfirmation = fa
     const safeFilename = path.basename(filename);
     if (
       safeFilename !== filename ||
-      !listPreviousResults()
-        .map((fileMeta) => fileMeta.fileName)
+      !listPreviousResultFilenames()
         .includes(safeFilename)
     ) {
       res.status(400).send('Invalid filename');


### PR DESCRIPTION
The `listPreviousResults` function loads a _lot_ into memory if you're passing around big config files (which happens quickly when using `file://`). It's called in a bunch of places where all that's actually needed are the filenames.

This PR introduces a new `listPreviousResultFilenames` method and calls that wherever possible, which turns out to be everywhere except the `/results` view.

Removes a ~30 second pause for me (and then eventually OOM errors) after promptfoo finished an eval. All of that waiting turned out to be my laptop struggling with the call to `cleanupOldResults`, which was loading all of those results into memory. (For me that was 60 ~200kb files * 70 results, which adds up!)