### PR TITLE
fix: gpt-4o-mini price

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -58,8 +58,8 @@ const OPENAI_CHAT_MODELS = [
   ...['gpt-4o-mini', 'gpt-4o-mini-2024-07-18'].map((model) => ({
     id: model,
     cost: {
-      input: 0.0015 / 1000,
-      output: 0.006 / 1000,
+      input: 0.00015 / 1000,
+      output: 0.0006 / 1000,
     },
   })),
   ...[


### PR DESCRIPTION
https://openai.com/api/pricing/#:~:text=gpt%2D4o%2Dmini-,US%240.150%20/,1M%20input%20tokens,-US%240.075%20/

⬆️ According to OpenAI pricing page, gpt-4o-mini price should be 0.00015/0.0006 per 1K tokens.