### PR TITLE
feat: `basic` strategy to represent raw payloads only

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -210,9 +210,10 @@ Strategies modify or generate additional test cases based on the output of other
 
 #### Available Strategies
 
-- `prompt-injection`: Creates prompt injection test cases (Default)
-- `jailbreak`: Applies a linear probe jailbreak technique (Default)
-- `jailbreak:tree`: Applies an advanced tree jailbreak technique
+- `basic` - Raw payloads only (Default)
+- `prompt-injection`: Wraps the payload in a prompt injection (Default)
+- `jailbreak`: Applies a linear probe jailbreak technique to deliver the payload (Default)
+- `jailbreak:tree`: Applies a tree-based jailbreak technique
 - `rot13`: Applies ROT13 encoding to the injected variable, shifting each letter 13 positions in the alphabet
 - `base64`: Encodes the injected variable using Base64 encoding
 - `leetspeak`: Converts the injected variable to leetspeak, replacing certain letters with numbers or symbols

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -123,12 +123,18 @@ export type DefaultStrategy = (typeof DEFAULT_STRATEGIES)[number];
 export const ADDITIONAL_STRATEGIES = ['jailbreak:tree', 'rot13', 'base64', 'leetspeak'] as const;
 export type AdditionalStrategy = (typeof ADDITIONAL_STRATEGIES)[number];
 
-export const ALL_STRATEGIES = ['default', ...DEFAULT_STRATEGIES, ...ADDITIONAL_STRATEGIES] as const;
+export const ALL_STRATEGIES = [
+  'basic',
+  'default',
+  ...DEFAULT_STRATEGIES,
+  ...ADDITIONAL_STRATEGIES,
+] as const;
 export type Strategy = (typeof ALL_STRATEGIES)[number];
 
 // Duplicated in src/web/nextui/src/app/report/constants.ts for frontend
 export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
   default: 'Includes common plugins',
+  basic: 'Raw attacks without any special attack strategies.',
   bola: 'Broken Object Level Authorization (BOLA) tests.',
   bfla: 'Broken Function Level Authorization (BFLA) tests.',
   ssrf: 'Server-Side Request Forgery (SSRF) tests.',

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -157,6 +157,9 @@ export const RedteamConfigSchema = z
     const strategies = data.strategies
       ?.map((strategy) => {
         if (typeof strategy === 'string') {
+          if (strategy === 'basic') {
+            return [];
+          }
           return strategy === 'default'
             ? DEFAULT_STRATEGIES.map((id) => ({ id }))
             : { id: strategy };

--- a/src/web/nextui/src/app/report/constants.ts
+++ b/src/web/nextui/src/app/report/constants.ts
@@ -196,6 +196,7 @@ export const displayNameOverrides = {
 // Duplicated in src/redteam/constants.ts for backend
 export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
   default: 'Includes common plugins',
+  basic: 'Raw attacks without any special attack strategies.',
   bola: 'Broken Object Level Authorization (BOLA) tests.',
   bfla: 'Broken Function Level Authorization (BFLA) tests.',
   ssrf: 'Server-Side Request Forgery (SSRF) tests.',

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -202,7 +202,9 @@ describe('redteamConfigSchema', () => {
   });
 
   it('should allow all valid plugin and strategy names', () => {
-    const strategiesExceptDefault = REDTEAM_ALL_STRATEGIES.filter((id) => id !== 'default');
+    const strategiesExceptDefault = REDTEAM_ALL_STRATEGIES.filter(
+      (id) => id !== 'default' && id !== 'basic',
+    );
     const input = {
       plugins: REDTEAM_ALL_PLUGINS,
       strategies: strategiesExceptDefault,


### PR DESCRIPTION
Example:
```
promptfoo generate redteam --strategies 'basic'
```