### PR TITLE
fix: prevent assertions from being modified as they run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "proxy-agent": "^6.4.0",
         "python-shell": "^5.0.0",
         "replicate": "^0.30.1",
+        "rfdc": "^1.4.1",
         "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
         "semver": "^7.6.2",
         "socket.io": "^4.7.5",
@@ -21774,6 +21775,11 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "proxy-agent": "^6.4.0",
     "python-shell": "^5.0.0",
     "replicate": "^0.30.1",
+    "rfdc": "^1.4.1",
     "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
     "semver": "^7.6.2",
     "socket.io": "^4.7.5",


### PR DESCRIPTION
Fixes a bug where if an assertion has a provider set on it, the provider got set on the test and overrode the default provider on the following assertion.