### PR TITLE
Print incorrect response from factuality checker

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -389,7 +389,7 @@ export async function matchesFactuality(
       reason = optionReasons[option];
     } else {
       pass = false;
-      reason = `Invalid option: ${option}`;
+      reason = `Invalid option: ${option}. Full response from factuality checker: ${resp.output}`;
     }
 
     let score = pass ? 1 : 0;


### PR DESCRIPTION
Messages like these are very mysterious:

    expected
    ```
    Foo is bar.
    ```
     to match factuality with "Foo is baz", but it did not.
    Reason:
    Invalid option: )

This failure is not a normal test-case failure. It's an internal failure in promptfoo. So it should print as much debug info as it can to report the bug.