### PR TITLE
feat: add support for provider-specific delays

### DIFF
--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -79,7 +79,15 @@ ProviderOptions is an object that includes the `id` of the provider and an optio
 interface ProviderOptions {
   id?: ProviderId;
   config?: any;
-  prompts?: string[]; // List of prompt display strings
+
+  // List of prompt display strings
+  prompts?: string[];
+
+  // Transform the output, either with inline Javascript or external py/js script (see `Transforms`)
+  transform?: string;
+
+  // Sleep this long before each request
+  delay?: number;
 }
 ```
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -321,8 +321,8 @@ class Evaluator {
       });
 
       if (!response.cached) {
-        let sleep = delay;
-        if (!delay && process.env.PROMPTFOO_DELAY_MS) {
+        let sleep = provider.delay ?? delay;
+        if (!sleep && process.env.PROMPTFOO_DELAY_MS) {
           sleep = parseInt(process.env.PROMPTFOO_DELAY_MS, 10) || 0;
         }
         if (sleep) {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -304,6 +304,7 @@ export async function loadApiProvider(
   }
 
   ret.transform = options.transform;
+  ret.delay = options.delay;
   return ret;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface ProviderOptions {
   config?: any;
   prompts?: string[]; // List of prompt display strings
   transform?: string;
+  delay?: number;
   env?: EnvOverrides;
 }
 
@@ -102,6 +103,9 @@ export interface ApiProvider {
   
   // Applied by the evaluator on provider response
   transform?: string;
+  
+  // Custom delay for the provider.
+  delay?: number;
 }
 
 export interface ApiEmbeddingProvider extends ApiProvider {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -720,4 +720,14 @@ config:
     expect(providers[1]).toBeInstanceOf(OpenAiCompletionProvider);
     expect(providers[2]).toBeInstanceOf(AnthropicCompletionProvider);
   });
+
+  test('loadApiProvider sets provider.delay', async () => {
+    const providerOptions = {
+      id: 'test-delay',
+      config: {},
+      delay: 500,
+    };
+    const provider = await loadApiProvider('echo', { options: providerOptions });
+    expect(provider.delay).toBe(500);
+  });
 });


### PR DESCRIPTION
For example:
```yaml
providers:
  - id: openai:chat:gpt-4-turbo
    delay: 2000
```