### PR TITLE
chore: warn when a var is named assert

### DIFF
--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -224,6 +224,26 @@ export async function readTests(
     }
   }
 
+  if (
+    ret.some((testCase) => testCase.vars?.assert) &&
+    !process.env.PROMPTFOO_NO_TESTCASE_ASSERT_WARNING
+  ) {
+    logger.warn(dedent`
+      Warning: Found 'assert' key in vars. This is likely a mistake in your configuration.
+
+      'assert' should be *unindented* so it is under the test itself, not vars. For example:
+
+      tests:
+        - vars:
+            foo: bar
+          assert:
+            - type: contains
+              value: "bar"
+
+      To disable this message, set the environment variable PROMPTFOO_NO_TESTCASE_ASSERT_WARNING=1.
+    `);
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
I've helped people with this multiple times, most recently https://discord.com/channels/1153767083381903389/1265701055195381781, so I think it might be worth adding a warning