### PR TITLE
feat(config): add writePromptfooConfig function and orderKeys utility

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
+import yaml from 'js-yaml';
 import * as os from 'os';
 import * as path from 'path';
+import type { UnifiedConfig } from '../types';
+import { orderKeys } from './json';
 
 let configDirectoryPath: string | undefined = process.env.PROMPTFOO_CONFIG_DIR;
 
@@ -14,4 +17,17 @@ export function getConfigDirectoryPath(createIfNotExists: boolean = false): stri
 
 export function setConfigDirectoryPath(newPath: string): void {
   configDirectoryPath = newPath;
+}
+
+export function writePromptfooConfig(config: Partial<UnifiedConfig>, outputPath: string) {
+  const orderedConfig = orderKeys(config, [
+    'description',
+    'prompts',
+    'providers',
+    'redteam',
+    'defaultTest',
+    'tests',
+    'scenarios',
+  ]);
+  fs.writeFileSync(outputPath, yaml.dump(orderedConfig, { skipInvalid: true }));
 }

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -25,3 +25,44 @@ export function safeJsonStringify(value: any, prettyPrint: boolean = false): str
     space,
   );
 }
+
+/**
+ * Reorders the keys of an object based on a specified order, preserving any unspecified keys.
+ * Symbol keys are preserved and added at the end.
+ *
+ * @param obj - The object whose keys need to be reordered.
+ * @param order - An array specifying the desired order of keys.
+ * @returns A new object with keys reordered according to the specified order.
+ *
+ * @example
+ * const obj = { c: 3, a: 1, b: 2 };
+ * const orderedObj = orderKeys(obj, ['a', 'b']);
+ * // Result: { a: 1, b: 2, c: 3 }
+ */
+export function orderKeys<T extends object>(obj: T, order: (keyof T)[]): T {
+  const result: T = {} as T;
+
+  // Add ordered keys (excluding undefined values)
+  for (const key of order) {
+    if (key in obj && obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+
+  // Add remaining keys (excluding undefined values)
+  for (const key in obj) {
+    if (!(key in result) && obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+
+  // Add symbol keys (excluding undefined values)
+  const symbolKeys = Object.getOwnPropertySymbols(obj);
+  for (const sym of symbolKeys) {
+    if (obj[sym as keyof T] !== undefined) {
+      result[sym as keyof T] = obj[sym as keyof T];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Implement writePromptfooConfig to write ordered config to YAML
- Add orderKeys utility function to reorder object keys
- Update tests for new config writing and key ordering functionality