### PR TITLE
feat: compare between multiple outputs with `select-best`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Model-assisted eval metrics
 | [context-relevance](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded)     | Ensure that context is relevant to original query                               |
 | [factuality](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
 | [model-graded-closedqa](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded) | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
+| [select-best](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded)           | Compare multiple outputs for a test case and pick the best one                  |
 
 Every test type can be negated by prepending `not-`. For example, `not-equals` or `not-regex`.
 

--- a/examples/select-best-example/README.md
+++ b/examples/select-best-example/README.md
@@ -1,0 +1,10 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, edit promptfooconfig.yaml.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/select-best-example/promptfooconfig.yaml
+++ b/examples/select-best-example/promptfooconfig.yaml
@@ -1,0 +1,18 @@
+prompts:
+  - "Write a tweet about {{topic}}"
+  - "Write a very concise, funny tweet about {{topic}}"
+
+providers: [openai:gpt-4]
+
+tests:
+  - vars:
+      topic: bananas
+    assert:
+      - type: select-best
+        value: choose the funniest tweet
+
+  - vars:
+      topic: nyc
+    assert:
+      - type: select-best
+        value: choose the tweet that contains the most facts

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -42,7 +42,7 @@ tests:
 
 ### Deterministic eval metrics
 
-These metrics are programmatic tests that are run on LLM output.  [See all details](/docs/configuration/expected-outputs/deterministic)
+These metrics are programmatic tests that are run on LLM output. [See all details](/docs/configuration/expected-outputs/deterministic)
 
 | Assertion Type                                                                                                     | Returns true if...                                               |
 | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
@@ -79,17 +79,18 @@ These metrics are model-assisted, and rely on LLMs or other machine learning mod
 
 See [Model-graded evals](/docs/configuration/expected-outputs/model-graded), [classification](/docs/configuration/expected-outputs/classifier), and [similarity](/docs/configuration/expected-outputs/similar) docs for more information.
 
-| Assertion Type                                                             | Method                                                                          |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [similar](/docs/configuration/expected-outputs/similar)                    | Embeddings and cosine similarity are above a threshold                          |
-| [classifier](/docs/configuration/expected-outputs/classifier)              | Run LLM output through a classifier                                             |
-| [llm-rubric](/docs/configuration/expected-outputs/model-graded)            | LLM output matches a given rubric, using a Language Model to grade output       |
-| [answer-relevance](/docs/configuration/expected-outputs/model-graded)      | Ensure that LLM output is related to original query                             |
-| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)  | Ensure that LLM output uses the context                                         |
-| [context-recall](/docs/configuration/expected-outputs/model-graded)        | Ensure that ground truth appears in context                                     |
-| [context-relevance](/docs/configuration/expected-outputs/model-graded)     | Ensure that context is relevant to original query                               |
-| [factuality](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
-| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded) | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
+| Assertion Type                                                                        | Method                                                                          |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [similar](/docs/configuration/expected-outputs/similar)                               | Embeddings and cosine similarity are above a threshold                          |
+| [classifier](/docs/configuration/expected-outputs/classifier)                         | Run LLM output through a classifier                                             |
+| [llm-rubric](/docs/configuration/expected-outputs/model-graded)                       | LLM output matches a given rubric, using a Language Model to grade output       |
+| [answer-relevance](/docs/configuration/expected-outputs/model-graded)                 | Ensure that LLM output is related to original query                             |
+| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)             | Ensure that LLM output uses the context                                         |
+| [context-recall](/docs/configuration/expected-outputs/model-graded)                   | Ensure that ground truth appears in context                                     |
+| [context-relevance](/docs/configuration/expected-outputs/model-graded)                | Ensure that context is relevant to original query                               |
+| [factuality](/docs/configuration/expected-outputs/model-graded)                       | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
+| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
+| [select-best](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded) | Compare multiple outputs for a test case and pick the best one                  |
 
 ## Weighted assertions
 

