### PR TITLE
feat: ability to transform output on per-assertion level

### DIFF
--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -37,8 +37,8 @@ tests:
 
   - vars:
       city: New York
-    # postprocess returns only the 'name' property
-    postprocess: output.name
+    # Transform returns only the 'name' property
+    outputTransform: output.name
     assert:
       - type: is-json
       - type: similar

--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -37,12 +37,17 @@ tests:
 
   - vars:
       city: New York
-    # Transform returns only the 'name' property
-    outputTransform: output.name
     assert:
-      - type: is-json
+      - type: equals
+        value: get_current_weather
+        # Transform is a cleaner way to pick out specific properties.
+        # This transform returns only the 'name' property
+        outputTransform: output.name
       - type: similar
         value: NYC
+        threshold: 0.5
+        # This transform returns only the parsed location argument.
+        outputTransform: JSON.parse(output.arguments).location
 
   - vars:
       city: Paris

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -40,8 +40,8 @@ tests:
 
   - vars:
       city: New York
-    # postprocess returns only the 'name' property
-    postprocess: output[0].function.name
+    # Transform returns only the 'name' property
+    outputTransform: output[0].function.name
     assert:
       - type: is-json
       - type: similar

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -40,15 +40,27 @@ tests:
 
   - vars:
       city: New York
-    # Transform returns only the 'name' property
-    outputTransform: output[0].function.name
+    options:
+      # Transform is a cleaner way to pick out specific properties.
+      # This transform returns only the 'name' property
+      outputTransform: output[0].function.name
     assert:
-      - type: is-json
-      - type: similar
-        value: NYC
+      - type: equals
+        value: get_current_weather
 
   - vars:
       city: Paris
