### PR TITLE
feat: add support for claude 2.1 on bedrock

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -17,7 +17,10 @@ export class AnthropicCompletionProvider implements ApiProvider {
     'claude-1',
     'claude-1-100k',
     'claude-instant-1',
+    'claude-instant-1.2',
     'claude-instant-1-100k',
+    'claude-2',
+    'claude-2.1',
   ];
 
   modelName: string;

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -68,6 +68,7 @@ const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'anthropic.claude-instant-v1': BEDROCK_MODEL.CLAUDE,
   'anthropic.claude-v1': BEDROCK_MODEL.CLAUDE,
   'anthropic.claude-v2': BEDROCK_MODEL.CLAUDE,
+  'anthropic.claude-v2.1': BEDROCK_MODEL.CLAUDE,
   'amazon.titan-text-lite-v1': BEDROCK_MODEL.TITAN_TEXT,
   'amazon.titan-text-express-v1': BEDROCK_MODEL.TITAN_TEXT,
 };
@@ -132,7 +133,11 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
       throw new Error(`BEDROCK_STOP is not a valid JSON string: ${err}`);
     }
 
-    const model = AWS_BEDROCK_MODELS[this.modelName];
+    let model = AWS_BEDROCK_MODELS[this.modelName];
+    if (!model) {
+      logger.warn(`Unknown Amazon Bedrock model: ${this.modelName}. Assuming its API is Claude-like.`);
+      model = BEDROCK_MODEL.CLAUDE;
+    }
     const params = model.params(this.config, prompt, stop);
 
     logger.debug(`Calling Amazon Bedrock API: ${JSON.stringify(params)}`);


### PR DESCRIPTION
Related to #469 

also adds a few more claude models to be recognized by the `anthropic` provider