### PR TITLE
feat(eslint): integrate eslint-plugin-jest and configure rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,10 +14,13 @@ export default [
     ...jest.configs['flat/recommended'],
     rules: {
       ...jest.configs['flat/recommended'].rules,
+      ...jest.configs['flat/style'].rules,
       'jest/consistent-test-it': 'error',
       'jest/expect-expect': 'error',
       'jest/prefer-expect-resolves': 'error',
       'jest/prefer-jest-mocked': 'error',
+      'jest/require-to-throw-message': 'error',
+      // 'jest/prefer-expect-assertions': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ export default [
       'jest/consistent-test-it': 'error',
       'jest/expect-expect': 'error',
       'jest/prefer-expect-resolves': 'error',
-      // 'jest/prefer-jest-mocked': 'error',
+      'jest/prefer-jest-mocked': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,9 +5,18 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 
 import unusedImports from 'eslint-plugin-unused-imports';
+// const jest = require('eslint-plugin-jest');
+import jest from 'eslint-plugin-jest';
 
 export default [
   ...tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended),
+  {
+    ...jest.configs['flat/recommended'],
+    rules: {
+      ...jest.configs['flat/recommended'].rules,
+      'jest/consistent-test-it': 'error',
+    },
+  },
   {
     ignores: [
       '**/src/web/nextui/_next/**/*',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,6 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 
 import unusedImports from 'eslint-plugin-unused-imports';
-// const jest = require('eslint-plugin-jest');
 import jest from 'eslint-plugin-jest';
 
 export default [
@@ -20,7 +19,6 @@ export default [
       'jest/prefer-expect-resolves': 'error',
       'jest/prefer-jest-mocked': 'error',
       'jest/require-to-throw-message': 'error',
-      // 'jest/prefer-expect-assertions': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ export default [
     rules: {
       ...jest.configs['flat/recommended'].rules,
       'jest/consistent-test-it': 'error',
+      'jest/expect-expect': 'error',
+      'jest/prefer-expect-resolves': 'error',
+      // 'jest/prefer-jest-mocked': 'error',
     },
   },
   {

--- a/examples/jest-integration/index.test.ts
+++ b/examples/jest-integration/index.test.ts
@@ -5,19 +5,19 @@ import type { GradingConfig } from '../../dist/src/types.js';
 installJestMatchers();
 
 describe('toMatchSemanticSimilarity', () => {
-  test('should pass when strings are semantically similar', async () => {
+  it('should pass when strings are semantically similar', async () => {
     await expect('The quick brown fox').toMatchSemanticSimilarity('A fast brown fox');
   });
 
-  test('should fail when strings are not semantically similar', async () => {
+  it('should fail when strings are not semantically similar', async () => {
     await expect('The quick brown fox').not.toMatchSemanticSimilarity('The weather is nice today');
   });
 
-  test('should pass when strings are semantically similar with custom threshold', async () => {
+  it('should pass when strings are semantically similar with custom threshold', async () => {
     await expect('The quick brown fox').toMatchSemanticSimilarity('A fast brown fox', 0.7);
   });
 
-  test('should fail when strings are not semantically similar with custom threshold', async () => {
+  it('should fail when strings are not semantically similar with custom threshold', async () => {
     await expect('The quick brown fox').not.toMatchSemanticSimilarity(
       'The weather is nice today',
       0.9,
@@ -30,14 +30,14 @@ const gradingConfig: GradingConfig = {
 };
 
 describe('toPassLLMRubric', () => {
-  test('should pass when strings meet the LLM Rubric criteria', async () => {
+  it('should pass when strings meet the LLM Rubric criteria', async () => {
     await expect('Four score and seven years ago').toPassLLMRubric(
       'Contains part of a famous speech',
       gradingConfig,
     );
   });
 
-  test('should fail when strings do not meet the LLM Rubric criteria', async () => {
+  it('should fail when strings do not meet the LLM Rubric criteria', async () => {
     await expect('It is time to do laundry').not.toPassLLMRubric(
       'Contains part of a famous speech',
       gradingConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,15 @@
         "langfuse": "^3.7.0"
       }
     },
+    "node_modules/@ai-zen/node-fetch-event-source": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@ai-zen/node-fetch-event-source/-/node-fetch-event-source-2.1.4.tgz",
+      "integrity": "sha512-OHFwPJecr+qwlyX5CGmTvKAKPZAdZaxvx/XDqS1lx4I2ZAk9riU0XnEaRGOOAEFrdcLZ98O5yWqubwjaQc0umg==",
+      "peer": true,
+      "dependencies": {
+        "cross-fetch": "^4.0.0"
+      }
+    },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
@@ -1015,9 +1024,37 @@
         }
       }
     },
+    "node_modules/@azure-rest/core-client": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.4.0.tgz",
+      "integrity": "sha512-ozTDPBVUDR5eOnMIwhggbnVmOrka4fXCs8n8mvUo4WLLc38kki6bAOByDoVZZPz/pZy2jMt2kwfpvy/UjALj6w==",
+      "peer": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.5.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@azure/abort-controller": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1028,7 +1065,6 @@
     },
     "node_modules/@azure/core-auth": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1041,7 +1077,6 @@
     },
     "node_modules/@azure/core-client": {
       "version": "1.7.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1058,7 +1093,6 @@
     },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.13.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.1.0",
@@ -1076,7 +1110,6 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -1087,7 +1120,6 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -1100,7 +1132,6 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -1112,7 +1143,6 @@
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1123,7 +1153,6 @@
     },
     "node_modules/@azure/core-util": {
       "version": "1.6.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1160,7 +1189,6 @@
     },
     "node_modules/@azure/logger": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1220,6 +1248,24 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/openai-assistants": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/openai-assistants/-/openai-assistants-1.0.0-beta.5.tgz",
+      "integrity": "sha512-j4KT4TwoLvAZJgUdnZgwqMBe99l8KZdORd/NbOyqpOHs0Ozj3ZfsVU81iL5/CG+Ps9LiZ8lKbaPaJq6Hi6Vz3Q==",
+      "peer": true,
+      "dependencies": {
+        "@azure-rest/core-client": "^1.1.4",
+        "@azure/core-auth": "^1.5.0",
+        "@azure/core-client": "^1.7.3",
+        "@azure/core-rest-pipeline": "^1.13.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4432,6 +4478,23 @@
       "version": "2.0.3",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@ibm-generative-ai/node-sdk": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ibm-generative-ai/node-sdk/-/node-sdk-2.0.6.tgz",
+      "integrity": "sha512-RX+2FMVZEy6giDlrMmbahZA/nrIZmyEO9Ss1I+a5yaask4Zs1YkrEI/+CjZI8x7MU9Mk6RRyOnLC33EdiJLKTw==",
+      "peer": true,
+      "dependencies": {
+        "@ai-zen/node-fetch-event-source": "^2.1.2",
+        "fetch-retry": "^5.0.6",
+        "http-status-codes": "^2.3.0",
+        "openapi-fetch": "^0.8.2",
+        "p-queue-compat": "^1.0.225",
+        "yaml": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.1.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4935,6 +4998,95 @@
     "node_modules/@kurkle/color": {
       "version": "0.3.2",
       "license": "MIT"
+    },
+    "node_modules/@langchain/core": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.6.tgz",
+      "integrity": "sha512-YB9F0vdi/PcgBLSKtDwQ3gV6w4xVfk4ph0U43Okz2dAapKfBkVVB0rzr/afYUt/WHs864MuaO8uLN64egSDtIA==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "~0.1.30",
+        "ml-distance": "^4.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/langsmith": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.31.tgz",
+      "integrity": "sha512-G9zi+84RvUZ7UP/ZC0dx/9SYHk8Bhe9GywUeVBzEyt8M4QeU6FPWT7TEjDSqp/XuPJf5o59Z2QlmNJgMnpUd8Q==",
+      "peer": true,
+      "dependencies": {
+        "@types/uuid": "^9.0.1",
+        "commander": "^10.0.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "*",
+        "langchain": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "langchain": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -7125,7 +7277,6 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7221,7 +7372,7 @@
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7731,8 +7882,7 @@
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -8954,6 +9104,15 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bin-check": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
@@ -9129,6 +9288,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "peer": true
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -9366,7 +9531,6 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -10438,6 +10602,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "peer": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "license": "MIT",
@@ -10923,6 +11096,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -11594,7 +11776,6 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -13175,6 +13356,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/fetch-retry": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
+      "peer": true
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "license": "MIT",
@@ -13854,6 +14041,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.6.0.tgz",
+      "integrity": "sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "license": "MIT",
@@ -14096,6 +14325,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "134.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-134.0.0.tgz",
+      "integrity": "sha512-o8LhD1754W6MHWtpwAPeP1WUHgNxuMxCnLMDFlMKAA5kCMTNqX9/eaTXnkkAIv6YRfoKMQ6D1vyR6/biXuhE9g==",
+      "peer": true,
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "license": "MIT",
@@ -14186,6 +14475,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/gzip-size": {
@@ -14812,6 +15114,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "peer": true
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "license": "MIT",
@@ -15160,6 +15468,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "peer": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -16525,6 +16839,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.12.tgz",
+      "integrity": "sha512-L7wURW1fH9Qaext0VzaUDpFGVQgjkdE3Dgsy9/+yXyGEpBKnylTd0mU0bfbNkKDlXRb6TEsZkwuflu1B8uQbJQ==",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -16551,6 +16874,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "peer": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -16665,7 +16997,6 @@
     },
     "node_modules/jwa": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
@@ -16675,7 +17006,6 @@
     },
     "node_modules/jws": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
@@ -16706,6 +17036,30 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/langfuse": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.11.2.tgz",
+      "integrity": "sha512-+XQNSZiWvHlpkIMYNCeuVNFu2l7KZbHD1FzozmOzV2vveDJkL+c9t0nby/WWnqFpAXJ2CA4LwGT7Al8uiFc7hg==",
+      "peer": true,
+      "dependencies": {
+        "langfuse-core": "^3.11.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/langfuse-core": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.11.2.tgz",
+      "integrity": "sha512-iBhX0oJXXg34SHxY/a3oA5A6Nozd+82XtmRnJ9yO7eYPsyLwCqIWIgj++38W9ffll5lbhKStpNk4ZWvVX94kDw==",
+      "peer": true,
+      "dependencies": {
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -18269,6 +18623,51 @@
       "version": "0.5.3",
       "license": "MIT"
     },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "peer": true,
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "peer": true,
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-distance": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
+      "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
+      "peer": true,
+      "dependencies": {
+        "ml-array-mean": "^1.1.6",
+        "ml-distance-euclidean": "^2.0.0",
+        "ml-tree-similarity": "^1.0.0"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
+      "peer": true
+    },
+    "node_modules/ml-tree-similarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
+      "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
+      "peer": true,
+      "dependencies": {
+        "binary-search": "^1.3.5",
+        "num-sort": "^2.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "license": "MIT",
@@ -18289,6 +18688,15 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "peer": true,
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stream": {
@@ -18585,6 +18993,18 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/num-sort": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
+      "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nunjucks": {
       "version": "3.2.4",
       "license": "BSD-2-Clause",
@@ -18817,6 +19237,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.8.2.tgz",
+      "integrity": "sha512-4g+NLK8FmQ51RW6zLcCBOVy/lwYmFJiiT+ckYZxJWxUxH4XFhsNcX2eeqVMfVOi+mDNFja6qDXIZAz2c5J/RVw==",
+      "peer": true,
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.5"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.5.tgz",
+      "integrity": "sha512-MRffg93t0hgGZbYTxg60hkRIK2sRuEOHEtCUgMuLgbCC33TMQ68AmxskzUlauzZYD47+ENeGV/ElI7qnWqrAxA==",
+      "peer": true
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "license": "(WTFPL OR MIT)",
@@ -18905,7 +19340,6 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18956,6 +19390,41 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue-compat": {
+      "version": "1.0.225",
+      "resolved": "https://registry.npmjs.org/p-queue-compat/-/p-queue-compat-1.0.225.tgz",
+      "integrity": "sha512-SdfGSQSJJpD7ZR+dJEjjn9GuuBizHPLW/yarJpXnmrHRruzrq7YM8OqsikSrKeoPv+Pi1YXw9IIBSIg5WveQHA==",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "5.x",
+        "p-timeout-compat": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/p-queue-compat/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "peer": true
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "license": "MIT",
@@ -18965,6 +19434,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "peer": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout-compat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/p-timeout-compat/-/p-timeout-compat-1.0.4.tgz",
+      "integrity": "sha512-HEsjA3Df/845IQD0BS2/4691Sh2fnf8lifKHPtHUC6dQJ80NsKRCVVLnB5dApnJOU5JZJDWlE2Z0fd/vrGrUIA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/p-try": {
@@ -23992,6 +24482,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "peer": true
+    },
     "node_modules/use-debounce": {
       "version": "10.0.1",
       "license": "MIT",
@@ -24864,6 +25360,18 @@
       "version": "3.1.1",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "dev": true,
@@ -24909,10 +25417,18 @@
     },
     "node_modules/zod": {
       "version": "3.23.4",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.1.tgz",
+      "integrity": "sha512-oT9INvydob1XV0v1d2IadrR74rLtDInLvDFfAa1CG0Pmg/vxATk7I2gSelfj271mbzeM4Da0uuDQE/Nkj3DWNw==",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.23.3"
       }
     },
     "node_modules/zustand": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "cloudflare": "^3.2.0",
         "drizzle-kit": "^0.20.13",
         "eslint": "^8.57.0",
+        "eslint-plugin-jest": "^28.6.0",
         "eslint-plugin-unused-imports": "^3.2.0",
         "jest": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
@@ -110,15 +111,6 @@
         "google-auth-library": "^9.7.0",
         "googleapis": "^134.0.0",
         "langfuse": "^3.7.0"
-      }
-    },
-    "node_modules/@ai-zen/node-fetch-event-source": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@ai-zen/node-fetch-event-source/-/node-fetch-event-source-2.1.4.tgz",
-      "integrity": "sha512-OHFwPJecr+qwlyX5CGmTvKAKPZAdZaxvx/XDqS1lx4I2ZAk9riU0XnEaRGOOAEFrdcLZ98O5yWqubwjaQc0umg==",
-      "peer": true,
-      "dependencies": {
-        "cross-fetch": "^4.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1023,37 +1015,9 @@
         }
       }
     },
-    "node_modules/@azure-rest/core-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.4.0.tgz",
-      "integrity": "sha512-ozTDPBVUDR5eOnMIwhggbnVmOrka4fXCs8n8mvUo4WLLc38kki6bAOByDoVZZPz/pZy2jMt2kwfpvy/UjALj6w==",
-      "peer": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.5.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure-rest/core-client/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@azure/abort-controller": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1064,6 +1028,7 @@
     },
     "node_modules/@azure/core-auth": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1076,6 +1041,7 @@
     },
     "node_modules/@azure/core-client": {
       "version": "1.7.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1092,6 +1058,7 @@
     },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.13.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.1.0",
@@ -1109,6 +1076,7 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -1119,6 +1087,7 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -1131,6 +1100,7 @@
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -1142,6 +1112,7 @@
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1152,6 +1123,7 @@
     },
     "node_modules/@azure/core-util": {
       "version": "1.6.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -1188,6 +1160,7 @@
     },
     "node_modules/@azure/logger": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -1247,24 +1220,6 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@azure/openai-assistants": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@azure/openai-assistants/-/openai-assistants-1.0.0-beta.5.tgz",
-      "integrity": "sha512-j4KT4TwoLvAZJgUdnZgwqMBe99l8KZdORd/NbOyqpOHs0Ozj3ZfsVU81iL5/CG+Ps9LiZ8lKbaPaJq6Hi6Vz3Q==",
-      "peer": true,
-      "dependencies": {
-        "@azure-rest/core-client": "^1.1.4",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.7.3",
-        "@azure/core-rest-pipeline": "^1.13.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.4",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4477,23 +4432,6 @@
       "version": "2.0.3",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@ibm-generative-ai/node-sdk": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@ibm-generative-ai/node-sdk/-/node-sdk-2.0.6.tgz",
-      "integrity": "sha512-RX+2FMVZEy6giDlrMmbahZA/nrIZmyEO9Ss1I+a5yaask4Zs1YkrEI/+CjZI8x7MU9Mk6RRyOnLC33EdiJLKTw==",
-      "peer": true,
-      "dependencies": {
-        "@ai-zen/node-fetch-event-source": "^2.1.2",
-        "fetch-retry": "^5.0.6",
-        "http-status-codes": "^2.3.0",
-        "openapi-fetch": "^0.8.2",
-        "p-queue-compat": "^1.0.225",
-        "yaml": "^2.3.3"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.1.0"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4997,95 +4935,6 @@
     "node_modules/@kurkle/color": {
       "version": "0.3.2",
       "license": "MIT"
-    },
-    "node_modules/@langchain/core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.6.tgz",
-      "integrity": "sha512-YB9F0vdi/PcgBLSKtDwQ3gV6w4xVfk4ph0U43Okz2dAapKfBkVVB0rzr/afYUt/WHs864MuaO8uLN64egSDtIA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": "~0.1.30",
-        "ml-distance": "^4.0.0",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.31.tgz",
-      "integrity": "sha512-G9zi+84RvUZ7UP/ZC0dx/9SYHk8Bhe9GywUeVBzEyt8M4QeU6FPWT7TEjDSqp/XuPJf5o59Z2QlmNJgMnpUd8Q==",
-      "peer": true,
-      "dependencies": {
-        "@types/uuid": "^9.0.1",
-        "commander": "^10.0.1",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@langchain/core": "*",
-        "langchain": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "langchain": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -7276,6 +7125,7 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7371,7 +7221,7 @@
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7881,7 +7731,8 @@
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -9103,15 +8954,6 @@
         "node": "*"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bin-check": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
@@ -9287,12 +9129,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/binary-search": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
-      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
-      "peer": true
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -9530,6 +9366,7 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -10601,15 +10438,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "license": "MIT",
@@ -11095,15 +10923,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -11775,6 +11594,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -12460,6 +12280,31 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "28.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
+      "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -13330,12 +13175,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/fetch-retry": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
-      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
-      "peer": true
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "license": "MIT",
@@ -14015,48 +13854,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gaxios": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.6.0.tgz",
-      "integrity": "sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==",
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
-      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "license": "MIT",
@@ -14299,66 +14096,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/google-auth-library": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
-      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/googleapis": {
-      "version": "134.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-134.0.0.tgz",
-      "integrity": "sha512-o8LhD1754W6MHWtpwAPeP1WUHgNxuMxCnLMDFlMKAA5kCMTNqX9/eaTXnkkAIv6YRfoKMQ6D1vyR6/biXuhE9g==",
-      "peer": true,
-      "dependencies": {
-        "google-auth-library": "^9.0.0",
-        "googleapis-common": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
-      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "gaxios": "^6.0.3",
-        "google-auth-library": "^9.7.0",
-        "qs": "^6.7.0",
-        "url-template": "^2.0.8",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "license": "MIT",
@@ -14449,19 +14186,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/gzip-size": {
@@ -15088,12 +14812,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "peer": true
-    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "license": "MIT",
@@ -15442,12 +15160,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-any-array": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
-      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
-      "peer": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -16813,15 +16525,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-tiktoken": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.12.tgz",
-      "integrity": "sha512-L7wURW1fH9Qaext0VzaUDpFGVQgjkdE3Dgsy9/+yXyGEpBKnylTd0mU0bfbNkKDlXRb6TEsZkwuflu1B8uQbJQ==",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -16848,15 +16551,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "peer": true,
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -16971,6 +16665,7 @@
     },
     "node_modules/jwa": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
@@ -16980,6 +16675,7 @@
     },
     "node_modules/jws": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
@@ -17010,30 +16706,6 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT"
-    },
-    "node_modules/langfuse": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.11.2.tgz",
-      "integrity": "sha512-+XQNSZiWvHlpkIMYNCeuVNFu2l7KZbHD1FzozmOzV2vveDJkL+c9t0nby/WWnqFpAXJ2CA4LwGT7Al8uiFc7hg==",
-      "peer": true,
-      "dependencies": {
-        "langfuse-core": "^3.11.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/langfuse-core": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.11.2.tgz",
-      "integrity": "sha512-iBhX0oJXXg34SHxY/a3oA5A6Nozd+82XtmRnJ9yO7eYPsyLwCqIWIgj++38W9ffll5lbhKStpNk4ZWvVX94kDw==",
-      "peer": true,
-      "dependencies": {
-        "mustache": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -18597,51 +18269,6 @@
       "version": "0.5.3",
       "license": "MIT"
     },
-    "node_modules/ml-array-mean": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
-      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
-      "peer": true,
-      "dependencies": {
-        "ml-array-sum": "^1.1.6"
-      }
-    },
-    "node_modules/ml-array-sum": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
-      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
-      "peer": true,
-      "dependencies": {
-        "is-any-array": "^2.0.0"
-      }
-    },
-    "node_modules/ml-distance": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
-      "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
-      "peer": true,
-      "dependencies": {
-        "ml-array-mean": "^1.1.6",
-        "ml-distance-euclidean": "^2.0.0",
-        "ml-tree-similarity": "^1.0.0"
-      }
-    },
-    "node_modules/ml-distance-euclidean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
-      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
-      "peer": true
-    },
-    "node_modules/ml-tree-similarity": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
-      "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
-      "peer": true,
-      "dependencies": {
-        "binary-search": "^1.3.5",
-        "num-sort": "^2.0.0"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "license": "MIT",
@@ -18662,15 +18289,6 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
-      }
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "peer": true,
-      "bin": {
-        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stream": {
@@ -18967,18 +18585,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/num-sort": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
-      "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/nunjucks": {
       "version": "3.2.4",
       "license": "BSD-2-Clause",
@@ -19211,21 +18817,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/openapi-fetch": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.8.2.tgz",
-      "integrity": "sha512-4g+NLK8FmQ51RW6zLcCBOVy/lwYmFJiiT+ckYZxJWxUxH4XFhsNcX2eeqVMfVOi+mDNFja6qDXIZAz2c5J/RVw==",
-      "peer": true,
-      "dependencies": {
-        "openapi-typescript-helpers": "^0.0.5"
-      }
-    },
-    "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.5.tgz",
-      "integrity": "sha512-MRffg93t0hgGZbYTxg60hkRIK2sRuEOHEtCUgMuLgbCC33TMQ68AmxskzUlauzZYD47+ENeGV/ElI7qnWqrAxA==",
-      "peer": true
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "license": "(WTFPL OR MIT)",
@@ -19314,6 +18905,7 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -19364,41 +18956,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "peer": true,
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue-compat": {
-      "version": "1.0.225",
-      "resolved": "https://registry.npmjs.org/p-queue-compat/-/p-queue-compat-1.0.225.tgz",
-      "integrity": "sha512-SdfGSQSJJpD7ZR+dJEjjn9GuuBizHPLW/yarJpXnmrHRruzrq7YM8OqsikSrKeoPv+Pi1YXw9IIBSIg5WveQHA==",
-      "peer": true,
-      "dependencies": {
-        "eventemitter3": "5.x",
-        "p-timeout-compat": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/p-queue-compat/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "peer": true
-    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "license": "MIT",
@@ -19408,27 +18965,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "peer": true,
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout-compat": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/p-timeout-compat/-/p-timeout-compat-1.0.4.tgz",
-      "integrity": "sha512-HEsjA3Df/845IQD0BS2/4691Sh2fnf8lifKHPtHUC6dQJ80NsKRCVVLnB5dApnJOU5JZJDWlE2Z0fd/vrGrUIA==",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/p-try": {
@@ -24456,12 +23992,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-      "peer": true
-    },
     "node_modules/use-debounce": {
       "version": "10.0.1",
       "license": "MIT",
@@ -25334,18 +24864,6 @@
       "version": "3.1.1",
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "dev": true,
@@ -25391,18 +24909,10 @@
     },
     "node_modules/zod": {
       "version": "3.23.4",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.1.tgz",
-      "integrity": "sha512-oT9INvydob1XV0v1d2IadrR74rLtDInLvDFfAa1CG0Pmg/vxATk7I2gSelfj271mbzeM4Da0uuDQE/Nkj3DWNw==",
-      "peer": true,
-      "peerDependencies": {
-        "zod": "^3.23.3"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "cloudflare": "^3.2.0",
     "drizzle-kit": "^0.20.13",
     "eslint": "^8.57.0",
+    "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-unused-imports": "^3.2.0",
     "jest": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -666,7 +666,7 @@ describe('runAssertion', () => {
       value: 'file:///output.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ key: 'value' }));
+    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ key: 'value' }));
 
     const output = '{"key": "value"}';
 
@@ -688,7 +688,7 @@ describe('runAssertion', () => {
       value: 'file:///output.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ key: 'value' }));
+    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ key: 'value' }));
 
     const output = '{"key": "not value"}';
 
@@ -852,7 +852,7 @@ describe('runAssertion', () => {
       value: 'file:///schema.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({
         required: ['latitude', 'longitude'],
         type: 'object',
@@ -891,7 +891,7 @@ describe('runAssertion', () => {
       value: 'file:///schema.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({
         required: ['latitude', 'longitude'],
         type: 'object',
@@ -1018,7 +1018,7 @@ describe('runAssertion', () => {
       value: 'file:///schema.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({
         required: ['latitude', 'longitude'],
         type: 'object',
@@ -1057,7 +1057,7 @@ describe('runAssertion', () => {
       value: 'file:///schema.json',
     };
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({
         required: ['latitude', 'longitude'],
         type: 'object',

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -90,8 +90,10 @@ describe('runAssertions', () => {
       test,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('All assertions passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'All assertions passed',
+    });
   });
 
   it('should fail when any assertion fails', async () => {
@@ -103,8 +105,10 @@ describe('runAssertions', () => {
       test,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output "Expected output" to equal "Different output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "Expected output" to equal "Different output"',
+    });
   });
 
   it('should handle output as an object', async () => {
@@ -116,13 +120,13 @@ describe('runAssertions', () => {
       test,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output "Expected output" to equal "{"key":"value"}"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "Expected output" to equal "{"key":"value"}"',
+    });
   });
 
   it('should fail when combined score is less than threshold', async () => {
-    const output = 'Different output';
-
     const result: GradingResult = await runAssertions({
       prompt: 'Some prompt',
       provider: new OpenAiChatCompletionProvider('gpt-4'),
@@ -143,13 +147,13 @@ describe('runAssertions', () => {
       },
       output: 'Hi there world',
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Aggregate score 0.33 < 0.5 threshold');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Aggregate score 0.33 < 0.5 threshold',
+    });
   });
 
   it('should pass when combined score is greater than threshold', async () => {
-    const output = 'Different output';
-
     const result: GradingResult = await runAssertions({
       prompt: 'Some prompt',
       provider: new OpenAiChatCompletionProvider('gpt-4'),
@@ -170,8 +174,10 @@ describe('runAssertions', () => {
       },
       output: 'Hi there world',
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Aggregate score 0.33 ≥ 0.25 threshold');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Aggregate score 0.33 ≥ 0.25 threshold',
+    });
   });
 
   describe('assert-set', () => {
@@ -200,8 +206,10 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('All assertions passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'All assertions passed',
+      });
     });
 
     it('assert-set failure', async () => {
@@ -226,10 +234,10 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toBe(false);
-      expect(result.reason).toBe(
-        'Expected output "Something different" to equal "Expected output"',
-      );
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Expected output "Something different" to equal "Expected output"',
+      });
     });
 
     it('assert-set threshold success', async () => {
@@ -261,8 +269,10 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toBe(true);
-      expect(result.reason).toBe('All assertions passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'All assertions passed',
+      });
     });
 
     it('assert-set threshold failure', async () => {
@@ -294,8 +304,10 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toBe(false);
-      expect(result.reason).toBe('Aggregate score 0.33 < 0.5 threshold');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Aggregate score 0.33 < 0.5 threshold',
+      });
     });
 
     it('assert-set with metric', async () => {
@@ -484,23 +496,6 @@ describe('runAssertion', () => {
     },
   };
 
-  const containsJsonAssertionWithSchemaYamlString: Assertion = {
-    type: 'contains-json',
-    value: `
-          required: ["latitude", "longitude"]
-          type: object
-          properties:
-            latitude:
-              type: number
-              minimum: -90
-              maximum: 90
-            longitude:
-              type: number
-              minimum: -180
-              maximum: 180
-`,
-  };
-
   const javascriptStringAssertion: Assertion = {
     type: 'javascript',
     value: 'output === "Expected output"',
@@ -564,8 +559,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the equality assertion fails', async () => {
@@ -578,8 +575,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output "Expected output" to equal "Different output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "Expected output" to equal "Different output"',
+    });
   });
 
   const notEqualsAssertion: Assertion = {
@@ -597,8 +596,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the not-equals assertion fails', async () => {
@@ -611,10 +612,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'Expected output "Unexpected output" to not equal "Unexpected output"',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "Unexpected output" to not equal "Unexpected output"',
+    });
   });
 
   it('should handle output as an object', async () => {
@@ -626,8 +627,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output "Expected output" to equal "{"key":"value"}"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "Expected output" to equal "{"key":"value"}"',
+    });
   });
 
   it('should pass when the equality assertion with object passes', async () => {
@@ -640,8 +643,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the equality assertion with object fails', async () => {
@@ -654,10 +659,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      `Expected output \"{\"key\":\"value\"}\" to equal \"{\"key\":\"not value\"}\"`,
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "{"key":"value"}" to equal "{"key":"not value"}"',
+    });
   });
 
   it('should pass when the equality assertion with object passes with external json', async () => {
@@ -678,8 +683,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/output.json'), 'utf8');
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the equality assertion with object fails with external object', async () => {
@@ -700,10 +707,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/output.json'), 'utf8');
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      `Expected output \"{\"key\":\"value\"}\" to equal \"{\"key\": \"not value\"}\"`,
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output "{"key":"value"}" to equal "{"key": "not value"}"',
+    });
   });
 
   it('should pass when the is-json assertion passes', async () => {
@@ -716,8 +723,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the is-json assertion fails', async () => {
@@ -730,8 +739,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toContain('Expected output to be valid JSON');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to be valid JSON',
+    });
   });
 
   it('should pass when the is-json assertion passes with schema', async () => {
@@ -744,8 +755,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the is-json assertion fails with schema', async () => {
@@ -758,10 +771,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    });
   });
 
   it('should pass when the is-json assertion passes with schema YAML string', async () => {
@@ -774,8 +787,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the is-json assertion fails with schema YAML string', async () => {
@@ -788,10 +803,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    });
   });
 
   it('should validate JSON with formats using ajv-formats', async () => {
@@ -815,8 +830,10 @@ describe('runAssertion', () => {
       output,
     });
 
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should validate JSON with formats using ajv-formats - failure', async () => {
@@ -840,10 +857,11 @@ describe('runAssertion', () => {
       output,
     });
 
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/date must match format "date"',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason:
+        'JSON does not conform to the provided schema. Errors: data/date must match format "date"',
+    });
   });
 
   it('should pass when the is-json assertion passes with external schema', async () => {
@@ -881,8 +899,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/schema.json'), 'utf8');
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the is-json assertion fails with external schema', async () => {
@@ -920,10 +940,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/schema.json'), 'utf8');
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    });
   });
 
   it('should pass when the contains-json assertion passes', async () => {
@@ -937,8 +957,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when the contains-json assertion passes with multiple json values', async () => {
@@ -952,8 +974,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when the contains-json assertion passes with valid and invalid json', async () => {
@@ -966,8 +990,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the contains-json assertion fails', async () => {
@@ -980,8 +1006,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toContain('Expected output to contain valid JSON');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain valid JSON',
+    });
   });
 
   it('should pass when the contains-json assertion passes with schema', async () => {
@@ -994,8 +1022,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when the contains-json assertion passes with schema with YAML string', async () => {
@@ -1008,8 +1038,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when the contains-json assertion passes with external schema', async () => {
@@ -1047,8 +1079,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/schema.json'), 'utf8');
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail contains-json assertion with invalid data against external schema', async () => {
@@ -1086,10 +1120,10 @@ describe('runAssertion', () => {
       output,
     });
     expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve('/schema.json'), 'utf8');
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    });
   });
 
   it('should fail contains-json assertion with predefined schema and invalid data', async () => {
@@ -1102,9 +1136,12 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+    expect(result).toEqual(
+      expect.objectContaining({
+        pass: false,
+        reason:
+          'JSON does not conform to the provided schema. Errors: data/latitude must be number',
+      }),
     );
   });
 
