### PR TITLE
fix(validator): fix errors in default example

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format:check": "prettier --check .",
     "db:migrate": "npx tsx src/migrate.ts",
     "db:generate": "npx drizzle-kit generate:sqlite",
-    "jsonSchema:generate": "npx tsx scripts/generateJsonSchema.ts > site/static/config-schema.json",
+    "jsonSchema:generate": "npx -y tsx scripts/generateJsonSchema.ts > site/static/config-schema.json",
     "audit:fix": "npm audit fix && npm audit fix --prefix src/web/nextui && npm audit fix --prefix site",
     "prepublishOnly": "npm run build:clean && npm run build"
   },

--- a/site/src/pages/validator.tsx
+++ b/site/src/pages/validator.tsx
@@ -14,7 +14,7 @@ const DEFAULT_INPUT = `prompts:
   - "Write a tweet about {{topic}}"
 
 providers:
-  - openai:chat:gpt-4o
+  - openai:chat:gpt-4o-mini
   - anthropic:messages:claude-3-5-sonnet-20240620
 
 tests:

--- a/site/src/pages/validator.tsx
+++ b/site/src/pages/validator.tsx
@@ -22,12 +22,12 @@ tests:
       topic: bananas
     assert:
       - type: contains
-        text: "banana"
+        value: "banana"
   - vars:
       topic: pineapples
     assert:
       - type: llm-rubric
-        text: "mentions health benefits"
+        value: "mentions health benefits"
         
 defaultTest:
   assert:

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -496,6 +496,10 @@
                       },
                       "threshold": {
                         "type": "number"
+                      },
+                      "metadata": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
                     "additionalProperties": false
@@ -538,6 +542,9 @@
                     },
                     "threshold": {
                       "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/threshold"
+                    },
+                    "metadata": {
+                      "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/metadata"
                     }
                   },
                   "additionalProperties": false
@@ -574,6 +581,9 @@
             },
             "threshold": {
               "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/threshold"
+            },
+            "metadata": {
+              "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/metadata"
             }
           },
           "additionalProperties": false
@@ -640,8 +650,177 @@
           }
         },
         "metadata": {
+          "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/metadata"
+        },
+        "redteam": {
           "type": "object",
-          "additionalProperties": {}
+          "properties": {
+            "injectVar": {
+              "type": "string",
+              "description": "Variable to inject. Can be a string or array of strings. If string, it's transformed to an array. Inferred from the prompts by default."
+            },
+            "purpose": {
+              "type": "string",
+              "description": "Purpose override string - describes the prompt templates"
+            },
+            "provider": {
+              "type": "string",
+              "description": "Provider used for generating adversarial inputs"
+            },
+            "numTests": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "default": 5,
+              "description": "Number of tests to generate"
+            },
+            "plugins": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "competitors",
+                      "contracts",
+                      "debug-access",
+                      "excessive-agency",
+                      "hallucination",
+                      "harmful",
+                      "harmful:chemical-biological-weapons",
+                      "harmful:child-exploitation",
+                      "harmful:copyright-violations",
+                      "harmful:cybercrime",
+                      "harmful:graphic-content",
+                      "harmful:harassment-bullying",
+                      "harmful:hate",
+                      "harmful:illegal-activities",
+                      "harmful:illegal-drugs",
+                      "harmful:indiscriminate-weapons",
+                      "harmful:insults",
+                      "harmful:intellectual-property",
+                      "harmful:misinformation-disinformation",
+                      "harmful:non-violent-crime",
+                      "harmful:privacy",
+                      "harmful:profanity",
+                      "harmful:radicalization",
+                      "harmful:self-harm",
+                      "harmful:sex-crime",
+                      "harmful:sexual-content",
+                      "harmful:specialized-advice",
+                      "harmful:unsafe-practices",
+                      "harmful:violent-crime",
+                      "hijacking",
+                      "overreliance",
+                      "pii",
+                      "pii:api-db",
+                      "pii:direct",
+                      "pii:session",
+                      "pii:social",
+                      "politics",
+                      "rbac",
+                      "shell-injection",
+                      "sql-injection"
+                    ],
+                    "description": "Name of the plugin"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "enum": [
+                          "competitors",
+                          "contracts",
+                          "debug-access",
+                          "excessive-agency",
+                          "hallucination",
+                          "harmful",
+                          "harmful:chemical-biological-weapons",
+                          "harmful:child-exploitation",
+                          "harmful:copyright-violations",
+                          "harmful:cybercrime",
+                          "harmful:graphic-content",
+                          "harmful:harassment-bullying",
+                          "harmful:hate",
+                          "harmful:illegal-activities",
+                          "harmful:illegal-drugs",
+                          "harmful:indiscriminate-weapons",
+                          "harmful:insults",
+                          "harmful:intellectual-property",
+                          "harmful:misinformation-disinformation",
+                          "harmful:non-violent-crime",
+                          "harmful:privacy",
+                          "harmful:profanity",
+                          "harmful:radicalization",
+                          "harmful:self-harm",
+                          "harmful:sex-crime",
+                          "harmful:sexual-content",
+                          "harmful:specialized-advice",
+                          "harmful:unsafe-practices",
+                          "harmful:violent-crime",
+                          "hijacking",
+                          "overreliance",
+                          "pii",
+                          "pii:api-db",
+                          "pii:direct",
+                          "pii:session",
+                          "pii:social",
+                          "politics",
+                          "rbac",
+                          "shell-injection",
+                          "sql-injection"
+                        ],
+                        "description": "Name of the plugin"
+                      },
+                      "numTests": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "description": "Number of tests to generate for this plugin"
+                      }
+                    },
+                    "required": ["id"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "description": "Plugins to use for redteam generation",
+              "default": []
+            },
+            "strategies": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": ["jailbreak", "prompt-injection", "experimental-jailbreak"],
+                    "description": "Name of the strategy"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "enum": ["jailbreak", "prompt-injection", "experimental-jailbreak"],
+                        "description": "Name of the strategy"
+                      }
+                    },
+                    "required": ["id"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "description": "Strategies to use for redteam generation.\n\nDefaults to jailbreak, prompt-injection\nSupports jailbreak, prompt-injection, experimental-jailbreak",
+              "default": [
+                {
+                  "id": "jailbreak"
+                },
+                {
+                  "id": "prompt-injection"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         },
         "evaluateOptions": {
           "type": "object",


### PR DESCRIPTION
- Correct DEFAULT_INPUT in validator.tsx to use current provider and assert syntax
- Add missing 'metadata' field to assert schema in config-schema.json
- Include 'redteam' configuration in schema to match current functionality
- Adjust npm script to use '-y' flag for smoother tsx installation