### PR TITLE
feat: ability to use js files as `transform`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ scratch
 node_modules
 dist
 .aider*
+
+__pycache__

--- a/examples/transform-file/README.md
+++ b/examples/transform-file/README.md
@@ -1,0 +1,10 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, edit promptfooconfig.yaml.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/transform-file/promptfooconfig.yaml
+++ b/examples/transform-file/promptfooconfig.yaml
@@ -1,0 +1,16 @@
+description: 'Transform with external function'
+
+prompts:
+  - "Write a tweet about {{topic}}"
+
+providers:
+  - openai:gpt-3.5-turbo-0613
+
+defaultTest:
+  options:
+    transform: file://transform.js
+    # transform: file://transform.py
+
+tests:
+  - vars:
+      topic: bananas

--- a/examples/transform-file/transform.js
+++ b/examples/transform-file/transform.js
@@ -1,0 +1,5 @@
+module.exports = (output, context) => {
+  // context.vars, context.prompt
+  // ...
+  return output.toUpperCase();
+};

--- a/examples/transform-file/transform.py
+++ b/examples/transform-file/transform.py
@@ -1,0 +1,5 @@
+def get_transform(output, context):
+    # context['vars'], context['prompt']
+    # ...
+    return output.upper()
+

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -428,6 +428,33 @@ tests:
 Use `defaultTest` apply a transform option to every test case in your test suite.
 :::
 
+### Transforms from separate files
+
+Transform functions can be executed from external Python or Javascript files.  For example:
+
+```yaml
+defaultTest:
+  options:
+    transform: file://transform.js
+```
+
+Here's `transform.js`:
+```js
+module.exports = (output, context) => {
+  // context.vars, context.prompt
+  // ...
+  return output.toUpperCase();
+};
+```
+
+Or the equivalent `transform.py`:
+```py
+def get_transform(output, context):
+    # context['vars'], context['prompt']
+    # ...
+    return output.upper()
+```
+
 ## Config structure and organization
 
 For detailed information on the config structure, see [Configuration Reference](/docs/configuration/reference).

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -208,7 +208,7 @@ export async function runAssertion({
   });
 
   if (assertion.transform) {
-    output = transformOutput(assertion.transform, output, {
+    output = await transformOutput(assertion.transform, output, {
       vars: test.vars,
       prompt: { display: prompt },
     });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -303,7 +303,7 @@ class Evaluator {
         let processedResponse = { ...response };
         const transform = test.options?.transform || test.options?.postprocess;
         if (transform) {
-          processedResponse.output = transformOutput(transform, processedResponse.output, {
+          processedResponse.output = await transformOutput(transform, processedResponse.output, {
             vars,
             prompt,
           });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -12,6 +12,7 @@ import {
   readFilters,
   readGlobalConfig,
   resetGlobalConfig,
+  transformOutput,
   writeMultipleOutputs,
   writeOutput,
 } from '../src/util';
@@ -749,6 +750,49 @@ describe('util', () => {
         },
       };
       expect(dereferencedConfig).toEqual(expectedOutput);
+    });
+  });
+
+  describe('transformOutput', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.resetModules();
+    });
+
+    test('transforms output using a direct function', async () => {
+      const output = 'original output';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const transformFunction = 'output.toUpperCase()';
+      const transformedOutput = await transformOutput(transformFunction, output, context);
+      expect(transformedOutput).toEqual('ORIGINAL OUTPUT');
+    });
+
+    test('transforms output using an imported function from a file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      jest.doMock(path.resolve('transform.js'), () => (output: string) => output.toUpperCase(), { virtual: true });
+      const transformFunctionPath = 'file://transform.js';
+      const transformedOutput = await transformOutput(transformFunctionPath, output, context);
+      expect(transformedOutput).toEqual('HELLO');
+    });
+
+    test('throws error if transform function does not return a value', async () => {
+      const output = 'test';
+      const context = { vars: {}, prompt: {} };
+      const transformFunction = ''; // Empty function, returns undefined
+      await expect(transformOutput(transformFunction, output, context)).rejects.toThrow(
+        'Transform function did not return a value',
+      );
+    });
+
+    test('throws error if file does not export a function', async () => {
+      const output = 'test';
+      const context = { vars: {}, prompt: {} };
+      jest.doMock(path.resolve('transform.js'), () => 'banana', { virtual: true });
+      const transformFunctionPath = 'file://transform.js';
+      await expect(transformOutput(transformFunctionPath, output, context)).rejects.toThrow(
+        'Transform transform.js must export a function or have a default export as a function',
+      );
     });
   });
 });


### PR DESCRIPTION
For example:

```yaml
# ...
tests:
  - vars:
      language: French
      body: Hello world
    options:
      transform: file://path/to/transform.js
    # ...
```

transform.js
```js
module.exports = (output, context) => {
  // Use context.vars, context.prompt ...
  return output.toUpperCase();
}
```