### PR TITLE
refactor(utils): move transform logic to separate file

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -47,8 +47,9 @@ import {
   AssertionValue,
   ProviderResponse,
 } from './types';
-import { transformOutput, extractJsonObjects } from './util';
+import { extractJsonObjects } from './util';
 import { getNunjucksEngine } from './util/templates';
+import { transform } from './util/transform';
 
 const ASSERTIONS_MAX_CONCURRENCY = process.env.PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY
   ? parseInt(process.env.PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY, 10)
@@ -292,7 +293,7 @@ export async function runAssertion({
   });
 
   if (assertion.transform) {
-    output = await transformOutput(assertion.transform, output, {
+    output = await transform(assertion.transform, output, {
       vars: test.vars,
       prompt: { label: prompt },
     });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -27,7 +27,8 @@ import type {
   ProviderResponse,
   Assertion,
 } from './types';
-import { transformOutput, sha256 } from './util';
+import { sha256 } from './util';
+import { transform } from './util/transform';
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
 
@@ -247,10 +248,10 @@ class Evaluator {
       } else if (response.output) {
         // Create a copy of response so we can potentially mutate it.
         const processedResponse = { ...response };
-        const transform =
+        const shouldTransform =
           test.options?.transform || test.options?.postprocess || provider.transform;
-        if (transform) {
-          processedResponse.output = await transformOutput(transform, processedResponse.output, {
+        if (shouldTransform) {
+          processedResponse.output = await transform(shouldTransform, processedResponse.output, {
             vars,
             prompt,
           });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -17,7 +17,6 @@ import { getDirectory, importModule } from '../esm';
 import { writeCsvToGoogleSheet } from '../googleSheets';
 import logger from '../logger';
 import { runDbMigrations } from '../migrate';
-import { runPython } from '../python/pythonUtils';
 import {
   type EvalWithMetadata,
   type EvaluateResult,
@@ -32,7 +31,6 @@ import {
   type TestCasesWithMetadataPrompt,
   type UnifiedConfig,
   type OutputFile,
-  type Prompt,
   type CompletedPrompt,
   type CsvRow,
   type ResultLightweight,
@@ -887,56 +885,6 @@ export async function readFilters(
 export function printBorder() {
   const border = '='.repeat(TERMINAL_MAX_WIDTH);
   logger.info(border);
-}
-
-export async function transformOutput(
-  codeOrFilepath: string,
-  output: string | object | undefined,
-  context: { vars?: Record<string, string | object | undefined>; prompt: Partial<Prompt> },
-) {
-  let postprocessFn;
-  if (codeOrFilepath.startsWith('file://')) {
-    const filePath = codeOrFilepath.slice('file://'.length);
-    if (
-      codeOrFilepath.endsWith('.js') ||
-      codeOrFilepath.endsWith('.cjs') ||
-      codeOrFilepath.endsWith('.mjs') ||
-      codeOrFilepath.endsWith('.ts') ||
-      codeOrFilepath.endsWith('.cts') ||
-      codeOrFilepath.endsWith('.mts')
-    ) {
-      const requiredModule = await importModule(filePath);
-      if (typeof requiredModule === 'function') {
-        postprocessFn = requiredModule;
-      } else if (requiredModule.default && typeof requiredModule.default === 'function') {
-        postprocessFn = requiredModule.default;
-      } else {
-        throw new Error(
-          `Transform ${filePath} must export a function or have a default export as a function`,
-        );
-      }
-    } else if (codeOrFilepath.endsWith('.py')) {
-      postprocessFn = async (
-        output: string,
-        context: { vars: Record<string, string | object> },
-      ) => {
-        return runPython(filePath, 'get_transform', [output, context]);
-      };
-    } else {
-      throw new Error(`Unsupported transform file format: ${codeOrFilepath}`);
-    }
-  } else {
-    postprocessFn = new Function(
-      'output',
-      'context',
-      codeOrFilepath.includes('\n') ? codeOrFilepath : `return ${codeOrFilepath}`,
-    );
-  }
-  const ret = await Promise.resolve(postprocessFn(output, context));
-  if (ret == null) {
-    throw new Error(`Transform function did not return a value\n\n${codeOrFilepath}`);
-  }
-  return ret;
 }
 
 export function setupEnv(envPath: string | undefined) {

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -1,0 +1,53 @@
+import { importModule } from '../esm';
+import { runPython } from '../python/pythonUtils';
+import { Prompt } from '../types';
+
+export async function transform(
+  codeOrFilepath: string,
+  output: string | object | undefined,
+  context: { vars?: Record<string, string | object | undefined>; prompt: Partial<Prompt> },
+) {
+  let postprocessFn;
+  if (codeOrFilepath.startsWith('file://')) {
+    const filePath = codeOrFilepath.slice('file://'.length);
+    if (
+      codeOrFilepath.endsWith('.js') ||
+      codeOrFilepath.endsWith('.cjs') ||
+      codeOrFilepath.endsWith('.mjs') ||
+      codeOrFilepath.endsWith('.ts') ||
+      codeOrFilepath.endsWith('.cts') ||
+      codeOrFilepath.endsWith('.mts')
+    ) {
+      const requiredModule = await importModule(filePath);
+      if (typeof requiredModule === 'function') {
+        postprocessFn = requiredModule;
+      } else if (requiredModule.default && typeof requiredModule.default === 'function') {
+        postprocessFn = requiredModule.default;
+      } else {
+        throw new Error(
+          `Transform ${filePath} must export a function or have a default export as a function`,
+        );
+      }
+    } else if (codeOrFilepath.endsWith('.py')) {
+      postprocessFn = async (
+        output: string,
+        context: { vars: Record<string, string | object> },
+      ) => {
+        return runPython(filePath, 'get_transform', [output, context]);
+      };
+    } else {
+      throw new Error(`Unsupported transform file format: ${codeOrFilepath}`);
+    }
+  } else {
+    postprocessFn = new Function(
+      'output',
+      'context',
+      codeOrFilepath.includes('\n') ? codeOrFilepath : `return ${codeOrFilepath}`,
+    );
+  }
+  const ret = await Promise.resolve(postprocessFn(output, context));
+  if (ret == null) {
+    throw new Error(`Transform function did not return a value\n\n${codeOrFilepath}`);
+  }
+  return ret;
+}

--- a/test/util.config.test.ts
+++ b/test/util.config.test.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getConfigDirectoryPath, setConfigDirectoryPath } from '../src/util/config';
+
+jest.mock('os');
+jest.mock('fs');
+
+describe('config', () => {
+  const mockHomedir = '/mock/home';
+  const defaultConfigPath = path.join(mockHomedir, '.promptfoo');
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(os.homedir).mockReturnValue(mockHomedir);
+    jest.mocked(fs.existsSync).mockReturnValue(false);
+    delete process.env.PROMPTFOO_CONFIG_DIR;
+  });
+
+  describe('getConfigDirectoryPath', () => {
+    it('returns default path when no custom path is set', () => {
+      expect(getConfigDirectoryPath()).toBe(defaultConfigPath);
+    });
+
+    it('does not create directory when createIfNotExists is false', () => {
+      getConfigDirectoryPath(false);
+      expect(fs.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('creates directory when createIfNotExists is true and directory does not exist', () => {
+      getConfigDirectoryPath(true);
+      expect(fs.mkdirSync).toHaveBeenCalledWith(defaultConfigPath, { recursive: true });
+    });
+
+    it('does not create directory when it already exists', () => {
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      getConfigDirectoryPath(true);
+      expect(fs.mkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setConfigDirectoryPath', () => {
+    it('updates the config directory path', () => {
+      const newPath = '/new/config/path';
+      setConfigDirectoryPath(newPath);
+      expect(getConfigDirectoryPath()).toBe(newPath);
+    });
+
+    it('overrides the environment variable', () => {
+      const envPath = '/env/path';
+      const newPath = '/new/path';
+      process.env.PROMPTFOO_CONFIG_DIR = envPath;
+      setConfigDirectoryPath(newPath);
+      expect(getConfigDirectoryPath()).toBe(newPath);
+    });
+  });
+});

--- a/test/util.json.test.ts
+++ b/test/util.json.test.ts
@@ -1,0 +1,86 @@
+import { isValidJson, safeJsonStringify } from '../src/util/json';
+
+describe('json utilities', () => {
+  describe('isValidJson', () => {
+    it('returns true for valid JSON', () => {
+      expect(isValidJson('{"key": "value"}')).toBe(true);
+      expect(isValidJson('[1, 2, 3]')).toBe(true);
+      expect(isValidJson('"string"')).toBe(true);
+      expect(isValidJson('123')).toBe(true);
+      expect(isValidJson('true')).toBe(true);
+      expect(isValidJson('null')).toBe(true);
+    });
+
+    it('returns false for invalid JSON', () => {
+      expect(isValidJson('{')).toBe(false);
+      expect(isValidJson('["unclosed array"')).toBe(false);
+      expect(isValidJson('{"key": value}')).toBe(false);
+      expect(isValidJson('undefined')).toBe(false);
+    });
+  });
+
+  describe('safeJsonStringify', () => {
+    it('stringifies simple objects', () => {
+      const obj = { key: 'value', number: 123 };
+      expect(safeJsonStringify(obj)).toBe('{"key":"value","number":123}');
+    });
+
+    it('handles circular references', () => {
+      const obj: any = { key: 'value' };
+      obj.circular = obj;
+      expect(safeJsonStringify(obj)).toBe('{"key":"value"}');
+    });
+
+    it('pretty prints when specified', () => {
+      const obj = { key: 'value', nested: { inner: 'content' } };
+      const expected = `{
+  "key": "value",
+  "nested": {
+    "inner": "content"
+  }
+}`;
+      expect(safeJsonStringify(obj, true)).toBe(expected);
+    });
+
+    it('handles arrays with circular references', () => {
+      const arr: any[] = [1, 2, 3];
+      arr.push(arr);
+      expect(safeJsonStringify(arr)).toBe('[1,2,3,null]');
+    });
+
+    it('handles null values', () => {
+      expect(safeJsonStringify(null)).toBe('null');
+    });
+
+    it('handles undefined values', () => {
+      expect(safeJsonStringify(undefined)).toBeUndefined();
+    });
+
+    it('handles complex nested structures', () => {
+      const complex = {
+        string: 'value',
+        number: 123,
+        boolean: true,
+        null: null,
+        array: [1, 'two', { three: 3 }],
+        nested: {
+          a: 1,
+          b: [2, 3],
+        },
+      };
+      const result = safeJsonStringify(complex);
+      expect(JSON.parse(result)).toEqual(complex);
+    });
+
+    it('handles nested circular references', () => {
+      const obj: any = { a: { b: {} } };
+      obj.a.b.c = obj.a;
+      expect(safeJsonStringify(obj)).toBe('{"a":{"b":{}}}');
+    });
+
+    it('preserves non-circular nested structures', () => {
+      const nested = { a: { b: { c: 1 } }, d: [1, 2, { e: 3 }] };
+      expect(JSON.parse(safeJsonStringify(nested))).toEqual(nested);
+    });
+  });
+});

--- a/test/util.json.test.ts
+++ b/test/util.json.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { isValidJson, safeJsonStringify } from '../src/util/json';
 
 describe('json utilities', () => {
@@ -33,12 +34,13 @@ describe('json utilities', () => {
 
     it('pretty prints when specified', () => {
       const obj = { key: 'value', nested: { inner: 'content' } };
-      const expected = `{
-  "key": "value",
-  "nested": {
-    "inner": "content"
-  }
-}`;
+      const expected = dedent`
+      {
+        "key": "value",
+        "nested": {
+          "inner": "content"
+        }
+      }`;
       expect(safeJsonStringify(obj, true)).toBe(expected);
     });
 

--- a/test/util.transform.test.ts
+++ b/test/util.transform.test.ts
@@ -1,0 +1,113 @@
+import * as path from 'path';
+import { transform } from '../src/util/transform';
+
+jest.mock('../src/esm');
+
+jest.mock('../src/python/pythonUtils', () => ({
+  runPython: jest.fn().mockImplementation(async (filePath, functionName, args) => {
+    const [output] = args;
+    return output.toUpperCase() + ' FROM PYTHON';
+  }),
+}));
+
+jest.mock('fs', () => ({
+  unlink: jest.fn(),
+}));
+
+describe('util', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('transform', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.resetModules();
+    });
+
+    it('transforms output using a direct function', async () => {
+      const output = 'original output';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const transformFunction = 'output.toUpperCase()';
+      const transformedOutput = await transform(transformFunction, output, context);
+      expect(transformedOutput).toBe('ORIGINAL OUTPUT');
+    });
+
+    it('transforms output using an imported function from a file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      jest.doMock(path.resolve('transform.js'), () => (output: string) => output.toUpperCase(), {
+        virtual: true,
+      });
+      const transformFunctionPath = 'file://transform.js';
+      const transformedOutput = await transform(transformFunctionPath, output, context);
+      expect(transformedOutput).toBe('HELLO');
+    });
+
+    it('throws error if transform function does not return a value', async () => {
+      const output = 'test';
+      const context = { vars: {}, prompt: {} };
+      const transformFunction = ''; // Empty function, returns undefined
+      await expect(transform(transformFunction, output, context)).rejects.toThrow(
+        'Transform function did not return a value',
+      );
+    });
+
+    it('throws error if file does not export a function', async () => {
+      const output = 'test';
+      const context = { vars: {}, prompt: {} };
+      jest.doMock(path.resolve('transform.js'), () => 'banana', { virtual: true });
+      const transformFunctionPath = 'file://transform.js';
+      await expect(transform(transformFunctionPath, output, context)).rejects.toThrow(
+        'Transform transform.js must export a function or have a default export as a function',
+      );
+    });
+
+    it('transforms output using a Python file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const pythonFilePath = 'file://transform.py';
+
+      const transformedOutput = await transform(pythonFilePath, output, context);
+      expect(transformedOutput).toBe('HELLO FROM PYTHON');
+    });
+
+    it('throws error for unsupported file format', async () => {
+      const output = 'test';
+      const context = { vars: {}, prompt: {} };
+      const unsupportedFilePath = 'file://transform.txt';
+
+      await expect(transform(unsupportedFilePath, output, context)).rejects.toThrow(
+        'Unsupported transform file format: file://transform.txt',
+      );
+    });
+
+    it('transforms output using a multi-line function', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const multiLineFunction = `
+        const uppercased = output.toUpperCase();
+        return uppercased + ' WORLD';
+      `;
+
+      const transformedOutput = await transform(multiLineFunction, output, context);
+      expect(transformedOutput).toBe('HELLO WORLD');
+    });
+
+    it('transforms output using a default export function from a file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      jest.doMock(
+        path.resolve('transform.js'),
+        () => ({
+          default: (output: string) => output.toUpperCase() + ' DEFAULT',
+        }),
+        { virtual: true },
+      );
+
+      const transformFunctionPath = 'file://transform.js';
+      const transformedOutput = await transform(transformFunctionPath, output, context);
+      expect(transformedOutput).toBe('HELLO DEFAULT');
+    });
+  });
+});


### PR DESCRIPTION
- Create new file util/transform.ts with transformOutput function
- rename transformOutput to transform in preparation for new use in input transforms
- Add tests for uncovered utils files 