### PR TITLE
Improve Error Handling for Python Assertions and Provider Exceptions

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -272,7 +272,6 @@ export async function runAssertion({
           valueFromScript = pythonScriptOutput;
           logger.debug(`Python script ${filePath} output: ${valueFromScript}`);
         } catch (error) {
-          // throw new Error(`Python script execution failed: ${error}`);
           return {
             pass: false,
             score: 0,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -272,7 +272,13 @@ export async function runAssertion({
           valueFromScript = pythonScriptOutput;
           logger.debug(`Python script ${filePath} output: ${valueFromScript}`);
         } catch (error) {
-          throw new Error(`Python script execution failed: ${error}`);
+          // throw new Error(`Python script execution failed: ${error}`);
+          return {
+            pass: false,
+            score: 0,
+            reason: (error as Error).message,
+            assertion,
+          };
         }
       } else if (filePath.endsWith('.json')) {
         renderedValue = JSON.parse(fs.readFileSync(path.resolve(basePath, filePath), 'utf8'));

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -34,19 +34,7 @@ export async function runPython(
 
   try {
     await fs.writeFile(tempJsonPath, safeJsonStringify(args));
-
-    let results;
-    try {
-      results = await PythonShell.run('wrapper.py', pythonOptions);
-    } catch (error) {
-      return {
-        pass: false,
-        score: 0,
-        reason: `Failed to execute Python script: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      };
-    }
+    const results = await PythonShell.run('wrapper.py', pythonOptions);
     logger.debug(`Python script ${absPath} returned: ${results.join('\n')}`);
     let result: { type: 'final_result'; data: any } | undefined;
     try {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -2026,6 +2026,33 @@ describe('runAssertion', () => {
     },
   );
 
+  it('should handle when python file assertions throw an error', async () => {
+    const output = 'Expected output';
+    const spy = jest.spyOn(pythonWrapper, 'runPython').mockRejectedValue(new Error('The Python script `call_api` function must return a dict with an `output`'));
+    const fileAssertion: Assertion = {
+      type: 'python',
+      value: 'file:///path/to/assert.py',
+    };
+    const result: GradingResult = await runAssertion({
+      prompt: 'Some prompt that includes "double quotes" and \'single quotes\'',
+      provider: new OpenAiChatCompletionProvider('gpt-4'),
+      assertion: fileAssertion,
+      test: {} as AtomicTestCase,
+      output,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      assertion: {
+        type: 'python',
+        value: "file:///path/to/assert.py"
+      },
+      pass: false,
+      reason: "The Python script `call_api` function must return a dict with an `output`",
+      score: 0,
+    });
+  });
+
+
   describe('latency assertion', () => {
     it('should pass when the latency assertion passes', async () => {
       const output = 'Expected output';

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -34,17 +34,13 @@ describe('Python Wrapper', () => {
       expect(fs.unlink).toHaveBeenCalledTimes(1);
     });
 
-    it('should return an failure reason if the Python script execution fails', async () => {
+    it('should throw an error if the Python script execution fails', async () => {
       const mockPythonShellRun = PythonShell.run as jest.Mock;
       mockPythonShellRun.mockRejectedValue(new Error('Test Error'));
 
-      const result = await pythonWrapper.runPython('testScript.py', 'testMethod', ['arg1']);
-
-      expect(result).toEqual({
-        pass: false,
-        score: 0,
-        reason: 'Failed to execute Python script: Test Error',
-      });
+      await expect(pythonWrapper.runPython('testScript.py', 'testMethod', ['arg1'])).rejects.toThrow(
+        'Error running Python script: Test Error',
+      );
     });
 
     it('should handle Python script returning incorrect result type', async () => {


### PR DESCRIPTION
@efung Thank you for identifying the issue around incorrectly handled Python exceptions for Python providers and providing a detailed explanation in [#857](https://github.com/promptfoo/promptfoo/issues/857). The error should have been handled in the assertion code only. This PR:

- Modifies `runPython` to throw an error directly if the Python script execution fails, which will be caught and logged by the calling function. This reverts the behavior introduced in [#833](https://github.com/promptfoo/promptfoo/pull/833).
- When a Python script execution fails, the `runAssertion` function now returns an object containing `pass: false`, `score: 0`, and the error message. This ensures that the failure reason is included in the GradingResult.
- Adds a test case to `assertions.test.ts` to verify that Python file assertions correctly handle errors and return the appropriate GradingResult.