### PR TITLE
Check runtime type of `getPrompt`, stringify the result

### DIFF
--- a/src/integrations/langfuse.ts
+++ b/src/integrations/langfuse.ts
@@ -1,17 +1,18 @@
 const langfuseParams = {
-    publicKey: process.env.LANGFUSE_PUBLIC_KEY,
-    secretKey: process.env.LANGFUSE_SECRET_KEY,
-    baseUrl: process.env.LANGFUSE_HOST,
-}
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_HOST,
+};
 
 import { Langfuse } from 'langfuse';
 
 const langfuse = new Langfuse(langfuseParams);
 
-export async function getPrompt(
-    id: string,
-    version?: number,
-): Promise<string> {
-    const prompt = await langfuse.getPrompt(id, version);
-    return prompt.getLangchainPrompt();
+export async function getPrompt(id: string, version?: number): Promise<string> {
+  const prompt = await langfuse.getPrompt(id, version);
+  const outputPrompt = prompt.getLangchainPrompt();
+  if (typeof outputPrompt !== 'string') {
+    return JSON.stringify(outputPrompt);
+  }
+  return outputPrompt;
 }


### PR DESCRIPTION
# Problem

![image](https://github.com/promptfoo/promptfoo/assets/14824254/47175fb7-0214-4703-b17d-690af267f37e)
Langfuse integration fails when prompt is `chat` type. It produces error `prompt.trim is not a function`

Langfuse has 2 different types of return values. `string` and `ChatMessage[]` when we're returning the output of `getLangchainPrompt(()`

We currently assume that `getPrompt` always returns `string`. But in reality, it can return either `string` or `ChatMessage[]`.

The solution that I propose here is simple, to stringify the output of `getLangchainPrompt` if the output is not string. However, the ideal situation is probably to let the prompt definition in the config to include the type of the prompt 

For example:
- instead of `langfuse://test-prompt:1`, we do `langfuse://test-prompt:1:chat` to indicate that this is a chat prompt, and do proper configuration.

# Solution

Stringify the result of `getLangchainPrompt`. 