### PR TITLE
fix: crash on db migration when cache is disabled on first run

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -156,11 +156,11 @@ export const llmOutputsRelations = relations(llmOutputs, ({ one }) => ({
 let dbInstance: ReturnType<typeof drizzle> | null = null;
 
 export function getDbPath() {
-  return path.resolve(getConfigDirectoryPath(), 'promptfoo.db');
+  return path.resolve(getConfigDirectoryPath(true /* createIfNotExists */), 'promptfoo.db');
 }
 
 export function getDbSignalPath() {
-  return path.resolve(getConfigDirectoryPath(), 'evalLastWritten');
+  return path.resolve(getConfigDirectoryPath(true /* createIfNotExists */), 'evalLastWritten');
 }
 
 export function getDb() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -85,7 +85,7 @@ export function maybeRecordFirstRun(): boolean {
     const config = readGlobalConfig();
     if (!config.hasRun) {
       config.hasRun = true;
-      fs.writeFileSync(path.join(getConfigDirectoryPath(), 'promptfoo.yaml'), yaml.dump(config));
+      fs.writeFileSync(path.join(getConfigDirectoryPath(true /* createIfNotExists */), 'promptfoo.yaml'), yaml.dump(config));
       return true;
     }
     return false;
@@ -465,8 +465,12 @@ export async function readOutput(outputPath: string): Promise<OutputFile> {
 
 let configDirectoryPath: string | undefined = process.env.PROMPTFOO_CONFIG_DIR;
 
-export function getConfigDirectoryPath(): string {
-  return configDirectoryPath || path.join(os.homedir(), '.promptfoo');
+export function getConfigDirectoryPath(createIfNotExists: boolean = false): string {
+  const p = configDirectoryPath || path.join(os.homedir(), '.promptfoo');
+  if (createIfNotExists && !fs.existsSync(p)) {
+    fs.mkdirSync(p, { recursive: true });
+  }
+  return p;
 }
 
 export function setConfigDirectoryPath(newPath: string): void {
@@ -673,7 +677,7 @@ export async function migrateResultsFromFileSystemToDatabase() {
   logger.info('This is a one-time operation and may take a minute...');
   attemptedMigration = true;
 
-  const outputDir = path.join(getConfigDirectoryPath(), 'output');
+  const outputDir = path.join(getConfigDirectoryPath(true /* createIfNotExists */), 'output');
   const backupDir = `${outputDir}-backup-${new Date()
     .toISOString()
     .slice(0, 10)


### PR DESCRIPTION
Fixes root cause of https://github.com/promptfoo/promptfoo-action/issues/123