--- a/site/docs/configuration/expected-outputs/model-graded.md
+++ b/site/docs/configuration/expected-outputs/model-graded.md
@@ -13,6 +13,7 @@ Output-based:
 - `factuality` - a factual consistency eval which, given a completion `A` and reference answer `B` evaluates whether A is a subset of B, A is a superset of B, A and B are equivalent, A and B disagree, or A and B differ, but difference don't matter from the perspective of factuality. Uses the prompt from OpenAI's public evals.
 - `answer-relevance` - ensure that LLM output is related to original query
 - `classifier` - see [classifier grading docs](/docs/configuration/expected-outputs/classifier).
+- `select-best` - compare outputs from multiple test cases and choose a winner
 
 RAG-based (requires `query` and/or `context` vars):
 
@@ -110,6 +111,33 @@ tests:
         threshold: 0.9
       - type: context-faithfulness
         threshold: 0.9
+```
+
+## Examples (comparison)
+
+The `select-best` assertion type is used to compare multiple outputs in the same TestCase row and select the one that best meets a specified criterion. 
+
+Here's an example of how to use `select-best` in a configuration file:
+
+```yaml
+prompts:
+  - "Write a tweet about {{topic}}"
+  - "Write a very concise, funny tweet about {{topic}}"
+
+providers: [openai:gpt-4]
+
+tests:
+  - vars:
+      topic: bananas
+    assert:
+      - type: select-best
+        value: choose the funniest tweet
+
+  - vars:
+      topic: nyc
+    assert:
+      - type: select-best
+        value: choose the tweet that contains the most facts
 ```
 
 ## Overriding the LLM grader

--- a/site/docs/usage/node-package.md
+++ b/site/docs/usage/node-package.md
@@ -100,7 +100,10 @@ The evaluate function takes the following parameters:
       | 'is-valid-openai-function-call'
       | 'is-valid-openai-tools-call'
       | 'latency'
-      | 'perplexity';
+      | 'perplexity'
+      | 'perplexity-score'
+      | 'cost'
+      | 'select-best';
 
     // The expected value, if applicable
     value?: string | string[] | object | AssertionFunction;

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -22,7 +22,7 @@ import {
   matchesContextRecall,
   matchesContextRelevance,
   matchesContextFaithfulness,
-  matchesComparisonBoolean,
+  matchesSelectBest,
 } from './matchers';
 
 import type { Assertion, AssertionType, GradingResult, AtomicTestCase, ApiProvider } from './types';
@@ -115,6 +115,7 @@ export async function runAssertions({
   const namedScores: Record<string, number> = {};
   for (const assertion of test.assert) {
     if (assertion.type.startsWith('select-')) {
+      // Select-type assertions are handled separately because they depend on multiple outputs.
       continue;
     }
     const weight = assertion.weight || 1;
@@ -1251,7 +1252,7 @@ export async function runCompareAssertion(
   outputs: string[],
 ): Promise<GradingResult[]> {
   invariant(typeof assertion.value === 'string', 'select-best must have a string value');
-  const comparisonResults = await matchesComparisonBoolean(assertion.value, outputs, undefined, test.vars);
+  const comparisonResults = await matchesSelectBest(assertion.value, outputs, undefined, test.vars);
   return comparisonResults.map(result => ({
     ...result,
     assertion
@@ -1281,4 +1282,5 @@ export default {
   matchesContextRecall,
   matchesContextRelevance,
   matchesContextFaithfulness,
+  matchesComparisonBoolean: matchesSelectBest,
 };

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -649,6 +649,17 @@ class Evaluator {
       },
     );
 
+    const compareRowsCount = table.body.reduce((count, row) => 
+      count + (row.test.assert?.some((a) => a.type === 'select-best') ? 1 : 0), 0);
+    
+    if (compareRowsCount > 0 && progressbar) {
+      progressbar.start(compareRowsCount, 0, {
+        provider: 'Running model-graded comparisons',
+        prompt: '',
+        vars: '',
+      });
+    }
+
     for (const row of table.body) {
       const compareAssertion = row.test.assert?.find((a) => a.type === 'select-best');
       if (compareAssertion) {
@@ -681,7 +692,16 @@ class Evaluator {
             output.gradingResult.componentResults.push(gradingResult);
           }
         });
+        if (progressbar) {
+          progressbar.increment({
+            prompt: row.outputs[0].text.slice(0, 10).replace(/\n/g, ''),
+          });
+        }
       }
+    }
+
+    if (progressbar) {
+      progressbar.stop();
     }
 
     // Finish up

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -730,7 +730,7 @@ export async function matchesContextFaithfulness(
   };
 }
 
-export async function matchesComparisonBoolean(
+export async function matchesSelectBest(
   criteria: string,
   outputs: string[],
   grading?: GradingConfig,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -330,3 +330,18 @@ export const AI_SELF_REFERENCE_PROMPT_SYSTEM_MESSAGE = {
   role: 'system',
   content: `In this task, you will be given a string of text produced by a large language model. Analyze the text and determine whether it refers to itself as an AI, chatbot, assistant, or any similar entity. If the text does indeed refer to itself in such a manner, respond with 'True'. Otherwise, respond with 'False'.`,
 };
+
+export const SELECT_BEST_PROMPT = JSON.stringify([{
+  role: 'system',
+  content: `You are comparing multiple pieces of text to see which best fits the following criteria: {{criteria}}
+
+Here are the pieces of text:
+
+{% for output in outputs %}
+<Text index="{{ loop.index0 }}">
+{{ output }}
+</Text>
+{% endfor %}
+
+Output the index of the text that best fits the criteria. You must output a single integer.`,
+}]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,7 @@ export interface EvaluateTableRow {
   description?: string;
   outputs: EvaluateTableOutput[];
   vars: string[];
+  test: AtomicTestCase;
 }
 
 export interface EvaluateTable {
@@ -322,8 +323,9 @@ type BaseAssertionTypes =
   | 'latency'
   | 'perplexity'
   | 'perplexity-score'
-  | 'cost';
-
+  | 'cost'
+  | 'select-best';
+  
 type NotPrefixed<T extends string> = `not-${T}`;
 
 export type AssertionType = BaseAssertionTypes | NotPrefixed<BaseAssertionTypes>;

--- a/src/web/nextui/src/app/setup/AssertsForm.tsx
+++ b/src/web/nextui/src/app/setup/AssertsForm.tsx
@@ -62,6 +62,7 @@ const assertTypes: AssertionType[] = [
   'context-faithfulness',
   'context-recall',
   'context-relevance',
+  'select-best',
 ];
 
 const AssertsForm: React.FC<AssertsFormProps> = ({ onAdd, initialValues }) => {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -85,6 +85,7 @@ describe('util', () => {
             },
           ],
           vars: ['value1', 'value2'],
+          test: {},
         },
       ],
     };
@@ -155,6 +156,7 @@ describe('util', () => {
             },
           ],
           vars: ['value1', 'value2'],
+          test: {},
         },
       ],
     };
@@ -225,6 +227,7 @@ describe('util', () => {
             },
           ],
           vars: ['value1', 'value2'],
+          test: {},
         },
       ],
     };
@@ -295,6 +298,7 @@ describe('util', () => {
             },
           ],
           vars: ['value1', 'value2'],
+          test: {},
         },
       ],
     };


### PR DESCRIPTION
For example:

```yaml
prompts:
  - "Write a tweet about {{topic}}"
  - "Write a very concise, funny tweet about {{topic}}"

providers: [openai:gpt-4]

tests:
  - vars:
      topic: bananas
    assert:
      - type: select-best
        value: choose the funniest tweet

  - vars:
      topic: nyc
    assert:
      - type: select-best
        value: choose the tweet that contains the most facts
```

Related to #289 