### PR TITLE
(docs): Replace references to deprecated postprocess option

### DIFF
--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -34,7 +34,7 @@ A test case represents a single example input that is fed into all prompts and p
 | options              | Object                                      | No       | Additional configuration settings                                                                                                           |
 | options.prefix       | string                                      | No       | This is prepended to the prompt                                                                                                             |
 | options.suffix       | string                                      | No       | This is appended to the prompt                                                                                                              |
-| options.postprocess  | string                                      | No       | A JavaScript snippet that runs on LLM output before any assertions                                                                          |
+| options.transform    | string                                      | No       | A JavaScript snippet that runs on LLM output before any assertions                                                                          |
 | options.provider     | string                                      | No       | The API provider to use for LLM rubric grading                                                                                              |
 | options.rubricPrompt | string                                      | No       | The prompt to use for LLM rubric grading                                                                                                    |
 

--- a/site/docs/guides/evaluate-json.md
+++ b/site/docs/guides/evaluate-json.md
@@ -113,7 +113,7 @@ tests:
 
 ## Conclusion
 
-By using JavaScript within your assertions, you can perform complex checks on JSON outputs, including targeting specific fields. The `postprocess` can be used to tailor the output for similarity checks.
+By using JavaScript within your assertions, you can perform complex checks on JSON outputs, including targeting specific fields. The `transform` can be used to tailor the output for similarity checks.
 
 promptfoo is free and open-source software.  To install promptfoo and get started, see the [getting started guide](/docs/getting-started).
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -418,7 +418,7 @@ tests:
 
 Sometimes OpenAI function calls don't match `tools` schemas. Use [`is-valid-openai-tools-call`](/docs/configuration/expected-outputs/#is-valid-openai-function-call) or [`is-valid-openai-tools-call`](/docs/configuration/expected-outputs/#is-valid-openai-tools-call) assertions to enforce an exact schema match between tools and the function definition.
 
-To further test `tools` definitions, you can use the `javascript` assertion and/or `postprocess` directives. For example:
+To further test `tools` definitions, you can use the `javascript` assertion and/or `transform` directives. For example:
 
 ```yaml
 tests:
@@ -434,8 +434,8 @@ tests:
 
   - vars:
       city: New York
-      # postprocess returns only the 'name' property
-    postprocess: output[0].function.name
+      # transform returns only the 'name' property
+    transform: output[0].function.name
     assert:
       - type: is-json
       - type: similar
@@ -489,7 +489,7 @@ tests:
 
 Sometimes OpenAI function calls don't match `functions` schemas. Use [`is-valid-openai-function-call`](/docs/configuration/expected-outputs/#is-valid-openai-function-call) assertions to enforce an exact schema match between function calls and the function definition.
 
-To further test function call definitions, you can use the `javascript` assertion and/or `postprocess` directives. For example:
+To further test function call definitions, you can use the `javascript` assertion and/or `transform` directives. For example:
 
 ```yaml
 tests:
@@ -504,8 +504,8 @@ tests:
 
   - vars:
       city: New York
-    # postprocess returns only the 'name' property for this testcase
-    postprocess: output.name
+    # transform returns only the 'name' property for this testcase
+    transform: output.name
     assert:
       - type: is-json
       - type: similar


### PR DESCRIPTION
Updates a few missed docs and examples to use `transform` instead of `postprocess`