### PR TITLE
feat: add support for `--var name=value` cli option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface CommandLineOptions {
   interactiveProviders?: boolean;
   firstN?: string;
   pattern?: string;
+  var?: Record<string, string>
 
   generateSuggestions?: boolean;
   promptPrefix?: string;


### PR DESCRIPTION
Enables setting defaultTest vars from the CLI:

```
promptfoo eval --var topic='spaghetti recipes' --var flavor=garlic
```