### PR TITLE
feat: support for prompt objects

### DIFF
--- a/examples/prompts-per-model/README.md
+++ b/examples/prompts-per-model/README.md
@@ -1,0 +1,12 @@
+This example shows how to set up a custom set of prompts for specific models.
+
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, edit promptfooconfig.yaml.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/prompts-per-model/prompt1.txt
+++ b/examples/prompts-per-model/prompt1.txt
@@ -1,0 +1,1 @@
+Write a tweet about {{topic}}

--- a/examples/prompts-per-model/prompt2.txt
+++ b/examples/prompts-per-model/prompt2.txt
@@ -1,0 +1,1 @@
+Write 4 words about {{topic}}

--- a/examples/prompts-per-model/promptfooconfig.yaml
+++ b/examples/prompts-per-model/promptfooconfig.yaml
@@ -1,0 +1,48 @@
+prompts:
+  - id: file://prompt1.txt
+    label: My first prompt
+  - id: file://prompt2.txt
+    label: My second prompt
+
+providers:
+  - id: openai:gpt-3.5-turbo-0613
+    prompts:
+      - My first prompt
+      - My second prompt
+  - id: openai:gpt-4
+    prompts:
+      - My first prompt
+
+tests:
+  - vars:
+      topic: bananas
+  - vars:
+      topic: space tourism
+  - vars:
+      topic: AI-created music
+  - vars:
+      topic: virtual reality adventures
+  - vars:
+      topic: moonlight dances
+  - vars:
+      topic: whispers of the forest
+  - vars:
+      topic: forgotten melodies
+  - vars:
+      topic: midnight snacking
+  - vars:
+      topic: silent disco parties
+  - vars:
+      topic: eco-friendly packaging
+  - vars:
+      topic: the ethical implications of AI
+  - vars:
+      topic: using quantum computing for climate models
+  - vars:
+      topic: the impact of deepfakes on societal trust
+  - vars:
+      topic: artificial intelligence in poetry
+  - vars:
+      topic: collaborative storytelling with AI
+  - vars:
+      topic: virtual reality classroom experiences

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -128,8 +128,10 @@ Here's an example of how to set separate prompts for Llama v2 and GPT models:
 
 ```yaml title=promptfooconfig.yaml
 prompts:
-  prompts/gpt_chat_prompt.json: gpt_chat_prompt
-  prompts/llama_completion_prompt.txt: llama_completion_prompt
+  - id: file://prompts/gpt_chat_prompt.json
+    label: gpt_chat_prompt
+  - id: file://prompts/llama_completion_prompt.txt
+    label: llama_completion_prompt
 
 providers:
   - id: openai:gpt-3.5-turbo-0613

--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -136,7 +136,7 @@ interface TestSuiteConfig {
   providers: ProviderId | ProviderFunction | (ProviderId | ProviderOptionsMap | ProviderOptions)[];
 
   // One or more prompts
-  prompts: (FilePath | object | PromptFunction)[];
+  prompts: (FilePath | Prompt | PromptFunction)[];
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
   tests: FilePath | (FilePath | TestCase)[];
@@ -193,8 +193,34 @@ interface Scenario {
 }
 ```
 
