### PR TITLE
fix(docker): add sqlite-dev to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /app/src/web/nextui
 RUN chown nextjs:nodejs /app/src/web/nextui
 
 # Install curl for the healthcheck
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl sqlite-dev
 
 # Create a script to write environment variables to .env file
 RUN echo -e '#!/bin/sh\n\


### PR DESCRIPTION
Added sqlite-dev to the list of packages installed in the final Docker image to resolve runtime issues with better-sqlite3 module.