### PR TITLE
feat(anthropic): update default model providers to claude 3.5

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -392,9 +392,13 @@ export class AnthropicCompletionProvider implements ApiProvider {
   }
 }
 
-export const DefaultGradingProvider = new AnthropicMessagesProvider('claude-3-opus-20240229');
-export const DefaultGradingJsonProvider = new AnthropicMessagesProvider('claude-3-opus-20240229');
-export const DefaultSuggestionsProvider = new AnthropicMessagesProvider('claude-3-opus-20240229');
+export const DefaultGradingProvider = new AnthropicMessagesProvider('claude-3-5-sonnet-20240620');
+export const DefaultGradingJsonProvider = new AnthropicMessagesProvider(
+  'claude-3-5-sonnet-20240620',
+);
+export const DefaultSuggestionsProvider = new AnthropicMessagesProvider(
+  'claude-3-5-sonnet-20240620',
+);
 
 export class AnthropicLlmRubricProvider extends AnthropicMessagesProvider {
   constructor(modelName: string) {


### PR DESCRIPTION
Updated default Anthropic model providers from `claude-3-opus-20240229` to `claude-3-5-sonnet-20240620` for:

- DefaultGradingProvider
- DefaultGradingJsonProvider
- DefaultSuggestionsProvider
