### PR TITLE
chore(deps): upgrade inquirer to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "fast-xml-parser": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "glob": "^10.4.3",
-        "inquirer": "^8.2.6",
+        "inquirer": "^10.0.2",
         "js-yaml": "^4.1.0",
         "mathjs": "^13.0.2",
         "node-fetch": "^2.6.7",
@@ -5329,6 +5329,242 @@
         "@langchain/core": ">=0.1.0"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.3.11.tgz",
+      "integrity": "sha512-pCt02FZNLX9u8j/42n6iJyJnInbrvrygOfX+Fc4TcASbNRwNUcvhjxR2t49AdlmiO8oXAT3GhFH1T+2GpZPCfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.15.tgz",
+      "integrity": "sha512-CiLGi3JmKGEsia5kYJN62yG/njHydbYIkzSBril7tCaKbsnIqxa2h/QiON9NjfwiKck/2siosz4h7lVhLFocMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-p2BRZv/vMmpwlU4ZR966vKQzGVCi4VhLjVofwnFLziTQia541T7i1Ar8/LPh+LzjkXzocme+g5Io6MRtzlCcNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.14.11",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.15.tgz",
+      "integrity": "sha512-UmtZnY36rGLS/4cCzvdRmk0xxsGgH2AsF0v1SSlBZ3C5JK/Bxm2gNW8fmUVzQ5vm8kpdWASXPapbUx4iV49ScA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.15.tgz",
+      "integrity": "sha512-aBnnrBw9vbFJROUlDCsbq8H/plX6JHfPwLmSphxaVqOR+b1hgLdw+oRhZkpcJhG2AZOlc8IKzGdZhji93gQg4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.4.tgz",
+      "integrity": "sha512-R7Gsg6elpuqdn55fBH2y9oYzrU/yKrSmIsDX4ROT51vohrECFzTf2zw9BfUbOW8xjfmM2QbVoVYdTwhrtEKWSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.2.tgz",
+      "integrity": "sha512-VjkzYSVH0606nLi9HHiSb4QYs2idwRgneiMoFoTAIwQ1Qwx6OIDugOYLtLta3gP8AWZx7qUvgDtj+/SJuiiKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.3.tgz",
+      "integrity": "sha512-GLTuhuhzK/QtB7BhM2pLJGKsv366kv237iNF8hTEOx+EGmXsPNGTydAgZmcuVizEmgC9VSVh1S0memXnIUTYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.15.tgz",
+      "integrity": "sha512-/JmiTtIcSYbZdPucEW5q2rhC71vGKPivm3LFqNDQEI6lJyffq7hlfKKFC+R1Qp19dMqkaG+O5L1XmcHpmlAUUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.1.3.tgz",
+      "integrity": "sha512-CguIOxmb5RevOGgkPToKcfaogx2IfgLmIFDmAjqWwvh5DfRWYl5qp1wAMo4SyH0BGQRuxbchkYJr0x1BgB7AVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.3.11",
+        "@inquirer/confirm": "^3.1.15",
+        "@inquirer/editor": "^2.1.15",
+        "@inquirer/expand": "^2.1.15",
+        "@inquirer/input": "^2.2.2",
+        "@inquirer/number": "^1.0.3",
+        "@inquirer/password": "^2.1.15",
+        "@inquirer/rawlist": "^2.1.15",
+        "@inquirer/select": "^2.3.11"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.15.tgz",
+      "integrity": "sha512-zwU6aWDMyuQNiY5Z0iYXkxi7pliRFXqUmiS7vG6lAGxqcbOSptYgIxGJnd3AU4Y91N0Tbt57+koJL0S2p6vSkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/type": "^1.5.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.3.11.tgz",
+      "integrity": "sha512-DebGErUSCyzwIP2zx3hs1X4TAzxSl/yNHzuYGE6KFkHq3ubg+5dJZacFxN1C1eBkJvQ0XBWGpY6MTzHsJbxkpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.3",
+        "@inquirer/figures": "^1.0.4",
+        "@inquirer/type": "^1.5.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.0.tgz",
+      "integrity": "sha512-L/UdayX9Z1lLN+itoTKqJ/X4DX5DaWu2Sruwt4XgZzMNv32x4qllbzMX4MbJlz0yxAQtU19UvABGOjmdq1u3qA==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -8982,6 +9218,15 @@
       "version": "0.7.34",
       "license": "MIT"
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
@@ -9198,6 +9443,12 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -11085,6 +11336,8 @@
     },
     "node_modules/chardet": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
     },
     "node_modules/chart.js": {
@@ -11292,16 +11545,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-progress": {
       "version": "3.12.0",
       "license": "MIT",
@@ -11314,6 +11557,8 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11337,10 +11582,12 @@
       }
     },
     "node_modules/cli-width": {
-      "version": "3.0.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -11393,13 +11640,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -12471,16 +12711,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/defer-to-connect": {
@@ -14800,6 +15030,8 @@
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
@@ -14972,26 +15204,6 @@
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
       "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
       "peer": true
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -16923,56 +17135,21 @@
       "license": "MIT"
     },
     "node_modules/inquirer": {
-      "version": "8.2.6",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.0.2.tgz",
+      "integrity": "sha512-G5n+WbW7oSF22wjTlQe69cRD8aokNMCtNreX8nVQ1XW1+UMGkaUYISYG0Se4UH2URWupOKAP+xM1CS+QvXqO2g==",
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
+        "@inquirer/prompts": "^5.1.3",
+        "@inquirer/type": "^1.5.0",
+        "@types/mute-stream": "^0.0.4",
+        "ansi-escapes": "^4.3.2",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/internal-slot": {
@@ -17308,13 +17485,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "license": "MIT",
@@ -17528,16 +17698,6 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -18868,20 +19028,6 @@
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/logform": {
       "version": "2.6.0",
@@ -20291,8 +20437,13 @@
       }
     },
     "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "license": "ISC"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -20888,44 +21039,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/os-filter-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
