### PR TITLE
feat: Allow functions in renderVarsInObject

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -461,11 +461,47 @@ tests:
         value: NYC
 ```
 
+:::tip
+Functions can use variables from test cases:
+
+```js
+{
+  type: "function",
+  function: {
+    description: "Get temperature in {{city}}"
+    // ...
+  }
+}
+```
+
+They can also include functions that dynamically reference vars:
+
+```js
+{
+  type: "function",
+  function: {
+    name: "get_temperature",
+    parameters: {
+      type: "object",
+        properties: {
+          unit: {
+            type: "string",
+            // highlight-start
+            enum: (vars) => vars.units,
+            // highlight-end
+          }
+        },
+    }
+  }
+}
+```
+:::
+
 ### Using functions
 
 > `functions` and `function_call` is deprecated in favor of `tools` and `tool_choice`, see detail in [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create#chat-create-function_call).
 
-In addition, you can use `functions` to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`. For example:
+Use the `functions` config to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`. For example:
 
 ```yaml
 prompts: [prompt.txt]

--- a/src/util.ts
+++ b/src/util.ts
@@ -1325,6 +1325,9 @@ export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | obj
       result[key] = renderVarsInObject((obj as Record<string, unknown>)[key], vars);
     }
     return result as T;
+  } else if (typeof obj === "function") {
+    const fn = obj as Function;
+    return renderVarsInObject(fn(vars) as T);
   }
   return obj;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1325,9 +1325,9 @@ export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | obj
       result[key] = renderVarsInObject((obj as Record<string, unknown>)[key], vars);
     }
     return result as T;
-  } else if (typeof obj === "function") {
+  } else if (typeof obj === 'function') {
     const fn = obj as Function;
-    return renderVarsInObject(fn(vars) as T);
+    return renderVarsInObject(fn({ vars }) as T);
   }
   return obj;
 }


### PR DESCRIPTION
This allows using functions to render vars in function calls where string interpolation doesn't work.

Example:
```javascript
{
  providers: {
    id: "openai:chat:gpt-3.5-turbo-0613",
    config: {
      tools: [
        {
          type: "function",
          function: {
            name: "get_temperature",
            parameters: {
              type: "object",
                properties: {
                  location: {
                    type: "string",
                    description: "The city and state, e.g. San Francisco, CA"
                  },
                  unit: {
                    type: "string",
                    enum: (vars) => vars.units,
                  }
                },
                required: ["location"]
              }
            }
          }
        }
      ]
    }
  }
}
```