### PR TITLE
feat: add support for PROMPTFOO_AUTHOR environment variable

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -10,5 +10,5 @@ export function setUserEmail(email: string) {
 }
 
 export function getAuthor(): string | null {
-  return getUserEmail() || null;
+  return process.env.PROMPTFOO_AUTHOR || getUserEmail() || null;
 }

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -1,0 +1,51 @@
+import { getUserEmail, setUserEmail, getAuthor } from '../src/accounts';
+import { writeGlobalConfig, readGlobalConfig } from '../src/globalConfig';
+
+jest.mock('../src/globalConfig', () => ({
+  writeGlobalConfig: jest.fn(),
+  readGlobalConfig: jest.fn(),
+}));
+
+describe('accounts module', () => {
+  beforeEach(() => {
+    delete process.env.PROMPTFOO_AUTHOR;
+    jest.resetModules();
+  });
+
+  describe('getUserEmail', () => {
+    it('should return the email from global config', () => {
+      jest.mocked(readGlobalConfig).mockReturnValue({ account: { email: 'test@example.com' } });
+      expect(getUserEmail()).toBe('test@example.com');
+    });
+
+    it('should return null if no email is set in global config', () => {
+      jest.mocked(readGlobalConfig).mockReturnValue({});
+      expect(getUserEmail()).toBeNull();
+    });
+  });
+
+  describe('setUserEmail', () => {
+    it('should write the email to global config', () => {
+      const writeGlobalConfigSpy = jest.mocked(writeGlobalConfig);
+      setUserEmail('test@example.com');
+      expect(writeGlobalConfigSpy).toHaveBeenCalledWith({ account: { email: 'test@example.com' } });
+    });
+  });
+
+  describe('getAuthor', () => {
+    it('should return the author from environment variable', () => {
+      process.env.PROMPTFOO_AUTHOR = 'envAuthor';
+      expect(getAuthor()).toBe('envAuthor');
+    });
+
+    it('should return the email if environment variable is not set', () => {
+      jest.mocked(readGlobalConfig).mockReturnValue({ account: { email: 'test@example.com' } });
+      expect(getAuthor()).toBe('test@example.com');
+    });
+
+    it('should return null if neither environment variable nor email is set', () => {
+      jest.mocked(readGlobalConfig).mockReturnValue({});
+      expect(getAuthor()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
This feature is useful for the CI 

- Updated `getAuthor` function in `accounts.ts` to return the value of `PROMPTFOO_AUTHOR` environment variable if set, falling back to `getUserEmail` or `null`.
- Added unit tests for `getUserEmail`, `setUserEmail`, and `getAuthor` in `account.test.ts`.
