### PR TITLE
feat: general purpose http/https provider

### DIFF
--- a/examples/http-provider/README.md
+++ b/examples/http-provider/README.md
@@ -1,0 +1,8 @@
+To get started, edit promptfooconfig.yaml. You may want to create your own test webhook endpoint at https://webhook.site.
+
+Then run:
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/http-provider/promptfooconfig.yaml
+++ b/examples/http-provider/promptfooconfig.yaml
@@ -1,0 +1,23 @@
+description: "HTTP provider test"
+
+prompts:
+  - "Write a tweet about {{topic}}"
+  - "Write a very concise, funny tweet about {{topic}}"
+
+providers:
+  - id: https://webhook.site/3d47d2dd-d450-4869-b80d-41862e577e45
+    config:
+      method: "POST"
+      headers:
+        "Content-Type": "application/json"
+      body:
+        "prompt": "{{prompt}}"
+        "model": "{{model}}"
+          #
+      # Parse OpenAI response
+      responseParser: "json.choices[0].message.content"
+
+tests:
+  - vars:
+      model: gpt-5
+      topic: bananas

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -50,7 +50,7 @@ This will create a `promptfooconfig.yaml` file in your current directory.
      export OPENAI_API_KEY=sk-abc123
      ```
 
-   - **Custom**: See how to call your existing [Javascript](/docs/providers/custom-api), [Python](/docs/providers/python), or [any other code](/docs/providers/custom-script).
+   - **Custom**: See how to call your existing [Javascript](/docs/providers/custom-api), [Python](/docs/providers/python), or [any other code](/docs/providers/custom-script) or [API endpoint](/docs/providers/http).
    - **APIs**: See setup instructions for [Azure](/docs/providers/azure), [Anthropic](/docs/providers/anthropic), [Mistral](/docs/providers/mistral), [HuggingFace](/docs/providers/huggingface), [AWS Bedrock](/docs/providers/aws-bedrock), and [more](/docs/providers).
 
 1. **Add test inputs**: Add some example inputs for your prompts. Optionally, add [assertions](/docs/configuration/expected-outputs) to set output requirements that are checked automatically.

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 50
+sidebar_label: HTTP API
+---
+
+# HTTP/HTTPS API
+
+Setting provider id to a URL sends an HTTP request to the endpoint.  This is a general-purpose way to use any HTTP endpoint for inference.
+
+The provider config gives you a way to construct the HTTP request and extract the inference result from the response.
+
+```yaml
+providers:
+  - id: 'https://example.com/generate'
+    config:
+      method: 'POST'
+      headers:
+        'Content-Type': 'application/json'
+      body:
+        myPrompt: '{{prompt}}'
+      responseParser: 'json.output'
+```
+
+The placeholder variable `{{prompt}}` will be replaced by the final prompt for the test case.  You can also reference test variables as you construct the request:
+
+```yaml
+providers:
+  - id: 'https://example.com/generateTranslation'
+    config:
+      body:
+        prompt: '{{prompt}}'
+        engine: '{{engine}}'
+        translate: '{{language}}'
+
+tests:
+  - vars:
+      engine: 'foo'
+      language: 'French'
+```
+
+If not specified, HTTP POST with content-type application/json is assumed.
+
+If your API responds with a JSON object and you want to pick out a specific value, use the `responseParser` property to set a Javascript snippet that manipulates the provided `json` object.  
+
+For example, this `responseParser` configuration:
+
+```yaml
+providers:
+  - id: 'https://example.com/openai-compatible/chat/completions'
+    config:
+      # ...
+      responseParser: 'json.choices[0].message.content'
+```
+
+Extracts the message content from this response:
+
+```json
+{
+    "id": "chatcmpl-abc123",
+    "object": "chat.completion",
+    "created": 1677858242,
+    "model": "gpt-3.5-turbo-0613",
+    "usage": {
+        "prompt_tokens": 13,
+        "completion_tokens": 7,
+        "total_tokens": 20
+    },
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                // highlight-start
+                "content": "\n\nThis is a test!"
+                // highlight-end
+            },
+            "logprobs": null,
+            "finish_reason": "stop",
+            "index": 0
+        }
+    ]
+}
+```

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -29,12 +29,12 @@ providers:
     config:
       body:
         prompt: '{{prompt}}'
-        engine: '{{engine}}'
+        model: '{{model}}'
         translate: '{{language}}'
 
 tests:
   - vars:
-      engine: 'foo'
+      model: 'gpt-4'
       language: 'French'
 ```
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -48,6 +48,7 @@ import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './pro
 import { PythonProvider } from './providers/pythonCompletion';
 import { CohereChatCompletionProvider } from './providers/cohere';
 import { BAMChatProvider, BAMEmbeddingProvider } from './providers/bam';
