### PR TITLE
chore(ci): add `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
 name: CI
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
This PR adds a `workflow_dispatch` to allow manual triggering of the ci workflow without a pull request or push to main.
