### PR TITLE
feat: ability to disable var expansion

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -116,12 +116,14 @@ Show details of a specific resource.
 
 These general-purpose environment variables are supported:
 
-| Name                                 | Description                                                      | Default        |
-| ------------------------------------ | ---------------------------------------------------------------- | -------------- |
-| `PROMPTFOO_CONFIG_DIR`               | Directory that stores eval history                               | `~/.promptfoo` |
-| `PROMPTFOO_DISABLE_JSON_AUTOESCAPE`  | If set, disables smart variable substitution within JSON prompts |                |
-| `PROMPTFOO_DISABLE_CONVERSATION_VAR` | Prevents the `_conversation` variable from being set             |                |
-| `PROMPTFOO_DISABLE_REF_PARSER`       | Prevents JSON schema dereferencing                               |                |
+| Name                                 | Description                                                           | Default        |
+| ------------------------------------ | --------------------------------------------------------------------- | -------------- |
+| `PROMPTFOO_CONFIG_DIR`               | Directory that stores eval history                                    | `~/.promptfoo` |
+| `PROMPTFOO_DISABLE_CONVERSATION_VAR` | Prevents the `_conversation` variable from being set                  |                |
+| `PROMPTFOO_DISABLE_JSON_AUTOESCAPE`  | If set, disables smart variable substitution within JSON prompts      |                |
+| `PROMPTFOO_DISABLE_REF_PARSER`       | Prevents JSON schema dereferencing                                    |                |
+| `PROMPTFOO_DISABLE_TEMPLATING`       | Disable Nunjucks rendering                                            |                |
+| `PROMPTFOO_DISABLE_VAR_EXPANSION`    | Prevents Array-type vars from being expanded into multiple test cases |                |
 
 ## `promptfoo generate dataset`
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -467,7 +467,9 @@ class Evaluator {
         testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
 
       // Finalize test case eval
-      const varCombinations = generateVarCombinations(testCase.vars || {});
+      const varCombinations = process.env.PROMPTFOO_DISABLE_VAR_EXPANSION
+        ? [testCase.vars]
+        : generateVarCombinations(testCase.vars || {});
 
       const numRepeat = this.options.repeat || 1;
       for (let repeatIndex = 0; repeatIndex < numRepeat; repeatIndex++) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -160,7 +160,11 @@ class Evaluator {
     const vars = test.vars || {};
     const conversationKey = `${provider.id()}:${prompt.id}`;
     const usesConversation = prompt.raw.includes('_conversation');
-    if (!process.env.PROMPTFOO_DISABLE_CONVERSATION_VAR && usesConversation) {
+    if (
+      !process.env.PROMPTFOO_DISABLE_CONVERSATION_VAR &&
+      !test.options?.disableConversationVar &&
+      usesConversation
+    ) {
       vars._conversation = this.conversations[conversationKey] || [];
     }
 
@@ -467,9 +471,10 @@ class Evaluator {
         testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
 
       // Finalize test case eval
-      const varCombinations = process.env.PROMPTFOO_DISABLE_VAR_EXPANSION
-        ? [testCase.vars]
-        : generateVarCombinations(testCase.vars || {});
+      const varCombinations =
+        process.env.PROMPTFOO_DISABLE_VAR_EXPANSION || testCase.options.disableVarExpansion
+          ? [testCase.vars]
+          : generateVarCombinations(testCase.vars || {});
 
       const numRepeat = this.options.repeat || 1;
       for (let repeatIndex = 0; repeatIndex < numRepeat; repeatIndex++) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -613,10 +613,6 @@ class Evaluator {
                 if (typeof varValue === 'string') {
                   return varValue;
                 }
-                if (Array.isArray(varValue)) {
-                  // Only flatten string arrays
-                  return typeof varValue[0] === 'string' ? varValue : JSON.stringify(varValue);
-                }
                 return JSON.stringify(varValue);
               })
               .flat(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,7 @@ export interface GradingConfig {
 
 export interface PromptConfig {
   prefix?: string;
-  suffix?: string;
+  suffix?: string; 
 }
 
 export interface OutputConfig {
@@ -400,7 +400,12 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   assert?: Assertion[];
 
   // Additional configuration settings for the prompt
-  options?: PromptConfig & OutputConfig & GradingConfig;
+  options?: PromptConfig & OutputConfig & GradingConfig & {
+    // If true, do not expand arrays of variables into multiple eval cases.
+    disableVarExpansion?: boolean;
+    // If true, do not include an implicit `_conversation` variable in the prompt.
+    disableConversationVar?: boolean;
+  };
 
   // The required score for this test case.  If not provided, the test case is graded pass/fail.
   threshold?: number;


### PR DESCRIPTION
Related to #475 

Can be used like so:
```yaml
defaultTest:
  options:
    disableVarExpansion: true

tests:
  - vars:
      ingredients:
        - Microwave popcorn
        - Ground beef
        - Pop Rocks
```