### PR TITLE
chore(deps): bump dependencies with patch and minor version updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@anthropic-ai/sdk": "^0.24.3",
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
         "@googleapis/sheets": "^9.0.0",
-        "ajv": "^8.16.0",
+        "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1",
         "async": "^3.2.5",
         "better-sqlite3": "^11.1.2",
@@ -44,7 +44,7 @@
         "mathjs": "^13.0.2",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
-        "openai": "^4.52.3",
+        "openai": "^4.52.7",
         "opener": "^1.5.2",
         "proxy-agent": "^6.4.0",
         "python-shell": "^5.0.0",
@@ -55,16 +55,16 @@
         "socket.io": "^4.7.5",
         "tiny-invariant": "^1.3.3",
         "uuid": "^10.0.0",
-        "winston": "^3.13.0",
+        "winston": "^3.13.1",
         "zod": "^3.23.8"
       },
       "bin": {
         "promptfoo": "dist/src/main.js"
       },
       "devDependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.609.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.614.0",
         "@azure/identity": "^4.3.0",
-        "@eslint/js": "^9.6.0",
+        "@eslint/js": "^9.7.0",
         "@libsql/client": "^0.7.0",
         "@swc/cli": "^0.4.0",
         "@swc/core": "^1.6.13",
@@ -100,11 +100,11 @@
         "jest-watch-typeahead": "^2.2.2",
         "next": "13.4.13",
         "nock": "^13.5.4",
-        "prettier": "^3.3.2",
+        "prettier": "^3.3.3",
         "shx": "^0.3.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.3",
-        "typescript-eslint": "^7.15.0"
+        "typescript-eslint": "^7.16.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5179,9 +5179,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.6.0.tgz",
-      "integrity": "sha512-D9B0/3vNg44ZeWbYMpBoXqNP4j6eQD5vNwIlGAuFRRzK/WtT/jvDQW3Bi9kkf3PMDMlM7Yi+73VLUsn5bJcl8A==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.7.0.tgz",
+      "integrity": "sha512-ChuWDQenef8OSFnvuxv0TCVxEwmu3+hPNKvM9B34qpM0rDRbjL8t5QkQeHHeAfsKQjuH9wS82WeCi1J/owatng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9234,14 +9234,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.15.0.tgz",
-      "integrity": "sha512-SkgriaeV6PDvpA6253PDVep0qCqgbO1IOBiycjnXsszNTVQe5flN5wR5jiczoEoDEnAqYFSFFc9al9BSGVltkg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.16.0.tgz",
+      "integrity": "sha512-j0fuUswUjDHfqV/UdW6mLtOQQseORqfdmoBNDFOqs9rvNVR2e+cmu6zJu/Ku4SDuqiJko6YnhwcL8x45r8Oqxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.15.0",
-        "@typescript-eslint/utils": "7.15.0",
+        "@typescript-eslint/typescript-estree": "7.16.0",
+        "@typescript-eslint/utils": "7.16.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -9262,9 +9262,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9276,14 +9276,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-      "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.0.tgz",
+      "integrity": "sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -9305,13 +9305,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-      "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
+      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -9376,16 +9376,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
-      "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.16.0.tgz",
+      "integrity": "sha512-PqP4kP3hb4r7Jav+NiRCntlVzhxBNWq6ZQ+zQwII1y/G/1gdIPeYDCKr2+dH6049yJQsWZiHU6RlwvIFBXXGNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.15.0",
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/typescript-estree": "7.15.0"
+        "@typescript-eslint/scope-manager": "7.16.0",
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/typescript-estree": "7.16.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -9399,14 +9399,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
-      "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.0.tgz",
+      "integrity": "sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0"
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -9417,9 +9417,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9431,14 +9431,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-      "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.0.tgz",
+      "integrity": "sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -9460,13 +9460,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-      "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
+      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -9732,14 +9732,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -14807,6 +14808,12 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
       "license": "MIT"
     },
     "node_modules/fast-url-parser": {
@@ -22004,10 +22011,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -25514,15 +25522,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.15.0.tgz",
-      "integrity": "sha512-Ta40FhMXBCwHura4X4fncaCVkVcnJ9jnOq5+Lp4lN8F4DzHZtOwZdRvVBiNUGznUDHPwdGnrnwxmUOU2fFQqFA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.16.0.tgz",
+      "integrity": "sha512-kaVRivQjOzuoCXU6+hLnjo3/baxyzWVO5GrnExkFzETRYJKVHYkrJglOu2OCm8Hi9RPDWX1PTNNTpU5KRV0+RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.15.0",
-        "@typescript-eslint/parser": "7.15.0",
-        "@typescript-eslint/utils": "7.15.0"
+        "@typescript-eslint/eslint-plugin": "7.16.0",
+        "@typescript-eslint/parser": "7.16.0",
+        "@typescript-eslint/utils": "7.16.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -25541,17 +25549,17 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.15.0.tgz",
-      "integrity": "sha512-uiNHpyjZtFrLwLDpHnzaDlP3Tt6sGMqTCiqmxaN4n4RP0EfYZDODJyddiFDF44Hjwxr5xAcaYxVKm9QKQFJFLA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.0.tgz",
+      "integrity": "sha512-py1miT6iQpJcs1BiJjm54AMzeuMPBSPuKPlnT8HlfudbcS5rYeX5jajpLf3mrdRh9dA/Ec2FVUY0ifeVNDIhZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.15.0",
-        "@typescript-eslint/type-utils": "7.15.0",
-        "@typescript-eslint/utils": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
+        "@typescript-eslint/scope-manager": "7.16.0",
+        "@typescript-eslint/type-utils": "7.16.0",
+        "@typescript-eslint/utils": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -25575,16 +25583,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.15.0.tgz",
-      "integrity": "sha512-k9fYuQNnypLFcqORNClRykkGOMOj+pV6V91R4GO/l1FDGwpqmSwoOQrOHo3cGaH63e+D3ZiCAOsuS/D2c99j/A==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.16.0.tgz",
+      "integrity": "sha512-ar9E+k7CU8rWi2e5ErzQiC93KKEFAXA2Kky0scAlPcxYblLt8+XZuHUZwlyfXILyQa95P6lQg+eZgh/dDs3+Vw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.15.0",
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/typescript-estree": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
+        "@typescript-eslint/scope-manager": "7.16.0",
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/typescript-estree": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -25604,14 +25612,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
-      "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.16.0.tgz",
+      "integrity": "sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0"
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -25622,9 +25630,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25636,14 +25644,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-      "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.16.0.tgz",
+      "integrity": "sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
+        "@typescript-eslint/visitor-keys": "7.16.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -25665,13 +25673,13 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-      "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.16.0.tgz",
+      "integrity": "sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/types": "7.16.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -26718,15 +26726,16 @@
       "license": "MIT"
     },
     "node_modules/winston": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.1.tgz",