@@ -20940,6 +21053,8 @@
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23438,21 +23553,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "license": "MIT",
@@ -23553,7 +23653,9 @@
       }
     },
     "node_modules/run-async": {
-      "version": "2.4.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -25182,10 +25284,6 @@
       "version": "0.2.0",
       "license": "MIT"
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "license": "MIT"
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "license": "MIT"
@@ -25205,6 +25303,8 @@
     },
     "node_modules/tmp": {
       "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -26280,13 +26380,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -27016,6 +27109,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "fast-xml-parser": "^4.4.0",
     "fastest-levenshtein": "^1.0.16",
     "glob": "^10.4.3",
-    "inquirer": "^8.2.6",
+    "inquirer": "^10.0.2",
     "js-yaml": "^4.1.0",
     "mathjs": "^13.0.2",
     "node-fetch": "^2.6.7",

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -83,7 +83,7 @@ export function redteamCommand(program: Command) {
           message: 'Choose a provider:',
           choices: [
             'openai:gpt-3.5-turbo',
-            'openai:gpt-4',
+            'openai:gpt-4o',
             'anthropic:messages:claude-3-5-sonnet-20240620',
             'anthropic:messages:claude-3-opus-20240307',
             'vertex:gemini-pro',
@@ -113,7 +113,7 @@ export function redteamCommand(program: Command) {
         checked: DEFAULT_PLUGINS.has(plugin),
       }));
 
-      const { selectedPlugins } = await inquirer.prompt([
+      const { selectedPlugins: plugins } = await inquirer.prompt([
         {
           type: 'checkbox',
           name: 'selectedPlugins',
@@ -122,8 +122,6 @@ export function redteamCommand(program: Command) {
           pageSize: 20,
         },
       ]);
-
-      const plugins = selectedPlugins;
 
       // Create config file
       const config = {
@@ -172,3 +170,4 @@ export function redteamCommand(program: Command) {
         );
       }
     });
+}

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -15,8 +15,6 @@ interface RunRedteamOptions {
   envFile: string;
 }
 
-export async function doRunRedteam(cmdObj: RunRedteamOptions) {}
-
 export function redteamCommand(program: Command) {
   const redteamCommand = program.command('redteam').description('Red team LLM applications');
 
@@ -180,12 +178,3 @@ export function redteamCommand(program: Command) {
         );
       }
     });
-
-  redteamCommand
-    .command('run')
-    .description('Run red teaming evaluation')
-    .option('-c, --config <path>', 'Path to configuration file')
-    .option('--no-cache', 'Disable cache', false)
-    .option('--env-file <path>', 'Path to .env file')
-    .action(doRunRedteam);
-}

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -9,12 +9,6 @@ import { ALL_PLUGINS, DEFAULT_PLUGINS, subCategoryDescriptions } from '../redtea
 import telemetry from '../telemetry';
 import { doGenerateRedteam } from './generate/redteam';
 
