### PR TITLE
chore: expose runAssertion and runAssertions to node package

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1395,6 +1395,8 @@ export async function readAssertions(filePath: string): Promise<Assertion[]> {
 
 // These exports are used by the node.js package (index.ts)
 export default {
+  runAssertion,
+  runAssertions,
   matchesSimilarity,
   matchesClassification,
   matchesLlmRubric,


### PR DESCRIPTION
Related to #1014

Exposes under `promptfoo.assertions.runAssertion` and `promptfoo.assertions.runAssertions`