### PR TITLE
test: fix assertion result mock pollution

### DIFF
--- a/src/web/nextui/src/app/eval/EvalOutputCell.tsx
+++ b/src/web/nextui/src/app/eval/EvalOutputCell.tsx
@@ -345,7 +345,7 @@ function EvalOutputCell({
       {output.prompt && (
         <>
           <span className="action" onClick={handlePromptOpen}>
-            <Tooltip title="View ouput and test details">
+            <Tooltip title="View output and test details">
               <span>🔎</span>
             </Tooltip>
           </span>

--- a/test/assertions/AssertionResult.test.ts
+++ b/test/assertions/AssertionResult.test.ts
@@ -1,7 +1,13 @@
 import { AssertionsResult } from '../../src/assertions/AssertionsResult';
 import { AssertionSet } from '../../src/types';
+import { jest } from '@jest/globals';
 
 describe('AssertionsResult', () => {
+
+  beforeEach(() => {
+    delete process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES;
+  });
+
   const succeedingResult = {
     pass: true,
     score: 1,
@@ -56,17 +62,13 @@ describe('AssertionsResult', () => {
   });
 
   it('handles PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES', () => {
-    const initialEnv = process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES;
     process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = 'true';
-
     expect(() =>
       assertionsResult.addResult({
         index: 0,
         result: failingResult,
       }),
     ).toThrow(new Error(failingResult.reason));
-
-    process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = initialEnv;
   });
 
   it('handles named metrics', () => {

--- a/test/assertions/AssertionResult.test.ts
+++ b/test/assertions/AssertionResult.test.ts
@@ -1,9 +1,7 @@
 import { AssertionsResult } from '../../src/assertions/AssertionsResult';
 import { AssertionSet } from '../../src/types';
-import { jest } from '@jest/globals';
 
 describe('AssertionsResult', () => {
-
   beforeEach(() => {
     delete process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES;
   });


### PR DESCRIPTION
This fixes an occasional test mock pollution allowing assertion tests to be run in any order. 