### PR TITLE
fix(http provider): fix JSON prompt escaping in HTTP provider and add LM Studio example

### DIFF
--- a/examples/lm-studio/README.md
+++ b/examples/lm-studio/README.md
@@ -1,0 +1,52 @@
+# LM Studio Example with PromptFoo
+
+This example demonstrates how to use PromptFoo with LM Studio for prompt evaluation. It showcases configuration for interacting with the LM Studio API using a locally hosted language model.
+
+## Prerequisites
+
+1. **LM Studio**: Install LM Studio from [lmstudio.ai](https://lmstudio.ai/).
+2. **Model**: Download the `bartowski/gemma-2-9b-it-GGUF` model in LM Studio.
+
+## Setup
+
+1. **Start LM Studio Server**:
+
+   - Open LM Studio and load the `bartowski/gemma-2-9b-it-GGUF` model.
+   - Start a local server to host the model (usually at `http://localhost:1234`).
+
+2. **Configure PromptFoo**:
+
+   Create a `promptfooconfig.yaml` file with the following content:
+
+   ```yaml
+   providers:
+     - id: 'http://localhost:1234/v1/chat/completions'
+       config:
+         method: 'POST'
+         headers:
+           'Content-Type': 'application/json'
+         body:
+           messages: '{{ prompt }}'
+           model: 'bartowski/gemma-2-9b-it-GGUF'
+           temperature: 0.7
+           max_tokens: -1
+         responseParser: 'json.choices[0].message.content'
+   ```
+
+   Note that you can view the specific configuration for each model within LM Studio's examples in the server tab.
+
+## Usage
+
+1. **Run Evaluation**:
+
+   ```
+   npx promptfoo eval
+   ```
+
+2. **View Results**:
+
+   ```sh
+   npx promptfoo view
+   ```
+
+For more information, see the [PromptFoo documentation](https://www.promptfoo.dev/docs/providers/http) on how to set up a custom HTTP provider.

--- a/examples/lm-studio/README.md
+++ b/examples/lm-studio/README.md
@@ -1,6 +1,6 @@
-# LM Studio Example with PromptFoo
+# LM Studio Example with Promptfoo
 
-This example demonstrates how to use PromptFoo with LM Studio for prompt evaluation. It showcases configuration for interacting with the LM Studio API using a locally hosted language model.
+This example demonstrates how to use Promptfoo with LM Studio for prompt evaluation. It showcases configuration for interacting with the LM Studio API using a locally hosted language model.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This example demonstrates how to use PromptFoo with LM Studio for prompt evaluat
    - Open LM Studio and load the `bartowski/gemma-2-9b-it-GGUF` model.
    - Start a local server to host the model (usually at `http://localhost:1234`).
 
-2. **Configure PromptFoo**:
+2. **Configure Promptfoo**:
 
    Create a `promptfooconfig.yaml` file with the following content:
 
@@ -49,4 +49,4 @@ This example demonstrates how to use PromptFoo with LM Studio for prompt evaluat
    npx promptfoo view
    ```
 
-For more information, see the [PromptFoo documentation](https://www.promptfoo.dev/docs/providers/http) on how to set up a custom HTTP provider.
+For more information, see the [Promptfoo documentation](https://www.promptfoo.dev/docs/providers/http) on how to set up a custom HTTP provider.

--- a/examples/lm-studio/promptfooconfig.yaml
+++ b/examples/lm-studio/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 description: 'LM Studio Eval Example'
 prompts:
-  - file://prompts.js
+  - file://prompts.json
 providers:
   - id: 'http://localhost:1234/v1/chat/completions'
     config:

--- a/examples/lm-studio/promptfooconfig.yaml
+++ b/examples/lm-studio/promptfooconfig.yaml
@@ -1,0 +1,18 @@
+description: 'LM Studio Eval Example'
+prompts:
+  - file://prompts.js
+providers:
+  - id: 'http://localhost:1234/v1/chat/completions'
+    config:
+      method: 'POST'
+      headers:
+        'Content-Type': 'application/json'
+      body:
+        messages: '{{ prompt }}'
+        model: 'bartowski/gemma-2-9b-it-GGUF'
+        temperature: 0.7
+        max_tokens: -1
+      responseParser: 'json.choices[0].message.content'
+tests:
+  - vars:
+      topic: bananas

--- a/examples/lm-studio/prompts.json
+++ b/examples/lm-studio/prompts.json
@@ -1,0 +1,4 @@
+[
+  { "role": "system", "content": "You are a helpful assistant" },
+  { "role": "user", "content": "Tell me about {{topic}}" }
+]

--- a/src/config.ts
+++ b/src/config.ts
@@ -345,7 +345,7 @@ export async function resolveConfigs(
     sharing:
       process.env.PROMPTFOO_DISABLE_SHARING === '1'
         ? false
-        : fileConfig.sharing ?? defaultConfig.sharing ?? true,
+        : (fileConfig.sharing ?? defaultConfig.sharing ?? true),
     defaultTest: defaultTestRaw ? await readTest(defaultTestRaw, basePath) : undefined,
     derivedMetrics: fileConfig.derivedMetrics || defaultConfig.derivedMetrics,
     outputPath: cmdObj.output || fileConfig.outputPath || defaultConfig.outputPath,

--- a/src/config.ts
+++ b/src/config.ts
@@ -345,7 +345,7 @@ export async function resolveConfigs(
     sharing:
       process.env.PROMPTFOO_DISABLE_SHARING === '1'
         ? false
-        : (fileConfig.sharing ?? defaultConfig.sharing ?? true),
+        : fileConfig.sharing ?? defaultConfig.sharing ?? true,
     defaultTest: defaultTestRaw ? await readTest(defaultTestRaw, basePath) : undefined,
     derivedMetrics: fileConfig.derivedMetrics || defaultConfig.derivedMetrics,
     outputPath: cmdObj.output || fileConfig.outputPath || defaultConfig.outputPath,

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -8,7 +8,7 @@ import type {
   ProviderOptions,
   ProviderResponse,
 } from '../types.js';
-import { getNunjucksEngine, safeJsonStringify } from '../util';
+import { getNunjucksEngine, isValidJson, safeJsonStringify } from '../util';
 import { REQUEST_TIMEOUT_MS } from './shared';
 
 function createResponseParser(parser: any): (data: any) => ProviderResponse {
@@ -19,15 +19,6 @@ function createResponseParser(parser: any): (data: any) => ProviderResponse {
     return new Function('json', `return ${parser}`) as (data: any) => ProviderResponse;
   }
   return (data) => ({ output: data });
-}
-
-function isValidJson(str: string): boolean {
-  try {
-    JSON.parse(str);
-    return true;
-  } catch (e) {
-    return false;
-  }
 }
 
 export class HttpProvider implements ApiProvider {

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -54,10 +54,11 @@ export class HttpProvider implements ApiProvider {
     const nunjucks = getNunjucksEngine();
     const stringifiedConfig = safeJsonStringify(this.config);
     const renderedConfigString = nunjucks.renderString(stringifiedConfig, {
-      // escape prompt if it's a JSON because nunjucks does not escape it
+      // nunjucks does not escape JSON strings, so we need to escape them manually
       prompt: isValidJson(prompt) ? prompt.replace(/"/g, '\\"') : prompt,
       ...context?.vars,
     });
+    // use yaml over json.parse because of trailing commas, quotes, and comments
     const renderedConfig = yaml.load(renderedConfigString) as {
       method: string;
       headers: Record<string, string>;

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -46,7 +46,7 @@ export class HttpProvider implements ApiProvider {
     const stringifiedConfig = safeJsonStringify(this.config);
     const renderedConfigString = nunjucks.renderString(stringifiedConfig, {
       // nunjucks does not escape JSON strings, so we need to escape them manually
-      prompt: isValidJson(prompt) ? prompt.replace(/"/g, '\\"') : prompt,
+      prompt: isValidJson(prompt) ? JSON.stringify(prompt).slice(1, -1) : prompt,
       ...context?.vars,
     });
     // use yaml over json.parse because of trailing commas, quotes, and comments

--- a/src/util.ts
+++ b/src/util.ts
@@ -1081,6 +1081,15 @@ export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | obj
   return obj;
 }
 
+export function isValidJson(str: string): boolean {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export function extractJsonObjects(str: string): object[] {
   // This will extract all json objects from a string
 
@@ -1163,13 +1172,4 @@ export function parsePathOrGlob(
     functionName,
     isPathPattern,
   };
-}
-
-export function isValidJson(str: string): boolean {
-  try {
-    JSON.parse(str);
-    return true;
-  } catch (e) {
-    return false;
-  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1164,3 +1164,12 @@ export function parsePathOrGlob(
     isPathPattern,
   };
 }
+
+export function isValidJson(str: string): boolean {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -153,7 +153,9 @@ describe('HttpProvider', () => {
       config: invalidConfig as any,
     });
 
-    await expect(provider.callApi('test prompt')).rejects.toThrow();
+    await expect(provider.callApi('test prompt')).rejects.toThrow(
+      new Error("Cannot read properties of undefined (reading 'data')"),
+    );
   });
 
   it('should return provider id and string representation', () => {

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -6,28 +6,41 @@ jest.mock('../src/cache', () => ({
 }));
 
 describe('HttpProvider', () => {
-  afterEach(() => {
+  const mockUrl = 'http://example.com/api';
+  let provider: HttpProvider;
+
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should call the API and return the response', async () => {
-    const provider = new HttpProvider('http://example.com/api', {
+    provider = new HttpProvider(mockUrl, {
       config: {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: { key: 'value' },
+        body: { key: '{{ prompt }}' },
         responseParser: (data: any) => data.result,
       },
     });
     const mockResponse = { data: { result: 'response text' }, cached: false };
-    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
     const result = await provider.callApi('test prompt');
     expect(result.output).toBe('response text');
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      mockUrl,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'test prompt' }),
+      }),
+      expect.any(Number),
+      'json'
+    );
   });
 
   it('should handle API call errors', async () => {
-    const provider = new HttpProvider('http://example.com/api', {
+    provider = new HttpProvider(mockUrl, {
       config: {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -35,12 +48,119 @@ describe('HttpProvider', () => {
         responseParser: (data: any) => data.result,
       },
     });
-    const mockError = new Error('something went wrong');
-    jest.mocked(fetchWithCache).mockRejectedValue(mockError);
+    const mockError = new Error('Network error');
+    jest.mocked(fetchWithCache).mockRejectedValueOnce(mockError);
 
     const result = await provider.callApi('test prompt');
     expect(result).toEqual({
-      error: `HTTP call error: Error: something went wrong`,
+      error: 'HTTP call error: Error: Network error',
     });
+  });
+
+  it('should use custom method and headers', async () => {
+    provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'GET',
+        headers: { 'Authorization': 'Bearer token' },
+        responseParser: (data: any) => data,
+      },
+    });
+    const mockResponse = { data: 'custom response', cached: false };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi('test prompt');
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      mockUrl,
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'Authorization': 'Bearer token' },
+      }),
+      expect.any(Number),
+      'json'
+    );
+  });
+
+  const testCases = [
+    { parser: (data: any) => data.custom, expected: 'parsed' },
+    { parser: 'json.result', expected: 'parsed' },
+  ];
+
+  testCases.forEach(({ parser, expected }) => {
+    it(`should handle response parser type: ${parser}`, async () => {
+      provider = new HttpProvider(mockUrl, {
+        config: { responseParser: parser },
+      });
+      const mockResponse = { data: { result: 'parsed', custom: 'parsed' }, cached: false };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test prompt');
+      expect(result.output).toEqual(expected);
+    });
+  });
+
+  it('should correctly render Nunjucks templates in config', async () => {
+    provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'POST',
+        headers: { 'X-Custom-Header': '{{ prompt | upper }}' },
+        body: { key: '{{ prompt }}' },
+        responseParser: (data: any) => data,
+      },
+    });
+    const mockResponse = { data: 'custom response', cached: false };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi('test prompt');
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      mockUrl,
+      {
+        method: 'POST',
+        headers: { 'X-Custom-Header': 'TEST PROMPT' },
+        body: JSON.stringify({ key: 'test prompt' }),
+      },
+      expect.any(Number),
+      'json'
+    );
+  });
+
+  it('should escape JSON prompts in Nunjucks rendering', async () => {
+    provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: { key: '{{ prompt }}' },
+        responseParser: (data: any) => data,
+      },
+    });
+    const jsonPrompt = '{"key": "value"}';
+    const mockResponse = { data: 'response', cached: false };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi(jsonPrompt);
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      mockUrl,
+      expect.objectContaining({
+        body: JSON.stringify({ key: '{"key": "value"}' }),
+      }),
+      expect.any(Number),
+      'json'
+    );
+  });
+
+  it('should handle invalid JSON in config', async () => {
+    const invalidConfig = '{invalid:json}';
+    provider = new HttpProvider(mockUrl, {
+      config: invalidConfig as any,
+    });
+
+    await expect(provider.callApi('test prompt')).rejects.toThrow();
+  });
+
+  it('should return provider id and string representation', () => {
+    provider = new HttpProvider(mockUrl, {
+      config: {},
+    });
+    expect(provider.id()).toBe(mockUrl);
+    expect(provider.toString()).toBe(`[HTTP Provider ${mockUrl}]`);
   });
 });

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -35,7 +35,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: 'test prompt' }),
       }),
       expect.any(Number),
-      'json'
+      'json',
     );
   });
 
@@ -61,7 +61,7 @@ describe('HttpProvider', () => {
     provider = new HttpProvider(mockUrl, {
       config: {
         method: 'GET',
-        headers: { 'Authorization': 'Bearer token' },
+        headers: { Authorization: 'Bearer token' },
         responseParser: (data: any) => data,
       },
     });
@@ -73,10 +73,10 @@ describe('HttpProvider', () => {
       mockUrl,
       expect.objectContaining({
         method: 'GET',
-        headers: { 'Authorization': 'Bearer token' },
+        headers: { Authorization: 'Bearer token' },
       }),
       expect.any(Number),
-      'json'
+      'json',
     );
   });
 
@@ -119,7 +119,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: 'test prompt' }),
       },
       expect.any(Number),
-      'json'
+      'json',
     );
   });
 
@@ -143,7 +143,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: '{"key": "value"}' }),
       }),
       expect.any(Number),
-      'json'
+      'json',
     );
   });
 


### PR DESCRIPTION
This PR  fixes an issue where JSON prompts were not being escaped properly when rendered by Nunjucks in HTTP providers and introduces a new example for using PromptFoo with LM Studio. This should resolve https://github.com/promptfoo/promptfoo/issues/1120 

How to Test:

1. Follow the setup instructions in `examples/lm-studio/README.md`.

CC @luiscosio @vaibhav-toddleapp
