### PR TITLE
feat(redteam): make it easier to add non default plugins

### DIFF
--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -45,7 +45,7 @@ const ALL_PLUGINS = new Set(
   ].concat(Object.keys(HARM_CATEGORIES)),
 );
 
-const DEFAULT_PLUGINS = new Set(
+export const DEFAULT_PLUGINS = new Set(
   [
     'contracts',
     'excessive-agency',


### PR DESCRIPTION
If you want to add `competitors`, you can use `--add-plugins competitors` instead of reproducing the entire default list.