### PR TITLE
fix: ensure tests inside scenarios are filtered by filter patterns

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ import { generateTable } from './table';
 import { createShareableUrl } from './share';
 import { filterTests } from './commands/eval/filterTests';
 import { validateAssertions } from './assertions/validateAssertions';
+import invariant from 'tiny-invariant';
 
 async function resolveConfigs(
   cmdObj: Partial<CommandLineOptions>,
@@ -153,6 +154,20 @@ async function resolveConfigs(
         cmdObj.tests ? undefined : basePath,
       );
       scenario.tests = parsedScenarioTests;
+      const filteredTests = await filterTests(
+        {
+          ...scenario,
+          providers: parsedProviders,
+          prompts: parsedPrompts,
+        },
+        {
+          firstN: cmdObj.filterFirstN,
+          pattern: cmdObj.filterPattern,
+          failing: cmdObj.filterFailing,
+        },
+      );
+      invariant(filteredTests, 'filteredTests are undefined');
+      scenario.tests = filteredTests;
     }
   }
 


### PR DESCRIPTION
#### Summary

This PR addresses an issue reported by @aantn where tests within scenarios were not being filtered as expected when using the `--filter-pattern` option. The `filterTests` function is now invoked to correctly apply the filter criteria, ensuring only the relevant tests are executed. There is currently no test coverage for this or most of the main file, and I will start working on addressing this.

#### Test Instructions

1. Check out this branch.
2. Run the following command to execute all tests:
   ```sh
   npm run local -- eval -c examples/multiple-translations-scenarios/promptfooconfig.yaml --no-cache
   ```
   - 36 tests should be executed.
3. Add a filter pattern, such as `--filter-pattern 'Translated Good Morning'` (or any other regex):
   ```sh
   npm run local -- eval -c examples/multiple-translations-scenarios/promptfooconfig.yaml --no-cache --filter-pattern 'Translated Good Morning'
   ```
   - Note that only 12 tests are executed, all corresponding to the 'Translated Good Morning' test scenario.
4. Repeat with other filters.

#### Issue Reference

Fixes #987

#### Acknowledgements

Special thank you to @aantn for reporting this issue and providing detailed instructions and context to reproduce it!