### PR TITLE
feat: add `delete eval latest` and `delete eval all`

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,7 +1,15 @@
+import confirm from '@inquirer/confirm';
 import type { Command } from 'commander';
 import logger from '../logger';
 import telemetry from '../telemetry';
-import { deleteEval, getEvalFromId, setupEnv } from '../util';
+import {
+  deleteAllEvals,
+  deleteEval,
+  getEvalFromId,
+  getEvals,
+  readLatestResults,
+  setupEnv,
+} from '../util';
 
 async function handleEvalDelete(evalId: string, envPath?: string) {
   try {
@@ -11,6 +19,18 @@ async function handleEvalDelete(evalId: string, envPath?: string) {
     logger.error(`Could not delete evaluation with ID ${evalId}:\n${error}`);
     process.exit(1);
   }
+}
+
+async function handleEvalDeleteAll() {
+  const confirmed = await confirm({
+    message:
+      'Are you sure you want to delete all stored evaluations? This action cannot be undone.',
+  });
+  if (!confirmed) {
+    return;
+  }
+  await deleteAllEvals();
+  logger.info('All evaluations have been deleted.');
 }
 
 export function deleteCommand(program: Command) {
@@ -35,7 +55,9 @@ export function deleteCommand(program: Command) {
 
   deleteCommand
     .command('eval <id>')
-    .description('Delete an evaluation by ID.')
+    .description(
+      'Delete an evaluation by ID. Use "latest" to delete the most recent evaluation, or "all" to delete all evaluations.',
+    )
     .option('--env-path <path>', 'Path to the environment file')
     .action(async (evalId, cmdObj) => {
       setupEnv(cmdObj.envPath);
@@ -46,6 +68,17 @@ export function deleteCommand(program: Command) {
       });
       await telemetry.send();
 
-      handleEvalDelete(evalId, cmdObj.envPath);
+      if (evalId === 'latest') {
+        const latestResults = await readLatestResults();
+        if (latestResults) {
+          await handleEvalDelete(latestResults.createdAt, cmdObj.envPath);
+        } else {
+          logger.error('No evaluations found.');
+        }
+      } else if (evalId === 'all') {
+        await handleEvalDeleteAll();
+      } else {
+        await handleEvalDelete(evalId, cmdObj.envPath);
+      }
     });
 }

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -6,7 +6,6 @@ import {
   deleteAllEvals,
   deleteEval,
   getEvalFromId,
-  getEvals,
   readLatestResults,
   setupEnv,
 } from '../util';

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,13 +2,7 @@ import confirm from '@inquirer/confirm';
 import type { Command } from 'commander';
 import logger from '../logger';
 import telemetry from '../telemetry';
-import {
-  deleteAllEvals,
-  deleteEval,
-  getEvalFromId,
-  readLatestResults,
-  setupEnv,
-} from '../util';
+import { deleteAllEvals, deleteEval, getEvalFromId, readLatestResults, setupEnv } from '../util';
 
 async function handleEvalDelete(evalId: string, envPath?: string) {
   try {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -869,6 +869,11 @@ export async function deleteEval(evalId: string) {
   });
 }
 
+export async function deleteAllEvals() {
+  const db = getDb();
+  await db.delete(evals).run();
+}
+
 export async function readFilters(
   filters: Record<string, string>,
   basePath: string = '',


### PR DESCRIPTION
Expand delete functionality from `promptfoo delete eval <id>` with `all` and `latest` aliases.