### PR TITLE
fix(vertex/gemini): add support for llm-rubric and other OpenAI-formatted prompts

### DIFF
--- a/examples/google-vertex/promptfooconfig.yaml
+++ b/examples/google-vertex/promptfooconfig.yaml
@@ -3,7 +3,12 @@
 prompts:
   - "You are a helpful assistant. Reply with a concise answer to this inquiry: '{{question}}'"
 
-providers: [vertex:gemini-pro, vertex:chat-bison] # or use the PaLM API: [palm:chat-bison-001]
+providers: [vertex:gemini-pro, vertex:chat-bison] # or use the Google AI Studio API: [google:gemini-pro]
+
+defaultTest:
+  options:
+    # Use gemini-pro for model-graded evals (e.g. assertions such as llm-rubric)
+    provider: vertex:gemini-pro
 
 tests:
   - vars:

--- a/src/providers/palm.ts
+++ b/src/providers/palm.ts
@@ -95,6 +95,7 @@ export class PalmChatProvider extends PalmGenericProvider {
     }
 
     // https://developers.generativeai.google/tutorials/curl_quickstart
+    // https://ai.google.dev/api/rest/v1beta/models/generateMessage
     const messages = parseChatPrompt(prompt, [{ content: prompt }]);
     const body = {
       prompt: { messages },

--- a/src/providers/vertexUtil.ts
+++ b/src/providers/vertexUtil.ts
@@ -53,3 +53,18 @@ export interface ResponseData {
 }
 
 export type GeminiApiResponse = (ResponseData | ErrorResponse)[];
+
+export function maybeCoerceToGeminiFormat(contents: any) {
+  let coerced = false;
+  if (Array.isArray(contents) && typeof contents[0].content === 'string') {
+    // This looks like an OpenAI chat prompt.  Convert it to a compatible format
+    contents = {
+      role: 'user',
+      parts: {
+        text: contents.map((item) => item.content).join(''),
+      },
+    };
+    coerced = true;
+  }
+  return { contents, coerced };
+}


### PR DESCRIPTION
This makes it so you can use `llm-rubric` and other model-graded evals with a Vertex `gemini-pro` provider, for example.

Related to #447 