### PR TITLE
chore(ci): implement multi-arch Docker image build and push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,12 @@
 name: Test and Publish Docker Image
 
 on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -82,9 +88,16 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
-        if: success()
+        if: success() && (github.event_name != 'pull_request')
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@
 # is running correctly, and then publishes the image to GitHub Container Registry
 # if all checks pass. This action is exclusively triggered via workflow dispatch.
 
-name: Test and Publish Docker Image
+name: Test and Publish Multi-arch Docker Image
 
 on:
   pull_request:
@@ -35,16 +35,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      - name: Build Docker image for testing
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: false
           load: true
           tags: local-test-image:latest
+          platforms: linux/amd64
           build-args: |
             NEXT_PUBLIC_PROMPTFOO_BASE_URL=http://localhost:3000
 
@@ -76,7 +80,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: success()
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -85,7 +89,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: success()
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -96,11 +100,12 @@ jobs:
             type=sha
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build and push Docker image
+      - name: Build and push multi-arch Docker image
         if: success() && (github.event_name != 'pull_request')
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 # ---- Build ----
-FROM node:20-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 
 ARG NEXT_PUBLIC_PROMPTFOO_BASE_URL
 ENV NEXT_PUBLIC_PROMPTFOO_BASE_URL=${NEXT_PUBLIC_PROMPTFOO_BASE_URL}
@@ -36,7 +36,7 @@ WORKDIR /app/src/web/nextui
 RUN npm prune --omit=dev
 
 # ---- Final Stage ----
-FROM node:20-alpine
+FROM --platform=$TARGETPLATFORM node:20-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/promptfoo/promptfoo"
 LABEL org.opencontainers.image.description="promptfoo is a tool for testing, evaluating, and red-teaming LLM apps."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 # ---- Build ----
-FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} node:20-alpine AS builder
 
 ARG NEXT_PUBLIC_PROMPTFOO_BASE_URL
 ENV NEXT_PUBLIC_PROMPTFOO_BASE_URL=${NEXT_PUBLIC_PROMPTFOO_BASE_URL}
@@ -36,7 +37,8 @@ WORKDIR /app/src/web/nextui
 RUN npm prune --omit=dev
 
 # ---- Final Stage ----
-FROM --platform=$TARGETPLATFORM node:20-alpine
+ARG TARGETPLATFORM=linux/amd64
+FROM --platform=${TARGETPLATFORM} node:20-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/promptfoo/promptfoo"
 LABEL org.opencontainers.image.description="promptfoo is a tool for testing, evaluating, and red-teaming LLM apps."

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,15 +55,19 @@ RUN adduser -S nextjs -u 1001
 RUN mkdir -p /root/.promptfoo/output
 RUN chown -R nextjs:nodejs /app /root/.promptfoo
 
+# Create the .env file directory with correct permissions
+RUN mkdir -p /app/src/web/nextui
+RUN chown nextjs:nodejs /app/src/web/nextui
+
 # Install curl for the healthcheck
 RUN apk add --no-cache curl
 
 # Create a script to write environment variables to .env file
 RUN echo -e '#!/bin/sh\n\
     echo "Writing environment variables to .env file..."\n\
-    env > src/web/nextui/.env\n\
+    env > /app/src/web/nextui/.env\n\
     echo "Loaded environment variables:"\n\
-    cat src/web/nextui/.env\n\
+    cat /app/src/web/nextui/.env\n\
     echo "Starting server..."\n\
     node src/web/nextui/server.js' > entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN npm prune --omit=dev
 # ---- Final Stage ----
 FROM node:20-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/promptfoo/promptfoo"
+LABEL org.opencontainers.image.description="promptfoo is a tool for testing, evaluating, and red-teaming LLM apps."
+LABEL org.opencontainers.image.licenses="MIT"
+
 ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -122,18 +122,22 @@ docker run -d --name promptfoo_container -p 3000:3000 \
   -e PROMPTFOO_SHARE_REDIS_HOST=redis_host \
   -e PROMPTFOO_SHARE_REDIS_PORT=6379 \
   -e PROMPTFOO_SHARE_REDIS_PASSWORD=your_password \
