### PR TITLE
feat: add support for async python providers

### DIFF
--- a/examples/python-provider/promptfooconfig.yaml
+++ b/examples/python-provider/promptfooconfig.yaml
@@ -3,7 +3,7 @@ prompts:
   - "Write a very concise, funny tweet about {{topic}}"
 
 providers:
-  - id: python:provider.py
+  - id: python:provider.py   # or provider_async.py
     config:
       foo: bar
 

--- a/examples/python-provider/provider_async.py
+++ b/examples/python-provider/provider_async.py
@@ -1,0 +1,19 @@
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI()
+
+async def call_api(prompt, options, context):
+    chat_completion = await client.chat.completions.create(
+            messages=[{
+                'role': 'system',
+                'content': 'You are a marketer working for a startup called Bananamax.',
+            }, {
+                'role': 'user',
+                'content': prompt,
+            }],
+            model='gpt-3.5-turbo',
+    )
+
+    return {
+        'output': chat_completion.choices[0].message.content
+    }

--- a/src/providers/wrapper.py
+++ b/src/providers/wrapper.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import importlib
+import asyncio
 
 def call_api(script_path, prompt, options, context):
     script_dir = os.path.dirname(os.path.abspath(script_path))
@@ -10,7 +11,10 @@ def call_api(script_path, prompt, options, context):
         sys.path.insert(0, script_dir)
     print(f'Importing module {module_name} from {script_dir}...')
     script_module = importlib.import_module(module_name)
-    return script_module.call_api(prompt, options, context)
+    if asyncio.iscoroutinefunction(script_module.call_api):
+        return asyncio.run(script_module.call_api(prompt, options, context))
+    else:
+        return script_module.call_api(prompt, options, context)
 
 if __name__ == '__main__':
     script_path = sys.argv[1]


### PR DESCRIPTION
For example:

```py
from openai import AsyncOpenAI

client = AsyncOpenAI()

async def call_api(prompt, options, context):
    chat_completion = await client.chat.completions.create(
            messages=[{
                'role': 'system',
                'content': 'You are a marketer working for a startup called Bananamax.',
            }, {
                'role': 'user',
                'content': prompt,
            }],
            model='gpt-3.5-turbo',
    )

    return {
        'output': chat_completion.choices[0].message.content
    }
```

with config:
```yaml
prompts:
  - "Write a tweet about {{topic}}"
  - "Write a very concise, funny tweet about {{topic}}"

providers:
  - id: python:provider_async.py
    config:
      foo: bar

tests:
  - vars:
      topic: turtles
    assert:
      - type: llm-rubric
        value: is funny
```