### PR TITLE
Introduce jest test coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 .aider*
 
 __pycache__
+
+# jest
+.coverage

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@ const tsJestConfig: TsJestTransformerOptions & Record<string, unknown> = { useES
 
 const config: Config = {
   transform: {
+    '^.+\\.js$': 'babel-jest',
     '^.+\\.m?[tj]sx?$': ['ts-jest', tsJestConfig],
   },
   /*
@@ -13,10 +14,13 @@ const config: Config = {
     '(.+)\\.js': '$1',
   },
   */
+  collectCoverage: true,
+  coverageDirectory: '.coverage',
+  coverageProvider: 'v8',
   extensionsToTreatAsEsm: ['.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/examples', '<rootDir>/node_modules', '<rootDir>/dist'],
   setupFiles: ['<rootDir>/.jest/setEnvVars.js'],
   testPathIgnorePatterns: ['<rootDir>/examples', '<rootDir>/node_modules', '<rootDir>/dist'],
-  modulePathIgnorePatterns: ['<rootDir>/examples', '<rootDir>/node_modules', '<rootDir>/dist'],
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,22 +5,22 @@ import type { TsJestTransformerOptions } from 'ts-jest';
 const tsJestConfig: TsJestTransformerOptions & Record<string, unknown> = { useESM: true };
 
 const config: Config = {
-  transform: {
-    '^.+\\.js$': 'babel-jest',
-    '^.+\\.m?[tj]sx?$': ['ts-jest', tsJestConfig],
-  },
+  collectCoverage: true,
+  coverageDirectory: '.coverage',
+  coverageProvider: 'v8',
+  extensionsToTreatAsEsm: ['.ts'],
   /*
   moduleNameMapper: {
     '(.+)\\.js': '$1',
   },
   */
-  collectCoverage: true,
-  coverageDirectory: '.coverage',
-  coverageProvider: 'v8',
-  extensionsToTreatAsEsm: ['.ts'],
   modulePathIgnorePatterns: ['<rootDir>/examples', '<rootDir>/node_modules', '<rootDir>/dist'],
   setupFiles: ['<rootDir>/.jest/setEnvVars.js'],
   testPathIgnorePatterns: ['<rootDir>/examples', '<rootDir>/node_modules', '<rootDir>/dist'],
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.m?[tj]sx?$': ['ts-jest', tsJestConfig],
+  },
 };
 
 export default config;


### PR DESCRIPTION
This introduces jest test coverage reports. To test, run `npx jest`. 

Note that this slows down the execution speed of the tests. If we don't want to run this all of the time I can turn it on just in the ci. it also resolves a jest warning about `js` files transformed with `ts-jest`. 

```
------------------------|---------|----------|---------|---------|-------------------------------------------------------------------------------------------------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                           
------------------------|---------|----------|---------|---------|-------------------------------------------------------------------------------------------------------------
All files               |   62.52 |    67.76 |   44.17 |   62.52 |                                                                                                             
 src                    |   68.58 |    72.32 |    58.1 |   68.58 |                                                                                                             
  assertions.ts         |   71.62 |    77.09 |      75 |   71.62 | ...1019-1046,1081,1129-1153,1157-1158,1177-1180,1198-1201,1222-1223,1225-1226,1238-1240,1273-1291,1294-1303 
  cache.ts              |   86.25 |    66.66 |     100 |   86.25 | 20,30-35,66-67,93-95,99-104                                                                                 
  cliState.ts           |     100 |      100 |     100 |     100 |                                                                                                             
  csv.ts                |   93.43 |    86.79 |     100 |   93.43 | 23,25,55-56,65-69                                                                                           
  database.ts           |   79.65 |      100 |       0 |   79.65 | 23,37,53-54,70,75-82,98,103-110,158-160,162-164,166-172                                                     
  esm.ts                |   34.61 |      100 |       0 |   34.61 | 8-15,18-26                                                                                                  
  evaluator.ts          |   70.96 |    66.47 |   81.81 |   70.96 | ...,698-699,723-726,762-763,766-784,806-807,810-820,827-849,854-906,909-910,922-927,933-969,974-975,977-978 
  fetch.ts              |   81.53 |       50 |     100 |   81.53 | 25-26,35-36,55-56,59-62,64-65                                                                               
  googleSheets.ts       |   11.42 |      100 |       0 |   11.42 | 5-17,20-26,29-39,42-72,75-105                                                                               
  logger.ts             |   76.08 |     87.5 |       0 |   76.08 | 21,34-36,38-44                                                                                              
  matchers.ts           |   74.55 |    62.37 |   82.35 |   74.55 | ...,499-500,512-513,551-555,571-575,585-586,636-637,683-684,724-725,737-738,751-752,766-767,785-845,854-900 
  migrate.ts            |   52.17 |        0 |       0 |   52.17 | 11-19,22-23                                                                                                 
  prompts.ts            |   73.69 |    84.44 |      25 |   73.69 | 27-74,76-87,110-113,154-155,191-197,199-204,227-251,299-300                                                 
  providers.ts          |   68.98 |    68.29 |      50 |   68.98 | ...-179,189,191-194,198-201,214-216,223,227-232,242-248,252-255,260,266-271,273-281,283-292,329-330,346-385 
  suggestions.ts        |   23.33 |      100 |       0 |   23.33 | 15-60                                                                                                       
  telemetry.ts          |   88.88 |     87.5 |      80 |   88.88 | 39-46                                                                                                       
  testCases.ts          |   54.54 |    74.28 |   77.77 |   54.54 | 30-31,69,134-143,174,178-181,193-194,223-231,234-374                                                        
  types.ts              |     100 |    54.54 |     100 |     100 | 398-400,402-404                                                                                             
  updates.ts            |    91.3 |       75 |     100 |    91.3 | 21-22,28-29                                                                                                 
  util.ts               |   44.75 |     77.3 |   44.82 |   44.75 | ...1113,1116-1156,1159-1171,1191-1194,1202-1203,1208-1211,1224,1230,1237-1245,1260-1267,1275-1306,1368-1372 
 src/assertions         |   98.72 |     93.1 |     100 |   98.72 |                                                                                                             
  AssertionsResult.ts   |   98.34 |    94.11 |     100 |   98.34 | 90-91                                                                                                       
  validateAssertions.ts |     100 |    91.66 |     100 |     100 | 5                                                                                                           
 src/commands/eval      |   95.58 |    90.47 |     100 |   95.58 |                                                                                                             
  filterFailingTests.ts |   90.47 |    85.71 |     100 |   90.47 | 8-9                                                                                                         
  filterTests.ts        |   97.87 |    92.85 |     100 |   97.87 | 27                                                                                                          
 src/external           |     100 |      100 |     100 |     100 |                                                                                                             
  ragas.ts              |     100 |      100 |     100 |     100 |                                                                                                             
 src/providers          |   52.64 |       50 |    31.1 |   52.64 |                                                                                                             
  anthropic.ts          |   56.74 |    63.33 |   23.07 |   56.74 | 20-34,36-54,61-85,148-149,160-161,164-165,168-236,276-277,280-281,285-288,296-297,329-332,338-339,347-350   
  azureopenai.ts        |   51.71 |    25.42 |   35.71 |   51.71 | ...,303-306,320-323,335-338,340-341,349-350,401-404,409-412,423-424,442-445,465-472,475-487,490-493,496-641 
  azureopenaiUtil.ts    |     100 |    88.23 |     100 |     100 | 28,33                                                                                                       
  bam.ts                |    48.2 |      100 |       0 |    48.2 | 72-93,104-119,122-123,126-127,130-139,142-150,153-192                                                       
  bedrock.ts            |   41.15 |    33.33 |    6.25 |   41.15 | 53-57,60,65-72,75,80-91,94,109-118,138-139,142-143,146-157,160-166,173-240,248-249,252-293                  
  cloudflare-ai.ts      |   91.89 |     62.5 |   82.35 |   91.89 | 89-91,103-105,146-147,218-221,242-247,268-269,276-278,286-290,359-360                                       
  cohere.ts             |   34.52 |      100 |       0 |   34.52 | 54-65,68-69,72-167                                                                                          
  defaults.ts           |   80.48 |       25 |     100 |   80.48 | 26-33                                                                                                       
  http.ts               |   33.73 |      100 |       0 |   33.73 | 21-24,27-28,31-32,35-72,75-83                                                                               
  huggingface.ts        |   59.13 |    51.42 |   32.25 |   59.13 | ...,289-292,294-297,303-306,320-327,330-331,334-335,338-339,342-343,346-395,409-416,419-420,423-478,481-486 
  llama.ts              |    87.5 |     9.09 |      40 |    87.5 | 38-39,42-43,81-84,91-94                                                                                     
  localai.ts            |      24 |      100 |       0 |      24 | 23-35,38-39,42-43,47-48,53-90,95-133,138-174                                                                
  mistral.ts            |   40.08 |      100 |       0 |   40.08 | 21-34,36-56,120-131,134-135,138-139,142-143,146-157,160-170,173-241                                         
  ollama.ts             |   76.06 |    70.37 |   54.54 |   76.06 | 133-134,141-145,165-168,171-174,194-197,217-218,227-231,251-254,257-260,280-283,289-329                     
  openai.ts             |   50.31 |     52.5 |   60.86 |   50.31 | ...,306-309,312-315,329-332,412-415,461-464,468-471,493-496,500-512,521-522,572-763,774-779,782-857,865-951 
  openaiUtil.ts         |   94.44 |       75 |     100 |   94.44 | 28-29                                                                                                       
  palm.ts               |   22.07 |      100 |       0 |   22.07 | 28-36,39-40,43-44,47-55,58-65,69-70,77-84,87-152,155-221                                                    
  portkey.ts            |   15.21 |      100 |       0 |   15.21 | 7-45                                                                                                        
  pythonCompletion.ts   |   35.89 |      100 |       0 |   35.89 | 24-26,29-30,33-77                                                                                           
  replicate.ts          |    32.5 |       20 |   16.66 |    32.5 | 63-64,67-68,71-178,200-278                                                                                  
  scriptCompletion.ts   |    83.5 |    53.33 |      75 |    83.5 | 26-27,39-40,52-53,74-77,81-86                                                                               
  shared.ts             |   69.44 |       40 |      50 |   69.44 | 10-15,26-27,34-36                                                                                           
  vertex.ts             |   34.61 |      100 |       0 |   34.61 | ...,115-123,126-127,130-131,134-140,143-149,152-153,156-159,162-168,172-173,208-215,218-222,225-350,353-441 
  vertexUtil.ts         |   83.72 |      100 |       0 |   83.72 | 73-86                                                                                                       
  webhook.ts            |   76.81 |    33.33 |      40 |   76.81 | 20-21,24-25,32-33,51-54,62-67                                                                               
 src/python             |   89.21 |    58.33 |     100 |   89.21 |                                                                                                             
  wrapper.ts            |   89.21 |    58.33 |     100 |   89.21 | 43-48,57,63,95-97                                                                                           
------------------------|---------|----------|---------|---------|-------------------------------------------------------------------------------------------------------------

Test Suites: 16 passed, 16 total
Tests:       537 passed, 537 total
```