### PR TITLE
fix(prompts): treat non-existent files as prompt strings

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -124,6 +124,13 @@ export async function processPrompt(
       );
       prompts.push(...processedPrompts);
     }
+    if (prompts.length === 0) {
+      // There was nothing at this filepath, so treat it as a prompt string.
+      logger.debug(
+        `Attempted to load file at "${prompt.raw}", but no file found. Using raw string.`,
+      );
+      return processString(prompt);
+    }
     return prompts;
   }
 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -124,13 +124,6 @@ export async function processPrompt(
       );
       prompts.push(...processedPrompts);
     }
-    if (prompts.length === 0) {
-      // There was nothing at this filepath, so treat it as a prompt string.
-      logger.debug(
-        `Attempted to load file at "${prompt.raw}", but no file found. Using raw string.`,
-      );
-      return processString(prompt);
-    }
     return prompts;
   }
 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -129,7 +129,7 @@ export async function processPrompt(
       logger.debug(
         `Attempted to load file at "${prompt.raw}", but no file found. Using raw string.`,
       );
-      return processString(prompt);
+      prompts.push(...processString(prompt));
     }
     return prompts;
   }

--- a/src/prompts/utils.ts
+++ b/src/prompts/utils.ts
@@ -25,7 +25,6 @@ export function maybeFilePath(str: string): boolean {
     }) ||
     str.charAt(str.length - 3) === '.' ||
     str.charAt(str.length - 4) === '.' ||
-    str.endsWith('.') ||
     str.includes('*') ||
     str.includes('/') ||
     str.includes('\\')

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -4,7 +4,6 @@ import { globSync } from 'glob';
 import * as yaml from 'js-yaml';
 import { importModule } from '../src/esm';
 import { readPrompts, readProviderPromptMap } from '../src/prompts';
