### PR TITLE
fix: defaultTest and scenario assert merging

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -593,6 +593,11 @@ class Evaluator {
                 ...testSuite.defaultTest?.options,
                 ...test.options,
               },
+              assert: [
+                // defaultTest.assert is omitted because it will be added to each test case later
+                ...(data.assert || []),
+                ...(test.assert || []),
+              ],
             };
           });
           // Add scenario tests to tests


### PR DESCRIPTION
This PR fixes two interactions among assertions defined in `defaultTest`, a scenario's config, and a scenario's test case:

1. If `defaultTest.assert` was defined and neither the scenario's config nor the scenario's test case defined `assert`, all assertions from `defaultTest.assert` were run twice for that test case.
2. If a test case in a scenario defined `assert`, none of the assertions in the scenario's `config.assert` were run for that test case.
