### PR TITLE
feat: Add support for threaded tests

### DIFF
--- a/examples/openai-assistant-thread/README.md
+++ b/examples/openai-assistant-thread/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, have a look at promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/openai-assistant-thread/promptfooconfig.yaml
+++ b/examples/openai-assistant-thread/promptfooconfig.yaml
@@ -1,0 +1,29 @@
+prompts: "{{ query }}"
+providers: [openai:assistant:asst_VXGBnVRee0ddzDH8wrAefQTU]
+
+# Test multiple follow-ups
+tests:
+  - vars:
+      query:
+        - banana
+        - lemon
+    thread:
+      - vars:
+          query: I will say a fruit, please specify what color it is
+        assert:
+          - type: llm-rubric
+            value: "Asks about which fruit that I'm interested in"
+      - assert:
+          - type: contains
+            value: yellow
+  - thread:
+      - vars:
+          query: I will specify a vehicle, please specify how many wheels it typically has
+        assert:
+          - type: llm-rubric
+            value: "Asks about what vehicle that I'm interested in"
+      - vars:
+          query: Car
+        assert:
+          - type: contains
+            value: four

--- a/examples/openai-chat-history/promptfooconfig.yaml
+++ b/examples/openai-chat-history/promptfooconfig.yaml
@@ -14,7 +14,9 @@ defaultTest:
 # Test multiple follow-ups
 tests:
   - vars:
