### PR TITLE
fix: report cached tokens from assertions

### DIFF
--- a/src/assertions/AssertionsResult.ts
+++ b/src/assertions/AssertionsResult.ts
@@ -4,6 +4,7 @@ const DEFAULT_TOKENS_USED = {
   total: 0,
   prompt: 0,
   completion: 0,
+  cached: 0,
 };
 
 interface ParentAssertionSet {
@@ -72,6 +73,7 @@ export class AssertionsResult {
       this.tokensUsed.total += result.tokensUsed.total || 0;
       this.tokensUsed.prompt += result.tokensUsed.prompt || 0;
       this.tokensUsed.completion += result.tokensUsed.completion || 0;
+      this.tokensUsed.cached += result.tokensUsed.cached || 0;
     }
 
     if (result.pass) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -274,6 +274,7 @@ class Evaluator {
           this.stats.tokenUsage.total += checkResult.tokensUsed.total || 0;
           this.stats.tokenUsage.prompt += checkResult.tokensUsed.prompt || 0;
           this.stats.tokenUsage.completion += checkResult.tokensUsed.completion || 0;
+          this.stats.tokenUsage.cached += checkResult.tokensUsed.cached || 0;
         }
         ret.response = processedResponse;
         ret.gradingResult = checkResult;

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -168,6 +168,7 @@ function fail(reason: string, tokensUsed?: Partial<TokenUsage>): Omit<GradingRes
       total: tokensUsed?.total || 0,
       prompt: tokensUsed?.prompt || 0,
       completion: tokensUsed?.completion || 0,
+      cached: tokensUsed?.cached || 0,
     },
   };
 }
@@ -191,6 +192,7 @@ export async function matchesSimilarity(
     total: 0,
     prompt: 0,
     completion: 0,
+    cached: 0,
   };
 
   if ('callSimilarityApi' in finalProvider) {
@@ -217,6 +219,8 @@ export async function matchesSimilarity(
       completion:
         (expectedEmbedding.tokenUsage?.completion || 0) +
         (outputEmbedding.tokenUsage?.completion || 0),
+      cached:
+        (expectedEmbedding.tokenUsage?.cached || 0) + (outputEmbedding.tokenUsage?.cached || 0),
     };
 
     if (expectedEmbedding.error || outputEmbedding.error) {
@@ -356,6 +360,7 @@ export async function matchesLlmRubric(
         total: resp.tokenUsage?.total || 0,
         prompt: resp.tokenUsage?.prompt || 0,
         completion: resp.tokenUsage?.completion || 0,
+        cached: resp.tokenUsage?.cached || 0,
       },
     };
   } catch (err) {
@@ -454,6 +459,7 @@ export async function matchesFactuality(
         total: resp.tokenUsage?.total || 0,
         prompt: resp.tokenUsage?.prompt || 0,
         completion: resp.tokenUsage?.completion || 0,
+        cached: resp.tokenUsage?.cached || 0,
       },
     };
   } catch (err) {
@@ -513,6 +519,7 @@ export async function matchesClosedQa(
         total: resp.tokenUsage?.total || 0,
         prompt: resp.tokenUsage?.prompt || 0,
         completion: resp.tokenUsage?.completion || 0,
+        cached: resp.tokenUsage?.cached || 0,
       },
     };
   } catch (err) {
@@ -543,6 +550,7 @@ export async function matchesAnswerRelevance(
     total: 0,
     prompt: 0,
     completion: 0,
+    cached: 0,
   };
 
   const candidateQuestions: string[] = [];
@@ -558,6 +566,7 @@ export async function matchesAnswerRelevance(
       tokensUsed.total += resp.tokenUsage?.total || 0;
       tokensUsed.prompt += resp.tokenUsage?.prompt || 0;
       tokensUsed.completion += resp.tokenUsage?.completion || 0;
+      tokensUsed.cached += resp.tokenUsage?.cached || 0;
       return fail(resp.error || 'No output', tokensUsed);
     }
 
@@ -578,6 +587,7 @@ export async function matchesAnswerRelevance(
     tokensUsed.total += inputEmbeddingResp.tokenUsage?.total || 0;
     tokensUsed.prompt += inputEmbeddingResp.tokenUsage?.prompt || 0;
     tokensUsed.completion += inputEmbeddingResp.tokenUsage?.completion || 0;
+    tokensUsed.cached += inputEmbeddingResp.tokenUsage?.cached || 0;
     return fail(inputEmbeddingResp.error || 'No embedding', tokensUsed);
   }
   const inputEmbedding = inputEmbeddingResp.embedding;
@@ -588,6 +598,7 @@ export async function matchesAnswerRelevance(
     tokensUsed.total += resp.tokenUsage?.total || 0;
     tokensUsed.prompt += resp.tokenUsage?.prompt || 0;
     tokensUsed.completion += resp.tokenUsage?.completion || 0;
+    tokensUsed.cached += resp.tokenUsage?.cached || 0;
     if (resp.error || !resp.embedding) {
       return fail(resp.error || 'No embedding', tokensUsed);
     }
@@ -661,6 +672,7 @@ export async function matchesContextRecall(
       total: resp.tokenUsage?.total || 0,
       prompt: resp.tokenUsage?.prompt || 0,
       completion: resp.tokenUsage?.completion || 0,
+      cached: resp.tokenUsage?.cached || 0,
     },
   };
 }
