### PR TITLE
Enable post-hoc evaluations through defining and using output value in TestSuite

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -317,7 +317,7 @@ class Evaluator {
       this.conversations[conversationKey].push({
         prompt: renderedJson || renderedPrompt,
         input: conversationLastInput || renderedJson || renderedPrompt,
-        output: test.output || response.output || '',
+        output: response.output || '',
       });
 
       if (!response.cached) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -291,7 +291,7 @@ class Evaluator {
         cost: 0,
         cached: false,
       };
-      if (!test.providerResponse){
+      if (!test.providerOutput){
         response = await provider.callApi(
           renderedPrompt,
           {
@@ -302,7 +302,7 @@ class Evaluator {
           },
         );
       } else {
-        response.output = test.providerResponse;
+        response.output = test.providerOutput;
       }
       const endTime = Date.now();
       latencyMs = endTime - startTime;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -291,7 +291,7 @@ class Evaluator {
         cost: 0,
         cached: false,
       };
-      if (!test.output){
+      if (!test.providerResponse){
         response = await provider.callApi(
           renderedPrompt,
           {
@@ -302,7 +302,7 @@ class Evaluator {
           },
         );
       } else {
-        response.output = test.output;
+        response.output = test.providerResponse;
       }
       const endTime = Date.now();
       latencyMs = endTime - startTime;

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,8 +428,8 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   // Key-value pairs to substitute in the prompt
   vars?: Vars;
 
-  // Output related from running values in Vars with prompt. Having this value would skip running the prompt through the provider, and go straight to the assertions
-  output?: string | object;
+  // Output related from running values in Vars with provider. Having this value would skip running the prompt through the provider, and go straight to the assertions
+  providerResponse?: string | object;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,7 +429,7 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   vars?: Vars;
 
   // Output related from running values in Vars with provider. Having this value would skip running the prompt through the provider, and go straight to the assertions
-  providerResponse?: string | object;
+  providerOutput?: string | object;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface CommandLineOptions {
   generateSuggestions?: boolean;
   promptPrefix?: string;
   promptSuffix?: string;
-  
+
   envFile?: FilePath;
 }
 
@@ -211,7 +211,7 @@ export interface Prompt {
   raw: string;
   display: string;
   function?: (
-    context: { 
+    context: {
       vars: Record<string, string | object>,
       provider?: ApiProvider,
     },
@@ -428,6 +428,9 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   // Key-value pairs to substitute in the prompt
   vars?: Vars;
 
+  // Output related from running values in Vars with prompt. Having this value would skip running the prompt through the provider, and go straight to the assertions
+  output?: string;
+
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];
 
@@ -459,6 +462,7 @@ export interface Scenario {
 // Same as a TestCase, except the `vars` object has been flattened into its final form.
 export interface AtomicTestCase<Vars = Record<string, string | object>> extends TestCase {
   vars?: Record<string, string | object>;
+  output?: string;
 }
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -462,7 +462,6 @@ export interface Scenario {
 // Same as a TestCase, except the `vars` object has been flattened into its final form.
 export interface AtomicTestCase<Vars = Record<string, string | object>> extends TestCase {
   vars?: Record<string, string | object>;
-  output?: string;
 }
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,7 +429,7 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   vars?: Vars;
 
   // Output related from running values in Vars with prompt. Having this value would skip running the prompt through the provider, and go straight to the assertions
-  output?: string;
+  output?: string | object;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];


### PR DESCRIPTION
## What this PR is trying to solve
Currently node module evaluate() works by running the values defined in `TestSuite.tests` through the prompts or providers defined in `TestSuite.prompts and TestSuite.providers`, and then evaluating the output through the assertions defined in `TestSuite.assert`. 

This evaluation process works well when we are running offline experiments or tests. However, this process would not allow us to efficiently evaluate LLM systems that are already in production (post-hoc or post-execution evaluations) where the output for each of the inputs/tests are already produced in production, as evaluate() expects to obtain those output values by first running the inputs/tests through a prompt or through a provider defined by the user in `TestSuite` (instead of leveraging the output values already produced in production and stored in a database or file).

IMO we should allow users to define the `output` value for a given `TestCase`, and if it is defined by the user then evaluate() should directly treat that as the output value in `ProviderResponse` and continue running `runEval` without calling `callApi` first. Allowing this would open up the ability for evaluate() to more efficiently evaluate the scenario described above, while taking advantage of all the assertions available today.

## How does this PR solves it
1. Add an `output` field to `TestCase` where user can define the output that they have for a given test case
2. Add a check in `runEval` whether a given test case being handled already contained an `output` value or not. If that is the case then skip calling the `callApi` function. Otherwise continue to run `callApi` as per usual.
3. Continue with the rest of the `runEval` function.