+      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
+        "logform": "^2.6.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "node-sql-parser": "^5.2.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.609.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.614.0",
     "@azure/identity": "^4.3.0",
-    "@eslint/js": "^9.6.0",
+    "@eslint/js": "^9.7.0",
     "@libsql/client": "^0.7.0",
     "@swc/cli": "^0.4.0",
     "@swc/core": "^1.6.13",
@@ -100,17 +100,17 @@
     "jest-watch-typeahead": "^2.2.2",
     "next": "13.4.13",
     "nock": "^13.5.4",
-    "prettier": "^3.3.2",
+    "prettier": "^3.3.3",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
-    "typescript-eslint": "^7.15.0"
+    "typescript-eslint": "^7.16.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.24.3",
     "@apidevtools/json-schema-ref-parser": "^11.6.4",
     "@googleapis/sheets": "^9.0.0",
-    "ajv": "^8.16.0",
+    "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1",
     "async": "^3.2.5",
     "better-sqlite3": "^11.1.2",
@@ -138,7 +138,7 @@
     "mathjs": "^13.0.2",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
-    "openai": "^4.52.3",
+    "openai": "^4.52.7",
     "opener": "^1.5.2",
     "proxy-agent": "^6.4.0",
     "python-shell": "^5.0.0",
@@ -149,7 +149,7 @@
     "socket.io": "^4.7.5",
     "tiny-invariant": "^1.3.3",
     "uuid": "^10.0.0",
-    "winston": "^3.13.0",
+    "winston": "^3.13.1",
     "zod": "^3.23.8"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -345,7 +345,7 @@ export async function resolveConfigs(
     sharing:
       process.env.PROMPTFOO_DISABLE_SHARING === '1'
         ? false
-        : fileConfig.sharing ?? defaultConfig.sharing ?? true,
+        : (fileConfig.sharing ?? defaultConfig.sharing ?? true),
     defaultTest: defaultTestRaw ? await readTest(defaultTestRaw, basePath) : undefined,
     derivedMetrics: fileConfig.derivedMetrics || defaultConfig.derivedMetrics,
     outputPath: cmdObj.output || fileConfig.outputPath || defaultConfig.outputPath,


### PR DESCRIPTION
Updated various dependencies to their latest versions in package-lock.json and package.json, including:

- ajv from 8.16.0 to 8.17.1
- openai from 4.52.3 to 4.52.7
- winston from 3.13.0 to 3.13.1
- @aws-sdk/client-bedrock-runtime from 3.609.0 to 3.614.0
- @eslint/js from 9.6.0 to 9.7.0
- prettier from 3.3.2 to 3.3.3
- typescript-eslint from 7.15.0 to 7.16.0