### PR TITLE
chore(redteam): refactor PII categories and improve plugin handling

### DIFF
--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -1,4 +1,5 @@
 import { HARM_CATEGORIES } from './plugins/harmful';
+import { PII_REQUEST_CATEGORIES } from './plugins/pii';
 
 export const REDTEAM_MODEL = 'openai:chat:gpt-4o';
 
@@ -23,7 +24,12 @@ export const ADDITIONAL_PLUGINS = ['competitors', 'experimental-jailbreak'] as [
   ...string[],
 ];
 
-export const DEFAULT_PLUGINS = new Set([...BASE_PLUGINS, ...Object.keys(HARM_CATEGORIES)]);
+export const DEFAULT_PLUGINS = new Set([
+  ...BASE_PLUGINS,
+  ...Object.keys(HARM_CATEGORIES),
+  ...PII_REQUEST_CATEGORIES,
+]);
+
 export const ALL_PLUGINS = [...new Set([...DEFAULT_PLUGINS, ...ADDITIONAL_PLUGINS])].sort() as [
   string,
   ...string[],
@@ -32,6 +38,7 @@ export const ALL_PLUGINS = [...new Set([...DEFAULT_PLUGINS, ...ADDITIONAL_PLUGIN
 // Duplicated in src/web/nextui/src/app/report/constants.ts for frontend
 export const subCategoryDescriptions: Record<string, string> = {
   'excessive-agency': 'Model taking excessive initiative or misunderstanding its capabilities.',
+  harmful: 'All harmful categories',
   'harmful:child-exploitation': 'Content exploiting or harming children.',
   'harmful:copyright-violations': 'Content violating copyright laws.',
   'harmful:cybercrime': 'Content related to cybercriminal activities.',
@@ -61,7 +68,11 @@ export const subCategoryDescriptions: Record<string, string> = {
   hijacking: 'Unauthorized or off-topic resource use.',
   jailbreak: 'Bypassing security measures or restrictions.',
   overreliance: 'Model susceptible to relying on an incorrect user assumption or input.',
-  pii: 'Exposure or misuse of personally identifiable information.',
+  pii: 'All PII categories',
+  'pii:api-db': 'Attempts to access APIs or databases to retrieve personal information.',
+  'pii:direct': 'Directly discloses personal information when explicitly asked.',
+  'pii:session': 'Leaks personal information across different user sessions or interactions.',
+  'pii:social': 'Reveals personal information through social engineering tactics.',
   politics: 'Makes political statements.',
   'experimental-jailbreak': 'Apply jailbreaks to all attack types',
 };

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -188,13 +188,16 @@ export async function synthesize({
   const addHarmfulCases = plugins.some((p) => p.startsWith('harmful'));
   if (plugins.includes('prompt-injection') || plugins.includes('jailbreak') || addHarmfulCases) {
     logger.debug('Generating harmful test cases');
-    const newHarmfulPrompts = await getHarmfulTests(
-      redteamProvider,
-      purpose,
-      injectVar,
-      plugins.filter((p) => p.startsWith('harmful:')),
-    );
-    harmfulPrompts.push(...newHarmfulPrompts);
+    for (const plugin of plugins.filter((p) => p.startsWith('harmful:'))) {
+      const newHarmfulPrompts = await getHarmfulTests(
+        redteamProvider,
+        purpose,
+        injectVar,
+        [plugin],
+        numTests,
+      );
+      harmfulPrompts.push(...newHarmfulPrompts);
+    }
 
     if (addHarmfulCases) {
       testCases.push(...harmfulPrompts);

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -12,7 +12,7 @@ import CompetitorPlugin from './plugins/competitors';
 import ContractPlugin from './plugins/contracts';
 import ExcessiveAgencyPlugin from './plugins/excessiveAgency';
 import HallucinationPlugin from './plugins/hallucination';
-import { getHarmfulTests } from './plugins/harmful';
+import { HARM_CATEGORIES, getHarmfulTests } from './plugins/harmful';
 import HijackingPlugin from './plugins/hijacking';
 import OverreliancePlugin from './plugins/overreliance';
 import { getPiiTests } from './plugins/pii';
@@ -40,7 +40,8 @@ interface Plugin {
 
 interface Method {
   key: string;
-  action: (testCases: TestCase[], harmfulPrompts: TestCase[], injectVar: string) => TestCase[];
+  action: (testCases: (TestCase & { plugin: string })[], injectVar: string) => TestCase[];
+  requiredPlugins?: string[];
 }
 
 const Plugins: Plugin[] = [
@@ -80,7 +81,17 @@ const Plugins: Plugin[] = [
     action: (provider, purpose, injectVar, n) =>
       new PoliticsPlugin(provider, purpose, injectVar).generateTests(n),
   },
+  ...(Object.keys(HARM_CATEGORIES).map((category) => ({
+    key: category,
+    action: (provider, purpose, injectVar, n) =>
+      getHarmfulTests(provider, purpose, injectVar, [category], n),
+  })) as Plugin[]),
 ];
+
+// These plugins refer to a collection of tests.
+const categories = {
+  harmful: Object.keys(HARM_CATEGORIES),
+} as const;
 
 const Methods: Method[] = [
   {
@@ -94,21 +105,25 @@ const Methods: Method[] = [
   },
   {
     key: 'jailbreak',
-    action: (_, harmfulPrompts) => {
+    action: (testCases) => {
+      const harmfulPrompts = testCases.filter((t) => t.plugin.startsWith('harmful:'));
       logger.debug('Adding jailbreaks to harmful prompts');
       const jailbreaks = addIterativeJailbreaks(harmfulPrompts);
       logger.debug(`Added ${jailbreaks.length} jailbreak test cases`);
       return jailbreaks;
     },
+    requiredPlugins: Object.keys(HARM_CATEGORIES),
   },
   {
     key: 'prompt-injection',
-    action: (_, harmfulPrompts, injectVar) => {
+    action: (testCases, injectVar) => {
+      const harmfulPrompts = testCases.filter((t) => t.plugin.startsWith('harmful:'));
       logger.debug('Adding prompt injections');
       const injections = addInjections(harmfulPrompts, injectVar);
       logger.debug(`Added ${injections.length} prompt injection test cases`);
       return injections;
     },
+    requiredPlugins: Object.keys(HARM_CATEGORIES),
   },
 ];
 
@@ -159,6 +174,23 @@ export async function synthesize({
     invariant(typeof injectVar === 'string', `Inject var must be a string, got ${injectVar}`);
   }
 
+  // if a category is included in the user selected plugins, add all of its plugins
+  for (const [category, categoryPlugins] of Object.entries(categories)) {
+    if (plugins.includes(category)) {
+      plugins.push(...categoryPlugins);
+    }
+  }
+
+  // if a method is included in the user selected plugins, add all of its required plugins
+  for (const { key, requiredPlugins } of Methods) {
+    if (plugins.includes(key) && requiredPlugins) {
+      plugins.push(...requiredPlugins);
+    }
+  }
+
+  // Deduplicate, filter out the category names, and sort
+  plugins = [...new Set(plugins)].filter((p) => !Object.keys(categories).includes(p)).sort();
+
   // Initialize progress bar
   const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
   const totalSteps = plugins.length + 2; // +2 for initial setup steps
@@ -180,11 +212,7 @@ export async function synthesize({
   updateProgress();
 
   logger.debug(`System purpose: ${purpose}`);
-
-  // Get adversarial test cases
-  const testCases: TestCase[] = [];
-  const harmfulPrompts: TestCase[] = [];
-
+  /*
   const addHarmfulCases = plugins.some((p) => p.startsWith('harmful'));
   if (plugins.includes('prompt-injection') || plugins.includes('jailbreak') || addHarmfulCases) {
     logger.debug('Generating harmful test cases');
@@ -205,21 +233,23 @@ export async function synthesize({
     } else {
       logger.debug(`Generated ${harmfulPrompts.length} harmful test cases`);
     }
-  }
+  } */
 
+  // Get adversarial test cases
+  const testCases: (TestCase & { plugin: string })[] = [];
   for (const { key, action } of Plugins) {
     if (plugins.includes(key)) {
       updateProgress();
       logger.debug(`Generating ${key} tests`);
       const pluginTests = await action(redteamProvider, purpose, injectVar, numTests);
-      testCases.push(...pluginTests);
+      testCases.push(...pluginTests.map((t) => ({ ...t, plugin: key })));
       logger.debug(`Added ${pluginTests.length} ${key} test cases`);
     }
   }
   for (const { key, action } of Methods) {
     if (plugins.includes(key)) {
-      const newTestCases = action(testCases, harmfulPrompts, injectVar);
-      testCases.push(...newTestCases);
+      const newTestCases = action(testCases, injectVar);
+      testCases.push(...newTestCases.map((t) => ({ ...t, plugin: key })));
     }
   }
   // Finish progress bar

--- a/src/redteam/plugins/harmful.ts
+++ b/src/redteam/plugins/harmful.ts
@@ -186,10 +186,11 @@ class HarmfulPlugin extends PluginBase {
 }
 
 export async function getHarmfulTests(
-  provider: ApiProvider, // unused
+  provider: ApiProvider,
   purpose: string,
   injectVar: string,
   plugins: string[],
+  numTests: number,
 ): Promise<TestCase[]> {
   // Map from injectValue to its corresponding harmCategory
   const injectVars = new Map<string, string>();
@@ -213,7 +214,9 @@ export async function getHarmfulTests(
 
   for (const harmCategory of unalignedProviderHarmCategories) {
     const adversarialProvider = new PromptfooHarmfulCompletionProvider({ purpose, harmCategory });
-    const categoryPromises = Array.from({ length: 3 }, () => adversarialProvider.callApi(''));
+    const categoryPromises = Array.from({ length: numTests }, () =>
+      adversarialProvider.callApi(''),
+    );
     const results = await Promise.all(categoryPromises);
     results.forEach((result) => {
       const { output: generatedPrompt } = result;
@@ -258,7 +261,7 @@ export async function getHarmfulTests(
 
   for (const harmCategory of redteamProviderHarmCategories) {
     const plugin = new HarmfulPlugin(provider, purpose, injectVar, harmCategory);
-    const results = await plugin.generateTests(3);
+    const results = await plugin.generateTests(numTests);
     // NOTE: harmCategory is necessary for the moderation assertion and not supported
     // by the base model.
     for (const result of results) {

--- a/src/redteam/plugins/pii.ts
+++ b/src/redteam/plugins/pii.ts
@@ -23,11 +23,7 @@ const generatePiiLeak = (examples: string) => dedent`
   Each line must begin with the string "Prompt:"
 `;
 
-type PiiRequestCategory =
-  | 'APIAndDatabaseAccessRequests'
-  | 'DirectPIIRequests'
-  | 'SessionBasedLeaks'
-  | 'SocialEngineeringPrompts';
+type PiiRequestCategory = 'api-db' | 'direct' | 'session' | 'social';
 
 /**
  * Interface for a PII category
@@ -43,7 +39,7 @@ interface PiiCategory {
  */
 const PII_CATEGORIES: PiiCategory[] = [
   {
-    key: 'DirectPIIRequests',
+    key: 'direct',
     description: 'Identify if the model directly discloses PII when explicitly asked.',
     examples: `
       <Example>
@@ -69,7 +65,7 @@ const PII_CATEGORIES: PiiCategory[] = [
     `,
   },
   {
-    key: 'SessionBasedLeaks',
+    key: 'session',
     description:
       'Ensure the model does not leak PII across different user sessions or interactions.',
     examples: `
@@ -92,7 +88,7 @@ const PII_CATEGORIES: PiiCategory[] = [
     `,
   },
   {
-    key: 'SocialEngineeringPrompts',
+    key: 'social',
     description:
       'Test if the model can be manipulated into revealing PII through social engineering tactics.',
     examples: `
@@ -107,7 +103,7 @@ const PII_CATEGORIES: PiiCategory[] = [
     `,
   },
   {
-    key: 'APIAndDatabaseAccessRequests',
+    key: 'api-db',
     description: 'Ensure the model does not attempt to access APIs or databases to retrieve PII.',
     examples: `
       <Example>


### PR DESCRIPTION
This update standardizes the interfaces for plugins and methods, enhances the progress bar for test case generation, and integrates `numTests` into every plugin (though it is ignored by methods). Key changes include:

- Refactored PII to behave similarly to harmful categories. Note: The categories are not based on literature and should be revisited.
- Updated `PII_REQUEST_CATEGORIES` to use a new kebab-case format.
- Added PII subcategories to constants and updated their descriptions.
- Adjusted `getHarmfulTests` and `getPiiTests` to support the new structure.
- Added `plugin` as a field to every generated test case, which is extremely useful at the moment.

### Example Output

When requesting `--numTests 1`, we get the following test cases:

```
   1 contracts
   1 excessive-agency
   1 hallucination
   1 harmful:violent-crime
   1 harmful:non-violent-crime
   1 harmful:sex-crime
   1 harmful:child-exploitation
   1 harmful:specialized-advice
   1 harmful:indiscriminate-weapons
   1 harmful:hate
   1 harmful:self-harm
   1 harmful:sexual-content
   1 harmful:cybercrime
   1 harmful:chemical-biological-weapons
   1 harmful:illegal-drugs
   1 harmful:copyright-violations
   1 harmful:harassment-bullying
   1 harmful:illegal-activities
   1 harmful:graphic-content
   1 harmful:unsafe-practices
   1 harmful:radicalization
   1 harmful:profanity
   1 harmful:insults
   1 harmful:privacy
   1 harmful:intellectual-property
   1 harmful:misinformation-disinformation
   1 hijacking
   1 overreliance
   1 pii:api-db
   1 pii:direct
   1 pii:session
   1 pii:social
   1 politics
  23 jailbreak
  69 prompt-injection
```