### PR TITLE
feat: support for inline yaml for is-json, contains-json in csv

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -294,11 +294,16 @@ export async function runAssertion({
 
     if (pass && renderedValue) {
       let validate: ValidateFunction;
-      if (typeof renderedValue === 'string' && renderedValue.startsWith('file://')) {
-        // Reference the JSON schema from external file
-        const schema = valueFromScript;
-        invariant(schema, 'is-json references a file that does not export a JSON schema');
-        validate = ajv.compile(schema as object);
+      if (typeof renderedValue === 'string') {
+        if (renderedValue.startsWith('file://')) {
+          // Reference the JSON schema from external file
+          const schema = valueFromScript;
+          invariant(schema, 'is-json references a file that does not export a JSON schema');
+          validate = ajv.compile(schema as object);
+        } else {
+          const scheme = yaml.load(renderedValue) as object;
+          validate = ajv.compile(scheme);
+        }
       } else if (typeof renderedValue === 'object') {
         // Value is JSON schema
         validate = ajv.compile(renderedValue);
@@ -472,16 +477,21 @@ export async function runAssertion({
       pass = jsonMatch !== inverse;
       if (pass && renderedValue) {
         let validate: ValidateFunction;
-        if (typeof renderedValue === 'string' && renderedValue.startsWith('file://')) {
-          // Reference the JSON schema from external file
-          const schema = valueFromScript;
-          invariant(schema, 'is-json references a file that does not export a JSON schema');
-          validate = ajv.compile(schema as object);
+        if (typeof renderedValue === 'string') {
+          if (renderedValue.startsWith('file://')) {
+            // Reference the JSON schema from external file
+            const schema = valueFromScript;
+            invariant(schema, 'contains-json references a file that does not export a JSON schema');
+            validate = ajv.compile(schema as object);
+          } else {
+            const scheme = yaml.load(renderedValue) as object;
+            validate = ajv.compile(scheme);
+          }
         } else if (typeof renderedValue === 'object') {
           // Value is JSON schema
           validate = ajv.compile(renderedValue);
         } else {
-          throw new Error('is-json assertion must have a string or object value');
+          throw new Error('contains-json assertion must have a string or object value');
         }
         pass = validate(jsonMatch);
         if (pass) {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -75,7 +75,7 @@ export function assertionFromString(expected: string): Assertion {
 
   // New options
   const assertionRegex =
-    /^(not-)?(equals|contains-any|contains-all|icontains-any|icontains-all|contains-json|is-json|regex|icontains|contains|webhook|rouge-n|similar|starts-with|levenshtein|classifier|model-graded-factuality|factuality|model-graded-closedqa|answer-relevance|context-recall|context-relevance|context-faithfulness|is-valid-openai-function-call|is-valid-openai-tools-call|latency|perplexity|perplexity-score|cost)(?:\((\d+(?:\.\d+)?)\))?(?::(.*))?$/;
+    /^(not-)?(equals|contains-any|contains-all|icontains-any|icontains-all|contains-json|is-json|regex|icontains|contains|webhook|rouge-n|similar|starts-with|levenshtein|classifier|model-graded-factuality|factuality|model-graded-closedqa|answer-relevance|context-recall|context-relevance|context-faithfulness|is-valid-openai-function-call|is-valid-openai-tools-call|latency|perplexity|perplexity-score|cost)(?:\((\d+(?:\.\d+)?)\))?(?::([\s\S]*))?$/;
   const regexMatch = expected.match(assertionRegex);
 
   if (regexMatch) {
@@ -96,6 +96,7 @@ export function assertionFromString(expected: string): Assertion {
     } else if (type === 'contains-json' || type === 'is-json') {
       return {
         type: fullType as AssertionType,
+        value: value,
       };
     } else if (
       type === 'rouge-n' ||


### PR DESCRIPTION
- if string value for is-json & contains-json does not start with file:// assume string would be yaml configuration
- Update regex to support multiline string