### PR TITLE
fix: Add tool calls to response from azure openai

### DIFF
--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -412,7 +412,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
               choice.message.role === 'assistant',
           )?.message
         : data.choices[0].message;
-      const output = message.content == null ? message.function_call : message.content;
+      const output = message.content == null ? message.tool_calls == null ? message.function_call : message.tool_calls : message.content;
       const logProbs = data.choices[0].logprobs?.content?.map(
         (logProbObj: { token: string; logprob: number }) => logProbObj.logprob,
       );


### PR DESCRIPTION
This PR makes it so tool calls in empty content messages are output with the response from azure openai