### PR TITLE
Langfuse need to compile variables

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -197,8 +197,19 @@ export async function renderPrompt(
   } else if (prompt.raw.startsWith('langfuse://')) {
     const { getPrompt } = await import('./integrations/langfuse');
     const langfusePrompt = prompt.raw.slice('langfuse://'.length);
-    const [helper, version] = langfusePrompt.split(':');
-    const langfuseResult = await getPrompt(helper, Number(version));
+
+    // we default to "text" type.
+    const [helper, version, promptType = 'text'] = langfusePrompt.split(':');
+    if (promptType !== 'text' && promptType !== 'chat') {
+      throw new Error('Unknown promptfoo prompt type');
+    }
+
+    const langfuseResult = await getPrompt(
+      helper,
+      vars,
+      promptType,
+      version !== 'latest' ? Number(version) : undefined,
+    );
     return langfuseResult;
   }
 

--- a/src/integrations/langfuse.ts
+++ b/src/integrations/langfuse.ts
@@ -8,11 +8,21 @@ import { Langfuse } from 'langfuse';
 
 const langfuse = new Langfuse(langfuseParams);
 
-export async function getPrompt(id: string, version?: number): Promise<string> {
-  const prompt = await langfuse.getPrompt(id, version);
-  const outputPrompt = prompt.getLangchainPrompt();
-  if (typeof outputPrompt !== 'string') {
-    return JSON.stringify(outputPrompt);
+export async function getPrompt(
+  id: string,
+  vars: Record<string, any>,
+  type: 'text' | 'chat' | undefined,
+  version?: number,
+): Promise<string> {
+  let prompt;
+  if (type === 'text' || type === undefined) {
+    prompt = await langfuse.getPrompt(id, version, { type: 'text' });
+  } else {
+    prompt = await langfuse.getPrompt(id, version, { type: 'chat' });
   }
-  return outputPrompt;
+  const compiledPrompt = prompt.compile(vars);
+  if (typeof compiledPrompt !== 'string') {
+    return JSON.stringify(compiledPrompt);
+  }
+  return compiledPrompt;
 }


### PR DESCRIPTION
## The problem
Continuing on https://github.com/promptfoo/promptfoo/pull/774, I just realized that the langfuse integration doesn't actually compile the variables inside the prompt. (Link to [docs](https://www.promptfoo.dev/docs/integrations/langfuse))

This PR makes sure that the variables are compiled to langfuse prompt client.

## Additional things

- Allow user to use "latest" string for grabbing the latest version of their prompt.
- Allow user to specify the prompt type. -> I think we don't need this, but for type safety purposes, maybe we should? I also made sure that the default still works by auto assigning it to `text` type if user doesn't specify it.