### PR TITLE
documentation: update python.md typo in yaml

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -14,7 +14,7 @@ To configure the Python provider, you need to specify the path to your Python sc
 
 ```yaml
 providers:
-  - id: 'python:my_script.py':
+  - id: 'python:my_script.py'
     config:
       additionalOption: 123
 ```


### PR DESCRIPTION
Hello!
testing the solution and following the documentation as well, it works without the `:`