### PR TITLE
feat(bedrock): add support for embeddings models

### DIFF
--- a/examples/amazon-bedrock/promptfooconfig.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.yaml
@@ -1,8 +1,23 @@
 prompts: [prompts.txt]
+
 providers: [bedrock:anthropic.claude-v2]
+
+defaultTest:
+  options:
+    provider:
+      # Override the embeddings provider for all assertion types that require it (such as similarity)
+      embedding:
+        id: bedrock:embeddings:amazon.titan-embed-text-v2:0
+        config:
+          region: us-east-1
+
 tests:
   - vars:
       question: What's the weather in New York?
+    assert:
+      # This uses the embeddings provider set above
+      - type: similar
+        value: sunny
   - vars:
       question: Who won the latest football match between the Giants and 49ers?
   - vars:
@@ -20,7 +35,8 @@ tests:
   - vars:
       question: "Which genus of moth in the world's seventh-largest country contains only one species?"
   - vars:
-      question: 'Who was once considered the best kick boxer in the world, however he has been involved in a number of controversies relating to his "unsportsmanlike conducts" in the sport and crimes of violence outside of the ring.'
+      question: 'Who was once considered the best kick boxer in the world, however he has been involved in a number of controversies relating to his "unsportsm
+nlike conducts" in the sport and crimes of violence outside of the ring.'
   - vars:
       question: 'The Dutch-Belgian television series that "House of Anubis" was based on first aired in what year?'
   - vars:
@@ -73,3 +89,29 @@ tests:
       question: 'Who was inducted into the Rock and Roll Hall of Fame, David Lee Roth or Cia Berg?'
   - vars:
       question: "Zimbabwe's Guwe Secondary School has a sister school in what New York county?"
+    assert:
+  - vars:
+      question: 'Who is the director of the 2003 film which has scenes in it fi
+med at the Quality Cafe in Los Angeles?'
+  - vars:
+      question: "Which actress played the part of fictitious character Kimberly
+Ann Hart, in the franchise built around a live action superhero television seri
+s taking much of its footage from the Japanese tokusatsu 'Super Sentai'?"
+  - vars:
+      question: 'Who was born first, Pablo Trapero or Aleksander Ford?'
+  - vars:
+      question: "Are Jane and First for Women both women's magazines?"
+  - vars:
+      question: 'What profession does Nicholas Ray and Elia Kazan have in commo
+?'
+  - vars:
+      question: 'Where is the company that purchased Aixam based in?'
+  - vars:
+      question: 'Which documentary is about Finnish rock groups, Adam Clayton P
+well or The Saimaa Gesture?'
+  - vars:
+      question: 'Who was inducted into the Rock and Roll Hall of Fame, David Le
+ Roth or Cia Berg?'
+  - vars:
+      question: "Zimbabwe's Guwe Secondary School has a sister school in what N
+ew York county?"

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -98,9 +98,11 @@ assert:
   - type: llm-rubric
     value: Do not mention that you are an AI or chat assistant
     provider:
-      id: provider:chat:modelname
-      config:
-        # Provider config options
+      text:
+        id: provider:chat:modelname
+        config:
+          region: us-east-1
+          # Other provider config options...
 ```
 
 Or individual tests:
@@ -118,4 +120,18 @@ tests:
     assert:
       - type: llm-rubric
         value: Do not mention that you are an AI or chat assistant
+```
+
+## Embeddings
+
+To override the embeddings provider for all assertions that require embeddings (such as similarity), use `defaultTest`:
+
+```yaml
+defaultTest:
+  options:
+    provider:
+      embedding:
+        id: bedrock:embeddings:amazon.titan-embed-text-v2:0
+        config:
+          region: us-east-1
 ```

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -43,7 +43,7 @@ import {
   HuggingfaceTextGenerationProvider,
   HuggingfaceTokenExtractionProvider,
 } from './providers/huggingface';
