### PR TITLE
feat(webui): add copy and highlight cell actions

### DIFF
--- a/src/web/nextui/src/app/contexts/ShiftKeyContext.tsx
+++ b/src/web/nextui/src/app/contexts/ShiftKeyContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+
+export const ShiftKeyContext = createContext<boolean | undefined>(undefined);
+
+export const ShiftKeyProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [isShiftKeyPressed, setShiftKeyPressed] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Shift') {
+        setShiftKeyPressed(true);
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Shift') {
+        setShiftKeyPressed(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  return (
+    <ShiftKeyContext.Provider value={isShiftKeyPressed}>
+      {children}
+    </ShiftKeyContext.Provider>
+  );
+};

--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -11,6 +11,7 @@ import ResultsView from './ResultsView';
 import { getApiBaseUrl } from '@/api';
 import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
 import { REMOTE_API_BASE_URL } from '@/../../../constants';
+import { ShiftKeyProvider } from '@/app/contexts/ShiftKeyContext';
 import { useStore } from './store';
 
 import type { EvaluateSummary, UnifiedConfig, SharedResults } from '@/../../../types';
@@ -230,10 +231,12 @@ export default function Eval({
   }
 
   return (
-    <ResultsView
-      defaultEvalId={defaultEvalId}
-      recentEvals={recentEvals}
-      onRecentEvalSelected={handleRecentEvalSelection}
-    />
+    <ShiftKeyProvider>
+      <ResultsView
+        defaultEvalId={defaultEvalId}
+        recentEvals={recentEvals}
+        onRecentEvalSelected={handleRecentEvalSelection}
+      />
+    </ShiftKeyProvider>
   );
 }

--- a/src/web/nextui/src/app/hooks/useShiftKey.tsx
+++ b/src/web/nextui/src/app/hooks/useShiftKey.tsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ShiftKeyContext } from '@/app/contexts/ShiftKeyContext';
+
+export const useShiftKey = () => {
+  const context = useContext(ShiftKeyContext);
+  if (context === undefined) {
+    throw new Error('useShiftKey must be used within a ShiftKeyProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
Currently visible only when user is holding down "shift" key, in order to avoid cluttering the hover icons.