### PR TITLE
Allow loading .{,m,c}ts files

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -143,6 +143,9 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
     case '.js':
     case '.cjs':
     case '.mjs':
+    case '.ts':
+    case '.cts':
+    case '.mts':
       return (await importModule(configPath)) as UnifiedConfig;
     default:
       throw new Error(`Unsupported configuration file format: ${ext}`);


### PR DESCRIPTION
This would allow using the upcoming experimental TypeScript support in node + allow using tools like swc, by supplying NODE_OPTIONS to inject swc as the loader/transpiler