@@ -1118,8 +1155,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass a score through when the javascript returns a number', async () => {
@@ -1132,9 +1171,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.score).toBe(output.length * 10);
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      score: output.length * 10,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when javascript returns a number above threshold', async () => {
@@ -1147,9 +1188,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.score).toBe(output.length * 10);
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      score: output.length * 10,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when javascript returns a number below threshold', async () => {
@@ -1162,9 +1205,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.score).toBe(output.length * 10);
-    expect(result.reason).toMatch('Custom function returned false');
+    expect(result).toMatchObject({
+      pass: false,
+      score: output.length * 10,
+      reason: expect.stringContaining('Custom function returned false'),
+    });
   });
 
   it('should set score when javascript returns false', async () => {
@@ -1182,9 +1227,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.score).toBe(0);
-    expect(result.reason).toMatch('Custom function returned false');
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: expect.stringContaining('Custom function returned false'),
+    });
   });
 
   it('should fail when the javascript assertion fails', async () => {
@@ -1197,8 +1244,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Custom function returned false\noutput === "Expected output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Custom function returned false\noutput === "Expected output"',
+    });
   });
 
   it('should pass when assertion passes - with vars', async () => {
@@ -1215,8 +1264,10 @@ describe('runAssertion', () => {
       test: { vars: { foo: 'Expected output' } } as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when javascript function assertion passes - with vars', async () => {
@@ -1233,8 +1284,10 @@ describe('runAssertion', () => {
       test: { vars: { foo: 'bar' } } as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the javascript does not match vars', async () => {
@@ -1251,10 +1304,11 @@ describe('runAssertion', () => {
       test: { vars: { foo: 'bar' } } as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'Custom function returned false\noutput === "Expected output" && context.vars.foo === "something else"',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason:
+        'Custom function returned false\noutput === "Expected output" && context.vars.foo === "something else"',
+    });
   });
 
   it('should pass when the function returns pass', async () => {
@@ -1267,9 +1321,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.score).toBe(0.5);
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      score: 0.5,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the function returns fail', async () => {
@@ -1282,9 +1338,11 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.score).toBe(0.5);
-    expect(result.reason).toBe('Assertion failed');
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0.5,
+      reason: 'Assertion failed',
+    });
   });
 
   it('should pass when the multiline javascript assertion passes', async () => {
@@ -1297,8 +1355,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should pass when the multiline javascript assertion fails', async () => {
@@ -1311,8 +1371,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Assertion failed');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Assertion failed',
+    });
   });
 
   const notContainsAssertion: Assertion = {
@@ -1330,8 +1392,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the not-contains assertion fails', async () => {
@@ -1344,8 +1408,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to not contain "Unexpected output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to not contain "Unexpected output"',
+    });
   });
 
   // Test for icontains assertion
