### PR TITLE
docs: add example and configuration guide for using llama.cpp

### DIFF
--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -1,0 +1,16 @@
+
+
+
+Install llama.cpp https://github.com/ggerganov/llama.cpp instructions can be found here 
+
+llama.cpp supports many models and can be converted to gguf format. We recommend downloading models from hugging face https://huggingface.co/models?library=gguf Note that you may have to authenticate with your hugging face account in their CLI to download models.
+
+Get the server started with
+
+```
+./llama-server -m your_model.gguf --port 8080
+```
+
+# Basic web UI can be accessed via browser: http://localhost:8080
+
+Note that we do not make any effort to format the prompts in a way that is compatible with llama.cpp. We simply pass the prompt as is. Therefore you may wish to add `[INST]` and `[/INST]` to the prompt to make it compatible with llama.cpp, etc. You should consult the docs for the specific model you are using to ensure compatibility with it's interface.

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -37,4 +37,3 @@ You can check to see if it's running by going to [http://localhost:8080](http://
 ## Note on Prompt Formatting
 
 We do not make any effort to format the prompts in a way that is compatible with `llama.cpp`. We simply pass the prompt as is. Therefore, you may wish to add `[INST]` and `[/INST]` to the prompt to make it compatible with `llama.cpp`, etc. You should consult the documentation for the specific model you are using to ensure compatibility with its interface. We provide a few different formatting examples to illustrate the different ways you can format your prompts.
-

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -21,18 +21,18 @@ You can check to see if it's running by going to [http://localhost:8080](http://
 2. Run the evaluation:
 
    ```sh
-   promptfoo eval
+   npx promptfoo@latest eval
    ```
 
 3. View the results:
 
    ```sh
-   promptfoo view
+   npx promptfoo@latest view
    ```
 
 ## Note on Supported Models
 
