### PR TITLE
chore: static imports for iterative providers

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -55,6 +55,8 @@ import { ScriptCompletionProvider } from './providers/scriptCompletion';
 import { VertexChatProvider, VertexEmbeddingProvider } from './providers/vertex';
 import { VoyageEmbeddingProvider } from './providers/voyage';
 import { WebhookProvider } from './providers/webhook';
+import RedteamIterativeProvider from './redteam/providers/iterative';
+import RedteamImageIterativeProvider from './redteam/providers/iterativeImage';
 import type {
   ApiProvider,
   EnvOverrides,
@@ -340,15 +342,9 @@ export async function loadApiProvider(
   } else if (providerPath.startsWith('http:') || providerPath.startsWith('https:')) {
     ret = new HttpProvider(providerPath, providerOptions);
   } else if (providerPath === 'promptfoo:redteam:iterative') {
-    const RedteamIterativeProvider = (
-      await import(path.join(__dirname, './redteam/providers/iterative'))
-    ).default;
-    ret = new RedteamIterativeProvider(providerOptions);
+    ret = new RedteamIterativeProvider();
   } else if (providerPath === 'promptfoo:redteam:iterative:image') {
-    const RedteamIterativeProvider = (
-      await import(path.join(__dirname, './redteam/providers/iterativeImage'))
-    ).default;
-    ret = new RedteamIterativeProvider(providerOptions);
+    ret = new RedteamImageIterativeProvider();
   } else {
     if (providerPath.startsWith('file://')) {
       providerPath = providerPath.slice('file://'.length);

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -191,7 +191,7 @@ async function runRedteamConversation(
 
 class RedteamIterativeJailbreaks implements ApiProvider {
   id() {
-    return 'redteam-iterative-jailbreaks';
+    return 'promptfoo:redteam:iterative';
   }
 
   async callApi(prompt: string, context?: CallApiContextParams, options?: CallApiOptionsParams) {

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -218,7 +218,7 @@ async function runRedteamConversation(
 
 class RedteamIterativeJailbreaks implements ApiProvider {
   id() {
-    return 'redteam-iterative-jailbreaks';
+    return 'promptfoo:redteam:iterative:image';
   }
 
   async callApi(prompt: string, context?: CallApiContextParams, options?: CallApiOptionsParams) {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -42,6 +42,8 @@ import { ScriptCompletionProvider } from '../src/providers/scriptCompletion';
 import { VertexChatProvider, VertexEmbeddingProvider } from '../src/providers/vertex';
 import { VoyageEmbeddingProvider } from '../src/providers/voyage';
 import { WebhookProvider } from '../src/providers/webhook';
+import RedteamIterativeProvider from '../src/redteam/providers/iterative';
+import RedteamImageIterativeProvider from '../src/redteam/providers/iterativeImage';
 import type { ProviderOptionsMap, ProviderFunction } from '../src/types';
 
 jest.mock('fs', () => ({
@@ -965,6 +967,18 @@ config:
       expect(cfProvider.id()).toMatch(`cloudflare-ai:${modelTypeForId}:${modelName}`);
       expect(cfProvider).toBeInstanceOf(providerKlass);
     }
+  });
+
+  it('loadApiProvider with promptfoo:redteam:iterative', async () => {
+    const provider = await loadApiProvider('promptfoo:redteam:iterative');
+    expect(provider).toBeInstanceOf(RedteamIterativeProvider);
+    expect(provider.id()).toBe('promptfoo:redteam:iterative');
+  });
+
+  it('loadApiProvider with promptfoo:redteam:iterative:image', async () => {
+    const provider = await loadApiProvider('promptfoo:redteam:iterative:image');
+    expect(provider).toBeInstanceOf(RedteamImageIterativeProvider);
+    expect(provider.id()).toBe('promptfoo:redteam:iterative:image');
   });
 
   it('loadApiProvider with RawProviderConfig', async () => {


### PR DESCRIPTION
Tested locally with `promptfoo generate redteam --plugins jailbreak` and `promptfoo eval` after a clean build