### PR TITLE
fix(ci): add registry URL to npm publish workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
This commit adds the registry URL to the GitHub Actions workflow for npm package publishing, which should resolve authentication issues during the publish step.