### PR TITLE
feat: support for authenticated google sheets access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,8 @@
         "@aws-sdk/client-bedrock-runtime": "^3.458.0",
         "@azure/identity": "^4.0.0",
         "@azure/openai-assistants": "^1.0.0-beta.5",
-        "google-auth-library": "^9.7.0"
+        "google-auth-library": "^9.7.0",
+        "googleapis": "^134.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6566,6 +6567,36 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "134.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-134.0.0.tgz",
+      "integrity": "sha512-o8LhD1754W6MHWtpwAPeP1WUHgNxuMxCnLMDFlMKAA5kCMTNqX9/eaTXnkkAIv6YRfoKMQ6D1vyR6/biXuhE9g==",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.1.0.tgz",
+      "integrity": "sha512-p3KHiWDBBWJEXk6SYauBEvxw5+UmRy7k2scxGtsNv9eHsTbpopJ3/7If4OrNnzJ9XMLg3IlyQXpVp8YPQsStiw==",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -10343,6 +10374,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.458.0",
     "@azure/identity": "^4.0.0",
     "@azure/openai-assistants": "^1.0.0-beta.5",
-    "google-auth-library": "^9.7.0"
+    "google-auth-library": "^9.7.0",
+    "googleapis": "^134.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.458.0",

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -306,7 +306,7 @@ Evaluates each `language` x `input` combination:
 
 <img alt="Multiple combinations of var inputs" src="https://user-images.githubusercontent.com/310310/243108917-dab27ca5-689b-4843-bb52-de8d459d783b.png" />
 
-Vars can also be imported from globbed filepaths. They are automatically expanded into an array.  For example:
+Vars can also be imported from globbed filepaths. They are automatically expanded into an array. For example:
 
 ```yaml
   - vars:
@@ -583,7 +583,7 @@ providers: [openai:gpt-3.5-turbo, vertex:gemini-pro]
 tests: tests.csv
 ```
 
-promptfoo also has built-in ability to pull test cases from a Google Sheet. The sheet must be visible to "anyone with the link". For example:
+promptfoo also has built-in ability to pull test cases from a Google Sheet. The easiest way to get started is to set the sheet visible to "anyone with the link". For example:
 
 ```yaml
 prompts: [prompt1.txt, prompt2.txt]
@@ -593,3 +593,5 @@ tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsK
 ```
 
 Here's a [full example](https://github.com/promptfoo/promptfoo/tree/main/examples/google-sheets).
+
+See [Google Sheets integration](/docs/integrations/google-sheets) for details on how to set up promptfoo to access a private spreadsheet.

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -1,14 +1,28 @@
+---
+sidebar_label: Google Sheets
+---
+
 # Importing Test Cases from Google Sheets
 
 promptfoo allows you to import eval test cases directly from Google Sheets. This can be done either unauthenticated (if the sheet is public) or authenticated using Google's Default Application Credentials, typically with a service account for programmatic access.
 
 ## Unauthenticated Access
 
-If the Google Sheet is set to be accessible by "anyone with the link," you can directly specify the share URL in your YAML configuration.
+If the Google Sheet is set to be accessible by "anyone with the link," you can directly specify the share URL in your YAML configuration. For example:
 
 ```yaml
+prompts:
+  - prompt1.txt
+  - prompt2.txt
+providers:
+  - anthropic:messages:claude-3-opus-20240229
+  - openai:chat:gpt-4-0125-preview
+// highlight-start
 tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
+// highlight-end
 ```
+
+Here's an [example sheet](https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit#gid=0). For more information on how to set up the sheet itself, see [loading assertions from CSV](/docs/configuration/expected-outputs/#load-assertions-from-csv).
 
 ## Authenticated Access with Default Application Credentials
 

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -16,17 +16,19 @@ For sheets that are not publicly accessible, you can use authenticated access. T
 
 1. **Install peer dependencies**: `npm install googleapis`
 
-2. **Service Account Setup**: Create a service account in your Google Cloud Platform project and download the JSON key file.
+1. **Service Account Setup**: Create a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) in your Google Cloud Platform project. Create a JSON key file and download it.
 
-3. **Share Sheet**: Share the Google Sheet with the email address of your service account with at least viewer permissions.
+1. **Enable Google Sheets API**: Enable the [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com) (`sheets.googleapis.com`).
 
-4. **Configure Environment**: Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of the JSON key file:
+1. **Share Sheet**: Share the Google Sheet with the email address of your service account (`your-service-account@project-name.iam.gserviceaccount.com`) with at least viewer permissions.
+
+1. **Configure Environment**: Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of the JSON key file:
 
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-file.json"
 ```
 
-5. **Update YAML Configuration**: Use the same URL format as in unauthenticated access, but the system will automatically use the authenticated method to access the sheet:
+1. **Update YAML Configuration**: Use the same URL format as in unauthenticated access, but the system will automatically use the authenticated method to access the sheet:
 
 ```yaml
 tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -1,0 +1,33 @@
