### PR TITLE
chore(dependencies): bump LLM providers in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "site"
       ],
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.22.0",
+        "@anthropic-ai/sdk": "^0.23.0",
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
         "ajv": "^8.16.0",
         "ajv-formats": "^2.1.1",
@@ -43,11 +43,11 @@
         "mathjs": "^12.4.1",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
-        "openai": "^4.49.1",
+        "openai": "^4.51.0",
         "opener": "^1.5.2",
         "proxy-agent": "^6.4.0",
         "python-shell": "^5.0.0",
-        "replicate": "^0.30.1",
+        "replicate": "^0.30.2",
         "rfdc": "^1.4.1",
         "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
         "semver": "^7.6.2",
@@ -60,8 +60,8 @@
         "promptfoo": "dist/src/main.js"
       },
       "devDependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.592.0",
-        "@azure/identity": "^4.2.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.598.0",
+        "@azure/identity": "^4.2.1",
         "@eslint/js": "^9.4.0",
         "@swc/cli": "^0.3.12",
         "@swc/core": "^1.5.27",
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-dv4BCC6FZJw3w66WNLsHlUFjhu19fS1L/5jMPApwhZLa/Oy1j0A2i3RypmDtHEPp4Wwg3aZkSHksp7VzYWjzmw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.23.0.tgz",
+      "integrity": "sha512-pRz7xamFPIUYW1w9H1iFiLJ2AK3oZC1crNLJXazyjLo9cDLCR5CCXWi8rH6CF9szVKRsI5h8Duno12/2cfSAfA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -352,157 +352,193 @@
       }
     },
     "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.592.0.tgz",
