### PR TITLE
feat: Ability to delete evals

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import { deleteEval, setupEnv } from '../util';
+import logger from '../logger';
+import telemetry from '../telemetry';
+
+export function deleteCommand(program: Command) {
+  program
+    .command('delete eval <id>')
+    .description('Delete an evaluation by ID.')
+    .option('--env-path <path>', 'Path to the environment file')
+    .action(async (evalId, cmdObj) => {
+      setupEnv(cmdObj.envPath);
+      telemetry.maybeShowNotice();
+      telemetry.record('command_used', {
+        name: 'delete eval',
+        evalId: evalId,
+      });
+      await telemetry.send();
+
+      try {
+        await deleteEval(evalId);
+        logger.info(`Evaluation with ID ${evalId} has been successfully deleted.`);
+      } catch (error) {
+        logger.error(`Error deleting evaluation with ID ${evalId}: ${error}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,11 +1,30 @@
 import { Command } from 'commander';
-import { deleteEval, setupEnv } from '../util';
+import { deleteEval, getEvalFromId, setupEnv } from '../util';
 import logger from '../logger';
 import telemetry from '../telemetry';
 
 export function deleteCommand(program: Command) {
-  program
-    .command('delete eval <id>')
+  const deleteCommand = program
+    .command('delete <id>')
+    .description('Delete various resources')
+    .option('--env-path <path>', 'Path to the environment file')
+    .action(async (id: string, cmdObj: { envPath?: string }) => {
+      setupEnv(cmdObj.envPath);
+      telemetry.maybeShowNotice();
+      telemetry.record('command_used', {
+        name: 'delete',
+      });
+
+      const evl = await getEvalFromId(id);
+      if (evl) {
+        return handleEvalDelete(id, cmdObj.envPath);
+      }
+
+      logger.error(`No resource found with ID ${id}`);
+    });
+
+  deleteCommand
+    .command('eval <id>')
     .description('Delete an evaluation by ID.')
     .option('--env-path <path>', 'Path to the environment file')
     .action(async (evalId, cmdObj) => {
@@ -17,12 +36,16 @@ export function deleteCommand(program: Command) {
       });
       await telemetry.send();
 
-      try {
-        await deleteEval(evalId);
-        logger.info(`Evaluation with ID ${evalId} has been successfully deleted.`);
-      } catch (error) {
-        logger.error(`Error deleting evaluation with ID ${evalId}: ${error}`);
-        process.exit(1);
-      }
+      handleEvalDelete(evalId, cmdObj.envPath);
     });
+}
+
+async function handleEvalDelete(evalId: string, envPath?: string) {
+  try {
+    await deleteEval(evalId);
+    logger.info(`Evaluation with ID ${evalId} has been successfully deleted.`);
+  } catch (error) {
+    logger.error(`Could not delete evaluation with ID ${evalId}:\n${error}`);
+    process.exit(1);
+  }
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -24,6 +24,7 @@ export function listCommand(program: Command) {
       const evals = await getEvals();
       const tableData = evals.map((evl) => ({
         'Eval ID': evl.id,
+        Description: evl.description || '',
         Prompts: evl.results.table.head.prompts.map((p) => sha256(p.raw).slice(0, 6)).join(', '),
         Vars: evl.results.table.head.vars.map((v) => v).join(', '),
       }));

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 
-import { getEvalFromHash, getPromptFromHash, getDatasetFromHash, printBorder, setupEnv } from '../util';
+import { getEvalFromId, getPromptFromHash, getDatasetFromHash, printBorder, setupEnv } from '../util';
 import { generateTable, wrapTable } from '../table';
 import logger from '../logger';
 import telemetry from '../telemetry';
@@ -13,7 +13,13 @@ export async function showCommand(program: Command) {
     .option('--env-path <path>', 'Path to the environment file')
     .action(async (id: string, cmdObj: { envPath?: string }) => {
       setupEnv(cmdObj.envPath);
-      const evl = await getEvalFromHash(id);
+      telemetry.maybeShowNotice();
+      telemetry.record('command_used', {
+        name: 'show',
+      });
+
+      await telemetry.send();
+      const evl = await getEvalFromId(id);
       if (evl) {
         return handleEval(id);
       }
@@ -54,7 +60,7 @@ async function handleEval(id: string) {
   });
   await telemetry.send();
 
-  const evl = await getEvalFromHash(id);
+  const evl = await getEvalFromId(id);
   if (!evl) {
     logger.error(`No evaluation found with ID ${id}`);
     return;

--- a/src/database.ts
+++ b/src/database.ts
@@ -60,6 +60,8 @@ export const evalsToPrompts = sqliteTable(
     evalId: text('eval_id')
       .notNull()
       .references(() => evals.id),
+    // Drizzle doesn't support this migration for sqlite, so we remove foreign keys manually.
+    //.references(() => evals.id, { onDelete: 'cascade' }),
     promptId: text('prompt_id')
       .notNull()
       .references(() => prompts.id),
@@ -86,6 +88,8 @@ export const evalsToDatasets = sqliteTable(
     evalId: text('eval_id')
       .notNull()
       .references(() => evals.id),
+    // Drizzle doesn't support this migration for sqlite, so we remove foreign keys manually.
+    //.references(() => evals.id, { onDelete: 'cascade' }),
     datasetId: text('dataset_id')
       .notNull()
       .references(() => datasets.id),

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { checkForUpdates } from './updates';
 import { gatherFeedback } from './feedback';
 import { listCommand } from './commands/list';
 import { showCommand } from './commands/show';
+import { deleteCommand } from './commands/delete';
 
 import type {
   CommandLineOptions,
@@ -739,6 +740,7 @@ async function main() {
 
   listCommand(program);
   showCommand(program);
+  deleteCommand(program);
 
   program.parse(process.argv);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -553,6 +553,7 @@ export interface EvalWithMetadata {
   date: Date;
   config: Partial<UnifiedConfig>;
   results: EvaluateSummary;
+  description?: string;
 }
 
 export type PromptFunction = (context: {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1009,7 +1009,7 @@ export async function getEvals() {
   return getEvalsWithPredicate(() => true);
 }
 
-export async function getEvalFromHash(hash: string) {
+export async function getEvalFromId(hash: string) {
   const evals_ = await getEvals();
   for (const eval_ of evals_) {
     if (eval_.id.startsWith(hash)) {
@@ -1029,6 +1029,7 @@ export async function getEvalsWithPredicate(
       createdAt: evals.createdAt,
       results: evals.results,
       config: evals.config,
+      description: evals.description,
     })
     .from(evals)
     .limit(100)
@@ -1051,6 +1052,7 @@ export async function getEvalsWithPredicate(
         date: new Date(eval_.createdAt),
         config: eval_.config,
         results: eval_.results,
+        description: eval_.description || undefined,
       });
     }
   }
@@ -1058,23 +1060,19 @@ export async function getEvalsWithPredicate(
   return ret;
 }
 
-export async function deleteEval(evalId: string): Promise<void> {
+export async function deleteEval(evalId: string) {
   const db = getDb();
-  try {
-    await db.transaction(async () => {
-      // We need to clean up foreign keys first. We don't have onDelete: 'cascade' set on all these relationships.
-      await db.delete(evalsToPrompts).where(eq(evalsToPrompts.evalId, evalId)).run();
-      await db.delete(evalsToDatasets).where(eq(evalsToDatasets.evalId, evalId)).run();
+  await db.transaction(async () => {
+    // We need to clean up foreign keys first. We don't have onDelete: 'cascade' set on all these relationships.
+    await db.delete(evalsToPrompts).where(eq(evalsToPrompts.evalId, evalId)).run();
+    await db.delete(evalsToDatasets).where(eq(evalsToDatasets.evalId, evalId)).run();
 
-      // Finally, delete the eval record
-      await db.delete(evals).where(eq(evals.id, evalId)).run();
-    });
-
-    logger.info(`Deleted eval with ID ${evalId} and all related records.`);
-  } catch (err) {
-    logger.error(`Failed to delete eval with ID ${evalId}: ${err}`);
-    throw new Error(`Failed to delete eval with ID ${evalId}`);
-  }
+    // Finally, delete the eval record
+    const deletedIds = await db.delete(evals).where(eq(evals.id, evalId)).run();
+    if (deletedIds.changes === 0) {
+      throw new Error(`Eval with ID ${evalId} not found`);
+    }
+  });
 }
 
 export async function readFilters(filters: Record<string, string>): Promise<NunjucksFilterMap> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1058,6 +1058,21 @@ export async function getEvalsWithPredicate(
   return ret;
 }
 
+export async function deleteEval(evalId: string): Promise<void> {
+  const db = getDb();
+  try {
+    await db
+      .delete(evals)
+      .where(eq(evals.id, evalId))
+      .run();
+    logger.info(`Deleted eval with ID ${evalId}`);
+  } catch (err) {
+    logger.error(`Failed to delete eval with ID ${evalId}: ${err}`);
+    throw new Error(`Failed to delete eval with ID ${evalId}`);
+  }
+}
+
+
 export async function readFilters(
   filters: Record<string, string>,
 ): Promise<NunjucksFilterMap> {

--- a/src/web/nextui/src/app/api/eval/[id]/route.ts
+++ b/src/web/nextui/src/app/api/eval/[id]/route.ts
@@ -7,7 +7,7 @@ import store from '@/app/api/eval/shareStore';
 import { IS_RUNNING_LOCALLY } from '@/constants';
 
 import type { EvaluateTable, FilePath, ResultsFile, UnifiedConfig } from '@/../../../types';
-import { readResult, updateResult } from '@/../../../util';
+import { readResult, updateResult, deleteEval } from '@/../../../util';
 
 export const dynamic = IS_RUNNING_LOCALLY ? 'auto' : 'force-dynamic';
 
@@ -83,6 +83,23 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     console.error(err);
     return NextResponse.json(
       { error: 'Failed to update eval', details: String(err) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  console.log('Deleting eval result with id', params.id);
+  try {
+    if (!params.id) {
+      return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+    }
+    await deleteEval(params.id);
+    return NextResponse.json({ message: 'Eval deleted successfully' }, { status: 200 });
+  } catch (error) {
+    console.error('Failed to delete eval', error);
+    return NextResponse.json(
+      { error: 'Failed to delete eval', details: String(error) },
       { status: 500 },
     );
   }

--- a/src/web/nextui/src/app/eval/DownloadMenu.tsx
+++ b/src/web/nextui/src/app/eval/DownloadMenu.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
 
 import yaml from 'js-yaml';
-import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
-import Menu from '@mui/material/Menu';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
-import Tooltip from '@mui/material/Tooltip';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 
 import { useStore as useResultsViewStore } from './store';
 
 function DownloadMenu() {
   const { table, config, evalId } = useResultsViewStore();
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [open, setOpen] = React.useState(false);
 
   const openDownloadDialog = (blob: Blob, downloadName: string) => {
     const url = URL.createObjectURL(blob);
@@ -25,15 +28,14 @@ function DownloadMenu() {
   };
 
   const downloadConfig = () => {
-    setAnchorEl(null);
     const configData = yaml.dump(config);
     const mimeType = 'text/yaml;charset=utf-8';
     const blob = new Blob([configData], { type: mimeType });
     openDownloadDialog(blob, 'promptfooconfig.yaml');
+    handleClose();
   };
 
   const downloadDpoJson = () => {
-    setAnchorEl(null);
     if (!table) {
       alert('No table data');
       return;
@@ -47,44 +49,65 @@ function DownloadMenu() {
     }));
     const blob = new Blob([JSON.stringify(formattedData, null, 2)], { type: 'application/json' });
     openDownloadDialog(blob, `${evalId}-dpo.json`);
+    handleClose();
   };
 
   const downloadTable = () => {
-    setAnchorEl(null);
     if (!table) {
       alert('No table data');
       return;
     }
     const blob = new Blob([JSON.stringify(table, null, 2)], { type: 'application/json' });
     openDownloadDialog(blob, `${evalId}-table.json`);
+    handleClose();
+  };
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
   };
 
   return (
     <>
-      <Tooltip title="Download options">
-        <Button
-          color="primary"
-          aria-controls="download-menu"
-          aria-haspopup="true"
-          onClick={(event) => {
-            setAnchorEl(event.currentTarget);
-          }}
-          startIcon={<DownloadIcon />}
-        >
-          Download
-        </Button>
-      </Tooltip>
-      <Menu
-        id="download-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={() => setAnchorEl(null)}
-      >
-        <MenuItem onClick={downloadConfig}>YAML config</MenuItem>
-        <MenuItem onClick={downloadTable}>Table JSON</MenuItem>
-        <MenuItem onClick={downloadDpoJson}>DPO JSON</MenuItem>
-      </Menu>
+      <MenuItem onClick={handleOpen}>
+        <ListItemIcon>
+          <DownloadIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Download</ListItemText>
+      </MenuItem>
+      <Dialog onClose={handleClose} open={open}>
+        <DialogContent>
+          <Stack direction="column" spacing={2} sx={{ width: '100%' }}>
+            <Button
+              onClick={downloadConfig}
+              startIcon={<DownloadIcon />}
+              fullWidth
+              sx={{ justifyContent: 'flex-start' }}
+            >
+              Download YAML Config
+            </Button>
+            <Button
+              onClick={downloadTable}
+              startIcon={<DownloadIcon />}
+              fullWidth
+              sx={{ justifyContent: 'flex-start' }}
+            >
+              Download Table JSON
+            </Button>
+            <Button
+              onClick={downloadDpoJson}
+              startIcon={<DownloadIcon />}
+              fullWidth
+              sx={{ justifyContent: 'flex-start' }}
+            >
+              Download DPO JSON
+            </Button>
+          </Stack>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import CircularProgress from '@mui/material/CircularProgress';
+import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import FormControl from '@mui/material/FormControl';
 import Heading from '@mui/material/Typography';
@@ -155,7 +156,7 @@ export default function ResultsView({
     setColumnVisibility(newColumnVisibility);
   };
 
-  const handleHeadingClick = async () => {
+  const handleDescriptionClick = async () => {
     invariant(config, 'Config must be loaded before clicking its description');
     const newDescription = window.prompt('Enter new description:', config.description);
     if (newDescription !== null && newDescription !== config.description) {
@@ -174,6 +175,23 @@ export default function ResultsView({
         setConfig(newConfig);
       } catch (error) {
         console.error('Failed to update table:', error);
+      }
+    }
+  };
+
+  const handleDeleteEvalClick = async () => {
+    if (window.confirm('Are you sure you want to delete this evaluation?')) {
+      try {
+        const response = await fetch(`${await getApiBaseUrl()}/api/eval/${evalId}`, {
+          method: 'DELETE',
+        });
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        router.push('/');
+      } catch (error) {
+        console.error('Failed to delete evaluation:', error);
+        alert('Failed to delete evaluation');
       }
     }
   };
@@ -206,7 +224,7 @@ export default function ResultsView({
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
       <Box mb={2} sx={{ display: 'flex', alignItems: 'center' }}>
         <Heading variant="h5" sx={{ flexGrow: 1 }}>
-          <span className="description" onClick={handleHeadingClick}>
+          <span className="description" onClick={handleDescriptionClick}>
             {config?.description || evalId}
           </span>{' '}
           {config?.description && <span className="description-filepath">{evalId}</span>}
@@ -336,6 +354,17 @@ export default function ResultsView({
                     startIcon={shareLoading ? <CircularProgress size={16} /> : <ShareIcon />}
                   >
                     Share
+                  </Button>
+                </Tooltip>
+              )}
+              {config && (
+                <Tooltip title="Delete this eval">
+                  <Button
+                    color="primary"
+                    onClick={handleDeleteEvalClick}
+                    startIcon={<DeleteIcon />}
+                  >
+                    Delete
                   </Button>
                 </Tooltip>
               )}

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -2,17 +2,21 @@ import * as React from 'react';
 
 import invariant from 'tiny-invariant';
 
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import Autocomplete, { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteIcon from '@mui/icons-material/Delete';
+import DownloadIcon from '@mui/icons-material/Download';
 import EditIcon from '@mui/icons-material/Edit';
 import FormControl from '@mui/material/FormControl';
 import Heading from '@mui/material/Typography';
 import InputLabel from '@mui/material/InputLabel';
 import ListItemText from '@mui/material/ListItemText';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Paper from '@mui/material/Box';
@@ -220,6 +224,19 @@ export default function ResultsView({
     setSelectedColumns(columnData.map((col) => col.value));
   }, [head]);
 
+  // State for anchor element
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  // Handle menu close
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  // Function to open the eval actions menu
+  const handleOpenMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
   return (
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
       <Box mb={2} sx={{ display: 'flex', alignItems: 'center' }}>
@@ -310,7 +327,64 @@ export default function ResultsView({
           <Box flexGrow={1} />
           <Box display="flex" justifyContent="flex-end">
             <ResponsiveStack direction="row" spacing={2}>
-              <Tooltip title="Edit table view settings">
+              <Button color="primary" onClick={handleOpenMenu} startIcon={<ArrowDropDownIcon />}>
+                Eval actions
+              </Button>
+              {config && (
+                <Menu
+                  id="eval-actions-menu"
+                  anchorEl={anchorEl}
+                  keepMounted
+                  open={Boolean(anchorEl)}
+                  onClose={handleMenuClose}
+                >
+                  <Tooltip title="View the configuration that defines this eval" placement="left">
+                    <MenuItem onClick={() => setConfigModalOpen(true)}>
+                      <ListItemIcon>
+                        <VisibilityIcon fontSize="small" />
+                      </ListItemIcon>
+                      View YAML
+                    </MenuItem>
+                  </Tooltip>
+                  <Tooltip title="Edit this eval in the web UI" placement="left">
+                    <MenuItem
+                      onClick={() => {
+                        setStateFromConfig(config);
+                        router.push('/setup/');
+                      }}
+                    >
+                      <ListItemIcon>
+                        <EditIcon fontSize="small" />
+                      </ListItemIcon>
+                      Edit Eval
+                    </MenuItem>
+                  </Tooltip>
+                  <DownloadMenu />
+                  {config?.sharing && (
+                    <Tooltip title="Generate a unique URL that others can access" placement="left">
+                      <MenuItem onClick={handleShareButtonClick} disabled={shareLoading}>
+                        <ListItemIcon>
+                          {shareLoading ? (
+                            <CircularProgress size={16} />
+                          ) : (
+                            <ShareIcon fontSize="small" />
+                          )}
+                        </ListItemIcon>
+                        Share
+                      </MenuItem>
+                    </Tooltip>
+                  )}
+                  <Tooltip title="Delete this eval" placement="left">
+                    <MenuItem onClick={handleDeleteEvalClick}>
+                      <ListItemIcon>
+                        <DeleteIcon fontSize="small" />
+                      </ListItemIcon>
+                      Delete
+                    </MenuItem>
+                  </Tooltip>
+                </Menu>
+              )}
+              <Tooltip title="Edit table view settings" placement="left">
                 <Button
                   color="primary"
                   onClick={() => setViewSettingsModalOpen(true)}
@@ -319,55 +393,6 @@ export default function ResultsView({
                   Table Settings
                 </Button>
               </Tooltip>
-              {config && (
-                <Tooltip title="View the configuration that defines this eval">
-                  <Button
-                    color="primary"
-                    onClick={() => setConfigModalOpen(true)}
-                    startIcon={<VisibilityIcon />}
-                  >
-                    View YAML
-                  </Button>
-                </Tooltip>
-              )}
-              {config && (
-                <Tooltip title="Edit eval">
-                  <Button
-                    color="primary"
-                    onClick={() => {
-                      setStateFromConfig(config);
-                      router.push('/setup/');
-                    }}
-                    startIcon={<EditIcon />}
-                  >
-                    Edit Eval
-                  </Button>
-                </Tooltip>
-              )}
-              {config && <DownloadMenu />}
-              {config?.sharing && (
-                <Tooltip title="Generate a unique URL that others can access">
-                  <Button
-                    color="primary"
-                    onClick={handleShareButtonClick}
-                    disabled={shareLoading}
-                    startIcon={shareLoading ? <CircularProgress size={16} /> : <ShareIcon />}
-                  >
-                    Share
-                  </Button>
-                </Tooltip>
-              )}
-              {config && (
-                <Tooltip title="Delete this eval">
-                  <Button
-                    color="primary"
-                    onClick={handleDeleteEvalClick}
-                    startIcon={<DeleteIcon />}
-                  >
-                    Delete
-                  </Button>
-                </Tooltip>
-              )}
             </ResponsiveStack>
           </Box>
         </ResponsiveStack>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -32,6 +32,7 @@ import {
   readLatestResults,
   migrateResultsFromFileSystemToDatabase,
   getStandaloneEvals,
+  deleteEval,
 } from '../util';
 import { synthesizeFromTestSuite } from '../testCases';
 import { getDbPath, getDbSignalPath } from '../database';
@@ -147,6 +148,16 @@ export async function startServer(port = 15500, apiBaseUrl = '', skipConfirmatio
       res.json({ message: 'Eval updated successfully' });
     } catch (error) {
       res.status(500).json({ error: 'Failed to update eval table' });
+    }
+  });
+
+  app.delete('/api/eval/:id', async (req, res) => {
+    const { id } = req.params;
+    try {
+      await deleteEval(id);
+      res.json({ message: 'Eval deleted successfully' });
+    } catch (error) {
+      res.status(500).json({ error: 'Failed to delete eval' });
     }
   });
 


### PR DESCRIPTION
This works via the CLI:

```
promptfoo delete <id>
# or
promptfoo delete eval <id>
```

and the webui has a new menu as well
![image](https://github.com/promptfoo/promptfoo/assets/310310/cc3a06b1-1b27-4346-94d3-c0bc7be3786d)
