### PR TITLE
feat: `--filter-providers` eval option

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -51,6 +51,7 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 | `--filter-failing <path>`           | Run only failing tests from previous evaluation. Path to JSON output file from the previous evaluation.                                                                                            |
 | `-n, --filter-first-n`              | Run the first N test cases                                                                                                                                                                         |
 | `--filter-pattern <pattern>`        | Run only test cases whose `description` matches the regex pattern                                                                                                                                  |
+| `--filter-providers <pattern>`      | Run only test cases whose provider ids or label match the regex pattern                                                                                                                            |
 
 [1]: /docs/providers/openai
 [2]: /docs/providers/localai

--- a/src/commands/eval/filterProviders.ts
+++ b/src/commands/eval/filterProviders.ts
@@ -1,0 +1,19 @@
+import type { ApiProvider } from '../../types';
+
+export function filterProviders(
+  providers: ApiProvider[],
+  filterProvidersOption?: string,
+): ApiProvider[] {
+  if (!filterProvidersOption) {
+    return providers;
+  }
+
+  const filterRegex = new RegExp(filterProvidersOption);
+
+  return providers.filter((provider) => {
+    const providerId = provider.id();
+    const providerLabel = provider.label;
+
+    return filterRegex.test(providerId) || (providerLabel && filterRegex.test(providerLabel));
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { checkNodeVersion } from './checkNodeVersion';
 import cliState from './cliState';
 import { configCommand } from './commands/config';
 import { deleteCommand } from './commands/delete';
+import { filterProviders } from './commands/eval/filterProviders';
 import { filterTests } from './commands/eval/filterTests';
 import { exportCommand } from './commands/export';
 import { importCommand } from './commands/import';
@@ -715,6 +716,7 @@ async function main() {
       '--filter-pattern <pattern>',
       'Only run tests whose description matches the regular expression pattern',
     )
+    .option('--filter-providers <providers>', 'Only run tests with these providers')
     .option('--filter-failing <path>', 'Path to json output file')
     .option(
       '--var <key=value>',
@@ -772,6 +774,8 @@ async function main() {
           pattern: cmdObj.filterPattern,
           failing: cmdObj.filterFailing,
         });
+
+        testSuite.providers = filterProviders(testSuite.providers, cmdObj.filterProviders);
 
         const options: EvaluateOptions = {
           showProgressBar: getLogLevel() === 'debug' ? false : cmdObj.progressBar,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface CommandLineOptions {
   filterFailing?: string;
   filterFirstN?: string;
   filterPattern?: string;
+  filterProviders?: string;
   var?: Record<string, string>;
 
   generateSuggestions?: boolean;

--- a/test/commands/eval/filterProviders.test.ts
+++ b/test/commands/eval/filterProviders.test.ts
@@ -1,0 +1,55 @@
+import { filterProviders } from '../../../src/commands/eval/filterProviders';
+import type { ApiProvider } from '../../../src/types';
+
+describe('filterProviders', () => {
+  const mockProviders: ApiProvider[] = [
+    {
+      id: () => 'provider1',
+      label: 'Provider One',
+      callApi: async () => ({ output: '' }),
+    },
+    {
+      id: () => 'provider2',
+      label: 'Provider Two',
+      callApi: async () => ({ output: '' }),
+    },
+    {
+      id: () => 'provider3',
+      callApi: async () => ({ output: '' }),
+    },
+  ];
+
+  it('should return all providers when no filter is provided', () => {
+    const result = filterProviders(mockProviders);
+    expect(result).toEqual(mockProviders);
+  });
+
+  it('should filter providers by id', () => {
+    const result = filterProviders(mockProviders, 'provider1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id()).toBe('provider1');
+  });
+
+  it('should filter providers by label', () => {
+    const result = filterProviders(mockProviders, 'Two');
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Provider Two');
+  });
+
+  it('should return empty array when no providers match the filter', () => {
+    const result = filterProviders(mockProviders, 'nonexistent');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle regex patterns in filter', () => {
+    const result = filterProviders(mockProviders, 'provider[12]');
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.id())).toEqual(['provider1', 'provider2']);
+  });
+
+  it('should handle providers without labels', () => {
+    const result = filterProviders(mockProviders, 'provider3');
+    expect(result).toHaveLength(1);
+    expect(result[0].id()).toBe('provider3');
+  });
+});


### PR DESCRIPTION
Use it like this:

```
promptfoo eval --filter-providers 'gpt-3.5'
```
to only run providers that match the ID or label

Related to #1048
