### PR TITLE
ci: add GitHub Action for automatic version tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,45 @@
+name: tag
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+permissions:
+  contents: write
+concurrency:
+  group: ${{ github.workflow }}
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Get package version
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Check if git tag exists
+        id: check_tag
+        run: |
+          git fetch --tags
+          VERSION=$(echo $VERSION)
+          if [[ $(git tag -l v$VERSION | wc -l) -eq '1' ]]; then
+            echo "git tag already exists"
+            echo "TAG=false" >> $GITHUB_ENV
+          else
+            echo "git tag does not exist"
+            echo "TAG=true" >> $GITHUB_ENV
+          fi
+      - name: Create git tag
+        if: env.TAG == 'true'
+        run: git tag v${{ env.VERSION }}
+      - name: Push git tag
+        if: env.TAG == 'true'
+        run: git push --tags

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git fetch --tags
           VERSION=$(echo $VERSION)
-          if [[ $(git tag -l v$VERSION | wc -l) -eq '1' ]]; then
+          if [[ $(git tag -l $VERSION | wc -l) -eq '1' ]]; then
             echo "git tag already exists"
             echo "TAG=false" >> $GITHUB_ENV
           else

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,7 +39,7 @@ jobs:
           fi
       - name: Create git tag
         if: env.TAG == 'true'
-        run: git tag v${{ env.VERSION }}
+        run: git tag ${{ env.VERSION }}
       - name: Push git tag
         if: env.TAG == 'true'
         run: git push --tags


### PR DESCRIPTION
This is a proposal - feel free to ignore or close. This pull request introduces a new GitHub Action workflow to automatically create a git tag whenever the `package.json` version is incremented on the `main` branch. The workflow is triggered by push events to the `main` branch affecting the `package.json` file. This change lays the groundwork for potential future enhancements, such as automatic publishing to npm upon version tagging. This will allow other contributors (me) to do releases without a team npm account. 