### PR TITLE
fix(schema): update config schema for strategies

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -13,30 +13,14 @@
               "type": "string"
             },
             {
-              "anyOf": [
+              "allOf": [
                 {
-                  "allOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        }
-                      }
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
                     }
-                  ]
-                },
-                {
-                  "allOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  ]
+                  }
                 }
               ]
             },
@@ -792,7 +776,12 @@
                 "anyOf": [
                   {
                     "type": "string",
-                    "enum": ["jailbreak", "prompt-injection", "experimental-jailbreak"],
+                    "enum": [
+                      "jailbreak",
+                      "prompt-injection",
+                      "experimental-jailbreak",
+                      "experimental-tree-jailbreak"
+                    ],
                     "description": "Name of the strategy"
                   },
                   {
@@ -800,7 +789,12 @@
                     "properties": {
                       "id": {
                         "type": "string",
-                        "enum": ["jailbreak", "prompt-injection", "experimental-jailbreak"],
+                        "enum": [
+                          "jailbreak",
+                          "prompt-injection",
+                          "experimental-jailbreak",
+                          "experimental-tree-jailbreak"
+                        ],
                         "description": "Name of the strategy"
                       }
                     },
@@ -809,7 +803,7 @@
                   }
                 ]
               },
-              "description": "Strategies to use for redteam generation.\n\nDefaults to jailbreak, prompt-injection\nSupports jailbreak, prompt-injection, experimental-jailbreak",
+              "description": "Strategies to use for redteam generation.\n\nDefaults to jailbreak, prompt-injection\nSupports jailbreak, prompt-injection, experimental-jailbreak, experimental-tree-jailbreak",
               "default": [
                 {
                   "id": "jailbreak"


### PR DESCRIPTION
- Changed `anyOf` to `allOf` for label properties in the schema.
- Added `experimental-tree-jailbreak` to the enum values for strategy names.
- Updated descriptions to reflect the new strategy options.