### PR TITLE
fix(replicate): support non-array outputs

### DIFF
--- a/examples/replicate-llama2/promptfooconfig.yaml
+++ b/examples/replicate-llama2/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 prompts: [prompts.txt]
 providers:
-  - replicate:replicate/llama70b-v2-chat:e951f18578850b652510200860fc4ea62b3b16fac280f83ff32282f87bbd2e48
+  - replicate:meta/llama-2-70b-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48
 tests:
   - vars:
       topic: bananas

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -139,8 +139,21 @@ export class ReplicateProvider implements ApiProvider {
     }
     logger.debug(`\tReplicate API response: ${JSON.stringify(response)}`);
     try {
+      let formattedOutput;
+      if (Array.isArray(response)) {
+        if (response.length === 0 || typeof response[0] === 'string') {
+          formattedOutput = response.join('');
+        } else {
+          formattedOutput = JSON.stringify(response);
+        }
+      } else if (typeof response === 'string') {
+        formattedOutput = response;
+      } else {
+        formattedOutput = JSON.stringify(response);
+      }
+
       const result = {
-        output: (response as string[]).join(''),
+        output: formattedOutput,
         tokenUsage: {}, // TODO: add token usage once Replicate API supports it
       };
       if (cache && cacheKey) {


### PR DESCRIPTION
Handle more varied model outputs.  Related to #546 