-  ghcr.io/promptfoo/promptfoo:main
+  promptfoo-ui
 ```
 
 ## Pointing the promptfoo client to your hosted instance
 
-When self-hosting, set the environment variables so that the `promptfoo share` command knows how to reach your hosted application:
+When self-hosting, you need to set the environment variables so that the `promptfoo share` command knows how to reach your hosted application. Here's an example:
 
 ```sh
 PROMPTFOO_REMOTE_API_BASE_URL=http://localhost:3000 PROMPTFOO_REMOTE_APP_BASE_URL=http://localhost:3000 promptfoo share -y
 ```
 
 This will create a shareable URL using your self-hosted service.
+
+The `PROMPTFOO_REMOTE_API_BASE_URL` environment variable specifies the base URL for the API endpoints of your self-hosted service. This is where the `promptfoo share` command sends data to create a shareable URL.
+
+Similarly, the `PROMPTFOO_REMOTE_APP_BASE_URL` environment variable sets the base URL for the UI of your self-hosted service. This will be a visible part of the shareable URL.
 
 These configuration options can also be set under the `sharing` property of your promptfoo config:
 

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -23,15 +23,56 @@ promptfoo provides a Docker image that allows you to host a central server that 
 
 The self-hosted app consists of:
 
-- Next.js application that runs the web ui.
-- filesystem store that persists the eval results.
-- key-value (KV) store that persists shared data (redis, filesystem, or memory).
+- Next.js application that runs the web UI.
+- Filesystem store that persists the eval results.
+- Key-value (KV) store that persists shared data (redis, filesystem, or memory).
 
-## Setup
+## Using the pre-built Docker image
+
+promptfoo is available as a Docker image published on GitHub Container Registry. This is the easiest way to get started with self-hosting.
+
+### 1. Pull the Docker image
+
+Pull the latest version of the promptfoo image:
+
+```bash
+docker pull ghcr.io/promptfoo/promptfoo:main
+```
+
+For a specific version, use a tag:
+
+```bash
+docker pull ghcr.io/promptfoo/promptfoo:v0.x.x
+```
+
+### 2. Run the Docker container
+
+Launch the Docker container using this command:
+
+```bash
+docker run -d --name promptfoo_container -p 3000:3000 -v /path/to/local_promptfoo:/root/.promptfoo ghcr.io/promptfoo/promptfoo:main
+```
+
+Key points:
+
+- `-v /path/to/local_promptfoo:/root/.promptfoo` maps the container's working directory to your local filesystem. Replace `/path/to/local_promptfoo` with your preferred path.
+- Omitting the `-v` argument will result in non-persistent evals.
+
+### 3. Set API Credentials (Optional)
+
+To run evals on the server, set API credentials:
+
+```bash
+docker run -d --name promptfoo_container -p 3000:3000 -e OPENAI_API_KEY=sk-abc123 ghcr.io/promptfoo/promptfoo:main
+```
+
+Replace `sk-abc123` with your actual API key.
+
+## Building your own Docker image
+
+If you need to customize the image, you can build it yourself.
 
 ### 1. Clone the Repository
-
-First, clone the promptfoo repository from GitHub:
 
 ```sh
 git clone https://github.com/promptfoo/promptfoo.git
@@ -40,38 +81,15 @@ cd promptfoo
 
 ### 2. Build the Docker Image
 
-Build the Docker image with the following command:
-
 ```sh
 docker build --build-arg NEXT_PUBLIC_PROMPTFOO_BASE_URL=http://localhost:3000 -t promptfoo-ui .
 ```
-
-`NEXT_PUBLIC_PROMPTFOO_BASE_URL` tells the web app where to send the API request when the user clicks the 'Share' button. This should be configured to match the URL of your self-hosted instance.
 
 Replace `http://localhost:3000` with your instance's URL if you're not running it locally.
 
 ### 3. Run the Docker Container
 
