### PR TITLE
feat(assertions): add option to disable AJV strict mode

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -156,12 +156,13 @@ These general-purpose environment variables are supported:
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
 | `PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY` | How many assertions to run at a time                                                                                                             | 3              |
 | `PROMPTFOO_CONFIG_DIR`                 | Directory that stores eval history                                                                                                               | `~/.promptfoo` |
+| `PROMPTFOO_DISABLE_AJV_STRICT_MODE`    | If set, disables AJV strict mode for JSON schema validation                                                                                      |                |
 | `PROMPTFOO_DISABLE_CONVERSATION_VAR`   | Prevents the `_conversation` variable from being set                                                                                             |                |
 | `PROMPTFOO_DISABLE_JSON_AUTOESCAPE`    | If set, disables smart variable substitution within JSON prompts                                                                                 |                |
 | `PROMPTFOO_DISABLE_REF_PARSER`         | Prevents JSON schema dereferencing                                                                                                               |                |
 | `PROMPTFOO_DISABLE_TEMPLATING`         | Disable Nunjucks rendering                                                                                                                       |                |
 | `PROMPTFOO_DISABLE_VAR_EXPANSION`      | Prevents Array-type vars from being expanded into multiple test cases                                                                            |                |
-| `PROMPTFOO_REQUIRE_JSON_PROMPTS`       | By default the chat completion provider will wrap non-JSON messages in a single user message. Setting this envar to true disables that behavior. |
+| `PROMPTFOO_REQUIRE_JSON_PROMPTS`       | By default the chat completion provider will wrap non-JSON messages in a single user message. Setting this envar to true disables that behavior. |                |
 
 :::tip
 promptfoo will load environment variables from the `.env` in your current working directory.

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -162,7 +162,9 @@ These general-purpose environment variables are supported:
 | `PROMPTFOO_DISABLE_REF_PARSER`         | Prevents JSON schema dereferencing                                                                                                               |                |
 | `PROMPTFOO_DISABLE_TEMPLATING`         | Disable Nunjucks rendering                                                                                                                       |                |
 | `PROMPTFOO_DISABLE_VAR_EXPANSION`      | Prevents Array-type vars from being expanded into multiple test cases                                                                            |                |
+| `PROMPTFOO_FAILED_TEST_EXIT_CODE`      | Override the exit code (100) when there is at least 1 test case failure                                                                          | 100            |
 | `PROMPTFOO_REQUIRE_JSON_PROMPTS`       | By default the chat completion provider will wrap non-JSON messages in a single user message. Setting this envar to true disables that behavior. |                |
+| `FORCE_COLOR`                          | Set to 0 to disable terminal colors for printed outputs                                                                                          |                |
 
 :::tip
 promptfoo will load environment variables from the `.env` in your current working directory.

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -66,8 +66,16 @@ export const MODEL_GRADED_ASSERTION_TYPES = new Set<AssertionType>([
   'model-graded-factuality',
 ]);
 
-const ajv = new Ajv();
-addFormats(ajv);
+export function createAjv(): Ajv {
+  const ajvOptions: ConstructorParameters<typeof Ajv>[0] = {
+    strictSchema: !['1', 'true'].includes(process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE || ''),
+  };
+  const ajv = new Ajv(ajvOptions);
+  addFormats(ajv);
+  return ajv;
+}
+
+const ajv = createAjv();
 
 const nunjucks = getNunjucksEngine();
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -2,7 +2,13 @@ import dedent from 'dedent';
 import * as fs from 'fs';
 import { Response } from 'node-fetch';
 import * as path from 'path';
-import { runAssertions, runAssertion, validateXml, containsXml } from '../src/assertions';
+import {
+  containsXml,
+  createAjv,
+  runAssertion,
+  runAssertions,
+  validateXml,
+} from '../src/assertions';
 import { fetchWithRetries } from '../src/fetch';
 import {
   DefaultGradingJsonProvider,
@@ -70,6 +76,35 @@ jest.mock('../src/cliState', () => ({
 }));
 
 const Grader = new TestGrader();
+
+describe('createAjv', () => {
+  beforeAll(() => {
+    delete process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE;
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    delete process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE;
+  });
+
+  it('should create an Ajv instance with default options', () => {
+    const ajv = createAjv();
+    expect(ajv).toBeDefined();
+    expect(ajv.opts.strictSchema).toBe(true);
+  });
+
+  it('should disable strict mode when PROMPTFOO_DISABLE_AJV_STRICT_MODE is set', () => {
+    process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE = 'true';
+    const ajv = createAjv();
+    expect(ajv.opts.strictSchema).toBe(false);
+  });
+
+  it('should add formats to the Ajv instance', () => {
+    const ajv = createAjv();
+    expect(ajv.formats).toBeDefined();
+    expect(Object.keys(ajv.formats)).not.toHaveLength(0);
+  });
+});
 
 describe('runAssertions', () => {
   const test: AtomicTestCase = {


### PR DESCRIPTION
Addresses https://github.com/promptfoo/promptfoo/issues/1414 

- Introduce PROMPTFOO_DISABLE_AJV_STRICT_MODE to disable strict mode in assertions.ts only. 
- Wraps Ajv init to make it easier to unit test.