-      "integrity": "sha512-Y5u+fJyDIdwSG4YN+peCgRnz1nRp1wdWHFzinJBRNFDn3zpKOhQuYqOeIEDvfIB2sxSu8167e+AAYBoYfX5qnQ==",
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.592.0",
-        "@aws-sdk/client-sts": "3.592.0",
-        "@aws-sdk/core": "3.592.0",
-        "@aws-sdk/credential-provider-node": "3.592.0",
-        "@aws-sdk/middleware-host-header": "3.577.0",
-        "@aws-sdk/middleware-logger": "3.577.0",
-        "@aws-sdk/middleware-recursion-detection": "3.577.0",
-        "@aws-sdk/middleware-user-agent": "3.587.0",
-        "@aws-sdk/region-config-resolver": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.587.0",
-        "@aws-sdk/util-user-agent-browser": "3.577.0",
-        "@aws-sdk/util-user-agent-node": "3.587.0",
-        "@smithy/config-resolver": "^3.0.1",
-        "@smithy/core": "^2.2.0",
-        "@smithy/eventstream-serde-browser": "^3.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.0",
-        "@smithy/eventstream-serde-node": "^3.0.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-retry": "^3.0.3",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.598.0.tgz",
+      "integrity": "sha512-+5xu31D0QBOCxlAiuHRECeLwjcV/1xR/qTAxzKjff/9frb0FRFpSEf3YQy48ycBzYNJ5gATNVS8m0+ZeLhhdUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.598.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/eventstream-serde-browser": "^3.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.1",
+        "@smithy/eventstream-serde-node": "^3.0.2",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.3",
-        "@smithy/util-defaults-mode-node": "^3.0.3",
-        "@smithy/util-endpoints": "^2.0.1",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-stream": "^3.0.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -511,47 +547,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.592.0.tgz",
-      "integrity": "sha512-w+SuW47jQqvOC7fonyjFjsOh3yjqJ+VpWdVrmrl0E/KryBE7ho/Wn991Buf/EiHHeJikoWgHsAIPkBH29+ntdA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.592.0",
-        "@aws-sdk/middleware-host-header": "3.577.0",
-        "@aws-sdk/middleware-logger": "3.577.0",
-        "@aws-sdk/middleware-recursion-detection": "3.577.0",
-        "@aws-sdk/middleware-user-agent": "3.587.0",
-        "@aws-sdk/region-config-resolver": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.587.0",
-        "@aws-sdk/util-user-agent-browser": "3.577.0",
-        "@aws-sdk/util-user-agent-node": "3.587.0",
-        "@smithy/config-resolver": "^3.0.1",
-        "@smithy/core": "^2.2.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-retry": "^3.0.3",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.3",
-        "@smithy/util-defaults-mode-node": "^3.0.3",
-        "@smithy/util-endpoints": "^2.0.1",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -560,49 +596,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.592.0.tgz",
-      "integrity": "sha512-11Zvm8nm0s/UF3XCjzFRpQU+8FFVW5rcr3BHfnH6xAe5JEoN6bJN/n+wOfnElnjek+90hh+Qc7s141AMrCjiiw==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.598.0.tgz",
+      "integrity": "sha512-jfdH1pAO9Tt8Nkta/JJLoUnwl7jaRdxToQTJfUtE+o3+0JP5sA4LfC2rBkJSWcU5BdAA+kyOs5Lv776DlN04Vg==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.592.0",
-        "@aws-sdk/core": "3.592.0",
-        "@aws-sdk/credential-provider-node": "3.592.0",
-        "@aws-sdk/middleware-host-header": "3.577.0",
-        "@aws-sdk/middleware-logger": "3.577.0",
-        "@aws-sdk/middleware-recursion-detection": "3.577.0",
-        "@aws-sdk/middleware-user-agent": "3.587.0",
-        "@aws-sdk/region-config-resolver": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.587.0",
-        "@aws-sdk/util-user-agent-browser": "3.577.0",
-        "@aws-sdk/util-user-agent-node": "3.587.0",
-        "@smithy/config-resolver": "^3.0.1",
-        "@smithy/core": "^2.2.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-retry": "^3.0.3",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.3",
-        "@smithy/util-defaults-mode-node": "^3.0.3",
-        "@smithy/util-endpoints": "^2.0.1",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -611,49 +647,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.592.0.tgz",
-      "integrity": "sha512-KUrOdszZfcrlpKr4dpdkGibZ/qq3Lnfu1rjv1U+V1QJQ9OuMo9J3sDWpWV9tigNqY0aGllarWH5cJbz9868W/w==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.598.0.tgz",
+      "integrity": "sha512-bXhz/cHL0iB9UH9IFtMaJJf4F8mV+HzncETCRFzZ9SyUMt5rP9j8A7VZknqGYSx/6mI8SsB1XJQkWSbhn6FiSQ==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sso-oidc": "3.592.0",
-        "@aws-sdk/core": "3.592.0",
-        "@aws-sdk/credential-provider-node": "3.592.0",
-        "@aws-sdk/middleware-host-header": "3.577.0",
-        "@aws-sdk/middleware-logger": "3.577.0",
-        "@aws-sdk/middleware-recursion-detection": "3.577.0",
-        "@aws-sdk/middleware-user-agent": "3.587.0",
-        "@aws-sdk/region-config-resolver": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.587.0",
-        "@aws-sdk/util-user-agent-browser": "3.577.0",
-        "@aws-sdk/util-user-agent-node": "3.587.0",
-        "@smithy/config-resolver": "^3.0.1",
-        "@smithy/core": "^2.2.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/hash-node": "^3.0.0",
-        "@smithy/invalid-dependency": "^3.0.0",
-        "@smithy/middleware-content-length": "^3.0.0",
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-retry": "^3.0.3",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.3",
-        "@smithy/util-defaults-mode-node": "^3.0.3",
-        "@smithy/util-endpoints": "^2.0.1",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -662,16 +698,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.592.0.tgz",
-      "integrity": "sha512-gLPMXR/HXDP+9gXAt58t7gaMTvRts9i6Q7NMISpkGF54wehskl5WGrbdtHJFylrlJ5BQo3XVY6i661o+EuR1wg==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
       "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.2.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/signature-v4": "^3.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/core": "^2.2.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
       },
