### PR TITLE
feat: add support for google ai studio gemini

### DIFF
--- a/site/docs/providers/palm.md
+++ b/site/docs/providers/palm.md
@@ -6,15 +6,16 @@ sidebar_position: 43
 
 The `palm` provider is compatible with Google AI Studio (formerly known as [PaLM](https://developers.generativeai.google/)), which offers access to Gemini models.
 
-You can use it by specifying one of the [available models](https://developers.generativeai.google/models/language). Currently, the following models are supported:
+You can use it by specifying one of the [available models](https://ai.google.dev/models). Currently, the following models are supported:
 
 - `palm:gemini-pro`
 - `palm:gemini-pro-vision`
+- `palm:aqa` (attributed question answering)
 - `palm:chat-bison-001`
 
 Supported environment variables:
 
-- `PALM_API_KEY` (required) - Google PaLM API token
+- `PALM_API_KEY` (required) - Google AI Studio/PaLM API token
 - `PALM_API_HOST` - used to override the Google API host, defaults to `generativelanguage.googleapis.com`
 
 The PaLM provider supports various [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/palm.ts#L9-L18) such as `safetySettings`, `stopSequences`, `temperature`, `maxOutputTokens`, `topP`, and `topK` that can be used to customize the behavior of the model like so:

--- a/site/docs/providers/palm.md
+++ b/site/docs/providers/palm.md
@@ -2,12 +2,14 @@
 sidebar_position: 43
 ---
 
-# Google PaLM
+# Google AI Studio
 
-The `palm` provider is compatible with Google's [PaLM](https://developers.generativeai.google/) offering, which offers access to models such as `text-bison-001`.
+The `palm` provider is compatible with Google AI Studio (formerly known as [PaLM](https://developers.generativeai.google/)), which offers access to Gemini models.
 
-You can use it by specifying one of the [available models](https://developers.generativeai.google/models/language) offered by PaLM. Currently, the following model is supported:
+You can use it by specifying one of the [available models](https://developers.generativeai.google/models/language). Currently, the following models are supported:
 
+- `palm:gemini-pro`
+- `palm:gemini-pro-vision`
 - `palm:chat-bison-001`
 
 Supported environment variables:
@@ -19,7 +21,7 @@ The PaLM provider supports various [configuration options](https://github.com/pr
 
 ```yaml
 providers:
-  - id: palm:text-bison-001
+  - id: palm:gemini-pro
     config:
       temperature: 0
       maxOutputTokens: 1024

--- a/site/docs/providers/palm.md
+++ b/site/docs/providers/palm.md
@@ -4,25 +4,25 @@ sidebar_position: 43
 
 # Google AI Studio
 
-The `palm` provider is compatible with Google AI Studio (formerly known as [PaLM](https://developers.generativeai.google/)), which offers access to Gemini models.
+The `google` provider is compatible with Google AI Studio (formerly known as [PaLM](https://developers.generativeai.google/)), which offers access to Gemini models.
 
 You can use it by specifying one of the [available models](https://ai.google.dev/models). Currently, the following models are supported:
 
-- `palm:gemini-pro`
-- `palm:gemini-pro-vision`
-- `palm:aqa` (attributed question answering)
-- `palm:chat-bison-001`
+- `google:gemini-pro`
+- `google:gemini-pro-vision`
+- `google:aqa` (attributed question answering)
+- `google:chat-bison-001`
 
 Supported environment variables:
 
-- `PALM_API_KEY` (required) - Google AI Studio/PaLM API token
-- `PALM_API_HOST` - used to override the Google API host, defaults to `generativelanguage.googleapis.com`
+- `GOOGLE_API_KEY` (required) - Google AI Studio/PaLM API token
+- `GOOGLE_API_HOST` - used to override the Google API host, defaults to `generativelanguage.googleapis.com`
 
 The PaLM provider supports various [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/palm.ts#L9-L18) such as `safetySettings`, `stopSequences`, `temperature`, `maxOutputTokens`, `topP`, and `topK` that can be used to customize the behavior of the model like so:
 
 ```yaml
 providers:
-  - id: palm:gemini-pro
+  - id: google:gemini-pro
     config:
       temperature: 0
       maxOutputTokens: 1024

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -263,7 +263,7 @@ export async function loadApiProvider(
       const modelName = splits.slice(1).join(':');
       return new OllamaCompletionProvider(modelName, providerOptions);
     }
-  } else if (providerPath.startsWith('palm:')) {
+  } else if (providerPath.startsWith('palm:') || providerPath.startsWith('google:')) {
     const modelName = providerPath.split(':')[1];
     return new PalmChatProvider(modelName, providerOptions);
   } else if (providerPath.startsWith('vertex')) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export interface EnvOverrides {
   LOCALAI_BASE_URL?: string;
   PALM_API_KEY?: string;
   PALM_API_HOST?: string;
+  GOOGLE_API_KEY?: string;
+  GOOGLE_API_HOST?: string;
   VERTEX_API_KEY?: string;
   VERTEX_API_HOST?: string;
   VERTEX_PROJECT_ID?: string;


### PR DESCRIPTION
Google PaLM seems to have rebranded to AI Studio and modified their API slightly.

Here's an example of how to use AI Studio/Gemini Pro
```yaml
prompts:
  - "Write a short tweet about {{topic}}"

providers:
  - palm:gemini-pro

tests:
  - vars:
      topic: bananas
  - vars:
      topic: walruses
```

Also adds support for `google:` prefix and related environment variables `GOOGLE_API_KEY` and `GOOGLE_API_HOST`

Related to #444 