### PR TITLE
fix: Improve Error Handling in Python Script Execution

### DIFF
--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -35,7 +35,16 @@ export async function runPython(
   try {
     await fs.writeFile(tempJsonPath, safeJsonStringify(args));
 
-    const results = await PythonShell.run('wrapper.py', pythonOptions);
+    let results;
+    try {
+      results = await PythonShell.run('wrapper.py', pythonOptions);
+    } catch (error) {
+      return {
+        pass: false,
+        score: 0,
+        reason: `Failed to execute Python script: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
     logger.debug(`Python script ${absPath} returned: ${results.join('\n')}`);
     let result: { type: 'final_result'; data: any } | undefined;
     try {
@@ -49,7 +58,7 @@ export async function runPython(
     }
     if (result?.type !== 'final_result') {
       throw new Error(
-        'The Python script `call_api` function must return a dict with an `output` or `error` string',
+        'The Python script `call_api` function must return a dict with an `output`',
       );
     }
     return result.data;

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -42,7 +42,9 @@ export async function runPython(
       return {
         pass: false,
         score: 0,
-        reason: `Failed to execute Python script: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        reason: `Failed to execute Python script: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
       };
     }
     logger.debug(`Python script ${absPath} returned: ${results.join('\n')}`);
@@ -57,9 +59,7 @@ export async function runPython(
       );
     }
     if (result?.type !== 'final_result') {
-      throw new Error(
-        'The Python script `call_api` function must return a dict with an `output`',
-      );
+      throw new Error('The Python script `call_api` function must return a dict with an `output`');
     }
     return result.data;
   } catch (error) {

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -2,6 +2,8 @@ import * as pythonWrapper from '../src/python/wrapper';
 import { promises as fs } from 'fs';
 import { PythonShell } from 'python-shell';
 
+jest.mock('../src/esm');
+
 jest.mock('python-shell');
 
 beforeEach(() => {

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -6,11 +6,11 @@ jest.mock('../src/esm');
 
 jest.mock('python-shell');
 
-beforeEach(() => {
-  jest.clearAllMocks(); // This clears all mock call counts
-});
-
 describe('Python Wrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('runPython', () => {
     it('should correctly run a Python script with provided arguments', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
@@ -34,7 +34,7 @@ describe('Python Wrapper', () => {
       expect(fs.unlink).toHaveBeenCalledTimes(1);
     });
 
-    it('should return an error object if the Python script execution fails', async () => {
+    it('should return an failure reason if the Python script execution fails', async () => {
       const mockPythonShellRun = PythonShell.run as jest.Mock;
       mockPythonShellRun.mockRejectedValue(new Error('Test Error'));
 
@@ -47,24 +47,14 @@ describe('Python Wrapper', () => {
       });
     });
 
-    it('should handle invalid JSON from the Python script', async () => {
-      jest.spyOn(fs, 'writeFile').mockResolvedValue();
-      jest.spyOn(fs, 'unlink').mockResolvedValue();
-
-      const mockPythonShellRun = PythonShell.run as jest.Mock;
-      mockPythonShellRun.mockResolvedValue(['invalid json']);
-
-      await expect(
-        pythonWrapper.runPython('testScript.py', 'testMethod', ['arg1']),
-      ).rejects.toThrow('Invalid JSON: Unexpected token i in JSON at position 0');
-    });
-
     it('should handle Python script returning incorrect result type', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       const mockPythonShellRun = PythonShell.run as jest.Mock;
-      mockPythonShellRun.mockResolvedValue(['{"type": "unexpected_result", "data": "test result"}']);
+      mockPythonShellRun.mockResolvedValue([
+        '{"type": "unexpected_result", "data": "test result"}',
+      ]);
 
       await expect(
         pythonWrapper.runPython('testScript.py', 'testMethod', ['arg1']),


### PR DESCRIPTION
**Summary**

This PR addresses issue [#827](https://github.com/promptfoo/promptfoo/issues/827) which involves suppressed grading results when an individual Python assertion raises an exception during test execution. The changes ensure that exceptions are properly captured and included in the `componentResults` of the JSON output, providing clearer feedback on test failures. In the future, we should consider treating Python exceptions separately from grading result failures as they are different classes of errors.

**Test Instructions**

To demonstrate the issue, an additional external assert file `fails.py` was created with the following contents:
```python
def get_assert(output, context):
    raise Exception("This is a forced failure")
```

This file was used in the `promptfooconfig.yaml` for testing purposes:
```yaml
prompts:
  - 'Tell me about {{topic}} in three words'
providers:
  - openai:gpt-4-1106-preview
tests:
  - vars:
      topic: yellow fruits
    assert:
      - type: python
        value: file://fails.py
      - type: python
        value: file://assert.py
```

Running the evaluation with `npm i` and then `npx [path/to/promptfoo] eval --config ./promptfooconfig.yaml --output exception.json` now correctly includes the exception details in the JSON output.

Thank you!