-import { maybeFilePath } from '../src/prompts/utils';
 import type { Prompt, ProviderResponse, UnifiedConfig } from '../src/types';
 
 jest.mock('proxy-agent', () => ({
@@ -37,13 +36,6 @@ jest.mock('../src/esm', () => {
   return {
     ...actual,
     importModule: jest.fn(actual.importModule),
-  };
-});
-jest.mock('../src/prompts/utils', () => {
-  const actual = jest.requireActual('../src/prompts/utils');
-  return {
-    ...actual,
-    maybeFilePath: jest.fn(actual.maybeFilePath),
   };
 });
 jest.mock('../src/logger');
@@ -433,18 +425,6 @@ describe('readPrompts', () => {
     ]);
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(fs.statSync).toHaveBeenCalledTimes(3);
-  });
-
-  it('should fall back to prompt string literal if file does not exist', async () => {
-    jest.mocked(globSync).mockImplementationOnce(() => []);
-    jest.mocked(maybeFilePath).mockReturnValueOnce(true);
-    await expect(readPrompts('Please tell me about /path/to/file.py')).resolves.toEqual([
-      {
-        label: '/path/to/file.py',
-        raw: '/path/to/file.py',
-      },
-    ]);
-    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -44,7 +44,7 @@ jest.mock('../src/python/wrapper');
 describe('readPrompts', () => {
   afterEach(() => {
     delete process.env.PROMPTFOO_STRICT_FILES;
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('should throw an error for invalid inputs', async () => {
@@ -63,6 +63,10 @@ describe('readPrompts', () => {
 
   it('should throw an error when PROMPTFOO_STRICT_FILES is true and the file does not exist', async () => {
     process.env.PROMPTFOO_STRICT_FILES = 'true';
+    jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
+    jest.mocked(fs.readFileSync).mockImplementationOnce(() => {
+      throw new Error("ENOENT: no such file or directory, stat 'non-existent-file.txt'");
+    });
     await expect(readPrompts('non-existent-file.txt')).rejects.toThrow(
       expect.objectContaining({
         message: expect.stringMatching(
@@ -70,11 +74,10 @@ describe('readPrompts', () => {
         ),
       }),
     );
-    delete process.env.PROMPTFOO_STRICT_FILES;
   });
 
   it('should throw an error for a .txt file with no prompts', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue('');
+    jest.mocked(fs.readFileSync).mockReturnValueOnce('');
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts(['prompts.txt'])).rejects.toThrow(
       'There are no prompts in "prompts.txt"',
@@ -83,7 +86,6 @@ describe('readPrompts', () => {
   });
 
   it('should throw an error for an unsupported file format', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ id: 'test prompt' }));
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts(['unsupported.for.mat'])).rejects.toThrow(
       'There are no prompts in "unsupported.for.mat"',
@@ -116,7 +118,7 @@ describe('readPrompts', () => {
   });
 
   it('should read a .txt file with a single prompt', async () => {
-    jest.mocked(fs.readFileSync).mockReturnValue('Sample Prompt');
+    jest.mocked(fs.readFileSync).mockReturnValueOnce('Sample Prompt');
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts('prompts.txt')).resolves.toEqual([
       {
@@ -148,10 +150,14 @@ describe('readPrompts', () => {
   );
 
   it('should read multiple prompt files', async () => {
-    jest
-      .mocked(fs.readFileSync)
-      .mockReturnValueOnce('Test prompt 1\n---\nTest prompt 2')
-      .mockReturnValueOnce('Test prompt 3\n---\nTest prompt 4\n---\nTest prompt 5');
+    jest.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (filePath.toString().endsWith('prompt1.txt')) {
+        return 'Test prompt 1\n---\nTest prompt 2';
+      } else if (filePath.toString().endsWith('prompt2.txt')) {
+        return 'Test prompt 3\n---\nTest prompt 4\n---\nTest prompt 5';
+      }
+      throw new Error(`Unexpected file path in test: ${filePath}`);
+    });
     jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as fs.Stats);
     jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob.toString()]);
     await expect(readPrompts(['prompt1.txt', 'prompt2.txt'])).resolves.toEqual([
@@ -200,7 +206,7 @@ describe('readPrompts', () => {
       { name: 'How do I get to the moon?', role: 'user' },
     ]);
 
-    jest.mocked(fs.readFileSync).mockReturnValue(mockJsonContent);
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(mockJsonContent);
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
 
     const filePath = 'file://path/to/mock.json';
@@ -226,7 +232,7 @@ describe('readPrompts', () => {
       ],
     ];
 
-    jest.mocked(fs.readFileSync).mockReturnValue(data.map((o) => JSON.stringify(o)).join('\n'));
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(data.map((o) => JSON.stringify(o)).join('\n'));
     jest.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts(['prompts.jsonl'])).resolves.toEqual([
       {
@@ -251,7 +257,7 @@ describe('readPrompts', () => {
           image_url:
             url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
     `;
-    jest.mocked(fs.readFileSync).mockReturnValue(yamlContent);
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(yamlContent);
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts('prompts.yaml')).resolves.toEqual([
       {
@@ -374,14 +380,14 @@ describe('readPrompts', () => {
   });
 
   it('should read a directory', async () => {
-    jest
-      .mocked(fs.statSync)
-      .mockReturnValue({
-        isDirectory: () => false,
-      } as fs.Stats)
-      .mockReturnValueOnce({
-        isDirectory: () => true,
-      } as fs.Stats);
+    jest.mocked(fs.statSync).mockImplementation((filePath) => {
+      if (filePath.toString().endsWith('prompt1.txt')) {
+        return { isDirectory: () => false } as fs.Stats;
+      } else if (filePath.toString().endsWith('prompts')) {
+        return { isDirectory: () => true } as fs.Stats;
+      }
+      throw new Error(`Unexpected file path in test: ${filePath}`);
+    });
     jest.mocked(globSync).mockImplementation(() => ['prompt1.txt', 'prompt2.txt']);
     // The mocked paths here are an artifact of our globSync mock. In a real
     // world setting we would get back `prompts/prompt1.txt` instead of `prompts/*/prompt1.txt`

--- a/test/prompts.utils.test.ts
+++ b/test/prompts.utils.test.ts
@@ -93,6 +93,10 @@ describe('maybeFilePath', () => {
     const longInvalidPath = 'a/'.repeat(100) + 'file\n.txt';
     expect(maybeFilePath(longInvalidPath)).toBe(false);
   });
+
+  it('should return false for strings ending with a dot', () => {
+    expect(maybeFilePath('Write a tweet about {{topic}}.')).toBe(false);
+  });
 });
 
 describe('normalizeInput', () => {


### PR DESCRIPTION
- In `src/prompts/index.ts`, added logic to process file paths as prompt strings if the file is not found. This ensures that missing files do not cause errors but are instead treated as raw prompt strings. This is because we sometimes misidentify a string as a filepath. 
- In `src/prompts/utils.ts`, removed the condition to exclude strings ending with a dot from being considered file paths.
- Updated `test/prompts.test.ts` and `test/prompts.utils.test.ts` to support the new behavior and ensure tests run correctly in random order.

Related to #1081
