### PR TITLE
feat: portkey.ai integration

### DIFF
--- a/examples/portkey-test/README.md
+++ b/examples/portkey-test/README.md
@@ -1,0 +1,10 @@
+To get started, set your OPENAI_API_KEY and PORTKEY_API_KEY environment variables.
+
+Next, edit promptfooconfig.yaml and replace the portkey prompt with your own portkey prompt id.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/portkey-test/promptfooconfig.yaml
+++ b/examples/portkey-test/promptfooconfig.yaml
@@ -1,0 +1,11 @@
+description: 'Portkey.ai integration'
+
+prompts:
+  - 'portkey://pp-test-promp-669f48'
+
+providers:
+  - openai:gpt-3.5-turbo-0613
+
+tests:
+  - vars:
+      topic: bananas

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -1,0 +1,29 @@
+---
+sidebar_label: Portkey AI
+---
+
+# Portkey AI integration
+
+Portkey is an AI observability suite that includes prompt management capabilities.
+
+To reference prompts in Portkey:
+
+1. Set the `PORTKEY_API_KEY` environment variable.
+
+2. Use the `portkey://` prefix for your prompts, followed by the Portkey prompt ID. For example:
+
+   ```yaml
+   prompts:
+     - 'portkey://pp-test-promp-669f48'
+
+   providers:
+     - openai:gpt-3.5-turbo-0613
+
+   tests:
+     - vars:
+         topic: ...
+   ```
+
+Variables from your promptfoo test cases will be automatically plugged into the Portkey prompt as variables. The resulting prompt will be rendered and returned to promptfoo, and used as the prompt for the test case.
+
+Note that promptfoo does not follow the temperature, model, and other parameters set in Portkey. You must set them in the `providers` configuration yourself.

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -33,6 +33,7 @@ import type {
   TestSuite,
   ProviderResponse,
 } from './types';
+import { getPrompt } from './integrations/portkey';
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
 
@@ -180,7 +181,14 @@ export async function renderPrompt(
 
   // Resolve variable mappings
   resolveVariables(vars);
+  
+  // Third party integrations
+  if (prompt.raw.startsWith('portkey://')) {
+    const portKeyResult = await getPrompt(prompt.raw.slice('portkey://'.length), vars);
+    return JSON.stringify(portKeyResult.messages);
+  }
 
+  // Render prompt
   try {
     if (process.env.PROMPTFOO_DISABLE_JSON_AUTOESCAPE) {
       return nunjucks.renderString(basePrompt, vars);

--- a/src/integrations/portkey.ts
+++ b/src/integrations/portkey.ts
@@ -1,0 +1,47 @@
+import fetch from 'node-fetch';
+import invariant from 'tiny-invariant';
+
+interface PortkeyResponse {
+  success: boolean;
+  data: {
+    model: string;
+    n: number;
+    top_p: number;
+    max_tokens: number;
+    temperature: number;
+    presence_penalty: number;
+    frequency_penalty: number;
+    messages: Array<{
+      role: string;
+      content: string;
+    }>;
+  };
+}
+
+export async function getPrompt(
+  id: string,
+  variables: Record<string, any>,
+): Promise<PortkeyResponse['data']> {
+  invariant(process.env.PORTKEY_API_KEY, 'PORTKEY_API_KEY is required');
+
+  const url = `https://api.portkey.ai/v1/prompts/${id}/render`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-portkey-api-key': process.env.PORTKEY_API_KEY,
+    },
+    body: JSON.stringify({ variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const result = (await response.json()) as PortkeyResponse;
+  if (!result.success) {
+    throw new Error(`Portkey error! ${JSON.stringify(result)}`);
+  }
+
+  return result.data;
+}

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -75,6 +75,7 @@ export function readProviderPromptMap(
 function maybeFilepath(str: string): boolean {
   return (
     !str.includes('\n') &&
+    !str.includes('portkey://') &&
     (str.includes('/') ||
       str.includes('\\') ||
       str.includes('*') ||


### PR DESCRIPTION
Support for fetching prompts from portkey.ai

Portkey is an AI observability suite that includes prompt management capabilities.

To reference prompts in Portkey:

1. Set the `PORTKEY_API_KEY` environment variable.

2. Use the `portkey://` prefix for your prompts, followed by the Portkey prompt ID. For example:

   ```yaml
   prompts:
     - 'portkey://pp-test-promp-669f48'

   providers:
     - openai:gpt-3.5-turbo-0613

   tests:
     - vars:
         topic: ...
   ```

Variables from your promptfoo test cases will be automatically plugged into the Portkey prompt as variables. The resulting prompt will be rendered and returned to promptfoo, and used as the prompt for the test case.

Note that promptfoo does not follow the temperature, model, and other parameters set in Portkey. You must set them in the `providers` configuration yourself.
