### PR TITLE
feat: support for deep equality check in equals assertion

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -198,7 +198,7 @@ assert:
     value: { 'key': 'value' }
 ```
 
-If your JSON schema is large, import it from a file:
+If your expected JSON is large, import it from a file:
 
 ```yaml
 assert:

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -190,6 +190,22 @@ assert:
     value: 'The expected output'
 ```
 
+You can also check whether it matches the expected JSON format.
+
+```yaml
+assert:
+  - type: equals
+    value: { 'key': 'value' }
+```
+
+If your JSON schema is large, import it from a file:
+
+```yaml
+assert:
+  - type: equals
+    value: "file://path/to/expected.json"
+```
+
 ### Is-JSON
 
 The `is-json` assertion checks if the LLM output is a valid JSON string.

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execFile, spawn } from 'child_process';
+import util from 'node:util';
 
 import async from 'async';
 import rouge from 'rouge';
@@ -294,13 +295,19 @@ export async function runAssertion({
   }
 
   if (baseType === 'equals') {
-    pass = (renderedValue == outputString) !== inverse;
+    if (typeof renderedValue === 'object') {
+      pass = util.isDeepStrictEqual(renderedValue, JSON.parse(outputString)) !== inverse;
+      renderedValue = JSON.stringify(renderedValue);
+    } else {
+      pass = (renderedValue == outputString) !== inverse;
+    }
+
     return {
       pass,
       score: pass ? 1 : 0,
       reason: pass
-        ? 'Assertion passed'
-        : `Expected output "${renderedValue}" to ${inverse ? 'not ' : ''}equal "${outputString}"`,
+          ? 'Assertion passed'
+          : `Expected output "${renderedValue}" to ${inverse ? 'not ' : ''}equal "${outputString}"`,
       assertion,
     };
   }

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -306,8 +306,8 @@ export async function runAssertion({
       pass,
       score: pass ? 1 : 0,
       reason: pass
-          ? 'Assertion passed'
-          : `Expected output "${renderedValue}" to ${inverse ? 'not ' : ''}equal "${outputString}"`,
+        ? 'Assertion passed'
+        : `Expected output "${renderedValue}" to ${inverse ? 'not ' : ''}equal "${outputString}"`,
       assertion,
     };
   }

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -610,11 +610,7 @@ describe('runAssertion', () => {
       value: 'file:///output.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify({
-          "key": "value"
-        }),
-    );
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({"key": "value"}));
 
     const output = '{"key": "value"}';
 
@@ -636,11 +632,7 @@ describe('runAssertion', () => {
       value: 'file:///output.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify({
-          "key": "value"
-        }),
-    );
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({"key": "value"}));
 
     const output = '{"key": "not value"}';
 


### PR DESCRIPTION
resolve #799

# What
We can now compare JSON output in the following way.

```yaml
assert:
  - type: equals
    value: {"key1": "value1", "key2": "value2"}  // expected json
```

or 

```yaml
assert:
  - type: equals
    value: "file://expected.json" // target file here
```

# How
I use deep equal comparison when an object is passed in with an equals assertion. There are several options for implementing deep equal.

1. Use the functions provided by the official Node.js
2. Use a third party library function (like [lodash](https://github.com/lodash/lodash), [node-deep-equal](https://github.com/inspect-js/node-deep-equal), ..etc)
3. Implement a custom deep equal function

I chose option 1 because option 3 seems difficult to operate accurately, and option 2 is often no longer maintained. And Node.js provide [assert.deepStrictEqual](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) and [util.isDeepStrictEqual](https://nodejs.org/api/util.html#utilisdeepstrictequalval1-val2). I implement the latter because the former throws an exception on failure.
