### PR TITLE
fix: upgrade rouge package and limit to strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "proxy-agent": "^6.3.1",
         "python-shell": "^5.0.0",
         "replicate": "^0.27.1",
-        "rouge": "^1.0.3",
+        "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
         "semver": "^7.5.3",
         "socket.io": "^4.6.1",
         "tiny-invariant": "^1.3.1",
@@ -7494,12 +7494,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/lodash-node": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
-      "integrity": "sha512-egEt8eNQp2kZWRmngahiqMoDCDCENv3uM188S7Ed5t4k3v6RrLELXC+FqLNMUnhCo7gvQX3G1V8opK/Lcslahg==",
-      "deprecated": "This package is discontinued. Use lodash@^4.0.0."
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -8941,12 +8935,10 @@
       }
     },
     "node_modules/rouge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rouge/-/rouge-1.0.3.tgz",
-      "integrity": "sha512-YCt74Dxsi99E8/uh943FTa80EmGboaOu1ij4q8WD4EAGyvyWYaH7MRHorrDbGgLY7iFUwDwyW/g9KJZx7D5fUQ==",
-      "dependencies": {
-        "lodash-node": "^2.4.1"
-      }
+      "version": "2.0.0",
+      "resolved": "git+ssh://git@github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
+      "integrity": "sha512-jMwLfAKwlk9C2MnFMBNYgmYXUUwhVrGFX8vISIX68blj5uyyzv8OYOdsoMV5kccxSZYGKYxND9X6in3PA2NZOg==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "proxy-agent": "^6.3.1",
     "python-shell": "^5.0.0",
     "replicate": "^0.27.1",
-    "rouge": "^1.0.3",
+    "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
     "semver": "^7.5.3",
     "socket.io": "^4.6.1",
     "tiny-invariant": "^1.3.1",

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -64,7 +64,7 @@ function coerceString(value: string | object): string {
 function handleRougeScore(
   baseType: 'rouge-n',
   assertion: Assertion,
-  expected: string | string[],
+  expected: string,
   output: string,
   inverted: boolean,
 ): GradingResult {
@@ -1041,8 +1041,8 @@ ${
 
   if (baseType === 'rouge-n') {
     invariant(
-      typeof renderedValue === 'string' || Array.isArray(renderedValue),
-      '"rouge" assertion type must be a value (string or string array)',
+      typeof renderedValue === 'string',
+      '"rouge" assertion type must be a string value',
     );
     return handleRougeScore(baseType, assertion, renderedValue, outputString, inverse);
   }

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -77,10 +77,10 @@ function handleRougeScore(
     pass,
     score: inverted ? 1 - score : score,
     reason: pass
-      ? `${baseType.toUpperCase()} score ${score} is greater than or equal to threshold ${
-          assertion.threshold || 0.75
-        }`
-      : `${baseType.toUpperCase()} score ${score} is less than threshold ${
+      ? `${baseType.toUpperCase()} score ${score.toFixed(
+          2,
+        )} is greater than or equal to threshold ${assertion.threshold || 0.75}`
+      : `${baseType.toUpperCase()} score ${score.toFixed(2)} is less than threshold ${
           assertion.threshold || 0.75
         }`,
     assertion,
@@ -1040,10 +1040,7 @@ ${
   }
 
   if (baseType === 'rouge-n') {
-    invariant(
-      typeof renderedValue === 'string',
-      '"rouge" assertion type must be a string value',
-    );
+    invariant(typeof renderedValue === 'string', '"rouge" assertion type must be a string value');
     return handleRougeScore(baseType, assertion, renderedValue, outputString, inverse);
   }
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1344,7 +1344,7 @@ describe('runAssertion', () => {
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
     expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('ROUGE-N score 1 is greater than or equal to threshold 0.75');
+    expect(result.reason).toBe('ROUGE-N score 1.00 is greater than or equal to threshold 0.75');
   });
 
   it('should fail when the rouge-n assertion fails', async () => {
@@ -1358,7 +1358,7 @@ describe('runAssertion', () => {
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
     expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('ROUGE-N score 0.2 is less than threshold 0.75');
+    expect(result.reason).toBe('ROUGE-N score 0.17 is less than threshold 0.75');
   });
 
   // Test for starts-with assertion

--- a/typings/rouge.d.ts
+++ b/typings/rouge.d.ts
@@ -1,10 +1,32 @@
 declare module 'rouge' {
   function n(
-    candidate: string,
-    reference: string | string[],
-    n?: number,
-    jackknife?: boolean,
+    cand: string,
+    ref: string,
+    opts?: {
+      n: number,
+      nGram: (tokens: Array<string>, n: number) => Array<string>,
+      tokenizer: (input: string) => Array<string>
+    }
   ): number;
-  function l(candidate: string, reference: string | string[], jackknife?: boolean): number;
-  function s(candidate: string, reference: string | string[], jackknife?: boolean): number;
+
+  function l(
+    cand: string,
+    ref: string,
+    opts?: {
+      beta: number,
+      lcs: (a: Array<string>, b: Array<string>) => Array<string>,
+      segmenter: (input: string) => Array<string>,
+      tokenizer: (input: string) => Array<string>
+    }
+  ): number;
+
+  function s(
+    cand: string,
+    ref: string,
+    opts?: {
+      beta: number,
+      skipBigram: (tokens: Array<string>) => Array<string>,
+      tokenizer: (input: string) => Array<string>
+    }
+  ): number;
 }


### PR DESCRIPTION
Related to #761 

This upgrades the `rouge` package to fix some issues.  Unfortunately it means that there can be only 1 reference string:

```yaml
assert:
  - type: rouge-n
    value: "My reference string"
    threshold: 0.5
```

Multiple reference strings can be broken into multiple assertions.