### PR TITLE
feat(openai): add support for `apiKeyEnvar`

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -4,9 +4,7 @@ sidebar_position: 1
 
 # OpenAI
 
-To use the OpenAI API, set the `OPENAI_API_KEY` environment variable,
-specify via `apiKey` field in the configuration file,
-or pass the API key as an argument to the constructor.
+To use the OpenAI API, set the `OPENAI_API_KEY` environment variable, specify via `apiKey` field in the configuration file or pass the API key as an argument to the constructor.
 
 Example:
 
@@ -92,6 +90,7 @@ Supported parameters include:
 | `response_format`   | Response format restrictions.                                                                                                                                   |
 | `seed`              | Seed used for deterministic output. Defaults to 0                                                                                                               |
 | `apiKey`            | Your OpenAI API key, equivalent to `OPENAI_API_KEY` environment variable                                                                                        |
+| `apiKeyEnvar`       | An environment variable that contains the API key                                                                                                               |
 | `apiHost`           | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                       |
 | `apiBaseUrl`        | The base URL of the OpenAI API, please also read `OPENAI_API_BASE_URL` below.                                                                                   |
 | `organization`      | Your OpenAI organization key.                                                                                                                                   |
@@ -128,6 +127,7 @@ interface OpenAiConfig {
 
   // General OpenAI parameters
   apiKey?: string;
+  apiKeyEnvar?: string;
   apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;

--- a/site/docs/providers/perplexity.md
+++ b/site/docs/providers/perplexity.md
@@ -11,10 +11,14 @@ providers:
   - id: openai:chat:pplx-70b-chat-alpha
     config:
       apiHost: api.perplexity.ai
+      apiKeyEnvar: PERPLEXITY_API_KEY
   - id: openai:chat:llama-2-70b-chat
     config:
       apiHost: api.perplexity.ai
+      apiKeyEnvar: PERPLEXITY_API_KEY
 ```
+
+In this example, you'd have to set the `PERPLEXITY_API_KEY` environment variable (you can also enter it directly in the config using the `apiKey` property).
 
 If desired, you can instead use the `OPENAI_API_HOST` environment variable instead of the `apiHost` config key.
 

--- a/site/docs/providers/togetherai.md
+++ b/site/docs/providers/togetherai.md
@@ -11,7 +11,9 @@ providers:
   - id: openai:chat:mistralai/Mixtral-8x7B-Instruct-v0.1
     config:
       apiBaseUrl: https://api.together.xyz
-      apiKey: xxx
+      apiKeyEnvar: TOGETHER_API_KEY
 ```
 
-If desired, you can instead use the `OPENAI_API_BASE_URL` and `OPENAI_API_KEY` environment variables instead of the `apiBaseUrl` and `apiKey` configs.
+If desired, you can instead use the `OPENAI_API_BASE_URL` environment variables instead of the `apiBaseUrl` config property.
+
+In this example, you'd also have to set the `TOGETHER_API_KEY` environment variable (you can also enter it directly in the config using the `apiKey` property).

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -17,6 +17,7 @@ import type {
 
 interface OpenAiSharedOptions {
   apiKey?: string;
+  apiKeyEnvar?: string;
   apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;
@@ -111,7 +112,12 @@ export class OpenAiGenericProvider implements ApiProvider {
   }
 
   getApiKey(): string | undefined {
-    return this.config.apiKey || this.env?.OPENAI_API_KEY || process.env.OPENAI_API_KEY;
+    return (
+      this.config.apiKey ||
+      (this.config.apiKeyEnvar ? process.env[this.config.apiKeyEnvar] : undefined) ||
+      this.env?.OPENAI_API_KEY ||
+      process.env.OPENAI_API_KEY
+    );
   }
 
   // @ts-ignore: Params are not used in this implementation


### PR DESCRIPTION
This makes it easier to use OpenAI-compatible APIs without having to hardcode API keys in config.