### PR TITLE
feat(openai): add max_num_results option to file_search type

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -588,7 +588,7 @@ type OpenAiAssistantOptions = OpenAiSharedOptions & {
     | 'none'
     | 'auto'
     | { type: 'function'; function?: { name: string } }
-    | { type: 'file_search' };
+    | { type: 'file_search'; file_search?: { max_num_results?: number } };
 };
 
 export class OpenAiAssistantProvider extends OpenAiGenericProvider {


### PR DESCRIPTION
OpenAI has released a new param, `max_num_results`, that controls the maximum number of results retrieved by the file_search tool. This PR adds it to the types.

https://platform.openai.com/docs/api-reference/assistants/createAssistant#assistants-createassistant-tools