### PR TITLE
feat(cli): add tests for CLI commands and fix version flag bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -223,7 +223,8 @@ async function main() {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(getDirectory(), '../package.json'), 'utf8'),
     );
-    logger.info(packageJson.version);
+    console.info(packageJson.version);
+    process.exit(0);
   });
 
   program

--- a/src/main.ts
+++ b/src/main.ts
@@ -223,7 +223,7 @@ async function main() {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(getDirectory(), '../package.json'), 'utf8'),
     );
-    console.info(packageJson.version);
+    logger.info(packageJson.version);
     process.exit(0);
   });
 

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI Tool --help and --version should display help menu 1`] = `
+"
+> promptfoo@0.65.0 local
+> ts-node --cwdMode --transpileOnly src/main.ts --help
+
+Usage: main [options] [command]
+
+Options:
+  --version                   Print version
+  -h, --help                  display help for command
+
+Commands:
+  init [options] [directory]  Initialize project with dummy files
+  view [options] [directory]  Start browser ui
+  share [options]             Create a shareable URL of your most recent eval
+  cache                       Manage cache
+  feedback [message]          Send feedback to the promptfoo developers
+  generate                    Generate synthetic data
+  eval [options]              Evaluate prompts
+  list                        List various resources
+  show [options] <id>         Show details of a specific resource
+  delete [options] <id>       Delete various resources
+  import <file>               Import an eval record from a JSON file
+  export [options] <evalId>   Export an eval record to a JSON file
+  help [command]              display help for command
+"
+`;

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`CLI Tool --help and --version should display help menu 1`] = `
 "
-> promptfoo@0.65.0 local
-> ts-node --cwdMode --transpileOnly src/main.ts --help
 
 Usage: main [options] [command]
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,26 +1,31 @@
 import { spawn } from 'child_process';
+import { version } from '../package.json';
 
 const runCliCommand = (args: string[]) => {
   return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-    const child = spawn('npm', ['run', 'local', '--', ...args], { shell: true });
-    let stdout = '';
-    let stderr = '';
+    try {
+      const child = spawn('npm', ['run', 'local', '--', ...args], { shell: true });
+      let stdout = '';
+      let stderr = '';
 
-    child.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
 
-    child.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
 
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve({ stdout, stderr });
-      } else {
-        reject(new Error(`Command failed with exit code ${code}\n${stderr}`));
-      }
-    });
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          reject(new Error(`Command failed with exit code ${code}\n${stderr}`));
+        }
+      });
+    } catch (error) {
+      reject(error);
+    }
   });
 };
 