-interface RunRedteamOptions {
-  config: string;
-  cache: boolean;
-  envFile: string;
-}
-
 export function redteamCommand(program: Command) {
   const redteamCommand = program.command('redteam').description('Red team LLM applications');
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,6 +1,7 @@
+import checkbox from '@inquirer/checkbox';
+import rawlist from '@inquirer/rawlist';
 import chalk from 'chalk';
 import fs from 'fs';
-import inquirer from 'inquirer';
 import path from 'path';
 import logger from './logger';
 import { getNunjucksEngine } from './util/templates';
@@ -245,36 +246,25 @@ export async function createDummyFiles(directory: string | null, interactive: bo
   let language: string;
   if (interactive) {
     // Choose use case
-    let resp = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'action',
-        message: 'What would you like to do?',
-        choices: [
-          { name: 'Not sure yet', value: 'compare' },
-          { name: 'Improve prompt and model performance', value: 'compare' },
-          { name: 'Improve RAG performance', value: 'rag' },
-          { name: 'Improve agent/chain of thought performance', value: 'agent' },
-        ],
-      },
-    ]);
-    action = resp.action;
-
+    action = await rawlist({
+      message: 'What would you like to do?',
+      choices: [
+        { name: 'Not sure yet', value: 'compare' },
+        { name: 'Improve prompt and model performance', value: 'compare' },
+        { name: 'Improve RAG performance', value: 'rag' },
+        { name: 'Improve agent/chain of thought performance', value: 'agent' },
+      ],
+    });
     language = 'not_sure';
     if (action === 'rag' || action === 'agent') {
-      resp = await inquirer.prompt([
-        {
-          type: 'list',
-          name: 'language',
-          message: 'What programming language are you developing the app in?',
-          choices: [
-            { name: 'Not sure yet', value: 'not_sure' },
-            { name: 'Python', value: 'python' },
-            { name: 'Javascript', value: 'javascript' },
-          ],
-        },
-      ]);
-      language = resp.language;
+      language = await rawlist({
+        message: 'What programming language are you developing the app in?',
+        choices: [
+          { name: 'Not sure yet', value: 'not_sure' },
+          { name: 'Python', value: 'python' },
+          { name: 'Javascript', value: 'javascript' },
+        ],
+      });
     }
 
     const choices: { name: string; value: (string | object)[] }[] = [
@@ -359,15 +349,10 @@ export async function createDummyFiles(directory: string | null, interactive: bo
         value: ['ollama:chat:llama3', 'ollama:chat:mixtral:8x22b'],
       },
     ];
-    const { providerChoices } = (await inquirer.prompt([
-      {
-        type: 'checkbox',
-        name: 'providerChoices',
-        message: 'Which model providers would you like to use? (press enter to skip)',
-        choices,
-      },
-    ])) as { providerChoices: (string | object)[] };
-
+    const providerChoices: (string | object)[] = await checkbox({
+      message: 'Which model providers would you like to use? (press enter to skip)',
+      choices,
+    });
     if (providerChoices.length > 0) {
       const flatProviders = providerChoices.flat();
       if (flatProviders.length > 3) {

--- a/src/providers/manualInput.ts
+++ b/src/providers/manualInput.ts
@@ -1,4 +1,5 @@
-import inquirer from 'inquirer';
+import editor from '@inquirer/editor';
+import input from '@inquirer/input';
 import { ApiProvider, ProviderResponse } from '../types';
 
 interface ManualInputProviderOptions {
@@ -28,29 +29,7 @@ export class ManualInputProvider implements ApiProvider {
     console.log(prompt);
     console.log('*'.repeat(40));
     console.log('\nPlease enter the output:');
-
-    let output: string;
-
-    if (this.config?.multiline) {
-      const { multilineOutput } = await inquirer.prompt([
-        {
-          type: 'editor',
-          name: 'multilineOutput',
-          message: 'Output:',
-        },
-      ]);
-      output = multilineOutput;
-    } else {
-      const { singlelineOutput } = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'singlelineOutput',
-          message: 'Output:',
-        },
-      ]);
-      output = singlelineOutput;
-    }
-
+    const output: string = await (this.config?.multiline ? editor : input)({ message: 'Output:' });
     console.log('='.repeat(80));
     return {
       output,


### PR DESCRIPTION
This was a low-priority thing but referencing the old inquirer docs was driving me crazy. 

- Update inquirer from v8.2.6 to v10.0.2
- Replace inquirer with @inquirer/* modules in redteam.ts and onboarding.ts
- Simplify manual input provider using new inquirer API

I tested every input and it all seems to work.