@@ -680,14 +716,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.587.0.tgz",
-      "integrity": "sha512-Hyg/5KFECIk2k5o8wnVEiniV86yVkhn5kzITUydmNGCkXdBFHMHRx6hleQ1bqwJHbBskyu8nbYamzcwymmGwmw==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -695,19 +731,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.587.0.tgz",
-      "integrity": "sha512-Su1SRWVRCuR1e32oxX3C1V4c5hpPN20WYcRfdcr2wXwHqSvys5DrnmuCC+JoEnS/zt3adUJhPliTqpfKgSdMrA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -715,47 +751,47 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.592.0.tgz",
-      "integrity": "sha512-3kG6ngCIOPbLJZZ3RV+NsU7HVK6vX1+1DrPJKj9fVlPYn7IXsk8NAaUT5885yC7+jKizjv0cWLrLKvAJV5gfUA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.587.0",
-        "@aws-sdk/credential-provider-http": "3.587.0",
-        "@aws-sdk/credential-provider-process": "3.587.0",
-        "@aws-sdk/credential-provider-sso": "3.592.0",
-        "@aws-sdk/credential-provider-web-identity": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/credential-provider-imds": "^3.1.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.592.0"
+        "@aws-sdk/client-sts": "^3.598.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.592.0.tgz",
-      "integrity": "sha512-BguihBGTrEjVBQ07hm+ZsO29eNJaxwBwUZMftgGAm2XcMIEClNPfm5hydxu2BmA4ouIJQJ6nG8pNYghEumM+Aw==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.598.0.tgz",
+      "integrity": "sha512-sXTlqL5I/awlF9Dg2MQ17SfrEaABVnsj2mf4jF5qQrIRhfbvQOIYdEqdy8Rn1AWlJMz/N450SGzc0XJ5owxxqw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.587.0",
-        "@aws-sdk/credential-provider-http": "3.587.0",
-        "@aws-sdk/credential-provider-ini": "3.592.0",
-        "@aws-sdk/credential-provider-process": "3.587.0",
-        "@aws-sdk/credential-provider-sso": "3.592.0",
-        "@aws-sdk/credential-provider-web-identity": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/credential-provider-imds": "^3.1.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -763,15 +799,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.587.0.tgz",
-      "integrity": "sha512-V4xT3iCqkF8uL6QC4gqBJg/2asd/damswP1h9HCfqTllmPWzImS+8WD3VjgTLw5b0KbTy+ZdUhKc0wDnyzkzxg==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -779,17 +815,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.592.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.592.0.tgz",
-      "integrity": "sha512-fYFzAdDHKHvhtufPPtrLdSv8lO6GuW3em6n3erM5uFdpGytNpjXvr3XGokIsuXcNkETAY/Xihg+G9ksNE8WJxQ==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.592.0",
-        "@aws-sdk/token-providers": "3.587.0",
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/token-providers": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -797,32 +833,32 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.587.0.tgz",
-      "integrity": "sha512-XqIx/I2PG7kyuw3WjAP9wKlxy8IvFJwB8asOFT1xPFoVfZYKIogjG9oLP5YiRtfvDkWIztHmg5MlVv3HdJDGRw==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.587.0"
+        "@aws-sdk/client-sts": "^3.598.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.577.0.tgz",
-      "integrity": "sha512-9ca5MJz455CODIVXs0/sWmJm7t3QO4EUa1zf8pE8grLpzf0J94bz/skDWm37Pli13T3WaAQBHCTiH2gUVfCsWg==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -830,13 +866,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.577.0.tgz",
-      "integrity": "sha512-aPFGpGjTZcJYk+24bg7jT4XdIp42mFXSuPt49lw5KygefLyJM/sB0bKKqPYYivW0rcuZ9brQ58eZUNthrzYAvg==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -844,14 +880,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.577.0.tgz",
-      "integrity": "sha512-pn3ZVEd2iobKJlR3H+bDilHjgRnNrQ6HMmK9ZzZw89Ckn3Dcbv48xOv4RJvu0aU8SDLl/SNCxppKjeLDTPGBNA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -859,15 +895,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.587.0.tgz",
-      "integrity": "sha512-SyDomN+IOrygLucziG7/nOHkjUXES5oH5T7p8AboO8oakMQJdnudNXiYWTicQWO52R51U6CR27rcMPTGeMedYA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@aws-sdk/util-endpoints": "3.587.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -875,16 +911,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.587.0.tgz",
-      "integrity": "sha512-93I7IPZtulZQoRK+O20IJ4a1syWwYPzoO2gc3v+/GNZflZPV3QJXuVbIm0pxBsu0n/mzKGUKqSOLPIaN098HcQ==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -892,31 +928,31 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.587.0.tgz",
-      "integrity": "sha512-ULqhbnLy1hmJNRcukANBWJmum3BbjXnurLPSFXoGdV0llXYlG55SzIla2VYqdveQEEjmsBuTZdFvXAtNpmS5Zg==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.587.0"
+        "@aws-sdk/client-sso-oidc": "^3.598.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-      "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -924,14 +960,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.587.0.tgz",
-      "integrity": "sha512-8I1HG6Em8wQWqKcRW6m358mqebRVNpL8XrrEoT4In7xqkKkmYtHRNVYP6lcmiQh5pZ/c/FXu8dSchuFIWyEtqQ==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-endpoints": "^2.0.1",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-endpoints": "^2.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -951,26 +987,26 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.577.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.577.0.tgz",
-      "integrity": "sha512-zEAzHgR6HWpZOH7xFgeJLc6/CzMcx4nxeQolZxVZoB5pPaJd3CjyRhZN0xXeZB0XIRCWmb4yJBgyiugXLNMkLA==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.587.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.587.0.tgz",
-      "integrity": "sha512-Pnl+DUe/bvnbEEDHP3iVJrOtE3HbFJBPgsD6vJ+ml/+IYk1Eq49jEG+EHZdNTPz3SDG0kbp2+7u41MKYJHR/iQ==",
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.577.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -983,15 +1019,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@azure-rest/core-client": {
@@ -5971,12 +5998,12 @@
       ]
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.1.tgz",
+      "integrity": "sha512-Jb7jg4E+C+uvrUQi+h9kbILY6ts6fglKZzseMCHlH9ayq+1f5QdpYf8MV/xppuiN6DAMJAmwGz53GwP3213dmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5984,15 +6011,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.1.tgz",
-      "integrity": "sha512-hbkYJc20SBDz2qqLzttjI/EqXemtmWk0ooRznLsiXp3066KQRTvuKHa7U4jCZCJq6Dozqvy0R1/vNESC9inPJg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.2.tgz",
+      "integrity": "sha512-wUyG6ezpp2sWAvfqmSYTROwFUmJqKV78GLf55WODrosBcT0BAMd9bOLO4HRhynWBgAobPml2cF9ZOdgCe00r+g==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6000,18 +6027,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-ygLZSSKgt9bR8HAxR9mK+U5obvAJBr6zlQuhN5soYWx/amjDoQN4dTkydTypgKe6rIbUjTILyLU+W5XFwXr4kg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.1.tgz",
+      "integrity": "sha512-R8Pzrr2v2oGUoj4CTZtKPr87lVtBsz7IUBGhSwS1kc6Cj0yPwNdYbkzhFsxhoDE9+BPl09VN/6rFsW9GJzWnBA==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-retry": "^3.0.3",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6019,15 +6046,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.0.tgz",
-      "integrity": "sha512-q4A4d38v8pYYmseu/jTS3Z5I3zXlEOe5Obi+EJreVKgSVyWUHOd7/yaVCinC60QG4MRyCs98tcxBH1IMC0bu7Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.1.tgz",
+      "integrity": "sha512-htndP0LwHdE3R3Nam9ZyVWhwPYOmD4xCL79kqvNxy8u/bv0huuy574CSiRY4cvEICgimv8jlVfLeZ7zZqbnB2g==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6035,25 +6062,25 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.0.0.tgz",
-      "integrity": "sha512-PUtyEA0Oik50SaEFCZ0WPVtF9tz/teze2fDptW6WRXl+RrEenH8UbEjudOz8iakiMl3lE3lCVqYf2Y+znL8QFQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.0.tgz",
+      "integrity": "sha512-XFDl70ZY+FabSnTX3oQGGYvdbEaC8vPEFkCEOoBkumqaZIwR1WjjJCDu2VMXlHbKWKshefWXdT0NYteL5v6uFw==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
-      "integrity": "sha512-NB7AFiPN4NxP/YCAnrvYR18z2/ZsiHiF7VtG30gshO9GbFrIb1rC8ep4NGpJSWrz6P64uhPXeo4M0UsCLnZKqw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.2.tgz",
+      "integrity": "sha512-6147vdedQGaWn3Nt4P1KV0LuV8IH4len1SAeycyko0p8oRLWFyYyx0L8JHGclePDSphkjxZqBHtyIfyupCaTGg==",
       "dev": true,
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.2",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6061,12 +6088,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
-      "integrity": "sha512-RUQG3vQ3LX7peqqHAbmayhgrF5aTilPnazinaSGF1P0+tgM3vvIRWPHmlLIz2qFqB9LqFIxditxc8O2Z6psrRw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.1.tgz",
+      "integrity": "sha512-6+B8P+5Q1mll4u7IoI7mpmYOSW3/c2r3WQoYLdqOjbIKMixJFGmN79ZjJiNMy4X2GZ4We9kQ6LfnFuczSlhcyw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6074,13 +6101,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-      "integrity": "sha512-baRPdMBDMBExZXIUAoPGm/hntixjt/VFpU6+VmCyiYJYzRHRxoaI1MN+5XE+hIS8AJ2GCHLMFEIOLzq9xx1EgQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.2.tgz",
+      "integrity": "sha512-DLtmGAfqxZAql8rB+HqyPlUne22u3EEVj+hxlUjgXk0hXt+SfLGK0ljzRFmiWQ3qGpHu1NdJpJA9e5JE/dJxFw==",
       "dev": true,
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.2",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6088,13 +6115,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-      "integrity": "sha512-HNFfShmotWGeAoW4ujP8meV9BZavcpmerDbPIjkJbxKbN8RsUcpRQ/2OyIxWNxXNH2GWCAxuSB7ynmIGJlQ3Dw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.2.tgz",
+      "integrity": "sha512-d3SgAIQ/s4EbU8HAHJ8m2MMJPAL30nqJktyVgvqZWNznA8PJl61gJw5gj/yjIt/Fvs3d4fU8FmPPAhdp2yr/7A==",
       "dev": true,
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/eventstream-codec": "^3.1.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6102,25 +6129,25 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
-      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.2.tgz",
+      "integrity": "sha512-0nW6tLK0b7EqSsfKvnOmZCgJqnodBAnvqcrlC5dotKfklLedPTRGsQamSVbVDWyuU/QGg+YbZDJUQ0CUufJXZQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.1.tgz",
+      "integrity": "sha512-w2ncjgk2EYO2+WhAsSQA8owzoOSY7IL1qVytlwpnL1pFGWTjIoIh5nROkEKXY51unB63bMGZqDiVoXaFbyKDlg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -6130,12 +6157,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.1.tgz",
+      "integrity": "sha512-RSNF/32BKygXKKMyS7koyuAq1rcdW5p5c4EFa77QenBFze9As+JiRnV9OWBh2cB/ejGZalEZjvIrMLHwJl7aGA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       }
     },
