### PR TITLE
feat: Support csv and json files in the `tests` array

### DIFF
--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import yaml from 'js-yaml';
 import { globSync } from 'glob';
 
-import { readTestsFile, readTest, readTests } from '../src/testCases';
+import { readStandaloneTestsFile, readTest, readTests } from '../src/testCases';
 import { testCaseFromCsvRow } from '../src/csv';
 
 import type { AssertionType, TestCase } from '../src/types';
@@ -32,35 +32,45 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('readTestsFile', () => {
-  test('readVars with CSV input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2\nvalue1,value2');
+describe('readStandaloneTestsFile', () => {
+  test('readStandaloneTestsFile with CSV input', async () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2\nvalue1,value2\nvalue3,value4');
     const varsPath = 'vars.csv';
 
-    const result = await readTestsFile(varsPath);
+    const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);
+    expect(result.length).toBe(2);
+    expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
+    expect(result[1].vars).toEqual({ var1: 'value3', var2: 'value4' });
   });
 
-  test('readVars with JSON input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('[{"var1": "value1", "var2": "value2"}]');
+  test('readStandaloneTestsFile with JSON input', async () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      '[{"var1": "value1", "var2": "value2"}, {"var3": "value3", "var4": "value4"}]',
+    );
     const varsPath = 'vars.json';
 
-    const result = await readTestsFile(varsPath);
+    const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);
+    expect(result.length).toBe(2);
+    expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
+    expect(result[1].vars).toEqual({ var3: 'value3', var4: 'value4' });
   });
 
-  test('readVars with YAML input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('- var1: value1\n  var2: value2');
+  test('readStandaloneTestsFile with YAML input', async () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      '- var1: value1\n  var2: value2\n- var3: value3\n  var4: value4',
+    );
     const varsPath = 'vars.yaml';
 
-    const result = await readTestsFile(varsPath);
+    const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([{ var1: 'value1', var2: 'value2' }]);
+    expect(result.length).toBe(2);
+    expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
+    expect(result[1].vars).toEqual({ var3: 'value3', var4: 'value4' });
   });
 });
 


### PR DESCRIPTION
Adds support for e.g. csv and json files in the tests array. Related to #517 

Example:

promptfooconfig.yaml:
```yaml
prompts:
  - "Write a 1 sentence customer service response to {{question}}"

providers: [openai:gpt-3.5-turbo-0613]

tests:
  - tests.csv
```
tests.csv:
```csv
name,question
Bob,Can you help me find a specific product on your website?
Jane,Do you have any promotions or discounts currently available?
Dave,What are your shipping and return policies?
Jim,Can you provide more information about the product specifications or features?
Alice,Can you recommend products that are similar to what I've been looking at?
Sophie,Do you have any recommendations for products that are currently popular or trending?
Ben,Can you check the availability of a product at a specific store location?
Jessie,How can I track my order after it has been shipped?
Kim,What payment methods do you accept?
Emily,Can you help me with a problem I'm having with my account or order?
```