@@ -1364,8 +1430,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the icontains assertion fails', async () => {
@@ -1378,8 +1446,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to contain "expected output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain "expected output"',
+    });
   });
 
   // Test for not-icontains assertion
@@ -1398,8 +1468,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the not-icontains assertion fails', async () => {
@@ -1412,8 +1484,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to not contain "unexpected output"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to not contain "unexpected output"',
+    });
   });
 
   // Test for contains-any assertion
@@ -1432,8 +1506,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the contains-any assertion fails', async () => {
@@ -1446,8 +1522,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to contain one of "option1, option2, option3"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain one of "option1, option2, option3"',
+    });
   });
 
   it('should pass when the icontains-any assertion passes', async () => {
@@ -1463,8 +1541,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the icontains-any assertion fails', async () => {
@@ -1480,8 +1560,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to contain one of "option1, option2, option3"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain one of "option1, option2, option3"',
+    });
   });
 
   // Test for contains-all assertion
@@ -1500,8 +1582,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the contains-all assertion fails', async () => {
@@ -1514,8 +1598,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to contain all of "option1, option2, option3"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain all of "option1, option2, option3"',
+    });
   });
 
   it('should pass when the icontains-all assertion passes', async () => {
@@ -1531,8 +1617,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the icontains-all assertion fails', async () => {
@@ -1548,10 +1636,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe(
-      'Expected output to contain all of "option1, option2, option3, option4"',
-    );
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to contain all of "option1, option2, option3, option4"',
+    });
   });
 
   // Test for regex assertion
@@ -1570,8 +1658,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the regex assertion fails', async () => {
@@ -1584,8 +1674,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to match regex "\\d{3}-\\d{2}-\\d{4}"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to match regex "\\d{3}-\\d{2}-\\d{4}"',
+    });
   });
 
   // Test for not-regex assertion
@@ -1604,8 +1696,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the not-regex assertion fails', async () => {
@@ -1618,8 +1712,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to not match regex "\\d{3}-\\d{2}-\\d{4}"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to not match regex "\\d{3}-\\d{2}-\\d{4}"',
+    });
   });
 
   // Tests for webhook assertion
@@ -1642,8 +1738,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the webhook assertion fails', async () => {
@@ -1660,8 +1758,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Webhook returned false');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Webhook returned false',
+    });
   });
 
   it('should fail when the webhook returns an error', async () => {
@@ -1676,8 +1776,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Webhook error: Webhook response status: 500');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Webhook error: Webhook response status: 500',
+    });
   });
 
   // Test for rouge-n assertion
@@ -1697,8 +1799,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('ROUGE-N score 1.00 is greater than or equal to threshold 0.75');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'ROUGE-N score 1.00 is greater than or equal to threshold 0.75',
+    });
   });
 
   it('should fail when the rouge-n assertion fails', async () => {
@@ -1711,8 +1815,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('ROUGE-N score 0.17 is less than threshold 0.75');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'ROUGE-N score 0.17 is less than threshold 0.75',
+    });
   });
 
   // Test for starts-with assertion
@@ -1731,8 +1837,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the starts-with assertion fails', async () => {
@@ -1745,8 +1853,10 @@ describe('runAssertion', () => {
       output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Expected output to start with "Expected"');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Expected output to start with "Expected"',
+    });
   });
 
   it('should use the provider from the assertion if it exists', async () => {
@@ -1782,8 +1892,10 @@ describe('runAssertion', () => {
       output: output,
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Test grading output');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Test grading output',
+    });
   });
 
   // Test for levenshtein assertion
@@ -1803,8 +1915,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeTruthy();
-    expect(result.reason).toBe('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should fail when the levenshtein assertion fails', async () => {
@@ -1817,8 +1931,10 @@ describe('runAssertion', () => {
       test: {} as AtomicTestCase,
       output,
     });
-    expect(result.pass).toBeFalsy();
-    expect(result.reason).toBe('Levenshtein distance 8 is greater than threshold 5');
+    expect(result).toMatchObject({
+      pass: false,
+      reason: 'Levenshtein distance 8 is greater than threshold 5',
+    });
   });
 
   it.each([
@@ -1879,8 +1995,10 @@ describe('runAssertion', () => {
         vars: {},
         test: {},
       });
-      expect(result.pass).toBe(expectedPass);
-      expect(result.reason).toContain(expectedReason);
+      expect(result).toMatchObject({
+        pass: expectedPass,
+        reason: expect.stringContaining(expectedReason),
+      });
     },
   );
 
@@ -1908,8 +2026,10 @@ describe('runAssertion', () => {
       vars: {},
       test: {},
     });
-    expect(result.pass).toBe(true);
-    expect(result.reason).toContain('Assertion passed');
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+    });
   });
 
   it('should handle output strings with both single and double quotes correctly in python assertion', async () => {
@@ -1939,9 +2059,11 @@ describe('runAssertion', () => {
       { prompt: 'Some prompt', test: {}, vars: {} },
     ]);
 
-    expect(result.reason).toBe('Assertion passed');
-    expect(result.score).toBe(Number(expectedPythonValue));
-    expect(result.pass).toBeTruthy();
+    expect(result).toMatchObject({
+      pass: true,
+      reason: 'Assertion passed',
+      score: Number(expectedPythonValue),
+    });
   });
 
   it.each([
@@ -2009,9 +2131,11 @@ describe('runAssertion', () => {
         { prompt: 'Some prompt', test: {}, vars: {} },
       ]);
 
-      expect(result.reason).toMatch(new RegExp(`^${expectedReason}`));
-      expect(result.score).toBe(expectedScore);
-      expect(result.pass).toBe(expectedPass);
+      expect(result).toMatchObject({
+        pass: expectedPass,
+        reason: expect.stringMatching(expectedReason),
+        score: expectedScore,
+      });
     },
   );
 
@@ -2062,8 +2186,10 @@ describe('runAssertion', () => {
         },
       ]);
 
-      expect(result.pass).toBe(expectedPass);
-      expect(result.reason).toContain(expectedReason);
+      expect(result).toMatchObject({
+        pass: expectedPass,
+        reason: expect.stringContaining(expectedReason),
+      });
       expect(runPython).toHaveBeenCalledTimes(1);
     },
   );
@@ -2111,8 +2237,10 @@ describe('runAssertion', () => {
         test: {} as AtomicTestCase,
         output,
       });
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail when the latency assertion fails', async () => {
@@ -2129,8 +2257,10 @@ describe('runAssertion', () => {
         test: {} as AtomicTestCase,
         output,
       });
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('Latency 1000ms is greater than threshold 100ms');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Latency 1000ms is greater than threshold 100ms',
+      });
     });
 
     it('should throw an error when grading result is missing latencyMs', async () => {
@@ -2171,8 +2301,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         logProbs,
       });
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail when the perplexity assertion fails', async () => {
@@ -2192,8 +2324,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         logProbs,
       });
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('Perplexity 1.28 is greater than threshold 0.2');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Perplexity 1.28 is greater than threshold 0.2',
+      });
     });
   });
 
@@ -2215,8 +2349,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         logProbs,
       });
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail when the perplexity-score assertion fails', async () => {
@@ -2236,8 +2372,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         logProbs,
       });
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('Perplexity score 0.44 is less than threshold 0.5');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Perplexity score 0.44 is less than threshold 0.5',
+      });
     });
   });
 
@@ -2259,8 +2397,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         cost,
       });
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail when the cost exceeds the threshold', async () => {
@@ -2280,8 +2420,10 @@ describe('runAssertion', () => {
         output: 'Some output',
         cost,
       });
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('Cost 0.0020 is greater than threshold 0.001');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Cost 0.0020 is greater than threshold 0.001',
+      });
     });
   });
 
@@ -2315,8 +2457,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail for an invalid function call with incorrect arguments', async () => {
@@ -2348,8 +2492,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toContain('Call to "add" does not match schema');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: expect.stringContaining('Call to "add" does not match schema'),
+      });
     });
   });
 
@@ -2388,8 +2534,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Assertion passed');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Assertion passed',
+      });
     });
 
     it('should fail for an invalid tools call with incorrect arguments', async () => {
@@ -2426,8 +2574,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toContain('Call to "add" does not match schema');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: expect.stringContaining('Call to "add" does not match schema'),
+      });
     });
   });
 
@@ -2466,8 +2616,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Similarity 1.00 is greater than threshold 0.75');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Similarity 1.00 is greater than threshold 0.75',
+      });
     });
 
     it('should fail for a similar assertion with a string value', async () => {
@@ -2483,8 +2635,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('Similarity 0.00 is less than threshold 0.75');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'Similarity 0.00 is less than threshold 0.75',
+      });
     });
 
     it('should pass for a similar assertion with an array of string values', async () => {
@@ -2500,8 +2654,10 @@ describe('runAssertion', () => {
         output,
       });
 
-      expect(result.pass).toBeTruthy();
-      expect(result.reason).toBe('Similarity 1.00 is greater than threshold 0.75');
+      expect(result).toMatchObject({
+        pass: true,
+        reason: 'Similarity 1.00 is greater than threshold 0.75',
+      });
     });
 
     it('should fail for a similar assertion with an array of string values', async () => {
@@ -2516,9 +2672,10 @@ describe('runAssertion', () => {
         test: {} as AtomicTestCase,
         output,
       });
-
-      expect(result.pass).toBeFalsy();
-      expect(result.reason).toBe('None of the provided values met the similarity threshold');
+      expect(result).toMatchObject({
+        pass: false,
+        reason: 'None of the provided values met the similarity threshold',
+      });
     });
   });
 });

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -20,6 +20,7 @@ import type {
   ProviderResponse,
   GradingResult,
 } from '../src/types';
+import { TestGrader } from './utils';
 
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
@@ -60,18 +61,6 @@ jest.mock('../src/cliState', () => ({
   basePath: '/config_path',
 }));
 
-export class TestGrader implements ApiProvider {
-  async callApi(): Promise<ProviderResponse> {
-    return {
-      output: JSON.stringify({ pass: true, reason: 'Test grading output' }),
-      tokenUsage: { total: 10, prompt: 5, completion: 5 },
-    };
-  }
-
-  id(): string {
-    return 'TestGradingProvider';
-  }
-}
 const Grader = new TestGrader();
 
 describe('runAssertions', () => {
@@ -1062,7 +1051,7 @@ describe('runAssertion', () => {
     expect(result.reason).toBe('Assertion passed');
   });
 
-  it('should fail when the contains-json assertion fails with external schema', async () => {
+  it('should fail contains-json assertion with invalid data against external schema', async () => {
     const assertion: Assertion = {
       type: 'contains-json',
       value: 'file:///schema.json',
@@ -1103,7 +1092,7 @@ describe('runAssertion', () => {
     );
   });
 
-  it('should fail when the contains-json assertion fails with external schema', async () => {
+  it('should fail contains-json assertion with predefined schema and invalid data', async () => {
     const output = 'here is the answer\n\n```{"latitude": "medium", "longitude": -1}```';
 
     const result: GradingResult = await runAssertion({

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -226,7 +226,7 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toStrictEqual(false);
+      expect(result.pass).toBe(false);
       expect(result.reason).toBe(
         'Expected output "Something different" to equal "Expected output"',
       );
@@ -261,7 +261,7 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toStrictEqual(true);
+      expect(result.pass).toBe(true);
       expect(result.reason).toBe('All assertions passed');
     });
 
@@ -294,7 +294,7 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.pass).toStrictEqual(false);
+      expect(result.pass).toBe(false);
       expect(result.reason).toBe('Aggregate score 0.33 < 0.5 threshold');
     });
 
@@ -360,7 +360,7 @@ describe('runAssertions', () => {
         test,
         output,
       });
-      expect(result.score).toStrictEqual(0.9);
+      expect(result.score).toBe(0.9);
     });
   });
 

--- a/test/assertions/AssertionResult.test.ts
+++ b/test/assertions/AssertionResult.test.ts
@@ -65,7 +65,7 @@ describe('AssertionsResult', () => {
         index: 0,
         result: failingResult,
       }),
-    ).toThrowError(new Error(failingResult.reason));
+    ).toThrow(new Error(failingResult.reason));
 
     process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = initialEnv;
   });

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -2,7 +2,7 @@ import { fetchWithCache, disableCache, enableCache, clearCache } from '../src/ca
 import fetch, { Response } from 'node-fetch';
 
 jest.mock('node-fetch');
