### PR TITLE
feat: assert-set

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -34,9 +34,60 @@ tests:
 | type         | string             | Yes      | Type of assertion                                                                                       |
 | value        | string             | No       | The expected value, if applicable                                                                       |
 | threshold    | number             | No       | The threshold value, applicable only to certain types such as `similar`, `cost`, `javascript`, `python` |
-| weight       | string             | No       | How heavily to weigh the assertion. Defaults to 1.0                                                     |
+| weight       | number             | No       | How heavily to weigh the assertion. Defaults to 1.0                                                     |
 | provider     | string             | No       | Some assertions (similarity, llm-rubric, model-graded-\*) require an [LLM provider](/docs/providers)    |
 | rubricPrompt | string \| string[] | No       | Model-graded LLM prompt                                                                                 |
+
+## Grouping assertions via Assertion Sets
+
+Assertions can be grouped together using an `assert-set`.
+
+Example:
+
+```yaml
+tests:
+  - description: 'Test that the output is cheap and fast'
+    vars:
+      example: 'Hello, World!'
+    assert:
+      - type: assert-set
+        assert:
+          - type: cost
+            threshold: 0.001
+          - type: latency
+            threshold: 200
+```
+
+In the above example if all assertions of the `assert-set` pass the entire `assert-set` passes.
+
+There are cases where you may only need a certain number of assertions to pass. Here you can use `threshold`.
+
+Example - if one of two assertions need to pass or 50%:
+
+```yaml
+tests:
+  - description: 'Test that the output is cheap or fast'
+    vars:
+      example: 'Hello, World!'
+    assert:
+      - type: assert-set
+        threshold: 0.5
+        assert:
+          - type: cost
+            threshold: 0.001
+          - type: latency
+            threshold: 200
+```
+
+## Assertion Set properties
+
+| Property     | Type               | Required | Description                                                                                                           |
+| ------------ | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| type         | string             | Yes      | Must be assert-set                                                                                                    |
+| assert       | array of asserts   | Yes      | Assertions to be run for the set                                                                                      |
+| threshold    | number             | No       | Success threshold for the assert-set. Ex. 1 out of 4 equal weights assertions need to pass. Threshold should be 0.25  |
+| weight       | number             | No       | How heavily to weigh the assertion set within test assertions. Defaults to 1.0                                        |
+| metric       | string             | No       | Metric name for this assertion set within the test                                                                    |
 
 ## Assertion types
 

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -33,6 +33,7 @@ import { runPython, runPythonCode } from './python/wrapper';
 import { importModule } from './esm';
 
 import type { Assertion, AssertionType, GradingResult, AtomicTestCase, ApiProvider } from './types';
+import { AssertionsResult } from './assertions/AssertionsResult';
 
 const ASSERTIONS_MAX_CONCURRENCY = process.env.PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY
   ? parseInt(process.env.PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY, 10)
