### PR TITLE
fix: only show the number of tests actually run in the eval

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -284,6 +284,7 @@ export function listPreviousResults(
       createdAt: evals.createdAt,
       description: evals.description,
       config: evals.config,
+      results: evals.results,
       datasetId: evalsToDatasets.datasetId,
     })
     .from(evals)
@@ -298,16 +299,12 @@ export function listPreviousResults(
   const results = query.orderBy(desc(evals.createdAt)).limit(limit).all();
 
   return results.map((result) => {
-    let numTests = result.config.tests?.length || 0;
-    for (const scenario of result.config.scenarios || []) {
-      numTests += scenario.config.length * scenario.tests.length;
-    }
-
+    const numTests = result.results.table.body.length;
     return {
       evalId: result.evalId,
       createdAt: result.createdAt,
       description: result.description,
-      numTests: numTests,
+      numTests,
       datasetId: result.datasetId,
     };
   });


### PR DESCRIPTION
`numTests` is used in the quick switcher.  Right now it shows the number of tests in the config, not the number of tests actually ran.  This fixes that