### PR TITLE
fix: dont try to parse yaml content on load

### DIFF
--- a/src/prompts/processors/yaml.ts
+++ b/src/prompts/processors/yaml.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import yaml from 'js-yaml';
 import { Prompt } from '../../types';
 
 /**
@@ -13,13 +12,11 @@ import { Prompt } from '../../types';
  * @throws Will throw an error if the file cannot be read or parsed.
  */
 export function processYamlFile(filePath: string, prompt: Partial<Prompt>): Prompt[] {
+  // Yaml is parsed later - just pass it through.
   const fileContents = fs.readFileSync(filePath, 'utf8');
-  const yamlContent = yaml.load(fileContents, {
-    json: true,
-  });
   return [
     {
-      raw: JSON.stringify(yamlContent),
+      raw: fileContents,
       label: prompt.label || `${filePath}: ${fileContents}`,
     },
   ];

--- a/test/prompts.processors.yaml.test.ts
+++ b/test/prompts.processors.yaml.test.ts
@@ -13,11 +13,10 @@ describe('processYamlFile', () => {
   it('should process a valid YAML file without a label', () => {
     const filePath = 'file.yaml';
     const fileContent = 'key: value';
-    const parsedYaml = { key: 'value' };
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processYamlFile(filePath, {})).toEqual([
       {
-        raw: JSON.stringify(parsedYaml),
+        raw: fileContent,
         label: `${filePath}: ${fileContent}`,
       },
     ]);
@@ -27,11 +26,10 @@ describe('processYamlFile', () => {
   it('should process a valid YAML file with a label', () => {
     const filePath = 'file.yaml';
     const fileContent = 'key: value';
-    const parsedYaml = { key: 'value' };
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processYamlFile(filePath, { label: 'Label' })).toEqual([
       {
-        raw: JSON.stringify(parsedYaml),
+        raw: fileContent,
         label: `Label`,
       },
     ]);
@@ -45,14 +43,6 @@ describe('processYamlFile', () => {
     });
 
     expect(() => processYamlFile(filePath, {})).toThrow('File not found');
-    expect(mockReadFileSync).toHaveBeenCalledWith(filePath, 'utf8');
-  });
-
-  it('should throw an error if the YAML content is invalid', () => {
-    const filePath = 'invalid.yaml';
-    const fileContent = 'invalid: yaml: content';
-    mockReadFileSync.mockReturnValue(fileContent);
-    expect(() => processYamlFile(filePath, {})).toThrow(/bad indentation of a mapping entry/);
     expect(mockReadFileSync).toHaveBeenCalledWith(filePath, 'utf8');
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -272,7 +272,7 @@ describe('readPrompts', () => {
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     await expect(readPrompts('prompts.yaml')).resolves.toEqual([
       {
-        raw: JSON.stringify(yaml.load(yamlContent)),
+        raw: yamlContent,
         label: `prompts.yaml: ${yamlContent}`,
       },
     ]);
@@ -300,7 +300,7 @@ describe('readPrompts', () => {
       ]),
     ).resolves.toEqual([
       {
-        raw: JSON.stringify(yaml.load(ymlContent)),
+        raw: ymlContent,
         label: `image-summary`,
       },
     ]);


### PR DESCRIPTION
This fixes behavior that breaks on templated YAML.  Related to #1225 