@@ -6152,13 +6179,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.1.tgz",
+      "integrity": "sha512-6QdK/VbrCfXD5/QolE2W/ok6VqxD+SM28Ds8iSlEHXZwv4buLsvWyvoEEy0322K/g5uFgPzBmZjGqesTmPL+yQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6166,17 +6193,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.1.tgz",
-      "integrity": "sha512-lQ/UOdGD4KM5kLZiAl0q8Qy3dPbynvAXKAdXnYlrA1OpaUwr+neSsVokDZpY6ZVb5Yx8jnus29uv6XWpM9P4SQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.2.tgz",
+      "integrity": "sha512-gWEaGYB3Bei17Oiy/F2IlUPpBazNXImytoOdJ1xbrUOaJKAOiUhx8/4FOnYLLJHdAwa9PlvJ2ULda2f/Dnwi9w==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6184,18 +6211,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.3.tgz",
-      "integrity": "sha512-Wve1qzJb83VEU/6q+/I0cQdAkDnuzELC6IvIBwDzUEiGpKqXgX1v10FUuZGbRS6Ov/P+HHthcAoHOJZQvZNAkA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.4.tgz",
+      "integrity": "sha512-Tu+FggbLNF5G9L6Wi8o32Mg4bhlBInWlhhaFKyytGRnkfxGopxFVXJQn7sjZdFYJyTz6RZZa06tnlvavUgtoVg==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/service-error-classification": "^3.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -6204,12 +6231,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.1.tgz",
+      "integrity": "sha512-ak6H/ZRN05r5+SR0/IUc5zOSyh2qp3HReg1KkrnaSLXmncy9lwOjNqybX4L4x55/e5mtVDn1uf/gQ6bw5neJPw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6217,12 +6244,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.1.tgz",
+      "integrity": "sha512-fS5uT//y1SlBdkzIvgmWQ9FufwMXrHSSbuR25ygMy1CRDIZkcBMoF4oTMYNfR9kBlVBcVzlv7joFdNrFuQirPA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6230,14 +6257,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.0.tgz",
-      "integrity": "sha512-ngfB8QItUfTFTfHMvKuc2g1W60V1urIgZHqD1JNFZC2tTWXahqf2XvKXqcBS7yZqR7GqkQQZy11y/lNOUWzq7Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.1.tgz",
+      "integrity": "sha512-z5G7+ysL4yUtMghUd2zrLkecu0mTfnYlt5dR76g/HsFqf7evFazwiZP1ag2EJenGxNBDwDM5g8nm11NPogiUVA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/shared-ini-file-loader": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6245,15 +6272,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.1.tgz",
+      "integrity": "sha512-hlBI6MuREA4o1wBMEt+QNhUzoDtFFvwR6ecufimlx9D79jPybE/r8kNorphXOi91PgSO9S2fxRjcKCLk7Jw8zA==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6261,12 +6288,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.0.tgz",
-      "integrity": "sha512-Tj3+oVhqdZgemjCiWjFlADfhvLF4C/uKDuKo7/tlEsRQ9+3emCreR2xndj970QSRSsiCEU8hZW3/8JQu+n5w4Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.1.tgz",
+      "integrity": "sha512-YknOMZcQkB5on+MU0DvbToCmT2YPtTETMXW0D3+/Iln7ezT+Zm1GMHhCW1dOH/X/+LkkQD9aXEoCX/B10s4Xdw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6274,12 +6301,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.1.tgz",
+      "integrity": "sha512-eBhm9zwcFPEazc654c0BEWtxYAzrw+OhoSf5pkwKzfftWKXRoqEhwOE2Pvn30v0iAdo7Mfsfb6pi1NnZlGCMpg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6287,12 +6314,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.1.tgz",
+      "integrity": "sha512-vKitpnG/2KOMVlx3x1S3FkBH075EROG3wcrcDaNerQNh8yuqnSL23btCD2UyX4i4lpPzNW6VFdxbn2Z25b/g5Q==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -6301,12 +6328,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.1.tgz",
+      "integrity": "sha512-Qt8DMC05lVS8NcQx94lfVbZSX+2Ym7032b/JR8AlboAa/D669kPzqb35dkjkvAG6+NWmUchef3ENtrD6F+5n8Q==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6314,24 +6341,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.1.tgz",
+      "integrity": "sha512-ubFUvIePjDCyIzZ+pLETqNC6KXJ/fc6g+/baqel7Zf6kJI/kZKgjwkCI7zbUhoUuOZ/4eA/87YasVu40b/B4bA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0"
+        "@smithy/types": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.0.tgz",
-      "integrity": "sha512-dAM7wSX0NR3qTNyGVN/nwwpEDzfV9T/3AN2eABExWmda5VqZKSsjlINqomO5hjQWGv+IIkoXfs3u2vGSNz8+Rg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.1.tgz",
+      "integrity": "sha512-nD6tXIX2126/P9e3wqRY1bm9dTtPZwRDyjVOd18G28o+1UOG+kOVgUwujE795HslSuPlEgqzsH5sgNP1hDjj9g==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6339,15 +6366,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
-      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.0.tgz",
+      "integrity": "sha512-m0/6LW3IQ3/JBcdhqjpkpABPTPhcejqeAn0U877zxBdNLiWAnG2WmCe5MfkUyVuvpFTPQnQwCo/0ZBR4uF5kxg==",
       "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -6357,16 +6384,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.1.tgz",
