### PR TITLE
feat: promptfoo eval --filter-failing outputFile.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "dotenv": "^16.4.5",
         "drizzle-orm": "^0.29.3",
         "express": "^4.18.2",
+        "fast-deep-equal": "^3.1.3",
         "fastest-levenshtein": "^1.0.16",
         "glob": "^10.2.6",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "@aws-sdk/client-bedrock-runtime": "^3.458.0",
     "@azure/identity": "^4.0.0",
     "@azure/openai-assistants": "^1.0.0-beta.5",
+    "@ibm-generative-ai/node-sdk": "^2.0.6",
     "google-auth-library": "^9.7.0",
     "googleapis": "^134.0.0",
-    "langfuse": "^3.7.0",
-    "@ibm-generative-ai/node-sdk": "^2.0.6"
+    "langfuse": "^3.7.0"
   },
   "devDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.458.0",
@@ -102,6 +102,7 @@
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.29.3",
     "express": "^4.18.2",
+    "fast-deep-equal": "^3.1.3",
     "fastest-levenshtein": "^1.0.16",
     "glob": "^10.2.6",
     "js-yaml": "^4.1.0",

--- a/src/commands/eval/filterFailingTests.ts
+++ b/src/commands/eval/filterFailingTests.ts
@@ -1,0 +1,21 @@
+import {TestSuite} from "../../types";
+import {readOutput, resultIsForTestCase} from "../../util";
+
+type Tests = NonNullable<TestSuite['tests']>;
+
+export async function filterFailingTests(testSuite: TestSuite, outputPath: string): Promise<Tests> {
+  if (!testSuite.tests) {
+    return [];
+  }
+
+  const {results} = await readOutput(outputPath);
+  const failingResults = results.results.filter((result) => !result.success);
+
+  if (failingResults.length === 0) {
+    return [];
+  }
+
+  return [...testSuite.tests].filter((test) => {
+    return failingResults.some((result) => resultIsForTestCase(result, test));
+  }) as Tests;
+}

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -1,11 +1,17 @@
 import {TestSuite} from "../../types";
+import {filterFailingTests} from "./filterFailingTests";
 
 interface Args {
   firstN?: string;
   pattern?: string;
+  failing?: string;
 }
 
