### PR TITLE
feat(transform): support custom function names in file transforms

### DIFF
--- a/examples/transform-file/promptfooconfig.yaml
+++ b/examples/transform-file/promptfooconfig.yaml
@@ -9,7 +9,7 @@ providers:
 defaultTest:
   options:
     transform: file://transform.js
-    # transform: file://transform.py
+    # transform: file://transform.py:custom_func_name
 
 tests:
   - vars:

--- a/examples/transform-file/transform.py
+++ b/examples/transform-file/transform.py
@@ -1,4 +1,4 @@
-def get_transform(output, context):
+def custom_func_name(output, context):
     # context['vars'], context['prompt']
     # ...
     return output.upper()

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -548,31 +548,52 @@ Use `defaultTest` apply a transform option to every test case in your test suite
 
 ### Transforms from separate files
 
-Transform functions can be executed from external Python or Javascript files. For example:
+Transform functions can be executed from external Python or Javascript files. You can optionally specify a function name to use. For example:
 
 ```yaml
 defaultTest:
   options:
-    transform: file://transform.js
+    transform: file://transform.js:customTransform
 ```
 
 Here's `transform.js`:
 
 ```js
-module.exports = (output, context) => {
-  // context.vars, context.prompt
-  // ...
-  return output.toUpperCase();
+module.exports = {
+  customTransform: (output, context) => {
+    // context.vars, context.prompt
+    // ...
+    return output.toUpperCase();
+  },
 };
 ```
 
-Or the equivalent `transform.py`:
+For Python files, if no function name is specified, it defaults to `get_transform`:
+
+```yaml
+defaultTest:
+  options:
+    transform: file://transform.py
+```
+
+Here's `transform.py`:
 
 ```py
 def get_transform(output, context):
     # context['vars'], context['prompt']
     # ...
     return output.upper()
+
+# You can also define custom named functions
+def custom_python_transform(output, context):
+    # ...
+    return output.lower()
+```
+
+To use a custom Python function, specify it in the file path:
+
+```yaml
+transform: file://transform.py:custom_python_transform
 ```
 
 ## Config structure and organization

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -548,7 +548,9 @@ Use `defaultTest` apply a transform option to every test case in your test suite
 
 ### Transforms from separate files
 
-Transform functions can be executed from external Python or Javascript files. You can optionally specify a function name to use. For example:
+Transform functions can be executed from external JavaScript or Python files. You can optionally specify a function name to use.
+
+For JavaScript:
 
 ```yaml
 defaultTest:
@@ -556,19 +558,16 @@ defaultTest:
     transform: file://transform.js:customTransform
 ```
 
-Here's `transform.js`:
-
 ```js
 module.exports = {
   customTransform: (output, context) => {
     // context.vars, context.prompt
-    // ...
     return output.toUpperCase();
   },
 };
 ```
 
-For Python files, if no function name is specified, it defaults to `get_transform`:
+For Python:
 
 ```yaml
 defaultTest:
@@ -576,21 +575,13 @@ defaultTest:
     transform: file://transform.py
 ```
 
-Here's `transform.py`:
-
-```py
+```python
 def get_transform(output, context):
     # context['vars'], context['prompt']
-    # ...
     return output.upper()
-
-# You can also define custom named functions
-def custom_python_transform(output, context):
-    # ...
-    return output.lower()
 ```
 
-To use a custom Python function, specify it in the file path:
+If no function name is specified for Python files, it defaults to `get_transform`. To use a custom Python function, specify it in the file path:
 
 ```yaml
 transform: file://transform.py:custom_python_transform

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -411,6 +411,9 @@ export const VarsSchema = z.record(
     z.array(z.any()),
   ]),
 );
