### PR TITLE
Fix type error eval page.tsx

### DIFF
--- a/src/web/nextui/src/app/eval/[id]/page.tsx
+++ b/src/web/nextui/src/app/eval/[id]/page.tsx
@@ -7,7 +7,7 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { getApiBaseUrl } from '@/api';
 import { IS_RUNNING_LOCALLY } from '@/constants';
 import { getResult } from '@/database';
-import { EvaluateSummary, EvaluateTestSuite, SharedResults } from '@/../../../types';
+import { EvaluateSummary, EvaluateTestSuite, SharedResults, UnifiedConfig } from '@/../../../types';
 import Eval from '../Eval';
 
 import './page.css';
@@ -59,7 +59,7 @@ export default async function Page({ params }: { params: { id: string } }) {
         version: result.version,
         createdAt: result.createdAt,
         results: result.results as unknown as EvaluateSummary,
-        config: result.config as unknown as EvaluateTestSuite,
+        config: result.config as unknown as UnifiedConfig,
       },
     };
 


### PR DESCRIPTION
Was getting this error on `npm run build` in on latest main branch. I'm not well versed in typescript so I'm not entirely confident that this is the correct way to fix this, but it seems to work for me locally.

```
./src/app/eval/[id]/page.tsx:62:9
Type error: Type 'EvaluateTestSuite' is not assignable to type 'Partial<UnifiedConfig>'.
  Types of property 'prompts' are incompatible.
    Type '(string | object | PromptFunction)[]' is not assignable to type 'string | (string | Prompt)[] | Record<string, string> | undefined'.
      Type '(string | object | PromptFunction)[]' is not assignable to type '(string | Prompt)[]'.
        Type 'string | object | PromptFunction' is not assignable to type 'string | Prompt'.
          Type 'object' is not assignable to type 'string | Prompt'.

  60 |         createdAt: result.createdAt,
  61 |         results: result.results as unknown as EvaluateSummary,
> 62 |         config: result.config as unknown as EvaluateTestSuite,
     |         ^
  63 |       },
  64 |     };
  65 | 
npm error Lifecycle script `build` failed with error:
npm error code 1
npm error path /home/adrien/Source/promptfoo/src/web/nextui
npm error workspace nextui@0.1.0
npm error location /home/adrien/Source/promptfoo/src/web/nextui
npm error command failed
npm error command sh -c next build
```
