### PR TITLE
feat: include prompt in transform

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -313,7 +313,6 @@ It is a function that takes a string output and a context object:
 
 ```
 transformFn: (output: string, context: {
-  vars: Record<string, any>;
   prompt: {
     // ID of the prompt, if assigned
     id?: string;
@@ -322,6 +321,7 @@ transformFn: (output: string, context: {
     // Prompt as sent to the LLM API and assertions.
     display?: string;
   };
+  vars?: Record<string, any>;
 }) => void;
 ```
 

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -313,8 +313,16 @@ It is a function that takes a string output and a context object:
 
 ```
 transformFn: (output: string, context: {
-  vars: Record<string, any>
-})
+  vars: Record<string, any>;
+  prompt: {
+    // ID of the prompt, if assigned
+    id?: string;
+    // Raw prompt as provided in the test case, without {{variable}} substitution.
+    raw?: string;
+    // Prompt as sent to the LLM API and assertions.
+    display?: string;
+  };
+}) => void;
 ```
 
 This is useful if you need to somehow transform or clean LLM output before running an eval.

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -206,9 +206,12 @@ export async function runAssertion({
   telemetry.record('assertion_used', {
     type: baseType,
   });
-  
+
   if (assertion.transform) {
-    output = transformOutput(assertion.transform, output, {vars: test.vars});
+    output = transformOutput(assertion.transform, output, {
+      vars: test.vars,
+      prompt: { display: prompt },
+    });
   }
 
   const outputString = coerceString(output);
@@ -1159,10 +1162,15 @@ export async function runCompareAssertion(
   test.options = test.options || {};
   test.options.provider = assertion.provider || test.options.provider;
   test.options.rubricPrompt = assertion.rubricPrompt || test.options.rubricPrompt;
-  const comparisonResults = await matchesSelectBest(assertion.value, outputs, test.options, test.vars);
-  return comparisonResults.map(result => ({
+  const comparisonResults = await matchesSelectBest(
+    assertion.value,
+    outputs,
+    test.options,
+    test.vars,
+  );
+  return comparisonResults.map((result) => ({
     ...result,
-    assertion
+    assertion,
   }));
 }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -243,7 +243,10 @@ class Evaluator {
         let processedResponse = { ...response };
         const transform = test.options?.transform || test.options?.postprocess;
         if (transform) {
-          processedResponse.output = transformOutput(transform, processedResponse.output, { vars });
+          processedResponse.output = transformOutput(transform, processedResponse.output, {
+            vars,
+            prompt,
+          });
         }
 
         invariant(processedResponse.output != null, 'Response output should not be null');

--- a/src/util.ts
+++ b/src/util.ts
@@ -777,7 +777,7 @@ export function printBorder() {
 export function transformOutput(
   code: string,
   output: string | object | undefined,
-  context: { vars: Record<string, string | object>; prompt: Partial<Prompt> },
+  context: { vars?: Record<string, string | object | undefined>; prompt: Partial<Prompt> },
 ) {
   const postprocessFn = new Function(
     'output',

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,6 +28,7 @@ import type {
   UnifiedConfig,
   OutputFile,
   ProviderOptions,
+  Prompt,
 } from './types';
 
 let globalConfigCache: any = null;
@@ -773,7 +774,11 @@ export function printBorder() {
   logger.info(border);
 }
 
-export function transformOutput(code: string, output: string | object | undefined, context: unknown) {
+export function transformOutput(
+  code: string,
+  output: string | object | undefined,
+  context: { vars: Record<string, string | object>; prompt: Partial<Prompt> },
+) {
   const postprocessFn = new Function(
     'output',
     'context',


### PR DESCRIPTION
Updates the transform type signature to be:

```ts
transformFn: (output: string, context: {
  vars: Record<string, any>;
  prompt: {
    // ID of the prompt, if assigned
    id?: string;
    // Raw prompt as provided in the test case, without {{variable}} substitution.
    raw?: string;
    // Prompt as sent to the LLM API and assertions.
    display?: string;
  };
}) => void;
```

This allows your transform to take into account the prompt.  Related to #509 