### PR TITLE
fix: consider modelname when caching bedrock responses

### DIFF
--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -600,7 +600,7 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
     logger.debug(`Calling Amazon Bedrock API: ${JSON.stringify(params)}`);
 
     const cache = await getCache();
-    const cacheKey = `bedrock:${JSON.stringify(params)}`;
+    const cacheKey = `bedrock:${this.modelName}:${JSON.stringify(params)}`;
 
     if (isCacheEnabled()) {
       // Try to get the cached response


### PR DESCRIPTION
When configuring two bedrock anthropic providers (see promptfooconfig), I notice they share the same cache as their `params` are equal. This should fix that.

promptfooconfig.yaml snippet:
```yaml
providers:
  - id: "bedrock:anthropic.claude-3-sonnet-20240229-v1:0"
    prompts:
      - my_prompt
    config:
      temperature: 0.3
      topP: 0.2
      maxTokenCount: 1024
      region: "eu-west-2"
  - id: "bedrock:anthropic.claude-3-5-sonnet-20240620-v1:0"
    prompts:
      - my_prompt
    config:
      temperature: 0.3
      topP: 0.2
      maxTokenCount: 1024
      region: "us-east-1"
```