### PR TITLE
chore(cli): add option to strip auth info from shared URLs

### DIFF
--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -1,10 +1,17 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 import readline from 'readline';
+import { URL } from 'url';
 import logger from '../logger';
 import { createShareableUrl } from '../share';
 import telemetry from '../telemetry';
+import { ResultsFile } from '../types';
 import { readLatestResults, readResult, setupEnv } from '../util';
+
+async function createPublicUrl(results: ResultsFile, showAuth: boolean) {
+  const url = await createShareableUrl(results.results, results.config, showAuth);
+  logger.info(`View results: ${chalk.greenBright.bold(url)}`);
+}
 
 export function shareCommand(program: Command) {
   program
@@ -12,8 +19,16 @@ export function shareCommand(program: Command) {
     .description('Create a shareable URL of an eval (defaults to most recent)')
     .option('-y, --yes', 'Skip confirmation')
     .option('--env-file <path>', 'Path to .env file')
+    .option(
+      '--show-auth',
+      'Show username/password authentication information in the URL if exists',
+      false,
+    )
     .action(
-      async (evalId: string | undefined, cmdObj: { yes: boolean; envFile?: string } & Command) => {
+      async (
+        evalId: string | undefined,
+        cmdObj: { yes: boolean; envFile?: string; showAuth: boolean } & Command,
+      ) => {
         setupEnv(cmdObj.envFile);
         telemetry.maybeShowNotice();
         telemetry.record('command_used', {
@@ -36,13 +51,8 @@ export function shareCommand(program: Command) {
           }
         }
 
-        const createPublicUrl = async () => {
-          const url = await createShareableUrl(results.results, results.config);
-          logger.info(`View results: ${chalk.greenBright.bold(url)}`);
-        };
-
         if (cmdObj.yes || process.env.PROMPTFOO_DISABLE_SHARE_WARNING) {
-          await createPublicUrl();
+          await createPublicUrl(results, cmdObj.showAuth);
         } else {
           const reader = readline.createInterface({
             input: process.stdin,
@@ -62,7 +72,7 @@ export function shareCommand(program: Command) {
               }
               reader.close();
 
-              await createPublicUrl();
+              await createPublicUrl(results, cmdObj.showAuth);
             },
           );
         }

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,11 +1,37 @@
+import { URL } from 'url';
 import { getAuthor } from './accounts';
 import { REMOTE_API_BASE_URL, REMOTE_APP_BASE_URL } from './constants';
 import { fetchWithProxy } from './fetch';
+import logger from './logger';
 import type { EvaluateSummary, SharedResults, UnifiedConfig } from './types';
+
+/**
+ * Removes authentication information (username and password) from a URL.
+ *
+ * This function addresses a security concern raised in GitHub issue #1184,
+ * where sensitive authentication information was being displayed in the CLI output.
+ * By default, we now strip this information to prevent accidental exposure of credentials.
+ *
+ * @param urlString - The URL string that may contain authentication information.
+ * @returns A new URL string with username and password removed, if present.
+ *          If URL parsing fails, it returns the original string.
+ */
+export function stripAuthFromUrl(urlString: string): string {
+  try {
+    const url = new URL(urlString);
+    url.username = '';
+    url.password = '';
+    return url.toString();
+  } catch (error) {
+    logger.warn('Failed to parse URL, returning original');
+    return urlString;
+  }
+}
 
 export async function createShareableUrl(
   results: EvaluateSummary,
   config: Partial<UnifiedConfig>,
+  showAuth: boolean = false,
 ): Promise<string> {
   const sharedResults: SharedResults = {
     data: {
@@ -34,5 +60,7 @@ export async function createShareableUrl(
   }
   const appBaseUrl =
     typeof config.sharing === 'object' ? config.sharing.appBaseUrl : REMOTE_APP_BASE_URL;
-  return `${appBaseUrl}/eval/${responseJson.id}`;
+  const fullUrl = `${appBaseUrl}/eval/${responseJson.id}`;
+
+  return showAuth ? fullUrl : stripAuthFromUrl(fullUrl);
 }

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -1,0 +1,39 @@
+import { stripAuthFromUrl } from '../src/share';
+
+jest.mock('../src/logger');
+
+describe('stripAuthFromUrl', () => {
+  it('removes username and password from URL', () => {
+    const input = 'https://user:pass@example.com/path?query=value#hash';
+    const expected = 'https://example.com/path?query=value#hash';
+    expect(stripAuthFromUrl(input)).toBe(expected);
+  });
+
+  it('handles URLs without auth info', () => {
+    const input = 'https://example.com/path?query=value#hash';
+    expect(stripAuthFromUrl(input)).toBe(input);
+  });
+
+  it('handles URLs with only username', () => {
+    const input = 'https://user@example.com/path';
+    const expected = 'https://example.com/path';
+    expect(stripAuthFromUrl(input)).toBe(expected);
+  });
+
+  it('handles URLs with special characters in auth', () => {
+    const input = 'https://user%40:p@ss@example.com/path';
+    const expected = 'https://example.com/path';
+    expect(stripAuthFromUrl(input)).toBe(expected);
+  });
+
+  it('returns original string for invalid URLs', () => {
+    const input = 'not a valid url';
+    expect(stripAuthFromUrl(input)).toBe(input);
+  });
+
+  it('handles URLs with IP addresses', () => {
+    const input = 'http://user:pass@192.168.1.1:8080/path';
+    const expected = 'http://192.168.1.1:8080/path';
+    expect(stripAuthFromUrl(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
- Implement stripAuthFromUrl function to remove username and password from URLs
- Add --show-auth option to share command to optionally display full URL
- Update createShareableUrl to use stripAuthFromUrl by default
- Add unit tests for stripAuthFromUrl function

Closes #1184