### PR TITLE
feat: support var interpolation in function calls

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -571,6 +571,7 @@ export async function runAssertion({
         validateFunctionCall(
           toolOutput.function,
           (provider as OpenAiChatCompletionProvider).config.tools?.map((tool) => tool.function),
+          test.vars,
         ),
       );
       return {
@@ -609,6 +610,7 @@ export async function runAssertion({
       validateFunctionCall(
         functionOutput,
         (provider as OpenAiChatCompletionProvider).config.functions,
+        test.vars,
       );
       return {
         pass: true,

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -1,8 +1,9 @@
 import invariant from 'tiny-invariant';
 
 import logger from '../logger';
-import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase } from './shared';
 import { fetchWithCache } from '../cache';
+import { renderVarsInObject } from '../util';
+import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase } from './shared';
 
 import type {
   AssistantsClient,
@@ -357,10 +358,10 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
         this.config.presence_penalty ?? parseFloat(process.env.OPENAI_PRESENCE_PENALTY || '0'),
       frequency_penalty:
         this.config.frequency_penalty ?? parseFloat(process.env.OPENAI_FREQUENCY_PENALTY || '0'),
-      functions: this.config.functions || undefined,
-      function_call: this.config.function_call || undefined,
+      ...(this.config.functions ? { functions: renderVarsInObject(this.config.functions, context?.vars) } : {}),
+      ...(this.config.function_call ? { function_call: this.config.function_call } : {}),
       ...(this.config.seed !== undefined ? { seed: this.config.seed } : {}),
-      ...(this.config.tools ? { tools: this.config.tools } : {}),
+      ...(this.config.tools ? { tools: renderVarsInObject(this.config.tools, context?.vars) } : {}),
       ...(this.config.tool_choice ? { tool_choice: this.config.tool_choice } : {}),
       ...(this.config.deployment_id ? { deployment_id: this.config.deployment_id } : {}),
       ...(this.config.dataSources ? { dataSources: this.config.dataSources } : {}),

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 
 import logger from '../logger';
 import { fetchWithCache, getCache, isCacheEnabled } from '../cache';
+import { renderVarsInObject } from '../util';
 import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase } from './shared';
 import { OpenAiFunction, OpenAiTool } from './openaiUtil';
 
@@ -428,9 +429,11 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         this.config.presence_penalty ?? parseFloat(process.env.OPENAI_PRESENCE_PENALTY || '0'),
       frequency_penalty:
         this.config.frequency_penalty ?? parseFloat(process.env.OPENAI_FREQUENCY_PENALTY || '0'),
-      ...(this.config.functions ? { functions: this.config.functions } : {}),
+      ...(this.config.functions
+        ? { functions: renderVarsInObject(this.config.functions, context?.vars) }
+        : {}),
       ...(this.config.function_call ? { function_call: this.config.function_call } : {}),
-      ...(this.config.tools ? { tools: this.config.tools } : {}),
+      ...(this.config.tools ? { tools: renderVarsInObject(this.config.tools, context?.vars) } : {}),
       ...(this.config.tool_choice ? { tool_choice: this.config.tool_choice } : {}),
       ...(this.config.response_format ? { response_format: this.config.response_format } : {}),
       ...(callApiOptions?.includeLogProbs ? { logprobs: callApiOptions.includeLogProbs } : {}),
@@ -575,7 +578,11 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
     this.assistantId = assistantId;
   }
 
-  async callApi(prompt: string): Promise<ProviderResponse> {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    callApiOptions?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
     if (!this.getApiKey()) {
       throw new Error(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
@@ -599,7 +606,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
       assistant_id: this.assistantId,
       model: this.assistantConfig.modelName || undefined,
       instructions: this.assistantConfig.instructions || undefined,
-      tools: this.assistantConfig.tools || undefined,
+      tools: renderVarsInObject(this.assistantConfig.tools, context?.vars) || undefined,
       metadata: this.assistantConfig.metadata || undefined,
       temperature: this.assistantConfig.temperature || undefined,
       tool_choice: this.assistantConfig.toolChoice || undefined,

--- a/src/providers/openaiUtil.ts
+++ b/src/providers/openaiUtil.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv';
-import { getNunjucksEngine } from '../util';
+import { getNunjucksEngine, renderVarsInObject } from '../util';
 
 const ajv = new Ajv();
 
@@ -17,11 +17,13 @@ export interface OpenAiTool {
 export function validateFunctionCall(
   functionCall: { arguments: string; name: string },
   functions?: OpenAiFunction[],
+  vars?: Record<string, string | object>,
 ) {
   // Parse function call and validate it against schema
+  const interpolatedFunctions = renderVarsInObject(functions, vars);
   const functionArgs = JSON.parse(functionCall.arguments);
   const functionName = functionCall.name;
-  const functionSchema = functions?.find((f) => f.name === functionName)?.parameters;
+  const functionSchema = interpolatedFunctions?.find((f) => f.name === functionName)?.parameters;
   if (!functionSchema) {
     throw new Error(`Called "${functionName}", but there is no function with that name`);
   }

--- a/src/providers/openaiUtil.ts
+++ b/src/providers/openaiUtil.ts
@@ -1,4 +1,5 @@
 import Ajv from 'ajv';
+import { getNunjucksEngine } from '../util';
 
 const ajv = new Ajv();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1307,23 +1307,23 @@ export function safeJsonStringify(value: any): string {
   });
 }
 
-export function renderVarsInObject(obj: any, vars?: Record<string, string | object>): any {
+export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | object>): T {
   // Renders nunjucks template strings with context variables
   if (!vars || process.env.PROMPTFOO_DISABLE_TEMPLATING) {
     return obj;
   }
   if (typeof obj === 'string') {
-    return nunjucks.renderString(obj, vars);
+    return nunjucks.renderString(obj, vars) as unknown as T;
   }
   if (Array.isArray(obj)) {
-    return obj.map((item) => renderVarsInObject(item, vars));
+    return obj.map((item) => renderVarsInObject(item, vars)) as unknown as T;
   }
   if (typeof obj === 'object' && obj !== null) {
-    const result: any = {};
+    const result: Record<string, unknown> = {};
     for (const key in obj) {
-      result[key] = renderVarsInObject(obj[key], vars);
+      result[key] = renderVarsInObject((obj as Record<string, unknown>)[key], vars);
     }
-    return result;
+    return result as T;
   }
   return obj;
 }


### PR DESCRIPTION
Allows you to use nunjucks variables in OpenAI `tools`/`functions`.  For example:

```yaml
prompts:
  - 'What is the weather like in {{city}}?'

providers:
  - id: openai:chat:gpt-3.5-turbo-0613
    config:
      tools: [
        {
          "type": "function",
          "function": {
            "name": "{{ functionName }}",
            "description": "Get the current weather in a given location",
            "parameters": {
              "type": "object",
              "properties": {
                "location": {
                  "type": "string",
                  "description": "The city and state, e.g. San Francisco, CA"
                },
                "unit": {
                  "type": "string",
                  "enum": ["celsius", "fahrenheit"]
                }
              },
              "required": ["location"]
            }
          }
        }
      ]

tests:
  - vars:
      city: Boston
      functionName: get_current_weather
    assert:
      - type: is-valid-openai-tools-call
      - type: javascript
        value: output[0].function.name === 'get_current_weather'
      - type: javascript
        value: JSON.parse(output[0].function.arguments).location === 'Boston, MA'
```
Related #775 