### PR TITLE
PR: Restore ProviderResponse class name

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -77,6 +77,7 @@ class TokenUsage:
     prompt: int
     completion: int
 
+class ProviderResponse:
     output: Optional[Union[str, Dict[str, Any]]]
     error: Optional[str]
     tokenUsage: Optional[TokenUsage]


### PR DESCRIPTION
When using the provided Python types for custom provider, noticed that the class name for ProviderResponse was missing.