-      "integrity": "sha512-tj4Ku7MpzZR8cmVuPcSbrLFVxmptWktmJMwST/uIEq4sarabEdF8CbmQdYB7uJ/X51Qq2EYwnRsoS7hdR4B7rA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.2.tgz",
+      "integrity": "sha512-f3eQpczBOFUtdT/ptw2WpUKu1qH1K7xrssrSiHYtd9TuLXkvFqb88l9mz9FHeUVNSUxSnkW1anJnw6rLwUKzQQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6374,9 +6401,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-qi4SeCVOUPjhSSZrxxB/mB8DrmuSFUcJnD9KXjuP+7C3LV/KFV4kpuUSH3OHDZgQB9TEH/1sO/Fq/5HyaK9MPw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6386,13 +6413,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.1.tgz",
+      "integrity": "sha512-G140IlNFlzYWVCedC4E2d6NycM1dCUbe5CnsGW1hmGt4hYKiGOw0v7lVru9WAn5T2w09QEjl4fOESWjGmCvVmg==",
       "dev": true,
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/querystring-parser": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       }
     },
@@ -6457,14 +6484,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.3.tgz",
-      "integrity": "sha512-3DFON2bvXJAukJe+qFgPV/rorG7ZD3m4gjCXHD1V5z/tgKQp5MCTCLntrd686tX6tj8Uli3lefWXJudNg5WmCA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.4.tgz",
+      "integrity": "sha512-sXtin3Mue3A3xo4+XkozpgPptgmRwvNPOqTvb3ANGTCzzoQgAPBNjpE+aXCINaeSMXwHmv7E2oEn2vWdID+SAQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -6473,17 +6500,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.3.tgz",
-      "integrity": "sha512-D0b8GJXecT00baoSQ3Iieu3k3mZ7GY8w1zmg8pdogYrGvWJeLcIclqk2gbkG4K0DaBGWrO6v6r20iwIFfDYrmA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.4.tgz",
+      "integrity": "sha512-CUF6TyxLh3CgBRVYgZNOPDfzHQjeQr0vyALR6/DkQkOm7rNfGEzW1BRFi88C73pndmfvoiIT7ochuT76OPz9Dw==",
       "dev": true,
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.1",
-        "@smithy/credential-provider-imds": "^3.1.0",
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/property-provider": "^3.1.0",
-        "@smithy/smithy-client": "^3.1.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6491,13 +6518,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.1.tgz",
-      "integrity": "sha512-ZRT0VCOnKlVohfoABMc8lWeQo/JEFuPWctfNRXgTHbyOVssMOLYFUNWukxxiHRGVAhV+n3c0kPW+zUqckjVPEA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.2.tgz",
+      "integrity": "sha512-4zFOcBFQvifd2LSD4a1dKvfIWWwh4sWNtS3oZ7mpob/qPPmJseqKB148iT+hWCDsG//TmI+8vjYPgZdvnkYlTg==",
       "dev": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6517,12 +6544,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.1.tgz",
