### PR TITLE
fix: include detail from external python assertion

### DIFF
--- a/examples/python-assert-external/assert.py
+++ b/examples/python-assert-external/assert.py
@@ -2,4 +2,15 @@ def get_assert(output, context):
     print('Prompt:', context['prompt'])
     print('Vars', context['vars']['topic'])
 
-    return 'bananas' in output.lower()
+    # You can return a bool...
+    # return 'bananas' in output.lower()
+
+    # A score (where 0 = Fail)...
+    # return 0.5
+
+    # Or an entire grading result...
+    return {
+        'pass': 'bananas' in output.lower(),
+        'score': 0.5,
+        'reason': 'Contains banana',
+    }

--- a/examples/python-assert-external/promptfooconfig.yaml
+++ b/examples/python-assert-external/promptfooconfig.yaml
@@ -18,3 +18,8 @@ tests:
     assert:
       - type: python
         value: file://assert.py
+  - vars:
+      topic: fruits that smell bad
+    assert:
+      - type: python
+        value: file://assert.py

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -746,17 +746,28 @@ ${
         }
         return parsed;
       } else if (typeof result === 'object') {
-        if (!result.hasOwnProperty('pass') || !result.hasOwnProperty('score')) {
+        if (
+          !result.hasOwnProperty('pass') ||
+          !result.hasOwnProperty('score') ||
+          !result.hasOwnProperty('reason')
+        ) {
           throw new Error(
-            `Python assertion must return a boolean, number, or {pass, score, reason} object. Got instead: ${result}`,
+            `Python assertion must return a boolean, number, or {pass, score, reason} object. Got instead:\n${JSON.stringify(
+              result,
+              null,
+              2,
+            )}`,
           );
         }
-        const pythonGradingResult = result as GradingResult;
+        const pythonGradingResult = result as Omit<GradingResult, 'assertion'>;
         if (assertion.threshold && pythonGradingResult.score < assertion.threshold) {
           pythonGradingResult.pass = false;
           pythonGradingResult.reason = `Python score ${pythonGradingResult.score} is less than threshold ${assertion.threshold}`;
         }
-        return pythonGradingResult;
+        return {
+          ...pythonGradingResult,
+          assertion,
+        };
       } else {
         score = parseFloat(String(result));
         pass = assertion.threshold ? score >= assertion.threshold : score > 0;


### PR DESCRIPTION
This fixes an issue where `type` and `value` don't appear in the webui

![image](https://github.com/promptfoo/promptfoo/assets/310310/7ab5c076-2436-486e-828a-3f34145b6a9b)