-`llama.cpp` supports many models, which can be converted to the GGUF format. We recommend downloading models from [Hugging Face](https://huggingface.co/models?library=gguf). Note that you may need to authenticate with your Hugging Face account in their CLI to download models.
+`llama.cpp` supports many models, which can be converted to the GGUF format. We recommend downloading models from [Hugging Face](https://huggingface.co/models?library=gguf). Note that you may need to [authenticate with your Hugging Face account](https://huggingface.co/docs/huggingface_hub/en/guides/cli) in their CLI to download models.
 
 ## Note on Prompt Formatting
 

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -1,23 +1,22 @@
-# Getting started with Promptfoo and llama.cpp
+# Getting Started with Promptfoo and llama.cpp
 
 ## Install llama.cpp
 
-To get started, install `llama.cpp` following the [instructions on their GitHub page](https://github.com/ggerganov/llama.cpp).
+To begin, install `llama.cpp` by following the [instructions on their GitHub page](https://github.com/ggerganov/llama.cpp).
 
 ## Starting the Server
 
-To get the server started, use the following command:
+To start the server, use the following command:
 
 ```bash
 ./llama-server -m your_model.gguf --port 8080
 ```
 
-You can check to see if it's running by going to [http://localhost:8080](http://localhost:8080).
+You can check if it's running by visiting [http://localhost:8080](http://localhost:8080).
 
 ## Configuring Promptfoo
 
-1. Edit the text files in the `prompts/` directory and make any necessary changes to `promptfooconfig.yaml`.
-
+1. Edit the prompts in `promptfooconfig.yaml`.
 2. Run the evaluation:
 
    ```sh
@@ -32,8 +31,12 @@ You can check to see if it's running by going to [http://localhost:8080](http://
 
 ## Note on Supported Models
 
-`llama.cpp` supports many models, which can be converted to the GGUF format. We recommend downloading models from [Hugging Face](https://huggingface.co/models?library=gguf). Note that you may need to [authenticate with your Hugging Face account](https://huggingface.co/docs/huggingface_hub/en/guides/cli) in their CLI to download models.
+`llama.cpp` supports many models that can be converted to the GGUF format. We recommend downloading models from [Hugging Face](https://huggingface.co/models?library=gguf). You may need to [authenticate with your Hugging Face account](https://huggingface.co/docs/huggingface_hub/en/guides/cli) using their CLI to download models.
 
 ## Note on Prompt Formatting
 
-We do not make any effort to format the prompts in a way that is compatible with `llama.cpp`. We simply pass the prompt as is. You should consult the documentation or model card for the specific model you are using to ensure compatibility with its interface. We provide a few different formatting examples to illustrate the different ways you can format your prompts.
+We do not format the prompts for compatibility with `llama.cpp`. Prompts are passed as-is. Refer to the documentation or model card for the specific model you are using to ensure compatibility with its interface. We provide various formatting examples to illustrate different ways to format your prompts.
+
+## Note on Caching
+
+Since promptfoo is unaware of the underlying model being run in `llama.cpp`, it will not invalidate the cache when the model is updated. This means you may see stale results from the cache if you change the model. Run `npx promptfoo@latest eval --no-cache` to perform the evaluation without using the cache.

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -1,16 +1,40 @@
+# Getting started with Promptfoo and llama.cpp
 
+## Install llama.cpp
 
+To get started, install `llama.cpp` following the [instructions on their GitHub page](https://github.com/ggerganov/llama.cpp).
 
-Install llama.cpp https://github.com/ggerganov/llama.cpp instructions can be found here 
+## Starting the Server
 
-llama.cpp supports many models and can be converted to gguf format. We recommend downloading models from hugging face https://huggingface.co/models?library=gguf Note that you may have to authenticate with your hugging face account in their CLI to download models.
+To get the server started, use the following command:
 
-Get the server started with
-
-```
+```bash
 ./llama-server -m your_model.gguf --port 8080
 ```
 
-# Basic web UI can be accessed via browser: http://localhost:8080
+You can check to see if it's running by going to [http://localhost:8080](http://localhost:8080).
 
-Note that we do not make any effort to format the prompts in a way that is compatible with llama.cpp. We simply pass the prompt as is. Therefore you may wish to add `[INST]` and `[/INST]` to the prompt to make it compatible with llama.cpp, etc. You should consult the docs for the specific model you are using to ensure compatibility with it's interface.
+## Configuring Promptfoo
+
+1. Edit the text files in the `prompts/` directory and make any necessary changes to `promptfooconfig.yaml`.
+
+2. Run the evaluation:
+
+   ```sh
+   promptfoo eval
+   ```
+
+3. View the results:
+
+   ```sh
+   promptfoo view
+   ```
+
+## Note on Supported Models
+
+`llama.cpp` supports many models, which can be converted to the GGUF format. We recommend downloading models from [Hugging Face](https://huggingface.co/models?library=gguf). Note that you may need to authenticate with your Hugging Face account in their CLI to download models.
+
+## Note on Prompt Formatting
+
+We do not make any effort to format the prompts in a way that is compatible with `llama.cpp`. We simply pass the prompt as is. Therefore, you may wish to add `[INST]` and `[/INST]` to the prompt to make it compatible with `llama.cpp`, etc. You should consult the documentation for the specific model you are using to ensure compatibility with its interface. We provide a few different formatting examples to illustrate the different ways you can format your prompts.
+

--- a/examples/llama-cpp/README.md
+++ b/examples/llama-cpp/README.md
@@ -36,4 +36,4 @@ You can check to see if it's running by going to [http://localhost:8080](http://
 
 ## Note on Prompt Formatting
 
-We do not make any effort to format the prompts in a way that is compatible with `llama.cpp`. We simply pass the prompt as is. Therefore, you may wish to add `[INST]` and `[/INST]` to the prompt to make it compatible with `llama.cpp`, etc. You should consult the documentation for the specific model you are using to ensure compatibility with its interface. We provide a few different formatting examples to illustrate the different ways you can format your prompts.
+We do not make any effort to format the prompts in a way that is compatible with `llama.cpp`. We simply pass the prompt as is. You should consult the documentation or model card for the specific model you are using to ensure compatibility with its interface. We provide a few different formatting examples to illustrate the different ways you can format your prompts.

--- a/examples/llama-cpp/promptfooconfig.yaml
+++ b/examples/llama-cpp/promptfooconfig.yaml
@@ -5,10 +5,10 @@ providers:
       baseUrl: http://localhost:8080
 
 prompts:
-  - "Write a funny tweet about {{topic}}"
+  - 'Write a funny tweet about {{topic}}'
   - "Human: Write a funny tweet about {{topic}}\nAI:"
   - "Q: Create a humorous tweet about {{topic}}\nA:"
-  - "[INST] Write a funny tweet about {{topic}} [/INST]"
+  - '[INST] Write a funny tweet about {{topic}} [/INST]'
   - "<human>: Craft a witty tweet about {{topic}}\n<assistant>:"
   - "### Instruction: Compose a clever tweet on the topic of {{topic}}\n### Response:"
   - "System: You are a witty AI.\nUser: Tweet about {{topic}}\nAssistant:"
@@ -18,8 +18,8 @@ prompts:
 
 tests:
   - vars:
-      topic: "San Francisco"
+      topic: 'San Francisco'
     assert:
       - type: icontains
-        value: "San Francisco"
+        value: 'San Francisco'
       - type: answer-relevance

--- a/examples/llama-cpp/promptfooconfig.yaml
+++ b/examples/llama-cpp/promptfooconfig.yaml
@@ -1,5 +1,6 @@
 providers:
   - id: llama
+    label: llama3-8b
     config:
       baseUrl: http://localhost:8080
 
@@ -16,11 +17,9 @@ prompts:
   - "# Context: You are a social media expert known for viral content.\n# Human: Create a funny tweet about {{topic}}\n# AI:"
 
 tests:
-  - description: "Test text summarization"
-    vars:
+  - vars:
       topic: "San Francisco"
     assert:
       - type: icontains
         value: "San Francisco"
       - type: answer-relevance
-        

--- a/examples/llama-cpp/promptfooconfig.yaml
+++ b/examples/llama-cpp/promptfooconfig.yaml
@@ -1,0 +1,26 @@
+providers:
+  - id: llama
+    config:
+      baseUrl: http://localhost:8080
+
+prompts:
+  - "Write a funny tweet about {{topic}}"
+  - "Human: Write a funny tweet about {{topic}}\nAI:"
+  - "Q: Create a humorous tweet about {{topic}}\nA:"
+  - "[INST] Write a funny tweet about {{topic}} [/INST]"
+  - "<human>: Craft a witty tweet about {{topic}}\n<assistant>:"
+  - "### Instruction: Compose a clever tweet on the topic of {{topic}}\n### Response:"
+  - "System: You are a witty AI.\nUser: Tweet about {{topic}}\nAssistant:"
+  - "<s>[INST] <<SYS>>\nYou're a comedy writer.\n<</SYS>>\nWrite a funny tweet about {{topic}} [/INST]"
+  - "{'role': 'system', 'content': 'You specialize in viral tweets.'}\n{'role': 'user', 'content': 'Write a hilarious tweet about {{topic}}'}\n{'role': 'assistant', 'content':"
+  - "# Context: You are a social media expert known for viral content.\n# Human: Create a funny tweet about {{topic}}\n# AI:"
+
+tests:
+  - description: "Test text summarization"
+    vars:
+      topic: "San Francisco"
+    assert:
+      - type: icontains
+        value: "San Francisco"
+      - type: answer-relevance
+        

--- a/site/docs/providers/llama.cpp.md
+++ b/site/docs/providers/llama.cpp.md
@@ -4,10 +4,14 @@ sidebar_position: 40
 
 # Llama.cpp
 
-The `llama` provider is compatible with the HTTP server bundled with [llama.cpp](https://github.com/ggerganov/llama.cpp).
+The `llama` provider is compatible with the HTTP server bundled with [llama.cpp](https://github.com/ggerganov/llama.cpp). This allows you to leverage the power of `llama.cpp` models within Promptfoo.
 
-You can use it by specifying `llama` as the provider.
+## Configuration
+
+To use the `llama` provider, specify `llama` as the provider in your `promptfooconfig.yaml` file.
 
 Supported environment variables:
 
-- `LLAMA_BASE_URL` - scheme, host name, and port (defaults to `http://localhost:8080`)
+- `LLAMA_BASE_URL` - Scheme, hostname, and port (defaults to `http://localhost:8080`)
+
+For a detailed example of how to use Promptfoo with `llama.cpp`, including configuration and setup, refer to the [example on GitHub](https://github.com/promptfoo/promptfoo/tree/main/examples/llama-cpp).

--- a/test/providers.llama.test.ts
+++ b/test/providers.llama.test.ts
@@ -1,0 +1,117 @@
+import { fetchWithCache } from '../src/cache';
+import { LlamaProvider } from '../src/providers/llama';
+import { REQUEST_TIMEOUT_MS } from '../src/providers/shared';
+
+jest.mock('../src/cache', () => ({
+  fetchWithCache: jest.fn(),
+}));
+
+describe('LlamaProvider', () => {
+  const modelName = 'testModel';
+  const config = {
+    temperature: 0.7,
+  };
+
+  describe('constructor', () => {
+    it('should initialize with modelName and config', () => {
+      const provider = new LlamaProvider(modelName, { config });
+      expect(provider.modelName).toBe(modelName);
+      expect(provider.config).toEqual(config);
+    });
+
+    it('should initialize with id function if id is provided', () => {
+      const id = 'testId';
+      const provider = new LlamaProvider(modelName, { config, id });
+      expect(provider.id()).toBe(id);
+    });
+  });
+
+  describe('id', () => {
+    it('should return the correct id string', () => {
+      const provider = new LlamaProvider(modelName);
+      expect(provider.id()).toBe(`llama:${modelName}`);
+    });
+  });
+
+  describe('toString', () => {
+    it('should return the correct string representation', () => {
+      const provider = new LlamaProvider(modelName);
+      expect(provider.toString()).toBe(`[Llama Provider ${modelName}]`);
+    });
+  });
+
+  describe('callApi', () => {
+    const prompt = 'test prompt';
+    const response = { data: { content: 'test response' } };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('should call fetchWithCache with correct parameters', async () => {
+      jest.mocked(fetchWithCache).mockResolvedValue({ ...response, cached: false });
+
+      const provider = new LlamaProvider(modelName, { config });
+      await provider.callApi(prompt);
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        `${process.env.LLAMA_BASE_URL || 'http://localhost:8080'}/completion`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            prompt,
+            n_predict: 512,
+            temperature: config.temperature,
+            top_k: undefined,
+            top_p: undefined,
+            n_keep: undefined,
+            stop: undefined,
+            repeat_penalty: undefined,
+            repeat_last_n: undefined,
+            penalize_nl: undefined,
+            presence_penalty: undefined,
+            frequency_penalty: undefined,
+            mirostat: undefined,
+            mirostat_tau: undefined,
+            mirostat_eta: undefined,
+            seed: undefined,
+            ignore_eos: undefined,
+            logit_bias: undefined,
+          }),
+        },
+        REQUEST_TIMEOUT_MS,
+      );
+    });
+    it('should return the correct response on success', async () => {
+      jest
+        .mocked(fetchWithCache)
+        .mockResolvedValue({ data: { content: 'test response' }, cached: false });
+
+      const provider = new LlamaProvider(modelName, { config });
+      const result = await provider.callApi(prompt);
+      expect(result).toEqual({ output: response.data.content });
+    });
+
+    it('should return an error if fetchWithCache throws an error', async () => {
+      const error = new Error('API call error');
+      jest.mocked(fetchWithCache).mockRejectedValue(error);
+
+      const provider = new LlamaProvider(modelName, { config });
+      const result = await provider.callApi(prompt);
+
+      expect(result).toEqual({ error: `API call error: ${String(error)}` });
+    });
+
+    it('should return an error if response data is malformed', async () => {
+      const malformedResponse = { data: null, cached: false };
+      jest.mocked(fetchWithCache).mockResolvedValue(malformedResponse);
+
+      const provider = new LlamaProvider(modelName, { config });
+      const result = await provider.callApi(prompt);
+      expect(result).toEqual({
+        error: `API response error: TypeError: Cannot read properties of null (reading 'content'): null`,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Addresses  https://github.com/promptfoo/promptfoo/issues/143 and adds a detailed example and configuration guide for integrating llama.cpp with Promptfoo.

Also adds tests for llama provider. 