### PR TITLE
Fixed according to Ollama API specifications

### DIFF
--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -333,7 +333,7 @@ export class OllamaEmbeddingProvider extends OllamaCompletionProvider {
     logger.debug(`\tOllama embeddings API response: ${JSON.stringify(response.data)}`);
 
     try {
-      const embedding = response.data.embeddings as number[];
+      const embedding = response.data.embedding as number[];
       if (!embedding) {
         throw new Error('No embedding found in Ollama embeddings API response');
       }


### PR DESCRIPTION
Description
According to the documentation provided [here](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings), the response returns "embedding" instead of "embeddings".


{
  "embedding": [
    0.5670403838157654, 0.009260174818336964, 0.23178744316101074, -0.2916173040866852, -0.8924556970596313,
    0.8785552978515625, -0.34576427936553955, 0.5742510557174683, -0.04222835972905159, -0.137906014919281
  ]
}

Therefore, I have modified the part of the code that references the response from the Ollama provider to use "embedding" instead of "embeddings".


before
![image](https://github.com/promptfoo/promptfoo/assets/48498919/438a4e4a-85df-49bb-a89f-49d77ee7149e)

after
![image](https://github.com/promptfoo/promptfoo/assets/48498919/a7951c2e-fd15-4c8b-a9ea-69eca85fccce)
