### PR TITLE
fix: color error in local checkNodeVersion test

### DIFF
--- a/src/checkNodeVersion.ts
+++ b/src/checkNodeVersion.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 import logger from './logger';
@@ -22,7 +23,9 @@ export const checkNodeVersion = (): void => {
   const versionMatch = process.version.match(/^v(\d+)\.(\d+)\.(\d+)/);
   if (!versionMatch) {
     logger.warn(
-      `Unexpected Node.js version format: ${process.version}. Please use Node.js ${requiredVersion}.`,
+      chalk.yellow(
+        `Unexpected Node.js version format: ${process.version}. Please use Node.js ${requiredVersion}.`,
+      ),
     );
     return;
   }
@@ -39,7 +42,9 @@ export const checkNodeVersion = (): void => {
     (major === requiredMajor && minor === requiredMinor && patch < requiredPatch)
   ) {
     logger.warn(
-      `You are using Node.js ${major}.${minor}.${patch}. This version is not supported. Please use Node.js ${requiredVersion}.`,
+      chalk.yellow(
+        `You are using Node.js ${major}.${minor}.${patch}. This version is not supported. Please use Node.js ${requiredVersion}.`,
+      ),
     );
     process.exit(1);
   }


### PR DESCRIPTION
- Use chalk.yellow() to colorize warning messages in checkNodeVersion function. This is normally done by logger but may be disabled locally causing the test to fail.