### PR TITLE
feat(webui): carousel for multiple failure reasons

### DIFF
--- a/src/web/nextui/src/app/eval/FailReasonCarousel.css
+++ b/src/web/nextui/src/app/eval/FailReasonCarousel.css
@@ -1,0 +1,5 @@
+.fail-reason-carousel-controls {
+  float: right;
+  color: var(--text-color);
+  font-weight: normal;
+}

--- a/src/web/nextui/src/app/eval/FailReasonCarousel.tsx
+++ b/src/web/nextui/src/app/eval/FailReasonCarousel.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+
+import './FailReasonCarousel.css';
+
+interface FailReasonCarouselProps {
+  failReasons: string[];
+}
+
+const FailReasonCarousel: React.FC<FailReasonCarouselProps> = ({ failReasons }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handlePrev = () => {
+    setCurrentIndex((prevIndex) => (prevIndex > 0 ? prevIndex - 1 : failReasons.length - 1));
+  };
+
+  const handleNext = () => {
+    setCurrentIndex((prevIndex) => (prevIndex < failReasons.length - 1 ? prevIndex + 1 : 0));
+  };
+
+  return (
+    <div className="fail-reason">
+      {failReasons.length > 1 && (
+        <span className="fail-reason-carousel-controls">
+          <IconButton onClick={handlePrev}>
+            <ArrowBackIosIcon sx={{ fontSize: 12 }} />
+          </IconButton>
+          <span>
+            {currentIndex + 1}/{failReasons.length}
+          </span>
+          <IconButton onClick={handleNext}>
+            <ArrowForwardIosIcon sx={{ fontSize: 12 }} />
+          </IconButton>
+        </span>
+      )}
+      {failReasons[currentIndex]
+        .trim()
+        .split('\n')
+        .map((line, index) => (
+          <React.Fragment key={index}>
+            {line}
+            <br />
+          </React.Fragment>
+        ))}
+    </div>
+  );
+};
+
+export default FailReasonCarousel;

--- a/src/web/nextui/src/app/eval/ResultsTable.css
+++ b/src/web/nextui/src/app/eval/ResultsTable.css
@@ -242,6 +242,9 @@ table.results-table,
 }
 
 .results-table .status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
   font-weight: bold;
   margin-bottom: 0.5rem;
 }
@@ -251,6 +254,7 @@ table.results-table,
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
   margin-right: 0.25rem;
+  align-self: flex-start; /* prevents it from stretching to fill width */
 }
 
 .results-table .pass .pill {

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -27,6 +27,7 @@ import Link from 'next/link';
 import CommentDialog from '@/app/eval/TableCommentDialog';
 import CustomMetrics from '@/app/eval/CustomMetrics';
 import EvalOutputPromptDialog from '@/app/eval/EvalOutputPromptDialog';
+import FailReasonCarousel from '@/app/eval/FailReasonCarousel';
 import GenerateTestCases from '@/app/eval/GenerateTestCases';
 import { getApiBaseUrl } from '@/api';
 import { useStore as useResultsViewStore } from './store';
@@ -219,14 +220,14 @@ function EvalOutputCell({
 
   let text = typeof output.text === 'string' ? output.text : JSON.stringify(output.text);
   let node: React.ReactNode | undefined;
-  let chunks: string[] = [];
+  let failReasons: string[] = [];
 
   // Handle failure messages by splitting the text at '---'
   if (!output.pass && text.includes('---')) {
-    chunks = text.split('---');
-    text = chunks.slice(1).join('---');
-  } else {
-    chunks = [text];
+    failReasons = (output.gradingResult?.componentResults || [])
+      .filter((result) => !result.pass)
+      .map((result) => result.reason);
+    text = text.split('---').slice(1).join('---');
   }
 
   if (showDiffs && firstOutput) {
@@ -595,15 +596,7 @@ function EvalOutputCell({
                 </div>
                 <CustomMetrics lookup={output.namedScores} />
                 <span className="fail-reason">
-                  {chunks[0]
-                    ?.trim()
-                    .split('\n')
-                    .map((line, index) => (
-                      <React.Fragment key={index}>
-                        {line}
-                        <br />
-                      </React.Fragment>
-                    ))}
+                  <FailReasonCarousel failReasons={failReasons} />
                 </span>
               </div>
             </>


### PR DESCRIPTION
Browse failure reasons without having to open the details dialog

![image](https://github.com/promptfoo/promptfoo/assets/310310/80864298-e50f-4593-81a8-3259e0104940)
