### PR TITLE
Pass tool_choice to anthropic when set in config

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -72,6 +72,7 @@ The Anthropic provider supports several options to customize the behavior of the
 - `top_p`: Controls nucleus sampling, affecting the randomness of the output.
 - `top_k`: Only sample from the top K options for each subsequent token.
 - `tools`: An array of tool or function definitions for the model to call.
+- `tool_choice`: An object specifying the tool to call.
 
 Example configuration with options and prompts:
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -16,6 +16,10 @@ interface AnthropicMessageOptions {
   model?: string;
   cost?: number;
   tools?: Anthropic.Tool[];
+  tool_choice?:
+    | Anthropic.MessageCreateParams.ToolChoiceAny
+    | Anthropic.MessageCreateParams.ToolChoiceAuto
+    | Anthropic.MessageCreateParams.ToolChoiceTool;
 }
 
 function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
@@ -200,6 +204,7 @@ export class AnthropicMessagesProvider implements ApiProvider {
       stream: false,
       temperature: this.config.temperature || 0,
       ...(this.config.tools ? { tools: this.config.tools } : {}),
+      ...(this.config.tool_choice ? { tool_choice: this.config.tool_choice } : {}),
     };
 
     logger.debug(`Calling Anthropic Messages API: ${JSON.stringify(params)}`);


### PR DESCRIPTION
Builds on @mldangelo's work in https://github.com/promptfoo/promptfoo/pull/932. Without this tool use in anthropic is a bit painful (the response is a message with some JSON at the end, rather than just JSON).