### PR TITLE
docs: fix javascript configuration guide variable example

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -168,7 +168,9 @@ tests:
 module.exports = function (varName, prompt, otherVars) {
   // Example logic to return a value based on the varName
   if (varName === 'context') {
-    return `Processed ${otherVars.input} for prompt: ${prompt}`;
+    return {
+      output: `Processed ${otherVars.input} for prompt: ${prompt}`,
+    };
   }
   return {
     output: 'default value',


### PR DESCRIPTION
Javascript variables are expected to return an object.