### PR TITLE
feat: ability to create derived metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "fastest-levenshtein": "^1.0.16",
         "glob": "^10.2.6",
         "js-yaml": "^4.1.0",
+        "mathjs": "^12.4.1",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
         "openai": "^4.19.0",
@@ -1592,6 +1593,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5019,6 +5031,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -5228,6 +5252,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5871,6 +5900,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -6298,6 +6332,18 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
+      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -7012,6 +7058,11 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
     },
     "node_modules/jest": {
       "version": "29.6.4",
@@ -8091,6 +8142,28 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/mathjs": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.1.tgz",
+      "integrity": "sha512-welnW3khgwYjPYvECFHO+xkCxAx9IKIIPDDWPi8B5rKAvmgoEHnQX9slEmHKZTNaJiE+OS4qrJJcB4sfDn/4sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.0",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "4.3.4",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.1.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -9111,6 +9184,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/replicate": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.27.1.tgz",
@@ -9249,6 +9327,11 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -9983,6 +10066,11 @@
         "next-tick": "1"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -10174,6 +10262,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
+      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "fastest-levenshtein": "^1.0.16",
     "glob": "^10.2.6",
     "js-yaml": "^4.1.0",
+    "mathjs": "^12.4.1",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
     "openai": "^4.19.0",

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -319,21 +319,21 @@ Derived metrics are calculated after all individual test evaluations are complet
 
 ### Configuring derived metrics
 
-To configure derived metrics in your test suite, you add a `compositeMetrics` array to the `TestSuite` object. Each entry in this array is an object that specifies the name of the metric and the formula or function used to calculate it.
+To configure derived metrics in your test suite, you add a `derivedMetrics` array to the `TestSuite` object. Each entry in this array is an object that specifies the name of the metric and the formula or function used to calculate it.
 
 #### Usage
 
-Each composite metric has the following properties:
+Each derived metric has the following properties:
 
 - **name**: The name of the metric. This is used as the identifier in the output results.
 - **value**: The calculation method for the metric. This can be a string representing a mathematical expression or a function that takes the current scores and the evaluation context as arguments and returns a numeric value.
 
 #### Example
 
-Here's an example of how to define composite metrics in a test suite configuration:
+Here's an example of how to define derived metrics in a test suite configuration:
 
 ```yaml
-compositeMetrics:
+derivedMetrics:
   - name: 'EfficiencyAdjustedPerformance'
     value: '(PerformanceScore / InferenceTime) * EfficiencyFactor'
   # - ...

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -311,6 +311,44 @@ These metrics will be shown in the UI:
 
 See [named metrics example](https://github.com/promptfoo/promptfoo/tree/main/examples/named-metrics).
 
+## Creating derived metrics
+
+Derived metrics, also known as composite or calculated metrics, are computed at runtime based on other metrics. They are aggregated and displayed as named metrics (see above).
+
+Derived metrics are calculated after all individual test evaluations are completed. They can be defined using mathematical expressions or custom functions that aggregate or transform the named scores collected during the tests.
+
+### Configuring derived metrics
+
+To configure derived metrics in your test suite, you add a `compositeMetrics` array to the `TestSuite` object. Each entry in this array is an object that specifies the name of the metric and the formula or function used to calculate it.
+
+#### Usage
+
+Each composite metric has the following properties:
+
+- **name**: The name of the metric. This is used as the identifier in the output results.
+- **value**: The calculation method for the metric. This can be a string representing a mathematical expression or a function that takes the current scores and the evaluation context as arguments and returns a numeric value.
+
+#### Example
+
+Here's an example of how to define composite metrics in a test suite configuration:
+
+```yaml
+compositeMetrics:
+  - name: 'EfficiencyAdjustedPerformance'
+    value: '(PerformanceScore / InferenceTime) * EfficiencyFactor'
+  # - ...
+```
+
+In this example, `EfficiencyAdjustedPerformance` is calculated using a simple mathematical expression that uses existing named scores.
+
+:::info
+Good to know:
+
+- Derived metrics are calculated in the order they are provided. You can reference previous derived metrics.
+- In order to reference a basic metric, you must name it (see named scores above).
+- In order to be used in a mathematical expression, named scores must not have any spaces or special characters in them.
+  :::
+
 ## Running assertions directly on outputs
 
 If you already have LLM outputs and want to run assertions on them, the `eval` command supports standalone assertion files.

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -701,6 +701,27 @@ class Evaluator {
       for (const [key, value] of Object.entries(row.namedScores)) {
         metrics.namedScores[key] = (metrics.namedScores[key] || 0) + value;
       }
+
+      if (testSuite.compositeMetrics) {
+        const math = await import('mathjs');
+        for (const metric of testSuite.compositeMetrics) {
+          if (metrics.namedScores[metric.name] === undefined) {
+            metrics.namedScores[metric.name] = 0;
+          }
+          try {
+            if (typeof metric.value === 'function') {
+              metrics.namedScores[metric.name] = metric.value(metrics.namedScores, evalStep);
+            } else {
+              const evaluatedValue = math.evaluate(metric.value, metrics.namedScores);
+              metrics.namedScores[metric.name] = evaluatedValue;
+            }
+          } catch (error) {
+            logger.debug(
+              `Could not evaluate composite metric '${metric.name}': ${(error as Error).message}`,
+            );
+          }
+        }
+      }
       metrics.testPassCount += row.success ? 1 : 0;
       metrics.testFailCount += row.success ? 0 : 1;
       metrics.assertPassCount +=

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -713,9 +713,9 @@ class Evaluator {
         metrics.namedScores[key] = (metrics.namedScores[key] || 0) + value;
       }
 
-      if (testSuite.compositeMetrics) {
+      if (testSuite.derivedMetrics) {
         const math = await import('mathjs');
-        for (const metric of testSuite.compositeMetrics) {
+        for (const metric of testSuite.derivedMetrics) {
           if (metrics.namedScores[metric.name] === undefined) {
             metrics.namedScores[metric.name] = 0;
           }
@@ -728,7 +728,7 @@ class Evaluator {
             }
           } catch (error) {
             logger.debug(
-              `Could not evaluate composite metric '${metric.name}': ${(error as Error).message}`,
+              `Could not evaluate derived metric '${metric.name}': ${(error as Error).message}`,
             );
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -471,7 +471,7 @@ export interface AtomicTestCase<Vars = Record<string, string | object>> extends 
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;
 
-export type CompositeMetric = {
+export type DerivedMetric = {
   // The name of this metric
   name: string;
   // The function to calculate the metric - either a mathematical expression or a function that takes the results and returns a number
@@ -509,7 +509,7 @@ export interface TestSuite {
   env?: EnvOverrides;
 
   // Metrics to calculate after the eval has been completed
-  compositeMetrics?: CompositeMetric[];
+  derivedMetrics?: DerivedMetric[];
 }
 
 export type ProviderId = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface CommandLineOptions {
   generateSuggestions?: boolean;
   promptPrefix?: string;
   promptSuffix?: string;
-  
+
   envFile?: FilePath;
 }
 
@@ -197,7 +197,12 @@ export interface RunEvalOptions {
 export interface EvaluateOptions {
   maxConcurrency?: number;
   showProgressBar?: boolean;
-  progressCallback?: (progress: number, total: number, index: number, evalStep: RunEvalOptions) => void;
+  progressCallback?: (
+    progress: number,
+    total: number,
+    index: number,
+    evalStep: RunEvalOptions,
+  ) => void;
   generateSuggestions?: boolean;
   repeat?: number;
   delay?: number;
@@ -210,12 +215,10 @@ export interface Prompt {
   id?: string;
   raw: string;
   display: string;
-  function?: (
-    context: { 
-      vars: Record<string, string | object>,
-      provider?: ApiProvider,
-    },
-  ) => Promise<string | object>;
+  function?: (context: {
+    vars: Record<string, string | object>;
+    provider?: ApiProvider;
+  }) => Promise<string | object>;
 }
 
 // Used for final prompt display
@@ -463,6 +466,13 @@ export interface AtomicTestCase<Vars = Record<string, string | object>> extends 
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;
 
+export type CompositeMetric = {
+  // The name of this metric
+  name: string;
+  // The function to calculate the metric - either a mathematical expression or a function that takes the results and returns a number
+  value: string | ((scores: Record<string, number>, context: RunEvalOptions) => number);
+};
+
 // The test suite defines the "knobs" that we are tuning in prompt engineering: providers and prompts
 export interface TestSuite {
   // Optional description of what your LLM is trying to do
@@ -492,6 +502,9 @@ export interface TestSuite {
 
   // Envar overrides
   env?: EnvOverrides;
+
+  // Metrics to calculate after the eval has been completed
+  compositeMetrics?: CompositeMetric[];
 }
 
 export type ProviderId = string;


### PR DESCRIPTION
Extends `TestSuite` include `derivedMetrics`, which are metrics formulated from existing named scores using either mathematical expressions or custom functions. The implementation uses mathjs to evaluate expressions or lets the user set any javascript function.

```yaml
# ... existing config
derivedMetrics:
  - name: foo
    value: (metric1 + metric2) / metric3
  - name: bar
    value: metric4 & metric5
```

```ts
interface DerivedMetric {
  // The name of this metric
  name: string;
  // The function to calculate the metric - either a mathematical expression or a function that takes the results and returns a number
  value: string | ((scores: Record<string, number>, context: RunEvalOptions) => number);
}
```
Related to #654 