### PR TITLE
Pass evaluateOptions from web ui yaml

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -539,13 +539,13 @@ export interface TestCase<Vars = Record<string, string | string[] | object>> {
 
   // Additional configuration settings for the prompt
   options?: PromptConfig &
-  OutputConfig &
-  GradingConfig & {
-    // If true, do not expand arrays of variables into multiple eval cases.
-    disableVarExpansion?: boolean;
-    // If true, do not include an implicit `_conversation` variable in the prompt.
-    disableConversationVar?: boolean;
-  };
+    OutputConfig &
+    GradingConfig & {
+      // If true, do not expand arrays of variables into multiple eval cases.
+      disableVarExpansion?: boolean;
+      // If true, do not include an implicit `_conversation` variable in the prompt.
+      disableConversationVar?: boolean;
+    };
 
   // The required score for this test case.  If not provided, the test case is graded pass/fail.
   threshold?: number;
@@ -643,11 +643,11 @@ export interface TestSuiteConfig {
 
   // Determines whether or not sharing is enabled.
   sharing?:
-  | boolean
-  | {
-    apiBaseUrl?: string;
-    appBaseUrl?: string;
-  };
+    | boolean
+    | {
+        apiBaseUrl?: string;
+        appBaseUrl?: string;
+      };
 
   // Nunjucks filters
   nunjucksFilters?: Record<string, FilePath>;
@@ -678,6 +678,10 @@ export type EvaluateTestSuite = {
   prompts: (string | object | PromptFunction)[];
   writeLatestResults?: boolean;
 } & TestSuiteConfig;
+
+export type EvaluateTestSuiteWithEvaluateOptions = EvaluateTestSuite & {
+  evaluateOptions: EvaluateOptions;
+};
 
 export interface SharedResults {
   data: ResultsFile;


### PR DESCRIPTION
I think this closes: https://github.com/promptfoo/promptfoo/issues/856

When hitting the "Run Evaluation" button in the web UI, I realized we're passing the following data in the request body:
https://github.com/promptfoo/promptfoo/blob/f7c420e7179792676ad870dba4b8bdf5b2cb3667/src/web/nextui/src/app/setup/RunTestSuiteButton.tsx#L19-L36

This includes the `evaluateOptions` data, however in the route resolver we drop that data and don't pass it in to the `promptfoo.evaluate(...)` call.

This PR attempts to fix that by ensuring we're forwarding the `evaluateOptions` data correctly.

@typpo can you double check this change doesn't break anything? I didn't get the chance to test locally yet