### PR TITLE
Bug fix: label not showing problem when using eval with config option

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -301,12 +301,12 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
     }
   };
 
-  const seenPrompts = new Set<string>();
+  const seenPrompts = new Set<string|Prompt>();
   const addSeenPrompt = (prompt: string | Prompt) => {
     if (typeof prompt === 'string') {
       seenPrompts.add(prompt);
     } else if (typeof prompt === 'object' && prompt.id) {
-      seenPrompts.add(prompt.id);
+      seenPrompts.add(prompt);
     } else {
       throw new Error('Invalid prompt object');
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -301,7 +301,7 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
     }
   };
 
-  const seenPrompts = new Set<string|Prompt>();
+  const seenPrompts = new Set<string | Prompt>();
   const addSeenPrompt = (prompt: string | Prompt) => {
     if (typeof prompt === 'string') {
       seenPrompts.add(prompt);


### PR DESCRIPTION
https://github.com/promptfoo/promptfoo/issues/927
Based on the above issue, I present the following PR.
This PR fixes an issue where the label did not work when using the `--config` option with `promptfoo eval`.

I tested it personally but it should be tested by others again.