### PR TITLE
Fixes to Python docs

### DIFF
--- a/site/docs/configuration/expected-outputs/python.md
+++ b/site/docs/configuration/expected-outputs/python.md
@@ -51,7 +51,9 @@ assert:
 A `context` object is available in the Python function. Here is its type definition:
 
 ```py
-class AssertContext:
+from typing import Dict, TypedDict, Union
+
+class AssertContext(TypedDict):
     prompt: str
     vars: Dict[str, Union[str, object]]
 ```
@@ -78,25 +80,24 @@ assert:
     value: file://relative/path/to/script.py
 ```
 
-This file will be called with an `output` string and an `AssertContext` object. It expects that either a bool (pass/fail), float (score), or `GradingResult` will be returned.
+This file will be called with an `output` string and an `AssertContext` object (see above).
+It expects that either a bool (pass/fail), float (score), or `GradingResult` will be returned.
 
-Here's an example assert.py:
+Here's an example `assert.py`:
 
 ```py
-def get_assert(output, context) -> Union[bool, float, Dict[str, Any]]
+from typing import Dict, TypedDict, Union
+
+def get_assert(output: str, context) -> Union[bool, float, Dict[str, Any]]:
     print('Prompt:', context['prompt'])
-    print('Vars', context['vars']['topic']
+    print('Vars', context['vars']['topic'])
 
-    # Determine the result...
-    result = test_output(output)
-
-    # Here's an example GradingResult dict
-    result = {
+    # This return is an example GradingResult dict
+    return {
       'pass': True,
       'score': 0.6,
       'reason': 'Looks good to me',
     }
-    return result
 ```
 
 ## Overriding the Python binary

--- a/site/docs/configuration/expected-outputs/python.md
+++ b/site/docs/configuration/expected-outputs/python.md
@@ -39,11 +39,10 @@ assert:
             'pass': True,
             'score': 0.5,
           }
-      else:
-          return {
-            'pass': False,
-            'score': 0,
-          }
+      return {
+        'pass': False,
+        'score': 0,
+      }
 ```
 
 ## Using test context
@@ -81,7 +80,7 @@ assert:
 ```
 
 This file will be called with an `output` string and an `AssertContext` object (see above).
-It expects that either a bool (pass/fail), float (score), or `GradingResult` will be returned.
+It expects that either a `bool` (pass/fail), `float` (score), or `GradingResult` will be returned.
 
 Here's an example `assert.py`:
 

--- a/site/docs/configuration/expected-outputs/python.md
+++ b/site/docs/configuration/expected-outputs/python.md
@@ -50,11 +50,12 @@ assert:
 A `context` object is available in the Python function. Here is its type definition:
 
 ```py
-from typing import Dict, TypedDict, Union
+from typing import Any, Dict, TypedDict, Union
 
 class AssertContext(TypedDict):
     prompt: str
-    vars: Dict[str, Union[str, object]]
+    vars: Dict[str, str]
+    test: Dict[str, Any]  # Contains keys like "vars", "assert", "options"
 ```
 
 For example, if the test case has a var `example`, access it in Python like this:


### PR DESCRIPTION
- Fixes missing syntax (e.g. closing paren, colon)
- Removes extra `else`
- Adds missing imports