### PR TITLE
Feature: eval tests matching pattern

### DIFF
--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -1,0 +1,35 @@
+import {TestSuite} from "../../types";
+
+interface Args {
+  firstN?: string;
+  pattern?: string;
+}
+
+export function filterTests(tests: TestSuite['tests'], args: Args) {
+  if (!tests) {
+    return tests;
+  }
+
+  if (Object.keys(args).length === 0) {
+    return tests;
+  }
+
+  const {firstN, pattern} = args;
+  let newTests = [...tests];
+
+  if (pattern)  {
+    newTests = newTests.filter((test) => test.description && test.description.match(pattern));
+  }
+
+  if (firstN) {
+    const count = parseInt(firstN);
+
+    if (isNaN(count)) {
+      throw new Error(`firstN must be a number, got: ${firstN}`);
+    }
+
+    newTests = newTests.slice(0, count);
+  }
+
+  return newTests;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import type {
 } from './types';
 import { generateTable } from './table';
 import { createShareableUrl } from './share';
+import {filterTests} from './commands/eval/filterTests';
 
 function createDummyFiles(directory: string | null) {
   if (directory) {
@@ -552,6 +553,7 @@ async function main() {
       defaultConfig?.evaluateOptions?.interactiveProviders,
     )
     .option('-n, --first-n <number>', 'Only run the first N tests')
+    .option('--pattern <pattern>', 'Only run tests whose description matches the regular expression pattern')
     .action(async (cmdObj: CommandLineOptions & Command) => {
       setupEnv(cmdObj.envFile);
       let config: Partial<UnifiedConfig> | undefined = undefined;
@@ -583,9 +585,10 @@ async function main() {
           );
         }
 
-        if (cmdObj.firstN) {
-          testSuite.tests = testSuite.tests?.slice(0, Number(cmdObj.firstN));
-        }
+        testSuite.tests = filterTests(testSuite.tests, {
+          firstN: cmdObj.firstN,
+          pattern: cmdObj.pattern,
+        });
 
         const options: EvaluateOptions = {
           showProgressBar: getLogLevel() === 'debug' ? false : cmdObj.progressBar,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface CommandLineOptions {
   watch?: boolean;
   interactiveProviders?: boolean;
   firstN?: string;
+  pattern?: string;
 
   generateSuggestions?: boolean;
   promptPrefix?: string;
@@ -106,10 +107,10 @@ export interface ApiProvider {
 
   // Shown on output
   label?: ProviderLabel;
-  
+
   // Applied by the evaluator on provider response
   transform?: string;
-  
+
   // Custom delay for the provider.
   delay?: number;
 }
@@ -451,7 +452,7 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
 
   // Key-value pairs to substitute in the prompt
   vars?: Vars;
-  
+
   // Override the provider.
   provider?: string | ProviderOptions | ApiProvider;
 

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -1,0 +1,62 @@
+import {TestCase, TestSuite} from "../../../src/types";
+
+import {filterTests} from '../../../src/commands/eval/filterTests';
+
+describe('filterTests', () => {
+  const testNoDescription = {};
+  const testHuey = {
+    description: 'Huey',
+  };
+  const testDewey = {
+    description: 'Dewey',
+  };
+  const testLouie = {
+    description: 'Louie',
+  };
+  const tests = [testHuey, testNoDescription, testDewey, testLouie];
+
+  it('should run all tests when no args', () => {
+    const result = filterTests(tests, {});
+
+    expect(result).toStrictEqual(tests);
+  });
+
+  it('handles no tests', () => {
+    const result = filterTests(undefined, {});
+
+    expect(result).toBe(undefined);
+  });
+
+  describe('firstN', () => {
+    it('should only run Huey and Dewey', () => {
+      const result = filterTests(tests, { firstN: '2' });
+
+      expect(result).toStrictEqual(tests.slice(0, 2));
+    });
+
+    it('throws an exception when firstN is not a number', () => {
+      expect(() => filterTests(tests, { firstN: 'NOPE' }))
+        .toThrow(new Error('firstN must be a number, got: NOPE'));
+    });
+  });
+
+  describe('pattern', () => {
+    it('should only return tests whose description ends in "ey"', () => {
+      const result = filterTests(tests, { pattern: 'ey$' });
+
+      expect(result).toStrictEqual([testHuey, testDewey]);
+    });
+
+    it('can combine firstN and pattern', () => {
+      const result = filterTests(tests, { firstN: '1', pattern: 'ey$' });
+
+      expect(result).toStrictEqual([testHuey]);
+    });
+
+    it('does not mutate when when has args', () => {
+      const result = filterTests(tests, { firstN: '1', pattern: 'ey$' });
+
+      expect(result).not.toBe(tests);
+    });
+  });
+});


### PR DESCRIPTION
This PR implements the ability to run:
```
promptfoo eval --pattern "Only tests matching this pattern"
```

To run tests whose `description` matches the regex pattern passed.

## Example

With the following config:
```
prompts:
  - "Write a tweet about {{topic}}"
  - "Write a very concise, funny tweet about {{topic}}"

providers:
  - openai:gpt-3.5-turbo-0613
  - openai:gpt-4

tests:
  - vars:
      topic: bananas
    description: banana joke

  - vars:
      topic: avocado toast
    description: avocado joke
```

Running:
```
npx /Users/mikkohaapoja/src/github.com/promptfoo/promptfoo eval --pattern avocado
```

Will output:

<img width="1064" alt="Screenshot 2024-04-29 at 5 52 23 PM" src="https://github.com/promptfoo/promptfoo/assets/496903/73d4c3c3-b52f-42f2-bfd1-3374b2593da0">

