### PR TITLE
feat(webui): clicking metric pills filters by nonzero only

### DIFF
--- a/src/web/nextui/src/app/eval/CustomMetrics.tsx
+++ b/src/web/nextui/src/app/eval/CustomMetrics.tsx
@@ -17,7 +17,7 @@ const CustomMetrics: React.FC<CustomMetricsProps> = ({ lookup, onSearchTextChang
         metric && typeof score !== 'undefined' ? (
           <span
             key={metric}
-            onClick={() => onSearchTextChange && onSearchTextChange(`metric=${metric}`)}
+            onClick={() => onSearchTextChange && onSearchTextChange(`metric=${metric}:[^0]`)}
             className={onSearchTextChange ? 'clickable' : ''}
           >
             {metric}: {score.toFixed(2)}

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -840,11 +840,13 @@ function ResultsTable({
             ? row.outputs.some((output) => {
                 const vars = row.vars.map((v) => `var=${v}`).join(' ');
                 const stringifiedOutput = `${output.text} ${Object.keys(output.namedScores)
-                  .map((k) => `metric=${k}`)
+                  .map((k) => `metric=${k}:${output.namedScores[k]}`)
                   .join(' ')} ${
                   output.gradingResult?.reason || ''
                 } ${output.gradingResult?.comment || ''}`;
-                return searchRegex.test(`${vars} ${stringifiedOutput}`);
+
+                const searchString = `${vars} ${stringifiedOutput}`;
+                return searchRegex.test(searchString);
               })
             : true;
         }) as ExtendedEvaluateTableRow[];


### PR DESCRIPTION
Metric scores are now included in search, and click a metric pill in the column header filters by nonzero scores.