-Also, see [this table here](/docs/configuration/scenarios#configuration)
-for descriptions.
+Also, see [this table here](/docs/configuration/scenarios#configuration) for descriptions.
+
+### Prompt
+
+A `Prompt` is what it sounds like.  When specifying a prompt object in a static config, it should look like this:
+
+```typescript
+interface Prompt {
+  id: string;    // Path, usually prefixed with file://
+  label: string; // How to display it in outputs and web UI
+}
+```
+
+When passing a `Prompt` object directly to the Javascript library:
+
+```typescript
+interface Prompt {
+  // The actual prompt
+  raw: string;  
+  // How it should appear in the UI
+  label: string;  
+  // A function to generate a prompt on a per-input basis. Overrides the raw prompt.
+  function?: (context: {
+    vars: Record<string, string | object>;
+    provider?: ApiProvider;
+  }) => Promise<string | object>;
+}
+```
 
 ### EvaluateOptions
 

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -232,7 +232,7 @@ export async function runAssertion({
   if (assertion.transform) {
     output = await transformOutput(assertion.transform, output, {
       vars: test.vars,
-      prompt: { display: prompt },
+      prompt: { label: prompt },
     });
   }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -269,8 +269,8 @@ class Evaluator {
     nunjucksFilters: filters,
     evaluateOptions,
   }: RunEvalOptions): Promise<EvaluateResult> {
-    // Use the original prompt to set the display, not renderedPrompt
-    let promptDisplay = prompt.display;
+    // Use the original prompt to set the label, not renderedPrompt
+    let promptLabel = prompt.label;
 
     // Set up the special _conversation variable
     const vars = test.vars || {};
@@ -299,7 +299,7 @@ class Evaluator {
       },
       prompt: {
         raw: renderedPrompt,
-        display: promptDisplay,
+        label: promptLabel,
       },
       vars,
     };
@@ -471,7 +471,7 @@ class Evaluator {
             async (answer) => {
               rl.close();
               if (answer.toLowerCase().startsWith('y')) {
-                testSuite.prompts.push({ raw: prompt, display: prompt });
+                testSuite.prompts.push({ raw: prompt, label: prompt });
                 numAdded++;
               } else {
                 logger.info('Skipping this prompt.');
@@ -491,10 +491,10 @@ class Evaluator {
     // Split prompts by provider
     for (const prompt of testSuite.prompts) {
       for (const provider of testSuite.providers) {
-        // Check if providerPromptMap exists and if it contains the current prompt's display
+        // Check if providerPromptMap exists and if it contains the current prompt's label
         if (testSuite.providerPromptMap) {
           const allowedPrompts = testSuite.providerPromptMap[provider.id()];
-          if (allowedPrompts && !allowedPrompts.includes(prompt.display)) {
+          if (allowedPrompts && !allowedPrompts.includes(prompt.label)) {
             continue;
           }
         }
@@ -502,7 +502,7 @@ class Evaluator {
           ...prompt,
           id: sha256(typeof prompt.raw === 'object' ? JSON.stringify(prompt.raw) : prompt.raw),
           provider: provider.label || provider.id(),
-          display: prompt.display,
+          label: prompt.label,
           metrics: {
             score: 0,
             testPassCount: 0,
@@ -623,7 +623,7 @@ class Evaluator {
             for (const provider of testSuite.providers) {
               if (testSuite.providerPromptMap) {
                 const allowedPrompts = testSuite.providerPromptMap[provider.id()];
-                if (allowedPrompts && !allowedPrompts.includes(prompt.display)) {
+                if (allowedPrompts && !allowedPrompts.includes(prompt.label)) {
                   // This prompt should not be used with this provider.
                   continue;
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,19 +44,19 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
           if (typeof promptInput === 'function') {
             return {
               raw: promptInput.toString(),
-              display: promptInput.toString(),
+              label: promptInput.toString(),
               function: promptInput as PromptFunction,
             };
           } else if (typeof promptInput === 'string') {
             const prompts = await readPrompts(promptInput);
             return prompts.map((p) => ({
               raw: p.raw,
-              display: p.display,
+              label: p.label,
             }));
           } else {
             return {
               raw: JSON.stringify(promptInput),
-              display: JSON.stringify(promptInput),
+              label: JSON.stringify(promptInput),
             };
           }
         }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -819,11 +819,14 @@ async function main() {
             const basePath = path.dirname(configPaths[0]);
             const promptPaths = Array.isArray(config.prompts)
               ? (config.prompts
-                  .map((p) =>
-                    p.startsWith('file://')
-                      ? path.resolve(basePath, p.slice('file://'.length))
-                      : null,
-                  )
+                  .map((p) => {
+                    if (typeof p === 'string' && p.startsWith('file://')) {
+                      return path.resolve(basePath, p.slice('file://'.length));
+                    } else if (typeof p === 'object' && p.id && p.id.startsWith('file://')) {
+                      return path.resolve(basePath, p.id.slice('file://'.length));
+                    }
+                    return null;
+                  })
                   .filter(Boolean) as string[])
               : [];
             const providerPaths = Array.isArray(config.providers)

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -36,7 +36,7 @@ export function readProviderPromptMap(
 
   const allPrompts = [];
   for (const prompt of parsedPrompts) {
-    allPrompts.push(prompt.display);
+    allPrompts.push(prompt.label);
   }
 
   if (typeof config.providers === 'string') {
@@ -119,17 +119,17 @@ export async function readPrompts(
     // TODO(ian): Handle object array, such as OpenAI messages
     inputType = PromptInputType.ARRAY;
     promptPathInfos = promptPathOrGlobs.flatMap((pathOrGlob) => {
-      let display;
+      let label;
       let rawPath: string;
       if (typeof pathOrGlob === 'object') {
-        // Parse prompt config object {id, display}
-        invariant(pathOrGlob.display, `Prompt object requires display, but got ${JSON.stringify(pathOrGlob)}`);
-        display = pathOrGlob.display;
+        // Parse prompt config object {id, label}
+        invariant(pathOrGlob.label, `Prompt object requires label, but got ${JSON.stringify(pathOrGlob)}`);
+        label = pathOrGlob.label;
         invariant(pathOrGlob.id, `Prompt object requires id, but got ${JSON.stringify(pathOrGlob)}`);
         rawPath = pathOrGlob.id;
         inputType = PromptInputType.NAMED;
       } else {
-        display = pathOrGlob;
+        label = pathOrGlob;
         rawPath = pathOrGlob;
       }
       invariant(typeof rawPath === 'string', `Prompt path must be a string, but got ${JSON.stringify(rawPath)}`);
@@ -139,7 +139,7 @@ export async function readPrompts(
         forceLoadFromFile.add(rawPath);
       }
       resolvedPath = path.resolve(basePath, rawPath);
-      resolvedPathToDisplay.set(resolvedPath, display);
+      resolvedPathToDisplay.set(resolvedPath, label);
       const globbedPaths = globSync(resolvedPath.replace(/\\/g, '/'), {
         windowsPathsNoEscape: true,
       });
@@ -192,7 +192,7 @@ export async function readPrompts(
         throw err;
       }
       // If the path doesn't exist, it's probably a raw prompt
-      promptContents.push({ raw: promptPathInfo.raw, display: promptPathInfo.raw });
+      promptContents.push({ raw: promptPathInfo.raw, label: promptPathInfo.raw });
       usedRaw = true;
     }
     if (usedRaw) {
@@ -211,14 +211,14 @@ export async function readPrompts(
         resolvedPathToDisplay.set(resolvedPath, joinedPath);
         return fs.readFileSync(resolvedPath, 'utf-8');
       });
-      promptContents.push(...fileContents.map((content) => ({ raw: content, display: content })));
+      promptContents.push(...fileContents.map((content) => ({ raw: content, label: content })));
     } else {
       const ext = path.parse(promptPath).ext;
       if (ext === '.js' || ext === '.cjs' || ext === '.mjs') {
         const promptFunction = await importModule(promptPath, functionName);
         promptContents.push({
           raw: String(promptFunction),
-          display: String(promptFunction),
+          label: String(promptFunction),
           function: promptFunction,
         });
       } else if (ext === '.py') {
@@ -250,36 +250,36 @@ export async function readPrompts(
             return results;
           }
         };
-        let display = fileContent;
+        let label = fileContent;
         if (inputType === PromptInputType.NAMED) {
           const resolvedPathLookup = functionName ? `${promptPath}:${functionName}` : promptPath;
-          display = resolvedPathToDisplay.get(resolvedPathLookup) || resolvedPathLookup;
+          label = resolvedPathToDisplay.get(resolvedPathLookup) || resolvedPathLookup;
         }
 
         promptContents.push({
           raw: fileContent,
-          display,
+          label,
           function: promptFunction,
         });
       } else {
         const fileContent = fs.readFileSync(promptPath, 'utf-8');
-        let display: string | undefined;
+        let label: string | undefined;
         if (inputType === PromptInputType.NAMED) {
-          display = resolvedPathToDisplay.get(promptPath) || promptPath;
+          label = resolvedPathToDisplay.get(promptPath) || promptPath;
         } else {
-          display = fileContent.length > 200 ? promptPath : fileContent;
+          label = fileContent.length > 200 ? promptPath : fileContent;
 
           const ext = path.parse(promptPath).ext;
           if (ext === '.jsonl') {
             // Special case for JSONL file
             const jsonLines = fileContent.split(/\r?\n/).filter((line) => line.length > 0);
             for (const json of jsonLines) {
-              promptContents.push({ raw: json, display: json });
+              promptContents.push({ raw: json, label: json });
             }
             continue;
           }
         }
-        promptContents.push({ raw: fileContent, display });
+        promptContents.push({ raw: fileContent, label });
       }
     }
   }
@@ -293,7 +293,7 @@ export async function readPrompts(
     const content = promptContents[0].raw;
     promptContents = content
       .split(PROMPT_DELIMITER)
-      .map((p) => ({ raw: p.trim(), display: p.trim() }));
+      .map((p) => ({ raw: p.trim(), label: p.trim() }));
   }
   if (promptContents.length === 0) {
     throw new Error(`There are no prompts in ${JSON.stringify(promptPathOrGlobs)}`);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -11,14 +11,13 @@ import { runPython } from './python/wrapper';
 import { importModule } from './esm';
 import { safeJsonStringify } from './util';
 
-import {
-  type UnifiedConfig,
-  type Prompt,
-  type ProviderOptionsMap,
-  type TestSuite,
-  type ProviderOptions,
-  type ApiProvider,
-  isPrompt,
+import type {
+  UnifiedConfig,
+  Prompt,
+  ProviderOptionsMap,
+  TestSuite,
+  ProviderOptions,
+  ApiProvider,
 } from './types';
 
 export * from './external/ragas';

--- a/src/table.ts
+++ b/src/table.ts
@@ -18,7 +18,7 @@ export function generateTable(summary: EvaluateSummary, tableCellMaxLength = 250
     head: [
       ...head.vars,
       ...head.prompts.map((prompt) =>
-        allProvidersSame ? prompt.display : `[${prompt.provider}] ${prompt.display}`,
+        allProvidersSame ? prompt.label : `[${prompt.provider}] ${prompt.label}`,
       ),
     ].map((h) => ellipsize(h, tableCellMaxLength)),
     colWidths: Array(headLength).fill(Math.floor(maxWidth / headLength)),

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,7 +245,11 @@ export interface EvaluateOptions {
 export interface Prompt {
   id?: string;
   raw: string;
-  display: string;
+  /**
+   * @deprecated in > 0.59.0. Use `label` instead.
+   */
+  display?: string;
+  label: string;
   function?: (context: {
     vars: Record<string, string | object>;
     provider?: ApiProvider;

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,17 +243,13 @@ export interface EvaluateOptions {
 }
 
 export interface Prompt {
-  id: string;
+  id?: string;
   raw: string;
   display: string;
   function?: (context: {
     vars: Record<string, string | object>;
     provider?: ApiProvider;
   }) => Promise<string | object>;
-}
-
-export function isPrompt(obj: any): obj is Prompt {
-  return typeof obj === 'object' && 'id' in obj && 'raw' in obj && 'display' in obj;
 }
 
 // Used for final prompt display

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,13 +243,17 @@ export interface EvaluateOptions {
 }
 
 export interface Prompt {
-  id?: string;
+  id: string;
   raw: string;
   display: string;
   function?: (context: {
     vars: Record<string, string | object>;
     provider?: ApiProvider;
   }) => Promise<string | object>;
+}
+
+export function isPrompt(obj: any): obj is Prompt {
+  return typeof obj === 'object' && 'id' in obj && 'raw' in obj && 'display' in obj;
 }
 
 // Used for final prompt display

--- a/src/types.ts
+++ b/src/types.ts
@@ -606,7 +606,7 @@ export interface TestSuiteConfig {
   providers: ProviderId | ProviderFunction | (ProviderId | ProviderOptionsMap | ProviderOptions)[];
 
   // One or more prompt files to load
-  prompts: FilePath | FilePath[] | Record<FilePath, string>;
+  prompts: FilePath | (FilePath | Prompt)[] | Record<FilePath, string>;
 
   // Path to a test file, OR list of LLM prompt variations (aka "test case")
   tests: FilePath | (FilePath | TestCase)[];

--- a/src/util.ts
+++ b/src/util.ts
@@ -380,7 +380,7 @@ ${gradingResultText}`.trim();
         csvRow[varName] = row.vars[index];
       });
       results.table.head.prompts.forEach((prompt, index) => {
-        csvRow[prompt.display] = outputToSimpleString(row.outputs[index]);
+        csvRow[prompt.label] = outputToSimpleString(row.outputs[index]);
       });
       return csvRow;
     });
@@ -415,7 +415,7 @@ ${gradingResultText}`.trim();
     } else if (outputExtension === 'html') {
       const template = fs.readFileSync(`${getDirectory()}/tableOutput.html`, 'utf-8');
       const table = [
-        [...results.table.head.vars, ...results.table.head.prompts.map((prompt) => prompt.display)],
+        [...results.table.head.vars, ...results.table.head.prompts.map((prompt) => prompt.label)],
         ...results.table.body.map((row) => [...row.vars, ...row.outputs.map(outputToSimpleString)]),
       ];
       const htmlOutput = getNunjucksEngine().renderString(template, {
@@ -489,14 +489,15 @@ export async function writeResultsToDatabase(
 
   // Record prompt relation
   for (const prompt of results.table.head.prompts) {
-    const promptId = sha256(prompt.display);
+    const label = prompt.label || prompt.display || prompt.raw;
+    const promptId = sha256(label);
 
     promises.push(
       db
         .insert(prompts)
         .values({
           id: promptId,
-          prompt: prompt.display,
+          prompt: label,
         })
         .onConflictDoNothing()
         .run(),

--- a/src/web/nextui/src/app/eval/DownloadMenu.tsx
+++ b/src/web/nextui/src/app/eval/DownloadMenu.tsx
@@ -45,7 +45,7 @@ function DownloadMenu() {
       rejected: row.outputs.filter((output) => !output.pass).map((output) => output.text),
       vars: row.test.vars,
       providers: table.head.prompts.map((prompt) => prompt.provider),
-      prompts: table.head.prompts.map((prompt) => prompt.display),
+      prompts: table.head.prompts.map((prompt) => prompt.label || prompt.display || prompt.raw),
     }));
     const blob = new Blob([JSON.stringify(formattedData, null, 2)], { type: 'application/json' });
     openDownloadDialog(blob, `${evalId}-dpo.json`);

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -34,7 +34,12 @@ import { useStore as useMainStore } from '@/app/eval/store';
 
 import type { CellContext, ColumnDef, VisibilityState } from '@tanstack/table-core';
 
-import type { EvaluateTableRow, EvaluateTableOutput, FilterMode, EvaluateTable } from './types';
+import {
+  EvaluateTableRow,
+  EvaluateTableOutput,
+  FilterMode,
+  EvaluateTable,
+} from './types';
 
 import './ResultsTable.css';
 
@@ -374,7 +379,8 @@ function EvalOutputCell({
       >
         <span>
           {totalTokens}
-          {(promptTokens !== '0' || completionTokens !== '0') && ` (${promptTokens}+${completionTokens})`}
+          {(promptTokens !== '0' || completionTokens !== '0') &&
+            ` (${promptTokens}+${completionTokens})`}
         </span>
       </Tooltip>
     );
@@ -866,7 +872,7 @@ function ResultsTable({
                   </div>
                   <TableHeader
                     className="prompt-container"
-                    text={prompt.display}
+                    text={prompt.label || prompt.display || prompt.raw}
                     expandedText={prompt.raw}
                     maxLength={maxTextLength}
                     resourceId={prompt.id}

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -81,9 +81,12 @@ export default function ResultsView({
   };
 
   const [failureFilter, setFailureFilter] = React.useState<{ [key: string]: boolean }>({});
-  const handleFailureFilterToggle = React.useCallback((columnId: string, checked: boolean) => {
-    setFailureFilter((prevFailureFilter) => ({ ...prevFailureFilter, [columnId]: checked }));
-  }, [setFailureFilter]);
+  const handleFailureFilterToggle = React.useCallback(
+    (columnId: string, checked: boolean) => {
+      setFailureFilter((prevFailureFilter) => ({ ...prevFailureFilter, [columnId]: checked }));
+    },
+    [setFailureFilter],
+  );
 
   const [filterMode, setFilterMode] = React.useState<FilterMode>('all');
   const handleFilterModeChange = (event: SelectChangeEvent<unknown>) => {
@@ -207,22 +210,22 @@ export default function ResultsView({
         }`,
         group: 'Variables',
       })),
-      ...head.prompts.map((_, idx) => ({
-        value: `Prompt ${idx + 1}`,
-        label: `Prompt ${idx + 1}: ${
-          head.prompts[idx].display.length > 100
-            ? head.prompts[idx].display.slice(0, 97) + '...'
-            : head.prompts[idx].display
-        }`,
-        group: 'Prompts',
-      })),
+      ...head.prompts.map((_, idx) => {
+        const prompt = head.prompts[idx];
+        const label = prompt.label || prompt.display || prompt.raw;
+        return {
+          value: `Prompt ${idx + 1}`,
+          label: `Prompt ${idx + 1}: ${label.length > 100 ? label.slice(0, 97) + '...' : label}`,
+          group: 'Prompts',
+        };
+      }),
     ];
   }, [head.vars, head.prompts]);
 
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
   const [selectedColumns, setSelectedColumns] = React.useState<string[]>(
-  columnData.map((col) => col.value)
-);
+    columnData.map((col) => col.value),
+  );
 
   // State for anchor element
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);

--- a/test/commands/eval/filterFailingTests.test.ts
+++ b/test/commands/eval/filterFailingTests.test.ts
@@ -21,7 +21,7 @@ describe('filterFailingTests', () => {
   const restResult = {
     prompt: {
       raw: 'prompt',
-      display: 'prompt',
+      label: 'prompt',
     },
     score: 0.5,
     latencyMs: 1_000,

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -63,7 +63,7 @@ const mockGradingApiProviderFails: ApiProvider = {
 };
 
 function toPrompt(text: string): Prompt {
-  return { raw: text, display: text };
+  return { raw: text, label: text };
 }
 
 describe('evaluator', () => {
@@ -89,7 +89,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
-    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1 }} {{ var2 }}');
+    expect(summary.results[0].prompt.label).toBe('Test prompt {{ var1 }} {{ var2 }}');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -111,7 +111,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt 1 < 2 he said "hello world"...');
-    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1 }} {{ var2 }}');
+    expect(summary.results[0].prompt.label).toBe('Test prompt {{ var1 }} {{ var2 }}');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -133,14 +133,14 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
-    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1.prop1 }} {{ var2 }}');
+    expect(summary.results[0].prompt.label).toBe('Test prompt {{ var1.prop1 }} {{ var2 }}');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
   test('evaluate with named prompt', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
-      prompts: [{ raw: 'Test prompt {{ var1 }} {{ var2 }}', display: 'test display name' }],
+      prompts: [{ raw: 'Test prompt {{ var1 }} {{ var2 }}', label: 'test display name' }],
       tests: [
         {
           vars: { var1: 'value1', var2: 'value2' },
@@ -155,7 +155,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
-    expect(summary.results[0].prompt.display).toBe('test display name');
+    expect(summary.results[0].prompt.label).toBe('test display name');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -177,7 +177,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 40, prompt: 20, completion: 20, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
-    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1 }} {{ var2 }}');
+    expect(summary.results[0].prompt.label).toBe('Test prompt {{ var1 }} {{ var2 }}');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -199,7 +199,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 20, prompt: 10, completion: 10, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
-    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1 }} {{ var2 }}');
+    expect(summary.results[0].prompt.label).toBe('Test prompt {{ var1 }} {{ var2 }}');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -216,7 +216,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt');
-    expect(summary.results[0].prompt.display).toBe('Test prompt');
+    expect(summary.results[0].prompt.label).toBe('Test prompt');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -233,7 +233,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 30, prompt: 15, completion: 15, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt');
-    expect(summary.results[0].prompt.display).toBe('Test prompt');
+    expect(summary.results[0].prompt.label).toBe('Test prompt');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
@@ -533,7 +533,7 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.stats.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5, cached: 0 });
     expect(summary.results[0].prompt.raw).toBe('Test prompt 1');
-    expect(summary.results[0].prompt.display).toBe('Test prompt 1');
+    expect(summary.results[0].prompt.label).toBe('Test prompt 1');
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -29,7 +29,7 @@ jest.mock('fs', () => ({
 jest.mock('../src/database');
 
 function toPrompt(text: string): Prompt {
-  return { raw: text, display: text };
+  return { raw: text, label: text };
 }
 
 beforeEach(() => {
@@ -106,8 +106,8 @@ describe('prompts', () => {
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ raw: 'some raw text', display: 'foo1' });
-    expect(result[1]).toEqual(expect.objectContaining({ raw: 'some raw text', display: 'foo2' }));
+    expect(result[0]).toEqual({ raw: 'some raw text', label: 'foo1' });
+    expect(result[1]).toEqual(expect.objectContaining({ raw: 'some raw text', label: 'foo2' }));
   });
 
   test('readPrompts with JSONL file', async () => {
@@ -138,14 +138,14 @@ describe('prompts', () => {
     const result = await readPrompts('prompt.py');
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result[0].raw).toEqual(code);
-    expect(result[0].display).toEqual(code);
+    expect(result[0].label).toEqual(code);
     expect(result[0].function).toBeDefined();
   });
 
   test('readPrompts with Prompt object array', async () => {
     const prompts = [
-      { id: 'prompts.py:prompt1', display: 'First prompt' },
-      { id: 'prompts.py:prompt2', display: 'Second prompt' },
+      { id: 'prompts.py:prompt1', label: 'First prompt' },
+      { id: 'prompts.py:prompt2', label: 'Second prompt' },
     ];
 
     const code = `def prompt1:
@@ -160,12 +160,12 @@ def prompt2:
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
       raw: code,
-      display: 'First prompt',
+      label: 'First prompt',
       function: expect.any(Function),
     });
     expect(result[1]).toEqual({
       raw: code,
-      display: 'Second prompt',
+      label: 'Second prompt',
       function: expect.any(Function),
     });
   });
@@ -214,7 +214,7 @@ def prompt2:
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(fs.statSync).toHaveBeenCalledTimes(1);
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ raw: fileContents['1.txt'], display: fileContents['1.txt'] });
-    expect(result[1]).toEqual({ raw: fileContents['2.txt'], display: fileContents['2.txt'] });
+    expect(result[0]).toEqual({ raw: fileContents['1.txt'], label: fileContents['1.txt'] });
+    expect(result[1]).toEqual({ raw: fileContents['2.txt'], label: fileContents['2.txt'] });
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -142,6 +142,34 @@ describe('prompts', () => {
     expect(result[0].function).toBeDefined();
   });
 
+  test('readPrompts with Prompt object array', async () => {
+    const prompts = [
+      { id: 'prompts.py:prompt1', display: 'First prompt' },
+      { id: 'prompts.py:prompt2', display: 'Second prompt' },
+    ];
+
+    const code = `def prompt1:
+  return 'First prompt'
+def prompt2:
+  return 'Second prompt'`;
+    (fs.readFileSync as jest.Mock).mockReturnValue(code);
+
+    const result = await readPrompts(prompts);
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      raw: code,
+      display: 'First prompt',
+      function: expect.any(Function),
+    });
+    expect(result[1]).toEqual({
+      raw: code,
+      display: 'Second prompt',
+      function: expect.any(Function),
+    });
+  });
+
   test('readPrompts with .js file', async () => {
     jest.doMock(
       path.resolve('prompt.js'),

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -21,7 +21,13 @@ import {
   writeOutput,
 } from '../src/util';
 
-import type { ApiProvider, EvaluateResult, EvaluateTable, TestCase, UnifiedConfig } from '../src/types';
+import type {
+  ApiProvider,
+  EvaluateResult,
+  EvaluateTable,
+  TestCase,
+  UnifiedConfig,
+} from '../src/types';
 
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
@@ -62,7 +68,7 @@ describe('util', () => {
           },
           prompt: {
             raw: 'Test prompt',
-            display: '[display] Test prompt',
+            label: '[display] Test prompt',
           },
           response: {
             output: 'Test output',
@@ -75,7 +81,7 @@ describe('util', () => {
       ];
       const table: EvaluateTable = {
         head: {
-          prompts: [{ raw: 'Test prompt', display: '[display] Test prompt', provider: 'foo' }],
+          prompts: [{ raw: 'Test prompt', label: '[display] Test prompt', provider: 'foo' }],
           vars: ['var1', 'var2'],
         },
         body: [
@@ -134,7 +140,7 @@ describe('util', () => {
           },
           prompt: {
             raw: 'Test prompt',
-            display: '[display] Test prompt',
+            label: '[display] Test prompt',
           },
           response: {
             output: 'Test output',
@@ -147,7 +153,7 @@ describe('util', () => {
       ];
       const table: EvaluateTable = {
         head: {
-          prompts: [{ raw: 'Test prompt', display: '[display] Test prompt', provider: 'foo' }],
+          prompts: [{ raw: 'Test prompt', label: '[display] Test prompt', provider: 'foo' }],
           vars: ['var1', 'var2'],
         },
         body: [
@@ -206,7 +212,7 @@ describe('util', () => {
           },
           prompt: {
             raw: 'Test prompt',
-            display: '[display] Test prompt',
+            label: '[display] Test prompt',
           },
           response: {
             output: 'Test output',
@@ -219,7 +225,7 @@ describe('util', () => {
       ];
       const table: EvaluateTable = {
         head: {
-          prompts: [{ raw: 'Test prompt', display: '[display] Test prompt', provider: 'foo' }],
+          prompts: [{ raw: 'Test prompt', label: '[display] Test prompt', provider: 'foo' }],
           vars: ['var1', 'var2'],
         },
         body: [
@@ -278,7 +284,7 @@ describe('util', () => {
           },
           prompt: {
             raw: 'Test prompt',
-            display: '[display] Test prompt',
+            label: '[display] Test prompt',
           },
           response: {
             output: 'Test output',
@@ -291,7 +297,7 @@ describe('util', () => {
       ];
       const table: EvaluateTable = {
         head: {
-          prompts: [{ raw: 'Test prompt', display: '[display] Test prompt', provider: 'foo' }],
+          prompts: [{ raw: 'Test prompt', label: '[display] Test prompt', provider: 'foo' }],
           vars: ['var1', 'var2'],
         },
         body: [
@@ -347,16 +353,19 @@ describe('util', () => {
     });
 
     it('fails for csv output', async () => {
-      await expect(readOutput('output.csv'))
-        .rejects.toThrow('Unsupported output file format: csv currently only supports json');
+      await expect(readOutput('output.csv')).rejects.toThrow(
+        'Unsupported output file format: csv currently only supports json',
+      );
     });
 
     it('fails for yaml output', async () => {
-      await expect(readOutput('output.yaml'))
-        .rejects.toThrow('Unsupported output file format: yaml currently only supports json');
+      await expect(readOutput('output.yaml')).rejects.toThrow(
+        'Unsupported output file format: yaml currently only supports json',
+      );
 
-      await expect(readOutput('output.yml'))
-        .rejects.toThrow('Unsupported output file format: yml currently only supports json');
+      await expect(readOutput('output.yml')).rejects.toThrow(
+        'Unsupported output file format: yml currently only supports json',
+      );
     });
   });
 
@@ -878,7 +887,7 @@ describe('util', () => {
       provider: 'provider',
       vars: {
         key: 'value',
-      }
+      },
     };
     const result = {
       provider: 'provider',
@@ -887,7 +896,7 @@ describe('util', () => {
       },
     } as any as EvaluateResult;
 
-    it ('is true', () => {
+    it('is true', () => {
       expect(resultIsForTestCase(result, testCase)).toStrictEqual(true);
     });
 


### PR DESCRIPTION
This makes it easier to set labels for prompts.  

For example:
```yaml
prompts:
  - id: prompts.py:prompt1
    label: First prompt
  - id: prompts.py:prompt2
    label: Second prompt

providers:
  - openai:gpt-3.5-turbo

tests:
  # ...
```

The internal representation is `display` right now.  I may change it to `label` to be consistent with the `provider.label` property, which is already exposed, but that will require some plumbing work in the UI as well as backwards compatibility.