@@ -708,6 +720,7 @@ export async function matchesContextRelevance(
       total: resp.tokenUsage?.total || 0,
       prompt: resp.tokenUsage?.prompt || 0,
       completion: resp.tokenUsage?.completion || 0,
+      cached: resp.tokenUsage?.cached || 0,
     },
   };
 }
@@ -790,6 +803,7 @@ export async function matchesContextFaithfulness(
       total: resp.tokenUsage?.total || 0,
       prompt: resp.tokenUsage?.prompt || 0,
       completion: resp.tokenUsage?.completion || 0,
+      cached: resp.tokenUsage?.cached || 0,
     },
   };
 }
@@ -837,6 +851,7 @@ export async function matchesSelectBest(
     total: resp.tokenUsage?.total || 0,
     prompt: resp.tokenUsage?.prompt || 0,
     completion: resp.tokenUsage?.completion || 0,
+    cached: resp.tokenUsage?.cached || 0,
   };
   return outputs.map((output, index) => {
     if (index === verdict) {

--- a/test/assertions/AssertionResult.test.ts
+++ b/test/assertions/AssertionResult.test.ts
@@ -10,14 +10,14 @@ describe('AssertionsResult', () => {
     pass: true,
     score: 1,
     reason: 'The succeeding reason',
-    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+    tokensUsed: { total: 1, prompt: 2, completion: 3, cached: 0 },
     assertion: null,
   };
   const failingResult = {
     pass: false,
     score: 0,
     reason: 'The failing reason',
-    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+    tokensUsed: { total: 1, prompt: 2, completion: 3, cached: 0 },
     assertion: null,
   };
   const testResult = {
@@ -27,7 +27,7 @@ describe('AssertionsResult', () => {
     componentResults: [succeedingResult],
     namedScores: {},
     assertion: null,
-    tokensUsed: { total: 1, prompt: 2, completion: 3 },
+    tokensUsed: { total: 1, prompt: 2, completion: 3, cached: 0 },
   };
   let assertionsResult: AssertionsResult;
 
@@ -100,7 +100,7 @@ describe('AssertionsResult', () => {
     expect(assertionsResult.testResult()).toEqual({
       ...testResult,
       componentResults: [resultWithoutTokensUsed],
-      tokensUsed: { total: 0, prompt: 0, completion: 0 },
+      tokensUsed: { total: 0, prompt: 0, completion: 0, cached: 0 },
     });
   });
 
@@ -207,7 +207,7 @@ describe('AssertionsResult', () => {
         pass: true,
         score: 1,
         reason: 'No assertions',
-        tokensUsed: { total: 0, prompt: 0, completion: 0 },
+        tokensUsed: { total: 0, prompt: 0, completion: 0, cached: 0 },
         assertion: null,
       });
     });

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -62,6 +62,7 @@ describe('matchesSimilarity', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -79,6 +80,7 @@ describe('matchesSimilarity', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -98,6 +100,7 @@ describe('matchesSimilarity', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -117,6 +120,7 @@ describe('matchesSimilarity', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -153,6 +157,7 @@ describe('matchesSimilarity', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith('Expected output');
@@ -201,6 +206,7 @@ describe('matchesLlmRubric', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -226,6 +232,7 @@ describe('matchesLlmRubric', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -262,6 +269,7 @@ describe('matchesLlmRubric', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith('Grading prompt');
@@ -292,6 +300,7 @@ describe('matchesFactuality', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -314,6 +323,7 @@ describe('matchesFactuality', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -347,6 +357,7 @@ describe('matchesFactuality', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -387,6 +398,7 @@ describe('matchesClosedQa', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -410,6 +422,7 @@ describe('matchesClosedQa', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
   });
@@ -456,6 +469,7 @@ describe('matchesClosedQa', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(isJson).toBeTruthy();
@@ -624,6 +638,7 @@ describe('matchesAnswerRelevance', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(
@@ -672,6 +687,7 @@ describe('matchesAnswerRelevance', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(
@@ -811,6 +827,7 @@ describe('matchesContextRelevance', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(
@@ -841,6 +858,7 @@ describe('matchesContextRelevance', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(
@@ -881,6 +899,7 @@ describe('matchesContextFaithfulness', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledTimes(2);
@@ -917,6 +936,7 @@ describe('matchesContextFaithfulness', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledTimes(2);
@@ -947,6 +967,7 @@ describe('matchesContextRecall', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(expect.stringContaining(CONTEXT_RECALL.slice(0, 100)));
@@ -975,6 +996,7 @@ describe('matchesContextRecall', () => {
         total: expect.any(Number),
         prompt: expect.any(Number),
         completion: expect.any(Number),
+        cached: expect.any(Number),
       },
     });
     expect(mockCallApi).toHaveBeenCalledWith(expect.stringContaining(CONTEXT_RECALL.slice(0, 100)));


### PR DESCRIPTION
When rerunning tests with model-graded metrics, the final `tokensUsed.cached` was less than `tokensUsed.total` which made it seem like model-graded metrics were being re-executed unnecessarily.