### PR TITLE
feat(mistral): Add Mistral provider

### DIFF
--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -1,0 +1,14 @@
+# Mistral AI
+
+The [Mistral AI API](https://docs.mistral.ai/api/) offers access to Mistral models such as `mistral-tiny`, `mistral-small`, and `mistral-medium`.
+
+Here's an example config that compares Mistral Medium, Mistral Small, and OpenAI GPT-3.5:
+
+```yaml
+providers:
+  - mistral:mistral-medium
+  - mistral:mistral-small
+  - openai:chat:gpt-3.5-turbo
+```
+
+Be sure to set the `MISTRAL_API_KEY` environment variable!

--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -2,7 +2,24 @@
 
 The [Mistral AI API](https://docs.mistral.ai/api/) offers access to Mistral models such as `mistral-tiny`, `mistral-small`, and `mistral-medium`.
 
-Here's an example config that compares Mistral Medium, Mistral Small, and OpenAI GPT-3.5:
+## API Key
+
+To use Mistral AI, you need to set the `MISTRAL_API_KEY` environment variable, or specify the `apiKey` in the provider configuration.
+
+Example of setting the environment variable:
+
+```bash
+export MISTRAL_API_KEY=your_api_key_here
+```
+
+## Model Selection
+
+You can specify which Mistral model to use in your configuration. Currently, the following 3 models are available:
+1. `mistral-tiny`
+2. `mistral-small`
+3. `mistral-medium`
+
+Here's an example config that compares Mistral-Medium, Mistral-Small, and OpenAI GPT-3.5:
 
 ```yaml
 providers:
@@ -11,4 +28,31 @@ providers:
   - openai:chat:gpt-3.5-turbo
 ```
 
-Be sure to set the `MISTRAL_API_KEY` environment variable!
+## Options
+
+The Mistral provider supports several options to customize the behavior of the model. These include:
+
+- `temperature`: Controls the randomness of the output.
+- `top_p`: Controls nucleus sampling, affecting the randomness of the output.
+- `max_tokens`: The maximum length of the generated text.
+- `safe_prompt`: Whether to enforce safe content in the prompt.
+- `random_seed`: A seed for deterministic outputs.
+- `fix_json`: Fixes common JSON formatting issues in the output, useful for parsing. Note: This is not a Mistral feature, but was added for convenience.
+
+Example configuration with options:
+
+```yaml
+providers:
+- id: mistral:mistral-medium
+  config:
+    temperature: 0.7
+    max_tokens: 512
+    safe_prompt: true
+    fix_json: true
+```
+
+## Additional Capabilities
+
+- **Caching**: Caches previous LLM requests by default.
+- **Token Usage Tracking**: Provides detailed information on the number of tokens used in each request, aiding in usage monitoring and optimization.
+- **Cost Calculation**: Calculates the cost of each request based on the number of tokens generated and the specific model used.

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -27,6 +27,7 @@ import {
   OllamaChatProvider,
 } from './providers/ollama';
 import { VertexChatProvider } from './providers/vertex';
+import { MistralChatCompletionProvider } from './providers/mistral';
 import { WebhookProvider } from './providers/webhook';
 import { ScriptCompletionProvider } from './providers/scriptCompletion';
 import {
@@ -269,6 +270,9 @@ export async function loadApiProvider(
   } else if (providerPath.startsWith('vertex')) {
     const modelName = providerPath.split(':')[1];
     return new VertexChatProvider(modelName, providerOptions);
+  } else if (providerPath.startsWith('mistral:')) {
+    const modelName = providerPath.split(':')[1];
+    return new MistralChatCompletionProvider(modelName, providerOptions);
   } else if (providerPath?.startsWith('localai:')) {
     const splits = providerPath.split(':');
     const modelType = splits[1];

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -1,0 +1,194 @@
+import logger from '../logger';
+import { fetchWithCache } from '../cache';
+
+import {
+  ApiProvider,
+  EnvOverrides,
+  ProviderResponse,
+  TokenUsage,
+} from '../types';
+import { REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
+
+interface MistralChatCompletionOptions {
+  apiKey?: string;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  safe_prompt?: boolean;
+  random_seed?: number;
+  fix_json?: boolean;
+  cost?: number;
+}
+
+function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
+  if (data.usage) {
+    if (cached) {
+      return { cached: data.usage.total_tokens, total: data.usage.total_tokens };
+    } else {
+      return {
+        total: data.usage.total_tokens,
+        prompt: data.usage.prompt_tokens || 0,
+        completion: data.usage.completion_tokens || 0,
+      };
+    }
+  }
+  return {};
+}
+
+function calculateCost(
+  modelName: string,
+  config: MistralChatCompletionOptions,
+  promptTokens?: number,
+  completionTokens?: number,
+): number | undefined {
+  if (!promptTokens || !completionTokens) {
+    return undefined;
+  }
+
+  const model = [
+    ...MistralChatCompletionProvider.MISTRAL_CHAT_MODELS,
+  ].find((m) => m.id === modelName);
+  if (!model || !model.cost) {
+    return undefined;
+  }
+
+  const inputCost = config.cost ?? model.cost.input;
+  const outputCost = config.cost ?? model.cost.output;
+  return inputCost * promptTokens + outputCost * completionTokens || undefined;
+}
+
+export class MistralChatCompletionProvider implements ApiProvider {
+  modelName: string;
+  config:  MistralChatCompletionOptions;
+  env?: EnvOverrides;
+
+  static MISTRAL_CHAT_MODELS = [
+    ...['mistral-tiny'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.00015 / 1000,
+        output: 0.00045 / 1000,
+      },
+    })),
+    ...['mistral-small'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.00064 / 1000,
+        output: 0.00193 / 1000,
+      },
+    })),
+    ...['mistral-medium'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.00269 / 1000,
+        output: 0.00806 / 1000,
+      },
+    }))
+  ];
+
+  static MISTRAL_CHAT_MODELS_NAMES = MistralChatCompletionProvider.MISTRAL_CHAT_MODELS.map(
+    (model) => model.id,
+  );
+
+  constructor(
+    modelName: string,
+    options: { id?: string; config?:  MistralChatCompletionOptions; env?: EnvOverrides } = {},
+  ) {
+    if (!MistralChatCompletionProvider.MISTRAL_CHAT_MODELS_NAMES.includes(modelName)) {
+      logger.warn(`Using unknown Mistral chat model: ${modelName}`);
+    }
+    const { id, config, env } = options;
+    this.env = env;
+    this.modelName = modelName;
+    this.id = id ? () => id : this.id;
+    this.config = config || {};
+  }
+
+  id(): string {
+    return `mistral:${this.modelName}`;
+  }
+
+  toString(): string {
+    return `[Mistral Provider ${this.modelName}]`;
+  }
+
+  getApiKey(): string | undefined {
+    return this.config.apiKey || this.env?.MISTRAL_API_KEY || process.env.MISTRAL_API_KEY;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    if (!this.getApiKey()) {
+      throw new Error(
+        'Mistra API key is not set. Set the MISTRAL_API_KEY environment variable or add `apiKey` to the provider config.',
+      );
+    }
+
+    const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
+    
+    const body = {
+      model: this.modelName,
+      messages: messages,
+      temperature: this.config?.temperature,
+      top_p: this.config?.top_p || 1,
+      max_tokens: this.config?.max_tokens || 1024,
+      safe_prompt: this.config?.safe_prompt || false,
+      random_seed: this.config?.random_seed || null,
+    };
+
+    const url = 'https://api.mistral.ai/v1/chat/completions';
+    logger.debug(`Mistral API request: ${url} ${JSON.stringify(body)}`);
+
+    let data, 
+      cached = false;
+
+    try {
+      ({ data, cached } = (await fetchWithCache(
+        url,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this.getApiKey()}`,
+          },
+          body: JSON.stringify(body),
+        },
+        REQUEST_TIMEOUT_MS,
+        )) as unknown as { data: any; cached: boolean });
+    } catch (err) {
+      return {
+        error: `API call error: ${String(err)}`,
+      };
+    }
+
+    logger.debug(`Mistral API response: ${JSON.stringify(data)}`);
+
+    if (data.error) {
+      return {
+        error: `API call error: ${data.error}`,
+      };
+    }
+    if (!data.choices[0] && !data.choices[0].message.content) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+      };
+    }
+    let content;
+    if (this.config?.fix_json){
+      // Mistral is often messing up JSON responses. This fixes the output to allow for the tests to pass.
+      content = data.choices[0].message.content.replace(/\\_/g, "_").replace(/\\\*/g, "*")
+    } else {
+      content = data.choices[0].message.content
+    }
+    return {
+      output: content,
+      tokenUsage: getTokenUsage(data, cached),
+      cached,
+      cost: calculateCost(
+        this.modelName,
+        this.config,
+        data.usage?.prompt_tokens,
+        data.usage?.completion_tokens,
+      ),
+    };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface EnvOverrides {
   VERTEX_PROJECT_ID?: string;
   VERTEX_REGION?: string;
   VERTEX_PUBLISHER?: string;
+  MISTRAL_API_KEY?: string;
 }
 
 export interface ProviderOptions {


### PR DESCRIPTION
This PR adds support for the Mistral Provider (#448). 

- [x] All API parameters are covered
- [x] The model cost has been converted to USD and will be shown
- [x] Caching is supported
- [x] API key can be provided in the config or via the `MISTRAL_API_KEY` environment variable
- [x] Added an optional custom config option `fix_json` that fixes some incorrect JSON responses.

More information about the API can be found [here](https://docs.mistral.ai/api/).

<img width="1040" alt="Mistral X PromptFoo" src="https://github.com/promptfoo/promptfoo/assets/5006784/66c6ee6c-1ff0-47c2-b50f-7a3287553af4">

@typpo I'm also happy to update the docs. 

Let me know if the PR is looking good, or what changes are needed.
I can also share a temporary API Key with you if you want to test it yourself.