-export function filterTests(tests: TestSuite['tests'], args: Args) {
+type Tests = TestSuite['tests'];
+
+export async function filterTests(testSuite: TestSuite, args: Args): Promise<Tests> {
+  const tests = testSuite.tests;
+
   if (!tests) {
     return tests;
   }
@@ -14,8 +20,14 @@ export function filterTests(tests: TestSuite['tests'], args: Args) {
     return tests;
   }
 
-  const {firstN, pattern} = args;
-  let newTests = [...tests];
+  const {firstN, pattern, failing} = args;
+  let newTests: NonNullable<Tests>;
+
+  if (failing) {
+    newTests = await filterFailingTests(testSuite, failing);
+  } else {
+    newTests = [...tests];
+  }
 
   if (pattern)  {
     newTests = newTests.filter((test) => test.description && test.description.match(pattern));

--- a/src/main.ts
+++ b/src/main.ts
@@ -552,8 +552,9 @@ async function main() {
       'Run providers interactively, one at a time',
       defaultConfig?.evaluateOptions?.interactiveProviders,
     )
-    .option('-n, --first-n <number>', 'Only run the first N tests')
-    .option('--pattern <pattern>', 'Only run tests whose description matches the regular expression pattern')
+    .option('-n, --filter-first-n <number>', 'Only run the first N tests')
+    .option('--filter-pattern <pattern>', 'Only run tests whose description matches the regular expression pattern')
+    .option('--filter-failing <path>', 'Path to json output file')
     .action(async (cmdObj: CommandLineOptions & Command) => {
       setupEnv(cmdObj.envFile);
       let config: Partial<UnifiedConfig> | undefined = undefined;
@@ -585,9 +586,10 @@ async function main() {
           );
         }
 
-        testSuite.tests = filterTests(testSuite.tests, {
-          firstN: cmdObj.firstN,
-          pattern: cmdObj.pattern,
+        testSuite.tests = await filterTests(testSuite, {
+          firstN: cmdObj.filterFirstN,
+          pattern: cmdObj.filterPattern,
+          failing: cmdObj.filterFailing,
         });
 
         const options: EvaluateOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,10 @@ export interface CommandLineOptions {
   progressBar?: boolean;
   watch?: boolean;
   interactiveProviders?: boolean;
-  firstN?: string;
-  pattern?: string;
+
+  filterFailing?: string;
+  filterFirstN?: string;
+  filterPattern?: string;
 
   generateSuggestions?: boolean;
   promptPrefix?: string;
@@ -79,6 +81,10 @@ export interface ProviderOptions {
   env?: EnvOverrides;
 }
 
+export function isProviderOptions(provider: any): provider is ProviderOptions {
+  return !isApiProvider(provider) && typeof provider === 'object';
+}
+
 export interface CallApiContextParams {
   vars: Record<string, string | object>;
 }
@@ -113,6 +119,10 @@ export interface ApiProvider {
 
   // Custom delay for the provider.
   delay?: number;
+}
+
+export function isApiProvider(provider: any): provider is ApiProvider {
+  return typeof provider === 'object' && 'id' in provider && typeof provider.id === 'function';
 }
 
 export interface ApiEmbeddingProvider extends ApiProvider {

--- a/test/commands/eval/filterFailingTests.test.ts
+++ b/test/commands/eval/filterFailingTests.test.ts
@@ -1,0 +1,72 @@
+import { filterFailingTests } from '../../../src/commands/eval/filterFailingTests';
+import { EvaluateResult, EvaluateSummary, TestSuite } from '../../../src/types';
+import { readOutput } from '../../../src/util';
+
+jest.mock('../../../src/util', () => {
+  return {
+    ...jest.requireActual('../../../src/util'),
+    readOutput: jest.fn(),
+  };
+});
+
+describe('filterFailingTests', () => {
+  const varsSuccess = { successKey: 'value' };
+  const varsFailure = { failureKey: 'value' };
+  const sucessTest = { vars: varsSuccess };
+  const failureTest = { vars: varsFailure };
+  const testSuite = {
+    tests: [sucessTest, failureTest],
+  } as unknown as TestSuite;
+  const outputPath = 'outputPath.json';
+  const restResult = {
+    prompt: {
+      raw: 'prompt',
+      display: 'prompt',
+    },
+    score: 0.5,
+    latencyMs: 1_000,
+    namedScores: {},
+  };
+
+  beforeEach(() => {
+    jest.mocked(readOutput).mockResolvedValue({
+      results: {
+        version: 2,
+        results: [
+          { ...restResult, success: true, provider: { id: 'provider1' }, vars: varsSuccess },
+          { ...restResult, success: false, provider: { id: 'provider2' }, vars: varsFailure },
+        ],
+        table: {} as any,
+        stats: {} as any,
+      } as EvaluateSummary,
+    } as any);
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  it('can filter using vars', async () => {
+    const result = await filterFailingTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([failureTest]);
+  });
+
+  it('can filter using test provider', async () => {
+    const failureTest1 = { provider: 'provider1', vars: varsFailure };
+    const failureTest2 = { provider: 'provider2', vars: varsFailure };
+    const testSuite = {
+      tests: [failureTest1, failureTest2],
+    } as unknown as TestSuite;
+
+    const result = await filterFailingTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([failureTest2]);
+  });
+
+  it('returns empty array when no failing tests', async () => {
+    (readOutput as jest.Mock).mockResolvedValue({ results: { version: 2, results: [{ success: true }] }});
+
+    const result = await filterFailingTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([]);
+  });
+});

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -14,47 +14,50 @@ describe('filterTests', () => {
     description: 'Louie',
   };
   const tests = [testHuey, testNoDescription, testDewey, testLouie];
+  const testSuite = {
+    tests,
+  } as TestSuite;
 
-  it('should run all tests when no args', () => {
-    const result = filterTests(tests, {});
+  it('should run all tests when no args', async () => {
+    const result = await filterTests(testSuite, {});
 
     expect(result).toStrictEqual(tests);
   });
 
-  it('handles no tests', () => {
-    const result = filterTests(undefined, {});
+  it('handles no tests', async () => {
+    const result = await filterTests({} as TestSuite, {});
 
     expect(result).toBe(undefined);
   });
 
   describe('firstN', () => {
-    it('should only run Huey and Dewey', () => {
-      const result = filterTests(tests, { firstN: '2' });
+    it('should only run Huey and Dewey', async () => {
+      const result = await filterTests(testSuite, { firstN: '2' });
 
       expect(result).toStrictEqual(tests.slice(0, 2));
     });
 
-    it('throws an exception when firstN is not a number', () => {
-      expect(() => filterTests(tests, { firstN: 'NOPE' }))
-        .toThrow(new Error('firstN must be a number, got: NOPE'));
+    it('throws an exception when firstN is not a number', async () => {
+      await expect(() => filterTests(testSuite, { firstN: 'NOPE' }))
+        .rejects.toEqual(new Error('firstN must be a number, got: NOPE'));
     });
   });
 
   describe('pattern', () => {
-    it('should only return tests whose description ends in "ey"', () => {
-      const result = filterTests(tests, { pattern: 'ey$' });
+    it('should only return tests whose description ends in "ey"', async () => {
+      const result = await filterTests(testSuite, { pattern: 'ey$' });
 
       expect(result).toStrictEqual([testHuey, testDewey]);
     });
 
-    it('can combine firstN and pattern', () => {
-      const result = filterTests(tests, { firstN: '1', pattern: 'ey$' });
+    it('can combine firstN and pattern', async () => {
+      const result = await filterTests(testSuite, { firstN: '1', pattern: 'ey$' });
 
       expect(result).toStrictEqual([testHuey]);
     });
 
-    it('does not mutate when when has args', () => {
-      const result = filterTests(tests, { firstN: '1', pattern: 'ey$' });
+    it('does not mutate when when has args', async () => {
+      const result = await filterTests(testSuite, { firstN: '1', pattern: 'ey$' });
 
       expect(result).not.toBe(tests);
     });


### PR DESCRIPTION
Makes it so that you can iterate more quickly by simply running failing tests given an output file.

## Example Flow

First run: `promptfoo eval --output result.json `
<img width="1099" alt="Screenshot 2024-04-30 at 5 17 28 PM" src="https://github.com/promptfoo/promptfoo/assets/496903/a58f706d-42bc-4e6e-adfc-916319856b61">

Next run: `promptfoo eval --failing result.json`
<img width="1094" alt="Screenshot 2024-04-30 at 5 18 41 PM" src="https://github.com/promptfoo/promptfoo/assets/496903/a0a88338-8ae2-4240-beda-d1417de16372">