@@ -29,11 +34,13 @@ describe('CLI Tool', () => {
     it('should display help menu', async () => {
       const { stdout } = await runCliCommand(['--help']);
       expect(stdout).toContain('Usage: main [options] [command]');
+      expect(stdout).toMatchSnapshot();
     });
 
     it('should display version', async () => {
       const { stdout } = await runCliCommand(['--version']);
-      expect(stdout).toMatch(/\d+\.\d+\.\d+/); // Expect version number format
+      expect(stdout).toMatch(/\d+\.\d+\.\d+/);
+      expect(stdout).toContain(version);
     });
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,209 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const cliPath = 'npm run local --';
+
+const runCliCommand = (args: string[]) => {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn('npm', ['run', 'local', '--', ...args], { shell: true });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`Command failed with exit code ${code}\n${stderr}`));
+      }
+    });
+  });
+};
+
+describe('CLI Tool', () => {
+  describe.only('--help and --version', () => {
+    it('should display help menu', async () => {
+      const { stdout } = await runCliCommand(['--help']);
+      expect(stdout).toContain('Usage: main [options] [command]');
+    });
+
+    it('should display version', async () => {
+      const { stdout } = await runCliCommand(['--version']);
+      expect(stdout).toMatch(/\d+\.\d+\.\d+/); // Expect version number format
+    });
+  });
+
+  describe('init command', () => {
+    it('should initialize project with dummy files in current directory', async () => {
+      const { stdout } = await runCliCommand(['init']);
+      expect(stdout).toContain('Project initialized with dummy files');
+    });
+
+    it('should initialize project with dummy files in specified directory', async () => {
+      const tempDir = path.join(__dirname, 'temp');
+      fs.mkdirSync(tempDir, { recursive: true });
+      const { stdout } = await runCliCommand(['init', tempDir]);
+      expect(stdout).toContain(`Project initialized with dummy files in ${tempDir}`);
+      fs.rmdirSync(tempDir, { recursive: true });
+    });
+
+    it('should run in non-interactive mode', async () => {
+      const { stdout } = await runCliCommand(['init', '--no-interactive']);
+      expect(stdout).toContain('Project initialized with dummy files');
+    });
+  });
+
+  describe('view command', () => {
+    it('should start browser UI on default port', async () => {
+      const { stdout } = await runCliCommand(['view']);
+      expect(stdout).toContain('Starting server on port 15500');
+    });
+
+    it('should start browser UI on specified port', async () => {
+      const { stdout } = await runCliCommand(['view', '--port', '16000']);
+      expect(stdout).toContain('Starting server on port 16000');
+    });
+
+    it('should start browser UI with specified options', async () => {
+      const { stdout } = await runCliCommand(['view', '--yes']);
+      expect(stdout).toContain('Auto-opening the URL');
+    });
+  });
+
+  describe('share command', () => {
+    it('should create a shareable URL', async () => {
+      const { stdout } = await runCliCommand(['share']);
+      expect(stdout).toContain('View results:');
+    });
+
+    it('should create a shareable URL with confirmation', async () => {
+      const { stdout } = await runCliCommand(['share', '--yes']);
+      expect(stdout).toContain('View results:');
+    });
+  });
+
+  describe('cache command', () => {
+    it('should clear cache', async () => {
+      const { stdout } = await runCliCommand(['cache', 'clear']);
+      expect(stdout).toContain('Clearing cache...');
+    });
+  });
+
+  describe('feedback command', () => {
+    it('should send feedback', async () => {
+      const { stdout } = await runCliCommand(['feedback', 'Great tool!']);
+      expect(stdout).toContain('Thank you for your feedback!');
+    });
+
+    it('should prompt for feedback if no message provided', async () => {
+      const { stdout } = await runCliCommand(['feedback']);
+      expect(stdout).toContain('Please provide your feedback:');
+    });
+  });
+
+  describe('generate command', () => {
+    describe('dataset subcommand', () => {
+      it('should generate synthetic data', async () => {
+        const { stdout } = await runCliCommand(['generate', 'dataset']);
+        expect(stdout).toContain('New test Cases');
+      });
+
+      it('should generate synthetic data with specific options', async () => {
+        const { stdout } = await runCliCommand(['generate', 'dataset', '--numPersonas', '3']);
+        expect(stdout).toContain('New test Cases');
+      });
+    });
+
+    describe('redteam subcommand', () => {
+      it('should generate adversarial test cases', async () => {
+        const { stdout } = await runCliCommand(['generate', 'redteam']);
+        expect(stdout).toContain('Wrote new test cases');
+      });
+
+      it('should generate adversarial test cases with specific options', async () => {
+        const { stdout } = await runCliCommand([
+          'generate',
+          'redteam',
+          '--purpose',
+          'test-purpose',
+        ]);
+        expect(stdout).toContain('Wrote new test cases');
+      });
+    });
+  });
+
+  describe('eval command', () => {
+    it('should evaluate prompts', async () => {
+      const { stdout } = await runCliCommand(['eval']);
+      expect(stdout).toContain('Evaluation complete');
+    });
+
+    it('should evaluate prompts with specific configuration', async () => {
+      const { stdout } = await runCliCommand(['eval', '--config', 'path/to/config']);
+      expect(stdout).toContain('Evaluation complete');
+    });
+  });
+
+  describe('list command', () => {
+    it('should list resources', async () => {
+      const { stdout } = await runCliCommand(['list']);
+      expect(stdout).toContain('List of resources');
+    });
+  });
+
+  describe('show command', () => {
+    it('should show details of a specific resource', async () => {
+      const { stdout } = await runCliCommand(['show', '1']);
+      expect(stdout).toContain('Resource details for ID 1');
+    });
+
+    it('should show details of a specific resource with options', async () => {
+      const { stdout } = await runCliCommand(['show', '1', '--verbose']);
+      expect(stdout).toContain('Resource details for ID 1');
+    });
+  });
+
+  describe('delete command', () => {
+    it('should delete specified resource', async () => {
+      const { stdout } = await runCliCommand(['delete', '1']);
+      expect(stdout).toContain('Deleted resource with ID 1');
+    });
+
+    it('should delete specified resource with options', async () => {
+      const { stdout } = await runCliCommand(['delete', '1', '--force']);
+      expect(stdout).toContain('Deleted resource with ID 1');
+    });
+  });
+
+  describe('import command', () => {
+    it('should import eval record from JSON file', async () => {
+      const { stdout } = await runCliCommand(['import', 'record.json']);
+      expect(stdout).toContain('Imported eval record from record.json');
+    });
+
+    it('should import eval record from JSON file with options', async () => {
+      const { stdout } = await runCliCommand(['import', 'record.json', '--verbose']);
+      expect(stdout).toContain('Imported eval record from record.json');
+    });
+  });
+
+  describe('export command', () => {
+    it('should export eval record to JSON file', async () => {
+      const { stdout } = await runCliCommand(['export', '1']);
+      expect(stdout).toContain('Exported eval record for ID 1');
+    });
+
+    it('should export eval record to JSON file with options', async () => {
+      const { stdout } = await runCliCommand(['export', '1', '--verbose']);
+      expect(stdout).toContain('Exported eval record for ID 1');
+    });
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -33,8 +33,9 @@ describe('CLI Tool', () => {
   describe('--help and --version', () => {
     it('should display help menu', async () => {
       const { stdout } = await runCliCommand(['--help']);
+      const subset = stdout.split('ts-node --cwdMode --transpileOnly src/main.ts --help')[1];
+      expect(subset).toMatchSnapshot();
       expect(stdout).toContain('Usage: main [options] [command]');
-      expect(stdout).toMatchSnapshot();
     });
 
     it('should display version', async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,8 +1,4 @@
 import { spawn } from 'child_process';
-import * as path from 'path';
-import * as fs from 'fs';
-
-const cliPath = 'npm run local --';
 
 const runCliCommand = (args: string[]) => {
   return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
@@ -29,7 +25,7 @@ const runCliCommand = (args: string[]) => {
 };
 
 describe('CLI Tool', () => {
-  describe.only('--help and --version', () => {
+  describe('--help and --version', () => {
     it('should display help menu', async () => {
       const { stdout } = await runCliCommand(['--help']);
       expect(stdout).toContain('Usage: main [options] [command]');
@@ -38,172 +34,6 @@ describe('CLI Tool', () => {
     it('should display version', async () => {
       const { stdout } = await runCliCommand(['--version']);
       expect(stdout).toMatch(/\d+\.\d+\.\d+/); // Expect version number format
-    });
-  });
-
-  describe('init command', () => {
-    it('should initialize project with dummy files in current directory', async () => {
-      const { stdout } = await runCliCommand(['init']);
-      expect(stdout).toContain('Project initialized with dummy files');
-    });
-
-    it('should initialize project with dummy files in specified directory', async () => {
-      const tempDir = path.join(__dirname, 'temp');
-      fs.mkdirSync(tempDir, { recursive: true });
-      const { stdout } = await runCliCommand(['init', tempDir]);
-      expect(stdout).toContain(`Project initialized with dummy files in ${tempDir}`);
-      fs.rmdirSync(tempDir, { recursive: true });
-    });
-
-    it('should run in non-interactive mode', async () => {
-      const { stdout } = await runCliCommand(['init', '--no-interactive']);
-      expect(stdout).toContain('Project initialized with dummy files');
-    });
-  });
-
-  describe('view command', () => {
-    it('should start browser UI on default port', async () => {
-      const { stdout } = await runCliCommand(['view']);
-      expect(stdout).toContain('Starting server on port 15500');
-    });
-
-    it('should start browser UI on specified port', async () => {
-      const { stdout } = await runCliCommand(['view', '--port', '16000']);
-      expect(stdout).toContain('Starting server on port 16000');
-    });
-
-    it('should start browser UI with specified options', async () => {
-      const { stdout } = await runCliCommand(['view', '--yes']);
-      expect(stdout).toContain('Auto-opening the URL');
-    });
-  });
-
-  describe('share command', () => {
-    it('should create a shareable URL', async () => {
-      const { stdout } = await runCliCommand(['share']);
-      expect(stdout).toContain('View results:');
-    });
-
-    it('should create a shareable URL with confirmation', async () => {
-      const { stdout } = await runCliCommand(['share', '--yes']);
-      expect(stdout).toContain('View results:');
-    });
-  });
-
-  describe('cache command', () => {
-    it('should clear cache', async () => {
-      const { stdout } = await runCliCommand(['cache', 'clear']);
-      expect(stdout).toContain('Clearing cache...');
-    });
-  });
-
-  describe('feedback command', () => {
-    it('should send feedback', async () => {
-      const { stdout } = await runCliCommand(['feedback', 'Great tool!']);
-      expect(stdout).toContain('Thank you for your feedback!');
-    });
-
-    it('should prompt for feedback if no message provided', async () => {
-      const { stdout } = await runCliCommand(['feedback']);
-      expect(stdout).toContain('Please provide your feedback:');
-    });
-  });
-
-  describe('generate command', () => {
-    describe('dataset subcommand', () => {
-      it('should generate synthetic data', async () => {
-        const { stdout } = await runCliCommand(['generate', 'dataset']);
-        expect(stdout).toContain('New test Cases');
-      });
-
-      it('should generate synthetic data with specific options', async () => {
-        const { stdout } = await runCliCommand(['generate', 'dataset', '--numPersonas', '3']);
-        expect(stdout).toContain('New test Cases');
-      });
-    });
-
-    describe('redteam subcommand', () => {
-      it('should generate adversarial test cases', async () => {
-        const { stdout } = await runCliCommand(['generate', 'redteam']);
-        expect(stdout).toContain('Wrote new test cases');
-      });
-
-      it('should generate adversarial test cases with specific options', async () => {
-        const { stdout } = await runCliCommand([
-          'generate',
-          'redteam',
-          '--purpose',
-          'test-purpose',
-        ]);
-        expect(stdout).toContain('Wrote new test cases');
-      });
-    });
-  });
-
-  describe('eval command', () => {
-    it('should evaluate prompts', async () => {
-      const { stdout } = await runCliCommand(['eval']);
-      expect(stdout).toContain('Evaluation complete');
-    });
-
-    it('should evaluate prompts with specific configuration', async () => {
-      const { stdout } = await runCliCommand(['eval', '--config', 'path/to/config']);
-      expect(stdout).toContain('Evaluation complete');
-    });
-  });
-
-  describe('list command', () => {
-    it('should list resources', async () => {
-      const { stdout } = await runCliCommand(['list']);
-      expect(stdout).toContain('List of resources');
-    });
-  });
-
-  describe('show command', () => {
-    it('should show details of a specific resource', async () => {
-      const { stdout } = await runCliCommand(['show', '1']);
-      expect(stdout).toContain('Resource details for ID 1');
-    });
-
-    it('should show details of a specific resource with options', async () => {
-      const { stdout } = await runCliCommand(['show', '1', '--verbose']);
-      expect(stdout).toContain('Resource details for ID 1');
-    });
-  });
-
-  describe('delete command', () => {
-    it('should delete specified resource', async () => {
-      const { stdout } = await runCliCommand(['delete', '1']);
-      expect(stdout).toContain('Deleted resource with ID 1');
-    });
-
-    it('should delete specified resource with options', async () => {
-      const { stdout } = await runCliCommand(['delete', '1', '--force']);
-      expect(stdout).toContain('Deleted resource with ID 1');
-    });
-  });
-
-  describe('import command', () => {
-    it('should import eval record from JSON file', async () => {
-      const { stdout } = await runCliCommand(['import', 'record.json']);
-      expect(stdout).toContain('Imported eval record from record.json');
-    });
-
-    it('should import eval record from JSON file with options', async () => {
-      const { stdout } = await runCliCommand(['import', 'record.json', '--verbose']);
-      expect(stdout).toContain('Imported eval record from record.json');
-    });
-  });
-
-  describe('export command', () => {
-    it('should export eval record to JSON file', async () => {
-      const { stdout } = await runCliCommand(['export', '1']);
-      expect(stdout).toContain('Exported eval record for ID 1');
-    });
-
-    it('should export eval record to JSON file with options', async () => {
-      const { stdout } = await runCliCommand(['export', '1', '--verbose']);
-      expect(stdout).toContain('Exported eval record for ID 1');
     });
   });
 });


### PR DESCRIPTION
**Summary:**

This introduces the concept of a black-box testing on the CLI, starting with the most basic commands, `--help` and `--version`. It also fixes a bug related to the `--version` flag where we would output the entire help menu instead of just the version. Additionally, it introduces a snapshot test on the help menu output which will need to be updated when the help menu is updated. 

Over time we can add exhaustive tests on every cli command when we figure out appropriate mocking. 