### PR TITLE
fix: hide unused plugins in report

### DIFF
--- a/src/web/nextui/src/app/report/RiskCard.tsx
+++ b/src/web/nextui/src/app/report/RiskCard.tsx
@@ -26,10 +26,8 @@ const RiskCard: React.FC<{
 }> = ({ title, subtitle, progressValue, numTestsPassed, numTestsFailed, testTypes }) => {
   const { showPercentagesOnRiskCards, pluginPassRateThreshold } = useReportStore();
 
-  // Filter out test types with total 0
+  // Hide risk cards with no tests
   const filteredTestTypes = testTypes.filter((test) => test.total > 0);
-
-  // If all test types have total 0, return null
   if (filteredTestTypes.length === 0) {
     return null;
   }

--- a/src/web/nextui/src/app/report/RiskCard.tsx
+++ b/src/web/nextui/src/app/report/RiskCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';

--- a/src/web/nextui/src/app/report/RiskCard.tsx
+++ b/src/web/nextui/src/app/report/RiskCard.tsx
@@ -25,6 +25,15 @@ const RiskCard: React.FC<{
   testTypes: { name: string; passed: boolean; percentage: number; total: number }[];
 }> = ({ title, subtitle, progressValue, numTestsPassed, numTestsFailed, testTypes }) => {
   const { showPercentagesOnRiskCards, pluginPassRateThreshold } = useReportStore();
+
+  // Filter out test types with total 0
+  const filteredTestTypes = testTypes.filter((test) => test.total > 0);
+
+  // If all test types have total 0, return null
+  if (filteredTestTypes.length === 0) {
+    return null;
+  }
+
   return (
     <Card>
       <CardContent className="risk-card-container">
@@ -85,7 +94,7 @@ const RiskCard: React.FC<{
           </Grid>
           <Grid item xs={6} md={4}>
             <List dense>
-              {testTypes.map((test, index) => (
+              {filteredTestTypes.map((test, index) => (
                 <Tooltip
                   key={index}
                   title={subCategoryDescriptions[test.name as keyof typeof subCategoryDescriptions]}
@@ -128,8 +137,6 @@ const RiskCard: React.FC<{
                       >
                         {`${Math.round(test.percentage * 100)}%`}
                       </Typography>
-                    ) : test.total === 0 ? (
-                      <RemoveCircleIcon className="risk-card-icon-no-tests" />
                     ) : test.percentage >= pluginPassRateThreshold ? (
                       <CheckCircleIcon className="risk-card-icon-passed" />
                     ) : (

--- a/src/web/nextui/src/app/report/constants.ts
+++ b/src/web/nextui/src/app/report/constants.ts
@@ -1,22 +1,16 @@
 import type { Plugin, Strategy } from '../../../../../redteam/constants';
 
 export const riskCategories = {
-  'Brand Risk': [
-    'competitors',
-    'excessive-agency',
-    'hallucination',
-    'harmful:graphic-content',
-    'harmful:harassment-bullying',
-    'harmful:indiscriminate-weapons',
-    'harmful:insults',
-    'harmful:misinformation-disinformation',
-    'harmful:non-violent-crime',
-    'harmful:profanity',
-    'harmful:radicalization',
-    'harmful:unsafe-practices',
-    'imitation',
-    'overreliance',
-    'politics',
+  'Security Risk': [
+    'debug-access',
+    'hijacking',
+    'pii',
+    'rbac',
+    'bola',
+    'bfla',
+    'ssrf',
+    'shell-injection',
+    'sql-injection',
   ],
   'Legal Risk': [
     'contracts',
@@ -34,18 +28,23 @@ export const riskCategories = {
     'harmful:specialized-advice',
     'harmful:violent-crime',
   ],
-  'Technical Risk': [
-    'debug-access',
-    'hijacking',
-    'jailbreak',
-    'pii',
-    'prompt-injection',
-    'rbac',
-    'bola',
-    'bfla',
-    'ssrf',
-    'shell-injection',
-    'sql-injection',
+  'Brand Risk': [
+    'policy',
+    'competitors',
+    'excessive-agency',
+    'hallucination',
+    'harmful:graphic-content',
+    'harmful:harassment-bullying',
+    'harmful:indiscriminate-weapons',
+    'harmful:insults',
+    'harmful:misinformation-disinformation',
+    'harmful:non-violent-crime',
+    'harmful:profanity',
+    'harmful:radicalization',
+    'harmful:unsafe-practices',
+    'imitation',
+    'overreliance',
+    'politics',
   ],
 };
 
@@ -100,6 +99,10 @@ export const riskCategorySeverityMap: Record<string, Severity> = {
   pii: Severity.High,
   politics: Severity.Low,
   rbac: Severity.High,
+  policy: Severity.Low,
+  bola: Severity.High,
+  bfla: Severity.High,
+  ssrf: Severity.High,
 };
 
 export type TopLevelCategory = keyof typeof riskCategories;
@@ -191,6 +194,7 @@ export const displayNameOverrides = {
   'harmful:cybercrime': 'Cybercrime',
   'harmful:copyright-violations': 'Copyright Violations',
   'harmful:misinformation-disinformation': 'Misinformation & disinformation',
+  policy: 'Custom Policy',
 };
 
 // Duplicated in src/redteam/constants.ts for backend

--- a/src/web/nextui/src/app/report/constants.ts
+++ b/src/web/nextui/src/app/report/constants.ts
@@ -99,7 +99,7 @@ export const riskCategorySeverityMap: Record<string, Severity> = {
   pii: Severity.High,
   politics: Severity.Low,
   rbac: Severity.High,
-  policy: Severity.Low,
+  policy: Severity.High,
   bola: Severity.High,
   bfla: Severity.High,
   ssrf: Severity.High,
@@ -163,6 +163,7 @@ export const categoryAliases = {
   pii: 'PIILeak',
   politics: 'PoliticalStatement',
   rbac: 'RbacEnforcement',
+  policy: 'PolicyViolation',
 };
 
 export const categoryAliasesReverse = Object.entries(categoryAliases).reduce(


### PR DESCRIPTION
Also
- reorders categories to more useful first
- relabels 'technical risk' to 'security risk'
- wires up a couple missing ones 