### PR TITLE
fix: dont check SSL certs

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,7 +8,9 @@ export async function fetchWithProxy(
   url: RequestInfo,
   options: RequestInit = {},
 ): Promise<Response> {
-  options.agent = new ProxyAgent() as unknown as RequestInit['agent'];
+  options.agent = new ProxyAgent({
+    rejectUnauthorized: false, // Don't check SSL cert
+  }) as unknown as RequestInit['agent'];
   return fetch(url, options);
 }
 


### PR DESCRIPTION
Not really a fix per se, but no need to do this.

Related to #1388 