### PR TITLE
feat: replicate image provider

### DIFF
--- a/site/docs/providers/replicate.md
+++ b/site/docs/providers/replicate.md
@@ -80,3 +80,44 @@ Supported environment variables:
 - `REPLICATE_SEED` - Sets a seed for reproducible results.
 - `REPLICATE_STOP_SEQUENCES` - Specifies stopping sequences that halt the generation.
 - `REPLICATE_SYSTEM_PROMPT` - Sets a system-level prompt for all requests.
+
+## Images
+
+Image generators such as SDXL can be used like so:
+
+```yaml
+prompts:
+  - 'Generate an image: {{subject}}'
+
+providers:
+  - id: replicate:image:stability-ai/sdxl:7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc
+    config:
+      width: 768
+      height: 768
+      num_inference_steps: 50
+
+tests:
+  - vars:
+      query: fruit loops
+```
+
+## Supported Parameters for Images
+
+These parameters are supported for image generation models:
+
+| Parameter             | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| `width`               | The width of the generated image.                             |
+| `height`              | The height of the generated image.                            |
+| `refine`              | Which refine style to use                                     |
+| `apply_watermark`     | Apply a watermark to the generated image.                     |
+| `num_inference_steps` | The number of inference steps to use during image generation. |
+
+:::warning
+Not every model supports every image parameter. Be sure to review the API provided by the model beforehand.
+:::
+
+Supported environment variables for images:
+
+- `REPLICATE_API_TOKEN` - Your Replicate API key.
+- `REPLICATE_API_KEY` - An alternative to `REPLICATE_API_TOKEN` for your API key.

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -46,7 +46,11 @@ import {
 import { PalmChatProvider } from './providers/palm';
 import { PortkeyChatCompletionProvider } from './providers/portkey';
 import { PythonProvider } from './providers/pythonCompletion';
-import { ReplicateModerationProvider, ReplicateProvider } from './providers/replicate';
+import {
+  ReplicateImageProvider,
+  ReplicateModerationProvider,
+  ReplicateProvider,
+} from './providers/replicate';
 import { ScriptCompletionProvider } from './providers/scriptCompletion';
 import { VertexChatProvider, VertexEmbeddingProvider } from './providers/vertex';
 import { VoyageEmbeddingProvider } from './providers/voyage';
@@ -228,6 +232,8 @@ export async function loadApiProvider(
     const modelName = splits.slice(2).join(':');
     if (modelType === 'moderation') {
       ret = new ReplicateModerationProvider(modelName, providerOptions);
+    } else if (modelType === 'image') {
+      ret = new ReplicateImageProvider(modelName, providerOptions);
     } else {
       // By default, there is no model type.
       ret = new ReplicateProvider(modelType + ':' + modelName, providerOptions);

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -6,11 +6,14 @@ import logger from '../logger';
 import type {
   ApiModerationProvider,
   ApiProvider,
+  CallApiContextParams,
+  CallApiOptionsParams,
   EnvOverrides,
   ModerationFlag,
   ProviderModerationResponse,
   ProviderResponse,
-} from '../types.js';
+} from '../types';
+import { safeJsonStringify } from '../util';
 
 interface ReplicateCompletionOptions {
   apiKey?: string;
@@ -278,3 +281,92 @@ export class ReplicateModerationProvider
 export const DefaultModerationProvider = new ReplicateModerationProvider(
   'meta/meta-llama-guard-2-8b:b063023ee937f28e922982abdbf97b041ffe34ad3b35a53d33e1d74bb19b36c4',
 );
+
+interface ReplicateImageOptions {
+  width?: number;
+  height?: number;
+  refine?: string;
+  apply_watermark?: boolean;
+  num_inference_steps?: number;
+}
+
+export class ReplicateImageProvider extends ReplicateProvider {
+  config: ReplicateImageOptions;
+
+  constructor(
+    modelName: string,
+    options: { config?: ReplicateImageOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    super(modelName, options);
+    this.config = options.config || {};
+  }
+
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    callApiOptions?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    const cache = getCache();
+    const cacheKey = `replicate:image:${safeJsonStringify({ context, prompt })}`;
+
+    if (!this.apiKey) {
+      throw new Error(
+        'Replicate API key is not set. Set the REPLICATE_API_TOKEN environment variable or add `apiKey` to the provider config.',
+      );
+    }
+
+    const replicate = new Replicate({
+      auth: this.apiKey,
+    });
+
+    let response: any | undefined;
+    let cached = false;
+    if (isCacheEnabled()) {
+      // Try to get the cached response
+      const cachedResponse = await cache.get(cacheKey);
+      if (cachedResponse) {
+        console.log(cachedResponse);
+        logger.debug(`Retrieved cached response for ${prompt}: ${cachedResponse}`);
+        response = JSON.parse(cachedResponse as string);
+        cached = true;
+      }
+    }
+
+    if (!response) {
+      const data = {
+        input: {
+          width: this.config.width || 768,
+          height: this.config.height || 768,
+          prompt,
+        },
+      };
+      response = await replicate.run(this.modelName as any, data);
+    }
+
+    const url = response[0];
+    if (!url) {
+      return {
+        error: `No image URL found in response: ${JSON.stringify(response)}`,
+      };
+    }
+
+    if (!cached && isCacheEnabled()) {
+      try {
+        await cache.set(cacheKey, JSON.stringify(response));
+      } catch (err) {
+        logger.error(`Failed to cache response: ${String(err)}`);
+      }
+    }
+
+    const sanitizedPrompt = prompt
+      .replace(/\r?\n|\r/g, ' ')
+      .replace(/\[/g, '(')
+      .replace(/\]/g, ')');
+    const ellipsizedPrompt =
+      sanitizedPrompt.length > 50 ? `${sanitizedPrompt.substring(0, 47)}...` : sanitizedPrompt;
+    return {
+      output: `![${ellipsizedPrompt}](${url})`,
+      cached,
+    };
+  }
+}

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -322,7 +322,6 @@ export class ReplicateImageProvider extends ReplicateProvider {
     let response: any | undefined;
     let cached = false;
     if (isCacheEnabled()) {
-      // Try to get the cached response
       const cachedResponse = await cache.get(cacheKey);
       if (cachedResponse) {
         console.log(cachedResponse);


### PR DESCRIPTION
Example:
```yaml
prompts:
  - 'Generate an image: {{subject}}'
 
providers:
  - replicate:image:stability-ai/sdxl:7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc
 
tests:
  - vars:
      subject: fruit loops
```