### PR TITLE
fix(redteam): allow arbitrary injectVar name for redteam providers

### DIFF
--- a/src/checkNodeVersion.ts
+++ b/src/checkNodeVersion.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 import logger from './logger';
@@ -22,7 +23,9 @@ export const checkNodeVersion = (): void => {
   const versionMatch = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/);
   if (!versionMatch) {
     logger.warn(
-      `Unexpected Node.js version format: ${process.version}. Please use Node.js ${requiredVersion}.`,
+      chalk.yellow(
+        `Unexpected Node.js version format: ${process.version}. Please use Node.js ${requiredVersion}.`,
+      ),
     );
     return;
   }
@@ -39,7 +42,9 @@ export const checkNodeVersion = (): void => {
     (major === requiredMajor && minor === requiredMinor && patch < requiredPatch)
   ) {
     logger.warn(
-      `You are using Node.js ${major}.${minor}.${patch}. This version is not supported. Please use Node.js ${requiredVersion}.`,
+      chalk.yellow(
+        `You are using Node.js ${major}.${minor}.${patch}. This version is not supported. Please use Node.js ${requiredVersion}.`,
+      ),
     );
     process.exit(1);
   }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -344,7 +344,7 @@ export async function loadApiProvider(
   } else if (providerPath.startsWith('http:') || providerPath.startsWith('https:')) {
     ret = new HttpProvider(providerPath, providerOptions);
   } else if (providerPath === 'promptfoo:redteam:iterative') {
-    ret = new RedteamIterativeProvider();
+    ret = new RedteamIterativeProvider(providerOptions.config);
   } else if (providerPath === 'promptfoo:redteam:iterative:image') {
     ret = new RedteamImageIterativeProvider();
   } else if (providerPath === 'promptfoo:redteam:iterative:tree') {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -345,10 +345,10 @@ export async function loadApiProvider(
     ret = new HttpProvider(providerPath, providerOptions);
   } else if (providerPath === 'promptfoo:redteam:iterative') {
     ret = new RedteamIterativeProvider(providerOptions.config);
+  } else if (providerPath === 'promptfoo:redteam:iterative:tree') {
+    ret = new RedteamIterativeTreeProvider(providerOptions.config);
   } else if (providerPath === 'promptfoo:redteam:iterative:image') {
     ret = new RedteamImageIterativeProvider();
-  } else if (providerPath === 'promptfoo:redteam:iterative:tree') {
-    ret = new RedteamIterativeTreeProvider();
   } else if (providerPath === 'promptfoo:manual-input') {
     ret = new ManualInputProvider(providerOptions);
   } else {

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -128,28 +128,28 @@ const categories = {
 const Strategies: Strategy[] = [
   {
     key: 'experimental-jailbreak',
-    action: (testCases) => {
+    action: (testCases, injectVar) => {
       logger.debug('Adding experimental jailbreaks to all test cases');
-      const experimentalJailbreaks = addIterativeJailbreaks(testCases, 'iterative');
+      const experimentalJailbreaks = addIterativeJailbreaks(testCases, injectVar, 'iterative');
       logger.debug(`Added ${experimentalJailbreaks.length} experimental jailbreak test cases`);
       return experimentalJailbreaks;
     },
   },
   {
     key: 'experimental-tree-jailbreak',
-    action: (testCases) => {
+    action: (testCases, injectVar) => {
       logger.debug('Adding experimental tree jailbreaks to all test cases');
-      const experimentalJailbreaks = addIterativeJailbreaks(testCases, 'iterative:tree');
+      const experimentalJailbreaks = addIterativeJailbreaks(testCases, injectVar, 'iterative:tree');
       logger.debug(`Added ${experimentalJailbreaks.length} experimental tree jailbreak test cases`);
       return experimentalJailbreaks;
     },
   },
   {
     key: 'jailbreak',
-    action: (testCases) => {
+    action: (testCases, injectVar) => {
       const harmfulPrompts = testCases.filter((t) => t.metadata.pluginId.startsWith('harmful:'));
       logger.debug('Adding jailbreaks to harmful prompts');
-      const jailbreaks = addIterativeJailbreaks(harmfulPrompts);
+      const jailbreaks = addIterativeJailbreaks(harmfulPrompts, injectVar, 'iterative');
       logger.debug(`Added ${jailbreaks.length} jailbreak test cases`);
       return jailbreaks;
     },

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import invariant from 'tiny-invariant';
+import logger from '../../logger';
 import { OpenAiChatCompletionProvider } from '../../providers/openai';
 import type { ApiProvider, CallApiContextParams, CallApiOptionsParams } from '../../types';
 import { getNunjucksEngine } from '../../util/templates';
-import logger from '../../logger';
 
 const ATTACKER_MODEL = 'gpt-4o';
 
@@ -204,7 +204,6 @@ async function runRedteamConversation(
 }
 
 class RedteamIterativeProvider implements ApiProvider {
-
   private readonly injectVar: string;
 
   constructor(private readonly config: Record<string, string | object>) {

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -3,6 +3,7 @@ import invariant from 'tiny-invariant';
 import { OpenAiChatCompletionProvider } from '../../providers/openai';
 import type { ApiProvider, CallApiContextParams, CallApiOptionsParams } from '../../types';
 import { getNunjucksEngine } from '../../util/templates';
+import logger from '../../logger';
 
 const ATTACKER_MODEL = 'gpt-4o';
 
@@ -92,6 +93,7 @@ async function runRedteamConversation(
   prompt: string,
   vars: Record<string, string | object>,
   provider: ApiProvider,
+  injectVar: string,
 ) {
   const redteamProvider = new OpenAiChatCompletionProvider(ATTACKER_MODEL, {
     config: {
@@ -100,9 +102,8 @@ async function runRedteamConversation(
     },
   });
   const targetProvider = provider;
-  const goal = vars.query; // TODO: change to inject var
   const nunjucks = getNunjucksEngine();
-
+  const goal = vars[injectVar];
   const redteamSystemPrompt = nunjucks.renderString(ATTACKER_SYSTEM_PROMPT, { goal });
   const onTopicSystemPrompt = nunjucks.renderString(ON_TOPIC_SYSTEM_PROMPT, { goal });
   const judgeSystemPrompt = nunjucks.renderString(JUDGE_SYSTEM_PROMPT, { goal });
@@ -113,7 +114,7 @@ async function runRedteamConversation(
       content: redteamSystemPrompt,
     },
   ];
-  const targetHistory: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
+
   let highestScore = 0;
   let bestResponse = '';
 
@@ -123,12 +124,11 @@ async function runRedteamConversation(
 
     // Get new prompt
     const redteamResp = await redteamProvider.callApi(redteamBody);
-    const redteamResponse = redteamResp.output || redteamResp.error;
     invariant(
       typeof redteamResp.output === 'string',
       `Expected output to be a string, but got response: ${JSON.stringify(redteamResp)}`,
     );
-    const { improvement, prompt: newPrompt } = JSON.parse(redteamResp.output) as {
+    const { prompt: newPrompt } = JSON.parse(redteamResp.output) as {
       improvement: string;
       prompt: string;
     };
@@ -203,7 +203,16 @@ async function runRedteamConversation(
   };
 }
 
-class RedteamIterativeJailbreaks implements ApiProvider {
+class RedteamIterativeProvider implements ApiProvider {
+
+  private readonly injectVar: string;
+
+  constructor(private readonly config: Record<string, string | object>) {
+    logger.debug(`RedteamIterativeProvider config: ${JSON.stringify(config)}`);
+    invariant(typeof config.injectVar === 'string', 'Expected injectVar to be set');
+    this.injectVar = config.injectVar;
+  }
+
   id() {
     return 'promptfoo:redteam:iterative';
   }
@@ -211,8 +220,8 @@ class RedteamIterativeJailbreaks implements ApiProvider {
   async callApi(prompt: string, context?: CallApiContextParams, options?: CallApiOptionsParams) {
     invariant(options?.originalProvider, 'Expected originalProvider to be set');
     invariant(context?.vars, 'Expected vars to be set');
-    return runRedteamConversation(prompt, context.vars, options?.originalProvider);
+    return runRedteamConversation(prompt, context.vars, options?.originalProvider, this.injectVar);
   }
 }
 
-export default RedteamIterativeJailbreaks;
+export default RedteamIterativeProvider;

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -216,7 +216,7 @@ async function runRedteamConversation(
   };
 }
 
-class RedteamIterativeJailbreaks implements ApiProvider {
+class RedteamIterativeProvider implements ApiProvider {
   id() {
     return 'promptfoo:redteam:iterative:image';
   }
@@ -228,4 +228,4 @@ class RedteamIterativeJailbreaks implements ApiProvider {
   }
 }
 
-export default RedteamIterativeJailbreaks;
+export default RedteamIterativeProvider;

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -433,8 +433,12 @@ class RedteamIterativeTreeJailbreaks implements ApiProvider {
     invariant(options?.originalProvider, 'Expected originalProvider to be set');
     invariant(context?.vars, 'Expected vars to be set');
 
-    const goal = context.vars.query;
+    logger.warn(`Context vars: ${JSON.stringify(context.vars)}`);
 
+    const injectVar = context.vars.injectVar;
+    invariant(typeof injectVar === 'string', 'Expected injectVar to be set');
+    const goal = context.vars[injectVar];
+  
     if (!goal) {
       logger.error('Goal is undefined. Make sure context.vars.query is set.');
       throw new Error('Goal is undefined');

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -412,13 +412,21 @@ async function runRedteamTreeSearch(
   }
 }
 
-class RedteamIterativeTreeJailbreaks implements ApiProvider {
+class RedteamIterativeTreeProvider implements ApiProvider {
+  private readonly injectVar: string;
+
+  constructor(private readonly config: Record<string, string | object>) {
+    logger.debug(`RedteamIterativeTreeProvider config: ${JSON.stringify(config)}`);
+    invariant(typeof config.injectVar === 'string', 'Expected injectVar to be set');
+    this.injectVar = config.injectVar;
+  }
+
   id() {
     return 'promptfoo:redteam:iterative:tree';
   }
 
   async callApi(prompt: string, context?: CallApiContextParams, options?: CallApiOptionsParams) {
-    logger.debug(`RedteamIterativeTreeJailbreaks callApi called with prompt: ${prompt}`);
+    logger.debug(`RedteamIterativeTreeProvider callApi called with prompt: ${prompt}`);
 
     if (context) {
       logger.debug(`Context vars: ${JSON.stringify(context.vars)}`);
@@ -432,14 +440,8 @@ class RedteamIterativeTreeJailbreaks implements ApiProvider {
 
     invariant(options?.originalProvider, 'Expected originalProvider to be set');
     invariant(context?.vars, 'Expected vars to be set');
-
-    logger.warn(`Context vars: ${JSON.stringify(context.vars)}`);
-
-    const injectVar = context.vars.injectVar;
-    invariant(typeof injectVar === 'string', 'Expected injectVar to be set');
-    const goal = context.vars[injectVar];
-  
-    if (!goal) {
+    const goal = context.vars[this.injectVar];
+    if (typeof goal !== 'string') {
       logger.error('Goal is undefined. Make sure context.vars.query is set.');
       throw new Error('Goal is undefined');
     }
@@ -455,7 +457,7 @@ class RedteamIterativeTreeJailbreaks implements ApiProvider {
       logger.debug(`runRedteamTreeSearch result: ${JSON.stringify(result)}`);
       return result;
     } catch (error) {
-      logger.error(`Error in RedteamIterativeTreeJailbreaks callApi: ${error}`);
+      logger.error(`Error in RedteamIterativeTreeProvider callApi: ${error}`);
       // Return a default response instead of throwing
       return {
         output: '',
@@ -468,5 +470,5 @@ class RedteamIterativeTreeJailbreaks implements ApiProvider {
   }
 }
 
-export default RedteamIterativeTreeJailbreaks;
+export default RedteamIterativeTreeProvider;
 export { parseJudgement, calculateScore };

--- a/src/redteam/strategies/iterative.ts
+++ b/src/redteam/strategies/iterative.ts
@@ -2,13 +2,19 @@ import { TestCase } from '../../types';
 
 export function addIterativeJailbreaks(
   testCases: TestCase[],
+  injectVar: string,
   strategy: 'iterative' | 'iterative:tree' = 'iterative',
 ): TestCase[] {
   const providerName =
     strategy === 'iterative' ? 'promptfoo:redteam:iterative' : 'promptfoo:redteam:iterative:tree';
   return testCases.map((testCase) => ({
     ...testCase,
-    provider: providerName,
+    provider: {
+      id: providerName,
+      config: {
+        injectVar,
+      },
+    },
     assert: testCase.assert?.map((assertion) => ({
       ...assertion,
       metric: `${assertion.metric}/${strategy === 'iterative' ? 'Iterative' : 'IterativeTree'}`,

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -48,6 +48,7 @@ import { VoyageEmbeddingProvider } from '../src/providers/voyage';
 import { WebhookProvider } from '../src/providers/webhook';
 import RedteamIterativeProvider from '../src/redteam/providers/iterative';
 import RedteamImageIterativeProvider from '../src/redteam/providers/iterativeImage';
+import RedteamIterativeTreeProvider from '../src/redteam/providers/iterativeTree';
 import type { ProviderOptionsMap, ProviderFunction } from '../src/types';
 
 jest.mock('fs', () => ({
@@ -992,9 +993,19 @@ config:
   });
 
   it('loadApiProvider with promptfoo:redteam:iterative', async () => {
-    const provider = await loadApiProvider('promptfoo:redteam:iterative');
+    const provider = await loadApiProvider('promptfoo:redteam:iterative', {
+      options: { config: { injectVar: 'foo' } },
+    });
     expect(provider).toBeInstanceOf(RedteamIterativeProvider);
     expect(provider.id()).toBe('promptfoo:redteam:iterative');
+  });
+
+  it('loadApiProvider with promptfoo:redteam:iterative:tree', async () => {
+    const provider = await loadApiProvider('promptfoo:redteam:iterative:tree', {
+      options: { config: { injectVar: 'foo' } },
+    });
+    expect(provider).toBeInstanceOf(RedteamIterativeTreeProvider);
+    expect(provider.id()).toBe('promptfoo:redteam:iterative:tree');
   });
 
   it('loadApiProvider with promptfoo:redteam:iterative:image', async () => {


### PR DESCRIPTION
This PR modifies the redteam providers to use a configurable `injectVar` instead of relying on a hardcoded `query` value. 

Key changes:
- Modified redteam providers to use a configurable `injectVar` instead of hardcoded `query`
- Updated provider initialization in test cases to track `injectVar`
- Refactored `RedteamIterativeProvider` and `RedteamIterativeTreeProvider` to accept configuration
- Updated related imports and class names for consistency

## Testing Instructions

1. In the main branch:
   - Create a redteam where the inject var is something other than `query`
   - Add experimental-jailbreaks
   - View the results

2. Checkout this branch and repeat the above steps:
   - Create a redteam with a custom inject var
   - Add experimental-jailbreaks
   - Observe the improved results with the configurable `injectVar`