### PR TITLE
fix: 656

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -36,7 +36,7 @@ export class Telemetry {
   }
 
   maybeShowNotice(): void {
-    if (maybeRecordFirstRun()) {
+    if (!this.disabled && maybeRecordFirstRun()) {
       logger.info(
         chalk.gray(
           'Anonymous telemetry is enabled. For more info, see https://www.promptfoo.dev/docs/configuration/telemetry',


### PR DESCRIPTION
## Summary

Telemetry notice should not render when telemetry is disabled.  

## Motivation

Was browsing the repo and encountered #656.