### PR TITLE
feat(webui): ability to extract json field for display

### DIFF
--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -167,7 +167,7 @@ function EvalOutputCell({
   showDiffs: boolean;
   searchText: string;
 }) {
-  const { renderMarkdown, prettifyJson, showPrompts } = useResultsViewStore();
+  const { renderMarkdown, prettifyJson, jsonExtractField, showPrompts } = useResultsViewStore();
   const [openPrompt, setOpen] = React.useState(false);
   const handlePromptOpen = () => {
     setOpen(true);
@@ -303,29 +303,45 @@ function EvalOutputCell({
     } catch (error) {
       console.error('Invalid regular expression:', (error as Error).message);
     }
-  } else if (renderMarkdown) {
-    node = (
-      <ReactMarkdown
-        components={{
-          img: ({ src, alt }) => (
-            <img
-              loading="lazy"
-              src={src}
-              alt={alt}
-              onClick={() => toggleLightbox(src)}
-              style={{ cursor: 'pointer' }}
-            />
-          ),
-        }}
-      >
-        {text}
-      </ReactMarkdown>
-    );
-  } else if (prettifyJson) {
-    try {
-      node = <pre>{JSON.stringify(JSON.parse(text), null, 2)}</pre>;
-    } catch (error) {
-      // Ignore because it's probably not JSON.
+  } else {
+    if (prettifyJson) {
+      try {
+        let json = JSON.parse(text);
+        if (jsonExtractField) {
+          json = json[jsonExtractField];
+          if (!json) {
+            node = (
+              <em>
+                Field <code>{jsonExtractField}</code> is undefined
+              </em>
+            );
+          }
+        }
+        if (json) {
+          node = <pre>{JSON.stringify(json, null, 2)}</pre>;
+        }
+      } catch (error) {
+        console.log(error);
+        // Ignore because it's probably not JSON.
+      }
+    } else if (renderMarkdown) {
+      node = (
+        <ReactMarkdown
+          components={{
+            img: ({ src, alt }) => (
+              <img
+                loading="lazy"
+                src={src}
+                alt={alt}
+                onClick={() => toggleLightbox(src)}
+                style={{ cursor: 'pointer' }}
+              />
+            ),
+          }}
+        >
+          {text}
+        </ReactMarkdown>
+      );
     }
   }
 

--- a/src/web/nextui/src/app/eval/ResultsViewSettingsModal.tsx
+++ b/src/web/nextui/src/app/eval/ResultsViewSettingsModal.tsx
@@ -5,7 +5,10 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import OutlinedInput from '@mui/material/OutlinedInput';
 import Slider from '@mui/material/Slider';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -31,6 +34,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
     setPrettifyJson,
     showPrompts,
     setShowPrompts,
+    jsonExtractField,
+    setJsonExtractField,
   } = useResultsViewStore();
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
@@ -70,6 +75,18 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
             }
             label="Prettify JSON outputs"
           />
+          <FormControl>
+            <InputLabel htmlFor="extract-field" size="small">
+              Extract field from JSON
+            </InputLabel>
+            <OutlinedInput
+              id="extract-field"
+              label="Extract field from JSON"
+              size="small"
+              value={jsonExtractField || ''}
+              onChange={(e) => setJsonExtractField(e.target.value)}
+            />
+          </FormControl>
         </Box>
         <Box>
           <Tooltip title="Show the final prompt that produced the output in each cell.">

--- a/src/web/nextui/src/app/eval/store.ts
+++ b/src/web/nextui/src/app/eval/store.ts
@@ -25,6 +25,8 @@ interface TableState {
   setPrettifyJson: (prettifyJson: boolean) => void;
   showPrompts: boolean;
   setShowPrompts: (showPrompts: boolean) => void;
+  jsonExtractField: string | null;
+  setJsonExtractField: (jsonExtractField: string) => void;
 }
 
 export const useStore = create<TableState>()(
@@ -51,6 +53,8 @@ export const useStore = create<TableState>()(
       setPrettifyJson: (prettifyJson: boolean) => set(() => ({ prettifyJson })),
       showPrompts: false,
       setShowPrompts: (showPrompts: boolean) => set(() => ({ showPrompts })),
+      jsonExtractField: null,
+      setJsonExtractField: (jsonExtractField: string) => set(() => ({ jsonExtractField })),
     }),
     {
       name: 'ResultsViewStorage',


### PR DESCRIPTION
Ability to extract a field from LLM JSON output

For example, given this setting:
<img width="497" alt="image" src="https://github.com/promptfoo/promptfoo/assets/310310/aa59efae-1c15-4b35-9173-6115b77cbb65">

An output of the form:
```json
{
  "foo": 1,
  "bar": "meow"
}
```

Would just display `1`

Related to #879 and #786 