### PR TITLE
Fix parsing of the model name tag in ollama embeddings provider

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -286,12 +286,6 @@ export async function loadApiProvider(
   } else if (providerPath === 'llama' || providerPath.startsWith('llama:')) {
     const modelName = providerPath.split(':')[1];
     ret = new LlamaProvider(modelName, providerOptions);
-  } else if (
-    providerPath.startsWith('ollama:embeddings:') ||
-    providerPath.startsWith('ollama:embedding:')
-  ) {
-    const modelName = providerPath.split(':')[2];
-    ret = new OllamaEmbeddingProvider(modelName, providerOptions);
   } else if (providerPath.startsWith('ollama:')) {
     const splits = providerPath.split(':');
     const firstPart = splits[1];
@@ -301,6 +295,9 @@ export async function loadApiProvider(
     } else if (firstPart === 'completion') {
       const modelName = splits.slice(2).join(':');
       ret = new OllamaCompletionProvider(modelName, providerOptions);
+    } else if (firstPart === 'embedding' || firstPart === 'embeddings') {
+      const modelName = splits.slice(2).join(':');
+      ret = new OllamaEmbeddingProvider(modelName, providerOptions);
     } else {
       // Default to completion provider
       const modelName = splits.slice(1).join(':');

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -27,7 +27,11 @@ import {
   HuggingfaceTextClassificationProvider,
 } from '../src/providers/huggingface';
 import { LlamaProvider } from '../src/providers/llama';
-import { OllamaChatProvider, OllamaCompletionProvider } from '../src/providers/ollama';
+import {
+  OllamaChatProvider,
+  OllamaCompletionProvider,
+  OllamaEmbeddingProvider,
+} from '../src/providers/ollama';
 import {
   OpenAiAssistantProvider,
   OpenAiCompletionProvider,
@@ -822,6 +826,16 @@ config:
     const provider = await loadApiProvider('ollama:completion:llama2:13b');
     expect(provider).toBeInstanceOf(OllamaCompletionProvider);
     expect(provider.id()).toBe('ollama:completion:llama2:13b');
+  });
+
+  it('loadApiProvider with ollama:embedding:modelName', async () => {
+    const provider = await loadApiProvider('ollama:embedding:llama2:13b');
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+  });
+
+  it('loadApiProvider with ollama:embeddings:modelName', async () => {
+    const provider = await loadApiProvider('ollama:embeddings:llama2:13b');
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
   });
 
   it('loadApiProvider with ollama:chat:modelName', async () => {


### PR DESCRIPTION
Fixes #1188

The model name tag was not being parsed correctly in the ollama embeddings provider. This patch fixes the parsing of the model name tag in the ollama embeddings provider.