### PR TITLE
fix: The ‘defaultTest’ option has no effect during evaluation.

### DIFF
--- a/src/web/nextui/src/app/setup/RunTestSuiteButton.tsx
+++ b/src/web/nextui/src/app/setup/RunTestSuiteButton.tsx
@@ -9,7 +9,7 @@ import { IS_RUNNING_LOCALLY, NEXTJS_BASE_URL, USE_SUPABASE } from '@/constants';
 
 const RunTestSuiteButton: React.FC = () => {
   const router = useRouter();
-  const { env, description, providers, prompts, testCases } = useStore();
+  const { env, description, providers, prompts, testCases, defaultTest, evaluateOptions } = useStore();
   const [isRunning, setIsRunning] = useState(false);
   const [progressPercent, setProgressPercent] = useState(0);
 
@@ -22,6 +22,8 @@ const RunTestSuiteButton: React.FC = () => {
       providers,
       prompts,
       tests: testCases,
+      defaultTest,
+      evaluateOptions
     };
 
     try {


### PR DESCRIPTION
The document at ‘https://promptfoo.dev/docs/configuration/expected-outputs/model-graded’ describes how to configure the ‘defaultTest’ option, but it has not been posted yet.