### PR TITLE
fix: glob behavior on windows

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -120,7 +120,9 @@ export async function readPrompts(
       }
       resolvedPath = path.resolve(basePath, pathOrGlob);
       resolvedPathToDisplay.set(resolvedPath, pathOrGlob);
-      const globbedPaths = globSync(resolvedPath);
+      const globbedPaths = globSync(resolvedPath, {
+        windowsPathsNoEscape: true,
+      });
       if (globbedPaths.length > 0) {
         return globbedPaths.map((globbedPath) => ({ raw: pathOrGlob, resolved: globbedPath }));
       }

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -42,7 +42,9 @@ export async function readVarsFiles(
   const ret: Record<string, string | string[] | object> = {};
   for (const pathOrGlob of pathOrGlobs) {
     const resolvedPath = path.resolve(basePath, pathOrGlob);
-    const paths = globSync(resolvedPath);
+    const paths = globSync(resolvedPath, {
+      windowsPathsNoEscape: true,
+    });
 
     for (const p of paths) {
       const yamlData = yaml.load(fs.readFileSync(p, 'utf-8'));
@@ -151,7 +153,9 @@ export async function readTests(
 
   const loadTestsFromGlob = async (loadTestsGlob: string) => {
     const resolvedPath = path.resolve(basePath, loadTestsGlob);
-    const testFiles = globSync(resolvedPath);
+    const testFiles = globSync(resolvedPath, {
+      windowsPathsNoEscape: true,
+    });
     const ret = [];
     for (const testFile of testFiles) {
       let testCases: TestCase[] | undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -216,7 +216,9 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
 export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig> {
   const configs: UnifiedConfig[] = [];
   for (const configPath of configPaths) {
-    const globPaths = globSync(configPath);
+    const globPaths = globSync(configPath, {
+      windowsPathsNoEscape: true,
+    });
     if (globPaths.length === 0) {
       throw new Error(`No configuration file found at ${configPath}`);
     }
@@ -1060,7 +1062,9 @@ export async function readFilters(
   const ret: NunjucksFilterMap = {};
   for (const [name, filterPath] of Object.entries(filters)) {
     const globPath = path.join(basePath, filterPath);
-    const filePaths = globSync(globPath);
+    const filePaths = globSync(globPath, {
+      windowsPathsNoEscape: true,
+    });
     for (const filePath of filePaths) {
       const finalPath = path.resolve(filePath);
       ret[name] = await importModule(finalPath);


### PR DESCRIPTION
Paths are resolved before globs, which causes issues on Windows machines.  This is a potential fix.

https://www.npmjs.com/package/glob#windows

https://discord.com/channels/1153767083381903389/1220819017376469093