### PR TITLE
Do not fail with api error when azure datasource is used

### DIFF
--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -405,8 +405,12 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
           error: `API response error: ${data.error.code} ${data.error.message}`,
         };
       }
-      const message = this.config.dataSources
-        ? data.choices[0].messages.find((msg: { role: string }) => msg.role === 'assistant')
+      const hasDataSources = !!this.config.dataSources;
+      const message = hasDataSources
+        ? data.choices.find(
+            (choice: { message: { role: string; content: string } }) =>
+              choice.message.role === 'assistant',
+          )?.message
         : data.choices[0].message;
       const output = message.content == null ? message.function_call : message.content;
       const logProbs = data.choices[0].logprobs?.content?.map(


### PR DESCRIPTION
This PR fixes an issue where azure tests that use a dataSource would fail with the following error: `API response error: TypeError: Cannot read properties of undefined (reading 'find')`.

The error seems to have been caused by an incorrectly specified inline type - `msg: { role: string }` is supposed to be `msg: { message: { role: string; content: string } }` in combination with incorrect array access. I chose to name the variable `choice` in my solution, but feel free to rename it.

For this PR I have assumed that for some reason, when dataSources is specified, the first message with the role `assistant` should be picked. If that is not the case, perhaps the code can be simplified further to just be
`const message = data.choices[0].message;`?