### PR TITLE
fix: trim model-graded-closedqa response

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -502,11 +502,11 @@ export async function matchesClosedQa(
 
   invariant(typeof resp.output === 'string', 'model-graded-closedqa produced malformed response');
   try {
-    const pass = resp.output.endsWith('Y');
+    const pass = resp.output.trimEnd().endsWith('Y');
     let reason;
     if (pass) {
       reason = 'The submission meets the criterion';
-    } else if (resp.output.endsWith('N')) {
+    } else if (resp.output.trimEnd().endsWith('N')) {
       reason = `The submission does not meet the criterion:\n${resp.output}`;
     } else {
       reason = `Model grader produced a malformed response:\n${resp.output}`;

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -386,7 +386,7 @@ describe('matchesClosedQa', () => {
     const grading = {};
 
     jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
-      output: 'foo \n \n bar\n Y Y',
+      output: 'foo \n \n bar\n Y Y \n',
       tokenUsage: { total: 10, prompt: 5, completion: 5 },
     });
 
@@ -410,13 +410,13 @@ describe('matchesClosedQa', () => {
     const grading = {};
 
     jest.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
-      output: 'foo bar N',
+      output: 'foo bar N \n',
       tokenUsage: { total: 10, prompt: 5, completion: 5 },
     });
 
     await expect(matchesClosedQa(input, expected, output, grading)).resolves.toEqual({
       pass: false,
-      reason: 'The submission does not meet the criterion:\nfoo bar N',
+      reason: 'The submission does not meet the criterion:\nfoo bar N \n',
       score: 0,
       tokensUsed: {
         total: expect.any(Number),


### PR DESCRIPTION
Fixes #1308

When gemma2:9b is used for model-graded-closedqa, the response often ends with a white space and a newline. It results in a malformed response error. In general, this problem can occur with models other than gemma2, but seems to occur more often with gemma2. The current implementation of response check is too strict.

This patch trim the end of the model-graded-closedqa response and relax the check.