### PR TITLE
feat: ability to override path to python binary

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -85,6 +85,19 @@ class ProviderResponse:
     logProbs: Optional[List[float]]
 ```
 
+### Setting the Python executable
+
+In some scenarios, you may need to specify a custom Python executable. This is particularly useful when working with virtual environments or when the default Python path does not point to the desired Python interpreter.
+
+Here's an example of how you can override the Python executable using the `pythonExecutable` option:
+
+```yaml
+providers:
+  - id: 'python:my_script.py'
+    config:
+      pythonExecutable: /path/to/python3.11
+```
+
 ### Troubleshooting
 
 #### Viewing python output

--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types';
 
 interface PythonProviderConfig {
-  pythonPath?: string;
+  pythonExecutable?: string;
 }
 
 export class PythonProvider implements ApiProvider {
@@ -54,7 +54,7 @@ export class PythonProvider implements ApiProvider {
         )}`,
       );
       const result = (await runPython(absPath, 'call_api', args, {
-        pythonPath: this.config.pythonPath,
+        pythonExecutable: this.config.pythonExecutable,
       })) as {
         output?: string;
         error?: string;

--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -13,9 +13,16 @@ import type {
   ProviderResponse,
 } from '../types';
 
+interface PythonProviderConfig {
+  pythonPath?: string;
+}
+
 export class PythonProvider implements ApiProvider {
+  private config: PythonProviderConfig;
+
   constructor(private scriptPath: string, private options?: ProviderOptions) {
     this.id = () => options?.id ?? `python:${this.scriptPath}`;
+    this.config = options?.config ?? {};
   }
 
   id() {
@@ -46,7 +53,9 @@ export class PythonProvider implements ApiProvider {
           '\n',
         )}`,
       );
-      const result = (await runPython(absPath, 'call_api', args)) as {
+      const result = (await runPython(absPath, 'call_api', args, {
+        pythonPath: this.config.pythonPath,
+      })) as {
         output?: string;
         error?: string;
       };

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -17,12 +17,12 @@ export async function runPython(
   scriptPath: string,
   method: string,
   args: (string | object | undefined)[],
-  options: { pythonPath?: string } = {},
+  options: { pythonExecutable?: string } = {},
 ): Promise<any> {
   const absPath = path.resolve(scriptPath);
   const pythonOptions: PythonShellOptions = {
     mode: 'text',
-    pythonPath: options.pythonPath || process.env.PROMPTFOO_PYTHON || 'python',
+    pythonPath: options.pythonExecutable || process.env.PROMPTFOO_PYTHON || 'python',
     scriptPath: __dirname,
     args: [absPath, method, ...args.map((arg) => JSON.stringify(arg))],
   };

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -17,11 +17,12 @@ export async function runPython(
   scriptPath: string,
   method: string,
   args: (string | object | undefined)[],
+  options: { pythonPath?: string } = {},
 ): Promise<any> {
   const absPath = path.resolve(scriptPath);
   const pythonOptions: PythonShellOptions = {
     mode: 'text',
-    pythonPath: process.env.PROMPTFOO_PYTHON || 'python',
+    pythonPath: options.pythonPath || process.env.PROMPTFOO_PYTHON || 'python',
     scriptPath: __dirname,
     args: [absPath, method, ...args.map((arg) => JSON.stringify(arg))],
   };


### PR DESCRIPTION
Can be done like this:

```yaml
providers:
  - id: python:provider.py
    config:
      pythonExecutable: '/path/to/python3.8'
```