### PR TITLE
chore: add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,0 +1,52 @@
+ARG VARIANT=22.04
+FROM ubuntu:${VARIANT}
+
+ARG USER=promptfoo
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_VERSION=20.x
+
+## Create unpriv user
+RUN groupadd --gid $USER_GID $USER \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USER \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER \
+    && chmod 0440 /etc/sudoers.d/$USER
+
+# Install curl
+RUN apt-get update && \
+    apt-get install -y wget curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install node
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install typescript global
+RUN npm install -g typescript@latest
+
+# Install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        git \
+        python3-dev \
+        python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+## Install oh my zsh
+USER $USER_UID
+ENV ZSH_THEME="spaceship"
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
+    -t https://github.com/denysdovhan/spaceship-prompt \
+    -a 'SPACESHIP_PROMPT_ADD_NEWLINE="false"' \
+    -a 'SPACESHIP_PROMPT_SEPARATE_LINE="false"' \
+    -p git \
+    -p ssh-agent \
+    -p https://github.com/zsh-users/zsh-autosuggestions \
+    -p https://github.com/zsh-users/zsh-completions

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+{
+  "name": "promptfoo_dev",
+  "dockerComposeFile": ["docker-compose.yml"],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.tabSize": 4,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "eslint.format.enable": true,
+        "eslint.alwaysShowStatus": true,
+        "typescript.validate.enable": true,
+        "editor.detectIndentation": true,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": "never",
+          "source.trimTrailingWhitespace": "always",
+          "source.trimAutoWhitespace": "always"
+        },
+        "[json][yaml]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.inlayHints.enabled": "on"
+        },
+        "[typescriptreact]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "zsh"
+          }
+        },
+        "workbench.iconTheme": "vscode-icons",
+        "files.watcherExclude": {
+          "**/.git/objects/**": true,
+          "**/node_modules/**": true
+        }
+      },
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "dbaeumer.vscode-eslint",
+        "wix.vscode-import-cost",
+        "oderwat.indent-rainbow",
+        "ms-azuretools.vscode-docker",
+        "bierner.markdown-preview-github-styles",
+        "GitHub.copilot"
+      ]
+    }
+  },
+  "service": "promptfoo_dev",
+  "workspaceFolder": "/workspace",
+  "userEnvProbe": "loginInteractiveShell",
+  "remoteUser": "promptfoo"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  promptfoo_dev:
+    build:
+      context: ..
+      dockerfile: ./.devcontainer/Dockerfile.dev
+    network_mode: 'host'
+    volumes:
+      - ..:/workspace:Z
+    user: promptfoo
+    command: 'sleep infinity'

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -28,9 +28,21 @@ We particularly welcome contributions in the following areas:
 
 3. Set up your development environment:
 
+   3.1. Setup locally
+
    ```sh
    # We recommend using the Node.js version specified in the .nvmrc file (ensure node >= 18)
    nvm use
+   npm install
+   ```
+
+   3.2 Setup using `devcontainer` (requires Docker and VSCode)
+
+   Open the repository in VSCode and click on the "Reopen in Container" button. This will build a Docker container with all the necessary dependencies.
+
+   Now install node based dependencies:
+
+   ```sh
    npm install
    ```
 


### PR DESCRIPTION
To make it easier for others to setup a dev environment for `promptfoo` to contribute, this PR adds a `devcontainer` setup.

- Add docker compose + dockerfile for a base dev environment
- Update contributing to mention devcontainer setup