### PR TITLE
feat(webui): "progress" page that shows provider/prompt pairs

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -41,6 +41,7 @@ import type {
   OutputFile,
   ProviderOptions,
   Prompt,
+  CompletedPrompt,
 } from './types';
 
 let globalConfigCache: any = null;
@@ -1142,4 +1143,42 @@ export async function transformOutput(
     throw new Error(`Transform function did not return a value\n\n${codeOrFilepath}`);
   }
   return ret;
+}
+
+export type StandaloneEval = CompletedPrompt & {
+  evalId: string;
+  datasetId: string | null;
+  promptId: string | null;
+};
+export function getStandaloneEvals(): StandaloneEval[] {
+  const db = getDb();
+  const results = db
+    .select({
+      evalId: evals.id,
+      description: evals.description,
+      config: evals.config,
+      results: evals.results,
+      promptId: evalsToPrompts.promptId,
+      datasetId: evalsToDatasets.datasetId,
+    })
+    .from(evals)
+    .leftJoin(evalsToPrompts, eq(evals.id, evalsToPrompts.evalId))
+    .leftJoin(evalsToDatasets, eq(evals.id, evalsToDatasets.evalId))
+    .orderBy(desc(evals.createdAt))
+    .limit(100)
+    .all();
+
+  const flatResults: StandaloneEval[] = [];
+  results.forEach((result) => {
+    const table = result.results.table;
+    table.head.prompts.forEach((col) => {
+      flatResults.push({
+        evalId: result.evalId,
+        promptId: result.promptId,
+        datasetId: result.datasetId,
+        ...col,
+      });
+    });
+  });
+  return flatResults;
 }

--- a/src/web/nextui/src/app/api/progress/route.ts
+++ b/src/web/nextui/src/app/api/progress/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+import { StandaloneEval, getStandaloneEvals, listPreviousResults } from '../../../../../../util';
+import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
+
+export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
+
+export async function GET() {
+  if (USE_SUPABASE) {
+    return NextResponse.json({ error: 'Not implemented' });
+  }
+  let results: StandaloneEval[];
+  try {
+    results = await getStandaloneEvals();
+  } catch (err) {
+    // Database potentially not yet set up.
+    results = [];
+  }
+  return NextResponse.json({
+    data: results,
+  });
+}

--- a/src/web/nextui/src/app/components/Navigation.tsx
+++ b/src/web/nextui/src/app/components/Navigation.tsx
@@ -40,6 +40,7 @@ export default function Navigation({
       <NavLink href="/eval" label="Evals" />
       <NavLink href="/prompts" label="Prompts" />
       <NavLink href="/datasets" label="Datasets" />
+      <NavLink href="/progress" label="Progress" />
       <div className="right-aligned">
         {USE_SUPABASE ? <LoggedInAs /> : null}
         <DarkMode darkMode={darkMode} onToggleDarkMode={onToggleDarkMode} />

--- a/src/web/nextui/src/app/progress/Progress.tsx
+++ b/src/web/nextui/src/app/progress/Progress.tsx
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Pagination from '@mui/material/Pagination';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -118,6 +119,9 @@ export default function Cols() {
     });
   }, [cols, sortField, sortOrder]);
 
