### PR TITLE
fix: allow loading of custom provider in windows (#518)

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-
+import { pathToFileURL } from 'node:url';
 // esm-specific crap that needs to get mocked out in tests
 
 //import path from 'path';
@@ -16,7 +16,7 @@ export function getDirectory(): string {
 
 export async function importModule(modulePath: string, functionName?: string) {
   // This is some hacky shit. It prevents typescript from transpiling `import` to `require`, which breaks mjs imports.
-  const resolvedPath = path.resolve(modulePath);
+  const resolvedPath = pathToFileURL(path.resolve(modulePath));
   const importedModule = await eval(`import('${resolvedPath}')`);
   const mod = importedModule?.default?.default || importedModule?.default || importedModule;
   if (functionName) {


### PR DESCRIPTION
- windows importing module requires file:// path url, however loading file://customProvider.js assumes that file is actually a yaml configuration