### PR TITLE
Add documentation for openai vision

### DIFF
--- a/examples/openai-vision/README.md
+++ b/examples/openai-vision/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, have a look at prompt.json and edit promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/openai-vision/prompt.json
+++ b/examples/openai-vision/prompt.json
@@ -1,0 +1,17 @@
+[
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "What’s in this image?"
+      },
+      {
+        "type": "image_url",
+        "image_url": {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+        }
+      }
+    ]
+  }
+]

--- a/examples/openai-vision/promptfooconfig.yaml
+++ b/examples/openai-vision/promptfooconfig.yaml
@@ -1,0 +1,7 @@
+prompts: [prompt.json]
+providers: [openai:chat:gpt-4-vision-preview]
+
+tests:
+  - assert:
+    - type: contains
+      value: 'boardwalk'

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -371,6 +371,12 @@ This has the effect of including the conversation history _within_ the prompt co
 ]
 ```
 
+## Images / gpt-4-vision
+
+You can include images in the prompt by using content blocks.
+
+See [OpenAI vision example](https://github.com/typpo/promptfoo/tree/main/examples/openai-vision).
+
 ## Using tools and functions
 
 OpenAI tools and functions are supported. See [OpenAI tools example](https://github.com/typpo/promptfoo/tree/main/examples/openai-tools-call) and [OpenAI functions example](https://github.com/typpo/promptfoo/tree/main/examples/openai-function-call).


### PR DESCRIPTION
OpenAI vision is actually supported by just including an image as part of content blocks. This wasn't documented so I took a stab at documenting it.