### PR TITLE
Fix broken progress callback in web ui

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -804,7 +804,7 @@ class Evaluator {
     this.options.progressCallback = (completed, total, index, evalStep) => {
       if (originalProgressCallback) {
         originalProgressCallback(completed, total, index, evalStep);
-      };
+      }
       
       if (multibar && evalStep) {
         const threadIndex = index % concurrency;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -800,7 +800,12 @@ class Evaluator {
     // Set up main progress bars
     let multibar: MultiBar | undefined;
     let multiProgressBars: SingleBar[] = [];
+    const originalProgressCallback = this.options.progressCallback;
     this.options.progressCallback = (completed, total, index, evalStep) => {
+      if (originalProgressCallback) {
+        originalProgressCallback(completed, total, index, evalStep);
+      };
+      
       if (multibar && evalStep) {
         const threadIndex = index % concurrency;
         const progressbar = multiProgressBars[threadIndex];


### PR DESCRIPTION
I think this closes: https://github.com/promptfoo/promptfoo/issues/858

The purpose of this PR is to ensure the callback defined via the web ui is executed. That callback is defined here:
https://github.com/promptfoo/promptfoo/blob/f7c420e7179792676ad870dba4b8bdf5b2cb3667/src/web/server.ts#L103-L109

The current code actually overrides the `progressCallback` function, which means the one specified in the web ui server never gets executed. We never get to know the progress of our job without it!

This ensures both `progressCallback` functions get executed.