### PR TITLE
Change variable name to what the prompt template expects

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -630,7 +630,7 @@ export async function matchesContextRelevance(
 
   const promptText = nunjucks.renderString(CONTEXT_RELEVANCE, {
     context: JSON.stringify(context).slice(1, -1),
-    question: JSON.stringify(question).slice(1, -1),
+    query: JSON.stringify(question).slice(1, -1),
   });
 
   const resp = await textProvider.callApi(promptText);


### PR DESCRIPTION
Before, the query part of the resulting prompt was always empty and the result was always "Insufficient Information" (i.e. 0)

Fixes https://github.com/promptfoo/promptfoo/issues/490