### PR TITLE
Add support for Mixtral 8x22B

### DIFF
--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -18,9 +18,10 @@ You can specify which Mistral model to use in your configuration. Currently, the
 
 1. `open-mistral-7b`
 2. `open-mixtral-8x7b`
-3. `mistral-small-latest`
-4. `mistral-medium-latest`
-5. `mistral-large-latest`
+3. `open-mixtral-8x22b`
+4. `mistral-small-latest`
+5. `mistral-medium-latest`
+6. `mistral-large-latest`
 
 Here's an example config that compares Mistral-Medium-Latest, Mistral-Small-Latest, and OpenAI GPT-3.5:
 

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -75,6 +75,13 @@ export class MistralChatCompletionProvider implements ApiProvider {
         output: 0.0007 / 1000,
       },
     })),
+    ...['open-mixtral-8x22b'].map((model) => ({
+      id: model,
+      cost: {
+        input: 0.002 / 1000,
+        output: 0.006 / 1000,
+      },
+    })),
     ...['mistral-small-latest'].map((model) => ({
       id: model,
       cost: {


### PR DESCRIPTION
## Overview

This PR adds support for the new Mistral model Mixtral 8x22B.

## References
- https://mistral.ai/news/mixtral-8x22b/
- https://docs.mistral.ai/getting-started/models/

![image](https://github.com/promptfoo/promptfoo/assets/5006784/cf30f977-e6ac-4d53-ab37-d2f9c20af4ec)