@@ -104,28 +105,18 @@ export async function runAssertions({
   logProbs?: number[];
   cost?: number;
 }): Promise<GradingResult> {
-  const tokensUsed = {
-    total: 0,
-    prompt: 0,
-    completion: 0,
-  };
   if (!test.assert || test.assert.length < 1) {
-    return { pass: true, score: 1, reason: 'No assertions', tokensUsed, assertion: null };
+    return AssertionsResult.noAssertsResult();
   }
-  let totalScore = 0;
-  let totalWeight = 0;
-  let allPass = true;
-  let failedReason = '';
-  const componentResults: GradingResult[] = [];
-  const namedScores: Record<string, number> = {};
+
+  const assertResults = new AssertionsResult();
 
   await async.forEachOfLimit(test.assert, ASSERTIONS_MAX_CONCURRENCY, async (assertion, index) => {
     if (assertion.type.startsWith('select-')) {
       // Select-type assertions are handled separately because they depend on multiple outputs.
       return;
     }
-    const weight = assertion.weight ?? 1;
-    totalWeight += weight;
+
     const result = await runAssertion({
       prompt,
       provider,
@@ -136,45 +127,18 @@ export async function runAssertions({
       logProbs,
       cost,
     });
-    totalScore += result.score * weight;
-    componentResults[Number(index)] = result;
-    if (assertion.metric) {
-      namedScores[assertion.metric] = (namedScores[assertion.metric] || 0) + result.score;
-    }
-    if (result.tokensUsed) {
-      tokensUsed.total += result.tokensUsed.total;
-      tokensUsed.prompt += result.tokensUsed.prompt;
-      tokensUsed.completion += result.tokensUsed.completion;
-    }
-    if (!result.pass) {
-      allPass = false;
-      failedReason = result.reason;
-      if (process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES) {
-        throw new Error(result.reason);
-      }
-    }
+
+    assertResults.addResult({
+      index: Number(index),
+      result,
+      metric: assertion.metric,
+      weight: assertion.weight,
+    });
   });
 
-  const finalScore = totalScore / totalWeight;
-  let finalReason = allPass ? 'All assertions passed' : failedReason;
-  if (test.threshold) {
-    // Existence of a test threshold overrides the pass/fail status of individual assertions
-    allPass = finalScore >= test.threshold;
-    if (allPass) {
-      finalReason = `Aggregate score ${finalScore.toFixed(2)} ≥ ${test.threshold} threshold`;
-    } else {
-      finalReason = `Aggregate score ${finalScore.toFixed(2)} < ${test.threshold} threshold`;
-    }
-  }
-  return {
-    pass: allPass,
-    score: finalScore,
-    namedScores: namedScores,
-    reason: finalReason,
-    tokensUsed,
-    componentResults,
-    assertion: null,
-  };
+  return assertResults.testResult({
+    threshold: test.threshold,
+  });
 }
 
 export async function runAssertion({

--- a/src/assertions/AssertionsResult.ts
+++ b/src/assertions/AssertionsResult.ts
@@ -1,0 +1,99 @@
+import { GradingResult } from '../types';
+
+const DEFAULT_TOKENS_USED = {
+  total: 0,
+  prompt: 0,
+  completion: 0,
+};
+
+export class AssertionsResult {
+  static noAssertsResult(): GradingResult {
+    return {
+      pass: true,
+      score: 1,
+      reason: 'No assertions',
+      tokensUsed: { ...DEFAULT_TOKENS_USED },
+      assertion: null,
+    };
+  }
+
+  private tokensUsed = {
+    ...DEFAULT_TOKENS_USED,
+  };
+  private totalScore: number = 0;
+  private totalWeight: number = 0;
+  private failedReason: string | undefined;
+  private componentResults: GradingResult[] = [];
+  private namedScores: Record<string, number> = {};
+  private result: GradingResult | null = null;
+
+  addResult({
+    index,
+    result,
+    metric,
+    weight = 1,
+  }: {
+    index: number;
+    result: GradingResult;
+    metric?: string;
+    weight?: number;
+  }) {
+    this.totalScore += result.score * weight;
+    this.totalWeight += weight;
+    this.componentResults[index] = result;
+
+    if (metric) {
+      this.namedScores[metric] = (this.namedScores[metric] || 0) + result.score;
+    }
+
+    if (result.tokensUsed) {
+      this.tokensUsed.total += result.tokensUsed.total;
+      this.tokensUsed.prompt += result.tokensUsed.prompt;
+      this.tokensUsed.completion += result.tokensUsed.completion;
+    }
+
+    if (result.pass) {
+      return;
+    }
+
+    this.failedReason = result.reason;
+
+    if (process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES) {
+      throw new Error(result.reason);
+    }
+  }
+
+  testResult({ threshold }: { threshold?: number }): GradingResult {
+    if (this.result) {
+      return this.result;
+    }
+
+    const score = this.totalScore / this.totalWeight;
+    let pass = !this.failedReason;
+
+    let reason = !this.failedReason ? 'All assertions passed' : this.failedReason;
+
+    if (threshold) {
+      // Existence of a test threshold overrides the pass/fail status of individual assertions
+      pass = score >= threshold;
+
+      if (pass) {
+        reason = `Aggregate score ${score.toFixed(2)} ≥ ${threshold} threshold`;
+      } else {
+        reason = `Aggregate score ${score.toFixed(2)} < ${threshold} threshold`;
+      }
+    }
+
+    this.result = {
+      pass,
+      score,
+      reason,
+      namedScores: this.namedScores,
+      tokensUsed: this.tokensUsed,
+      componentResults: this.componentResults,
+      assertion: null,
+    };
+
+    return this.result;
+  }
+}

--- a/src/assertions/validateAssertions.ts
+++ b/src/assertions/validateAssertions.ts
@@ -1,0 +1,36 @@
+import { TestCase } from '../types';
+
+export class AssertValiationError extends Error {
+  constructor(message: string, testCase: TestCase) {
+    const testCaseDescription = testCase.description || JSON.stringify(testCase);
+
+    super(`${message} in:\n${testCaseDescription}`);
+    this.name = 'AssertValiationError';
+  }
+}
+
+export function validateAssertions(tests: TestCase<Record<string, string | object | string[]>>[]) {
+  for (const test of tests) {
+    if (test.assert) {
+      for (const assertion of test.assert) {
+        if (assertion.type === 'assert-set') {
+          validateAssertSet(assertion, test);
+        }
+      }
+    }
+  }
+}
+
+function validateAssertSet(assertion: object, test: TestCase) {
+  if (!('assert' in assertion)) {
+    throw new AssertValiationError('assert-set must have an `assert` property', test);
+  }
+
+  if (!Array.isArray(assertion.assert)) {
+    throw new AssertValiationError('assert-set `assert` must be an array of assertions', test);
+  }
+
+  if (assertion.assert.some((assertion) => assertion.type === 'assert-set')) {
+    throw new AssertValiationError('assert-set must not have child assert-sets', test);
+  }
+}

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -33,6 +33,7 @@ import type {
   RunEvalOptions,
   TestSuite,
   ProviderResponse,
+  Assertion,
 } from './types';
 export const DEFAULT_MAX_CONCURRENCY = 4;
 
@@ -903,7 +904,7 @@ class Evaluator {
 
     for (let index = 0; index < table.body.length; index++) {
       const row = table.body[index];
-      const compareAssertion = row.test.assert?.find((a) => a.type === 'select-best');
+      const compareAssertion = row.test.assert?.find((a) => a.type === 'select-best') as Assertion;
       if (compareAssertion) {
         const outputs = row.outputs.map((o) => o.text);
         const gradingResults = await runCompareAssertion(row.test, compareAssertion, outputs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,10 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     }
     if (test.assert) {
       for (const assertion of test.assert) {
+        if (assertion.type === 'assert-set' || typeof assertion.provider === 'function') {
+          continue;
+        }
+
         if (assertion.provider) {
           if (typeof assertion.provider === 'object') {
             const casted = assertion.provider as ProviderOptions;
@@ -79,7 +83,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
           } else if (typeof assertion.provider === 'string') {
             assertion.provider = await loadApiProvider(assertion.provider);
           } else {
-            // It's a function, no need to do anything
+            throw new Error('Invalid provider type');
           }
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ import type {
 import { generateTable } from './table';
 import { createShareableUrl } from './share';
 import { filterTests } from './commands/eval/filterTests';
+import { validateAssertions } from './assertions/validateAssertions';
 
 function createDummyFiles(directory: string | null) {
   if (directory) {
@@ -221,6 +222,11 @@ async function resolveConfigs(
       fileConfig.nunjucksFilters || defaultConfig.nunjucksFilters || {},
     ),
   };
+
+  if (testSuite.tests) {
+    validateAssertions(testSuite.tests);
+  }
+
   return { config, testSuite, basePath };
 }
 
@@ -555,7 +561,10 @@ async function main() {
       defaultConfig?.evaluateOptions?.interactiveProviders,
     )
     .option('-n, --filter-first-n <number>', 'Only run the first N tests')
-    .option('--filter-pattern <pattern>', 'Only run tests whose description matches the regular expression pattern')
+    .option(
+      '--filter-pattern <pattern>',
+      'Only run tests whose description matches the regular expression pattern',
+    )
     .option('--filter-failing <path>', 'Path to json output file')
     .option(
       '--var <key=value>',

--- a/src/providers/azureopenaiUtil.ts
+++ b/src/providers/azureopenaiUtil.ts
@@ -26,7 +26,11 @@ export function maybeEmitAzureOpenAiWarning(testSuite: TestSuite, tests: TestCas
   if (hasAzure && !hasOpenAi && !testSuite.defaultTest?.options?.provider) {
     const modelGradedAsserts = tests.flatMap((t) =>
       (t.assert || []).filter(
-        (a) => MODEL_GRADED_ASSERTION_TYPES.has(a.type) && !a.provider && !t.options?.provider,
+        (a) =>
+          a.type !== 'assert-set' &&
+          MODEL_GRADED_ASSERTION_TYPES.has(a.type) &&
+          !a.provider &&
+          !t.options?.provider,
       ),
     );
     if (modelGradedAsserts.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import type logger from "./logger";
-import type { fetchWithCache, getCache } from "./cache";
+import type logger from './logger';
+import type { fetchWithCache, getCache } from './cache';
 
 export type FilePath = string;
 
@@ -33,7 +33,7 @@ export interface CommandLineOptions {
   filterFailing?: string;
   filterFirstN?: string;
   filterPattern?: string;
-  var?: Record<string, string>
+  var?: Record<string, string>;
 
   generateSuggestions?: boolean;
   promptPrefix?: string;
@@ -403,6 +403,22 @@ type NotPrefixed<T extends string> = `not-${T}`;
 
 export type AssertionType = BaseAssertionTypes | NotPrefixed<BaseAssertionTypes>;
 
+export interface AssertionSet {
+  type: 'assert-set';
+
+  // Sub assertions to be run for this assertion set
+  assert: Assertion[];
+
+  // The weight of this assertion compared to other assertions in the test case. Defaults to 1.
+  weight?: number;
+
+  // Tag this assertion result as a named metric
+  metric?: string;
+
+  // The required score for this assert set. If not provided, the test case is graded pass/fail.
+  threshold?: number;
+}
+
 // TODO(ian): maybe Assertion should support {type: config} to make the yaml cleaner
 export interface Assertion {
   // Type of assertion
@@ -476,7 +492,7 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
   providerOutput?: string | object;
 
   // Optional list of automatic checks to run on the LLM output
-  assert?: Assertion[];
+  assert?: (AssertionSet | Assertion)[];
 
   // Additional configuration settings for the prompt
   options?: PromptConfig &

--- a/test/assertions/AssertionResult.test.ts
+++ b/test/assertions/AssertionResult.test.ts
@@ -1,0 +1,173 @@
+import { AssertionSet, TestCase } from '../../src/types';
+
+import { AssertionsResult } from '../../src/assertions/AssertionsResult';
+import { satisfies } from 'semver';
+
+describe('AssertionsResult', () => {
+  const succeedingResult = {
+    pass: true,
+    score: 1,
+    reason: 'The succeeding reason',
+    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+    assertion: null,
+  };
+  const failingResult = {
+    pass: false,
+    score: 0,
+    reason: 'The failing reason',
+    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+    assertion: null,
+  };
+  const testResult = {
+    pass: true,
+    score: 1,
+    reason: 'All assertions passed',
+    componentResults: [succeedingResult],
+    namedScores: {},
+    assertion: null,
+    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+  };
+  let assertionsResult: AssertionsResult;
+
+  beforeEach(() => {
+    assertionsResult = new AssertionsResult();
+  });
+
+  it('can return a succeeding testResult', () => {
+    assertionsResult.addResult({
+      index: 0,
+      result: succeedingResult,
+    });
+
+    expect(assertionsResult.testResult()).toEqual(testResult);
+  });
+
+  it('can return a failing testResult', () => {
+    assertionsResult.addResult({
+      index: 0,
+      result: failingResult,
+    });
+
+    expect(assertionsResult.testResult()).toEqual({
+      ...testResult,
+      pass: false,
+      reason: failingResult.reason,
+      score: 0,
+      componentResults: [failingResult],
+    });
+  });
+
+  it('handles PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES', () => {
+    const initialEnv = process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES;
+    process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = 'true';
+
+    expect(() =>
+      assertionsResult.addResult({
+        index: 0,
+        result: failingResult,
+      }),
+    ).toThrowError(new Error(failingResult.reason));
+
+    process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = initialEnv;
+  });
+
+  it('handles named metrics', () => {
+    const metric = 'metric-name';
+
+    assertionsResult.addResult({
+      index: 0,
+      metric,
+      result: succeedingResult,
+    });
+
+    expect(assertionsResult.testResult()).toEqual({
+      ...testResult,
+      namedScores: {
+        [metric]: 1,
+      },
+    });
+  });
+
+  it('handles result without tokensUsed', () => {
+    const resultWithoutTokensUsed = {
+      ...succeedingResult,
+      tokensUsed: undefined,
+    };
+
+    assertionsResult.addResult({
+      index: 0,
+      result: resultWithoutTokensUsed,
+    });
+
+    expect(assertionsResult.testResult()).toEqual({
+      ...testResult,
+      componentResults: [resultWithoutTokensUsed],
+      tokensUsed: { total: 0, prompt: 0, completion: 0 },
+    });
+  });
+
+  it('respects succeeding threshold', () => {
+    const threshold = 0.5;
+
+    assertionsResult = new AssertionsResult({ threshold });
+
+    assertionsResult.addResult({
+      index: 0,
+      result: succeedingResult,
+    });
+
+    expect(assertionsResult.testResult()).toEqual({
+      ...testResult,
+      reason: 'Aggregate score 1.00 ≥ 0.5 threshold',
+    });
+  });
+
+  it('respects failing threshold', () => {
+    const threshold = 0.5;
+    const failingResult = {
+      ...succeedingResult,
+      score: 0.4,
+    };
+
+    assertionsResult = new AssertionsResult({ threshold });
+
+    assertionsResult.addResult({
+      index: 0,
+      result: failingResult,
+    });
+
+    expect(assertionsResult.testResult()).toEqual({
+      ...testResult,
+      pass: false,
+      reason: 'Aggregate score 0.40 < 0.5 threshold',
+      score: 0.4,
+      componentResults: [failingResult],
+    });
+  });
+
+  it('can use a parentAssertionSet', () => {
+    const parentAssertionSet = {
+      index: 3,
+      assertionSet: {
+        type: 'assert-set',
+        assert: [],
+      } satisfies AssertionSet,
+    };
+
+    assertionsResult = new AssertionsResult({ parentAssertionSet });
+
+    expect(assertionsResult.parentAssertionSet).toBe(parentAssertionSet);
+  });
+
+  describe('noAssertsResult', () => {
+    it('returns correct value', () => {
+      expect(AssertionsResult.noAssertsResult()).toEqual({
+        pass: true,
+        score: 1,
+        reason: 'No assertions',
+        tokensUsed: { total: 0, prompt: 0, completion: 0 },
+        assertion: null,
+      });
+    });
+  });
+});

--- a/test/assertions/validateAssertions.test.ts
+++ b/test/assertions/validateAssertions.test.ts
@@ -1,0 +1,55 @@
+import { TestCase } from '../../src/types';
+
+import { validateAssertions, AssertValiationError } from '../../src/assertions/validateAssertions';
+
+describe('validateAssertions', () => {
+  const test: TestCase = {
+    description: 'The test case',
+  };
+
+  describe('asssert-set', () => {
+    function testCaseWithAssertSet(assertSet: object) {
+      return {
+        ...test,
+        assert: [{ type: 'assert-set', ...assertSet } as any],
+      };
+    }
+
+    it('does not fail on valid assert-set', () => {
+      const test = testCaseWithAssertSet({
+        assert: [
+          {
+            type: 'equals',
+            value: 'Expected output',
+          },
+        ],
+      });
+
+      expect(() => validateAssertions([test])).not.toThrow();
+    });
+
+    it('has assert', () => {
+      const test = testCaseWithAssertSet({});
+
+      expect(() => validateAssertions([test])).toThrow(
+        new AssertValiationError('assert-set must have an `assert` property', test),
+      );
+    });
+
+    it('has assert as an array', () => {
+      const test = testCaseWithAssertSet({ assert: {} });
+
+      expect(() => validateAssertions([test])).toThrow(
+        new AssertValiationError('assert-set `assert` must be an array of assertions', test),
+      );
+    });
+
+    it('does not have child assert-sets', () => {
+      const test = testCaseWithAssertSet({ assert: [{ type: 'assert-set' }] });
+
+      expect(() => validateAssertions([test])).toThrow(
+        new AssertValiationError('assert-set must not have child assert-sets', test),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/promptfoo/promptfoo/issues/757

## What

This PR implements a new feature `assert-set`. It groups assertions.

Example:
```
assert:
    - type: context-faithfulness
      threshold: 0.9
      metric: Groundedness
    - type: assert-set
      assert:
        - type: equals
           value: 'Hello, World!'
        - type: contains
           value: 'World'
```

The assertions within an `assert-set` determine of the success/failure of the entire `assert-set`.

A threshold can be used if not all assertions are required to pass:
```
assert:
    - type: context-faithfulness
      threshold: 0.9
      metric: Groundedness
    - type: assert-set
      threshold: 0.5
      assert:
        - type: equals
           value: 'Hello, World!'
        - type: contains
           value: 'World'
```

In the above example only one of the assertions needs to pass for the entire `assert-set` to succeed.

`weight` and `metric` can also be used on an `assert-set`. This function the same as any other assertion. They are used for `TestCase` results and don't modify the execution of child assertions of the `assert-set`.

## How

An aim for this PR was to keep the running of assertions as simple as possible and to ensure we can have maximum concurrency when running assertions.

This aim keeps the running of assertions as a flat array. The assertions from the `assert-set` are flattened to be run with all other assertions.

To group these assertions a class `AssertionsResult` is introduced which aggregates the results of the assert set. It also isolates result calculations to be outside of the running of assertions hopefully making the code be more testable in isolation.

For simplicity (for now) `assert-sets` cannot contain `assert-sets`.