### PR TITLE
feat: add support for calling specific functions for python prompt

### DIFF
--- a/examples/custom-prompt-function/prompt_python.py
+++ b/examples/custom-prompt-function/prompt_python.py
@@ -1,6 +1,9 @@
 import sys
 import json
 
+def prompt1(context):
+    return f'Write a one-sentence insult for anyone who likes {context["vars"]["topic"]}.'
+
 def generate_prompt(context):
     return f'Describe {context["vars"]["topic"]} concisely, comparing it to the Python programming language.'
 

--- a/examples/custom-prompt-function/promptfooconfig.yaml
+++ b/examples/custom-prompt-function/promptfooconfig.yaml
@@ -3,6 +3,7 @@ prompts:
   - prompt_string.js
   - prompt_multiple.js:prompt2
   - prompt_python.py
+  - prompt_python.py:prompt1
 providers: [openai:gpt-3.5-turbo-0613]
 tests:
   - vars:

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -193,20 +193,21 @@ module.exports.prompt1 = async function ({ vars }) {
 };
 ```
 
-A Python prompt function, `prompt.py`:
+A Python prompt function, `prompt.py:my_prompt_function`:
 
 ```python title=prompt.py
 import json
 import sys
 
-def generate_prompt(context: dict) -> str:
+def my_prompt_function(context: dict) -> str:
     return (
         f"Describe {context['vars']['topic']} concisely, comparing it to the Python"
         " programming language."
     )
 
 if __name__ == "__main__":
-    print(generate_prompt(json.loads(sys.argv[1])))
+    # If you don't specify a `function_name` in the provider string, it will run the main
+    print(my_prompt_function(json.loads(sys.argv[1])))
 ```
 
 To verify that your function is producing the correct prompt:

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -7,6 +7,7 @@ import { globSync } from 'glob';
 import { PythonShell, Options as PythonShellOptions } from 'python-shell';
 
 import logger from './logger';
+import { runPython } from './python/wrapper';
 
 import type {
   UnifiedConfig,
@@ -136,10 +137,13 @@ export function readPrompts(
   for (const promptPathInfo of promptPathInfos) {
     const parsedPath = path.parse(promptPathInfo.resolved);
     let filename = parsedPath.base;
-    let functionName;
+    let functionName: string | undefined;
     if (parsedPath.base.includes(':')) {
       const splits = parsedPath.base.split(':');
-      if (splits[0] && (splits[0].endsWith('.js') || splits[0].endsWith('.cjs'))) {
+      if (
+        splits[0] &&
+        (splits[0].endsWith('.js') || splits[0].endsWith('.cjs') || splits[0].endsWith('.py'))
+      ) {
         [filename, functionName] = splits;
       }
     }
@@ -191,15 +195,20 @@ export function readPrompts(
       } else if (ext === '.py') {
         const fileContent = fs.readFileSync(promptPath, 'utf-8');
         const promptFunction = async (context: { vars: Record<string, string | object> }) => {
-          const options: PythonShellOptions = {
-            mode: 'text',
-            pythonPath: process.env.PROMPTFOO_PYTHON || 'python',
-            args: [JSON.stringify(context)],
-          };
-          logger.debug(`Executing python prompt script ${promptPath}`);
-          const results = (await PythonShell.run(promptPath, options)).join('\n');
-          logger.debug(`Python prompt script ${promptPath} returned: ${results}`);
-          return results;
+          if (functionName) {
+            return runPython(promptPath, functionName, [context]);
+          } else {
+            // Legacy: run the whole file
+            const options: PythonShellOptions = {
+              mode: 'text',
+              pythonPath: process.env.PROMPTFOO_PYTHON || 'python',
+              args: [JSON.stringify(context)],
+            };
+            logger.debug(`Executing python prompt script ${promptPath}`);
+            const results = (await PythonShell.run(promptPath, options)).join('\n');
+            logger.debug(`Python prompt script ${promptPath} returned: ${results}`);
+            return results;
+          }
         };
         let display = fileContent;
         if (inputType === PromptInputType.NAMED) {
@@ -335,9 +344,10 @@ export const AI_SELF_REFERENCE_PROMPT_SYSTEM_MESSAGE = {
   content: `In this task, you will be given a string of text produced by a large language model. Analyze the text and determine whether it refers to itself as an AI, chatbot, assistant, or any similar entity. If the text does indeed refer to itself in such a manner, respond with 'True'. Otherwise, respond with 'False'.`,
 };
 
-export const SELECT_BEST_PROMPT = JSON.stringify([{
-  role: 'system',
-  content: `You are comparing multiple pieces of text to see which best fits the following criteria: {{criteria}}
+export const SELECT_BEST_PROMPT = JSON.stringify([
+  {
+    role: 'system',
+    content: `You are comparing multiple pieces of text to see which best fits the following criteria: {{criteria}}
 
 Here are the pieces of text:
 
@@ -348,4 +358,5 @@ Here are the pieces of text:
 {% endfor %}
 
 Output the index of the text that best fits the criteria. You must output a single integer.`,
-}]);
+  },
+]);


### PR DESCRIPTION
Related to #507 

Example:

promptfooconfig.yaml:
```yaml
prompts:
  - prompt_python.py:prompt1
  - prompt_python.py:prompt2
providers: 
  - openai:gpt-3.5-turbo-0613
tests:
  - vars:
      topic: bananas
```
prompt_python.py:
```py
def prompt1(context):
    return f'Write a one-sentence compliment for anyone who likes {context["vars"]["topic"]}.'

def prompt2(context):
    return f'Describe {context["vars"]["topic"]} concisely, comparing it to the Python programming language.'
```