### PR TITLE
fix: func => function in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { evaluate as doEvaluate } from './evaluator';
 import { loadApiProviders } from './providers';
 import { readTests } from './testCases';
 import { readFilters, writeLatestResults, writeMultipleOutputs, writeOutput } from './util';
-import type { EvaluateOptions, TestSuite, EvaluateTestSuite, ProviderOptions } from './types';
+import type { EvaluateOptions, TestSuite, EvaluateTestSuite, ProviderOptions, PromptFunction } from './types';
 
 export * from './types';
 
@@ -30,7 +30,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
         return {
           raw: promptInput.toString(),
           display: promptInput.toString(),
-          func: promptInput,
+          function: promptInput as PromptFunction,
         };
       } else if (typeof promptInput === 'string') {
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,9 +505,11 @@ export interface EvalWithMetadata {
   results: EvaluateSummary;
 }
 
+export type PromptFunction = (context: { vars: Record<string, string | object> }) => Promise<string | object>
+
 // node.js package interface
 export type EvaluateTestSuite = {
-  prompts: (string | object | Function)[];
+  prompts: (string | object | PromptFunction)[];
   writeLatestResults?: boolean;
 } & TestSuiteConfig;
 


### PR DESCRIPTION
Functions are not working when provided as the prompt in the node interface. They are being treated as strings.

e.g.
Sample file:

```javascript
import promptfoo from 'promptfoo';

const prompts = [
  (vars) => {
    const genres = ['fantasy', 'sci-fi', 'mystery', 'horror'];
    const characters = {
      'fantasy': 'wizard',
      'sci-fi': 'alien',
      'mystery': 'detective',
      'horror': 'ghost'
    };
    const genre = genres[Math.floor(Math.random() * genres.length)];
    const character = characters[genre];
    return [
      {
        role: 'system',
        content: `You have encountered a ${character} in a ${genre} setting. Engage with the character using the knowledge typical for that genre.`,
      },
      {
        role: 'user',
        content: '{{body}}',
      }
    ];
  },
];

const providers = [
  'openai:chat:gpt-4-1106-preview',
];

const tests = [{
  vars: {
    body: 'Hello world',
  },
}];

(async () => {
  const results = await promptfoo.evaluate({ prompts, providers, tests });
  console.log(JSON.stringify(results, null, 2));
})();
```

Output:
```
{
  "version": 2,
  "results": [
    {
      "provider": {
        "id": "openai:gpt-4-1106-preview"
      },
      "prompt": {
        "raw": "(vars) => {\n    const genres = ['fantasy', 'sci-fi', 'mystery', 'horror'];\n    const characters = {\n      'fantasy': 'wizard',\n      'sci-fi': 'alien',\n      'mystery': 'detective',\n      'horror': 'ghost'\n    };\n    const genre = genres[Math.floor(Math.random() * genres.length)];\n    const character = characters[genre];\n    return [\n      {\n        role: 'system',\n        content: `You have encountered a ${character} in a ${genre} setting. Engage with the character using the knowledge typical for that genre.`,\n      },\n      {\n        role: 'user',\n        content: 'Hello world',\n      }\n    ];\n  }",
...
```