### PR TITLE
refactor(types): convert interfaces to Zod schemas

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -98,7 +98,7 @@ export async function loadApiProvider(
   } else if (providerPath === 'echo') {
     ret = {
       id: () => 'echo',
-      callApi: async (input) => ({ output: input }),
+      callApi: async (input: string) => ({ output: input }),
     };
   } else if (providerPath.startsWith('exec:')) {
     // Load script module

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,21 +312,24 @@ export type PromptFunctionContext = {
   };
 };
 
-export type PromptFunction = (context: {
-  vars: Record<string, string | object>;
-  provider?: ApiProvider;
-}) => Promise<string | object>;
+export const PromptFunctionSchema = z.function()
+  .args(z.object({
+    vars: z.record(z.union([z.string(), z.any()])),
+    provider: z.custom<ApiProvider>().optional()
+  }))
+  .returns(z.promise(z.union([z.string(), z.any()])));
 
-export interface Prompt {
-  id?: string;
-  raw: string;
-  /**
-   * @deprecated in > 0.59.0. Use `label` instead.
-   */
-  display?: string;
-  label: string;
-  function?: PromptFunction;
-}
+export type PromptFunction = z.infer<typeof PromptFunctionSchema>;
+
+export const PromptSchema = z.object({
+  id: z.string().optional(),
+  raw: z.string(),
+  display: z.string().optional(), // deprecated
+  label: z.string(),
+  function: PromptFunctionSchema.optional(),
+});
+
+export type Prompt = z.infer<typeof PromptSchema>;
 
 // Used for final prompt display
 export type CompletedPrompt = Prompt & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,7 +294,10 @@ export type PromptFunction = z.infer<typeof PromptFunctionSchema>;
 export const PromptSchema = z.object({
   id: z.string().optional(),
   raw: z.string(),
-  display: z.string().optional(), // deprecated
+  /**
+   * @deprecated in > 0.59.0. Use `label` instead.
+   */
+  display: z.string().optional(),
   label: z.string(),
   function: PromptFunctionSchema.optional(),
 });


### PR DESCRIPTION
This is part of ongoing work to validate all user inputs via zod 

- Convert several interfaces to Zod schemas including CommandLineOptions, EnvOverrides, ProviderOptions, CallApiContextParams, CallApiOptionsParams, and others
- Introduce new Zod schemas: CallApiFunctionSchema, PromptFunctionSchema, PromptSchema, AssertionSchema
- Reorder type definitions for better organization
- Update ApiProvider type in providers.ts to use explicit string type for input parameter