### PR TITLE
feat: ability to import vars using glob

### DIFF
--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -4,6 +4,8 @@ tests:
   - vars:
       language: [French, German, Spanish]
       input: ['Hello world', 'Good morning', 'How are you?']
+      # You can also import vars from file. For example:
+      # input: 'file://vars/*.txt'
     assert:
       - type: similar
         value: 'Hello world'

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -306,6 +306,16 @@ Evaluates each `language` x `input` combination:
 
 <img alt="Multiple combinations of var inputs" src="https://user-images.githubusercontent.com/310310/243108917-dab27ca5-689b-4843-bb52-de8d459d783b.png" />
 
+Vars can also be imported from globbed filepaths. They are automatically expanded into an array.  For example:
+
+```yaml
+  - vars:
+      language: [French, German, Spanish]
+      // highlight-start
+      input: file://path/to/inputs/*.txt
+      // highlight-end
+```
+
 ## Using nunjucks templates
 
 Use Nunjucks templates to exert additional control over your prompt templates, including loops, conditionals, and more.

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -6,6 +6,7 @@ import async from 'async';
 import chalk from 'chalk';
 import invariant from 'tiny-invariant';
 import yaml from 'js-yaml';
+import { globSync } from 'glob';
 
 import cliState from './cliState';
 import logger from './logger';
@@ -54,7 +55,16 @@ function generateVarCombinations(
   const combinations: Record<string, string | any[]>[] = [{}];
 
   for (const key of keys) {
-    let values: any[] = Array.isArray(vars[key]) ? vars[key] : [vars[key]];
+    let values: any[] = [];
+
+    if (typeof vars[key] === 'string' && vars[key].startsWith('file://')) {
+      const filePath = vars[key].slice('file://'.length);
+      const resolvedPath = path.resolve(cliState.basePath || '', filePath);
+      const filePaths = globSync(resolvedPath.replace(/\\/g, '/'));
+      values = filePaths.map((path: string) => `file://${path}`);
+    } else {
+      values = Array.isArray(vars[key]) ? vars[key] : [vars[key]];
+    }
 
     // Check if it's an array but not a string array
     if (Array.isArray(vars[key]) && typeof vars[key][0] !== 'string') {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -48,7 +48,7 @@ interface RunEvalOptions {
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
 
-function generateVarCombinations(
+export function generateVarCombinations(
   vars: Record<string, string | string[] | any>,
 ): Record<string, string | any[]>[] {
   const keys = Object.keys(vars);

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -1,7 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import glob from 'glob';
 
-import { evaluate, renderPrompt, resolveVariables } from '../src/evaluator';
+import {
+  evaluate,
+  renderPrompt,
+  resolveVariables,
+  generateVarCombinations,
+} from '../src/evaluator';
 
 import type { ApiProvider, TestSuite, Prompt } from '../src/types';
 
@@ -795,5 +801,56 @@ describe('resolveVariables', () => {
       greeting: 'Hello, {{unknown}}!',
       name: '{{unknown}}',
     });
+  });
+});
+
+describe('generateVarCombinations', () => {
+  it('should generate combinations for simple variables', () => {
+    const vars = { language: 'English', greeting: 'Hello' };
+    const expected = [{ language: 'English', greeting: 'Hello' }];
+    expect(generateVarCombinations(vars)).toEqual(expected);
+  });
+
+  it('should generate combinations for array variables', () => {
+    const vars = { language: ['English', 'French'], greeting: 'Hello' };
+    const expected = [
+      { language: 'English', greeting: 'Hello' },
+      { language: 'French', greeting: 'Hello' },
+    ];
+    expect(generateVarCombinations(vars)).toEqual(expected);
+  });
+
+  it('should handle file paths and expand them into combinations', () => {
+    const vars = { language: 'English', greeting: 'file:///path/to/greetings/*.txt' };
+    jest.spyOn(glob, 'globSync').mockReturnValue(['greeting1.txt', 'greeting2.txt']);
+    const expected = [
+      { language: 'English', greeting: 'file://greeting1.txt' },
+      { language: 'English', greeting: 'file://greeting2.txt' },
+    ];
+    expect(generateVarCombinations(vars)).toEqual(expected);
+  });
+
+  it('should correctly handle nested array variables', () => {
+    const vars = {
+      options: [
+        ['opt1', 'opt2'],
+        ['opt3', 'opt4'],
+      ],
+    };
+    const expected = [
+      {
+        options: [
+          ['opt1', 'opt2'],
+          ['opt3', 'opt4'],
+        ],
+      },
+    ];
+    expect(generateVarCombinations(vars)).toEqual(expected);
+  });
+
+  it('should return an empty array for empty input', () => {
+    const vars = {};
+    const expected = [{}];
+    expect(generateVarCombinations(vars)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Vars can be imported from globbed filepaths. They are automatically expanded into an array.  For example:

```yaml
  - vars:
      language: [French, German, Spanish]
      input: file://path/to/inputs/*.txt
```