### PR TITLE
feat(webui): eval picker

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -764,6 +764,16 @@ export interface ResultsFile {
   author: string | null;
 }
 
+// The eval results list returned by the server and used for the eval picker
+export interface ResultLightweight {
+  evalId: string;
+  createdAt: number;
+  description: string | null;
+  numTests: number;
+}
+
+export type ResultLightweightWithLabel = ResultLightweight & { label: string };
+
 // File exported as --output option
 export interface OutputFile {
   evalId: string | null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,6 +44,7 @@ import {
   type Prompt,
   type CompletedPrompt,
   type CsvRow,
+  type ResultLightweight,
   isApiProvider,
   isProviderOptions,
   OutputFileExtension,
@@ -316,12 +317,14 @@ export async function writeResultsToDatabase(
 export function listPreviousResults(
   limit: number = DEFAULT_QUERY_LIMIT,
   filterDescription?: string,
-): { evalId: string; description?: string | null }[] {
+): ResultLightweight[] {
   const db = getDb();
   let results = db
     .select({
-      name: evals.id,
+      evalId: evals.id,
+      createdAt: evals.createdAt,
       description: evals.description,
+      config: evals.config,
     })
     .from(evals)
     .orderBy(desc(evals.createdAt))
@@ -334,8 +337,10 @@ export function listPreviousResults(
   }
 
   return results.map((result) => ({
-    evalId: result.name,
+    evalId: result.evalId,
+    createdAt: result.createdAt,
     description: result.description,
+    numTests: result.config.tests?.length || 0,
   }));
 }
 

--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import { REMOTE_API_BASE_URL } from '@/../../../constants';
-import type { EvaluateSummary, UnifiedConfig, SharedResults } from '@/../../../types';
+import type {
+  EvaluateSummary,
+  UnifiedConfig,
+  SharedResults,
+  ResultLightweightWithLabel,
+} from '@/../../../types';
 import { getApiBaseUrl } from '@/api';
 import { ShiftKeyProvider } from '@/app/contexts/ShiftKeyContext';
 import { IS_RUNNING_LOCALLY, USE_SUPABASE } from '@/constants';
@@ -43,7 +48,7 @@ async function fetchEvalFromSupabase(
 interface EvalOptions {
   fetchId?: string;
   preloadedData?: SharedResults;
-  recentEvals?: { id: string; label: string }[];
+  recentEvals?: ResultLightweightWithLabel[];
   defaultEvalId?: string;
 }
 
@@ -57,7 +62,7 @@ export default function Eval({
   const { table, setTable, setConfig, setEvalId, setAuthor } = useStore();
   const [loaded, setLoaded] = React.useState(false);
   const [failed, setFailed] = React.useState(false);
-  const [recentEvals, setRecentEvals] = React.useState<{ id: string; label: string }[]>(
+  const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>(
     recentEvalsProp || [],
   );
 
@@ -90,7 +95,7 @@ export default function Eval({
   };
 
   const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
-    defaultEvalIdProp || recentEvals[0]?.id,
+    defaultEvalIdProp || recentEvals[0]?.evalId,
   );
 
   const searchParams = useSearchParams();
@@ -166,8 +171,11 @@ export default function Eval({
       fetchEvalsFromSupabase().then((records) => {
         setRecentEvals(
           records.map((r) => ({
-            id: r.id,
+            evalId: r.id,
             label: r.createdAt,
+            createdAt: new Date(r.createdAt).getTime(),
+            description: 'None',
+            numTests: -1,
           })),
         );
         if (records.length > 0) {

--- a/src/web/nextui/src/app/eval/EvalSelector.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelector.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import { ResultLightweightWithLabel } from './types';
+
+interface EvalSelectorProps {
+  recentEvals: ResultLightweightWithLabel[];
+  onRecentEvalSelected: (evalId: string) => void;
+  currentEval: ResultLightweightWithLabel | null;
+}
+
+const EvalSelector: React.FC<EvalSelectorProps> = ({
+  recentEvals,
+  onRecentEvalSelected,
+  currentEval,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleOpen = () => {
+    setOpen(true);
+    // Focus the search box when the dialog is opened
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 0);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSearchText('');
+  };
+
+  const filteredEvals = recentEvals.filter(
+    (_eval) =>
+      _eval.label.toLowerCase().includes(searchText.toLowerCase()) ||
+      _eval.description?.toLowerCase().includes(searchText.toLowerCase()),
+  );
+
+  const handleSelectEval = (evalId: string) => {
+    onRecentEvalSelected(evalId);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button variant="contained" onClick={handleOpen}>
+        Switch Eval
+      </Button>
+      <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+        <DialogTitle>Select Eval</DialogTitle>
+        <DialogContent>
+          <Box sx={{ width: '100%', mt: 2 }}>
+            <TextField
+              fullWidth
+              variant="outlined"
+              placeholder="Search"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              sx={{ mb: 2 }}
+              inputRef={searchInputRef}
+            />
+            <TableContainer component={Paper} sx={{ height: '600px', overflow: 'auto' }}>
+              <Table stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Created</TableCell>
+                    <TableCell>Description</TableCell>
+                    <TableCell># Tests</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {filteredEvals.map((_eval) => (
+                    <TableRow
+                      key={_eval.evalId}
+                      hover
+                      onClick={() => handleSelectEval(_eval.evalId)}
+                      sx={{ cursor: 'pointer' }}
+                    >
+                      <TableCell>{new Date(_eval.createdAt).toLocaleString()}</TableCell>
+                      <TableCell>{_eval.description || _eval.label}</TableCell>
+                      <TableCell>{_eval.numTests}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default EvalSelector;

--- a/src/web/nextui/src/app/eval/EvalSelector.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelector.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import FolderIcon from '@mui/icons-material/FolderOpen';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -56,9 +58,9 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
 
   return (
     <>
-      <Button variant="contained" onClick={handleOpen}>
-        Switch Eval
-      </Button>
+      <IconButton onClick={handleOpen} color="primary">
+        <FolderIcon />
+      </IconButton>
       <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>Select Eval</DialogTitle>
         <DialogContent>

--- a/src/web/nextui/src/app/eval/EvalSelector.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelector.tsx
@@ -101,7 +101,7 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
 
   React.useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {
-      if (!open && (event.ctrlKey || event.metaKey) && event.key === 'k') {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
         event.preventDefault();
         handleOpen();
       }

--- a/src/web/nextui/src/app/eval/EvalSelector.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelector.tsx
@@ -61,7 +61,7 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
     handleClose();
   };
 
-  const scrollToFocusedItem = () => {
+  const scrollToFocusedItem = React.useCallback(() => {
     if (focusedIndex >= 0 && tableContainerRef.current) {
       const tableRows = tableContainerRef.current.querySelectorAll('tbody tr');
       const targetIndex = Math.min(focusedIndex + 3, tableRows.length - 1);
@@ -72,7 +72,7 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
         });
       }
     }
-  };
+  }, [focusedIndex]);
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     switch (event.key) {
@@ -97,7 +97,7 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
 
   React.useEffect(() => {
     scrollToFocusedItem();
-  }, [focusedIndex]);
+  }, [scrollToFocusedItem]);
 
   React.useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {

--- a/src/web/nextui/src/app/eval/EvalSelector.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelector.tsx
@@ -114,10 +114,16 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
     };
   }, []);
 
+  const isMac =
+    typeof navigator === 'undefined'
+      ? false
+      : navigator.platform.toUpperCase().indexOf('MAC') !== -1;
+  const tooltipTitle = isMac ? 'Search for Evals (⌘ + K)' : 'Search for Evals (Ctrl + K)';
+
   return (
     <>
-      <Tooltip title="Search for Evals (Ctrl/Cmd + K)" arrow>
-        <IconButton onClick={handleOpen} color="primary">
+      <Tooltip title={tooltipTitle} arrow>
+        <IconButton onClick={handleOpen} color="primary" size="small">
           <FolderIcon />
         </IconButton>
       </Tooltip>

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -40,7 +40,7 @@ import ResultsTable from './ResultsTable';
 import SettingsModal from './ResultsViewSettingsModal';
 import ShareModal from './ShareModal';
 import { useStore as useResultsViewStore } from './store';
-import type { FilterMode } from './types';
+import type { FilterMode, ResultLightweightWithLabel } from './types';
 import './ResultsView.css';
 
 const ResponsiveStack = styled(Stack)(({ theme }) => ({
@@ -52,10 +52,7 @@ const ResponsiveStack = styled(Stack)(({ theme }) => ({
 }));
 
 interface ResultsViewProps {
-  recentEvals: {
-    id: string;
-    label: string;
-  }[];
+  recentEvals: ResultLightweightWithLabel[];
   onRecentEvalSelected: (file: string) => void;
   defaultEvalId?: string;
 }
@@ -320,18 +317,20 @@ export default function ResultsView({
                 size="small"
                 options={recentEvals}
                 renderOption={(props, option) => (
-                  <li {...props} key={option.id}>
-                    {option.label}
+                  <li {...props} key={option.evalId}>
+                    {option.label} - {option.numTests} tests
                   </li>
                 )}
                 style={{ width: 350 }}
                 renderInput={(params: AutocompleteRenderInputParams) => (
                   <TextField {...params} label="Eval run" variant="outlined" />
                 )}
-                defaultValue={recentEvals.find((evl) => evl.id === defaultEvalId) || recentEvals[0]}
-                onChange={(event, newValue: { label: string; id?: string } | null) => {
-                  if (newValue && newValue.id) {
-                    onRecentEvalSelected(newValue.id);
+                defaultValue={
+                  recentEvals.find((evl) => evl.evalId === defaultEvalId) || recentEvals[0]
+                }
+                onChange={(event, newValue: ResultLightweightWithLabel | null) => {
+                  if (newValue && newValue.evalId) {
+                    onRecentEvalSelected(newValue.evalId);
 
                     // Reset all filters and search
                     setSearchText('');

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -264,7 +264,13 @@ export default function ResultsView({
 
   return (
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
-      <Box mb={2} className="eval-header">
+      <ResponsiveStack
+        direction="row"
+        mb={2}
+        spacing={1}
+        alignItems="center"
+        className="eval-header"
+      >
         {recentEvals && recentEvals.length > 0 && (
           <EvalSelector
             recentEvals={recentEvals}
@@ -315,7 +321,7 @@ export default function ResultsView({
             sx={{ opacity: 0.7 }}
           />
         </Tooltip>
-      </Box>
+      </ResponsiveStack>
       <ResponsiveStack direction="row" spacing={4} alignItems="center">
         <Box>
           <FormControl sx={{ m: 1, minWidth: 200, maxWidth: 350 }} size="small">

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -265,6 +265,13 @@ export default function ResultsView({
   return (
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
       <Box mb={2} className="eval-header">
+        {recentEvals && recentEvals.length > 0 && (
+          <EvalSelector
+            recentEvals={recentEvals}
+            onRecentEvalSelected={onRecentEvalSelected}
+            currentEval={recentEvals.find((evl) => evl.evalId === evalId) || null}
+          />
+        )}
         <Typography variant="h5" sx={{ display: 'flex', alignItems: 'center' }}>
           <Tooltip title="Click to edit description">
             <span className="description" onClick={handleDescriptionClick}>
@@ -283,7 +290,6 @@ export default function ResultsView({
                   </>
                 }
                 sx={{
-                  ml: 1,
                   opacity: 0.7,
                   cursor: 'pointer',
                 }}
@@ -306,7 +312,7 @@ export default function ResultsView({
                 <strong>Author:</strong> {author || 'Unknown'}
               </>
             }
-            sx={{ ml: 1, opacity: 0.7 }}
+            sx={{ opacity: 0.7 }}
           />
         </Tooltip>
       </Box>
@@ -362,13 +368,6 @@ export default function ResultsView({
         <Box flexGrow={1} />
         <Box display="flex" justifyContent="flex-end">
           <ResponsiveStack direction="row" spacing={2}>
-            {recentEvals && recentEvals.length > 0 && (
-              <EvalSelector
-                recentEvals={recentEvals}
-                onRecentEvalSelected={onRecentEvalSelected}
-                currentEval={recentEvals.find((evl) => evl.evalId === evalId) || null}
-              />
-            )}
             <Button color="primary" onClick={handleOpenMenu} startIcon={<ArrowDropDownIcon />}>
               Eval actions
             </Button>

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -35,6 +35,7 @@ import invariant from 'tiny-invariant';
 import { useDebounce } from 'use-debounce';
 import ConfigModal from './ConfigModal';
 import DownloadMenu from './DownloadMenu';
+import EvalSelector from './EvalSelector';
 import ResultsCharts from './ResultsCharts';
 import ResultsTable from './ResultsTable';
 import SettingsModal from './ResultsViewSettingsModal';
@@ -311,39 +312,6 @@ export default function ResultsView({
       </Box>
       <ResponsiveStack direction="row" spacing={4} alignItems="center">
         <Box>
-          {recentEvals && recentEvals.length > 0 && (
-            <FormControl sx={{ m: 1, minWidth: 200 }} size="small">
-              <Autocomplete
-                size="small"
-                options={recentEvals}
-                renderOption={(props, option) => (
-                  <li {...props} key={option.evalId}>
-                    {option.label} - {option.numTests} tests
-                  </li>
-                )}
-                style={{ width: 350 }}
-                renderInput={(params: AutocompleteRenderInputParams) => (
-                  <TextField {...params} label="Eval run" variant="outlined" />
-                )}
-                defaultValue={
-                  recentEvals.find((evl) => evl.evalId === defaultEvalId) || recentEvals[0]
-                }
-                onChange={(event, newValue: ResultLightweightWithLabel | null) => {
-                  if (newValue && newValue.evalId) {
-                    onRecentEvalSelected(newValue.evalId);
-
-                    // Reset all filters and search
-                    setSearchText('');
-                    setFilterMode('all');
-                    setFailureFilter({});
-                  }
-                }}
-                disableClearable
-              />
-            </FormControl>
-          )}
-        </Box>
-        <Box>
           <FormControl sx={{ m: 1, minWidth: 200, maxWidth: 350 }} size="small">
             <InputLabel id="visible-columns-label">Columns</InputLabel>
             <Select
@@ -394,6 +362,13 @@ export default function ResultsView({
         <Box flexGrow={1} />
         <Box display="flex" justifyContent="flex-end">
           <ResponsiveStack direction="row" spacing={2}>
+            {recentEvals && recentEvals.length > 0 && (
+              <EvalSelector
+                recentEvals={recentEvals}
+                onRecentEvalSelected={onRecentEvalSelected}
+                currentEval={recentEvals.find((evl) => evl.evalId === evalId) || null}
+              />
+            )}
             <Button color="primary" onClick={handleOpenMenu} startIcon={<ArrowDropDownIcon />}>
               Eval actions
             </Button>

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -9,7 +9,6 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import ShareIcon from '@mui/icons-material/Share';
 import EyeIcon from '@mui/icons-material/Visibility';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import Autocomplete, { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';

--- a/src/web/nextui/src/app/eval/[id]/page.tsx
+++ b/src/web/nextui/src/app/eval/[id]/page.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { EvaluateSummary, SharedResults, UnifiedConfig } from '@/../../../types';
+import {
+  EvaluateSummary,
+  ResultLightweightWithLabel,
+  SharedResults,
+  UnifiedConfig,
+} from '@/../../../types';
 import { getApiBaseUrl } from '@/api';
 import { IS_RUNNING_LOCALLY } from '@/constants';
 import { getResult } from '@/database';
@@ -25,7 +30,7 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: { params: { id: string } }) {
   let sharedResults: SharedResults;
-  let recentEvals: { id: string; label: string }[] = [];
+  let recentEvals: ResultLightweightWithLabel[] = [];
   let defaultEvalId: string | undefined;
   const decodedId = decodeURIComponent(params.id);
   if (decodedId.startsWith('local:')) {
@@ -74,7 +79,13 @@ export default async function Page({ params }: { params: { id: string } }) {
         .order('createdAt', { ascending: false })
         .limit(100);
       if (data) {
-        recentEvals = data.map((row) => ({ id: row.id, label: row.createdAt }));
+        recentEvals = data.map((row) => ({
+          evalId: row.id,
+          label: row.createdAt,
+          createdAt: row.createdAt,
+          description: 'None',
+          numTests: 0,
+        }));
       }
     }
   } else {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -89,7 +89,7 @@ export async function startServer(
     res.json({
       data: previousResults.map((meta) => {
         return {
-          id: meta.evalId,
+          ...meta,
           label: meta.description ? `${meta.description} (${meta.evalId})` : meta.evalId,
         };
       }),


### PR DESCRIPTION
Replaces eval dropdown with 

![image](https://github.com/user-attachments/assets/aae0f691-dafb-4ffe-85c0-b6346e40aef3)

- includes ctrl/cmd + k keyboard shortcut and keyboard nav
- also plumbs through a little more info on each eval (we can add more later)

This component will also be used for "combine evals" use case (#1098, #1025) and favoriting evals (#1031)