### PR TITLE
Allow local files to define providerOutput value for TestCase

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,6 +8,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
   const vars: Record<string, string> = {};
   const asserts: Assertion[] = [];
   const options: TestCase['options'] = {};
+  let providerOutput: string | undefined; // Change made
   let description: string | undefined;
   for (const [key, value] of Object.entries(row)) {
     if (key.startsWith('__expected')) {
@@ -20,13 +21,15 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
       options.suffix = value;
     } else if (key === '__description') {
       description = value;
+    } else if (key === 'provider_output') { // Change made
+      providerOutput = value; // Change made
     } else {
       vars[key] = value;
     }
   }
-
   return {
     vars,
+    ...(providerOutput ? { providerOutput } : {}),
     assert: asserts,
     options,
     ...(description ? { description } : {}),

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -21,7 +21,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
       options.suffix = value;
     } else if (key === '__description') {
       description = value;
-    } else if (key === 'provider_output') {
+    } else if (key === '__providerOutput') {
       providerOutput = value;
     } else {
       vars[key] = value;

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,7 +8,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
   const vars: Record<string, string> = {};
   const asserts: Assertion[] = [];
   const options: TestCase['options'] = {};
-  let providerOutput: string | undefined; // Change made
+  let providerOutput: string | undefined;
   let description: string | undefined;
   for (const [key, value] of Object.entries(row)) {
     if (key.startsWith('__expected')) {
@@ -21,8 +21,8 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
       options.suffix = value;
     } else if (key === '__description') {
       description = value;
-    } else if (key === 'provider_output') { // Change made
-      providerOutput = value; // Change made
+    } else if (key === 'provider_output') {
+      providerOutput = value;
     } else {
       vars[key] = value;
     }

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,7 +8,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
   const vars: Record<string, string> = {};
   const asserts: Assertion[] = [];
   const options: TestCase['options'] = {};
-  let providerOutput: string | undefined;
+  let providerOutput: string | object | undefined;
   let description: string | undefined;
   for (const [key, value] of Object.entries(row)) {
     if (key.startsWith('__expected')) {


### PR DESCRIPTION
Continuation of PR #671 by allowing users to define the `providerOutput` value that is available in `TestCase` from local files. I am using `provider_output` as the key/column value to look out for within the local file, and assume that if the column name is that then we can treat it as the `providerOutput` value for `TestCase`