+    assert:
+      - type: equals
+        value: get_current_weather
+        # Transform is a cleaner way to pick out specific properties.
+        # This transform returns only the 'name' property
+        outputTransform: output[0].function.name
+      - type: similar
+        value: Paris, France
+        threshold: 0.5
+        # This transform returns only the parsed location argument.
+        outputTransform: JSON.parse(output[0].function.arguments).location
 
   - vars:
       city: Mars

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -305,14 +305,14 @@ promptfoo supports OpenAI tools, functions, and other provider-specific configur
 
 To use, override the `config` key of the provider. See example [here](/docs/providers/openai#using-functions).
 
-### Postprocessing
+### Transforming outputs
 
-The `TestCase.options.postprocess` field is a Javascript snippet that modifies the LLM output. Postprocessing occurs before any assertions are run.
+The `TestCase.options.outputTransform` field is a Javascript snippet that modifies the LLM output before it is run through the test assertions.
 
-Postprocess is a function that takes a string output and a context object:
+It is a function that takes a string output and a context object:
 
 ```
-postprocessFn: (output: string, context: {
+outputTransformFn: (output: string, context: {
   vars: Record<string, any>
 })
 ```
@@ -329,7 +329,7 @@ tests:
       body: Hello world
     options:
       // highlight-start
-      postprocess: output.toUpperCase()
+      outputTransform: output.toUpperCase()
       // highlight-end
     # ...
 ```
@@ -344,7 +344,7 @@ tests:
       body: Hello world
     options:
       // highlight-start
-      postprocess: |
+      outputTransform: |
         output = output.replace(context.vars.language, 'foo');
         const words = output.split(' ').filter(x => !!x);
         return JSON.stringify(words);
@@ -352,7 +352,21 @@ tests:
     # ...
 ```
 
-Tip: use `defaultTest` apply a postprocessing option to every test case in your test suite.
+It also works for assertions, which is useful for picking values out of JSON:
+
+```yaml
+tests:
+  - vars:
+      # ...
+    assert:
+      - type: equals
+        value: 'foo'
+        outputTransform: output.category  # Select the 'category' key from output json
+```
+
+:::tip
+Use `defaultTest` apply a transform option to every test case in your test suite.
+:::
 
 ## Config structure and organization
 

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -11,7 +11,7 @@ import { distance as levenshtein } from 'fastest-levenshtein';
 
 import telemetry from './telemetry';
 import { fetchWithRetries } from './fetch';
-import { getNunjucksEngine } from './util';
+import { applyOutputTransform, getNunjucksEngine } from './util';
 import {
   matchesSimilarity,
   matchesLlmRubric,
@@ -201,6 +201,10 @@ export async function runAssertion({
   telemetry.record('assertion_used', {
     type: baseType,
   });
+  
+  if (assertion.outputTransform) {
+    output = applyOutputTransform(assertion.outputTransform, output, {vars: test.vars});
+  }
 
   const outputString = coerceString(output);
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -8,7 +8,7 @@ import logger from './logger';
 import telemetry from './telemetry';
 import { runAssertions } from './assertions';
 import { generatePrompts } from './suggestions';
-import { getNunjucksEngine, sha256 } from './util';
+import { getNunjucksEngine, applyOutputTransform, sha256 } from './util';
 import { maybeEmitAzureOpenAiWarning } from './providers/azureopenaiUtil';
 
 import type { SingleBar } from 'cli-progress';
@@ -237,19 +237,9 @@ class Evaluator {
       } else if (response.output) {
         // Create a copy of response so we can potentially mutate it.
         let processedResponse = { ...response };
-        if (test.options?.postprocess) {
-          const { postprocess } = test.options;
-          const postprocessFn = new Function(
-            'output',
-            'context',
-            postprocess.includes('\n') ? postprocess : `return ${postprocess}`,
-          );
-          processedResponse.output = postprocessFn(processedResponse.output, {
-            vars,
-          });
-          if (processedResponse.output == null) {
-            throw new Error('Postprocess function did not return a value');
-          }
+        const outputTransform = test.options?.outputTransform || test.options?.postprocess;
+        if (outputTransform) {
+          processedResponse.output = applyOutputTransform(outputTransform, processedResponse.output, { vars });
         }
 
         invariant(processedResponse.output != null, 'Response output should not be null');

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,11 @@ export interface PromptConfig {
 }
 
 export interface OutputConfig {
+  /**
+   * @deprecated in > 0.38.0. Use `outputTransform` instead.
+   */
   postprocess?: string;
+  outputTransform?: string;
 }
 
 export interface EvaluateOptions {
@@ -354,6 +358,9 @@ export interface Assertion {
 
   // Tag this assertion result as a named metric
   metric?: string;
+  
+  // Process the output before running the assertion
+  outputTransform?: string;
 }
 
 // Used when building prompts index from files.

--- a/src/util.ts
+++ b/src/util.ts
@@ -772,3 +772,16 @@ export function printBorder() {
   const border = '='.repeat((process.stdout.columns || 80) - 10);
   logger.info(border);
 }
+
+export function applyOutputTransform(code: string, output: string | object | undefined, context: unknown) {
+  const postprocessFn = new Function(
+    'output',
+    'context',
+    code.includes('\n') ? code : `return ${code}`,
+  );
+  const ret = postprocessFn(output, context);
+  if (output == null) {
+    throw new Error(`Postprocess function did not return a value\n\n${code}`);
+  }
+  return ret;
+}

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -365,13 +365,13 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with postprocess option - default test', async () => {
+  test('evaluate with outputTransform option - default test', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
       defaultTest: {
         options: {
-          postprocess: 'output + " postprocessed"',
+          outputTransform: 'output + " postprocessed"',
         },
       },
     };
@@ -384,7 +384,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
 
-  test('evaluate with postprocess option - single test', async () => {
+  test('evaluate with outputTransform option - single test', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -397,7 +397,7 @@ describe('evaluator', () => {
             },
           ],
           options: {
-            postprocess: 'output + " postprocessed"',
+            outputTransform: 'output + " postprocessed"',
           },
         },
       ],
@@ -411,7 +411,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
 
-  test('evaluate with postprocess option - json provider', async () => {
+  test('evaluate with outputTransform option - json provider', async () => {
     const mockApiJsonProvider: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider-json'),
       callApi: jest.fn().mockResolvedValue({
@@ -432,7 +432,7 @@ describe('evaluator', () => {
             },
           ],
           options: {
-            postprocess: `JSON.parse(output).value`,
+            outputTransform: `JSON.parse(output).value`,
           },
         },
       ],
@@ -630,7 +630,7 @@ it('should use the options from the test if they exist', async () => {
       {
         vars: { var1: 'value1', var2: 'value2' },
         options: {
-          postprocess: 'output + " postprocessed"',
+          outputTransform: 'output + " postprocessed"',
         },
       },
     ],


### PR DESCRIPTION
- Add an `outputTransform` property to assertions
- Rename `postprocess` to `outputTransform` on TestCase

This makes it easy to pick keys out of JSON objects for an assertion, and do other logical transformations