### PR TITLE
feat(mistral): Add new models, JSON mode, and update pricing

### DIFF
--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -14,17 +14,19 @@ export MISTRAL_API_KEY=your_api_key_here
 
 ## Model Selection
 
-You can specify which Mistral model to use in your configuration. Currently, the following 3 models are available:
-1. `mistral-tiny`
-2. `mistral-small`
-3. `mistral-medium`
+You can specify which Mistral model to use in your configuration. Currently, the following 5 models are available:
+1. `open-mistral-7b`
+2. `open-mixtral-8x7b`
+3. `mistral-small-latest`
+4. `mistral-medium-latest`
+5. `mistral-large-latest`
 
-Here's an example config that compares Mistral-Medium, Mistral-Small, and OpenAI GPT-3.5:
+Here's an example config that compares Mistral-Medium-Latest, Mistral-Small-Latest, and OpenAI GPT-3.5:
 
 ```yaml
 providers:
-  - mistral:mistral-medium
-  - mistral:mistral-small
+  - mistral:mistral-medium-latest
+  - mistral:mistral-small-latest
   - openai:chat:gpt-3.5-turbo
 ```
 
@@ -37,18 +39,18 @@ The Mistral provider supports several options to customize the behavior of the m
 - `max_tokens`: The maximum length of the generated text.
 - `safe_prompt`: Whether to enforce safe content in the prompt.
 - `random_seed`: A seed for deterministic outputs.
-- `fix_json`: Fixes common JSON formatting issues in the output, useful for parsing. Note: This is not a Mistral feature, but was added for convenience.
+- `response_format`: Enable JSON mode, by setting the `response_format` to `{"type": "json_object"}`. The model must be asked explicitly to generate JSON output. This is currently only supported for their updated models `mistral-small-latest` and `mistral-large-latest`.
 
 Example configuration with options:
 
 ```yaml
 providers:
-- id: mistral:mistral-medium
+- id: mistral:mistral-large-latest
   config:
     temperature: 0.7
     max_tokens: 512
     safe_prompt: true
-    fix_json: true
+    response_format: {"type": "json_object"}
 ```
 
 ## Additional Capabilities

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -77,13 +77,6 @@ export class MistralChatCompletionProvider implements ApiProvider {
         output: 0.0007 / 1000,
       },
     })),
-    ...['mistral-tiny'].map((model) => ({
-      id: model,
-      cost: {
-        input: 0.00015 / 1000,
-        output: 0.00045 / 1000,
-      },
-    })),
     ...['mistral-small-latest'].map((model) => ({
       id: model,
       cost: {

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -63,6 +63,20 @@ export class MistralChatCompletionProvider implements ApiProvider {
   env?: EnvOverrides;
 
   static MISTRAL_CHAT_MODELS = [
+    ...['open-mistral-7b'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.00025 / 1000,
+        output: 0.00025 / 1000,
+      },
+    })),
+    ...['open-mixtral-8x7b'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.0007 / 1000,
+        output: 0.0007 / 1000,
+      },
+    })),
     ...['mistral-tiny'].map((model) => ({
       id: model,
       cost: {
@@ -70,18 +84,25 @@ export class MistralChatCompletionProvider implements ApiProvider {
         output: 0.00045 / 1000,
       },
     })),
-    ...['mistral-small'].map((model) => ({
+    ...['mistral-small-latest'].map((model) => ({
       id: model,
       cost: {
-        input: 0.00064 / 1000,
-        output: 0.00193 / 1000,
+        input: 0.002 / 1000,
+        output: 0.006 / 1000,
       },
     })),
-    ...['mistral-medium'].map((model) => ({
+    ...['mistral-medium-latest'].map((model) => ({
       id: model,
       cost: {
-        input: 0.00269 / 1000,
-        output: 0.00806 / 1000,
+        input: 0.0027 / 1000,
+        output: 0.0081 / 1000,
+      },
+    })),
+    ...['mistral-large-latest'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.008 / 1000,
+        output: 0.024 / 1000,
       },
     }))
   ];

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -16,7 +16,7 @@ interface MistralChatCompletionOptions {
   max_tokens?: number;
   safe_prompt?: boolean;
   random_seed?: number;
-  fix_json?: boolean;
+  response_format?: { type: 'json_object' };
   cost?: number;
 }
 
@@ -147,6 +147,7 @@ export class MistralChatCompletionProvider implements ApiProvider {
       max_tokens: this.config?.max_tokens || 1024,
       safe_prompt: this.config?.safe_prompt || false,
       random_seed: this.config?.random_seed || null,
+      ...(this.config.response_format ? { response_format: this.config.response_format } : {}),
     };
 
     const url = 'https://api.mistral.ai/v1/chat/completions';
@@ -186,15 +187,9 @@ export class MistralChatCompletionProvider implements ApiProvider {
         error: `Malformed response data: ${JSON.stringify(data)}`,
       };
     }
-    let content;
-    if (this.config?.fix_json){
-      // Mistral is often messing up JSON responses. This fixes the output to allow for the tests to pass.
-      content = data.choices[0].message.content.replace(/\\_/g, "_").replace(/\\\*/g, "*")
-    } else {
-      content = data.choices[0].message.content
-    }
+
     return {
-      output: content,
+      output: data.choices[0].message.content,
       tokenUsage: getTokenUsage(data, cached),
       cached,
       cost: calculateCost(


### PR DESCRIPTION
## Overview
Mistral has released a few more models, including their new flagship model `mistral-large`.
Mistral has also added JSON mode for their new small/large models. The fix_json workaround has been removed.

## Changelog
<img width="658" alt="image" src="https://github.com/promptfoo/promptfoo/assets/5006784/39e72bcf-717e-4638-8869-18f0af4be60a">

## References
- Release notes: https://mistral.ai/news/mistral-large/
- Pricing: https://docs.mistral.ai/platform/pricing/
- Changelog: https://docs.mistral.ai/platform/changelog/
- JSON Model: https://docs.mistral.ai/platform/client/#json-mode

@typpo these changes should be good to go, they were tested locally.