### PR TITLE
docs: fix broken links

### DIFF
--- a/site/blog/jailbreak-dalle.md
+++ b/site/blog/jailbreak-dalle.md
@@ -321,7 +321,7 @@ Tips:
 
 ## What's next
 
-The red team [implementation](https://github.com/promptfoo/promptfoo/blob/main/src/redteam/iterativeImage.ts) is not state-of-the-art and has been purposely simplified from the original TAP implementation in order to improve speed and cost. But, it gets the job done. Contributions are welcome!
+The red team [implementation](https://github.com/promptfoo/promptfoo/blob/main/src/redteam/providers/iterativeImage.ts) is not state-of-the-art and has been purposely simplified from the original TAP implementation in order to improve speed and cost. But, it gets the job done. Contributions are welcome!
 
 With images, it's very hard to toe the line between easily generating disturbing content versus being overly censorious. The above examples drive this point home.
 

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -142,7 +142,7 @@ LLMs are configured with the `providers` property in `promptfooconfig.yaml`. An 
 
 ### LLM APIs
 
-Promptfoo supports [many LLM providers](https://www.notion.so/docs/providers) including OpenAI, Anthropic, Mistral, Azure, Groq, Perplexity, Cohere, and more. In most cases all you need to do is set the appropriate API key environment variable.
+Promptfoo supports [many LLM providers](/docs/providers) including OpenAI, Anthropic, Mistral, Azure, Groq, Perplexity, Cohere, and more. In most cases all you need to do is set the appropriate API key environment variable.
 
 You should choose at least one provider. If desired, set multiple in order to compare their performance in the red team eval. In this example, we’re comparing performance of GPT, Claude, and Llama:
 
@@ -173,10 +173,10 @@ providers:
 
 To learn more, see:
 
-- [Javascript provider](https://www.notion.so/docs/providers/custom-api)
-- [Python provider](https://www.notion.so/docs/providers/python)
-- [Exec provider](https://www.notion.so/docs/providers/custom-script) (Used to run any executable from any programming language)
-- [Webhook provider](https://www.notion.so/docs/providers/webhook) (HTTP requests, useful for testing an app that is online or running locally)
+- [Javascript provider](/docs/providers/custom-api/)
+- [Python provider](/docs/providers/python)
+- [Exec provider](/docs/providers/custom-script) (Used to run any executable from any programming language)
+- [Webhook provider](/docs/providers/webhook) (HTTP requests, useful for testing an app that is online or running locally)
 
 ### HTTP endpoints
 

--- a/site/docs/guides/mistral-vs-llama.md
+++ b/site/docs/guides/mistral-vs-llama.md
@@ -232,9 +232,9 @@ Contrast this with generic public benchmarks, which show that Llama3 >> Mixtral 
 | Model                                                                                     | Average | ARC   | HellaSwag | MMLU  | TruthfulQA | Winogrande | GSM8k | GPQA | MATH | HumanEval | DROP |
 | ----------------------------------------------------------------------------------------- | ------- | ----- | --------- | ----- | ---------- | ---------- | ----- | ---- | ---- | --------- | ---- |
 | [Mixtral-8x7B-Instruct-v0.1](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1) | 72.70   | 70.14 | 87.55     | 71.40 | 64.98      | 81.06      | 61.11 |      |      |           |      |
-| [llama2_70b_mmlu](https://huggingface.co/itsliupeng/llama2_70b_mmlu)                      | 68.24   | 65.61 | 87.37     | 71.89 | 49.15      | 82.40      | 52.99 |      |      |           |      |
+| [Llama 2 70B](https://huggingface.co/meta-llama/Llama-2-70b-hf)                           | 68.24   | 65.61 | 87.37     | 71.89 | 49.15      | 82.40      | 52.99 |      |      |           |      |
 | [Mistral-7B-Instruct-v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)     | 65.71   | 63.14 | 84.88     | 60.78 | 68.26      | 77.19      | 40.03 |      |      |           |      |
-| [llama2_7b_mmlu](https://huggingface.co/itsliupeng/llama2_7b_mmlu)                        | 53.10   | 56.14 | 79.13     | 60.04 | 40.95      | 74.43      | 7.88  |      |      |           |      |
+| [Llama 2 7B](https://huggingface.co/meta-llama/Llama-2-7b-hf)                             | 53.10   | 56.14 | 79.13     | 60.04 | 40.95      | 74.43      | 7.88  |      |      |           |      |
 | [Llama 3 8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)                  |         |       |           | 68.4  | 34.2       |            |       | 34.2 | 30.0 | 62.2      | 58.4 |
 | [Llama 3 70B](https://huggingface.co/meta-llama/Meta-Llama-3-70B-Instruct)                |         |       |           | 82.0  | 39.5       |            |       | 39.5 | 50.4 | 81.7      | 79.7 |
 

--- a/site/docs/integrations/mocha-chai.md
+++ b/site/docs/integrations/mocha-chai.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Testing prompts with Mocha/Chai
 
-`promptfoo` can be integrated with test frameworks like [Mocha](https://mochajs.org/) and assertion libraries like [Chai](https://www.chaijs.org/) in order to evaluate prompts as part of existing testing and CI workflows.
+`promptfoo` can be integrated with test frameworks like [Mocha](https://mochajs.org/) and assertion libraries like [Chai](https://www.chaijs.com/) in order to evaluate prompts as part of existing testing and CI workflows.
 
 This guide includes examples that show how to create Mocha test cases for desired prompt quality using semantic similarity and LLM grading.
 

--- a/site/docs/providers/litellm.md
+++ b/site/docs/providers/litellm.md
@@ -1,6 +1,6 @@
 # LiteLLM
 
-The [LiteLLM](https://docs.litellm.com/docs) provides access to hundreds of LLMs.
+The [LiteLLM](https://docs.litellm.ai/docs/) provides access to hundreds of LLMs.
 
 Because it's compatible with the OpenAI API, you can configure promptfoo to use LiteLLM by overriding the `apiBaseUrl` variable to point to the LiteLLM service.
 

--- a/site/docs/providers/localai.md
+++ b/site/docs/providers/localai.md
@@ -23,7 +23,7 @@ The model name is typically the filename of the `.bin` file that you downloaded 
 
 ## Configuring parameters
 
-You can set parameters like `temperature` and `apiBaseUrl` ([full list here](https://github.com/promptfoo/promptfoo/blob/main/src/providers/localai.ts#L7)). For example, using [LocalAI's lunademo](https://localai.io/howtos/easy-request-curl/):
+You can set parameters like `temperature` and `apiBaseUrl` ([full list here](https://github.com/promptfoo/promptfoo/blob/main/src/providers/localai.ts#L7)). For example, using [LocalAI's lunademo](https://localai.io/docs/getting-started/models/):
 
 ```yaml title=promptfooconfig.yaml
 providers:

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -97,7 +97,7 @@ AI safety settings can be configured using the `safetySettings` key. For example
         threshold: BLOCK_MEDIUM_AND_ABOVE
 ```
 
-See more details on Google's SafetySetting API [here](https://ai.google.dev/api/rest/v1/SafetySetting).
+See more details on Google's SafetySetting API [here](https://ai.google.dev/api/generate-content#safetysetting).
 
 ## Overriding graders
 
@@ -115,22 +115,22 @@ defaultTest:
 
 ## Other configuration options
 
-| Option                             | Description                                                                                     | Default Value                        |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `apiKey`                           | gcloud API token.                                                                               | None                                 |
-| `apiHost`                          | Full Google API host, e.g., for an LLM proxy.                                                   | `{region}-aiplatform.googleapis.com` |
-| `projectId`                        | gcloud project ID.                                                                              | None                                 |
-| `region`                           | gcloud region.                                                                                  | `us-central1`                        |
-| `publisher`                        | Model publisher.                                                                                | `google`                             |
-| `context`                          | Context for the model to consider when generating responses.                                    | None                                 |
-| `examples`                         | Examples to prime the model.                                                                    | None                                 |
-| `safetySettings`                   | [Safety settings](https://ai.google.dev/api/rest/v1/SafetySetting) to filter generated content. | None                                 |
-| `generationConfig.temperature`     | Controls randomness. Lower values make the model more deterministic.                            | None                                 |
-| `generationConfig.maxOutputTokens` | Maximum number of tokens to generate.                                                           | None                                 |
-| `generationConfig.topP`            | Nucleus sampling: higher values cause the model to consider more candidates.                    | None                                 |
-| `generationConfig.topK`            | Controls diversity via random sampling: lower values make sampling more deterministic.          | None                                 |
-| `generationConfig.stopSequences`   | Set of string outputs that will stop output generation.                                         | []                                   |
-| `toolConfig`                       | Configuration for tool usage                                                                    | None                                 |
-| `systemInstruction`                | System prompt. Nunjucks template variables `{{var}}` are supported                              | None                                 |
+| Option                             | Description                                                                                              | Default Value                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `apiKey`                           | gcloud API token.                                                                                        | None                                 |
+| `apiHost`                          | Full Google API host, e.g., for an LLM proxy.                                                            | `{region}-aiplatform.googleapis.com` |
+| `projectId`                        | gcloud project ID.                                                                                       | None                                 |
+| `region`                           | gcloud region.                                                                                           | `us-central1`                        |
+| `publisher`                        | Model publisher.                                                                                         | `google`                             |
+| `context`                          | Context for the model to consider when generating responses.                                             | None                                 |
+| `examples`                         | Examples to prime the model.                                                                             | None                                 |
+| `safetySettings`                   | [Safety settings](https://ai.google.dev/api/generate-content#safetysetting) to filter generated content. | None                                 |
+| `generationConfig.temperature`     | Controls randomness. Lower values make the model more deterministic.                                     | None                                 |
+| `generationConfig.maxOutputTokens` | Maximum number of tokens to generate.                                                                    | None                                 |
+| `generationConfig.topP`            | Nucleus sampling: higher values cause the model to consider more candidates.                             | None                                 |
+| `generationConfig.topK`            | Controls diversity via random sampling: lower values make sampling more deterministic.                   | None                                 |
+| `generationConfig.stopSequences`   | Set of string outputs that will stop output generation.                                                  | []                                   |
+| `toolConfig`                       | Configuration for tool usage                                                                             | None                                 |
+| `systemInstruction`                | System prompt. Nunjucks template variables `{{var}}` are supported                                       | None                                 |
 
 Note that not all models support all parameters. Please consult the [Google documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/overview) on how to use and format parameters.


### PR DESCRIPTION
Fix broken links in various documentation files.

Thanks @jamesbraza for reporting this in https://github.com/promptfoo/promptfoo/issues/1206 and suggesting a link checker.