### PR TITLE
fix(evaluator): ensure unique prompt handling with labeled and unlabeled providers

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -525,13 +525,14 @@ class Evaluator {
     for (const provider of testSuite.providers) {
       for (const prompt of testSuite.prompts) {
         // Check if providerPromptMap exists and if it contains the current prompt's label
-        if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[provider.id()])) {
+        const providerKey = provider.label || provider.id();
+        if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[providerKey])) {
           continue;
         }
         const completedPrompt = {
           ...prompt,
           id: sha256(typeof prompt.raw === 'object' ? JSON.stringify(prompt.raw) : prompt.raw),
-          provider: provider.label || provider.id(),
+          provider: providerKey,
           label: prompt.label,
           metrics: {
             score: 0,
@@ -652,7 +653,8 @@ class Evaluator {
           // Order matters - keep provider in outer loop to reduce need to swap models during local inference.
           for (const provider of testSuite.providers) {
             for (const prompt of testSuite.prompts) {
-              if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[provider.id()])) {
+              const providerKey = provider.label || provider.id();
+              if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[providerKey])) {
                 continue;
               }
               runEvalOptions.push({


### PR DESCRIPTION
This PR addresses an issue where providing different prompts per model is broken if the same provider id is used. It ensures that prompts are correctly mapped and processed based on either the provider's label or id. It resolves https://github.com/promptfoo/promptfoo/issues/1127 to test: 

```yaml
prompts:
  - prompt1
  - prompt2

providers:
  - id: 'python:provider.py'
    label: 'Provider 1'
    prompts:
      - prompt1
  - id: 'python:provider.py'
    label: 'Provider 2'
    prompts:
      - prompt2

tests:
  - description: 'Assert equals'
    assert:
      - type: equals
        value: 'prompt1'
```