### PR TITLE
fix(openai): add missing `gpt-4-turbo-2024-04-09`

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -31,6 +31,7 @@ const OPENAI_CHAT_MODELS = [
     'gpt-4-1106-preview',
     'gpt-4-1106-vision-preview',
     'gpt-4-0125-preview',
+    'gpt-4-turbo-2024-04-09',
     'gpt-4-turbo-preview',
     'gpt-4-turbo',
   ].map((model) => ({


### PR DESCRIPTION
See https://platform.openai.com/docs/models/continuous-model-upgrades

As of 2024-07-05 (today), `gpt-4-turbo` points to `gpt-4-turbo-2024-04-09`:

![image](https://github.com/promptfoo/promptfoo/assets/19716675/598cabff-28f1-48e1-a87e-d9c5872e3ba3)

Pricing is at https://openai.com/api/pricing/:

![image](https://github.com/promptfoo/promptfoo/assets/19716675/85bb5df5-88fa-4bf6-8466-2d13cf850a87)
