### PR TITLE
fix(self-hosting): remove supabase dependency from webui eval view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ COPY --from=builder /app/src/web/nextui/public ./public
 COPY --from=builder /app/src/web/nextui/.next/standalone ./
 COPY --from=builder /app/src/web/nextui/.next/static ./.next/static
 
+RUN mkdir -p /root/.promptfoo/output
+
 EXPOSE 3000
 
 ENV PORT 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ ENV NEXT_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL=${NEXT_PUBLIC_PROMPTFOO_REMOTE_API
 ENV NEXT_PUBLIC_PROMPTFOO_BUILD_STANDALONE_SERVER=1
 ENV NEXT_TELEMETRY_DISABLED 1
 
-# These envars are not used, but must be set to prevent the build process from erroring.
+
+# Supabase opt-in
+ARG NEXT_PUBLIC_PROMPTFOO_USE_SUPABASE
+ENV NEXT_PUBLIC_PROMPTFOO_USE_SUPABASE=${NEXT_PUBLIC_PROMPTFOO_USE_SUPABASE}
+
+# These envars are not necessarily used, but must be set to prevent the build process from erroring.
 ENV NEXT_PUBLIC_SUPABASE_URL=http://placeholder.promptfoo.dev
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder
 

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,7 @@ primary_region = "sjc"
 
 [env]
   NODE_ENV = "production"
+  PROMPTFOO_USE_SUPABASE = "1"
 
 [build]
 

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,9 @@ primary_region = "sjc"
 
 [env]
   NODE_ENV = "production"
-  PROMPTFOO_USE_SUPABASE = "1"
+
+[build.args]
+  NEXT_PUBLIC_PROMPTFOO_USE_SUPABASE = "1"
 
 [build]
 

--- a/src/web/nextui/src/app/api/config/route.ts
+++ b/src/web/nextui/src/app/api/config/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
 
+import { IS_RUNNING_LOCALLY } from '@/constants';
+
 export async function GET() {
   // When Next.js app is running in local dev mode, the base URL points to the
   // `promptfoo view` server.
   return NextResponse.json({
-    apiBaseUrl: 'http://localhost:15500'
+    apiBaseUrl: IS_RUNNING_LOCALLY ? 'http://localhost:15500' : '/api',
   });
 }

--- a/src/web/nextui/src/app/api/eval/route.ts
+++ b/src/web/nextui/src/app/api/eval/route.ts
@@ -3,15 +3,22 @@ import { v4 as uuidv4 } from 'uuid';
 
 import store from '@/app/api/eval/shareStore';
 import { IS_RUNNING_LOCALLY } from '@/constants';
+import { writeLatestResults } from '@/../../../util';
+
+import type { SharedResults } from '@/../../../types';
 
 export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
-    const payload = await req.json();
+    const payload = (await req.json()) as SharedResults;
     const newId = `f:${uuidv4()}`;
     console.log('Storing eval result with id', newId);
     await store.set(newId, JSON.stringify(payload.data));
+
+    // Also write it to disk
+    await writeLatestResults(payload.data.results, payload.data.config);
+
     return NextResponse.json({ id: newId }, { status: 200 });
   } catch (error) {
     return NextResponse.json(

--- a/src/web/nextui/src/app/api/eval/route.ts
+++ b/src/web/nextui/src/app/api/eval/route.ts
@@ -11,6 +11,7 @@ export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    // Share endpoint
     const payload = (await req.json()) as SharedResults;
     const newId = `f:${uuidv4()}`;
     console.log('Storing eval result with id', newId);

--- a/src/web/nextui/src/app/api/results/[filename]/route.ts
+++ b/src/web/nextui/src/app/api/results/[filename]/route.ts
@@ -1,25 +1,18 @@
-/*
 import path from 'path';
 
 import { NextResponse } from 'next/server';
 
-import { readResult, listPreviousResults } from '../../../../../../../util';
+import { readResult, listPreviousResultFilenames } from '../../../../../../../util';
 
 export async function GET(request: Request, { params }: { params: { filename: string } }) {
   const { filename } = params;
   const safeFilename = path.basename(filename);
-  if (safeFilename !== filename || !listPreviousResults().includes(safeFilename)) {
+  if (safeFilename !== filename || !listPreviousResultFilenames().includes(safeFilename)) {
     return NextResponse.json({ error: 'Invalid filename' }, { status: 400 });
   }
-  const result = readResult(safeFilename);
-  if (!result) {
+  const file = readResult(safeFilename);
+  if (!file) {
     return NextResponse.json({ error: 'Result not found' }, { status: 404 });
   }
-  return NextResponse.json({ data: result });
-}
-*/
-
-import { NextResponse } from 'next/server';
-export async function POST() {
-  return NextResponse.json({ data: 'NYI' });
+  return NextResponse.json({ data: file.result });
 }

--- a/src/web/nextui/src/app/api/results/[filename]/route.ts
+++ b/src/web/nextui/src/app/api/results/[filename]/route.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import { NextResponse } from 'next/server';
 
 import { readResult, listPreviousResultFilenames } from '../../../../../../../util';
+import { IS_RUNNING_LOCALLY } from '@/constants';
+
+export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function GET(request: Request, { params }: { params: { filename: string } }) {
   const { filename } = params;

--- a/src/web/nextui/src/app/api/results/[filename]/route.ts
+++ b/src/web/nextui/src/app/api/results/[filename]/route.ts
@@ -3,11 +3,14 @@ import path from 'path';
 import { NextResponse } from 'next/server';
 
 import { readResult, listPreviousResultFilenames } from '../../../../../../../util';
-import { IS_RUNNING_LOCALLY } from '@/constants';
+import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
 
 export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function GET(request: Request, { params }: { params: { filename: string } }) {
+  if (USE_SUPABASE) {
+    return NextResponse.json({error: 'Not implemented'});
+  }
   const { filename } = params;
   const safeFilename = path.basename(filename);
   if (safeFilename !== filename || !listPreviousResultFilenames().includes(safeFilename)) {

--- a/src/web/nextui/src/app/api/results/route.ts
+++ b/src/web/nextui/src/app/api/results/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 
 import { filenameToDate, listPreviousResults } from '../../../../../../util';
+import { IS_RUNNING_LOCALLY } from '@/constants';
+
+export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function GET() {
   const previousResults = listPreviousResults();

--- a/src/web/nextui/src/app/api/results/route.ts
+++ b/src/web/nextui/src/app/api/results/route.ts
@@ -1,16 +1,15 @@
-/*
 import { NextResponse } from 'next/server';
 
-import { listPreviousResults } from '../../../../../../util';
+import { filenameToDate, listPreviousResults } from '../../../../../../util';
 
 export async function GET() {
   const previousResults = listPreviousResults();
   previousResults.reverse();
-  return NextResponse.json({ data: previousResults });
-}
-*/
-
-import { NextResponse } from 'next/server';
-export async function POST() {
-  return NextResponse.json(['meow', 'foo', 'bar']);
+  return NextResponse.json({data: previousResults.map((fileMeta) => {
+    const dateString = filenameToDate(fileMeta.fileName);
+    return {
+      id: fileMeta.fileName,
+      label: fileMeta.description ? `${fileMeta.description} (${dateString})` : dateString,
+    };
+  })});
 }

--- a/src/web/nextui/src/app/api/results/route.ts
+++ b/src/web/nextui/src/app/api/results/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server';
 
 import { filenameToDate, listPreviousResults } from '../../../../../../util';
-import { IS_RUNNING_LOCALLY } from '@/constants';
+import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
 
 export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
 export async function GET() {
+  if (USE_SUPABASE) {
+    return NextResponse.json({error: 'Not implemented'});
+  }
   const previousResults = listPreviousResults();
   previousResults.reverse();
   return NextResponse.json({data: previousResults.map((fileMeta) => {

--- a/src/web/nextui/src/app/components/Navigation.tsx
+++ b/src/web/nextui/src/app/components/Navigation.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import LoggedInAs from './LoggedInAs';
 import DarkMode from './DarkMode';
-import { IS_RUNNING_LOCALLY } from '@/constants';
+import { USE_SUPABASE } from '@/constants';
 
 import './Navigation.css';
 
@@ -41,7 +41,7 @@ export default function Navigation({
       <NavLink href="/prompts" label="Prompts" />
       <NavLink href="/datasets" label="Datasets" />
       <div className="right-aligned">
-        {IS_RUNNING_LOCALLY ? null : <LoggedInAs />}
+        {USE_SUPABASE ? null : <LoggedInAs />}
         <DarkMode darkMode={darkMode} onToggleDarkMode={onToggleDarkMode} />
       </div>
     </Stack>

--- a/src/web/nextui/src/app/eval/Eval.css
+++ b/src/web/nextui/src/app/eval/Eval.css
@@ -3,7 +3,7 @@ body {
   color: var(--text-color);
 }
 
-.loading {
+.notice {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -57,8 +57,8 @@ export default function Eval({
 }: EvalOptions) {
   const router = useRouter();
   const { table, setTable, setConfig, setFilePath } = useStore();
-  const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [failed, setFailed] = React.useState<boolean>(false);
+  const [loaded, setLoaded] = React.useState(false);
+  const [failed, setFailed] = React.useState(false);
   const [recentEvals, setRecentEvals] = React.useState<{ id: string; label: string }[]>(
     recentEvalsProp || [],
   );
@@ -179,15 +179,15 @@ export default function Eval({
       // Fetch from next.js server
       const run = async () => {
         const evals = await fetchRecentFileEvals();
-        const defaultEval = evals[0];
-        if (defaultEval) {
+        if (evals.length > 0) {
           const apiBaseUrl = await getApiBaseUrl();
-          const resp = await fetch(`${apiBaseUrl}/results/${defaultEval.id}`);
+          const defaultEvalId = evals[0].id;
+          const resp = await fetch(`${apiBaseUrl}/results/${defaultEvalId}`);
           const body = await resp.json();
           setTable(body.data.results.table);
           setConfig(body.data.config);
           setLoaded(true);
-          setDefaultEvalId(defaultEval.id);
+          setDefaultEvalId(defaultEvalId);
         } else {
           return (
             <div className="notice">No evals yet. Share some evals to this server and they will appear here.</div> 

--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -188,6 +188,10 @@ export default function Eval({
           setConfig(body.data.config);
           setLoaded(true);
           setDefaultEvalId(defaultEval.id);
+        } else {
+          return (
+            <div className="notice">No evals yet. Share some evals to this server and they will appear here.</div> 
+          );
         }
       };
       run();
@@ -195,12 +199,12 @@ export default function Eval({
   }, [fetchId, setTable, setConfig, setFilePath, fetchEvalById, preloadedData, setDefaultEvalId, file]);
 
   if (failed) {
-    return <div className="loading">404 Eval not found</div>;
+    return <div className="notice">404 Eval not found</div>;
   }
 
   if (!loaded || !table) {
     return (
-      <div className="loading">
+      <div className="notice">
         <div>
           <CircularProgress size={22} />
         </div>

--- a/src/web/nextui/src/app/eval/page.tsx
+++ b/src/web/nextui/src/app/eval/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 
 import Eval from './Eval';
-import { IS_RUNNING_LOCALLY } from '@/constants';
+import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
 
 export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
@@ -13,7 +13,7 @@ export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 export const revalidate = 1;
 
 export default async function Page() {
-  if (!IS_RUNNING_LOCALLY) {
+  if (USE_SUPABASE) {
     const supabase = createServerComponentClient({ cookies });
     const {
       data: { user },

--- a/src/web/nextui/src/constants.ts
+++ b/src/web/nextui/src/constants.ts
@@ -1,5 +1,7 @@
-// Behavior varies depending on whether the app is running locally or not (e.g. connecting to local socket).
+// Behavior varies depending on whether the app is running as a static HTML app on the user's local machine.
 export const IS_RUNNING_LOCALLY = !process.env.NEXT_PUBLIC_PROMPTFOO_BUILD_STANDALONE_SERVER;
+
+export const USE_SUPABASE = !!process.env.NEXT_PUBLIC_PROMPTFOO_USE_SUPABASE;
 
 // The base URL of API routes built into the Next.js app.
 export const NEXTJS_BASE_URL = ``;


### PR DESCRIPTION
- Fix issue with loading the evals list when self-hosting the promptfoo server
- When an eval is shared to a self-hosted instance using `promptfoo share`, it appears in the recent evals list.

Related to #462 and #412 