### PR TITLE
feat(redteam): improve test generation logic and add batching

### DIFF
--- a/src/commands/generate/redteam.ts
+++ b/src/commands/generate/redteam.ts
@@ -168,7 +168,12 @@ export function generateRedteamCommand(
       `,
       (val) => val.split(',').map((x) => x.trim()),
     )
-    .option('-n, --num-tests <number>', 'Number of test cases to generate per plugin', parseInt, 5)
+    .option(
+      '-n, --num-tests <number>',
+      'Number of test cases to generate per plugin',
+      (val) => (Number.isInteger(val) ? val : parseInt(val, 10)),
+      5,
+    )
     .option('--no-cache', 'Do not read or write results to disk cache', false)
     .option('--env-file <path>', 'Path to .env file')
     .action((opts: Partial<RedteamGenerateOptions>): void => {

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -4,6 +4,19 @@ import type { ApiProvider, Assertion, TestCase } from '../../types';
 import { getNunjucksEngine } from '../../util/templates';
 
 /**
+ * Randomly samples n items from an array.
+ *
+ * @param array The array to sample from
+ * @param n The number of items to sample
+ * @returns A new array with n randomly sampled items
+ */
+export function sampleArray<T>(array: T[], n: number): T[] {
+  logger.debug(`Sampling ${n} items from array of length ${array.length}`);
+  const shuffled = array.slice().sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, n);
+}
+
+/**
  * Abstract base class for creating plugins that generate test cases.
  */
 export default abstract class PluginBase {
@@ -77,7 +90,7 @@ export default abstract class PluginBase {
     // If we have more prompts than requested, randomly sample to get exact number
     if (allPrompts.length > n) {
       logger.debug(`Sampling ${n} prompts from ${allPrompts.length} total prompts`);
-      allPrompts = this.sampleArray(allPrompts, n);
+      allPrompts = sampleArray(allPrompts, n);
     }
 
     logger.debug(`Generating test cases from ${allPrompts.length} prompts`);
@@ -87,11 +100,5 @@ export default abstract class PluginBase {
       },
       assert: this.getAssertions(prompt),
     }));
-  }
-
-  private sampleArray<T>(array: T[], n: number): T[] {
-    logger.debug(`Sampling ${n} items from array of length ${array.length}`);
-    const shuffled = array.slice().sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, n);
   }
 }

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -58,6 +58,12 @@ export default abstract class PluginBase {
    */
   protected abstract template: string;
 
+  /**
+   * Creates an instance of PluginBase.
+   * @param provider - The API provider used for generating prompts.
+   * @param purpose - The purpose of the plugin.
+   * @param injectVar - The variable name to inject the generated prompt into.
+   */
   constructor(
     protected provider: ApiProvider,
     protected purpose: string,
@@ -66,12 +72,27 @@ export default abstract class PluginBase {
     logger.debug(`PluginBase initialized with purpose: ${purpose}, injectVar: ${injectVar}`);
   }
 
+  /**
+   * Abstract method to get assertions for a given prompt.
+   * @param prompt - The prompt to generate assertions for.
+   * @returns An array of Assertion objects.
+   */
   protected abstract getAssertions(prompt: string): Assertion[];
 
+  /**
+   * Generates test cases based on the plugin's configuration.
+   * @param n - The number of test cases to generate.
+   * @returns A promise that resolves to an array of TestCase objects.
+   */
   async generateTests(n: number): Promise<TestCase[]> {
     logger.debug(`Generating ${n} test cases`);
     const batchSize = 20;
 
+    /**
+     * Generates a batch of prompts using the API provider.
+     * @param currentPrompts - The current list of prompts.
+     * @returns A promise that resolves to an array of new prompts.
+     */
     const generatePrompts = async (currentPrompts: string[]): Promise<string[]> => {
       const remainingCount = n - currentPrompts.length;
       const currentBatchSize = Math.min(remainingCount, batchSize);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1163,3 +1163,17 @@ export function parsePathOrGlob(
     isPathPattern,
   };
 }
+
+/**
+ * Randomly samples n items from an array.
+ * If n is greater than the length of the array, the entire array is returned.
+ *
+ * @param array The array to sample from
+ * @param n The number of items to sample
+ * @returns A new array with n randomly sampled items
+ */
+export function sampleArray<T>(array: T[], n: number): T[] {
+  logger.debug(`Sampling ${n} items from array of length ${array.length}`);
+  const shuffled = array.slice().sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, Math.min(n, array.length));
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -13,6 +13,7 @@ import {
   writeOutput,
   extractJsonObjects,
   parsePathOrGlob,
+  sampleArray,
 } from '../src/util';
 
 jest.mock('proxy-agent', () => ({
@@ -716,5 +717,60 @@ describe('parsePathOrGlob', () => {
       isPathPattern: false,
       filePath: expect.stringMatching(/^relative[/\\]base[/\\]file\.txt$/),
     });
+  });
+});
+
+describe('sampleArray', () => {
+  it('should return n random items when n is less than array length', () => {
+    const array = [1, 2, 3, 4, 5];
+    const result = sampleArray(array, 3);
+
+    expect(result).toHaveLength(3);
+    expect(new Set(result).size).toBe(3); // All items are unique
+    result.forEach((item) => expect(array).toContain(item));
+  });
+
+  it('should return all items when n is equal to array length', () => {
+    const array = [1, 2, 3, 4, 5];
+    const result = sampleArray(array, 5);
+
+    expect(result).toHaveLength(5);
+    expect(new Set(result).size).toBe(5);
+    expect(result).toEqual(expect.arrayContaining(array));
+  });
+
+  it('should return all items when n is greater than array length', () => {
+    const array = [1, 2, 3];
+    const result = sampleArray(array, 5);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(expect.arrayContaining(array));
+  });
+
+  it('should return an empty array when input array is empty', () => {
+    const result = sampleArray([], 3);
+    expect(result).toEqual([]);
+  });
+
+  it('should return a new array, not modifying the original', () => {
+    const array = [1, 2, 3, 4, 5];
+    const originalArray = [...array];
+    sampleArray(array, 3);
+
+    expect(array).toEqual(originalArray);
+  });
+
+  it('should return random samples across multiple calls', () => {
+    const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const samples = new Set();
+
+    for (let i = 0; i < 100; i++) {
+      const result = sampleArray(array, 5);
+      samples.add(result.join(','));
+    }
+
+    // With 100 samples, it's extremely unlikely to get the same sample every time
+    // unless the randomization is not working
+    expect(samples.size).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
This allows us to generate a potentially very large number of tests for a specific use case

- Enhance generateTests method in PluginBase to support batching
- Add deduplication of generated prompts
- Implement retry mechanism with max 2 (?) consecutive retries
- Add sampling for cases when more prompts are generated than requested
- Update tests to cover new functionality
- Add debug logging throughout the generation process
- Fix num-tests option parsing in redteam command