### PR TITLE
Update openai package to 3.48.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "mathjs": "^12.4.1",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
-        "openai": "^4.19.0",
+        "openai": "^4.38.5",
         "opener": "^1.5.2",
         "proxy-agent": "^6.3.1",
         "python-shell": "^5.0.0",
@@ -3775,11 +3775,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4178,14 +4173,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -4601,14 +4588,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/csv-parse": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.0.tgz",
@@ -4828,15 +4807,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
       }
     },
     "node_modules/dotenv": {
@@ -6316,11 +6286,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-core-module": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
@@ -7689,16 +7654,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -8204,15 +8159,14 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.19.0.tgz",
-      "integrity": "sha512-cJbl0noZyAaXVKBTMMq6X5BAvP1pm2rWYDBnZes99NL+Zh5/4NmlAwyuhTZEru5SqGGZIoiYKeMPXy4bm9DI0w==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.39.0.tgz",
+      "integrity": "sha512-8RcdppE8RKC17VnacZxru1OQL76rhI1107i32nE2RsSsvrd2yyDLAKp//2zzJxLY3iz8Sw1ywcwF5kEcreim6Q==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
         "abort-controller": "^3.0.0",
         "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "mathjs": "^12.4.1",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
-    "openai": "^4.19.0",
+    "openai": "^4.38.5",
     "opener": "^1.5.2",
     "proxy-agent": "^6.3.1",
     "python-shell": "^5.0.0",

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -94,6 +94,7 @@ Supported parameters include:
 | `apiHost`           | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                       |
 | `apiBaseUrl`        | The base URL of the OpenAI API, please also read `OPENAI_BASE_URL` below.                                                                                       |
 | `organization`      | Your OpenAI organization key.                                                                                                                                   |
+| `headers`           | Additional headers to include in the request.                                                                                                                   |
 
 Here are the type declarations of `config` parameters:
 
@@ -120,7 +121,7 @@ interface OpenAiConfig {
       parameters: any;
     };
   }[];
-  tool_choice?: 'none' | 'auto' | { type: 'function'; function?: { name: string } };
+  tool_choice?: 'none' | 'auto' | { type: 'function'; function?: { name: string } } | { type: 'file_search' };
   stop?: string[];
   response_format?: { type: string };
   seed?: number;
@@ -131,6 +132,7 @@ interface OpenAiConfig {
   apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;
+  headers?: { [key: string]: string };
 }
 ```
 
@@ -607,6 +609,8 @@ The following properties can be overwritten in provider config:
 - `instructions` - System prompt
 - `tools` - Enabled [tools](https://platform.openai.com/docs/api-reference/runs/createRun)
 - `thread.messages` - A list of message objects that the thread is created with.
+- `temperature` - Temperature for the model
+- `toolChoice` - Controls whether the AI should use a tool
 
 Here's an example of a more detailed config:
 
@@ -619,9 +623,12 @@ providers:
     config:
       model: gpt-4-1106-preview
       instructions: "You always speak like a pirate"
+      temperature: 0.2
+      toolChoice:
+        type: file_search
       tools:
         - type: code_interpreter
-        - type: retrieval
+        - type: file_search
       thread:
         messages:
           - role: user


### PR DESCRIPTION
Hi 👋 
We're using promptfoo with the new assistants API and it seems like it lacks some features so I've updated the package to support the new tool type `file_search` and added a few configuration options. We also need a way to pass custom headers because we use a proxy for our openai calls and we need to pass `Cache-Control: none`. 

Let me know if you need anything else!