### PR TITLE
feat(openai)!: Allow apiBaseUrl to override /v1 endpoint

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,27 +54,9 @@ export async function fetchWithCache(
 ): Promise<{ data: any; cached: boolean }> {
   if (!enabled || bust) {
     const resp = await fetchWithRetries(url, options, timeout);
-    if (!resp.ok) {
-      throw new Error(
-        `Request failed with status ${resp.status} ${resp.statusText}:\n\n${await resp.text()}`,
-      );
-    }
-    const contentType = resp.headers.get('content-type');
-    let data;
-    if (contentType?.includes('application/json')) {
-      try {
-        data = await resp.json();
-      } catch (error) {
-        throw new Error(`Expected JSON response, but parsing failed.`);
-      }
-    } else if (format === 'json') {
-      throw new Error(`Expected JSON response, but got ${contentType}:\n\n${await resp.text()}`);
-    } else {
-      data = await resp.text();
-    }
     return {
       cached: false,
-      data: data,
+      data: format === 'json' ? await resp.json() : await resp.text(),
     };
   }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,9 +54,27 @@ export async function fetchWithCache(
 ): Promise<{ data: any; cached: boolean }> {
   if (!enabled || bust) {
     const resp = await fetchWithRetries(url, options, timeout);
+    if (!resp.ok) {
+      throw new Error(
+        `Request failed with status ${resp.status} ${resp.statusText}:\n\n${await resp.text()}`,
+      );
+    }
+    const contentType = resp.headers.get('content-type');
+    let data;
+    if (contentType?.includes('application/json')) {
+      try {
+        data = await resp.json();
+      } catch (error) {
+        throw new Error(`Expected JSON response, but parsing failed.`);
+      }
+    } else if (format === 'json') {
+      throw new Error(`Expected JSON response, but got ${contentType}:\n\n${await resp.text()}`);
+    } else {
+      data = await resp.text();
+    }
     return {
       cached: false,
-      data: format === 'json' ? await resp.json() : await resp.text(),
+      data: data,
     };
   }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -99,13 +99,13 @@ export class OpenAiGenericProvider implements ApiProvider {
   }
 
   getApiUrlDefault(): string {
-    return 'https://api.openai.com';
+    return 'https://api.openai.com/v1';
   }
 
   getApiUrl(): string {
     const apiHost = this.config.apiHost || this.env?.OPENAI_API_HOST || process.env.OPENAI_API_HOST;
     if (apiHost) {
-      return `https://${apiHost}`;
+      return `https://${apiHost}/v1`;
     }
     return (
       this.config.apiBaseUrl ||
@@ -148,7 +148,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `${this.getApiUrl()}/v1/embeddings`,
+        `${this.getApiUrl()}/embeddings`,
         {
           method: 'POST',
           headers: {
@@ -275,7 +275,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `${this.getApiUrl()}/v1/completions`,
+        `${this.getApiUrl()}/completions`,
         {
           method: 'POST',
           headers: {
@@ -422,7 +422,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       cached = false;
     try {
       ({ data, cached } = (await fetchWithCache(
-        `${this.getApiUrl()}/v1/chat/completions`,
+        `${this.getApiUrl()}/chat/completions`,
         {
           method: 'POST',
           headers: {
@@ -541,7 +541,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
       apiKey: this.getApiKey(),
       organization: this.getOrganization(),
       // Unfortunate, but the OpenAI SDK's implementation of base URL is different from how we treat base URL elsewhere.
-      baseURL: this.getApiUrl() + '/v1',
+      baseURL: this.getApiUrl(),
       maxRetries: 3,
       timeout: REQUEST_TIMEOUT_MS,
     });
@@ -698,7 +698,7 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
       apiKey: this.getApiKey(),
       organization: this.getOrganization(),
       // Unfortunate, but the OpenAI SDK's implementation of base URL is different from how we treat base URL elsewhere.
-      baseURL: this.getApiUrl() + '/v1',
+      baseURL: this.getApiUrl(),
       maxRetries: 3,
       timeout: REQUEST_TIMEOUT_MS,
     });

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -4,6 +4,22 @@ import fetch, { Response } from 'node-fetch';
 jest.mock('node-fetch');
 const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
 
+const mockedFetchResponse = (ok: boolean, response: object) => {
+  return {
+    ok,
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve('error'),
+    headers: {
+      get: (name: string) => {
+        if (name === 'content-type') {
+          return 'application/json';
+        }
+        return null;
+      },
+    },
+  } as Response;
+};
+
 describe('fetchWithCache', () => {
   afterEach(() => {
     mockedFetch.mockReset();
@@ -15,10 +31,7 @@ describe('fetchWithCache', () => {
     const url = 'https://api.example.com/data';
     const response = { data: 'test data' };
 
-    mockedFetch.mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve(response),
-    } as Response);
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(false, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 
@@ -32,10 +45,7 @@ describe('fetchWithCache', () => {
     const url = 'https://api.example.com/data';
     const response = { data: 'test data' };
 
-    mockedFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(response),
-    } as Response);
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 
@@ -47,10 +57,7 @@ describe('fetchWithCache', () => {
     const url = 'https://api.example.com/data';
     const response = { data: 'test data' };
 
-    mockedFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(response),
-    } as Response);
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 
@@ -64,9 +71,7 @@ describe('fetchWithCache', () => {
     const url = 'https://api.example.com/data';
     const response = { data: 'test data' };
 
-    mockedFetch.mockResolvedValueOnce({
-      json: () => Promise.resolve(response),
-    } as Response);
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 
@@ -82,10 +87,7 @@ describe('fetchWithCache', () => {
     const url = 'https://api.example.com/data';
     const response = { data: 'test data' };
 
-    mockedFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(response),
-    } as Response);
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 


### PR DESCRIPTION
This is a potentially breaking change for anyone using the `apiBaseUrl` property on OpenAI provider. 

Before:  `/v1` was automatically appended to the base URL.
After: `/v1` is not automatically appended to the base URL.  

**If this breaks you, you probably just have to append `/v1` to `apiBaseUrl`**

This change brings the behavior in line with OpenAI's SDK, and solves compatibility issues with other OpenAI-compatible APIs such as perplexity.