### PR TITLE
chore: better error messages when expecting json but getting text

### DIFF
--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -7,8 +7,7 @@ const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
 const mockedFetchResponse = (ok: boolean, response: object) => {
   return {
     ok,
-    json: () => Promise.resolve(response),
-    text: () => Promise.resolve('error'),
+    text: () => Promise.resolve(JSON.stringify(response)),
     headers: {
       get: (name: string) => {
         if (name === 'content-type') {
@@ -17,7 +16,7 @@ const mockedFetchResponse = (ok: boolean, response: object) => {
         return null;
       },
     },
-  } as Response;
+  } as unknown as Response;
 };
 
 describe('fetchWithCache', () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -72,10 +72,10 @@ describe('call provider apis', () => {
 
   test('OpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ text: 'Test output' }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -89,10 +89,10 @@ describe('call provider apis', () => {
 
   test('OpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ message: { content: 'Test output' } }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
       ok: true,
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
@@ -109,10 +109,10 @@ describe('call provider apis', () => {
 
   test('OpenAiChatCompletionProvider callApi with caching', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ message: { content: 'Test output 2' } }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
       ok: true,
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
@@ -137,10 +137,10 @@ describe('call provider apis', () => {
 
   test('OpenAiChatCompletionProvider callApi with cache disabled', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ message: { content: 'Test output' } }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
       ok: true,
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
@@ -188,10 +188,10 @@ describe('call provider apis', () => {
 
   test('AzureOpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ text: 'Test output' }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -205,10 +205,10 @@ describe('call provider apis', () => {
 
   test('AzureOpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ message: { content: 'Test output' } }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -226,10 +226,10 @@ describe('call provider apis', () => {
     disableCache();
 
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         choices: [{ message: { content: 'Test output' } }],
         usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -300,9 +300,9 @@ describe('call provider apis', () => {
 
   test('LlamaProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         content: 'Test output',
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -357,9 +357,9 @@ describe('call provider apis', () => {
 
   test('WebhookProvider callApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue({
+      text: jest.fn().mockResolvedValue(JSON.stringify({
         output: 'Test output',
-      }),
+      })),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -376,7 +376,7 @@ describe('call provider apis', () => {
   ])('HuggingfaceTextGenerationProvider callApi with %s', (format, mockedData) => {
     test('returns expected output', async () => {
       const mockResponse = {
-        json: jest.fn().mockResolvedValue(mockedData),
+        text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
       (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -390,7 +390,7 @@ describe('call provider apis', () => {
 
   test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
     const mockResponse = {
-      json: jest.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]),
+      text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -415,7 +415,7 @@ describe('call provider apis', () => {
       ],
     ];
     const mockResponse = {
-      json: jest.fn().mockResolvedValue(mockClassification),
+      text: jest.fn().mockResolvedValue(JSON.stringify(mockClassification)),
     };
     (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
 


### PR DESCRIPTION
This is useful for providers that throw cloudflare errors and similar, and would have helped in the case of #571 