### PR TITLE
feat: `llm-rubric` uses tools API for model-grading anthropic evals

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -325,10 +325,13 @@ export async function matchesLlmRubric(
     ...fromVars(vars),
   });
 
+  const defaultProviders = await getDefaultProviders();
+  const defaultProvider =
+    defaultProviders.llmRubricProvider || defaultProviders.gradingJsonProvider;
   const finalProvider = await getAndCheckProvider(
     'text',
     grading.provider,
-    (await getDefaultProviders()).gradingJsonProvider,
+    defaultProvider,
     'llm-rubric check',
   );
   const resp = await finalProvider.callApi(prompt);

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -26,6 +26,27 @@ Rubric: Does not speak like a pirate
   },
 ]);
 
+export const ANTHROPIC_GRADING_PROMPT = JSON.stringify([
+  {
+    role: 'system',
+    content: `You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. 
+
+Examples:
+
+Output: Hello world
+Rubric: Content contains a greeting
+{"pass": true, "score": 1.0, "reason": "the content contains the word 'world'"}
+
+Output: Avast ye swabs, repel the invaders!
+Rubric: Does not speak like a pirate
+{"pass": false, "score": 0.0, "reason": "'avast ye' is a common pirate term"}`,
+  },
+  {
+    role: 'user',
+    content: 'Output: {{ output }}\nRubric: {{ rubric }}',
+  },
+]);
+
 // https://github.com/openai/evals/blob/main/evals/registry/modelgraded/fact.yaml
 export const OPENAI_FACTUALITY_PROMPT = JSON.stringify([
   {

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -4,6 +4,7 @@ import {
   DefaultGradingProvider as AnthropicGradingProvider,
   DefaultGradingJsonProvider as AnthropicGradingJsonProvider,
   DefaultSuggestionsProvider as AnthropicSuggestionsProvider,
+  DefaultLlmRubricProvider as AnthropicLlmRubricProvider,
 } from './anthropic';
 import {
   DefaultEmbeddingProvider as OpenAiEmbeddingProvider,
@@ -32,6 +33,7 @@ export async function getDefaultProviders(env?: EnvOverrides) {
       gradingJsonProvider: AnthropicGradingJsonProvider,
       suggestionsProvider: AnthropicSuggestionsProvider,
       moderationProvider: OpenAiModerationProvider,
+      llmRubricProvider: AnthropicLlmRubricProvider,
     };
   }
 

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -4,6 +4,7 @@ import { clearCache, disableCache, enableCache, getCache } from '../src/cache';
 import { loadApiProvider } from '../src/providers';
 import {
   AnthropicCompletionProvider,
+  AnthropicLlmRubricProvider,
   AnthropicMessagesProvider,
   calculateCost,
   outputFromMessage,
@@ -219,6 +220,77 @@ describe('Anthropic', () => {
         tokenUsage: { total: 100, prompt: 50, completion: 50 },
         cost: 1.5,
       });
+    });
+  });
+
+  describe('AnthropicLlmRubricProvider', () => {
+    let provider: AnthropicLlmRubricProvider;
+
+    beforeEach(() => {
+      provider = new AnthropicLlmRubricProvider('claude-3-5-sonnet-20240620');
+    });
+
+    it('should initialize with forced tool configuration', () => {
+      expect(provider.modelName).toBe('claude-3-5-sonnet-20240620');
+      expect(provider.config.tool_choice).toEqual({ type: 'tool', name: 'grade_output' });
+    });
+
+    it('should call API and parse the result correctly', async () => {
+      const mockApiResponse = {
+        output: JSON.stringify({
+          type: 'tool_use',
+          id: 'test-id',
+          name: 'grade_output',
+          input: {
+            pass: true,
+            score: 0.85,
+            reason: 'The output meets the criteria.',
+          },
+        }),
+      };
+
+      jest.spyOn(AnthropicMessagesProvider.prototype, 'callApi').mockResolvedValue(mockApiResponse);
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result).toEqual({
+        output: {
+          pass: true,
+          score: 0.85,
+          reason: 'The output meets the criteria.',
+        },
+      });
+    });
+
+    it('should handle non-string API response', async () => {
+      const mockApiResponse = {
+        output: { confession: 'I am not a string' },
+      };
+
+      jest.spyOn(AnthropicMessagesProvider.prototype, 'callApi').mockResolvedValue(mockApiResponse);
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toContain('Anthropic LLM rubric grader - malformed non-string output');
+    });
+
+    it('should handle malformed API response', async () => {
+      const mockApiResponse = {
+        output: 'Invalid JSON',
+      };
+
+      jest.spyOn(AnthropicMessagesProvider.prototype, 'callApi').mockResolvedValue(mockApiResponse);
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toContain('Anthropic LLM rubric grader - invalid JSON');
+    });
+
+    it('should handle API errors', async () => {
+      const mockError = new Error('API Error');
+      jest.spyOn(AnthropicMessagesProvider.prototype, 'callApi').mockRejectedValue(mockError);
+
+      await expect(provider.callApi('Test prompt')).rejects.toThrow('API Error');
     });
   });
 


### PR DESCRIPTION
On systems configured to use Anthropic, use claude's tool API for `llm-rubric` model grading.