### PR TITLE
site: improve human readability of validator errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7566,6 +7566,14 @@
       "version": "1.10.3",
       "license": "MIT"
     },
+    "node_modules/@segment/ajv-human-errors": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@segment/ajv-human-errors/-/ajv-human-errors-2.13.0.tgz",
+      "integrity": "sha512-rubuhyhxCHmVdTmA5G3aMiWoN8Yutp+LG/AGUSiIKJVs1r7EEE/yjqSzSqyANGj5ZkqGUP802Ur9s19MuWelZQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -30083,6 +30091,7 @@
         "@mdx-js/react": "^3.0.1",
         "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "^5.16.4",
+        "@segment/ajv-human-errors": "^2.13.0",
         "clsx": "^2.1.1",
         "docusaurus-plugin-image-zoom": "^2.0.0",
         "prism-react-renderer": "^2.3.1",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
     "@mdx-js/react": "^3.0.1",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "^5.16.4",
+    "@segment/ajv-human-errors": "^2.13.0",
     "clsx": "^2.1.1",
     "docusaurus-plugin-image-zoom": "^2.0.0",
     "prism-react-renderer": "^2.3.1",

--- a/site/src/pages/validator.tsx
+++ b/site/src/pages/validator.tsx
@@ -6,6 +6,7 @@ import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import { AggregateAjvError } from '@segment/ajv-human-errors';
 import Layout from '@theme/Layout';
 import Ajv from 'ajv';
 import yaml from 'js-yaml';
@@ -61,30 +62,42 @@ const ConfigValidator = () => {
         parsedConfig = yaml.load(value);
       }
 
-      const ajv = new Ajv();
-      const validate = ajv.compile(schema);
-      const valid = validate(parsedConfig);
+      const ajv = new Ajv({
+        allErrors: false,
+        verbose: true,
+      });
 
-      if (valid) {
+      ajv.validate(schema, parsedConfig);
+
+      const errors = new AggregateAjvError(ajv.errors);
+      const errorsByPath: Record<string, string[]> = {};
+
+      for (const error of Array.from(errors)) {
+        if (!errorsByPath[error.path]) {
+          errorsByPath[error.path] = [];
+        }
+        errorsByPath[error.path].push(error.message);
+      }
+
+      if (Object.keys(errorsByPath).length === 0) {
         setValidationOutput('Configuration is valid.');
       } else {
-        const errorsByPath = validate.errors.reduce<Record<string, string[]>>((acc, error) => {
-          const path = error.instancePath || 'root';
-          if (!acc[path]) {
-            acc[path] = [];
-          }
-          acc[path].push(error.message);
-          return acc;
-        }, {});
-
-        const formattedErrors = Object.entries(errorsByPath)
-          .map(([path, messages]) => {
-            const location = path === 'root' ? 'In root' : `At ${path}`;
-            return `• ${location}:\n  ${messages.join('\n  ')}`;
-          })
-          .join('\n\n');
-
-        setValidationOutput(`Validation errors:\n\n${formattedErrors}`);
+        let output = 'Validation errors:\n\n';
+        // Only show the deepest errors for each path, otherwise it's too verbose
+        const deepestPaths = Object.keys(errorsByPath).filter(
+          (path) =>
+            !Object.keys(errorsByPath).some(
+              (otherPath) => otherPath !== path && otherPath.startsWith(path),
+            ),
+        );
+        for (const path of deepestPaths) {
+          output += `${path}:\n`;
+          errorsByPath[path].forEach((message) => {
+            output += `  - ${message}\n`;
+          });
+          output += '\n';
+        }
+        setValidationOutput(output.trim());
       }
     } catch (error) {
       setValidationOutput(`Error parsing input: ${error.message}`);
@@ -125,7 +138,9 @@ const ConfigValidator = () => {
           </Grid>
           <Grid item xs={12} md={6}>
             <Paper elevation={3} sx={{ height: '80vh', p: 2, overflow: 'auto' }}>
-              <pre>{validationOutput}</pre>
+              <pre style={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}>
+                {validationOutput}
+              </pre>
             </Paper>
           </Grid>
         </Grid>


### PR DESCRIPTION
This is only a slight improvement, but at least includes actionable information.

Before
![image](https://github.com/user-attachments/assets/8db7fffc-a0a2-4ead-b14b-3d45c0dc2631)

After
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/6db1d2d6-1477-4798-ba1a-a8bfade45cd9">
