### PR TITLE
Fix `E2BIG` error during the execution of Python asserts

### DIFF
--- a/src/python/wrapper.py
+++ b/src/python/wrapper.py
@@ -20,9 +20,11 @@ def call_method(script_path, method_name, *args):
 if __name__ == '__main__':
     script_path = sys.argv[1]
     method_name = sys.argv[2]
-    args = [json.loads(arg) for arg in sys.argv[3:]]
+    json_path = sys.argv[3]
+    with open(json_path, 'r') as fp:
+        data = json.load(fp)
 
-    result = call_method(script_path, method_name, *args)
+    result = call_method(script_path, method_name, *data)
     print(json.dumps({
       'type': 'final_result',
       'data': result

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -22,7 +22,7 @@ export async function runPython(
   const absPath = path.resolve(scriptPath);
   const tempJsonPath = path.join(
       os.tmpdir(),
-      `temp-python-input-json-${Date.now()}-${Math.random().toString(16).slice(2)}.json`
+      `promptfoo-python-input-json-${Date.now()}-${Math.random().toString(16).slice(2)}.json`
     );
   const pythonOptions: PythonShellOptions = {
     mode: 'text',

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -6,9 +6,16 @@ jest.mock('../src/esm');
 
 jest.mock('python-shell');
 
+beforeEach(() => {
+  jest.clearAllMocks(); // This clears all mock call counts
+});
+
 describe('Python Wrapper', () => {
   describe('runPython', () => {
     it('should correctly run a Python script with provided arguments', async () => {
+      jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'unlink').mockResolvedValue();
+
       const mockPythonShellRun = PythonShell.run as jest.Mock;
       mockPythonShellRun.mockResolvedValue(['{"type": "final_result", "data": "test result"}']);
 
@@ -21,9 +28,10 @@ describe('Python Wrapper', () => {
       expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
       expect(mockPythonShellRun.mock.calls[0][1].args).toEqual([
         expect.stringContaining('testScript.py'),
-        "testMethod",
+        'testMethod',
         expect.stringContaining('promptfoo-python-input-json'),
       ]);
+      expect(fs.unlink).toHaveBeenCalledTimes(1);
     });
 
     it('should throw an error if the Python script execution fails', async () => {
@@ -59,7 +67,7 @@ describe('Python Wrapper', () => {
 
       await pythonWrapper.runPythonCode('print("cleanup test")', 'main', []);
 
-      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      expect(fs.unlink).toHaveBeenCalledTimes(2);
     });
 
     it('should throw an error if Python code execution fails', async () => {

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -21,9 +21,8 @@ describe('Python Wrapper', () => {
       expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
       expect(mockPythonShellRun.mock.calls[0][1].args).toEqual([
         expect.stringContaining('testScript.py'),
-        'testMethod',
-        '"arg1"',
-        '{"key":"value"}',
+        "testMethod",
+        expect.stringContaining('temp-python-input-json'),
       ]);
     });
 

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -22,7 +22,7 @@ describe('Python Wrapper', () => {
       expect(mockPythonShellRun.mock.calls[0][1].args).toEqual([
         expect.stringContaining('testScript.py'),
         "testMethod",
-        expect.stringContaining('temp-python-input-json'),
+        expect.stringContaining('promptfoo-python-input-json'),
       ]);
     });
 


### PR DESCRIPTION
This resolves #646 .

As a workaround, this fix uses temporary JSON files for passing inputs (model output, context, prompts, etc.) without any change of original signatures.

I've tested this fix locally and it worked. I've also changed the related tests.
Let me know if I have additional corrections to make.
Thank you!