+      "integrity": "sha512-WRODCQtUsO7vIvfrdxS8RFPeLKcewYtaCglZsBsedIKSUGIIvMlZT5oh+pCe72I+1L+OjnZuqRNpN2LKhWA4KQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6530,13 +6557,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.1.tgz",
+      "integrity": "sha512-5lRtYm+8fNFEUTdqZXg5M4ppVp40rMIJfR1TpbHAhKQgPIDpWT+iYMaqgnwEbtpi9U1smyUOPv5Sg+M1neOBgw==",
       "dev": true,
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/service-error-classification": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6544,14 +6571,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.2.tgz",
+      "integrity": "sha512-n5Obp5AnlI6qHo8sbupwrcpBe6vFp4qkl0SRNuExKPNrH3ABAMG2ZszRTIUIv2b4AsFrCO+qiy4uH1Q3z1dxTA==",
       "dev": true,
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -19171,9 +19198,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.49.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.49.1.tgz",
-      "integrity": "sha512-bsFSNhhTNon+g6r4UYPKGLi+PlfP1G9TJGSkZS5nZx+PTwW2YUTlfxXxpOKrPab5auIXJdlYpC/g/wkHGR1xug==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.51.0.tgz",
+      "integrity": "sha512-UKuWc3/qQyklqhHM8CbdXCv0Z0obap6T0ECdcO5oATQxAbKE5Ky3YCXFQY207z+eGG6ez4U9wvAcuMygxhmStg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -21623,9 +21650,9 @@
       }
     },
     "node_modules/replicate": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.30.1.tgz",
