### PR TITLE
feat(ollama): add OLLAMA_API_KEY to support authentication

### DIFF
--- a/site/docs/providers/ollama.md
+++ b/site/docs/providers/ollama.md
@@ -33,6 +33,7 @@ We also support the `/api/embeddings` endpoint via `ollama:embeddings:<model nam
 Supported environment variables:
 
 - `OLLAMA_BASE_URL` - protocol, host name, and port (defaults to `http://localhost:11434`)
+- `OLLAMA_API_KEY` - (optional) api key that is passed as the Bearer token in the Authorization Header when calling the API
 - `REQUEST_TIMEOUT_MS` - request timeout in milliseconds
 
 To pass configuration options to Ollama, use the `config` key like so:

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -155,7 +155,9 @@ export class OllamaCompletionProvider implements ApiProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
+            ...(process.env.OLLAMA_API_KEY
+              ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` }
+              : {}),
           },
           body: JSON.stringify(params),
         },
@@ -242,7 +244,9 @@ export class OllamaChatProvider implements ApiProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
+            ...(process.env.OLLAMA_API_KEY
+              ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` }
+              : {}),
           },
           body: JSON.stringify(params),
         },
@@ -302,7 +306,9 @@ export class OllamaEmbeddingProvider extends OllamaCompletionProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
+            ...(process.env.OLLAMA_API_KEY
+              ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` }
+              : {}),
           },
           body: JSON.stringify(params),
         },

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -155,6 +155,7 @@ export class OllamaCompletionProvider implements ApiProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
           },
           body: JSON.stringify(params),
         },
@@ -241,6 +242,7 @@ export class OllamaChatProvider implements ApiProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
           },
           body: JSON.stringify(params),
         },
@@ -300,6 +302,7 @@ export class OllamaEmbeddingProvider extends OllamaCompletionProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(process.env.OLLAMA_API_KEY ? { Authorization: `Bearer ${process.env.OLLAMA_API_KEY}` } : {})
           },
           body: JSON.stringify(params),
         },


### PR DESCRIPTION
This PR adds the option to set the `OLLAMA_API_KEY` Environment Variable for the ollama provider that is further used optionally as the Bearer Token within the Authorization Header when calling the Ollama `generate` endpoints.

Since Ollama is providing an OpenAI compatible API (see [this blogpost](https://ollama.com/blog/openai-compatibility)) and OpenAI itself uses the `OPENAI_API_KEY` as its corresponding bearer token, it would be very useful to provide a similar option for the ollama provider in promptfoo.

Currently ollama does not support authentication out of the box, but a lot people are having a reverse proxy in front of ollama to utilize it as a protected service within an isolated network.

The documentation for the ollama provider has been updated accordingly.

Adding optional paramters to the http headers has been done similar to other providers (e.g. huggingface.ts)

If i can add more information please feel free to reach out anytime. 
Thanks for the great project and work you have put into this!