### PR TITLE
Support custom gateway URLs in Portkey

### DIFF
--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -53,4 +53,5 @@ providers:
     team: xxx
   portkeyConfig: xxx
   portkeyProvider: xxx
+  portkeyApiBaseUrl: xxx
 ```

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -28,7 +28,7 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
       {
         key: 'x-portkey-provider',
         value: process.env.PORTKEY_PROVIDER || providerOptions.config?.portkeyProvider,
-      }
+      },
     ].reduce((acc: Record<string, string>, { key, value }) => {
       if (value) acc[key] = value;
       return acc;

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -28,7 +28,7 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
       {
         key: 'x-portkey-provider',
         value: process.env.PORTKEY_PROVIDER || providerOptions.config?.portkeyProvider,
-      },
+      }
     ].reduce((acc: Record<string, string>, { key, value }) => {
       if (value) acc[key] = value;
       return acc;
@@ -38,7 +38,7 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
       ...providerOptions,
       config: {
         ...providerOptions.config,
-        apiBaseUrl: 'https://api.portkey.ai/v1',
+        apiBaseUrl: process.env.PORTKEY_API_BASE_URL || providerOptions.config?.portkeyApiBaseUrl || 'https://api.portkey.ai/v1',
         headers,
       },
     });


### PR DESCRIPTION
This PR explores support for a custom AI gateway URL that can be configured while setting up Portkey.

```yaml
portkeyApiBaseUrl: xxx
```