-      "integrity": "sha512-9JZPia6p7UCNfye2kddb2AHcTf3ngyckzq4y5FZkuhhF06AuuOHKN1q6NRSp9iAch7Htmlhm+kRGc+EQbzY8Kw==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.30.2.tgz",
+      "integrity": "sha512-U3yDrlwAV/zhaCd5Tcb8IPXqwkzvfXbN+YABM6RGPugtmuo8W5uwxoEQAetWD+xjS5jWLzISBYR5gPNBZPLOQw==",
       "engines": {
         "git": ">=2.11.0",
         "node": ">=18.0.0",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "langfuse": "^3.7.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.592.0",
-    "@azure/identity": "^4.2.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.598.0",
+    "@azure/identity": "^4.2.1",
     "@eslint/js": "^9.4.0",
     "@swc/cli": "^0.3.12",
     "@swc/core": "^1.5.27",
@@ -97,7 +97,7 @@
     "typescript-eslint": "^7.12.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.22.0",
+    "@anthropic-ai/sdk": "^0.23.0",
     "@apidevtools/json-schema-ref-parser": "^11.6.4",
     "ajv": "^8.16.0",
     "ajv-formats": "^2.1.1",
@@ -127,11 +127,11 @@
     "mathjs": "^12.4.1",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
-    "openai": "^4.49.1",
+    "openai": "^4.51.0",
     "opener": "^1.5.2",
     "proxy-agent": "^6.4.0",
     "python-shell": "^5.0.0",
-    "replicate": "^0.30.1",
+    "replicate": "^0.30.2",
     "rfdc": "^1.4.1",
     "rouge": "git+https://github.com/kenlimmj/rouge.git#f35111b599aca55f1d4dc1d4a3d15e28e7f7c55f",
     "semver": "^7.6.2",


### PR DESCRIPTION
Bumps the versions of the following LLM providers:

- `@anthropic-ai/sdk` from `^0.22.0` to `^0.23.0`
- `@aws-sdk/client-bedrock-runtime` from `^3.592.0` to `^3.598.0`
- `@azure/identity` from `^4.2.0` to `^4.2.1`
- `openai` from `^4.49.1` to `^4.51.0`
- `replicate` from `^0.30.1` to `^0.30.2`
