### PR TITLE
feat: add support for gemini default grader if credentials are present

### DIFF
--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -31,6 +31,7 @@ You can use it by specifying any of the available stable or latest [model versio
 - `vertex:gemini-1.5-pro-latest`
 - `vertex:gemini-1.5-pro-preview-0409`
 - `vertex:gemini-1.5-pro-preview-0514`
+- `vertex:gemini-1.5-pro`
 - `vertex:gemini-1.5-pro-001`
 - `vertex:gemini-1.0-pro-vision-001`
 - `vertex:gemini-1.5-flash-preview-0514`

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -182,7 +182,7 @@ export async function matchesSimilarity(
   const finalProvider = (await getAndCheckProvider(
     'embedding',
     grading?.provider,
-    getDefaultProviders().embeddingProvider,
+    (await getDefaultProviders()).embeddingProvider,
     'similarity check',
   )) as ApiEmbeddingProvider | ApiSimilarityProvider;
 
@@ -329,7 +329,7 @@ export async function matchesLlmRubric(
   const finalProvider = await getAndCheckProvider(
     'text',
     grading.provider,
-    getDefaultProviders().gradingJsonProvider,
+    (await getDefaultProviders()).gradingJsonProvider,
     'llm-rubric check',
   );
   const resp = await finalProvider.callApi(prompt);
@@ -384,7 +384,7 @@ export async function matchesFactuality(
   const finalProvider = await getAndCheckProvider(
     'text',
     grading.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'factuality check',
   );
   const resp = await finalProvider.callApi(prompt);
@@ -479,7 +479,7 @@ export async function matchesClosedQa(
   const finalProvider = await getAndCheckProvider(
     'text',
     grading.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'model-graded-closedqa check',
   );
   const resp = await finalProvider.callApi(prompt);
@@ -522,13 +522,13 @@ export async function matchesAnswerRelevance(
   const embeddingProvider = await getAndCheckProvider(
     'embedding',
     grading?.provider,
-    getDefaultProviders().embeddingProvider,
+    (await getDefaultProviders()).embeddingProvider,
     'answer relevancy check',
   );
   const textProvider = await getAndCheckProvider(
     'text',
     grading?.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'answer relevancy check',
   );
 
@@ -619,7 +619,7 @@ export async function matchesContextRecall(
   const textProvider = await getAndCheckProvider(
     'text',
     grading?.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'context recall check',
   );
 
@@ -667,7 +667,7 @@ export async function matchesContextRelevance(
   const textProvider = await getAndCheckProvider(
     'text',
     grading?.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'context relevance check',
   );
 
@@ -716,7 +716,7 @@ export async function matchesContextFaithfulness(
   const textProvider = await getAndCheckProvider(
     'text',
     grading?.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'faithfulness check',
   );
 
@@ -794,7 +794,7 @@ export async function matchesSelectBest(
   const textProvider = await getAndCheckProvider(
     'text',
     grading?.provider,
-    getDefaultProviders().gradingProvider,
+    (await getDefaultProviders()).gradingProvider,
     'select-best check',
   );
 
@@ -857,7 +857,7 @@ export async function matchesModeration(
   const moderationProvider = (await getAndCheckProvider(
     'moderation',
     grading?.provider,
-    getDefaultProviders().moderationProvider,
+    (await getDefaultProviders()).moderationProvider,
     'moderation check',
   )) as ApiModerationProvider;
 

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -7,14 +7,18 @@ import {
 } from './openai';
 
 import {
-  DefaultGradingProvider as AnthropicGradeProvider,
+  DefaultGradingProvider as AnthropicGradingProvider,
   DefaultGradingJsonProvider as AnthropicGradingJsonProvider,
   DefaultSuggestionsProvider as AnthropicSuggestionsProvider,
 } from './anthropic';
 
+import { DefaultGradingProvider as GeminiGradingProvider } from './vertex';
+
+import { hasGoogleDefaultCredentials } from './vertexUtil';
+
 import { EnvOverrides } from '../types';
 
-export function getDefaultProviders(env?: EnvOverrides) {
+export async function getDefaultProviders(env?: EnvOverrides) {
   const preferAnthropic =
     !process.env.OPENAI_API_KEY &&
     !env?.OPENAI_API_KEY &&
@@ -22,13 +26,26 @@ export function getDefaultProviders(env?: EnvOverrides) {
 
   if (preferAnthropic) {
     return {
-      embeddingProvider: OpenAiEmbeddingProvider, // TODO(ian): AnthropicEmbeddingProvider
-      gradingProvider: AnthropicGradeProvider,
+      embeddingProvider: OpenAiEmbeddingProvider, // TODO(ian): Voyager instead?
+      gradingProvider: AnthropicGradingProvider,
       gradingJsonProvider: AnthropicGradingJsonProvider,
       suggestionsProvider: AnthropicSuggestionsProvider,
       moderationProvider: OpenAiModerationProvider,
     };
   }
+
+  const preferGoogle =
+    !process.env.OPENAI_API_KEY && !env?.OPENAI_API_KEY && (await hasGoogleDefaultCredentials());
+  if (preferGoogle) {
+    return {
+      embeddingProvider: OpenAiEmbeddingProvider,
+      gradingProvider: GeminiGradingProvider,
+      gradingJsonProvider: GeminiGradingProvider,
+      suggestionsProvider: GeminiGradingProvider,
+      moderationProvider: OpenAiModerationProvider,
+    };
+  }
+
   return {
     embeddingProvider: OpenAiEmbeddingProvider,
     gradingProvider: OpenAiGradingProvider,

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -1,3 +1,4 @@
+import logger from '../logger';
 import {
   DefaultEmbeddingProvider as OpenAiEmbeddingProvider,
   DefaultGradingJsonProvider as OpenAiGradingJsonProvider,
@@ -5,18 +6,15 @@ import {
   DefaultSuggestionsProvider as OpenAiSuggestionsProvider,
   DefaultModerationProvider as OpenAiModerationProvider,
 } from './openai';
-
 import {
   DefaultGradingProvider as AnthropicGradingProvider,
   DefaultGradingJsonProvider as AnthropicGradingJsonProvider,
   DefaultSuggestionsProvider as AnthropicSuggestionsProvider,
 } from './anthropic';
-
 import { DefaultGradingProvider as GeminiGradingProvider } from './vertex';
-
 import { hasGoogleDefaultCredentials } from './vertexUtil';
 
-import { EnvOverrides } from '../types';
+import type { EnvOverrides } from '../types';
 
 export async function getDefaultProviders(env?: EnvOverrides) {
   const preferAnthropic =
@@ -25,6 +23,7 @@ export async function getDefaultProviders(env?: EnvOverrides) {
     (process.env.ANTHROPIC_API_KEY || env?.ANTHROPIC_API_KEY);
 
   if (preferAnthropic) {
+    logger.debug('Using Anthropic default providers');
     return {
       embeddingProvider: OpenAiEmbeddingProvider, // TODO(ian): Voyager instead?
       gradingProvider: AnthropicGradingProvider,
@@ -37,6 +36,7 @@ export async function getDefaultProviders(env?: EnvOverrides) {
   const preferGoogle =
     !process.env.OPENAI_API_KEY && !env?.OPENAI_API_KEY && (await hasGoogleDefaultCredentials());
   if (preferGoogle) {
+    logger.debug('Using Google default providers');
     return {
       embeddingProvider: OpenAiEmbeddingProvider,
       gradingProvider: GeminiGradingProvider,
@@ -46,6 +46,7 @@ export async function getDefaultProviders(env?: EnvOverrides) {
     };
   }
 
+  logger.debug('Using OpenAI default providers');
   return {
     embeddingProvider: OpenAiEmbeddingProvider,
     gradingProvider: OpenAiGradingProvider,

--- a/src/providers/vertex.ts
+++ b/src/providers/vertex.ts
@@ -165,34 +165,36 @@ export class VertexChatProvider extends VertexGenericProvider {
   // TODO(ian): Completion models
   // https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning#gemini-model-versions
   static CHAT_MODELS = [
+    'aqa',
     'chat-bison',
-    'chat-bison@001',
-    'chat-bison@002',
     'chat-bison-32k',
     'chat-bison-32k@001',
     'chat-bison-32k@002',
+    'chat-bison@001',
+    'chat-bison@002',
     'codechat-bison',
-    'codechat-bison@001',
-    'codechat-bison@002',
     'codechat-bison-32k',
     'codechat-bison-32k@001',
     'codechat-bison-32k@002',
-    'gemini-pro',
-    'gemini-ultra',
-    'gemini-1.0-pro-vision',
-    'gemini-1.0-pro-vision-001',
+    'codechat-bison@001',
+    'codechat-bison@002',
     'gemini-1.0-pro',
     'gemini-1.0-pro-001',
     'gemini-1.0-pro-002',
-    'gemini-pro-vision',
+    'gemini-1.0-pro-vision',
+    'gemini-1.0-pro-vision-001',
+    'gemini-1.0-pro-vision-001',
+    'gemini-1.5-flash',
+    'gemini-1.5-flash-001',
+    'gemini-1.5-flash-preview-0514',
+    'gemini-1.5-pro',
+    'gemini-1.5-pro-001',
     'gemini-1.5-pro-latest',
     'gemini-1.5-pro-preview-0409',
     'gemini-1.5-pro-preview-0514',
-    'gemini-1.5-pro-001',
-    'gemini-1.0-pro-vision-001',
-    'gemini-1.5-flash-preview-0514',
-    'gemini-1.5-flash-001',
-    'aqa',
+    'gemini-pro',
+    'gemini-pro-vision',
+    'gemini-ultra',
   ];
 
   constructor(
@@ -285,8 +287,12 @@ export class VertexChatProvider extends VertexGenericProvider {
         data: body,
       });
       data = res.data as GeminiApiResponse;
+      logger.debug(`Gemini API response: ${JSON.stringify(data)}`);
     } catch (err) {
       const geminiError = err as any;
+      logger.debug(
+        `Gemini API error:\nString:\n${String(geminiError)}\nJSON:\n${JSON.stringify(geminiError)}]`,
+      );
       if (
         geminiError.response &&
         geminiError.response.data &&
@@ -302,7 +308,7 @@ export class VertexChatProvider extends VertexGenericProvider {
         };
       }
       return {
-        error: `API call error: ${JSON.stringify(err, null, 2)}`,
+        error: `API call error: ${String(err)}`,
       };
     }
 
@@ -440,3 +446,5 @@ export class VertexChatProvider extends VertexGenericProvider {
     }
   }
 }
+
+export const DefaultGradingProvider = new VertexChatProvider('gemini-1.5-pro');

--- a/src/providers/vertexUtil.ts
+++ b/src/providers/vertexUtil.ts
@@ -107,3 +107,12 @@ export async function getGoogleClient() {
   const projectId = await cachedAuth.getProjectId();
   return { client, projectId };
 }
+
+export async function hasGoogleDefaultCredentials() {
+  try {
+    await getGoogleClient();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/test/providers.vertex.test.ts
+++ b/test/providers.vertex.test.ts
@@ -104,7 +104,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
   });
 
   it('should handle API call errors', async () => {
-    const mockError = new Error('API call error');
+    const mockError = new Error('something went wrong');
     jest.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
       client: {
         request: jest.fn().mockRejectedValue(mockError),
@@ -115,7 +115,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
     const response = await provider.callGeminiApi('test prompt');
 
     expect(response).toEqual({
-      error: `API call error: ${JSON.stringify(mockError)}`,
+      error: `API call error: Error: something went wrong`,
     });
   });
 


### PR DESCRIPTION
If the system looks like it's configured to use Gemini, then use it as a grader.  

Also includes some improvements to error messages, for example when default application credentials are not provided.