-Launch the Docker container using this command:
-
-```sh
-docker run -d --name promptfoo_container -p 3000:3000 -v /path/to/local_promptfoo:/root/.promptfoo promptfoo-ui
-```
-
-Key points:
-
-- `-v /path/to/local_promptfoo:/root/.promptfoo` maps the container's working directory to your local filesystem. Replace `/path/to/local_promptfoo` with your preferred path.
-- Omitting the `-v` argument will result in non-persistent evals.
-
-### 4. Set API Credentials
-
-You can also set API credentials on the running Docker instance so that evals can be run on the server. For example, we'll set the OpenAI API key so users can run evals directly from the web ui:
-
-```sh
-docker run -d --name promptfoo_container -p 3000:3000 -e OPENAI_API_KEY=sk-abc123 promptfoo-ui
-```
-
-Replace `sk-abc123` with your actual API key.
+Follow the same steps as in the pre-built image section, but use your custom image name (`promptfoo-ui`) instead of `ghcr.io/promptfoo/promptfoo:main`.
 
 ## Advanced Configuration
 
@@ -104,22 +122,18 @@ docker run -d --name promptfoo_container -p 3000:3000 \
   -e PROMPTFOO_SHARE_REDIS_HOST=redis_host \
   -e PROMPTFOO_SHARE_REDIS_PORT=6379 \
   -e PROMPTFOO_SHARE_REDIS_PASSWORD=your_password \
