### PR TITLE
chore(docker): add multi-arch image description

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,3 +111,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_PROMPTFOO_BASE_URL=http://localhost:3000
+          outputs: |
+            type=image,name=target,annotation-index.org.opencontainers.image.description=promptfoo is a tool for testing, evaluating, and red-teaming LLM apps.


### PR DESCRIPTION
- ci: add image description annotation to Docker build action based on https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images