### PR TITLE
refactor: transform function

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -47,7 +47,7 @@ import {
   type TestCase,
   isGradingResult,
 } from './types';
-import { extractJsonObjects } from './util';
+import { extractJsonObjects, isJavascriptFile } from './util';
 import { getNunjucksEngine } from './util/templates';
 import { transform } from './util/transform';
 
@@ -323,14 +323,7 @@ export async function runAssertion({
       const basePath = cliState.basePath || '';
       const filePath = path.resolve(basePath, renderedValue.slice('file://'.length));
 
-      if (
-        filePath.endsWith('.js') ||
-        filePath.endsWith('.cjs') ||
-        filePath.endsWith('.mjs') ||
-        filePath.endsWith('.ts') ||
-        filePath.endsWith('.cts') ||
-        filePath.endsWith('.mts')
-      ) {
+      if (isJavascriptFile(filePath)) {
         const requiredModule = await importModule(filePath);
         if (typeof requiredModule === 'function') {
           valueFromScript = await Promise.resolve(requiredModule(output, context));

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -8,7 +8,7 @@ import type {
   TestSuite,
   ProviderOptions,
 } from '../types';
-import { parsePathOrGlob } from '../util';
+import { isJavascriptFile, parsePathOrGlob } from '../util';
 import { processJsFile } from './processors/javascript';
 import { processJsonFile } from './processors/json';
 import { processJsonlFile } from './processors/jsonl';
@@ -140,7 +140,7 @@ export async function processPrompt(
   if (extension === '.jsonl') {
     return processJsonlFile(filePath, prompt);
   }
-  if (extension && ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts'].includes(extension)) {
+  if (extension && isJavascriptFile(extension)) {
     return processJsFile(filePath, prompt, functionName);
   }
   if (extension === '.py') {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -44,6 +44,16 @@ import { getNunjucksEngine } from './templates';
 
 const DEFAULT_QUERY_LIMIT = 100;
 
+/**
+ * Checks if a file is a JavaScript or TypeScript file based on its extension.
+ *
+ * @param filePath - The path of the file to check.
+ * @returns True if the file has a JavaScript or TypeScript extension, false otherwise.
+ */
+export function isJavascriptFile(filePath: string): boolean {
+  return /\.(js|cjs|mjs|ts|cts|mts)$/.test(filePath);
+}
+
 const outputToSimpleString = (output: EvaluateTableOutput) => {
   const passFailText = output.pass ? '[PASS]' : '[FAIL]';
   const namedScoresText = Object.entries(output.namedScores)
@@ -1061,10 +1071,7 @@ export function parsePathOrGlob(
 
   if (filename.includes(':')) {
     const splits = filename.split(':');
-    if (
-      splits[0] &&
-      ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts', '.py'].some((ext) => splits[0].endsWith(ext))
-    ) {
+    if (splits[0] && (isJavascriptFile(splits[0]) || splits[0].endsWith('.py'))) {
       [filename, functionName] = splits;
     }
   }

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -1,53 +1,79 @@
+import { isJavascriptFile } from '.';
 import { importModule } from '../esm';
 import { runPython } from '../python/pythonUtils';
 import type { Prompt } from '../types';
 
+type TransformVars = Record<string, string | object | undefined>;
+
+export type TransformContext = {
+  vars?: TransformVars;
+  prompt: Partial<Prompt>;
+};
+
+async function getJavascriptTransformFunction(filePath: string): Promise<Function> {
+  const requiredModule = await importModule(filePath);
+
+  if (typeof requiredModule === 'function') {
+    return requiredModule;
+  } else if (requiredModule.default && typeof requiredModule.default === 'function') {
+    return requiredModule.default;
+  }
+  throw new Error(
+    `Transform ${filePath} must export a function or have a default export as a function`,
+  );
+}
+
+function getPythonTransformFunction(filePath: string): Function {
+  return async (output: string, context: { vars: TransformVars }) => {
+    return runPython(filePath, 'get_transform', [output, context]);
+  };
+}
+
+async function getFileTransformFunction(filePath: string): Promise<Function> {
+  const actualFilePath = filePath.slice('file://'.length);
+
+  if (isJavascriptFile(filePath)) {
+    return getJavascriptTransformFunction(actualFilePath);
+  } else if (filePath.endsWith('.py')) {
+    return getPythonTransformFunction(actualFilePath);
+  }
+  throw new Error(`Unsupported transform file format: ${filePath}`);
+}
+
+function getInlineTransformFunction(code: string): Function {
+  return new Function('output', 'context', code.includes('\n') ? code : `return ${code}`);
+}
+
+async function getTransformFunction(codeOrFilepath: string): Promise<Function> {
+  if (codeOrFilepath.startsWith('file://')) {
+    return getFileTransformFunction(codeOrFilepath);
+  }
+  return getInlineTransformFunction(codeOrFilepath);
+}
+
+/**
+ * Transforms the output using a specified function or file.
+ *
+ * @param codeOrFilepath - The transformation function code or file path.
+ * If it starts with 'file://', it's treated as a file path.  Otherwise, it's
+ * treated as inline code.
+ * @param transformInput - The output to be transformed. Can be a string or an object.
+ * @param context - The context object containing variables and prompt information.
+ * @returns A promise that resolves to the transformed output.
+ * @throws Error if the file format is unsupported or if the transform function
+ * doesn't return a value.
+ */
 export async function transform(
   codeOrFilepath: string,
-  output: string | object | undefined,
-  context: { vars?: Record<string, string | object | undefined>; prompt: Partial<Prompt> },
-) {
-  let postprocessFn;
-  if (codeOrFilepath.startsWith('file://')) {
-    const filePath = codeOrFilepath.slice('file://'.length);
-    if (
-      codeOrFilepath.endsWith('.js') ||
-      codeOrFilepath.endsWith('.cjs') ||
-      codeOrFilepath.endsWith('.mjs') ||
-      codeOrFilepath.endsWith('.ts') ||
-      codeOrFilepath.endsWith('.cts') ||
-      codeOrFilepath.endsWith('.mts')
-    ) {
-      const requiredModule = await importModule(filePath);
-      if (typeof requiredModule === 'function') {
-        postprocessFn = requiredModule;
-      } else if (requiredModule.default && typeof requiredModule.default === 'function') {
-        postprocessFn = requiredModule.default;
-      } else {
-        throw new Error(
-          `Transform ${filePath} must export a function or have a default export as a function`,
-        );
-      }
-    } else if (codeOrFilepath.endsWith('.py')) {
-      postprocessFn = async (
-        output: string,
-        context: { vars: Record<string, string | object> },
-      ) => {
-        return runPython(filePath, 'get_transform', [output, context]);
-      };
-    } else {
-      throw new Error(`Unsupported transform file format: ${codeOrFilepath}`);
-    }
-  } else {
-    postprocessFn = new Function(
-      'output',
-      'context',
-      codeOrFilepath.includes('\n') ? codeOrFilepath : `return ${codeOrFilepath}`,
-    );
-  }
-  const ret = await Promise.resolve(postprocessFn(output, context));
+  transformInput: string | object | undefined,
+  context: TransformContext,
+): Promise<string | object> {
+  const postprocessFn = await getTransformFunction(codeOrFilepath);
+  const ret = await Promise.resolve(postprocessFn(transformInput, context));
+
   if (ret == null) {
     throw new Error(`Transform function did not return a value\n\n${codeOrFilepath}`);
   }
+
   return ret;
 }

--- a/test/util.transform.test.ts
+++ b/test/util.transform.test.ts
@@ -14,6 +14,14 @@ jest.mock('fs', () => ({
   unlink: jest.fn(),
 }));
 
+jest.mock('glob', () => ({
+  globSync: jest.fn(),
+}));
+
+jest.mock('../src/database', () => ({
+  getDb: jest.fn(),
+}));
+
 describe('util', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
- Add isJavascriptFile function to util/index.ts
- Refactor transform.ts to use isJavascriptFile and improve code structure
- Replace multiple file extension checks with isJavascriptFile across the codebase
- Update and reorganize tests in util.test.ts

This pulls changes out of https://github.com/promptfoo/promptfoo/pull/1249