-      question: Did he create any other companies?
+      question:
+        - Did he create any other companies?
+        - Is he human?
   - vars:
       question: What is his role at Internet.org?
   - vars:

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -659,7 +659,7 @@ class Evaluator {
                       ? [threadAndTestVars]
                       : generateVarCombinations(threadAndTestVars || {});
                 } else {
-                  varCombinations = threadVarCombinations
+                  varCombinations = [threadVars]
                 }
                 for (const vars of varCombinations) {
                   const runEvalOption: RunEvalOptions = {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -600,15 +600,13 @@ class Evaluator {
 
     // Set up eval cases
     let runEvalOptions: RunEvalOptions[][] = [];
-    let rowIndex = 0;
-    for (let index = 0; index < tests.length; index++) {
-      const mainTestCase = tests[index];
-      const allTestCases = mainTestCase.thread || [mainTestCase];
-      const startRow = rowIndex
-      let colIndex = 0;
-      for (const prompt of testSuite.prompts) {
-        for (const provider of testSuite.providers) {
-          rowIndex = startRow
+    let colIndex = 0;
+    for (const prompt of testSuite.prompts) {
+      for (const provider of testSuite.providers) {
+        let rowIndex = 0;
+        for (let index = 0; index < tests.length; index++) {
+          const mainTestCase = tests[index];
+          const allTestCases = mainTestCase.thread || [mainTestCase];
           if (testSuite.providerPromptMap) {
             const allowedPrompts = testSuite.providerPromptMap[provider.id()];
             if (allowedPrompts && !allowedPrompts.includes(prompt.display)) {
@@ -690,8 +688,8 @@ class Evaluator {
               }
             }
           }
-          colIndex++
         }
+        colIndex++
       }
     }
 

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -20,7 +20,6 @@ import type {
   ProviderEmbeddingResponse,
   ProviderResponse,
 } from '../types';
-import Anthropic from '@anthropic-ai/sdk';
 
 interface AzureOpenAiCompletionOptions {
   // Azure identity params

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -75,7 +75,10 @@ const BEDROCK_MODEL = {
       return responseJson?.content[0].text;
     },
     thread: (thread: any, responseJson: any) => {
-      const newThread = [...thread];
+      const newThread = [];
+      if (thread) {
+
+      }
       if (responseJson && responseJson.content) {
         newThread.push(responseJson);
       }

--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -3,7 +3,8 @@ import { fetchWithCache } from '../cache';
 import { REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
 
 import type {
-  ApiProvider, CallApiContextParams,
+  ApiProvider,
+  CallApiContextParams,
   EnvOverrides,
   ProviderEmbeddingResponse,
   ProviderResponse,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -407,7 +407,13 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       );
     }
 
-    const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
+    const messages = [];
+    if (context?.thread.useThread) {
+      if (context.thread.thread) {
+        messages.push(...context.thread.thread);
+      }
+    }
+    messages.push(...parseChatPrompt(prompt, [{ role: 'user', content: prompt }]));
 
     let stop: string;
     try {
@@ -476,8 +482,12 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         (logProbObj: { token: string; logprob: number }) => logProbObj.logprob,
       );
 
+      if (message.content) {
+        messages.push(message)
+      }
       return {
         output,
+        thread: messages,
         tokenUsage: getTokenUsage(data, cached),
         cached,
         logProbs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,9 +90,15 @@ export function isProviderOptions(provider: any): provider is ProviderOptions {
 
 export interface CallApiContextParams {
   vars: Record<string, string | object>;
+  thread: ThreadContext;
   logger?: typeof logger;
   fetchWithCache?: typeof fetchWithCache;
   getCache?: typeof getCache;
+}
+
+export interface ThreadContext {
+  useThread: boolean;
+  thread?: any;
 }
 
 export interface CallApiOptionsParams {
@@ -157,6 +163,7 @@ export interface ProviderResponse {
   cost?: number;
   cached?: boolean;
   logProbs?: number[];
+  thread?: any;
 }
 
 export interface ProviderEmbeddingResponse {
@@ -219,6 +226,7 @@ export interface RunEvalOptions {
   test: AtomicTestCase;
   nunjucksFilters?: NunjucksFilterMap;
   evaluateOptions: EvaluateOptions;
+  thread: ThreadContext;
 
   rowIndex: number;
   colIndex: number;
@@ -233,6 +241,7 @@ export interface EvaluateOptions {
     total: number,
     index: number,
     evalStep: RunEvalOptions,
+    threadIndex: number,
   ) => void;
   generateSuggestions?: boolean;
   repeat?: number;
@@ -510,6 +519,8 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
 
   // Optional list of automatic checks to run on the LLM output
   assert?: (AssertionSet | Assertion)[];
+
+  thread?: TestCase<Vars>[];
 
   // Additional configuration settings for the prompt
   options?: PromptConfig &

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -521,7 +521,7 @@ describe('call provider apis', () => {
                   inputArgs.concat([
                     'Test prompt',
                     '{"config":{"some_config_val":42}}',
-                    '{"vars":{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""}}',
+                    '{"vars":{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""},"thread":{"useThread":false}}',
                   ]),
                 ),
               );
@@ -541,6 +541,9 @@ describe('call provider apis', () => {
           var1: 'value 1',
           var2: 'value 2 "with some double "quotes""',
         },
+        thread: {
+          useThread: false
+        }
       });
 
       expect(result.output).toBe(mockResponse);

--- a/test/threads.test.ts
+++ b/test/threads.test.ts
@@ -1,0 +1,193 @@
+import { evaluate } from '../src/evaluator';
+
+import type { ApiProvider, Prompt, TestSuite } from '../src/types';
+import { TestCase } from '../dist/src';
+import { CallApiContextParams } from '../src/types';
+
+jest.mock('node-fetch', () => jest.fn());
+jest.mock('proxy-agent', () => ({
+  ProxyAgent: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('glob', () => ({
+  globSync: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  statSync: jest.fn(),
+  readdirSync: jest.fn(),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  promises: {
+    readFile: jest.fn(),
+  },
+}));
+
+jest.mock('../src/esm');
+jest.mock('../src/database');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const mockApiProviderThreadCommaConcatenator: ApiProvider = {
+  id: jest.fn().mockReturnValue('test-provider'),
+  callApi: jest.fn().mockImplementation((prompt: string, context?: CallApiContextParams) => ({
+    output: (context?.thread.thread || '') + ',' + prompt,
+    tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+    thread: (context?.thread.thread || '') + ',' + prompt
+  })),
+};
+
+const mockApiProviderThreadColonConcatenator: ApiProvider = {
+  id: jest.fn().mockReturnValue('test-provider'),
+  callApi: jest.fn().mockImplementation((prompt: string, context?: CallApiContextParams) => ({
+    output: (context?.thread.thread || '') + ':' + prompt,
+    tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+    thread: (context?.thread.thread || '') + ':' + prompt
+  })),
+};
+
+function toPrompt(text: string): Prompt {
+  return { raw: text, display: text };
+}
+
+describe('runAssertions', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Tests in a thread keeps thread context', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderThreadCommaConcatenator],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          thread: [{
+            assert: [{
+              type: 'equals',
+              value: ',Test prompt'
+            }]
+          },{
+            assert: [{
+              type: 'equals',
+              value: ',Test prompt,Test prompt'
+            }]
+          }]
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProviderThreadCommaConcatenator.callApi).toHaveBeenCalledTimes(2);
+    expect(summary.stats.successes).toBe(2);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].prompt.raw).toBe('Test prompt');
+    expect(summary.results[0].response?.output).toBe(',Test prompt');
+    expect(summary.results[1].prompt.raw).toBe('Test prompt');
+    expect(summary.results[1].response?.output).toBe(',Test prompt,Test prompt');
+  });
+
+  test('Columns are correctly filled in when using multiple providers', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderThreadCommaConcatenator, mockApiProviderThreadColonConcatenator],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          thread: [{
+            assert: [{
+              type: 'contains',
+              value: 'Test prompt'
+            }]
+          },{
+            assert: [{
+              type: 'regex',
+              value: '.Test prompt.Test prompt'
+            }]
+          }]
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProviderThreadCommaConcatenator.callApi).toHaveBeenCalledTimes(2);
+    expect(mockApiProviderThreadColonConcatenator.callApi).toHaveBeenCalledTimes(2);
+    expect(summary.stats.successes).toBe(4);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.table.body[0].outputs[0].text).toBe(',Test prompt')
+    expect(summary.table.body[1].outputs[0].text).toBe(',Test prompt,Test prompt')
+    expect(summary.table.body[0].outputs[1].text).toBe(':Test prompt')
+    expect(summary.table.body[1].outputs[1].text).toBe(':Test prompt:Test prompt')
+  });
+
+  test('variables on thread level causes many threads instead of many sub-threads', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderThreadCommaConcatenator],
+      prompts: [toPrompt('{{query}}')],
+      tests: [
+        {
+          vars: { 'query': [ 'banana', 'apple' ] },
+          thread: [{
+            vars: { 'query': 'I will name fruit, please repeat it back to me' }
+          },{
+            assert: [{
+              type: 'equals',
+              value: ',I will name fruit, please repeat it back to me,{{query}}'
+            }]
+          }]
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProviderThreadCommaConcatenator.callApi).toHaveBeenCalledTimes(4);
+    expect(summary.stats.successes).toBe(4);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.table.body[0].outputs[0].text).toBe(',I will name fruit, please repeat it back to me')
+    expect(summary.table.body[1].outputs[0].text).toBe(',I will name fruit, please repeat it back to me,banana')
+    expect(summary.table.body[2].outputs[0].text).toBe(',I will name fruit, please repeat it back to me')
+    expect(summary.table.body[3].outputs[0].text).toBe(',I will name fruit, please repeat it back to me,apple')
+  });
+
+  test('threads are not run concurrently', async () => {
+    let running = 0
+    const mockApiProvider: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider'),
+      callApi: () => {
+        running += 1;
+        return new Promise(resolve => setTimeout(() => {
+          expect(running).toBeLessThan(2)
+          running -= 1;
+          resolve({ output: "test" })
+        }, 100));
+      },
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          thread: [{
+            assert: [{
+              type: 'equals',
+              value: 'Test output'
+            }]
+          },
+          {
+            assert: [{
+              type: 'equals',
+              value: 'Test output'
+            }]
+          }]
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+  });
+});


### PR DESCRIPTION
# What

This is a draft for adding support for threaded tests that can be used with e.g. OpenAI chats or assistants.

I created it as a very early draft to ask if this is a feature you want to have, and as a base for discussions on implementation details. I hope that you are interested in the suggestion.

# Why

In my case, my assistant will be used almost exclusively with a sequence of questions and answers. This can not be tested sufficiently with a single request. I can not initiate the provider with a list of messages since the OpenAI assistants only allows the client to add messages with `role: user`.

# How

I have a suggestion for syntax but I expect feedback and it's welcome! I have an [example](https://github.com/promptfoo/promptfoo/compare/main...SiXoS:promptfoo-sixos:main#diff-1a1c9b8aa57802e55f48ed1cf41d5115567091448f9abcf41d5b2b9a2705b5a0) in the PR. Basically, a test case can have a property called `thread` which is a list of test cases that will be run sequentially on the same thread. This is not recursive. A test case that has `thread` can not have `assert` and vice versa.

The `ApiProvider` uses the `CallApiContextParams.thread` to keep track of which threadId to use. See the `OpenAiAssistantProvider` for an example.

One concern is that this use-case doesn't fit the structure of having one main prompt and then variables per case. You probably want a prompt per case.

# What makes this a draft?

1. I have to add a lot more tests.
2. Concurrency has to be handled correctly, threaded tests can't be concurrent.
3. I have not even looked at what the output looks like, that has to be inspected.
4. Add implementation for all relevant providers.

Let me know what you think about the feature suggestion and if you have any concerns with my suggested implementation.