### PR TITLE
chore: Don't commit `.env` to Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 scratch
 *.sw[op]
 *.log


### PR DESCRIPTION
## Summary

This PR adds `.env` to gitignore.

## Motivation

`.env` is a common paradigm for setting environment variables in local development and support was added in #602.  In practice, it typically contains secrets which should not be tracked in version control, such as the developer's individual `OPENAI_API_KEY`.