### PR TITLE
fix: improve `CallApiFunctionSchema`/`ProviderFunction` type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,22 +100,15 @@ export const CallApiOptionsParamsSchema = z.object({
   originalProvider: z.optional(z.any()), // Assuming ApiProvider is not a zod schema, using z.any()
 });
 
-const CallApiFunctionSchema = z.union([
-  z
-    .function()
-    .args(
-      z.string().describe('prompt'),
-      CallApiContextParamsSchema.optional(),
-      CallApiOptionsParamsSchema.optional(),
-    )
-    .returns(z.promise(z.custom<ProviderResponse>()))
-    .and(z.object({ label: z.string().optional() })),
-  z
-    .function()
-    .args(z.string().describe('prompt'), CallApiOptionsParamsSchema.optional())
-    .returns(z.promise(z.custom<ProviderResponse>()))
-    .and(z.object({ label: z.string().optional() })),
-]);
+const CallApiFunctionSchema = z
+  .function()
+  .args(
+    z.string().describe('prompt'),
+    CallApiContextParamsSchema.optional(),
+    CallApiOptionsParamsSchema.optional(),
+  )
+  .returns(z.promise(z.custom<ProviderResponse>()))
+  .and(z.object({ label: z.string().optional() }));
 
 export const ApiProviderSchema = z.object({
   id: z.function().returns(z.string()),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,7 +209,20 @@ export type ProviderOptions = z.infer<typeof ProviderOptionsSchema>;
 export type ProviderResponse = z.infer<typeof ProviderResponseSchema>;
 export type ProviderSimilarityResponse = z.infer<typeof ProviderSimilarityResponseSchema>;
 export type TokenUsage = z.infer<typeof TokenUsageSchema>;
-type CallApiFunction = z.infer<typeof CallApiFunctionSchema>;
+
+// The z.infer type is not as good as a manually created type
+type CallApiFunction = {
+  (
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse>;
+  label?: string;
+};
+// Confirm that manually created type is equivalent to z.infer type
+function assert<T extends never>() {}
+type TypeEqualityGuard<A, B> = Exclude<A, B> | Exclude<B, A>;
+assert<TypeEqualityGuard<CallApiFunction, z.infer<typeof CallApiFunctionSchema>>>();
 
 export interface ModerationFlag {
   code: string;

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1017,7 +1017,7 @@ config:
   });
 
   it('loadApiProviders with ProviderFunction', async () => {
-    const providerFunction: ProviderFunction = async (prompt: string) => {
+    const providerFunction: ProviderFunction = async (prompt) => {
       return {
         output: `Output for ${prompt}`,
         tokenUsage: { total: 10, prompt: 5, completion: 5 },


### PR DESCRIPTION
This PR partially reverts some of the changes in https://github.com/promptfoo/promptfoo/pull/1178 for `CallApiFunctionSchema` and the `CallApiFunction` type (which is exported as the `ProviderFunction` type).

Let me know if you want me to make two separate PRs for this!

1. Remove `callApi(prompt: string, options?:  CallApiOptionsParams)` from `CallApiFunctionSchema`

    This looks like a bug to me. Everywhere I see `callApi()` being used, the `options` parameter is always in the third position, not the second position, e.g. `callApi(prompt, context, options)`.

2. Use the old manually created `CallApiFunction` type instead of the new `z.infer` type

    Instead of using the `z.infer` type from `zod`, we should keep using the type from before commit https://github.com/promptfoo/promptfoo/commit/08e9e387bcaf197686bd5b9f79f97969146a17f5, as TypeScript can infer parameter types better using the former definition, e.g.

    https://github.com/promptfoo/promptfoo/blob/b1d21534099f541be641b450325f860aedee2a16/src/types.ts#L113-L120

    For example, see the update I made in `test/providers.test.ts`, where TypeScript can automatically infer that the type of the `prompt` param is `string`, but this doesn't work with the `z.infer` type. I think this is because the `z.infer` creates an intersection between a function type and an object type that `z.infer` creates, e.g. `(myFunction: xxxx) => void & {object: val}`, which isn't as well supported by TypeScript.

    We can use a TypeScript guard to confirm that the manually created type matches the `z.infer` type.



