### PR TITLE
Make errors uncached in Python completion.

### DIFF
--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -64,7 +64,7 @@ export class PythonProvider implements ApiProvider {
           'The Python script `call_api` function must return a dict with an `output` or `error` string',
         );
       }
-      if (isCacheEnabled()) {
+      if (isCacheEnabled() && !('error' in result)) {
         await cache.set(cacheKey, JSON.stringify(result));
       }
       return result;


### PR DESCRIPTION
This change only caches a result if the response does not contain an error. This helps in rerunning failing executions quickly.