### PR TITLE
feat(anthropic): Add Claude 3 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.44.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.5.2",
+        "@anthropic-ai/sdk": "0.16.1",
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.5.10.tgz",
-      "integrity": "sha512-P8xrIuTUO/6wDzcjQRUROXp4WSqtngbXaE4GpEu0PhEmnq/1Q8vbF1s0o7W07EV3j8zzRoyJxAKovUJtNXH7ew==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-vHgvfWEyFy5ktqam56Nrhv8MVa7EJthsRYNi+1OrFFfyrj9tR2/aji1QbVbQjYU/pPhPFaYrdCEC/MLPFrmKwA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -108,13 +108,22 @@
         "digest-fetch": "^1.3.0",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
       "version": "18.17.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.11.tgz",
       "integrity": "sha512-r3hjHPBu+3LzbGBa8DHnr/KAeTEEOrahkcL+cZc4MaBMTM+mk8LtXR+zw+nqfjuDZZzYTYgTcpHuP+BEQk069g=="
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.5.2",
+    "@anthropic-ai/sdk": "0.16.1",
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -4,6 +4,86 @@ sidebar_position: 10
 
 # Anthropic
 
+This provider supports the [Anthropic Claude](https://www.anthropic.com/claude) series of models.
+
+## API Key
+
+To use Anthropic, you need to set the `ANTHROPIC_API_KEY` environment variable or specify the `apiKey` in the provider configuration.
+
+Create Anthropic API keys [here](https://console.anthropic.com/settings/keys).
+
+Example of setting the environment variable:
+
+```bash
+export ANTHROPIC_API_KEY=your_api_key_here
+```
+
+## Latest API (Messages)
+
+> The messages API supports all the latest Anthropic models.
+
+The `anthropic` provider supports the following models via the messages API:
+
+- `anthropic:messages:claude-instant-1.2`
+- `anthropic:messages:claude-2.0`
+- `anthropic:messages:claude-2.1`
+- `anthropic:messages:claude-3-sonnet-20240229`
+- `anthropic:messages:claude-3-opus-20240229`
+
+### Prompt Template
+
+To allow for compatibility with the OpenAI prompt template, the following format is supported.
+
+Example: `prompt.json`
+```json
+[
+  {
+    "role": "system",
+    "content": "{{ system_message }}"
+  },
+  {
+    "role": "user",
+    "content": "{{ question }}"
+  }
+]
+```
+
+If the role `system` is specified, then it will be automatically added to the API request.
+All `user` or `assistant` roles will automatically converted into the right format for the API request.
+Currently, only type `text` is supported.
+
+The `system_message` and `question` are example variables that can be set with the `var` directive.
+
+### Options
+
+The Anthropic provider supports several options to customize the behavior of the model. These include:
+
+- `temperature`: Controls the randomness of the output.
+- `max_tokens`: The maximum length of the generated text.
+- `top_p`: Controls nucleus sampling, affecting the randomness of the output.
+- `top_k`: Only sample from the top K options for each subsequent token.
+
+Example configuration with options and prompts:
+
+```yaml
+providers:
+- id: anthropic:messages:claude-3-opus-20240229
+  config:
+    temperature: 0.0
+    max_tokens: 512
+prompts: [prompt.json]
+```
+
+### Additional Capabilities
+
+- **Caching**: Caches previous LLM requests by default.
+- **Token Usage Tracking**: Provides detailed information on the number of tokens used in each request, aiding in usage monitoring and optimization.
+- **Cost Calculation**: Calculates the cost of each request based on the number of tokens generated and the specific model used.
+
+## Deprecated API (Completions)
+
+> The completions API is deprecated, see the migration guide [here](https://docs.anthropic.com/claude/reference/migrating-from-text-completions-to-messages).
+
 The `anthropic` provider supports the following models:
 
 - `anthropic:completion:claude-1`

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -12,7 +12,10 @@ import {
   OpenAiEmbeddingProvider,
   OpenAiImageProvider,
 } from './providers/openai';
-import { AnthropicCompletionProvider } from './providers/anthropic';
+import { 
+  AnthropicCompletionProvider, 
+  AnthropicMessagesProvider
+} from './providers/anthropic';
 import { ReplicateProvider } from './providers/replicate';
 import {
   LocalAiCompletionProvider,
@@ -155,7 +158,7 @@ export async function loadApiProvider(
     } else if (modelType === 'assistant') {
       return new OpenAiAssistantProvider(modelName, providerOptions);
     } else if (modelType === 'image') {
-      return new OpenAiImageProvider(modelName, providerOptions)
+      return new OpenAiImageProvider(modelName, providerOptions);
     } else {
       throw new Error(
         `Unknown OpenAI model type: ${modelType}. Use one of the following providers: openai:chat:<model name>, openai:completion:<model name>, openai:embeddings:<model name>, openai:image:<model name>`,
@@ -186,7 +189,9 @@ export async function loadApiProvider(
     const modelType = splits[1];
     const modelName = splits[2];
 
-    if (modelType === 'completion') {
+    if (modelType === 'messages'){
+      return new AnthropicMessagesProvider(modelName || 'claude-instant-1', providerOptions)
+    } else if (modelType === 'completion') {
       return new AnthropicCompletionProvider(modelName || 'claude-instant-1', providerOptions);
     } else if (AnthropicCompletionProvider.ANTHROPIC_COMPLETION_MODELS.includes(modelType)) {
       return new AnthropicCompletionProvider(modelType, providerOptions);

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import logger from '../logger';
 
-import {
+import type {
   ApiProvider,
   EnvOverrides,
   ProviderResponse,


### PR DESCRIPTION
## Overview
Anthropic has released the Claude-3 series of models. This PR adds support for that (#523).
The code is updated to use the latest anthropic SDK and the new messages API.
The legacy completions API is still supported and this PR does not introduce any breaking changes.

- [x] All API parameters are covered
- [x] System messages are supported
- [x] The cost of all models is supported
- [x] Caching is supported
- [x] API key can be provided in the config or via the `ANTHROPIC_API_KEY` environment variable

## References
- Release notes: https://www.anthropic.com/news/claude-3-family
- Pricing: https://www.anthropic.com/api#pricing

@typpo these changes should be good to go, they were tested locally.