### PR TITLE
docs: add TypeScript promptfooconfig example

### DIFF
--- a/examples/ts-config/README.md
+++ b/examples/ts-config/README.md
@@ -1,0 +1,35 @@
+# TypeScript Configuration Example for promptfoo
+
+This guide demonstrates how to set up a TypeScript configuration for promptfoo using `promptfooconfig.ts`.
+
+## Prerequisites
+
+**Note:** This example requires Node.js 20 or later.
+
+Before running the evaluation, install the `@swc-node/register` package or another suitable TypeScript loader for Node.js:
+
+```bash
+npm install @swc-node/register
+```
+
+## Running the Evaluation
+
+To execute the evaluation, use the following command:
+
+```bash
+NODE_OPTIONS='--import @swc-node/register/esm-register' promptfoo eval -c examples/ts-config/promptfooconfig.ts
+```
+
+After the evaluation completes, view the results with:
+
+```bash
+promptfoo view
+```
+
+## TypeScript Support in Node.js
+
+Currently, Node.js requires external loaders like `@swc-node/register` to run TypeScript files directly. However, future versions of Node.js are expected to include native TypeScript support:
+
+- Node.js 20 introduced the `--experimental-loader` flag for ES modules, marking progress toward native TypeScript support.
+- The Node.js team is actively working on enhancing TypeScript integration.
+- Once native support is available, the reliance on external loaders may be reduced or eliminated.

--- a/examples/ts-config/promptfooconfig.ts
+++ b/examples/ts-config/promptfooconfig.ts
@@ -1,0 +1,38 @@
+import type { UnifiedConfig } from 'promptfoo';
+
+const config: UnifiedConfig = {
+  description: 'A translator built with LLM',
+  prompts: [
+    'Rephrase this in {{language}}: {{body}}',
+    'Translate this to conversational {{language}}: {{body}}',
+  ],
+  providers: ['openai:gpt-4o-mini'],
+  tests: [
+    {
+      vars: {
+        language: 'French',
+        body: 'Hello world',
+      },
+    },
+    {
+      vars: {
+        language: 'French',
+        body: "I'm hungry",
+      },
+    },
+    {
+      vars: {
+        language: 'Pirate',
+        body: 'Hello world',
+      },
+    },
+    {
+      vars: {
+        language: 'Pirate',
+        body: "I'm hungry",
+      },
+    },
+  ],
+};
+
+export default config;


### PR DESCRIPTION
- Create README.md with setup instructions and Node.js TypeScript support info
- Add promptfooconfig.ts as an example TypeScript configuration
