### PR TITLE
fix: more robust json extraction for llm-rubric

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,4 +1,3 @@
-import { json } from 'drizzle-orm/mysql-core';
 import invariant from 'tiny-invariant';
 import logger from './logger';
 import {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1325,3 +1325,33 @@ export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | obj
   }
   return obj;
 }
+
+export function extractJsonObjects(str: string): object[] {
+  // This will extract all json objects from a string
+
+  const jsonObjects = [];
+  let openBracket = str.indexOf('{');
+  let closeBracket = str.indexOf('}', openBracket);
+  // Iterate over the string until we find a valid JSON-like pattern
+  // Iterate over all trailing } until the contents parse as json
+  while (openBracket !== -1) {
+    const jsonStr = str.slice(openBracket, closeBracket + 1);
+    try {
+      jsonObjects.push(JSON.parse(jsonStr));
+      // This is a valid JSON object, so start looking for
+      // an opening bracket after the last closing bracket
+      openBracket = str.indexOf('{', closeBracket + 1);
+      closeBracket = str.indexOf('}', openBracket);
+    } catch (err) {
+      // Not a valid object, move on to the next closing bracket
+      closeBracket = str.indexOf('}', closeBracket + 1);
+      while (closeBracket === -1) {
+        // No closing brackets made a valid json object, so
+        // start looking with the next opening bracket
+        openBracket = str.indexOf('{', openBracket + 1);
+        closeBracket = str.indexOf('}', openBracket);
+      }
+    }
+  }
+  return jsonObjects;
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -19,6 +19,7 @@ import {
   varsMatch,
   writeMultipleOutputs,
   writeOutput,
+  extractJsonObjects,
 } from '../src/util';
 
 jest.mock('proxy-agent', () => ({
@@ -859,5 +860,37 @@ describe('util', () => {
 
       expect(resultIsForTestCase(result, nonMatchTestCase)).toBe(false);
     });
+  });
+});
+
+describe('extractJsonObjects', () => {
+  it('should extract a single JSON object from a string', () => {
+    const input = '{"key": "value"}';
+    const expectedOutput = [{ key: 'value' }];
+    expect(extractJsonObjects(input)).toEqual(expectedOutput);
+  });
+
+  it('should extract multiple JSON objects from a string', () => {
+    const input = 'yolo {"key1": "value1"} some text {"key2": "value2"} fomo';
+    const expectedOutput = [{ key1: 'value1' }, { key2: 'value2' }];
+    expect(extractJsonObjects(input)).toEqual(expectedOutput);
+  });
+
+  it('should return an empty array if no JSON objects are found', () => {
+    const input = 'no json here';
+    const expectedOutput = [];
+    expect(extractJsonObjects(input)).toEqual(expectedOutput);
+  });
+
+  it('should handle nested JSON objects', () => {
+    const input = 'wassup {"outer": {"inner": "value"}, "foo": [1,2,3,4]}';
+    const expectedOutput = [{ outer: { inner: 'value' }, foo: [1, 2, 3, 4] }];
+    expect(extractJsonObjects(input)).toEqual(expectedOutput);
+  });
+
+  it('should handle invalid JSON gracefully', () => {
+    const input = '{"key": "value" some text {"key2": "value2"}';
+    const expectedOutput = [{ key2: 'value2' }];
+    expect(extractJsonObjects(input)).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
This fixes an issue where llm-rubric can incorrectly parse json with nested curly braces.

Context https://discord.com/channels/1153767083381903389/1255250654872600686