+  const [page, setPage] = React.useState(1);
+  const rowsPerPage = 25;
+
   return (
     <Box paddingX={2}>
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -147,9 +151,7 @@ export default function Cols() {
           </Menu>
         </div>
       </Box>
-      <Box>
-        This page shows performance metrics for provider/prompt combinations from recent evals.
-      </Box>
+      <Box>This page shows performance metrics for recent evals.</Box>
       <Table>
         <TableHead>
           <TableRow>
@@ -204,7 +206,7 @@ export default function Cols() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortedCols.map((col, index) => (
+          {sortedCols.slice((page - 1) * rowsPerPage, page * rowsPerPage).map((col, index) => (
             <TableRow key={index} hover style={{ cursor: 'pointer' }}>
               <TableCell>
                 <Link href={`/eval?evalId=${col.evalId}`}>{col.evalId}</Link>
@@ -231,6 +233,14 @@ export default function Cols() {
           ))}
         </TableBody>
       </Table>
+      {Math.ceil(cols.length / rowsPerPage) > 1 && (
+        <Pagination
+          count={Math.ceil(sortedCols.length / rowsPerPage)}
+          page={page}
+          onChange={(event, value) => setPage(value)}
+          sx={{ pt: 2, pb: 4, display: 'flex', justifyContent: 'center' }}
+        />
+      )}
     </Box>
   );
 }

--- a/src/web/nextui/src/app/progress/Progress.tsx
+++ b/src/web/nextui/src/app/progress/Progress.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -137,6 +138,22 @@ export default function Cols() {
   const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFilter({ ...filter, [event.target.name]: event.target.value });
   };
+  const evalIdOptions = React.useMemo(
+    () => Array.from(new Set(cols.map((col) => col.evalId))),
+    [cols],
+  );
+  const datasetIdOptions = React.useMemo(
+    () => Array.from(new Set(cols.map((col) => col.datasetId))),
+    [cols],
+  );
+  const providerOptions = React.useMemo(
+    () => Array.from(new Set(cols.map((col) => col.provider))),
+    [cols],
+  );
+  const promptIdOptions = React.useMemo(
+    () => Array.from(new Set(cols.map((col) => col.promptId))),
+    [cols],
+  );
 
   return (
     <Box paddingX={2}>
@@ -169,37 +186,49 @@ export default function Cols() {
       </Box>
       <Box>This page shows performance metrics for recent evals.</Box>
       <Box display="flex" flexDirection="row" gap={2} mt={2}>
-        <TextField
-          label="Eval ID"
-          variant="outlined"
-          size="small"
-          name="evalId"
-          value={filter.evalId || ''}
-          onChange={handleFilterChange}
+        <Autocomplete
+          options={evalIdOptions}
+          value={filter.evalId}
+          onChange={(event, newValue) => {
+            setFilter({ ...filter, evalId: newValue || '' });
+          }}
+          renderInput={(params) => (
+            <TextField {...params} label="Eval ID" variant="outlined" size="small" fullWidth />
+          )}
+          sx={{ width: 220 }}
         />
-        <TextField
-          label="Dataset ID"
-          variant="outlined"
-          size="small"
-          name="datasetId"
-          value={filter.datasetId || ''}
-          onChange={handleFilterChange}
+        <Autocomplete
+          options={datasetIdOptions}
+          value={filter.datasetId}
+          onChange={(event, newValue) => {
+            setFilter({ ...filter, datasetId: newValue || '' });
+          }}
+          renderInput={(params) => (
+            <TextField {...params} label="Dataset ID" variant="outlined" size="small" fullWidth />
+          )}
+          sx={{ width: 220 }}
         />
-        <TextField
-          label="Provider"
-          variant="outlined"
-          size="small"
-          name="provider"
-          value={filter.provider || ''}
-          onChange={handleFilterChange}
+        <Autocomplete
+          options={providerOptions}
+          value={filter.provider}
+          onChange={(event, newValue) => {
+            setFilter({ ...filter, provider: newValue || '' });
+          }}
+          renderInput={(params) => (
+            <TextField {...params} label="Provider" variant="outlined" size="small" fullWidth />
+          )}
+          sx={{ width: 220 }}
         />
-        <TextField
-          label="Prompt ID"
-          variant="outlined"
-          size="small"
-          name="promptId"
-          value={filter.promptId || ''}
-          onChange={handleFilterChange}
+        <Autocomplete
+          options={promptIdOptions}
+          value={filter.promptId}
+          onChange={(event, newValue) => {
+            setFilter({ ...filter, promptId: newValue || '' });
+          }}
+          renderInput={(params) => (
+            <TextField {...params} label="Prompt ID" variant="outlined" size="small" fullWidth />
+          )}
+          sx={{ width: 220 }}
         />
       </Box>
       <Table>
@@ -271,14 +300,20 @@ export default function Cols() {
               }
             >
               <TableCell>
-                <Link href={`/eval?evalId=${col.evalId}`}>{col.evalId}</Link>
+                <Link href={`/eval?evalId=${col.evalId}`} onClick={(e) => e.stopPropagation()}>
+                  {col.evalId}
+                </Link>
               </TableCell>
               <TableCell>
-                <Link href={`/datasets?id=${col.datasetId}`}>{col.datasetId?.slice(0, 6)}</Link>
+                <Link href={`/datasets?id=${col.datasetId}`} onClick={(e) => e.stopPropagation()}>
+                  {col.datasetId?.slice(0, 6)}
+                </Link>
               </TableCell>
               <TableCell>{col.provider}</TableCell>
               <TableCell>
-                <Link href={`/prompts?id=${col.promptId}`}>[{col.promptId?.slice(0, 6)}]</Link>{' '}
+                <Link href={`/prompts?id=${col.promptId}`} onClick={(e) => e.stopPropagation()}>
+                  [{col.promptId?.slice(0, 6)}]
+                </Link>{' '}
                 {col.raw}
               </TableCell>
               <TableCell>{calculatePassRate(col.metrics)}</TableCell>

--- a/src/web/nextui/src/app/progress/Progress.tsx
+++ b/src/web/nextui/src/app/progress/Progress.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import DownloadIcon from '@mui/icons-material/Download';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+
+import type { StandaloneEval } from '@/../../../util';
+
+export default function Cols() {
+  const [cols, setCols] = useState<StandaloneEval[]>([]);
+  const [sortField, setSortField] = useState<string | null>(null);
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  useEffect(() => {
+    (async () => {
+      const response = await fetch(`/api/progress`);
+      const data = await response.json();
+      if (data && data.data) {
+        setCols(data.data);
+      }
+    })();
+  }, []);
+
+  const handleSort = (field: string) => {
+    const isAsc = sortField === field && sortOrder === 'asc';
+    setSortField(field);
+    setSortOrder(isAsc ? 'desc' : 'asc');
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleExport = (format: string) => {
+    const dataStr = format === 'json' ? JSON.stringify(cols) : convertToCSV(cols);
+    const blob = new Blob([dataStr], { type: `text/${format};charset=utf-8;` });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `cols_export.${format}`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+    setAnchorEl(null);
+  };
+
+  const calculatePassRate = (
+    metrics: { testPassCount: number; testFailCount: number } | undefined,
+  ) => {
+    if (metrics?.testPassCount != null && metrics?.testFailCount != null) {
+      return (
+        (metrics.testPassCount / (metrics.testPassCount + metrics.testFailCount)) *
+        100
+      ).toFixed(2);
+    }
+    return '-';
+  };
+
+  const convertToCSV = (arr: StandaloneEval[]) => {
+    const headers = [
+      'Eval',
+      'Dataset',
+      'Provider',
+      'Prompt',
+      'Pass Rate %',
+      'Pass Count',
+      'Fail Count',
+      'Raw score',
+    ];
+    const rows = arr.map((col) => [
+      col.evalId ?? '',
+      col.datasetId?.slice(0, 6) ?? '',
+      col.provider ?? '',
+      (col.promptId?.slice(0, 6) ?? '') + ' ' + (col.raw ?? ''),
+      calculatePassRate(col.metrics),
+      col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`,
+      col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`,
+      col.metrics?.score == null ? '-' : col.metrics.score.toFixed(2),
+    ]);
+    return [headers]
+      .concat(rows)
+      .map((it) => it.map((value) => value ?? '').join(','))
+      .join('\n');
+  };
+
+  const sortedCols = React.useMemo(() => {
+    return cols.sort((a, b) => {
+      if (!sortField) return 0;
+      if (sortField === 'passRate') {
+        const aValue = parseFloat(calculatePassRate(a.metrics));
+        const bValue = parseFloat(calculatePassRate(b.metrics));
+        return sortOrder === 'asc' ? aValue - bValue : bValue - aValue;
+      } else {
+        // Ensure sortField is a key of StandaloneEval
+        if (sortField in a && sortField in b) {
+          const aValue = a[sortField as keyof StandaloneEval] || '';
+          const bValue = b[sortField as keyof StandaloneEval] || '';
+          return sortOrder === 'asc'
+            ? aValue.toString().localeCompare(bValue.toString())
+            : bValue.toString().localeCompare(aValue.toString());
+        }
+        return 0;
+      }
+    });
+  }, [cols, sortField, sortOrder]);
+
+  return (
+    <Box paddingX={2}>
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <h2>Progress summary</h2>
+        <div>
+          <Button
+            id="export-button"
+            aria-controls={open ? 'export-menu' : undefined}
+            aria-haspopup="true"
+            aria-expanded={open ? 'true' : undefined}
+            onClick={handleClick}
+            startIcon={<DownloadIcon />}
+          >
+            Export
+          </Button>
+          <Menu
+            id="export-menu"
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            MenuListProps={{
+              'aria-labelledby': 'export-button',
+            }}
+          >
+            <MenuItem onClick={() => handleExport('csv')}>CSV</MenuItem>
+            <MenuItem onClick={() => handleExport('json')}>JSON</MenuItem>
+          </Menu>
+        </div>
+      </Box>
+      <Box>
+        This page shows performance metrics for provider/prompt combinations from recent evals.
+      </Box>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'evalId'}
+                direction={sortField === 'evalId' ? sortOrder : 'asc'}
+                onClick={() => handleSort('evalId')}
+              >
+                Eval
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>Dataset</TableCell>
+            <TableCell>Provider</TableCell>
+            <TableCell>Prompt</TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'passRate'}
+                direction={sortField === 'passRate' ? sortOrder : 'asc'}
+                onClick={() => handleSort('passRate')}
+              >
+                Pass Rate %
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'testPassCount'}
+                direction={sortField === 'testPassCount' ? sortOrder : 'asc'}
+                onClick={() => handleSort('testPassCount')}
+              >
+                Pass Count
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'testFailCount'}
+                direction={sortField === 'testFailCount' ? sortOrder : 'asc'}
+                onClick={() => handleSort('testFailCount')}
+              >
+                Fail Count
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'score'}
+                direction={sortField === 'score' ? sortOrder : 'asc'}
+                onClick={() => handleSort('score')}
+              >
+                Raw score
+              </TableSortLabel>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedCols.map((col, index) => (
+            <TableRow key={index} hover style={{ cursor: 'pointer' }}>
+              <TableCell>
+                <Link href={`/eval?evalId=${col.evalId}`}>{col.evalId}</Link>
+              </TableCell>
+              <TableCell>
+                <Link href={`/datasets?id=${col.datasetId}`}>{col.datasetId?.slice(0, 6)}</Link>
+              </TableCell>
+              <TableCell>{col.provider}</TableCell>
+              <TableCell>
+                <Link href={`/prompts?id=${col.promptId}`}>[{col.promptId?.slice(0, 6)}]</Link>{' '}
+                {col.raw}
+              </TableCell>
+              <TableCell>{calculatePassRate(col.metrics)}</TableCell>
+              <TableCell>
+                {col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`}
+              </TableCell>
+              <TableCell>
+                {col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`}
+              </TableCell>
+              <TableCell>
+                {col.metrics?.score == null ? '-' : col.metrics.score.toFixed(2)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/src/web/nextui/src/app/progress/page.tsx
+++ b/src/web/nextui/src/app/progress/page.tsx
@@ -1,0 +1,9 @@
+import Progress from './Progress';
+
+export default function Page() {
+  return (
+    <div>
+      <Progress />
+    </div>
+  );
+}


### PR DESCRIPTION
Add a page that makes it easier to see eval improvement over time.  It's currently labeled "Progress"

The page is somewhat useful but still kinda half baked.  I actually think all of the Prompts, Datasets, and Progress pages should be replaced by a single more flexible page with filtering and grouping options.

![eval improvement over time](https://github.com/promptfoo/promptfoo/assets/310310/cef92033-9386-462d-bb74-0439f3ef4226)
