### PR TITLE
docs: fix incorrect yaml ref in guide

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -258,13 +258,13 @@ tests:
       language: French
       input: Hello world
     assert:
-      - $ref: '#assertionTemplates/startsUpperCase'
+      - $ref: '#/assertionTemplates/startsUpperCase'
   - vars:
       language: German
       input: How's it going?
     assert:
-      - $ref: '#assertionTemplates/noAIreference'
-      - $ref: '#assertionTemplates/startsUpperCase'
+      - $ref: '#/assertionTemplates/noAIreference'
+      - $ref: '#/assertionTemplates/startsUpperCase'
 
 // highlight-start
 assertionTemplates:


### PR DESCRIPTION
Prior to the fix the config isn't actually dereferenced.