### PR TITLE
fix: numTests calculation for previous evals

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -297,13 +297,20 @@ export function listPreviousResults(
 
   const results = query.orderBy(desc(evals.createdAt)).limit(limit).all();
 
-  return results.map((result) => ({
-    evalId: result.evalId,
-    createdAt: result.createdAt,
-    description: result.description,
-    numTests: result.config.tests?.length || 0,
-    datasetId: result.datasetId,
-  }));
+  return results.map((result) => {
+    let numTests = result.config.tests?.length || 0;
+    for (const scenario of result.config.scenarios || []) {
+      numTests += scenario.config.length * scenario.tests.length;
+    }
+
+    return {
+      evalId: result.evalId,
+      createdAt: result.createdAt,
+      description: result.description,
+      numTests: numTests,
+      datasetId: result.datasetId,
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
The "# Tests" displayed by the eval picker in the UI was incorrect for evals that used scenarios.