### PR TITLE
feat(openai): add gpt-4o-mini models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29092,7 +29092,6 @@
     "src/web/nextui": {
       "version": "0.1.0",
       "dependencies": {
-        "@calcom/embed-react": "^1.5.0",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.16.1",

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -55,6 +55,13 @@ const OPENAI_CHAT_MODELS = [
       output: 0.015 / 1000,
     },
   })),
+  ...['gpt-4o-mini', 'gpt-4o-mini-2024-07-18'].map((model) => ({
+    id: model,
+    cost: {
+      input: 0.0015 / 1000,
+      output: 0.006 / 1000,
+    },
+  })),
   ...[
     'gpt-3.5-turbo',
     'gpt-3.5-turbo-0301',


### PR DESCRIPTION
- Add gpt-4o-mini and gpt-4o-mini-2024-07-18 models to OPENAI_CHAT_MODELS

I will follow this up with a few examples and updates to docs. 