+import { HttpProvider } from './providers/http';
 import { importModule } from './esm';
 
 import type {
@@ -332,6 +333,8 @@ export async function loadApiProvider(
     } else {
       ret = new LocalAiChatProvider(modelType, providerOptions);
     }
+  } else if (providerPath.startsWith('http:') || providerPath.startsWith('https:')) {
+    ret = new HttpProvider(providerPath, providerOptions);
   } else if (providerPath === 'promptfoo:redteam:iterative') {
     const RedteamIterativeProvider = (await import(path.join(__dirname, './redteam/iterative'))).default;
     ret = new RedteamIterativeProvider(providerOptions);

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1,0 +1,74 @@
+import invariant from 'tiny-invariant';
+
+import logger from '../logger';
+import { fetchWithCache } from '../cache';
+import { REQUEST_TIMEOUT_MS } from './shared';
+import { getNunjucksEngine } from '../util';
+
+import type { ApiProvider, ProviderResponse } from '../types.js';
+
+export class HttpProvider implements ApiProvider {
+  url: string;
+  config: any;
+  responseParser: (data: any) => ProviderResponse;
+
+  constructor(url: string, config: any) {
+    this.url = url;
+    this.config = config;
+    this.responseParser = createResponseParser(config.responseParser);
+  }
+
+  id(): string {
+    return this.url;
+  }
+
+  toString(): string {
+    return `[HTTP Provider ${this.url}]`;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    // Render all nested strings
+    const nunjucks = getNunjucksEngine();
+    const renderedConfig: { method: string; headers: Record<string, string>; body: any } =
+      JSON.parse(nunjucks.renderString(JSON.stringify(this.config), { prompt }));
+
+    const method = renderedConfig.method || 'POST';
+    const headers = renderedConfig.headers || { 'Content-Type': 'application/json' };
+    invariant(typeof method === 'string', 'Expected method to be a string');
+    invariant(typeof headers === 'object', 'Expected headers to be an object');
+
+    logger.debug(
+      `Calling HTTP provider: ${this.url} with config: ${JSON.stringify(renderedConfig)}`,
+    );
+    let response;
+    try {
+      response = await fetchWithCache(
+        this.url,
+        {
+          method,
+          headers,
+          body: JSON.stringify(renderedConfig.body),
+        },
+        REQUEST_TIMEOUT_MS,
+        'json',
+      );
+    } catch (err) {
+      return {
+        error: `HTTP call error: ${String(err)}`,
+      };
+    }
+    logger.debug(`\tHTTP response: ${JSON.stringify(response.data)}`);
+
+    return this.responseParser(response.data);
+  }
+}
+
+function createResponseParser(parser: any): (data: any) => ProviderResponse {
+  if (typeof parser === 'function') {
+    return parser;
+  }
+  if (typeof parser === 'string') {
+    return new Function('json', `return ${parser}`) as (data: any) => ProviderResponse;
+  }
+  return (data) => ({ output: data });
+}


### PR DESCRIPTION
Setting provider id to a URL sends an HTTP request to the endpoint.  It expects that the LLM or agent output will be in the HTTP response.

```yaml
providers:
  - id: 'https://example.com/generate'
    config:
      method: 'POST'
      headers:
        'Content-Type': 'application/json'
      body:
        myPrompt: '{{prompt}}'
      responseParser: 'json.output'
```

Customize the HTTP request using a placeholder variable `{{prompt}}` that will be replaced by the final prompt.

If your API responds with a JSON object and you want to pick out a specific value, use the `responseParser` key to set a Javascript snippet that manipulates the provided `json` object.  

For example, `json.choices[0].message.content` will reference the output in the following API response:

```json
{
    "id": "chatcmpl-abc123",
    "object": "chat.completion",
    "created": 1677858242,
    "model": "gpt-3.5-turbo-0613",
    "usage": {
        "prompt_tokens": 13,
        "completion_tokens": 7,
        "total_tokens": 20
    },
    "choices": [
        {
            "message": {
                "role": "assistant",
                "content": "\n\nThis is a test!"
            },
            "logprobs": null,
            "finish_reason": "stop",
            "index": 0
        }
    ]
}
```