### PR TITLE
feat(webui): make eval switcher more obvious

### DIFF
--- a/src/web/nextui/src/app/components/PageShell.tsx
+++ b/src/web/nextui/src/app/components/PageShell.tsx
@@ -51,6 +51,9 @@ const createAppTheme = (darkMode: boolean) =>
             color: darkMode ? '#FFFFFF' : '#000000',
             fontWeight: 'bold',
           },
+          stickyHeader: {
+            backgroundColor: darkMode ? '#1E1E1E' : '#F5F5F5',
+          },
         },
       },
       MuiInputBase: {

--- a/src/web/nextui/src/app/eval/EvalSelectorKeyboardShortcut.tsx
+++ b/src/web/nextui/src/app/eval/EvalSelectorKeyboardShortcut.tsx
@@ -1,21 +1,13 @@
 import React, { useState } from 'react';
-import FolderIcon from '@mui/icons-material/FolderOpen';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
 import EvalSelectorDialog from './EvalSelectorDialog';
 import type { ResultLightweightWithLabel } from './types';
 
 interface EvalSelectorProps {
   recentEvals: ResultLightweightWithLabel[];
   onRecentEvalSelected: (evalId: string) => void;
-  currentEval: ResultLightweightWithLabel | null;
 }
 
-const EvalSelector: React.FC<EvalSelectorProps> = ({
-  recentEvals,
-  onRecentEvalSelected,
-  currentEval,
-}) => {
+const EvalSelector: React.FC<EvalSelectorProps> = ({ recentEvals, onRecentEvalSelected }) => {
   const [open, setOpen] = useState(false);
   const isMac =
     typeof navigator === 'undefined'
@@ -48,11 +40,6 @@ const EvalSelector: React.FC<EvalSelectorProps> = ({
 
   return (
     <>
-      <Tooltip title={tooltipTitle} arrow>
-        <IconButton onClick={handleOpen} color="primary" size="small">
-          <FolderIcon />
-        </IconButton>
-      </Tooltip>
       <EvalSelectorDialog
         title="Open an Eval"
         open={open}

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -5,8 +5,10 @@ import { useStore as useMainStore } from '@/state/evalConfig';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ShareIcon from '@mui/icons-material/Share';
+import SearchIcon from '@mui/icons-material/Source';
 import EyeIcon from '@mui/icons-material/Visibility';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import Box from '@mui/material/Box';
@@ -15,6 +17,7 @@ import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import FormControl from '@mui/material/FormControl';
+import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -26,7 +29,6 @@ import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 import { styled } from '@mui/system';
 import type { VisibilityState } from '@tanstack/table-core';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -35,7 +37,8 @@ import { useDebounce } from 'use-debounce';
 import CompareEvalMenuItem from './CompareEvalMenuItem';
 import ConfigModal from './ConfigModal';
 import DownloadMenu from './DownloadMenu';
-import EvalSelectorButton from './EvalSelectorButton';
+import EvalSelectorDialog from './EvalSelectorDialog';
+import EvalSelectorKeyboardShortcut from './EvalSelectorKeyboardShortcut';
 import ResultsCharts from './ResultsCharts';
 import ResultsTable from './ResultsTable';
 import SettingsModal from './ResultsViewSettingsModal';
@@ -299,6 +302,7 @@ export default function ResultsView({
   };
 
   const [evalIdCopied, setEvalIdCopied] = React.useState(false);
+  const [evalSelectorDialogOpen, setEvalSelectorDialogOpen] = React.useState(false);
 
   const handleEvalIdCopyClick = async () => {
     if (!evalId) {
@@ -315,27 +319,43 @@ export default function ResultsView({
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
       <ResponsiveStack
         direction="row"
+        ml={1}
         mb={2}
         spacing={1}
         alignItems="center"
         className="eval-header"
       >
-        {recentEvals && recentEvals.length > 0 && (
-          <EvalSelectorButton
+        <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', maxWidth: 250 }}>
+          <TextField
+            variant="outlined"
+            size="small"
+            fullWidth
+            value={config?.description || evalId || ''}
+            InputProps={{
+              readOnly: true,
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end">
+                  <ArrowDropDownIcon />
+                </InputAdornment>
+              ),
+            }}
+            onClick={() => setEvalSelectorDialogOpen(true)}
+            placeholder="Search or select an eval..."
+            sx={{ cursor: 'pointer' }}
+          />
+          <EvalSelectorDialog
+            open={evalSelectorDialogOpen}
+            onClose={() => setEvalSelectorDialogOpen(false)}
             recentEvals={recentEvals}
             onRecentEvalSelected={onRecentEvalSelected}
-            currentEval={recentEvals.find((evl) => evl.evalId === evalId) || null}
+            title="Select an Eval"
           />
-        )}
-        {!inComparisonMode && (
-          <Typography variant="h5" sx={{ display: 'flex', alignItems: 'center' }}>
-            <Tooltip title="Click to edit description">
-              <span className="description" onClick={handleDescriptionClick}>
-                {config?.description || evalId}
-              </span>
-            </Tooltip>
-          </Typography>
-        )}
+        </Box>
         {config?.description && evalId && (
           <>
             <Tooltip title="Click to copy">
@@ -373,7 +393,7 @@ export default function ResultsView({
           />
         </Tooltip>
       </ResponsiveStack>
-      <ResponsiveStack direction="row" spacing={4} alignItems="center">
+      <ResponsiveStack direction="row" spacing={1} alignItems="center">
         <Box>
           <FormControl sx={{ m: 1, minWidth: 200, maxWidth: 350 }} size="small">
             <InputLabel id="visible-columns-label">Columns</InputLabel>
@@ -436,16 +456,12 @@ export default function ResultsView({
                 open={Boolean(anchorEl)}
                 onClose={handleMenuClose}
               >
-                <CompareEvalMenuItem
-                  initialEvals={recentEvals}
-                  onComparisonEvalSelected={handleComparisonEvalSelected}
-                />
-                <Tooltip title="View the configuration that defines this eval" placement="left">
-                  <MenuItem onClick={() => setConfigModalOpen(true)}>
+                <Tooltip title="Edit the name of this eval" placement="left">
+                  <MenuItem onClick={handleDescriptionClick}>
                     <ListItemIcon>
-                      <VisibilityIcon fontSize="small" />
+                      <EditIcon fontSize="small" />
                     </ListItemIcon>
-                    View YAML
+                    Edit name
                   </MenuItem>
                 </Tooltip>
                 <Tooltip title="Edit this eval in the web UI" placement="left">
@@ -456,9 +472,21 @@ export default function ResultsView({
                     }}
                   >
                     <ListItemIcon>
-                      <EditIcon fontSize="small" />
+                      <PlayArrowIcon fontSize="small" />
                     </ListItemIcon>
-                    Edit Eval
+                    Edit and re-run
+                  </MenuItem>
+                </Tooltip>
+                <CompareEvalMenuItem
+                  initialEvals={recentEvals}
+                  onComparisonEvalSelected={handleComparisonEvalSelected}
+                />
+                <Tooltip title="View the configuration that defines this eval" placement="left">
+                  <MenuItem onClick={() => setConfigModalOpen(true)}>
+                    <ListItemIcon>
+                      <VisibilityIcon fontSize="small" />
+                    </ListItemIcon>
+                    View YAML
                   </MenuItem>
                 </Tooltip>
                 <DownloadMenu />
@@ -529,6 +557,10 @@ export default function ResultsView({
         shareUrl={shareUrl}
       />
       <SettingsModal open={viewSettingsModalOpen} onClose={() => setViewSettingsModalOpen(false)} />
+      <EvalSelectorKeyboardShortcut
+        recentEvals={recentEvals}
+        onRecentEvalSelected={onRecentEvalSelected}
+      />
     </div>
   );
 }

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -319,8 +319,7 @@ export default function ResultsView({
     <div style={{ marginLeft: '1rem', marginRight: '1rem' }}>
       <ResponsiveStack
         direction="row"
-        ml={1}
-        mb={2}
+        mb={3}
         spacing={1}
         alignItems="center"
         className="eval-header"
@@ -395,7 +394,7 @@ export default function ResultsView({
       </ResponsiveStack>
       <ResponsiveStack direction="row" spacing={1} alignItems="center">
         <Box>
-          <FormControl sx={{ m: 1, minWidth: 200, maxWidth: 350 }} size="small">
+          <FormControl sx={{ minWidth: 200, maxWidth: 350 }} size="small">
             <InputLabel id="visible-columns-label">Columns</InputLabel>
             <Select
               labelId="visible-columns-label"


### PR DESCRIPTION
See alternatives in `feat/global-search` (search in navbar) and `feat/eval-drawer` (thingy that slides out with list) for longer term solutions.

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/eb0ec51e-4780-4e8f-bfd5-52ba57645d76">
