### PR TITLE
fix: allow falsy provider response outputs

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -245,7 +245,7 @@ class Evaluator {
       };
       if (response.error) {
         ret.error = response.error;
-      } else if (response.output) {
+      } else if (response.output != null) {
         // Create a copy of response so we can potentially mutate it.
         const processedResponse = { ...response };
         const transforms: string[] = [

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -1064,6 +1064,55 @@ describe('evaluator', () => {
     );
     expect(mockApiProviderWithTransform.callApi).toHaveBeenCalledTimes(1);
   });
+
+  it('evaluate with no output', async () => {
+    const mockApiProviderNoOutput: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider-no-output'),
+      callApi: jest.fn().mockResolvedValue({
+        output: null,
+        tokenUsage: { total: 5, prompt: 5, completion: 0, cached: 0 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderNoOutput],
+      prompts: [toPrompt('Test prompt')],
+      tests: [],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(summary.stats.successes).toBe(0);
+    expect(summary.stats.failures).toBe(1);
+    expect(summary.results[0].error).toBe('No output');
+    expect(summary.results[0].success).toBe(false);
+    expect(summary.results[0].score).toBe(0);
+    expect(mockApiProviderNoOutput.callApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('evaluate with false output', async () => {
+    const mockApiProviderNoOutput: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider-no-output'),
+      callApi: jest.fn().mockResolvedValue({
+        output: false,
+        tokenUsage: { total: 5, prompt: 5, completion: 0, cached: 0 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderNoOutput],
+      prompts: [toPrompt('Test prompt')],
+      tests: [],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.results[0].success).toBe(true);
+    expect(summary.results[0].score).toBe(1);
+    expect(mockApiProviderNoOutput.callApi).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('renderPrompt', () => {


### PR DESCRIPTION
Related to #1351 