-  promptfoo-ui
+  ghcr.io/promptfoo/promptfoo:main
 ```
 
 ## Pointing the promptfoo client to your hosted instance
 
-When self-hosting, you need to set the environment variables so that the `promptfoo share` command knows how to reach your hosted application. Here's an example:
+When self-hosting, set the environment variables so that the `promptfoo share` command knows how to reach your hosted application:
 
 ```sh
 PROMPTFOO_REMOTE_API_BASE_URL=http://localhost:3000 PROMPTFOO_REMOTE_APP_BASE_URL=http://localhost:3000 promptfoo share -y
 ```
 
 This will create a shareable URL using your self-hosted service.
-
-The `PROMPTFOO_REMOTE_API_BASE_URL` environment variable specifies the base URL for the API endpoints of your self-hosted service. This is where the `promptfoo share` command sends data to create a shareable URL.
-
-Similarly, the `PROMPTFOO_REMOTE_APP_BASE_URL` environment variable sets the base URL for the UI of your self-hosted service. This will be a visible part of the shareable URL.
 
 These configuration options can also be set under the `sharing` property of your promptfoo config:
 
@@ -128,3 +142,14 @@ sharing:
   apiBaseUrl: http://localhost:3000
   appBaseUrl: http://localhost:3000
 ```
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check Docker logs: `docker logs promptfoo_container`
+2. Ensure all required environment variables are set
+3. Verify the volume mounting is correct for persistent storage
+4. Check your firewall settings if you can't access the web UI
+
+For more help, visit our [GitHub issues page](https://github.com/promptfoo/promptfoo/issues) or join our community Discord.

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -27,52 +27,11 @@ The self-hosted app consists of:
 - Filesystem store that persists the eval results.
 - Key-value (KV) store that persists shared data (redis, filesystem, or memory).
 
-## Using the pre-built Docker image
-
-promptfoo is available as a Docker image published on GitHub Container Registry. This is the easiest way to get started with self-hosting.
-
-### 1. Pull the Docker image
-
-Pull the latest version of the promptfoo image:
-
-```bash
-docker pull ghcr.io/promptfoo/promptfoo:main
-```
-
-For a specific version, use a tag:
-
-```bash
-docker pull ghcr.io/promptfoo/promptfoo:v0.x.x
-```
-
-### 2. Run the Docker container
-
-Launch the Docker container using this command:
-
-```bash
-docker run -d --name promptfoo_container -p 3000:3000 -v /path/to/local_promptfoo:/root/.promptfoo ghcr.io/promptfoo/promptfoo:main
-```
-
-Key points:
-
-- `-v /path/to/local_promptfoo:/root/.promptfoo` maps the container's working directory to your local filesystem. Replace `/path/to/local_promptfoo` with your preferred path.
-- Omitting the `-v` argument will result in non-persistent evals.
-
-### 3. Set API Credentials (Optional)
-
-To run evals on the server, set API credentials:
-
-```bash
-docker run -d --name promptfoo_container -p 3000:3000 -e OPENAI_API_KEY=sk-abc123 ghcr.io/promptfoo/promptfoo:main
-```
-
-Replace `sk-abc123` with your actual API key.
-
-## Building your own Docker image
-
-If you need to customize the image, you can build it yourself.
+## Building from Source
 
 ### 1. Clone the Repository
+
+First, clone the promptfoo repository from GitHub:
 
 ```sh
 git clone https://github.com/promptfoo/promptfoo.git
@@ -81,15 +40,58 @@ cd promptfoo
 
 ### 2. Build the Docker Image
 
+Build the Docker image with the following command:
+
 ```sh
 docker build --build-arg NEXT_PUBLIC_PROMPTFOO_BASE_URL=http://localhost:3000 -t promptfoo-ui .
 ```
+
+`NEXT_PUBLIC_PROMPTFOO_BASE_URL` tells the web app where to send the API request when the user clicks the 'Share' button. This should be configured to match the URL of your self-hosted instance.
 
 Replace `http://localhost:3000` with your instance's URL if you're not running it locally.
 
 ### 3. Run the Docker Container
 
-Follow the same steps as in the pre-built image section, but use your custom image name (`promptfoo-ui`) instead of `ghcr.io/promptfoo/promptfoo:main`.
+Launch the Docker container using this command:
+
+```sh
+docker run -d --name promptfoo_container -p 3000:3000 -v /path/to/local_promptfoo:/root/.promptfoo promptfoo-ui
+```
+
+Key points:
+
+- `-v /path/to/local_promptfoo:/root/.promptfoo` maps the container's working directory to your local filesystem. Replace `/path/to/local_promptfoo` with your preferred path.
+- Omitting the `-v` argument will result in non-persistent evals.
+
+### 4. Set API Credentials
+
+You can also set API credentials on the running Docker instance so that evals can be run on the server. For example, we'll set the OpenAI API key so users can run evals directly from the web UI:
+
+```sh
+docker run -d --name promptfoo_container -p 3000:3000 -e OPENAI_API_KEY=sk-abc123 promptfoo-ui
+```
+
+Replace `sk-abc123` with your actual API key.
+
+## Using Pre-built Docker Images
+
+As an alternative to building from source, we also publish pre-built Docker images on GitHub Container Registry. This can be a quicker way to get started if you don't need to customize the image. However, we generally recommend building from source due to static variable inlining in the pre-built image. Some features, such as the `promptfoo share` command, may not work out of the box with the pre-built image (by default, `promptfoo share` will point to `localhost:3000`).
+
+To use a pre-built image:
+
+1. Pull the image:
+
+```bash
+docker pull ghcr.io/promptfoo/promptfoo:main
+```
+
+2. Run the container:
+
+```bash
+docker run -d --name promptfoo_container -p 3000:3000 -v /path/to/local_promptfoo:/root/.promptfoo ghcr.io/promptfoo/promptfoo:main
+```
+
+You can use specific version tags instead of `main` for more stable releases.
 
 ## Advanced Configuration
 
@@ -146,14 +148,3 @@ sharing:
   apiBaseUrl: http://localhost:3000
   appBaseUrl: http://localhost:3000
 ```
-
-## Troubleshooting
-
-If you encounter issues:
-
-1. Check Docker logs: `docker logs promptfoo_container`
-2. Ensure all required environment variables are set
-3. Verify the volume mounting is correct for persistent storage
-4. Check your firewall settings if you can't access the web UI
-
-For more help, visit our [GitHub issues page](https://github.com/promptfoo/promptfoo/issues) or join our community Discord.


### PR DESCRIPTION
- Update GitHub Actions workflow to build and push multi-arch images
- Add support for amd64 and arm64 architectures
- Update Dockerfile to use platform-specific base images
- Add metadata labels to the Docker image
- Trigger workflow on pull requests, pushes to main, and releases

CC @rrbanda