+
+export type Vars = z.infer<typeof VarsSchema>;
+
 // Each test case is graded pass/fail with a score.  A test case represents a unique input to the LLM after substituting `vars` in the prompt.
 export const TestCaseSchema = z.object({
   // Optional description of what you're testing

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -1,49 +1,98 @@
+import path from 'path';
 import { isJavascriptFile } from '.';
+import cliState from '../cliState';
 import { importModule } from '../esm';
 import { runPython } from '../python/pythonUtils';
-import type { Prompt } from '../types';
-
-type TransformVars = Record<string, string | object | undefined>;
+import type { Prompt, Vars } from '../types';
 
 export type TransformContext = {
-  vars?: TransformVars;
+  vars?: Vars;
   prompt: Partial<Prompt>;
 };
 
-async function getJavascriptTransformFunction(filePath: string): Promise<Function> {
+/**
+ * Parses a file path string to extract the file path and function name.
+ * @param filePath - The file path string, potentially including a function name.
+ * @returns A tuple containing the file path and function name (if present).
+ */
+function parseFilePathAndFunctionName(filePath: string): [string, string | undefined] {
+  const parts = filePath.split(':');
+  return parts.length === 2 ? [parts[0], parts[1]] : [filePath, undefined];
+}
+
+/**
+ * Retrieves a JavaScript transform function from a file.
+ * @param filePath - The path to the JavaScript file.
+ * @param functionName - Optional name of the function to retrieve.
+ * @returns A Promise resolving to the requested function.
+ * @throws Error if the file doesn't export a valid function.
+ */
+async function getJavascriptTransformFunction(
+  filePath: string,
+  functionName?: string,
+): Promise<Function> {
   const requiredModule = await importModule(filePath);
 
-  if (typeof requiredModule === 'function') {
+  if (functionName && typeof requiredModule[functionName] === 'function') {
+    return requiredModule[functionName];
+  } else if (typeof requiredModule === 'function') {
     return requiredModule;
   } else if (requiredModule.default && typeof requiredModule.default === 'function') {
     return requiredModule.default;
   }
   throw new Error(
-    `Transform ${filePath} must export a function or have a default export as a function`,
+    `Transform ${filePath} must export a function, have a default export as a function, or export the specified function "${functionName}"`,
   );
 }
 
-function getPythonTransformFunction(filePath: string): Function {
-  return async (output: string, context: { vars: TransformVars }) => {
-    return runPython(filePath, 'get_transform', [output, context]);
+/**
+ * Creates a function that runs a Python transform function.
+ * @param filePath - The path to the Python file.
+ * @param functionName - The name of the function to run (defaults to 'get_transform').
+ * @returns A function that executes the Python transform.
+ */
+function getPythonTransformFunction(
+  filePath: string,
+  functionName: string = 'get_transform',
+): Function {
+  return async (output: string, context: { vars: Vars }) => {
+    return runPython(filePath, functionName, [output, context]);
   };
 }
 
+/**
+ * Retrieves a transform function from a file, supporting both JavaScript and Python.
+ * @param filePath - The path to the file, including the 'file://' prefix.
+ * @returns A Promise resolving to the requested function.
+ * @throws Error if the file format is unsupported.
+ */
 async function getFileTransformFunction(filePath: string): Promise<Function> {
-  const actualFilePath = filePath.slice('file://'.length);
-
-  if (isJavascriptFile(filePath)) {
-    return getJavascriptTransformFunction(actualFilePath);
-  } else if (filePath.endsWith('.py')) {
-    return getPythonTransformFunction(actualFilePath);
+  const [actualFilePath, functionName] = parseFilePathAndFunctionName(
+    filePath.slice('file://'.length),
+  );
+  const fullPath = path.join(cliState.basePath || '', actualFilePath);
+  if (isJavascriptFile(fullPath)) {
+    return getJavascriptTransformFunction(fullPath, functionName);
+  } else if (fullPath.endsWith('.py')) {
+    return getPythonTransformFunction(fullPath, functionName);
   }
-  throw new Error(`Unsupported transform file format: ${filePath}`);
+  throw new Error(`Unsupported transform file format: file://${actualFilePath}`);
 }
 
+/**
+ * Creates a function from inline JavaScript code.
+ * @param code - The JavaScript code to convert into a function.
+ * @returns A Function created from the provided code.
+ */
 function getInlineTransformFunction(code: string): Function {
   return new Function('output', 'context', code.includes('\n') ? code : `return ${code}`);
 }
 
+/**
+ * Determines and retrieves the appropriate transform function based on the input.
+ * @param codeOrFilepath - Either inline code or a file path starting with 'file://'.
+ * @returns A Promise resolving to the appropriate transform function.
+ */
 async function getTransformFunction(codeOrFilepath: string): Promise<Function> {
   if (codeOrFilepath.startsWith('file://')) {
     return getFileTransformFunction(codeOrFilepath);
@@ -55,8 +104,10 @@ async function getTransformFunction(codeOrFilepath: string): Promise<Function> {
  * Transforms the output using a specified function or file.
  *
  * @param codeOrFilepath - The transformation function code or file path.
- * If it starts with 'file://', it's treated as a file path.  Otherwise, it's
- * treated as inline code.
+ * If it starts with 'file://', it's treated as a file path. The file path can
+ * optionally include a function name (e.g., 'file://transform.js:myFunction').
+ * If no function name is provided for Python files, it defaults to 'get_transform'.
+ * For inline code, it's treated as JavaScript.
  * @param transformInput - The output to be transformed. Can be a string or an object.
  * @param context - The context object containing variables and prompt information.
  * @returns A promise that resolves to the transformed output.

--- a/test/util.transform.test.ts
+++ b/test/util.transform.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { runPython } from '../src/python/pythonUtils';
 import { transform } from '../src/util/transform';
 
 jest.mock('../src/esm');
@@ -67,7 +68,7 @@ describe('util', () => {
       jest.doMock(path.resolve('transform.js'), () => 'banana', { virtual: true });
       const transformFunctionPath = 'file://transform.js';
       await expect(transform(transformFunctionPath, output, context)).rejects.toThrow(
-        'Transform transform.js must export a function or have a default export as a function',
+        'Transform transform.js must export a function, have a default export as a function, or export the specified function "undefined"',
       );
     });
 
@@ -116,6 +117,50 @@ describe('util', () => {
       const transformFunctionPath = 'file://transform.js';
       const transformedOutput = await transform(transformFunctionPath, output, context);
       expect(transformedOutput).toBe('HELLO DEFAULT');
+    });
+
+    it('transforms output using a named function from a JavaScript file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      jest.doMock(
+        path.resolve('transform.js'),
+        () => ({
+          namedFunction: (output: string) => output.toUpperCase() + ' NAMED',
+        }),
+        { virtual: true },
+      );
+
+      const transformFunctionPath = 'file://transform.js:namedFunction';
+      const transformedOutput = await transform(transformFunctionPath, output, context);
+      expect(transformedOutput).toBe('HELLO NAMED');
+    });
+
+    it('transforms output using a named function from a Python file', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const pythonFilePath = 'file://transform.py:custom_transform';
+
+      const transformedOutput = await transform(pythonFilePath, output, context);
+      expect(transformedOutput).toBe('HELLO FROM PYTHON');
+      expect(runPython).toHaveBeenCalledWith(
+        expect.stringContaining('transform.py'),
+        'custom_transform',
+        [output, expect.any(Object)],
+      );
+    });
+
+    it('falls back to get_transform for Python files when no function name is provided', async () => {
+      const output = 'hello';
+      const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+      const pythonFilePath = 'file://transform.py';
+
+      const transformedOutput = await transform(pythonFilePath, output, context);
+      expect(transformedOutput).toBe('HELLO FROM PYTHON');
+      expect(runPython).toHaveBeenCalledWith(
+        expect.stringContaining('transform.py'),
+        'get_transform',
+        [output, expect.any(Object)],
+      );
     });
   });
 });


### PR DESCRIPTION
- Add ability to specify custom function names for JavaScript and Python transforms
- Fix base path errors where file transforms were not loaded when promptfooconfig was in a subdirectory