### PR TITLE
fix: improve handling of json objects in http provider

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -40,6 +40,36 @@ tests:
 
 If not specified, HTTP POST with content-type application/json is assumed.
 
+### Nested objects
+
+Nested objects are supported and should be passed to the `dump` function.
+
+```yaml
+providers:
+  - id: 'https://example.com/generateTranslation'
+    config:
+      body:
+        // highlight-start
+        messages: '{{messages | dump}}'
+        // highlight-end
+        model: '{{model}}'
+        translate: '{{language}}'
+
+tests:
+  - vars:
+      // highlight-start
+      messages:
+        - role: 'user'
+          content: 'foobar'
+        - role: 'assistant'
+          content: 'baz'
+      // highlight-end
+      model: 'gpt-4'
+      language: 'French'
+```
+
+Note that any valid JSON string within `body` will be converted to a JSON object.
+
 ## Parsing a JSON response
 
 If your API responds with a JSON object and you want to pick out a specific value, use the `responseParser` property to set a Javascript snippet that manipulates the provided `json` object.

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1,4 +1,3 @@
-import yaml from 'js-yaml';
 import invariant from 'tiny-invariant';
 import { fetchWithCache } from '../cache';
 import logger from '../logger';
@@ -8,9 +7,18 @@ import type {
   ProviderOptions,
   ProviderResponse,
 } from '../types';
-import { isValidJson, safeJsonStringify } from '../util/json';
+import { safeJsonStringify } from '../util/json';
 import { getNunjucksEngine } from '../util/templates';
 import { REQUEST_TIMEOUT_MS } from './shared';
+
+const nunjucks = getNunjucksEngine();
+
+interface HttpProviderConfig {
+  method: string;
+  headers: Record<string, string>;
+  body: Record<string, any>;
+  responseParser: string | Function;
+}
 
 function createResponseParser(parser: any): (data: any) => ProviderResponse {
   if (typeof parser === 'function') {
@@ -22,15 +30,53 @@ function createResponseParser(parser: any): (data: any) => ProviderResponse {
   return (data) => ({ output: data });
 }
 
+export function processBody(
+  body: Record<string, any>,
+  vars: Record<string, any>,
+): Record<string, any> {
+  const processedBody: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(body)) {
+    if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        processedBody[key] = value.map((item) =>
+          typeof item === 'object' && item !== null
+            ? processBody(item, vars)
+            : nunjucks.renderString(item, vars),
+        );
+      } else {
+        processedBody[key] = processBody(value, vars);
+      }
+    } else if (typeof value === 'string') {
+      const renderedValue = nunjucks.renderString(value, vars || {});
+      try {
+        processedBody[key] = JSON.parse(renderedValue);
+      } catch (error) {
+        processedBody[key] = renderedValue;
+      }
+    } else {
+      processedBody[key] = value;
+    }
+  }
+
+  return processedBody;
+}
+
 export class HttpProvider implements ApiProvider {
   url: string;
-  config: any;
+  config: HttpProviderConfig;
   responseParser: (data: any) => ProviderResponse;
 
   constructor(url: string, options: ProviderOptions) {
     this.url = url;
     this.config = options.config;
     this.responseParser = createResponseParser(this.config.responseParser);
+    invariant(
+      this.config.body,
+      `Expected HTTP provider ${this.url} to have a config containing {body}, but instead got ${safeJsonStringify(
+        this.config,
+      )}`,
+    );
   }
 
   id(): string {
@@ -42,33 +88,36 @@ export class HttpProvider implements ApiProvider {
   }
 
   async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
-    // Render all nested strings
-    const nunjucks = getNunjucksEngine();
-    const stringifiedConfig = safeJsonStringify(this.config);
-    const renderedConfigString = nunjucks.renderString(stringifiedConfig, {
-      // nunjucks does not escape JSON strings, so we need to escape them manually
-      prompt: isValidJson(prompt) ? JSON.stringify(prompt).slice(1, -1) : prompt,
-      ...context?.vars,
-    });
-    // use yaml over json.parse because of trailing commas, quotes, and comments
-    const renderedConfig = yaml.load(renderedConfigString) as {
-      method: string;
-      headers: Record<string, string>;
-      body: Record<string, any>;
+    const vars = {
+      ...(context?.vars || {}),
+      prompt,
     };
+    const renderedConfig: Partial<HttpProviderConfig> = {
+      method: nunjucks.renderString(this.config.method || 'GET', vars),
+      headers: Object.fromEntries(
+        Object.entries(this.config.headers || { 'content-type': 'application/json' }).map(
+          ([key, value]) => [key, nunjucks.renderString(value, vars)],
+        ),
+      ),
+      body: processBody(this.config.body, vars),
+      responseParser: this.config.responseParser,
+    };
+
     const method = renderedConfig.method || 'POST';
     const headers = renderedConfig.headers || { 'Content-Type': 'application/json' };
     invariant(typeof method === 'string', 'Expected method to be a string');
     invariant(typeof headers === 'object', 'Expected headers to be an object');
 
-    logger.debug(`Calling HTTP provider: ${this.url} with config: ${stringifiedConfig}`);
+    logger.debug(
+      `Calling HTTP provider: ${this.url} with config: ${safeJsonStringify(renderedConfig)}`,
+    );
     let response;
     try {
       response = await fetchWithCache(
         this.url,
         {
-          method,
-          headers,
+          method: renderedConfig.method,
+          headers: renderedConfig.headers,
           body: JSON.stringify(renderedConfig.body),
         },
         REQUEST_TIMEOUT_MS,


### PR DESCRIPTION
Related to #1265 

Nested objects are supported and should be passed to the `dump` function.

```yaml
providers:
  - id: 'https://example.com/generateTranslation'
    config:
      body:
        // highlight-start
        messages: '{{messages | dump}}'
        // highlight-end
        model: '{{model}}'
        translate: '{{language}}'

tests:
  - vars:
      // highlight-start
      messages:
        - role: 'user'
          content: 'foobar'
        - role: 'assistant'
          content: 'baz'
      // highlight-end
      model: 'gpt-4'
      language: 'French'
```

Note that any valid JSON string within `body` will be converted to a JSON object.