### PR TITLE
feat(openai): support handling OpenAI Assistant functions tool calls

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -618,6 +618,62 @@ tests:
   # ...
 ```
 
+### Automatically handling function tool calls
+
+You can specify JavaScript callbacks that are automatically called to create
+the output of a function tool call.
+
+This requires definining your config in a JavaScript file instead of YAML.
+
+```js
+module.exports = /** @type {import('promptfoo').TestSuiteConfig} */ ({
+  prompts: 'Please add the following numbers together: {{a}} and {{b}}',
+  providers: [
+    {
+      id: 'openai:assistant:asst_fEhNN3MClMamLfKLkIaoIpgZ',
+      config:
+        /** @type {InstanceType<import('promptfoo')["providers"]["OpenAiAssistantProvider"]>["config"]} */ ({
+          model: 'gpt-4-1106-preview',
+          instructions: 'You can add two numbers together using the `addNumbers` tool',
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'addNumbers',
+                description: 'Add two numbers together',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    a: { type: 'number' },
+                    b: { type: 'number' }
+                  },
+                  required: ['a', 'b']
+                }
+              }
+            }
+          ],
+          /**
+           * Map of function tool names to function callback.
+           */
+          functionToolCallbacks: {
+            // this function should accept a string, and return a string
+            // or a `Promise<string>`.
+            addNumbers: (parametersJsonString) => {
+              const { a, b } = JSON.parse(parametersJsonString);
+              return JSON.stringify(a + b);
+            }
+          }
+        })
+    }
+  ],
+  tests: [
+    {
+      vars: { a: 5, b: 6 }
+    }
+  ]
+});
+```
+
 ## Troubleshooting
 
 ### OpenAI rate limits


### PR DESCRIPTION
Currently, promptfoo doesn't know how to handle OpenAI function tool invocations, so it just quits and prints:
`[Function output: undefined]`. See https://github.com/promptfoo/promptfoo/issues/324 and https://github.com/promptfoo/promptfoo/commit/71af29f5266a89b446fbc65eea3d6f2a845f562e.

I'd like to propose adding some way to tell promptfoo to handle these.

This commit adds support for a new config option for `OpenAiAssistantProvider` called `functionToolCallbacks` that contains JavaScript callbacks for functions. It's currently only supported in JavaScript promptfoo configs.

These callbacks be automatically called, then the results sent to OpenAI using [`openai.beta.threads.runs.submitToolOutputs`][1].

## Example

Given the `openai-assistant-functionToolsCallbacks-example-promptfooconfig.js`:

```javascript
module.exports = /** @type {import('promptfoo').TestSuiteConfig} */ ({
  prompts: 'Please add the following numbers together: {{a}} and {{b}}',
  providers: [
    {
      id: 'openai:assistant:asst_nGI2HgkZDpmFgW4XAwEKKtmR',
      config:
        /** @type {InstanceType<import('promptfoo')["providers"]["OpenAiAssistantProvider"]>["config"]} */ ({
          model: 'gpt-4-1106-preview',
          instructions: 'You can add two numbers together using the `addNumbers` tool',
          tools: [
            {
              type: 'function',
              function: {
                name: 'addNumbers',
                description: 'Add two numbers together',
                parameters: {
                  type: 'object',
                  properties: {
                    a: { type: 'number' },
                    b: { type: 'number' }
                  },
                  required: ['a', 'b']
                }
              }
            }
          ],
          /**
           * Map of function tool names to function callback.
           */
          functionToolCallbacks: {
            // this function should accept a string, and return a string
            // or a `Promise<string>`.
            addNumbers: (parametersJsonString) => {
              const { a, b } = JSON.parse(parametersJsonString);
              return JSON.stringify(a + b);
            }
          }
        })
    }
  ],
  tests: [
    {
      vars: { a: 5, b: 6 }
    }
  ]
});
```

### Current behaviour (as of 0.41.0)

Evaluation stops with `[Function output: undefined]` after a function call.

```console
alois@pc:~ $ npx promptfoo@0.41.0 eval --config "$(realpath openai-assistant-functionToolsCallbacks-example-promptfooconfig.js)"
Eval: [████████████████████████████████████████] 100% | ETA: 0s | 1/1 | openai:assistant:asst_nGI2HgkZDp6

┌───────────────────────────────┬───────────────────────────────┬───────────────────────────────┐
│ a                             │ b                             │ Please add the following numb │
│                               │                               │ ers together: {{a}} and {{b}} │
├───────────────────────────────┼───────────────────────────────┼───────────────────────────────┤
│ 5                             │ 6                             │ [PASS] [Call functi           │
│                               │                               │ on addNumbers with arguments  │
│                               │                               │ {"a":5,"b":6}]                │
│                               │                               │ [Function output: undefined]  │
└───────────────────────────────┴───────────────────────────────┴───────────────────────────────┘
===============================================================================================
✔ Evaluation complete.

» Run promptfoo view to use the local web viewer
» Run promptfoo share to create a shareable URL
» This project needs your feedback. What's one thing we can improve? https://forms.gle/YFLgTe1dKJKNSCsU7
===============================================================================================
Successes: 1
Failures: 0
Token usage: Total 0, Prompt 0, Completion 0, Cached 0
Done.
```

### After this PR

`promptfoo` automatically calls `functionToolCallbacks['addNumbers']`, allowing evaluation to continue.

```console
alois@pc:~ $ npx promptfoo eval --config "$(realpath openai-assistant-functionToolsCallbacks-example-promptfooconfig.js)"

Eval: [████████████████████████████████████████] 100% | ETA: 0s | 1/1 | openai:assistant:asst_nGI2HgkZDp6

┌───────────────────────────────┬───────────────────────────────┬───────────────────────────────┐
│ a                             │ b                             │ Please add the following numb │
│                               │                               │ ers together: {{a}} and {{b}} │
├───────────────────────────────┼───────────────────────────────┼───────────────────────────────┤
│ 5                             │ 6                             │ [PASS] [Call functi           │
│                               │                               │ on addNumbers with arguments  │
│                               │                               │ {"a":5,"b":6}]                │
│                               │                               │ [Function output: 11]         │
│                               │                               │ [Assistant] The sum of 5 and  │
│                               │                               │ 6 is 11.                      │
└───────────────────────────────┴───────────────────────────────┴───────────────────────────────┘
===============================================================================================
✔ Evaluation complete.

» Run promptfoo view to use the local web viewer
» Run promptfoo share to create a shareable URL
» This project needs your feedback. What's one thing we can improve? https://forms.gle/YFLgTe1dKJKNSCsU7
===============================================================================================
Successes: 1
Failures: 0
Token usage: Total 0, Prompt 0, Completion 0, Cached 0
Done.
```

[1]: https://platform.openai.com/docs/api-reference/runs/submitToolOutputs