### PR TITLE
fix: better-sqlite3 in arm64 docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,22 @@ COPY --from=builder /app/src/web/nextui/.next/standalone ./
 COPY --from=builder /app/src/web/nextui/.next/static ./src/web/nextui/.next/static
 COPY --from=builder /app/drizzle ./src/web/nextui/.next/server/drizzle
 
+## build + install better-sqlite3
+## This is a kludge to get better-sqlite3 to work on mac M1
+## see: https://github.com/promptfoo/promptfoo/issues/1330
+ARG BSQL3_VERSION=v11.1.2
+RUN apk update && apk add --no-cache python3 build-base git && \
+    mkdir -p /tmp/build/ && \
+    cd /tmp/build/ && \
+    git clone https://github.com/WiseLibs/better-sqlite3.git && \
+    cd better-sqlite3 && git checkout $BSQL3_VERSION && \
+    cd /app && \
+    cp -r /tmp/build/better-sqlite3/* /app/node_modules/better-sqlite3/ && \
+    cd node_modules/better-sqlite3 && \
+    npm run build-release && \
+    rm -rf /tmp/build/ && \
+    apk del python3 build-base git
+
 RUN mkdir -p /root/.promptfoo/output
 
 # Permissions


### PR DESCRIPTION
Fixes #1330 

This PR adds a `RUN` step in the base Dockerfile of `promptfoo` to build `better-sqlite`. This is due to a manifested bug in `better-sqlite` on mac M1. See #1330 for details on the bug.

I followed the same build + run procedure as listed in the issue for Mac M1 and Linux amd64 successfully.