-const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
+const mockedFetch = jest.mocked(fetch);
 
 const mockedFetchResponse = (ok: boolean, response: object) => {
   return {

--- a/test/commands/eval/filterFailingTests.test.ts
+++ b/test/commands/eval/filterFailingTests.test.ts
@@ -64,7 +64,7 @@ describe('filterFailingTests', () => {
   });
 
   it('returns empty array when no failing tests', async () => {
-    (readOutput as jest.Mock).mockResolvedValue({
+    jest.mocked(readOutput).mockResolvedValue({
       results: { version: 2, results: [{ success: true }] },
     });
 

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -27,7 +27,7 @@ describe('filterTests', () => {
   it('handles no tests', async () => {
     const result = await filterTests({} as TestSuite, {});
 
-    expect(result).toBe(undefined);
+    expect(result).toBeUndefined();
   });
 
   describe('firstN', () => {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -71,7 +71,7 @@ describe('evaluator', () => {
     jest.clearAllMocks();
   });
 
-  test('evaluate with vars', async () => {
+  it('evaluate with vars', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt {{ var1 }} {{ var2 }}')],
@@ -93,7 +93,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with vars - no escaping', async () => {
+  it('evaluate with vars - no escaping', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt {{ var1 }} {{ var2 }}')],
@@ -115,7 +115,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with vars as object', async () => {
+  it('evaluate with vars as object', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt {{ var1.prop1 }} {{ var2 }}')],
@@ -137,7 +137,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with named prompt', async () => {
+  it('evaluate with named prompt', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [{ raw: 'Test prompt {{ var1 }} {{ var2 }}', label: 'test display name' }],
@@ -159,7 +159,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with multiple vars', async () => {
+  it('evaluate with multiple vars', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt {{ var1 }} {{ var2 }}')],
@@ -181,7 +181,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with multiple providers', async () => {
+  it('evaluate with multiple providers', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider, mockApiProvider],
       prompts: [toPrompt('Test prompt {{ var1 }} {{ var2 }}')],
@@ -203,7 +203,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate without tests', async () => {
+  it('evaluate without tests', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -220,7 +220,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate without tests with multiple providers', async () => {
+  it('evaluate without tests with multiple providers', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider, mockApiProvider, mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -237,7 +237,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with expected value matching output', async () => {
+  it('evaluate with expected value matching output', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -262,7 +262,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with expected value not matching output', async () => {
+  it('evaluate with expected value not matching output', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -287,7 +287,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with fn: expected value', async () => {
+  it('evaluate with fn: expected value', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -312,7 +312,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with fn: expected value not matching output', async () => {
+  it('evaluate with fn: expected value not matching output', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -337,7 +337,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with grading expected value', async () => {
+  it('evaluate with grading expected value', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -367,7 +367,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with grading expected value does not pass', async () => {
+  it('evaluate with grading expected value does not pass', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -397,7 +397,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with transform option - default test', async () => {
+  it('evaluate with transform option - default test', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -416,7 +416,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
 
-  test('evaluate with transform option - single test', async () => {
+  it('evaluate with transform option - single test', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt')],
@@ -443,7 +443,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output postprocessed');
   });
 
-  test('evaluate with transform option - json provider', async () => {
+  it('evaluate with transform option - json provider', async () => {
     const mockApiJsonProvider: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider-json'),
       callApi: jest.fn().mockResolvedValue({
@@ -478,7 +478,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe(123);
   });
 
-  test('evaluate with provider transform', async () => {
+  it('evaluate with provider transform', async () => {
     const mockApiProviderWithTransform: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider-transform'),
       callApi: jest.fn().mockResolvedValue({
@@ -512,7 +512,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Transformed: Original output');
   });
 
-  test('evaluate with providerPromptMap', async () => {
+  it('evaluate with providerPromptMap', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt('Test prompt 1'), toPrompt('Test prompt 2')],
@@ -537,7 +537,7 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
-  test('evaluate with scenarios', async () => {
+  it('evaluate with scenarios', async () => {
     const mockApiProvider: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider'),
       callApi: jest
@@ -594,7 +594,7 @@ describe('evaluator', () => {
     expect(summary.results[1].response?.output).toBe('Bonjour le monde');
   });
 
-  test('evaluate with scenarios and multiple vars', async () => {
+  it('evaluate with scenarios and multiple vars', async () => {
     const mockApiProvider: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider'),
       callApi: jest
@@ -654,7 +654,7 @@ describe('evaluator', () => {
     expect(summary.results[3].response?.output).toBe('French Bonjour');
   });
 
-  test('evaluate with _conversation variable', async () => {
+  it('evaluate with _conversation variable', async () => {
     const mockApiProvider: ApiProvider = {
       id: jest.fn().mockReturnValue('test-provider'),
       callApi: jest.fn().mockImplementation((prompt) => {
@@ -688,7 +688,7 @@ describe('evaluator', () => {
   });
 });
 
-it('should use the options from the test if they exist', async () => {
+test('should use the options from the test if they exist', async () => {
   const testSuite: TestSuite = {
     providers: [mockApiProvider],
     prompts: [toPrompt('Test prompt')],

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -405,9 +405,9 @@ describe('getGradingProvider', () => {
 
 describe('getAndCheckProvider', () => {
   it('should return the default provider when provider is not defined', async () => {
-    await expect(getAndCheckProvider('text', undefined, DefaultGradingProvider, 'test check')).resolves.toBe(
-      DefaultGradingProvider,
-    );
+    await expect(
+      getAndCheckProvider('text', undefined, DefaultGradingProvider, 'test check'),
+    ).resolves.toBe(DefaultGradingProvider);
   });
 
   it('should return the default provider when provider does not support type', async () => {

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/matchers';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai';
 
-import { TestGrader } from './assertions.test';
+import { TestGrader } from './utils';
 
 import type {
   GradingConfig,
@@ -434,9 +434,7 @@ describe('getAndCheckProvider', () => {
     );
     expect(result).toBe(provider);
   });
-});
 
-describe('getGradingProvider', () => {
   it('should return the default provider when no provider is specified', async () => {
     const provider = await getGradingProvider('text', undefined, DefaultGradingProvider);
     expect(provider).toBe(DefaultGradingProvider);

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -405,7 +405,7 @@ describe('getGradingProvider', () => {
 
 describe('getAndCheckProvider', () => {
   it('should return the default provider when provider is not defined', async () => {
-    expect(await getAndCheckProvider('text', undefined, DefaultGradingProvider, 'test check')).toBe(
+    await expect(getAndCheckProvider('text', undefined, DefaultGradingProvider, 'test check')).resolves.toBe(
       DefaultGradingProvider,
     );
   });
@@ -415,9 +415,9 @@ describe('getAndCheckProvider', () => {
       id: () => 'test-provider',
       callApi: () => Promise.resolve({ output: 'test' }),
     };
-    expect(
-      await getAndCheckProvider('embedding', provider, DefaultEmbeddingProvider, 'test check'),
-    ).toBe(DefaultEmbeddingProvider);
+    await expect(
+      getAndCheckProvider('embedding', provider, DefaultEmbeddingProvider, 'test check'),
+    ).resolves.toBe(DefaultEmbeddingProvider);
   });
 
   it('should return the provider if it implements the required method', async () => {

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -50,7 +50,8 @@ describe('prompts', () => {
   });
 
   it('readPrompts with multiple prompt files', async () => {
-    jest.mocked(fs.readFileSync)
+    jest
+      .mocked(fs.readFileSync)
       .mockReturnValueOnce('Test prompt 1')
       .mockReturnValueOnce('Test prompt 2');
     jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 describe('prompts', () => {
-  test('readPrompts with single prompt file', async () => {
+  it('readPrompts with single prompt file', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('Test prompt 1\n---\nTest prompt 2');
     (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompts.txt'];
@@ -49,7 +49,7 @@ describe('prompts', () => {
     expect(result).toEqual([toPrompt('Test prompt 1'), toPrompt('Test prompt 2')]);
   });
 
-  test('readPrompts with multiple prompt files', async () => {
+  it('readPrompts with multiple prompt files', async () => {
     (fs.readFileSync as jest.Mock)
       .mockReturnValueOnce('Test prompt 1')
       .mockReturnValueOnce('Test prompt 2');
@@ -63,7 +63,7 @@ describe('prompts', () => {
     expect(result).toEqual([toPrompt('Test prompt 1'), toPrompt('Test prompt 2')]);
   });
 
-  test('readPrompts with directory', async () => {
+  it('readPrompts with directory', async () => {
     (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
     (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
     (fs.readdirSync as jest.Mock).mockReturnValue(['prompt1.txt', 'prompt2.txt']);
@@ -84,7 +84,7 @@ describe('prompts', () => {
     expect(result).toEqual([toPrompt('Test prompt 1'), toPrompt('Test prompt 2')]);
   });
 
-  test('readPrompts with empty input', async () => {
+  it('readPrompts with empty input', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('');
     (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompts.txt'];
@@ -95,7 +95,7 @@ describe('prompts', () => {
     expect(result).toEqual([toPrompt('')]);
   });
 
-  test('readPrompts with map input', async () => {
+  it('readPrompts with map input', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('some raw text');
     (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
 
@@ -110,7 +110,7 @@ describe('prompts', () => {
     expect(result[1]).toEqual(expect.objectContaining({ raw: 'some raw text', label: 'foo2' }));
   });
 
-  test('readPrompts with JSONL file', async () => {
+  it('readPrompts with JSONL file', async () => {
     const data = [
       [
         { role: 'system', content: 'You are a helpful assistant.' },
@@ -132,7 +132,7 @@ describe('prompts', () => {
     expect(result).toEqual([toPrompt(JSON.stringify(data[0])), toPrompt(JSON.stringify(data[1]))]);
   });
 
-  test('readPrompts with .py file', async () => {
+  it('readPrompts with .py file', async () => {
     const code = `print('dummy prompt')`;
     (fs.readFileSync as jest.Mock).mockReturnValue(code);
     const result = await readPrompts('prompt.py');
@@ -142,7 +142,7 @@ describe('prompts', () => {
     expect(result[0].function).toBeDefined();
   });
 
-  test('readPrompts with Prompt object array', async () => {
+  it('readPrompts with Prompt object array', async () => {
     const prompts = [
       { id: 'prompts.py:prompt1', label: 'First prompt' },
       { id: 'prompts.py:prompt2', label: 'Second prompt' },
@@ -170,7 +170,7 @@ def prompt2:
     });
   });
 
-  test('readPrompts with .js file', async () => {
+  it('readPrompts with .js file', async () => {
     jest.doMock(
       path.resolve('prompt.js'),
       () => {
@@ -182,7 +182,7 @@ def prompt2:
     expect(result[0].function).toBeDefined();
   });
 
-  test('readPrompts with glob pattern for .txt files', async () => {
+  it('readPrompts with glob pattern for .txt files', async () => {
     const fileContents: Record<string, string> = {
       '1.txt': 'First text file content',
       '2.txt': 'Second text file content',

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -38,10 +38,10 @@ beforeEach(() => {
 
 describe('prompts', () => {
   it('readPrompts with single prompt file', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('Test prompt 1\n---\nTest prompt 2');
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    jest.mocked(fs.readFileSync).mockReturnValue('Test prompt 1\n---\nTest prompt 2');
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompts.txt'];
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
 
     const result = await readPrompts(promptPaths);
 
@@ -50,12 +50,12 @@ describe('prompts', () => {
   });
 
   it('readPrompts with multiple prompt files', async () => {
-    (fs.readFileSync as jest.Mock)
+    jest.mocked(fs.readFileSync)
       .mockReturnValueOnce('Test prompt 1')
       .mockReturnValueOnce('Test prompt 2');
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompt1.txt', 'prompt2.txt'];
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
 
     const result = await readPrompts(promptPaths);
 
@@ -64,10 +64,10 @@ describe('prompts', () => {
   });
 
   it('readPrompts with directory', async () => {
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
-    (fs.readdirSync as jest.Mock).mockReturnValue(['prompt1.txt', 'prompt2.txt']);
-    (fs.readFileSync as jest.Mock).mockImplementation((filePath) => {
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true });
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(fs.readdirSync).mockReturnValue(['prompt1.txt', 'prompt2.txt']);
+    jest.mocked(fs.readFileSync).mockImplementation((filePath) => {
       if (filePath.endsWith(path.join('prompts', 'prompt1.txt'))) {
         return 'Test prompt 1';
       } else if (filePath.endsWith(path.join('prompts', 'prompt2.txt'))) {
@@ -85,8 +85,8 @@ describe('prompts', () => {
   });
 
   it('readPrompts with empty input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('');
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    jest.mocked(fs.readFileSync).mockReturnValue('');
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompts.txt'];
 
     const result = await readPrompts(promptPaths);
@@ -96,8 +96,8 @@ describe('prompts', () => {
   });
 
   it('readPrompts with map input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('some raw text');
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    jest.mocked(fs.readFileSync).mockReturnValue('some raw text');
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });
 
     const result = await readPrompts({
       'prompts.txt': 'foo1',
@@ -122,8 +122,8 @@ describe('prompts', () => {
       ],
     ];
 
-    (fs.readFileSync as jest.Mock).mockReturnValue(data.map((o) => JSON.stringify(o)).join('\n'));
-    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+    jest.mocked(fs.readFileSync).mockReturnValue(data.map((o) => JSON.stringify(o)).join('\n'));
+    jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false });
     const promptPaths = ['prompts.jsonl'];
 
     const result = await readPrompts(promptPaths);
@@ -134,7 +134,7 @@ describe('prompts', () => {
 
   it('readPrompts with .py file', async () => {
     const code = `print('dummy prompt')`;
-    (fs.readFileSync as jest.Mock).mockReturnValue(code);
+    jest.mocked(fs.readFileSync).mockReturnValue(code);
     const result = await readPrompts('prompt.py');
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(result[0].raw).toEqual(code);
@@ -152,7 +152,7 @@ describe('prompts', () => {
   return 'First prompt'
 def prompt2:
   return 'Second prompt'`;
-    (fs.readFileSync as jest.Mock).mockReturnValue(code);
+    jest.mocked(fs.readFileSync).mockReturnValue(code);
 
     const result = await readPrompts(prompts);
 
@@ -188,7 +188,7 @@ def prompt2:
       '2.txt': 'Second text file content',
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
+    jest.mocked(fs.readFileSync).mockImplementation((path: string) => {
       if (path.includes('1.txt')) {
         return fileContents['1.txt'];
       } else if (path.includes('2.txt')) {
@@ -196,10 +196,10 @@ def prompt2:
       }
       throw new Error('Unexpected file path in test');
     });
-    (fs.statSync as jest.Mock).mockImplementation((path: string) => ({
+    jest.mocked(fs.statSync).mockImplementation((path: string) => ({
       isDirectory: () => path.includes('prompts'),
     }));
-    (fs.readdirSync as jest.Mock).mockImplementation((path: string) => {
+    jest.mocked(fs.readdirSync).mockImplementation((path: string) => {
       if (path.includes('prompts')) {
         return ['prompt1.txt', 'prompt2.txt'];
       }

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -47,7 +47,7 @@ describe('Anthropic', () => {
       config: { tools },
     });
 
-    test('should use cache by default for ToolUse requests', async () => {
+    it('should use cache by default for ToolUse requests', async () => {
       provider.anthropic.messages.create = jest.fn().mockResolvedValue({
         content: [
           {
@@ -97,7 +97,7 @@ describe('Anthropic', () => {
       expect(result).toMatchObject(resultFromCache);
     });
 
-    test('should not use cache if caching is disabled for ToolUse requests', async () => {
+    it('should not use cache if caching is disabled for ToolUse requests', async () => {
       provider.anthropic.messages.create = jest.fn().mockResolvedValue({
         content: [
           {
@@ -130,7 +130,7 @@ describe('Anthropic', () => {
       enableCache();
     });
 
-    test('should return cached response for legacy caching behavior', async () => {
+    it('should return cached response for legacy caching behavior', async () => {
       provider.anthropic.messages.create = jest.fn().mockResolvedValue({
         content: [],
       } as unknown as Anthropic.Messages.Message);
@@ -146,7 +146,7 @@ describe('Anthropic', () => {
       expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(0);
     });
 
-    test('should handle missing apiKey', async () => {
+    it('should handle missing apiKey', async () => {
       const provider = new AnthropicMessagesProvider('claude-3-opus-20240229', {
         config: { apiKey: undefined },
       });
@@ -156,7 +156,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should handle API call error', async () => {
+    it('should handle API call error', async () => {
       const provider = new AnthropicMessagesProvider('claude-3-opus-20240229');
       provider.anthropic.messages.create = jest
         .fn()
@@ -168,7 +168,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should return token usage and cost', async () => {
+    it('should return token usage and cost', async () => {
       const provider = new AnthropicMessagesProvider('claude-3-opus-20240229', {
         config: { max_tokens: 100, temperature: 0.5, cost: 0.015 },
       });
@@ -187,7 +187,7 @@ describe('Anthropic', () => {
   });
 
   describe('AnthropicCompletionProvider callApi', () => {
-    test('should return output for default behavior', async () => {
+    it('should return output for default behavior', async () => {
       const provider = new AnthropicCompletionProvider('claude-1');
       provider.anthropic.completions.create = jest.fn().mockResolvedValue({
         completion: 'Test output',
@@ -201,7 +201,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should return cached output with caching enabled', async () => {
+    it('should return cached output with caching enabled', async () => {
       const provider = new AnthropicCompletionProvider('claude-1');
       provider.anthropic.completions.create = jest.fn().mockResolvedValue({
         completion: 'Test output',
@@ -224,7 +224,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should return fresh output with caching disabled', async () => {
+    it('should return fresh output with caching disabled', async () => {
       const provider = new AnthropicCompletionProvider('claude-1');
       provider.anthropic.completions.create = jest.fn().mockResolvedValue({
         completion: 'Test output',
@@ -250,7 +250,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should handle missing apiKey', async () => {
+    it('should handle missing apiKey', async () => {
       const provider = new AnthropicCompletionProvider('claude-1', {
         config: { apiKey: undefined },
       });
@@ -261,7 +261,7 @@ describe('Anthropic', () => {
       });
     });
 
-    test('should handle API call error', async () => {
+    it('should handle API call error', async () => {
       const provider = new AnthropicCompletionProvider('claude-1');
       provider.anthropic.completions.create = jest
         .fn()
@@ -275,19 +275,19 @@ describe('Anthropic', () => {
   });
 
   describe('calculateCost', () => {
-    test('should calculate cost for valid input and output tokens', () => {
+    it('should calculate cost for valid input and output tokens', () => {
       const cost = calculateCost('claude-3-opus-20240229', { cost: 0.015 }, 100, 200);
 
       expect(cost).toBe(4.5); // (0.015 * 100) + (0.075 * 200)
     });
 
-    test('should return undefined for missing model', () => {
+    it('should return undefined for missing model', () => {
       const cost = calculateCost('non-existent-model', { cost: 0.015 });
 
       expect(cost).toBeUndefined();
     });
 
-    test('should return undefined for missing tokens', () => {
+    it('should return undefined for missing tokens', () => {
       const cost = calculateCost('claude-3-opus-20240229', { cost: 0.015 });
 
       expect(cost).toBeUndefined();
@@ -295,7 +295,7 @@ describe('Anthropic', () => {
   });
 
   describe('outputFromMessage', () => {
-    test('should return an empty string for empty content array', () => {
+    it('should return an empty string for empty content array', () => {
       const message: Anthropic.Messages.Message = {
         content: [],
         id: '',
@@ -314,7 +314,7 @@ describe('Anthropic', () => {
       expect(result).toBe('');
     });
 
-    test('should return text from a single text block', () => {
+    it('should return text from a single text block', () => {
       const message: Anthropic.Messages.Message = {
         content: [{ type: 'text', text: 'Hello' }],
         id: '',
@@ -333,7 +333,7 @@ describe('Anthropic', () => {
       expect(result).toBe('Hello');
     });
 
-    test('should concatenate text blocks without tool_use blocks', () => {
+    it('should concatenate text blocks without tool_use blocks', () => {
       const message: Anthropic.Messages.Message = {
         content: [
           { type: 'text', text: 'Hello' },
@@ -355,7 +355,7 @@ describe('Anthropic', () => {
       expect(result).toBe('Hello\n\nWorld');
     });
 
-    test('should handle content with tool_use blocks', () => {
+    it('should handle content with tool_use blocks', () => {
       const message: Anthropic.Messages.Message = {
         content: [
           {
@@ -389,7 +389,7 @@ describe('Anthropic', () => {
       );
     });
 
-    test('should concatenate text and tool_use blocks as JSON strings', () => {
+    it('should concatenate text and tool_use blocks as JSON strings', () => {
       const message: Anthropic.Messages.Message = {
         content: [
           { type: 'text', text: 'Hello' },
@@ -421,7 +421,7 @@ describe('Anthropic', () => {
   });
 
   describe('parseMessages', () => {
-    test('should parse messages with user and assistant roles', () => {
+    it('should parse messages with user and assistant roles', () => {
       const inputMessages = dedent`user: What is the weather?
           assistant: The weather is sunny.`;
 
@@ -442,7 +442,7 @@ describe('Anthropic', () => {
       ]);
     });
 
-    test('should handle system messages', () => {
+    it('should handle system messages', () => {
       const inputMessages = dedent`system: This is a system message.
         user: What is the weather?
         assistant: The weather is sunny.`;
@@ -465,7 +465,7 @@ describe('Anthropic', () => {
       ]);
     });
 
-    test('should handle empty input', () => {
+    it('should handle empty input', () => {
       const inputMessages = '';
 
       const { system, extractedMessages } = parseMessages(inputMessages);

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -214,7 +214,7 @@ describe('Anthropic', () => {
         tokenUsage: {},
       });
 
-      (provider.anthropic.completions.create as jest.Mock).mockClear();
+      jest.mocked(provider.anthropic.completions.create).mockClear();
       const cachedResult = await provider.callApi('Test prompt');
 
       expect(provider.anthropic.completions.create).toHaveBeenCalledTimes(0);
@@ -237,7 +237,7 @@ describe('Anthropic', () => {
         tokenUsage: {},
       });
 
-      (provider.anthropic.completions.create as jest.Mock).mockClear();
+      jest.mocked(provider.anthropic.completions.create).mockClear();
 
       disableCache();
 

--- a/test/providers.azure.test.ts
+++ b/test/providers.azure.test.ts
@@ -6,7 +6,7 @@ import type { TestSuite, TestCase } from '../src/types';
 import { HuggingfaceTextGenerationProvider } from '../src/providers/huggingface';
 
 describe('maybeEmitAzureOpenAiWarning', () => {
-  test('should not emit warning when no Azure providers are used', () => {
+  it('should not emit warning when no Azure providers are used', () => {
     const testSuite: TestSuite = {
       providers: [new OpenAiCompletionProvider('foo')],
       defaultTest: {},
@@ -21,7 +21,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
     expect(result).toBe(false);
   });
 
-  test('should not emit warning when Azure provider is used alone, but no model graded eval', () => {
+  it('should not emit warning when Azure provider is used alone, but no model graded eval', () => {
     const testSuite: TestSuite = {
       providers: [new AzureOpenAiCompletionProvider('foo')],
       defaultTest: {},
@@ -36,7 +36,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
     expect(result).toBe(false);
   });
 
-  test('should emit warning when Azure provider is used alone, but with model graded eval', () => {
+  it('should emit warning when Azure provider is used alone, but with model graded eval', () => {
     const testSuite: TestSuite = {
       providers: [new AzureOpenAiCompletionProvider('foo')],
       defaultTest: {},
@@ -51,7 +51,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
     expect(result).toBe(true);
   });
 
-  test('should emit warning when Azure provider used with non-OpenAI provider', () => {
+  it('should emit warning when Azure provider used with non-OpenAI provider', () => {
     const testSuite: TestSuite = {
       providers: [
         new AzureOpenAiCompletionProvider('foo'),
@@ -69,7 +69,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
     expect(result).toBe(true);
   });
 
-  test('should not emit warning when Azure providers are used with a default provider set', () => {
+  it('should not emit warning when Azure providers are used with a default provider set', () => {
     const testSuite: TestSuite = {
       providers: [new AzureOpenAiCompletionProvider('foo')],
       defaultTest: { options: { provider: 'azureopenai:....' } },
@@ -84,7 +84,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
     expect(result).toBe(false);
   });
 
-  test('should not emit warning when both Azure and OpenAI providers are used', () => {
+  it('should not emit warning when both Azure and OpenAI providers are used', () => {
     const testSuite: TestSuite = {
       providers: [new AzureOpenAiCompletionProvider('foo'), new OpenAiCompletionProvider('bar')],
       defaultTest: {},

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -88,7 +88,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
@@ -108,7 +108,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
     const result = await provider.callApi(
@@ -130,7 +130,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
     const result = await provider.callApi(
@@ -160,7 +160,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
     const result = await provider.callApi(
@@ -212,7 +212,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
@@ -231,7 +231,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo');
     const result = await provider.callApi(
@@ -265,7 +265,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo', {
       config: { dataSources },
@@ -293,7 +293,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo');
     const result = await provider.callApi(
@@ -315,7 +315,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new LlamaProvider('llama.cpp');
     const result = await provider.callApi('Test prompt');
@@ -337,7 +337,7 @@ describe('call provider apis', () => {
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:35.117166Z","response":" blue","done":false}
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:41.695299Z","done":true,"context":[1,29871,1,13,9314],"total_duration":10411943458,"load_duration":458333,"sample_count":217,"sample_duration":154566000,"prompt_eval_count":11,"prompt_eval_duration":3334582000,"eval_count":216,"eval_duration":6905134000}`),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OllamaCompletionProvider('llama');
     const result = await provider.callApi('Test prompt');
@@ -357,7 +357,7 @@ describe('call provider apis', () => {
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.324309782Z","message":{"role":"assistant","content":".","images":null},"done":false}
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.337165395Z","done":true,"total_duration":1486443841,"load_duration":1280794143,"prompt_eval_count":35,"prompt_eval_duration":142384000,"eval_count":6,"eval_duration":61912000}`),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new OllamaChatProvider('llama');
     const result = await provider.callApi('Test prompt');
@@ -374,7 +374,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new WebhookProvider('http://example.com/webhook');
     const result = await provider.callApi('Test prompt');
@@ -391,7 +391,7 @@ describe('call provider apis', () => {
       const mockResponse = {
         text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
-      (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+      jest.mocked(fetch).mockResolvedValue(mockResponse);
 
       const provider = new HuggingfaceTextGenerationProvider('gpt2');
       const result = await provider.callApi('Test prompt');
@@ -405,7 +405,7 @@ describe('call provider apis', () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
     const result = await provider.callEmbeddingApi('Test text');
@@ -430,7 +430,7 @@ describe('call provider apis', () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(JSON.stringify(mockClassification)),
     };
-    (fetch as unknown as jest.Mock).mockResolvedValue(mockResponse);
+    jest.mocked(fetch).mockResolvedValue(mockResponse);
 
     const provider = new HuggingfaceTextClassificationProvider('foo');
     const result = await provider.callClassificationApi('Test text');
@@ -447,7 +447,7 @@ describe('call provider apis', () => {
       enableCache();
     });
 
-    const fetchMock = fetch as unknown as jest.Mock;
+    const fetchMock = jest.mocked(fetch);
     const cloudflareMinimumConfig: Required<
       Pick<ICloudflareProviderBaseConfig, 'accountId' | 'apiKey'>
     > = {
@@ -742,7 +742,7 @@ describe('loadApiProvider', () => {
     const mockYamlContent = `id: 'openai:gpt-4'
 config:
   key: 'value'`;
-    (fs.readFileSync as jest.Mock).mockReturnValueOnce(mockYamlContent);
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(mockYamlContent);
 
     const provider = await loadApiProvider('file://path/to/mock-provider-file.yaml');
     expect(provider.id()).toBe('openai:gpt-4');

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -79,7 +79,7 @@ describe('call provider apis', () => {
     await clearCache();
   });
 
-  test('OpenAiCompletionProvider callApi', async () => {
+  it('OpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -98,7 +98,7 @@ describe('call provider apis', () => {
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('OpenAiChatCompletionProvider callApi', async () => {
+  it('OpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -120,7 +120,7 @@ describe('call provider apis', () => {
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('OpenAiChatCompletionProvider callApi with caching', async () => {
+  it('OpenAiChatCompletionProvider callApi with caching', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -150,7 +150,7 @@ describe('call provider apis', () => {
     expect(result2.tokenUsage).toEqual({ total: 10, cached: 10 });
   });
 
-  test('OpenAiChatCompletionProvider callApi with cache disabled', async () => {
+  it('OpenAiChatCompletionProvider callApi with cache disabled', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -184,7 +184,7 @@ describe('call provider apis', () => {
     enableCache();
   });
 
-  test('OpenAiChatCompletionProvider constructor with config', async () => {
+  it('OpenAiChatCompletionProvider constructor with config', async () => {
     const config = {
       temperature: 3.1415926,
       max_tokens: 201,
@@ -203,7 +203,7 @@ describe('call provider apis', () => {
     expect(provider.config.max_tokens).toBe(config.max_tokens);
   });
 
-  test('AzureOpenAiCompletionProvider callApi', async () => {
+  it('AzureOpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -222,7 +222,7 @@ describe('call provider apis', () => {
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('AzureOpenAiChatCompletionProvider callApi', async () => {
+  it('AzureOpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -243,7 +243,7 @@ describe('call provider apis', () => {
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('AzureOpenAiChatCompletionProvider callApi with dataSources', async () => {
+  it('AzureOpenAiChatCompletionProvider callApi with dataSources', async () => {
     const dataSources = [
       {
         type: 'AzureCognitiveSearch',
@@ -282,7 +282,7 @@ describe('call provider apis', () => {
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('AzureOpenAiChatCompletionProvider callApi with cache disabled', async () => {
+  it('AzureOpenAiChatCompletionProvider callApi with cache disabled', async () => {
     disableCache();
 
     const mockResponse = {
@@ -307,7 +307,7 @@ describe('call provider apis', () => {
     enableCache();
   });
 
-  test('LlamaProvider callApi', async () => {
+  it('LlamaProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -324,7 +324,7 @@ describe('call provider apis', () => {
     expect(result.output).toBe('Test output');
   });
 
-  test('OllamaCompletionProvider callApi', async () => {
+  it('OllamaCompletionProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn()
         .mockResolvedValue(`{"model":"llama2:13b","created_at":"2023-08-08T21:50:34.898068Z","response":"Gre","done":false}
@@ -346,7 +346,7 @@ describe('call provider apis', () => {
     expect(result.output).toBe('Great question! The sky appears blue');
   });
 
-  test('OllamaChatProvider callApi', async () => {
+  it('OllamaChatProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn()
         .mockResolvedValue(`{"model":"orca-mini","created_at":"2023-12-16T01:46:19.263682972Z","message":{"role":"assistant","content":" Because","images":null},"done":false}
@@ -366,7 +366,7 @@ describe('call provider apis', () => {
     expect(result.output).toBe(' Because of Rayleigh scattering.');
   });
 
-  test('WebhookProvider callApi', async () => {
+  it('WebhookProvider callApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
@@ -387,7 +387,7 @@ describe('call provider apis', () => {
     ['Array format', [{ generated_text: 'Test output' }]], // Array format
     ['Object format', { generated_text: 'Test output' }], // Object format
   ])('HuggingfaceTextGenerationProvider callApi with %s', (format, mockedData) => {
-    test('returns expected output', async () => {
+    it('returns expected output', async () => {
       const mockResponse = {
         text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
@@ -401,7 +401,7 @@ describe('call provider apis', () => {
     });
   });
 
-  test('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
+  it('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
     const mockResponse = {
       text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
@@ -414,7 +414,7 @@ describe('call provider apis', () => {
     expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
   });
 
-  test('HuggingfaceTextClassificationProvider callClassificationApi', async () => {
+  it('HuggingfaceTextClassificationProvider callClassificationApi', async () => {
     const mockClassification = [
       [
         {
@@ -465,7 +465,7 @@ describe('call provider apis', () => {
     };
 
     describe('CloudflareAiCompletionProvider', () => {
-      test('callApi with caching enabled', async () => {
+      it('callApi with caching enabled', async () => {
         const PROMPT = 'Test prompt for caching';
         const provider = new CloudflareAiCompletionProvider(testModelName, {
           config: cloudflareMinimumConfig,
@@ -498,7 +498,7 @@ describe('call provider apis', () => {
         expect(resultFromCache.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
 
-      test('callApi with caching disabled', async () => {
+      it('callApi with caching disabled', async () => {
         const PROMPT = 'test prompt without caching';
         try {
           disableCache();
@@ -535,7 +535,7 @@ describe('call provider apis', () => {
         }
       });
 
-      test('callApi handles cloudflare error properly', async () => {
+      it('callApi handles cloudflare error properly', async () => {
         const PROMPT = 'Test prompt for caching';
         const provider = new CloudflareAiCompletionProvider(testModelName, {
           config: cloudflareMinimumConfig,
@@ -557,7 +557,7 @@ describe('call provider apis', () => {
         expect(result.error).toContain(JSON.stringify(responsePayload.errors));
       });
 
-      test('Can be invoked with custom configuration', async () => {
+      it('Can be invoked with custom configuration', async () => {
         const cloudflareChatConfig: ICloudflareProviderConfig = {
           accountId: 'MADE_UP_ACCOUNT_ID',
           apiKey: 'MADE_UP_API_KEY',
@@ -612,7 +612,7 @@ describe('call provider apis', () => {
     });
 
     describe('CloudflareAiChatCompletionProvider', () => {
-      test('Should handle chat provider', async () => {
+      it('Should handle chat provider', async () => {
         const provider = new CloudflareAiChatCompletionProvider(testModelName, {
           config: cloudflareMinimumConfig,
         });
@@ -640,7 +640,7 @@ describe('call provider apis', () => {
     });
 
     describe('CloudflareAiEmbeddingProvider', () => {
-      test('Should return embeddings in the proper format', async () => {
+      it('Should return embeddings in the proper format', async () => {
         const provider = new CloudflareAiEmbeddingProvider(testModelName, {
           config: cloudflareMinimumConfig,
         });
@@ -676,13 +676,14 @@ describe('call provider apis', () => {
     ['./path/to/file.py run', './path/to/file.py', ['run']],
     ['"/Path/To/My File.py"', '/Path/To/My File.py', []],
   ])('ScriptCompletionProvider callApi with script %s', (script, inputFile, inputArgs) => {
-    test('returns expected output', async () => {
+    it('returns expected output', async () => {
       const mockResponse = 'Test script output';
       const mockChildProcess = {
         stdout: new Stream.Readable(),
         stderr: new Stream.Readable(),
       } as child_process.ChildProcess;
-      jest
+
+      const execFileSpy = jest
         .spyOn(child_process, 'execFile')
         .mockImplementation(
           (
@@ -697,20 +698,9 @@ describe('call provider apis', () => {
                   stderr: string | Buffer,
                 ) => void),
           ) => {
-            expect(callback).toBeTruthy();
-            if (callback) {
-              expect(file).toContain(inputFile);
-              expect(args).toEqual(
-                expect.arrayContaining(
-                  inputArgs.concat([
-                    'Test prompt',
-                    '{"config":{"some_config_val":42}}',
-                    '{"vars":{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""}}',
-                  ]),
-                ),
-              );
-              process.nextTick(() => callback(null, Buffer.from(mockResponse), Buffer.from('')));
-            }
+            process.nextTick(
+              () => callback && callback(null, Buffer.from(mockResponse), Buffer.from('')),
+            );
             return mockChildProcess;
           },
         );
@@ -728,7 +718,19 @@ describe('call provider apis', () => {
       });
 
       expect(result.output).toBe(mockResponse);
-      expect(child_process.execFile).toHaveBeenCalledTimes(1);
+      expect(execFileSpy).toHaveBeenCalledTimes(1);
+      expect(execFileSpy).toHaveBeenCalledWith(
+        expect.stringContaining(inputFile),
+        expect.arrayContaining(
+          inputArgs.concat([
+            'Test prompt',
+            '{"config":{"some_config_val":42}}',
+            '{"vars":{"var1":"value 1","var2":"value 2 \\"with some double \\"quotes\\"\\""}}',
+          ]),
+        ),
+        expect.any(Object),
+        expect.any(Function),
+      );
 
       jest.restoreAllMocks();
     });
@@ -736,7 +738,7 @@ describe('call provider apis', () => {
 });
 
 describe('loadApiProvider', () => {
-  test('loadApiProvider with filepath', async () => {
+  it('loadApiProvider with filepath', async () => {
     const mockYamlContent = `id: 'openai:gpt-4'
 config:
   key: 'value'`;
@@ -748,124 +750,124 @@ config:
     expect(fs.readFileSync).toHaveBeenCalledWith('path/to/mock-provider-file.yaml', 'utf8');
   });
 
-  test('loadApiProvider with openai:chat', async () => {
+  it('loadApiProvider with openai:chat', async () => {
     const provider = await loadApiProvider('openai:chat');
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
   });
 
-  test('loadApiProvider with openai:completion', async () => {
+  it('loadApiProvider with openai:completion', async () => {
     const provider = await loadApiProvider('openai:completion');
     expect(provider).toBeInstanceOf(OpenAiCompletionProvider);
   });
 
-  test('loadApiProvider with openai:assistant', async () => {
+  it('loadApiProvider with openai:assistant', async () => {
     const provider = await loadApiProvider('openai:assistant:foobar');
     expect(provider).toBeInstanceOf(OpenAiAssistantProvider);
   });
 
-  test('loadApiProvider with openai:chat:modelName', async () => {
+  it('loadApiProvider with openai:chat:modelName', async () => {
     const provider = await loadApiProvider('openai:chat:gpt-3.5-turbo');
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
   });
 
-  test('loadApiProvider with openai:completion:modelName', async () => {
+  it('loadApiProvider with openai:completion:modelName', async () => {
     const provider = await loadApiProvider('openai:completion:text-davinci-003');
     expect(provider).toBeInstanceOf(OpenAiCompletionProvider);
   });
 
-  test('loadApiProvider with OpenAI finetuned model', async () => {
+  it('loadApiProvider with OpenAI finetuned model', async () => {
     const provider = await loadApiProvider('openai:chat:ft:gpt-3.5-turbo-0613:company-name::ID:');
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
     expect(provider.id()).toBe('openai:ft:gpt-3.5-turbo-0613:company-name::ID:');
   });
 
-  test('loadApiProvider with azureopenai:completion:modelName', async () => {
+  it('loadApiProvider with azureopenai:completion:modelName', async () => {
     const provider = await loadApiProvider('azureopenai:completion:text-davinci-003');
     expect(provider).toBeInstanceOf(AzureOpenAiCompletionProvider);
   });
 
-  test('loadApiProvider with azureopenai:chat:modelName', async () => {
+  it('loadApiProvider with azureopenai:chat:modelName', async () => {
     const provider = await loadApiProvider('azureopenai:chat:gpt-3.5-turbo');
     expect(provider).toBeInstanceOf(AzureOpenAiChatCompletionProvider);
   });
 
-  test('loadApiProvider with anthropic:completion', async () => {
+  it('loadApiProvider with anthropic:completion', async () => {
     const provider = await loadApiProvider('anthropic:completion');
     expect(provider).toBeInstanceOf(AnthropicCompletionProvider);
   });
 
-  test('loadApiProvider with anthropic:completion:modelName', async () => {
+  it('loadApiProvider with anthropic:completion:modelName', async () => {
     const provider = await loadApiProvider('anthropic:completion:claude-1');
     expect(provider).toBeInstanceOf(AnthropicCompletionProvider);
   });
 
-  test('loadApiProvider with ollama:modelName', async () => {
+  it('loadApiProvider with ollama:modelName', async () => {
     const provider = await loadApiProvider('ollama:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaCompletionProvider);
     expect(provider.id()).toBe('ollama:completion:llama2:13b');
   });
 
-  test('loadApiProvider with ollama:completion:modelName', async () => {
+  it('loadApiProvider with ollama:completion:modelName', async () => {
     const provider = await loadApiProvider('ollama:completion:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaCompletionProvider);
     expect(provider.id()).toBe('ollama:completion:llama2:13b');
   });
 
-  test('loadApiProvider with ollama:chat:modelName', async () => {
+  it('loadApiProvider with ollama:chat:modelName', async () => {
     const provider = await loadApiProvider('ollama:chat:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaChatProvider);
     expect(provider.id()).toBe('ollama:chat:llama2:13b');
   });
 
-  test('loadApiProvider with llama:modelName', async () => {
+  it('loadApiProvider with llama:modelName', async () => {
     const provider = await loadApiProvider('llama');
     expect(provider).toBeInstanceOf(LlamaProvider);
   });
 
-  test('loadApiProvider with webhook', async () => {
+  it('loadApiProvider with webhook', async () => {
     const provider = await loadApiProvider('webhook:http://example.com/webhook');
     expect(provider).toBeInstanceOf(WebhookProvider);
   });
 
-  test('loadApiProvider with huggingface:text-generation', async () => {
+  it('loadApiProvider with huggingface:text-generation', async () => {
     const provider = await loadApiProvider('huggingface:text-generation:foobar/baz');
     expect(provider).toBeInstanceOf(HuggingfaceTextGenerationProvider);
   });
 
-  test('loadApiProvider with huggingface:feature-extraction', async () => {
+  it('loadApiProvider with huggingface:feature-extraction', async () => {
     const provider = await loadApiProvider('huggingface:feature-extraction:foobar/baz');
     expect(provider).toBeInstanceOf(HuggingfaceFeatureExtractionProvider);
   });
 
-  test('loadApiProvider with huggingface:text-classification', async () => {
+  it('loadApiProvider with huggingface:text-classification', async () => {
     const provider = await loadApiProvider('huggingface:text-classification:foobar/baz');
     expect(provider).toBeInstanceOf(HuggingfaceTextClassificationProvider);
   });
 
-  test('loadApiProvider with hf:text-classification', async () => {
+  it('loadApiProvider with hf:text-classification', async () => {
     const provider = await loadApiProvider('hf:text-classification:foobar/baz');
     expect(provider).toBeInstanceOf(HuggingfaceTextClassificationProvider);
   });
 
-  test('loadApiProvider with bedrock:completion', async () => {
+  it('loadApiProvider with bedrock:completion', async () => {
     const provider = await loadApiProvider('bedrock:completion:anthropic.claude-v2:1');
     expect(provider).toBeInstanceOf(AwsBedrockCompletionProvider);
   });
 
-  test('loadApiProvider with openrouter', async () => {
+  it('loadApiProvider with openrouter', async () => {
     const provider = await loadApiProvider('openrouter:mistralai/mistral-medium');
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
     // Intentionally openai, because it's just a wrapper around openai
     expect(provider.id()).toBe('mistralai/mistral-medium');
   });
 
-  test('loadApiProvider with voyage', async () => {
+  it('loadApiProvider with voyage', async () => {
     const provider = await loadApiProvider('voyage:voyage-2');
     expect(provider).toBeInstanceOf(VoyageEmbeddingProvider);
     expect(provider.id()).toBe('voyage:voyage-2');
   });
 
-  test('loadApiProvider with cloudflare-ai', async () => {
+  it('loadApiProvider with cloudflare-ai', async () => {
     const supportedModelTypes = [
       { modelType: 'chat', providerKlass: CloudflareAiChatCompletionProvider },
       { modelType: 'embedding', providerKlass: CloudflareAiEmbeddingProvider },
@@ -876,14 +878,14 @@ config:
     const modelName = 'mistralai/mistral-medium';
 
     // Without any model type should throw an error
-    await expect(() => loadApiProvider(`cloudflare-ai:${modelName}`)).rejects.toThrowError(
+    await expect(() => loadApiProvider(`cloudflare-ai:${modelName}`)).rejects.toThrow(
       /Unknown Cloudflare AI model type/,
     );
 
     for (const unsupportedModelType of unsupportedModelTypes) {
       await expect(() =>
         loadApiProvider(`cloudflare-ai:${unsupportedModelType}:${modelName}`),
-      ).rejects.toThrowError(/Unknown Cloudflare AI model type/);
+      ).rejects.toThrow(/Unknown Cloudflare AI model type/);
     }
 
     for (const { modelType, providerKlass } of supportedModelTypes) {
@@ -896,7 +898,7 @@ config:
     }
   });
 
-  test('loadApiProvider with RawProviderConfig', async () => {
+  it('loadApiProvider with RawProviderConfig', async () => {
     const rawProviderConfig = {
       'openai:chat': {
         id: 'test',
@@ -909,7 +911,7 @@ config:
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
   });
 
-  test('loadApiProviders with ProviderFunction', async () => {
+  it('loadApiProviders with ProviderFunction', async () => {
     const providerFunction: ProviderFunction = async (prompt: string) => {
       return {
         output: `Output for ${prompt}`,
@@ -924,7 +926,7 @@ config:
     expect(response.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
 
-  test('loadApiProviders with RawProviderConfig[]', async () => {
+  it('loadApiProviders with RawProviderConfig[]', async () => {
     const rawProviderConfigs: ProviderOptionsMap[] = [
       {
         'openai:chat:abc123': {
@@ -949,7 +951,7 @@ config:
     expect(providers[2]).toBeInstanceOf(AnthropicCompletionProvider);
   });
 
-  test('loadApiProvider sets provider.delay', async () => {
+  it('loadApiProvider sets provider.delay', async () => {
     const providerOptions = {
       id: 'test-delay',
       config: {},

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -597,7 +597,7 @@ describe('call provider apis', () => {
         await cfProvider.callApi(PROMPT);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(fetchMock.mock.calls).toHaveLength(1);
         const [url, { body, headers, method }] = fetchMock.mock.calls[0];
         expect(url).toContain(cloudflareChatConfig.accountId);
         expect(method).toBe('POST');

--- a/test/providers.vertex.test.ts
+++ b/test/providers.vertex.test.ts
@@ -33,12 +33,12 @@ describe('VertexChatProvider.callGeminiApi', () => {
       },
     });
 
-    (getCache as jest.Mock).mockReturnValue({
+    jest.mocked(getCache).mockReturnValue({
       get: jest.fn(),
       set: jest.fn(),
     });
 
-    (isCacheEnabled as jest.Mock).mockReturnValue(true);
+    jest.mocked(isCacheEnabled).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -90,7 +90,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       },
     };
 
-    (getCache().get as jest.Mock).mockResolvedValue(JSON.stringify(mockCachedResponse));
+    jest.mocked(getCache().get).mockResolvedValue(JSON.stringify(mockCachedResponse));
 
     const response = await provider.callGeminiApi('test prompt');
 

--- a/test/providers.vertex.test.ts
+++ b/test/providers.vertex.test.ts
@@ -45,7 +45,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
     jest.clearAllMocks();
   });
 
-  test('should call the Gemini API and return the response', async () => {
+  it('should call the Gemini API and return the response', async () => {
     const mockResponse = {
       data: [
         {
@@ -79,7 +79,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
     });
   });
 
-  test('should return cached response if available', async () => {
+  it('should return cached response if available', async () => {
     const mockCachedResponse = {
       cached: true,
       output: 'cached response text',
@@ -103,7 +103,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
     });
   });
 
-  test('should handle API call errors', async () => {
+  it('should handle API call errors', async () => {
     const mockError = new Error('API call error');
     jest.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
       client: {
@@ -119,7 +119,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
     });
   });
 
-  test('should handle API response errors', async () => {
+  it('should handle API response errors', async () => {
     const mockResponse = {
       data: [
         {

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -16,7 +16,7 @@ describe('Python Wrapper', () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
-      const mockPythonShellRun = PythonShell.run as jest.Mock;
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
       mockPythonShellRun.mockResolvedValue(['{"type": "final_result", "data": "test result"}']);
 
       const result = await pythonWrapper.runPython('testScript.py', 'testMethod', [
@@ -35,7 +35,7 @@ describe('Python Wrapper', () => {
     });
 
     it('should throw an error if the Python script execution fails', async () => {
-      const mockPythonShellRun = PythonShell.run as jest.Mock;
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
       mockPythonShellRun.mockRejectedValue(new Error('Test Error'));
 
       await expect(
@@ -47,7 +47,7 @@ describe('Python Wrapper', () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
-      const mockPythonShellRun = PythonShell.run as jest.Mock;
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
       mockPythonShellRun.mockResolvedValue([
         '{"type": "unexpected_result", "data": "test result"}',
       ]);
@@ -62,7 +62,7 @@ describe('Python Wrapper', () => {
 
   describe('runPythonCode', () => {
     it('should execute Python code from a string', async () => {
-      const mockPythonShellRun = PythonShell.run as jest.Mock;
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
       mockPythonShellRun.mockResolvedValue([
         '{"type": "final_result", "data": "execution result"}',
       ]);

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -24,7 +24,7 @@ describe('Python Wrapper', () => {
         { key: 'value' },
       ]);
 
-      expect(result).toEqual('test result');
+      expect(result).toBe('test result');
       expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
       expect(mockPythonShellRun.mock.calls[0][1].args).toEqual([
         expect.stringContaining('testScript.py'),
@@ -72,7 +72,7 @@ describe('Python Wrapper', () => {
       const code = 'print("Hello, world!")';
       const result = await pythonWrapper.runPythonCode(code, 'main', []);
 
-      expect(result).toEqual('execution result');
+      expect(result).toBe('execution result');
       expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
       expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining('.py'), code);
     });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -19,7 +19,7 @@ describe('Telemetry', () => {
   beforeEach(() => {
     originalEnv = process.env;
     process.env = { ...originalEnv };
-    (fetchWithTimeout as jest.Mock).mockClear();
+    jest.mocked(fetchWithTimeout).mockClear();
   });
 
   afterEach(() => {
@@ -45,7 +45,7 @@ describe('Telemetry', () => {
   });
 
   it('should send events and clear events array when telemetry is enabled and send is called', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValue({ ok: true });
+    jest.mocked(fetchWithTimeout).mockResolvedValue({ ok: true });
 
     const telemetry = new Telemetry();
     telemetry.record('eval_ran', { foo: 'bar' });

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 });
 
 describe('readStandaloneTestsFile', () => {
-  test('readStandaloneTestsFile with CSV input', async () => {
+  it('readStandaloneTestsFile with CSV input', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2\nvalue1,value2\nvalue3,value4');
     const varsPath = 'vars.csv';
 
@@ -47,7 +47,7 @@ describe('readStandaloneTestsFile', () => {
     expect(result[1].vars).toEqual({ var1: 'value3', var2: 'value4' });
   });
 
-  test('readStandaloneTestsFile with JSON input', async () => {
+  it('readStandaloneTestsFile with JSON input', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue(
       '[{"var1": "value1", "var2": "value2"}, {"var3": "value3", "var4": "value4"}]',
     );
@@ -61,7 +61,7 @@ describe('readStandaloneTestsFile', () => {
     expect(result[1].vars).toEqual({ var3: 'value3', var4: 'value4' });
   });
 
-  test('readStandaloneTestsFile with YAML input', async () => {
+  it('readStandaloneTestsFile with YAML input', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue(
       '- var1: value1\n  var2: value2\n- var3: value3\n  var4: value4',
     );
@@ -77,7 +77,7 @@ describe('readStandaloneTestsFile', () => {
 });
 
 describe('readTest', () => {
-  test('readTest with string input (path to test config)', async () => {
+  it('readTest with string input (path to test config)', async () => {
     const testPath = 'test1.yaml';
     const testContent = {
       description: 'Test 1',
@@ -92,7 +92,7 @@ describe('readTest', () => {
     expect(result).toEqual(testContent);
   });
 
-  test('readTest with TestCase input', async () => {
+  it('readTest with TestCase input', async () => {
     const input: TestCase = {
       description: 'Test 1',
       vars: { var1: 'value1', var2: 'value2' },
@@ -104,13 +104,13 @@ describe('readTest', () => {
     expect(result).toEqual(input);
   });
 
-  test('readTest with invalid input', async () => {
+  it('readTest with invalid input', async () => {
     const input: any = 123;
 
     await expect(readTest(input)).rejects.toThrow();
   });
 
-  test('readTest with TestCase that contains a vars glob input', async () => {
+  it('readTest with TestCase that contains a vars glob input', async () => {
     const input = {
       description: 'Test 1',
       vars: 'vars/*.yaml',
@@ -140,7 +140,7 @@ describe('readTests', () => {
     jest.resetAllMocks();
   });
 
-  test('readTests with string input (CSV file path)', async () => {
+  it('readTests with string input (CSV file path)', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue(
       'var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5',
     );
@@ -165,7 +165,7 @@ describe('readTests', () => {
     ]);
   });
 
-  test('readTests with multiple __expected in CSV', async () => {
+  it('readTests with multiple __expected in CSV', async () => {
     (fs.readFileSync as jest.Mock).mockReturnValue(
       'var1,var2,__expected1,__expected2,__expected3\nvalue1,value2,value1,value1.2,value1.3\nvalue3,value4,fn:value5,fn:value5.2,fn:value5.3',
     );
@@ -198,7 +198,7 @@ describe('readTests', () => {
     ]);
   });
 
-  test('readTests with array input (TestCase[])', async () => {
+  it('readTests with array input (TestCase[])', async () => {
     const input: TestCase[] = [
       {
         description: 'Test 1',
@@ -217,7 +217,7 @@ describe('readTests', () => {
     expect(result).toEqual(input);
   });
 
-  test('readTests with string array input (paths to test configs)', async () => {
+  it('readTests with string array input (paths to test configs)', async () => {
     const testsPaths = ['test1.yaml', 'test2.yaml'];
     const test1Content = [
       {
@@ -244,7 +244,7 @@ describe('readTests', () => {
     expect(result).toEqual([...test1Content, ...test2Content]);
   });
 
-  test('readTests with vars glob input (paths to vars configs)', async () => {
+  it('readTests with vars glob input (paths to vars configs)', async () => {
     const testsPaths = ['test1.yaml'];
     const test1Content = [
       {
@@ -270,7 +270,7 @@ describe('readTests', () => {
 });
 
 describe('testCaseFromCsvRow', () => {
-  test('should convert a CSV row to a TestCase object', () => {
+  it('should convert a CSV row to a TestCase object', () => {
     const csvRow = {
       var1: 'value1',
       var2: 'value2',

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -42,7 +42,7 @@ describe('readStandaloneTestsFile', () => {
     const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
     expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
     expect(result[1].vars).toEqual({ var1: 'value3', var2: 'value4' });
   });
@@ -56,7 +56,7 @@ describe('readStandaloneTestsFile', () => {
     const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
     expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
     expect(result[1].vars).toEqual({ var3: 'value3', var4: 'value4' });
   });
@@ -70,7 +70,7 @@ describe('readStandaloneTestsFile', () => {
     const result = await readStandaloneTestsFile(varsPath);
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
     expect(result[0].vars).toEqual({ var1: 'value1', var2: 'value2' });
     expect(result[1].vars).toEqual({ var3: 'value3', var4: 'value4' });
   });
@@ -107,7 +107,7 @@ describe('readTest', () => {
   it('readTest with invalid input', async () => {
     const input: any = 123;
 
-    await expect(readTest(input)).rejects.toThrow();
+    await expect(readTest(input)).rejects.toThrow('Test case must have either assert, vars, or options property. Instead got {}');
   });
 
   it('readTest with TestCase that contains a vars glob input', async () => {

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -48,9 +48,11 @@ describe('readStandaloneTestsFile', () => {
   });
 
   it('readStandaloneTestsFile with JSON input', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue(
-      '[{"var1": "value1", "var2": "value2"}, {"var3": "value3", "var4": "value4"}]',
-    );
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue(
+        '[{"var1": "value1", "var2": "value2"}, {"var3": "value3", "var4": "value4"}]',
+      );
     const varsPath = 'vars.json';
 
     const result = await readStandaloneTestsFile(varsPath);
@@ -62,9 +64,9 @@ describe('readStandaloneTestsFile', () => {
   });
 
   it('readStandaloneTestsFile with YAML input', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue(
-      '- var1: value1\n  var2: value2\n- var3: value3\n  var4: value4',
-    );
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue('- var1: value1\n  var2: value2\n- var3: value3\n  var4: value4');
     const varsPath = 'vars.yaml';
 
     const result = await readStandaloneTestsFile(varsPath);
@@ -107,7 +109,9 @@ describe('readTest', () => {
   it('readTest with invalid input', async () => {
     const input: any = 123;
 
-    await expect(readTest(input)).rejects.toThrow('Test case must have either assert, vars, or options property. Instead got {}');
+    await expect(readTest(input)).rejects.toThrow(
+      'Test case must have either assert, vars, or options property. Instead got {}',
+    );
   });
 
   it('readTest with TestCase that contains a vars glob input', async () => {
@@ -119,7 +123,8 @@ describe('readTest', () => {
     const varsContent1 = { var1: 'value1' };
     const varsContent2 = { var2: 'value2' };
     jest.mocked(globSync).mockReturnValueOnce(['vars/vars1.yaml', 'vars/vars2.yaml']);
-    jest.mocked(fs.readFileSync)
+    jest
+      .mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(varsContent1))
       .mockReturnValueOnce(yaml.dump(varsContent2));
 
@@ -141,9 +146,9 @@ describe('readTests', () => {
   });
 
   it('readTests with string input (CSV file path)', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue(
-      'var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5',
-    );
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue('var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5');
     const testsPath = 'tests.csv';
 
     const result = await readTests(testsPath);
@@ -166,9 +171,11 @@ describe('readTests', () => {
   });
 
   it('readTests with multiple __expected in CSV', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue(
-      'var1,var2,__expected1,__expected2,__expected3\nvalue1,value2,value1,value1.2,value1.3\nvalue3,value4,fn:value5,fn:value5.2,fn:value5.3',
-    );
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue(
+        'var1,var2,__expected1,__expected2,__expected3\nvalue1,value2,value1,value1.2,value1.3\nvalue3,value4,fn:value5,fn:value5.2,fn:value5.3',
+      );
     const testsPath = 'tests.csv';
 
     const result = await readTests(testsPath);
@@ -233,7 +240,8 @@ describe('readTests', () => {
         assert: [{ type: 'contains-json', value: 'value3' }],
       },
     ];
-    jest.mocked(fs.readFileSync)
+    jest
+      .mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(test1Content))
       .mockReturnValueOnce(yaml.dump(test2Content));
     jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
@@ -257,7 +265,8 @@ describe('readTests', () => {
       var1: 'value1',
       var2: 'value2',
     };
-    jest.mocked(fs.readFileSync)
+    jest
+      .mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(test1Content))
       .mockReturnValueOnce(yaml.dump(vars1Content));
     jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 
 describe('readStandaloneTestsFile', () => {
   it('readStandaloneTestsFile with CSV input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2\nvalue1,value2\nvalue3,value4');
+    jest.mocked(fs.readFileSync).mockReturnValue('var1,var2\nvalue1,value2\nvalue3,value4');
     const varsPath = 'vars.csv';
 
     const result = await readStandaloneTestsFile(varsPath);
@@ -48,7 +48,7 @@ describe('readStandaloneTestsFile', () => {
   });
 
   it('readStandaloneTestsFile with JSON input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       '[{"var1": "value1", "var2": "value2"}, {"var3": "value3", "var4": "value4"}]',
     );
     const varsPath = 'vars.json';
@@ -62,7 +62,7 @@ describe('readStandaloneTestsFile', () => {
   });
 
   it('readStandaloneTestsFile with YAML input', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       '- var1: value1\n  var2: value2\n- var3: value3\n  var4: value4',
     );
     const varsPath = 'vars.yaml';
@@ -84,7 +84,7 @@ describe('readTest', () => {
       vars: { var1: 'value1', var2: 'value2' },
       assert: [{ type: 'equals', value: 'value1' }],
     };
-    (fs.readFileSync as jest.Mock).mockReturnValueOnce(yaml.dump(testContent));
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(yaml.dump(testContent));
 
     const result = await readTest(testPath);
 
@@ -118,8 +118,8 @@ describe('readTest', () => {
     };
     const varsContent1 = { var1: 'value1' };
     const varsContent2 = { var2: 'value2' };
-    (globSync as jest.Mock).mockReturnValueOnce(['vars/vars1.yaml', 'vars/vars2.yaml']);
-    (fs.readFileSync as jest.Mock)
+    jest.mocked(globSync).mockReturnValueOnce(['vars/vars1.yaml', 'vars/vars2.yaml']);
+    jest.mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(varsContent1))
       .mockReturnValueOnce(yaml.dump(varsContent2));
 
@@ -141,7 +141,7 @@ describe('readTests', () => {
   });
 
   it('readTests with string input (CSV file path)', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       'var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5',
     );
     const testsPath = 'tests.csv';
@@ -166,7 +166,7 @@ describe('readTests', () => {
   });
 
   it('readTests with multiple __expected in CSV', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue(
+    jest.mocked(fs.readFileSync).mockReturnValue(
       'var1,var2,__expected1,__expected2,__expected3\nvalue1,value2,value1,value1.2,value1.3\nvalue3,value4,fn:value5,fn:value5.2,fn:value5.3',
     );
     const testsPath = 'tests.csv';
@@ -233,10 +233,10 @@ describe('readTests', () => {
         assert: [{ type: 'contains-json', value: 'value3' }],
       },
     ];
-    (fs.readFileSync as jest.Mock)
+    jest.mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(test1Content))
       .mockReturnValueOnce(yaml.dump(test2Content));
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
 
     const result = await readTests(testsPaths);
 
@@ -257,10 +257,10 @@ describe('readTests', () => {
       var1: 'value1',
       var2: 'value2',
     };
-    (fs.readFileSync as jest.Mock)
+    jest.mocked(fs.readFileSync)
       .mockReturnValueOnce(yaml.dump(test1Content))
       .mockReturnValueOnce(yaml.dump(vars1Content));
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
 
     const result = await readTests(testsPaths);
 

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -12,7 +12,7 @@ jest.mock('../package.json', () => ({
 
 describe('getLatestVersion', () => {
   it('should return the latest version of the package', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ latestVersion: '1.1.0' }),
     });
@@ -22,7 +22,7 @@ describe('getLatestVersion', () => {
   });
 
   it('should throw an error if the response is not ok', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
       ok: false,
     });
 
@@ -38,11 +38,11 @@ describe('checkForUpdates', () => {
   });
 
   afterEach(() => {
-    (console.log as jest.Mock).mockRestore();
+    jest.mocked(console.log).mockRestore();
   });
 
   it('should log an update message if a newer version is available - minor ver', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ latestVersion: '1.1.0' }),
     });
@@ -52,7 +52,7 @@ describe('checkForUpdates', () => {
   });
 
   it('should log an update message if a newer version is available - major ver', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ latestVersion: '1.1.0' }),
     });
@@ -62,7 +62,7 @@ describe('checkForUpdates', () => {
   });
 
   it('should not log an update message if the current version is up to date', async () => {
-    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ latestVersion: packageJson.version }),
     });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -476,7 +476,8 @@ describe('util', () => {
       };
 
       jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
-      jest.mocked(fs.readFileSync)
+      jest
+        .mocked(fs.readFileSync)
         .mockReturnValueOnce(JSON.stringify(config1))
         .mockReturnValueOnce(JSON.stringify(config2))
         .mockReturnValueOnce(JSON.stringify(config1))

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -347,7 +347,7 @@ describe('util', () => {
   describe('readOutput', () => {
     it('reads JSON output', async () => {
       const outputPath = 'output.json';
-      (fs.readFileSync as jest.Mock).mockReturnValue('{}');
+      jest.mocked(fs.readFileSync).mockReturnValue('{}');
       const output = await readOutput(outputPath);
       expect(output).toEqual({});
     });
@@ -377,8 +377,8 @@ describe('util', () => {
 
     it('reads from existing config', () => {
       const config = { hasRun: false };
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockReturnValue(yaml.dump(config));
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
 
       const result = readGlobalConfig();
 
@@ -388,8 +388,8 @@ describe('util', () => {
     });
 
     it('creates new config if none exists', () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(false);
-      (fs.writeFileSync as jest.Mock).mockImplementation();
+      jest.mocked(fs.existsSync).mockReturnValue(false);
+      jest.mocked(fs.writeFileSync).mockImplementation();
 
       const result = readGlobalConfig();
 
@@ -406,8 +406,8 @@ describe('util', () => {
     });
 
     it('returns true if it is the first run', () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(false);
-      (fs.writeFileSync as jest.Mock).mockImplementation();
+      jest.mocked(fs.existsSync).mockReturnValue(false);
+      jest.mocked(fs.writeFileSync).mockImplementation();
 
       const result = maybeRecordFirstRun();
 
@@ -417,8 +417,8 @@ describe('util', () => {
 
     it('returns false if it is not the first run', () => {
       const config = { hasRun: true };
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockReturnValue(yaml.dump(config));
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
 
       const result = maybeRecordFirstRun();
 
@@ -431,7 +431,7 @@ describe('util', () => {
     const mockFilter = jest.fn();
     jest.doMock(path.resolve('filter.js'), () => mockFilter, { virtual: true });
 
-    (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
 
     const filters = await readFilters({ testFilter: 'filter.js' });
 
@@ -475,8 +475,8 @@ describe('util', () => {
         sharing: true,
       };
 
-      (globSync as jest.Mock).mockImplementation((pathOrGlob) => [pathOrGlob]);
-      (fs.readFileSync as jest.Mock)
+      jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob]);
+      jest.mocked(fs.readFileSync)
         .mockReturnValueOnce(JSON.stringify(config1))
         .mockReturnValueOnce(JSON.stringify(config2))
         .mockReturnValueOnce(JSON.stringify(config1))
@@ -484,8 +484,8 @@ describe('util', () => {
         .mockReturnValue('you should not see this');
 
       // Mocks for prompt loading
-      (fs.readdirSync as jest.Mock).mockReturnValue([]);
-      (fs.statSync as jest.Mock).mockImplementation(() => {
+      jest.mocked(fs.readdirSync).mockReturnValue([]);
+      jest.mocked(fs.statSync).mockImplementation(() => {
         throw new Error('File does not exist');
       });
 
@@ -559,7 +559,7 @@ describe('util', () => {
     });
 
     it('throws error for unsupported configuration file format', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      jest.mocked(fs.existsSync).mockReturnValue(true);
 
       await expect(readConfigs(['config1.unsupported'])).rejects.toThrow(
         'Unsupported configuration file format: .unsupported',
@@ -567,8 +567,8 @@ describe('util', () => {
     });
 
     it('makeAbsolute should resolve file:// syntax and plaintext prompts', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      jest.mocked(fs.readFileSync).mockImplementation((path: string) => {
         if (path === 'config1.json') {
           return JSON.stringify({
             description: 'test1',
@@ -595,8 +595,8 @@ describe('util', () => {
     });
 
     it('dedupes prompts when reading configs', async () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      jest.mocked(fs.readFileSync).mockImplementation((path: string) => {
         if (path === 'config1.json') {
           return JSON.stringify({
             description: 'test1',

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -808,7 +808,7 @@ describe('util', () => {
       const context = { vars: { key: 'value' }, prompt: { id: '123' } };
       const transformFunction = 'output.toUpperCase()';
       const transformedOutput = await transformOutput(transformFunction, output, context);
-      expect(transformedOutput).toEqual('ORIGINAL OUTPUT');
+      expect(transformedOutput).toBe('ORIGINAL OUTPUT');
     });
 
     it('transforms output using an imported function from a file', async () => {
@@ -819,7 +819,7 @@ describe('util', () => {
       });
       const transformFunctionPath = 'file://transform.js';
       const transformedOutput = await transformOutput(transformFunctionPath, output, context);
-      expect(transformedOutput).toEqual('HELLO');
+      expect(transformedOutput).toBe('HELLO');
     });
 
     it('throws error if transform function does not return a value', async () => {
@@ -850,7 +850,7 @@ describe('util', () => {
     });
 
     it('works with provider id undefined', () => {
-      expect(providerToIdentifier(undefined)).toStrictEqual(undefined);
+      expect(providerToIdentifier(undefined)).toBeUndefined();
     });
 
     it('works with ApiProvider', () => {
@@ -876,12 +876,12 @@ describe('util', () => {
 
   describe('varsMatch', () => {
     it('true with both undefined', () => {
-      expect(varsMatch(undefined, undefined)).toStrictEqual(true);
+      expect(varsMatch(undefined, undefined)).toBe(true);
     });
 
     it('false with one undefined', () => {
-      expect(varsMatch(undefined, {})).toStrictEqual(false);
-      expect(varsMatch({}, undefined)).toStrictEqual(false);
+      expect(varsMatch(undefined, {})).toBe(false);
+      expect(varsMatch({}, undefined)).toBe(false);
     });
   });
 
@@ -900,7 +900,7 @@ describe('util', () => {
     } as any as EvaluateResult;
 
     it('is true', () => {
-      expect(resultIsForTestCase(result, testCase)).toStrictEqual(true);
+      expect(resultIsForTestCase(result, testCase)).toBe(true);
     });
 
     it('is false if provider is different', () => {
@@ -911,7 +911,7 @@ describe('util', () => {
         },
       };
 
-      expect(resultIsForTestCase(result, nonMatchTestCase)).toStrictEqual(false);
+      expect(resultIsForTestCase(result, nonMatchTestCase)).toBe(false);
     });
 
     it('is false if vars are different', () => {
@@ -922,7 +922,7 @@ describe('util', () => {
         },
       };
 
-      expect(resultIsForTestCase(result, nonMatchTestCase)).toStrictEqual(false);
+      expect(resultIsForTestCase(result, nonMatchTestCase)).toBe(false);
     });
   });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -55,7 +55,7 @@ beforeEach(() => {
 
 describe('util', () => {
   describe('writeOutput', () => {
-    test('writeOutput with CSV output', () => {
+    it('writeOutput with CSV output', () => {
       const outputPath = 'output.csv';
       const results: EvaluateResult[] = [
         {
@@ -127,7 +127,7 @@ describe('util', () => {
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
     });
 
-    test('writeOutput with JSON output', () => {
+    it('writeOutput with JSON output', () => {
       const outputPath = 'output.json';
       const results: EvaluateResult[] = [
         {
@@ -199,7 +199,7 @@ describe('util', () => {
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
     });
 
-    test('writeOutput with YAML output', () => {
+    it('writeOutput with YAML output', () => {
       const outputPath = 'output.yaml';
       const results: EvaluateResult[] = [
         {
@@ -271,7 +271,7 @@ describe('util', () => {
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
     });
 
-    test('writeOutput with json and txt output', () => {
+    it('writeOutput with json and txt output', () => {
       const outputPath = ['output.json', 'output.txt'];
       const results: EvaluateResult[] = [
         {
@@ -375,7 +375,7 @@ describe('util', () => {
       resetGlobalConfig();
     });
 
-    test('reads from existing config', () => {
+    it('reads from existing config', () => {
       const config = { hasRun: false };
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockReturnValue(yaml.dump(config));
@@ -387,7 +387,7 @@ describe('util', () => {
       expect(result).toEqual(config);
     });
 
-    test('creates new config if none exists', () => {
+    it('creates new config if none exists', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);
       (fs.writeFileSync as jest.Mock).mockImplementation();
 
@@ -405,7 +405,7 @@ describe('util', () => {
       jest.clearAllMocks();
     });
 
-    test('returns true if it is the first run', () => {
+    it('returns true if it is the first run', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);
       (fs.writeFileSync as jest.Mock).mockImplementation();
 
@@ -415,7 +415,7 @@ describe('util', () => {
       expect(result).toBe(true);
     });
 
-    test('returns false if it is not the first run', () => {
+    it('returns false if it is not the first run', () => {
       const config = { hasRun: true };
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockReturnValue(yaml.dump(config));
@@ -427,7 +427,7 @@ describe('util', () => {
     });
   });
 
-  test('readFilters', async () => {
+  it('readFilters', async () => {
     const mockFilter = jest.fn();
     jest.doMock(path.resolve('filter.js'), () => mockFilter, { virtual: true });
 
@@ -439,7 +439,7 @@ describe('util', () => {
   });
 
   describe('readConfigs', () => {
-    test('reads from existing configs', async () => {
+    it('reads from existing configs', async () => {
       const config1 = {
         description: 'test1',
         providers: ['provider1'],
@@ -558,7 +558,7 @@ describe('util', () => {
       });
     });
 
-    test('throws error for unsupported configuration file format', async () => {
+    it('throws error for unsupported configuration file format', async () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
 
       await expect(readConfigs(['config1.unsupported'])).rejects.toThrow(
@@ -566,7 +566,7 @@ describe('util', () => {
       );
     });
 
-    test('makeAbsolute should resolve file:// syntax and plaintext prompts', async () => {
+    it('makeAbsolute should resolve file:// syntax and plaintext prompts', async () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
         if (path === 'config1.json') {
@@ -594,7 +594,7 @@ describe('util', () => {
       ]);
     });
 
-    test('dedupes prompts when reading configs', async () => {
+    it('dedupes prompts when reading configs', async () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockImplementation((path: string) => {
         if (path === 'config1.json') {
@@ -624,7 +624,7 @@ describe('util', () => {
   });
 
   describe('dereferenceConfig', () => {
-    test('should dereference a config with no $refs', async () => {
+    it('should dereference a config with no $refs', async () => {
       const rawConfig = {
         prompts: ['Hello world'],
         description: 'Test config',
@@ -637,7 +637,7 @@ describe('util', () => {
       expect(dereferencedConfig).toEqual(rawConfig);
     });
 
-    test('should dereference a config with $refs', async () => {
+    it('should dereference a config with $refs', async () => {
       const rawConfig = {
         prompts: [],
         tests: [],
@@ -668,7 +668,7 @@ describe('util', () => {
       expect(dereferencedConfig).toEqual(expectedConfig);
     });
 
-    test('should preserve regular functions when dereferencing', async () => {
+    it('should preserve regular functions when dereferencing', async () => {
       const rawConfig = {
         description: 'Test config with function parameters',
         prompts: [],
@@ -701,7 +701,7 @@ describe('util', () => {
       expect(dereferencedConfig).toEqual(rawConfig);
     });
 
-    test('should preserve tools with references and definitions when dereferencing', async () => {
+    it('should preserve tools with references and definitions when dereferencing', async () => {
       const rawConfig = {
         prompts: [{ $ref: '#/definitions/prompt' }],
         tests: [],
@@ -803,7 +803,7 @@ describe('util', () => {
       jest.resetModules();
     });
 
-    test('transforms output using a direct function', async () => {
+    it('transforms output using a direct function', async () => {
       const output = 'original output';
       const context = { vars: { key: 'value' }, prompt: { id: '123' } };
       const transformFunction = 'output.toUpperCase()';
@@ -811,7 +811,7 @@ describe('util', () => {
       expect(transformedOutput).toEqual('ORIGINAL OUTPUT');
     });
 
-    test('transforms output using an imported function from a file', async () => {
+    it('transforms output using an imported function from a file', async () => {
       const output = 'hello';
       const context = { vars: { key: 'value' }, prompt: { id: '123' } };
       jest.doMock(path.resolve('transform.js'), () => (output: string) => output.toUpperCase(), {
@@ -822,7 +822,7 @@ describe('util', () => {
       expect(transformedOutput).toEqual('HELLO');
     });
 
-    test('throws error if transform function does not return a value', async () => {
+    it('throws error if transform function does not return a value', async () => {
       const output = 'test';
       const context = { vars: {}, prompt: {} };
       const transformFunction = ''; // Empty function, returns undefined
@@ -831,7 +831,7 @@ describe('util', () => {
       );
     });
 
-    test('throws error if file does not export a function', async () => {
+    it('throws error if file does not export a function', async () => {
       const output = 'test';
       const context = { vars: {}, prompt: {} };
       jest.doMock(path.resolve('transform.js'), () => 'banana', { virtual: true });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,14 @@
+import { ApiProvider, ProviderResponse } from '../src/types';
+
+export class TestGrader implements ApiProvider {
+  async callApi(): Promise<ProviderResponse> {
+    return {
+      output: JSON.stringify({ pass: true, reason: 'Test grading output' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    };
+  }
+
+  id(): string {
+    return 'TestGradingProvider';
+  }
+}


### PR DESCRIPTION
## Summary 
This PR introduces [`eslint-plugin-jest`](https://www.npmjs.com/package/eslint-plugin-jest?activeTab=readme) to our ESLint configuration and applies several Jest-specific rules to enhance our testing code quality. The changes are applied across multiple files in the codebase. For more information on specific rules, refer to the plugin documentation. Notable changes include:

- Using `jest.mocked(...)` instead of `as Jest.Mock`
- Preferring `it(` over `test(` for consistency across the codebase
- Disallowing conditional expectations
- Preferring `expect(result).toMatchObject({` in `assertions.test.ts` over expectations on individual fields. This is a pattern we should adopt incrementally and eventually universally