-import { AwsBedrockCompletionProvider } from './providers/bedrock';
+import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './providers/bedrock';
 import { PythonProvider } from './providers/pythonCompletion';
 import { CohereChatCompletionProvider } from './providers/cohere';
 import { BAMChatProvider, BAMEmbeddingProvider } from './providers/bam';
@@ -225,11 +225,14 @@ export async function loadApiProvider(
     if (modelType === 'completion') {
       // Backwards compatibility: `completion` used to be required
       ret = new AwsBedrockCompletionProvider(modelName, providerOptions);
+    } else if (modelType === 'embeddings' || modelType === 'embedding') {
+      ret = new AwsBedrockEmbeddingProvider(modelName, providerOptions);
+    } else {
+      ret = new AwsBedrockCompletionProvider(
+        `${modelType}${modelName ? `:${modelName}` : ''}`,
+        providerOptions,
+      );
     }
-    ret = new AwsBedrockCompletionProvider(
-      `${modelType}${modelName ? `:${modelName}` : ''}`,
-      providerOptions,
-    );
   } else if (providerPath.startsWith('huggingface:') || providerPath.startsWith('hf:')) {
     const splits = providerPath.split(':');
     if (splits.length < 3) {

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -6,8 +6,13 @@ import { parseMessages } from './anthropic';
 
 import type { BedrockRuntime } from '@aws-sdk/client-bedrock-runtime';
 
-import type { ApiProvider, EnvOverrides, ProviderResponse, ProviderEmbeddingResponse } from '../types.js';
-import { ApiEmbeddingProvider } from 'promptfoo';
+import type {
+  ApiProvider,
+  ApiEmbeddingProvider,
+  EnvOverrides,
+  ProviderResponse,
+  ProviderEmbeddingResponse,
+} from '../types.js';
 
 interface BedrockOptions {
   region?: string;
@@ -131,11 +136,11 @@ export abstract class AwsBedrockGenericProvider {
   id(): string {
     return `bedrock:${this.modelName}`;
   }
-  
+
   toString(): string {
     return `[Amazon Bedrock Provider ${this.modelName}]`;
   }
-  
+
   async getBedrockInstance() {
     if (!this.bedrock) {
       try {
@@ -234,7 +239,10 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
   }
 }
 
-export class AwsBedrockEmbeddingProvider extends AwsBedrockGenericProvider implements ApiEmbeddingProvider {
+export class AwsBedrockEmbeddingProvider
+  extends AwsBedrockGenericProvider
+  implements ApiEmbeddingProvider
+{
   async callApi(): Promise<ProviderEmbeddingResponse> {
     throw new Error('callApi is not implemented for embedding provider');
   }
@@ -259,7 +267,11 @@ export class AwsBedrockEmbeddingProvider extends AwsBedrockGenericProvider imple
         error: `API call error: ${String(err)}`,
       };
     }
-    logger.debug(`\tAWS Bedrock API response (embeddings): ${JSON.stringify(response.body.transformToString())}`);
+    logger.debug(
+      `\tAWS Bedrock API response (embeddings): ${JSON.stringify(
+        response.body.transformToString(),
+      )}`,
+    );
 
     try {
       const data = JSON.parse(response.body.transformToString());
@@ -272,9 +284,10 @@ export class AwsBedrockEmbeddingProvider extends AwsBedrockGenericProvider imple
       };
     } catch (err) {
       return {
-        error: `API response error: ${String(err)}: ${JSON.stringify(response.body.transformToString())}`,
+        error: `API response error: ${String(err)}: ${JSON.stringify(
+          response.body.transformToString(),
+        )}`,
       };
     }
   }
 }
-

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -2,11 +2,12 @@ import Anthropic from '@anthropic-ai/sdk';
 
 import logger from '../logger';
 import { getCache, isCacheEnabled } from '../cache';
+import { parseMessages } from './anthropic';
 
 import type { BedrockRuntime } from '@aws-sdk/client-bedrock-runtime';
 
-import type { ApiProvider, EnvOverrides, ProviderResponse } from '../types.js';
-import { parseMessages } from './anthropic';
+import type { ApiProvider, EnvOverrides, ProviderResponse, ProviderEmbeddingResponse } from '../types.js';
+import { ApiEmbeddingProvider } from 'promptfoo';
 
 interface BedrockOptions {
   region?: string;
@@ -110,13 +111,11 @@ function getHandlerForModel(modelName: string) {
   throw new Error(`Unknown Amazon Bedrock model: ${modelName}`);
 }
 
-export class AwsBedrockCompletionProvider implements ApiProvider {
-  static AWS_BEDROCK_COMPLETION_MODELS = Object.keys(AWS_BEDROCK_MODELS);
-
+export abstract class AwsBedrockGenericProvider {
   modelName: string;
-  config: BedrockOptions;
   env?: EnvOverrides;
   bedrock?: BedrockRuntime;
+  config: BedrockOptions;
 
   constructor(
     modelName: string,
@@ -132,7 +131,11 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
   id(): string {
     return `bedrock:${this.modelName}`;
   }
-
+  
+  toString(): string {
+    return `[Amazon Bedrock Provider ${this.modelName}]`;
+  }
+  
   async getBedrockInstance() {
     if (!this.bedrock) {
       try {
@@ -147,10 +150,6 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
     return this.bedrock;
   }
 
-  toString(): string {
-    return `[Amazon Bedrock Provider ${this.modelName}]`;
-  }
-
   getRegion(): string {
     return (
       this.config?.region ||
@@ -159,6 +158,10 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
       'us-west-2'
     );
   }
+}
+
+export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider implements ApiProvider {
+  static AWS_BEDROCK_COMPLETION_MODELS = Object.keys(AWS_BEDROCK_MODELS);
 
   async callApi(prompt: string): Promise<ProviderResponse> {
     let stop: string[];
@@ -230,3 +233,48 @@ export class AwsBedrockCompletionProvider implements ApiProvider {
     }
   }
 }
+
+export class AwsBedrockEmbeddingProvider extends AwsBedrockGenericProvider implements ApiEmbeddingProvider {
+  async callApi(): Promise<ProviderEmbeddingResponse> {
+    throw new Error('callApi is not implemented for embedding provider');
+  }
+
+  async callEmbeddingApi(text: string): Promise<ProviderEmbeddingResponse> {
+    const params = {
+      inputText: text,
+    };
+
+    logger.debug(`Calling AWS Bedrock API for embeddings: ${JSON.stringify(params)}`);
+    let response;
+    try {
+      const bedrockInstance = await this.getBedrockInstance();
+      response = await bedrockInstance.invokeModel({
+        modelId: this.modelName,
+        accept: 'application/json',
+        contentType: 'application/json',
+        body: JSON.stringify(params),
+      });
+    } catch (err) {
+      return {
+        error: `API call error: ${String(err)}`,
+      };
+    }
+    logger.debug(`\tAWS Bedrock API response (embeddings): ${JSON.stringify(response.body.transformToString())}`);
+
+    try {
+      const data = JSON.parse(response.body.transformToString());
+      const embedding = data?.embedding;
+      if (!embedding) {
+        throw new Error('No embedding found in AWS Bedrock API response');
+      }
+      return {
+        embedding,
+      };
+    } catch (err) {
+      return {
+        error: `API response error: ${String(err)}: ${JSON.stringify(response.body.transformToString())}`,
+      };
+    }
+  }
+}
+


### PR DESCRIPTION
Related to #795 

For example:

```yaml
prompts: [prompts.txt]

providers: [bedrock:anthropic.claude-v2]

defaultTest:
  options:
    provider:
      # Override the embeddings provider for all assertion types that require it (such as similarity)
      embedding:
        id: bedrock:embeddings:amazon.titan-embed-text-v2:0
        config:
          region: us-east-1

tests:
  - vars:
      question: What's the weather in New York?
    assert:
      # This uses the embeddings provider set above
      - type: similar
        value: sunny
```