### PR TITLE
refactor(redteam): relocate harmful and pii plugins from legacy directory

### DIFF
--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -1,4 +1,4 @@
-import { HARM_CATEGORIES } from './plugins/legacy/harmful';
+import { HARM_CATEGORIES } from './plugins/harmful';
 
 export const REDTEAM_MODEL = 'openai:chat:gpt-4o';
 

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -10,10 +10,10 @@ import CompetitorPlugin from './plugins/competitors';
 import ContractPlugin from './plugins/contracts';
 import ExcessiveAgencyPlugin from './plugins/excessiveAgency';
 import HallucinationPlugin from './plugins/hallucination';
+import { getHarmfulTests, addInjections, addIterativeJailbreaks } from './plugins/harmful';
 import HijackingPlugin from './plugins/hijacking';
-import { getHarmfulTests, addInjections, addIterativeJailbreaks } from './plugins/legacy/harmful';
-import { getPiiTests } from './plugins/legacy/pii';
 import OverreliancePlugin from './plugins/overreliance';
+import { getPiiTests } from './plugins/pii';
 import PoliticsPlugin from './plugins/politics';
 
 interface SynthesizeOptions {

--- a/src/redteam/plugins/harmful.ts
+++ b/src/redteam/plugins/harmful.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import invariant from 'tiny-invariant';
-import PromptfooHarmfulCompletionProvider from '../../../providers/promptfoo';
-import type { ApiProvider, TestCase } from '../../../types';
+import PromptfooHarmfulCompletionProvider from '../../providers/promptfoo';
+import type { ApiProvider, TestCase } from '../../types';
 
 const LLAMA_GUARD_REPLICATE_PROVIDER =
   'replicate:moderation:meta/meta-llama-guard-2-8b:b063023ee937f28e922982abdbf97b041ffe34ad3b35a53d33e1d74bb19b36c4';

--- a/src/redteam/plugins/pii.ts
+++ b/src/redteam/plugins/pii.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import invariant from 'tiny-invariant';
-import type { ApiProvider, TestCase } from '../../../types';
-import { getNunjucksEngine } from '../../../util';
+import type { ApiProvider, TestCase } from '../../types';
+import { getNunjucksEngine } from '../../util';
 
 /**
  * Generates a template for PII leak tests based on the provided examples.


### PR DESCRIPTION
These plugins were incorrectly placed in the legacy directory and should be in the main plugins directory.