### PR TITLE
fix!: make `javascript` assert function call consistent with external js function call

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -620,7 +620,7 @@ export async function runAssertion({
       };
 
       if (typeof assertion.value === 'function') {
-        let ret = assertion.value(outputString, test, assertion);
+        let ret = assertion.value(outputString, context);
         ret = await validateResult(ret);
         if (!ret.assertion) {
           // Populate the assertion object if the custom function didn't return it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface CommandLineOptions {
   generateSuggestions?: boolean;
   promptPrefix?: string;
   promptSuffix?: string;
-  
+
   envFile?: FilePath;
 }
 
@@ -197,7 +197,12 @@ export interface RunEvalOptions {
 export interface EvaluateOptions {
   maxConcurrency?: number;
   showProgressBar?: boolean;
-  progressCallback?: (progress: number, total: number, index: number, evalStep: RunEvalOptions) => void;
+  progressCallback?: (
+    progress: number,
+    total: number,
+    index: number,
+    evalStep: RunEvalOptions,
+  ) => void;
   generateSuggestions?: boolean;
   repeat?: number;
   delay?: number;
@@ -210,12 +215,10 @@ export interface Prompt {
   id?: string;
   raw: string;
   display: string;
-  function?: (
-    context: { 
-      vars: Record<string, string | object>,
-      provider?: ApiProvider,
-    },
-  ) => Promise<string | object>;
+  function?: (context: {
+    vars: Record<string, string | object>;
+    provider?: ApiProvider;
+  }) => Promise<string | object>;
 }
 
 // Used for final prompt display
@@ -375,15 +378,7 @@ export interface Assertion {
   type: AssertionType;
 
   // The expected value, if applicable
-  value?:
-    | string
-    | string[]
-    | object
-    | ((
-        output: string | object,
-        testCase: AtomicTestCase,
-        assertion: Assertion,
-      ) => Promise<GradingResult>);
+  value?: AssertionValue;
 
   // The threshold value, only applicable for similarity (cosine distance)
   threshold?: number;
@@ -403,6 +398,25 @@ export interface Assertion {
   // Process the output before running the assertion
   transform?: string;
 }
+
+export type AssertionValue =
+  | string
+  | string[]
+  | object
+  | AssertionValueFunction;
+
+export type AssertionValueFunction = (
+  output: string,
+  context: AssertionValueFunctionContext
+) => AssertionValueFunctionResult | Promise<AssertionValueFunctionResult>;
+
+export interface AssertionValueFunctionContext {
+  prompt: string | undefined;
+  vars: Record<string, string | object>;
+  test: AtomicTestCase<Record<string, string | object>>;
+}
+
+export type AssertionValueFunctionResult = boolean | number | GradingResult;
 
 // Used when building prompts index from files.
 export interface TestCasesWithMetadataPrompt {


### PR DESCRIPTION
Related to #673 