### PR TITLE
Export AnthropicMessagesProvider from providers

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -400,6 +400,7 @@ export default {
   OpenAiChatCompletionProvider,
   OpenAiAssistantProvider,
   AnthropicCompletionProvider,
+  AnthropicMessagesProvider,
   ReplicateProvider,
   LocalAiCompletionProvider,
   LocalAiChatProvider,


### PR DESCRIPTION
Allows the `AnthropicMessagesProvider` to be accessed from `promptfoo.providers.AnthropicMessagesProvider`, consistent with OpenAI providers.