### PR TITLE
fix: pass through `PROMPTFOO_*` variables from `docker run`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,21 @@ COPY --from=builder /app/src/web/nextui/.next/static ./.next/static
 
 RUN mkdir -p /root/.promptfoo/output
 
+# Create a script to write environment variables to .env file
+RUN echo -e '#!/bin/sh\n\
+echo "Writing environment variables to .env file..."\n\
+env | grep PROMPTFOO_ > .env\n\
+echo "Loaded environment variables:"\n\
+cat .env\n\
+echo "Starting server..."\n\
+node server.js' > entrypoint.sh
+
+# Make the script executable
+RUN chmod +x entrypoint.sh
+
 EXPOSE 3000
 
 ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
-CMD ["node", "server.js"]
+CMD ["sh", "entrypoint.sh"]

--- a/src/web/nextui/src/app/api/eval/shareStore.ts
+++ b/src/web/nextui/src/app/api/eval/shareStore.ts
@@ -7,6 +7,7 @@ const ttl = parseInt(process.env.PROMPTFOO_SHARE_TTL || String(60 * 60 * 24 * 14
 function getStore() {
   switch (storeType) {
     case 'redis':
+      console.log('Using Redis store');
       return cacheManager.caching({
         store: require('cache-manager-ioredis'),
         host: process.env.PROMPTFOO_SHARE_REDIS_HOST,
@@ -16,6 +17,7 @@ function getStore() {
         ttl,
       });
     case 'filesystem':
+      console.log('Using Filesystem store');
       return cacheManager.caching({
         store: require('cache-manager-fs-hash'),
         options: {
@@ -25,6 +27,7 @@ function getStore() {
       });
     case 'memory':
     default:
+      console.log('Using Memory store');
       return cacheManager.caching({
         store: 'memory',
         ttl,


### PR DESCRIPTION
Next.js in `standalone` doesn't seem to pass through environment variables outside of `.env`

Related to #495 