### PR TITLE
feat: `config get/set` commands, ability for users to set their email

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,10 @@
+import { readGlobalConfig, writeGlobalConfig } from './globalConfig';
+
+export function getUserEmail(): string | undefined {
+  const globalConfig = readGlobalConfig();
+  return globalConfig.account?.email;
+}
+
+export function setUserEmail(email: string) {
+  writeGlobalConfig({ account: { email } });
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,33 @@
+import { Command } from 'commander';
+import { getUserEmail, setUserEmail } from '../accounts';
+import logger from '../logger';
+
+export function configCommand(program: Command) {
+  const configCommand = program.command('config').description('Edit configuration settings');
+  const getCommand = configCommand.command('get').description('Get configuration settings.');
+  const setCommand = configCommand.command('set').description('Set configuration settings.');
+
+  getCommand
+    .command('email')
+    .description('Get user email')
+    .action(() => {
+      const email = getUserEmail();
+      if (email) {
+        logger.info(email);
+      } else {
+        logger.info('No email set.');
+      }
+    });
+
+  setCommand
+    .command('email <email>')
+    .description('Set user email')
+    .action((email: string) => {
+      setUserEmail(email);
+      if (email) {
+        logger.info(`Email set to ${email}`);
+      } else {
+        logger.info('Email unset.');
+      }
+    });
+}

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,0 +1,85 @@
+/**
+ * Functions for manipulating the global configuration file, which lives at
+ * ~/.promptfoo/promptfoo.yaml by default.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import yaml from 'js-yaml';
+
+import { getConfigDirectoryPath } from './util';
+
+interface GlobalConfig {
+  hasRun?: boolean;
+  account?: {
+    email?: string;
+  };
+}
+
+let globalConfigCache: GlobalConfig | null = null;
+
+export function resetGlobalConfig(): void {
+  globalConfigCache = null;
+}
+
+export function readGlobalConfig(): GlobalConfig {
+  if (!globalConfigCache) {
+    const configDir = getConfigDirectoryPath();
+    const configFilePath = path.join(configDir, 'promptfoo.yaml');
+
+    if (fs.existsSync(configFilePath)) {
+      globalConfigCache = yaml.load(fs.readFileSync(configFilePath, 'utf-8')) as GlobalConfig;
+    } else {
+      if (!fs.existsSync(configDir)) {
+        fs.mkdirSync(configDir, { recursive: true });
+      }
+      globalConfigCache = { hasRun: false };
+      fs.writeFileSync(configFilePath, yaml.dump(globalConfigCache));
+    }
+  }
+
+  return globalConfigCache;
+}
+
+export function writeGlobalConfig(config: GlobalConfig): void {
+  fs.writeFileSync(
+    path.join(getConfigDirectoryPath(true /* createIfNotExists */), 'promptfoo.yaml'),
+    yaml.dump(config),
+  );
+}
+
+/**
+ * Merges the top-level keys into existing config.
+ * @param partialConfig New keys to merge into the existing config.
+ */
+export function writeGlobalConfigPartial(partialConfig: Partial<GlobalConfig>): void {
+  const currentConfig = readGlobalConfig();
+  const updatedConfig = { ...currentConfig };
+
+  for (const key in partialConfig) {
+    const value = partialConfig[key as keyof GlobalConfig];
+    if (value) {
+      updatedConfig[key as keyof GlobalConfig] = value as any;
+    } else {
+      delete updatedConfig[key as keyof GlobalConfig];
+    }
+  }
+
+  writeGlobalConfig(updatedConfig);
+}
+
+export function maybeRecordFirstRun(): boolean {
+  // Return true if first run
+  try {
+    const config = readGlobalConfig();
+    if (!config.hasRun) {
+      config.hasRun = true;
+      writeGlobalConfig(config);
+      return true;
+    }
+    return false;
+  } catch (err) {
+    return false;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ import { showCommand } from './commands/show';
 import { deleteCommand } from './commands/delete';
 import { importCommand } from './commands/import';
 import { exportCommand } from './commands/export';
+import { configCommand } from './commands/config';
 
 import type {
   CommandLineOptions,
@@ -925,6 +926,7 @@ async function main() {
   deleteCommand(program);
   importCommand(program);
   exportCommand(program);
+  configCommand(program);
 
   program.parse(process.argv);
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import packageJson from '../package.json';
 import logger from './logger';
 import { fetchWithTimeout } from './fetch';
-import { maybeRecordFirstRun } from './util';
+import { maybeRecordFirstRun } from './globalConfig';
 
 type EventValue = string | number | boolean | string[];
 type TelemetryEvent = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,49 +54,6 @@ import { writeCsvToGoogleSheet } from './googleSheets';
 
 const DEFAULT_QUERY_LIMIT = 100;
 
-let globalConfigCache: any = null;
-
-export function resetGlobalConfig(): void {
-  globalConfigCache = null;
-}
-
-export function readGlobalConfig(): any {
-  if (!globalConfigCache) {
-    const configDir = getConfigDirectoryPath();
-    const configFilePath = path.join(configDir, 'promptfoo.yaml');
-
-    if (fs.existsSync(configFilePath)) {
-      globalConfigCache = yaml.load(fs.readFileSync(configFilePath, 'utf-8'));
-    } else {
-      if (!fs.existsSync(configDir)) {
-        fs.mkdirSync(configDir, { recursive: true });
-      }
-      globalConfigCache = { hasRun: false };
-      fs.writeFileSync(configFilePath, yaml.dump(globalConfigCache));
-    }
-  }
-
-  return globalConfigCache;
-}
-
-export function maybeRecordFirstRun(): boolean {
-  // Return true if first run
-  try {
-    const config = readGlobalConfig();
-    if (!config.hasRun) {
-      config.hasRun = true;
-      fs.writeFileSync(
-        path.join(getConfigDirectoryPath(true /* createIfNotExists */), 'promptfoo.yaml'),
-        yaml.dump(config),
-      );
-      return true;
-    }
-    return false;
-  } catch (err) {
-    return false;
-  }
-}
-
 export async function maybeReadConfig(configPath: string): Promise<UnifiedConfig | undefined> {
   if (!fs.existsSync(configPath)) {
     return undefined;

--- a/test/globalConfig.test.ts
+++ b/test/globalConfig.test.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs';
+
+import yaml from 'js-yaml';
+
+import { readGlobalConfig, resetGlobalConfig, maybeRecordFirstRun } from '../src/globalConfig';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  statSync: jest.fn(),
+  readdirSync: jest.fn(),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+jest.mock('proxy-agent', () => ({
+  ProxyAgent: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('glob', () => ({
+  globSync: jest.fn(),
+}));
+
+jest.mock('../src/database');
+
+describe('readCliConfig', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    resetGlobalConfig();
+  });
+
+  it('reads from existing config', () => {
+    const config = { hasRun: false };
+    jest.mocked(fs.existsSync).mockReturnValue(true);
+    jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
+
+    const result = readGlobalConfig();
+
+    expect(fs.existsSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(config);
+  });
+
+  it('creates new config if none exists', () => {
+    jest.mocked(fs.existsSync).mockReturnValue(false);
+    jest.mocked(fs.writeFileSync).mockImplementation();
+
+    const result = readGlobalConfig();
+
+    expect(fs.existsSync).toHaveBeenCalledTimes(2);
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ hasRun: false });
+  });
+});
+
+describe('maybeRecordFirstRun', () => {
+  afterEach(() => {
+    resetGlobalConfig();
+    jest.clearAllMocks();
+  });
+
+  it('returns true if it is the first run', () => {
+    jest.mocked(fs.existsSync).mockReturnValue(false);
+    jest.mocked(fs.writeFileSync).mockImplementation();
+
+    const result = maybeRecordFirstRun();
+
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
+  });
+
+  it('returns false if it is not the first run', () => {
+    const config = { hasRun: true };
+    jest.mocked(fs.existsSync).mockReturnValue(true);
+    jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
+
+    const result = maybeRecordFirstRun();
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -5,7 +5,7 @@ import { fetchWithTimeout } from '../src/fetch';
 jest.mock('../src/fetch', () => ({
   fetchWithTimeout: jest.fn(),
 }));
-jest.mock('../src/util', () => ({
+jest.mock('../src/globalConfig', () => ({
   maybeRecordFirstRun: jest.fn(),
 }));
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -3,17 +3,12 @@ import * as path from 'path';
 
 import { globSync } from 'glob';
 
-import yaml from 'js-yaml';
-
 import {
   dereferenceConfig,
-  maybeRecordFirstRun,
   providerToIdentifier,
   readConfigs,
   readFilters,
-  readGlobalConfig,
   readOutput,
-  resetGlobalConfig,
   resultIsForTestCase,
   transformOutput,
   varsMatch,
@@ -366,64 +361,6 @@ describe('util', () => {
       await expect(readOutput('output.yml')).rejects.toThrow(
         'Unsupported output file format: yml currently only supports json',
       );
-    });
-  });
-
-  describe('readCliConfig', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-      resetGlobalConfig();
-    });
-
-    it('reads from existing config', () => {
-      const config = { hasRun: false };
-      jest.mocked(fs.existsSync).mockReturnValue(true);
-      jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
-
-      const result = readGlobalConfig();
-
-      expect(fs.existsSync).toHaveBeenCalledTimes(1);
-      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(config);
-    });
-
-    it('creates new config if none exists', () => {
-      jest.mocked(fs.existsSync).mockReturnValue(false);
-      jest.mocked(fs.writeFileSync).mockImplementation();
-
-      const result = readGlobalConfig();
-
-      expect(fs.existsSync).toHaveBeenCalledTimes(2);
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ hasRun: false });
-    });
-  });
-
-  describe('maybeRecordFirstRun', () => {
-    afterEach(() => {
-      resetGlobalConfig();
-      jest.clearAllMocks();
-    });
-
-    it('returns true if it is the first run', () => {
-      jest.mocked(fs.existsSync).mockReturnValue(false);
-      jest.mocked(fs.writeFileSync).mockImplementation();
-
-      const result = maybeRecordFirstRun();
-
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
-      expect(result).toBe(true);
-    });
-
-    it('returns false if it is not the first run', () => {
-      const config = { hasRun: true };
-      jest.mocked(fs.existsSync).mockReturnValue(true);
-      jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(config));
-
-      const result = maybeRecordFirstRun();
-
-      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
-      expect(result).toBe(false);
     });
   });
 


### PR DESCRIPTION
Part 1 of a couple PRs.  Give people a way to set their email.  Currently isn't used for anything, but next PR will add it to the UI so self-hosted teams can see who ran the eval.