+# Importing Test Cases from Google Sheets
+
+promptfoo allows you to import eval test cases directly from Google Sheets. This can be done either unauthenticated (if the sheet is public) or authenticated using Google's Default Application Credentials, typically with a service account for programmatic access.
+
+## Unauthenticated Access
+
+If the Google Sheet is set to be accessible by "anyone with the link," you can directly specify the share URL in your YAML configuration.
+
+```yaml
+tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
+```
+
+## Authenticated Access with Default Application Credentials
+
+For sheets that are not publicly accessible, you can use authenticated access. This requires setting up Google [Default Application Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). Here’s how you can configure it:
+
+1. **Install peer dependencies**: `npm install googleapis`
+
+2. **Service Account Setup**: Create a service account in your Google Cloud Platform project and download the JSON key file.
+
+3. **Share Sheet**: Share the Google Sheet with the email address of your service account with at least viewer permissions.
+
+4. **Configure Environment**: Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of the JSON key file:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-file.json"
+```
+
+5. **Update YAML Configuration**: Use the same URL format as in unauthenticated access, but the system will automatically use the authenticated method to access the sheet:
+
+```yaml
+tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
+```

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,4 +1,4 @@
-// Helpers for parsing CSV eval files, shared by frontend and backend.
+// Helpers for parsing CSV eval files, shared by frontend and backend. Cannot import native modules.
 
 import type { Assertion, AssertionType, CsvRow, TestCase } from './types';
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -3,16 +3,6 @@ import { ProxyAgent } from 'proxy-agent';
 
 import type { RequestInfo, RequestInit, Response } from 'node-fetch';
 
-export async function fetchCsvFromGoogleSheet(url: string): Promise<string> {
-  const csvUrl = url.replace(/\/edit.*$/, '/export?format=csv');
-  const response = await fetchWithProxy(csvUrl);
-  if (response.status !== 200) {
-    throw new Error(`Failed to fetch CSV from Google Sheets URL: ${url}`);
-  }
-  const csvData = await response.text();
-  return csvData;
-}
-
 export async function fetchWithProxy(
   url: RequestInfo,
   options: RequestInit = {},

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -1,0 +1,71 @@
+import logger from './logger';
+
+import type { CsvRow } from './types';
+
+async function checkGoogleSheetAccess(url: string) {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    if (response.ok) {
+      return { public: true, status: response.status };
+    } else {
+      return { public: false, status: response.status };
+    }
+  } catch (error) {
+    logger.error('Error checking sheet access:', error);
+    return { public: false };
+  }
+}
+
+export async function fetchCsvFromGoogleSheet(url: string): Promise<CsvRow[]> {
+  const { public: isPublic } = await checkGoogleSheetAccess(url);
+  if (isPublic) {
+    return fetchCsvFromGoogleSheetUnauthenticated(url);
+  }
+  return fetchCsvFromGoogleSheetAuthenticated(url);
+}
+
+export async function fetchCsvFromGoogleSheetUnauthenticated(url: string): Promise<CsvRow[]> {
+  const { parse: parseCsv } = await import('csv-parse/sync');
+  const { fetchWithProxy } = await import('./fetch');
+
+  const csvUrl = url.replace(/\/edit.*$/, '/export?format=csv');
+  const response = await fetchWithProxy(csvUrl);
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch CSV from Google Sheets URL: ${url}`);
+  }
+  const csvData = await response.text();
+  return parseCsv(csvData, { columns: true });
+}
+
+export async function fetchCsvFromGoogleSheetAuthenticated(url: string): Promise<CsvRow[]> {
+  const { google } = await import('googleapis');
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+  const sheets = google.sheets('v4');
+
+  const match = url.match(/\/d\/([^/]+)/);
+  if (!match) {
+    throw new Error(`Invalid Google Sheets URL: ${url}`);
+  }
+  const spreadsheetId = match[1];
+  const range = 'A1:ZZZ';
+  const response = await sheets.spreadsheets.values.get({ spreadsheetId, range, auth });
+
+  const rows = response.data.values;
+  if (!rows?.length) {
+    throw new Error(`No data found in Google Sheets URL: ${url}`);
+  }
+
+  // Assuming the first row contains headers
+  const headers = rows[0];
+  const dataRows = rows.slice(1);
+
+  return dataRows.map((row) => {
+    const csvRow: CsvRow = {};
+    headers.forEach((header, index) => {
+      csvRow[header] = row[index];
+    });
+    return csvRow;
+  });
+}

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -4,7 +4,7 @@ import type { CsvRow } from './types';
 
 async function checkGoogleSheetAccess(url: string) {
   try {
-    const response = await fetch(url, { method: 'HEAD' });
+    const response = await fetch(url);
     if (response.ok) {
       return { public: true, status: response.status };
     } else {
@@ -18,6 +18,7 @@ async function checkGoogleSheetAccess(url: string) {
 
 export async function fetchCsvFromGoogleSheet(url: string): Promise<CsvRow[]> {
   const { public: isPublic } = await checkGoogleSheetAccess(url);
+  logger.debug(`Google Sheets URL: ${url}, isPublic: ${isPublic}`);
   if (isPublic) {
     return fetchCsvFromGoogleSheetUnauthenticated(url);
   }

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -7,9 +7,9 @@ import { parse as parseCsv } from 'csv-parse/sync';
 import { globSync } from 'glob';
 
 import logger from './logger';
-import { fetchCsvFromGoogleSheet } from './fetch';
 import { OpenAiChatCompletionProvider } from './providers/openai';
 import { testCaseFromCsvRow } from './csv';
+import { fetchCsvFromGoogleSheet } from './googleSheets';
 
 import type {
   Assertion,
@@ -66,8 +66,7 @@ export async function readStandaloneTestsFile(
   let rows: CsvRow[] = [];
 
   if (varsPath.startsWith('https://docs.google.com/spreadsheets/')) {
-    const csvData = await fetchCsvFromGoogleSheet(varsPath);
-    rows = parseCsv(csvData, { columns: true });
+    rows = await fetchCsvFromGoogleSheet(varsPath);
   } else if (fileExtension === 'csv') {
     rows = parseCsv(fs.readFileSync(resolvedVarsPath, 'utf-8'), { columns: true });
   } else if (fileExtension === 'json') {


### PR DESCRIPTION
A config like this:

```yaml
tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
```

Now supports Google Default Application Credentials, so you can share your sheet with a Google Cloud Service Account.