### PR TITLE
fix: google sheets async loading

### DIFF
--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -181,7 +181,7 @@ export async function readTests(
       // Points to a tests file with multiple test cases
       return loadTestsFromGlob(tests);
     } else {
-      // Points to a legacy vars.csv
+      // Points to a tests.csv or Google Sheet
       return readStandaloneTestsFile(tests, basePath);
     }
   } else if (Array.isArray(tests)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -254,14 +254,14 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
   });
 
   const tests: UnifiedConfig['tests'] = [];
-  configs.forEach(async (config) => {
+  for (const config of configs) {
     if (typeof config.tests === 'string') {
       const newTests = await readTests(config.tests, path.dirname(configPaths[0]));
       tests.push(...newTests);
     } else if (Array.isArray(config.tests)) {
       tests.push(...config.tests);
     }
-  });
+  }
 
   const configsAreStringOrArray = configs.every(
     (config) => typeof config.prompts === 'string' || Array.isArray(config.prompts),


### PR DESCRIPTION
Fixes an issue where test loading wouldn't be awaited when the --config parameter is set.  This seems to apply only to google sheets, which is the only time when test loading is async.