### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "site"
       ],
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.25.0",
+        "@anthropic-ai/sdk": "^0.26.0",
         "@apidevtools/json-schema-ref-parser": "^11.7.0",
         "@googleapis/sheets": "^9.0.0",
         "ajv": "^8.17.1",
@@ -40,12 +40,12 @@
         "fast-xml-parser": "^4.4.1",
         "fastest-levenshtein": "^1.0.16",
         "glob": "^10.4.3",
-        "inquirer": "^10.1.6",
+        "inquirer": "^10.1.8",
         "js-yaml": "^4.1.0",
         "mathjs": "^13.0.3",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
-        "openai": "^4.54.0",
+        "openai": "^4.55.7",
         "opener": "^1.5.2",
         "proxy-agent": "^6.4.0",
         "python-shell": "^5.0.0",
@@ -56,19 +56,19 @@
         "socket.io": "^4.7.5",
         "tiny-invariant": "^1.3.3",
         "uuid": "^10.0.0",
-        "winston": "^3.13.1",
+        "winston": "^3.14.2",
         "zod": "^3.23.8"
       },
       "bin": {
         "promptfoo": "dist/src/main.js"
       },
       "devDependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.623.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.631.0",
         "@azure/identity": "^4.4.1",
-        "@eslint/js": "^9.8.0",
-        "@libsql/client": "^0.8.1",
+        "@eslint/js": "^9.9.0",
+        "@libsql/client": "^0.9.0",
         "@swc/cli": "^0.4.0",
-        "@swc/core": "^1.7.6",
+        "@swc/core": "^1.7.11",
         "@swc/jest": "^0.2.36",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/async": "^3.2.24",
@@ -95,7 +95,7 @@
         "drizzle-kit": "^0.23.1",
         "esbuild": "^0.23.0",
         "eslint": "^8.57.0",
-        "eslint-plugin-jest": "^28.6.0",
+        "eslint-plugin-jest": "28.6.0",
         "eslint-plugin-unused-imports": "^3.2.0",
         "jest": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
@@ -330,9 +330,10 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.25.2.tgz",
-      "integrity": "sha512-F1Hck/asswwidFLtGdMg3XYgRxEUfygNbpkq5KEaEGsHNaSfxeX18/uZGQCL0oQNcj/tYNx8BaFXVwRhFDi45g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.26.0.tgz",
+      "integrity": "sha512-vNbZ2rnnMfk8Bf4OdeVy6GA4EXao8tGC0tLEoSAl1NZrip9oOxnEGUkXl3FsPQgeBM5hmpGE1tSLuu9HEVJiHg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -387,6 +388,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -402,6 +404,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -414,6 +417,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -427,6 +431,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -440,6 +445,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -454,6 +460,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -508,24 +515,25 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.629.0.tgz",
-      "integrity": "sha512-Z22b1sP6GKCu7WEpLBUPEFjwLIzIdfWvjBBx+iOUOaAz+UeraZ4Yr3MRJxbsw4HiVePeQiFBxsZui+EJ9flKDA==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.631.0.tgz",
+      "integrity": "sha512-Z8bHyd5W5pBZm/ccDAB7tsPmHFbAS1JvdcfSDXPaE16Yao7PegHPzkzAjThf6sHBQ5M1Q82uPV8Q6syW2owhuA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.629.0",
-        "@aws-sdk/client-sts": "3.629.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
         "@aws-sdk/core": "3.629.0",
-        "@aws-sdk/credential-provider-node": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
         "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
@@ -564,10 +572,11 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.629.0.tgz",
-      "integrity": "sha512-2w8xU4O0Grca5HmT2dXZ5fF0g39RxODtmoqHJDsK5DSt750LqDG4w3ktmBvQs3+SrpkkJOjlX5v/hb2PCxVbww==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+      "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -575,10 +584,10 @@
         "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
@@ -613,22 +622,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.629.0.tgz",
-      "integrity": "sha512-3if0LauNJPqubGYf8vnlkp+B3yAeKRuRNxfNbHlE6l510xWGcKK/ZsEmiFmfePzKKSRrDh/cxMFMScgOrXptNg==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+      "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.629.0",
-        "@aws-sdk/credential-provider-node": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
         "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
@@ -662,27 +672,28 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.629.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.629.0.tgz",
-      "integrity": "sha512-RjOs371YwnSVGxhPjuluJKaxl4gcPYTAky0nPjwBime0i9/iS9nI8R8l5j7k7ec9tpFWjBPvNnThCU07pvjdzw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.629.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
         "@aws-sdk/core": "3.629.0",
-        "@aws-sdk/credential-provider-node": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
         "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
         "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
@@ -721,6 +732,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
       "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^2.3.2",
         "@smithy/node-config-provider": "^3.1.4",
@@ -742,6 +754,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
       "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -757,6 +770,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
       "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/fetch-http-handler": "^3.2.4",
@@ -773,15 +787,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.629.0.tgz",
-      "integrity": "sha512-r9fI7BABARvVDp77DBUImQzYdvarAIdhbvpCEZib0rlpvfWu3zxE9KZcapCAAi0MPjxeDfb7RMehFQIkAP7mYw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+      "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.620.1",
         "@aws-sdk/credential-provider-http": "3.622.0",
         "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.629.0",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
         "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/credential-provider-imds": "^3.2.0",
@@ -794,20 +809,21 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.629.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.629.0.tgz",
-      "integrity": "sha512-868hnVOLlXOBHk91Rl0jZIRgr/M4WJCa0nOrW9A9yidsQxuZp9P0vshDmm4hMvNZadmPIfo0Rra2MpA4RELoCw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+      "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.620.1",
         "@aws-sdk/credential-provider-http": "3.622.0",
-        "@aws-sdk/credential-provider-ini": "3.629.0",
+        "@aws-sdk/credential-provider-ini": "3.631.0",
         "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.629.0",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
         "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/credential-provider-imds": "^3.2.0",
@@ -825,6 +841,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
       "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -837,12 +854,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.629.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.629.0.tgz",
-      "integrity": "sha512-Lf4XOuj6jamxgGZGrVojERh5S+NS2t2S4CUOnAu6tJ5U0GPlpjhINUKlcVxJBpsIXudMGW1nkumAd3+kazCPig==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+      "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.629.0",
+        "@aws-sdk/client-sso": "3.631.0",
         "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -859,6 +877,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
       "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -877,6 +896,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
       "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/protocol-http": "^4.1.0",
@@ -892,6 +912,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
       "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
@@ -906,6 +927,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
       "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/protocol-http": "^4.1.0",
@@ -917,13 +939,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
-      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+      "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -937,6 +960,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
       "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/node-config-provider": "^3.1.4",
@@ -954,6 +978,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
       "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -982,10 +1007,11 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
-      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+      "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
@@ -1001,6 +1027,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
       "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1013,6 +1040,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
       "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
@@ -1025,6 +1053,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
       "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/node-config-provider": "^3.1.4",
@@ -5993,9 +6022,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.8.0.tgz",
-      "integrity": "sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
+      "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6130,14 +6159,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.5.tgz",
-      "integrity": "sha512-+YlCyS6JBWeZugIvReh/YL5HJcowlklz5RykQuYKQfgWQeCJh5Us0nWcRddvIVkjmYa0I/8bwWioSLu850J8sA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.7.tgz",
+      "integrity": "sha512-5YwCySyV1UEgqzz34gNsC38eKxRBtlRDpJLlKcRtTjlYA/yDKuc1rfw+hjw+2WJxbAZtaDPsRl5Zk7J14SBoBw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
+        "@inquirer/core": "^9.0.10",
         "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/type": "^1.5.2",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -6146,28 +6175,28 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.20.tgz",
-      "integrity": "sha512-UvG5Plh0MfCqUvZB8RKzBBEWB/EeMzO59Awy/Jg4NgeSjIPqhPaQFnnmxiyWUTwZh4uENB7wCklEFUwckioXWg==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.22.tgz",
+      "integrity": "sha512-gsAKIOWBm2Q87CDfs9fEo7wJT3fwWIJfnDGMn9Qy74gBnNFOACDNfhUzovubbJjWnKLGBln7/NcSmZwj5DuEXg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1"
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.8.tgz",
-      "integrity": "sha512-ttnI/BGlP9SxjbQnv1nssv7dPAwiR82KmjJZx2SxSZyi2mGbaEvh4jg0I4yU/4mVQf7QvCVGGr/hGuJFEYhwnw==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.10.tgz",
+      "integrity": "sha512-TdESOKSVwf6+YWDz8GhS6nKscwzkIyakEzCLJ5Vh6O3Co2ClhCJ0A4MG909MUWfaWdpJm7DE45ii51/2Kat9tA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/type": "^1.5.2",
         "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.0.0",
+        "@types/node": "^22.1.0",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "cli-spinners": "^2.9.2",
@@ -6195,13 +6224,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.20.tgz",
-      "integrity": "sha512-vtIN9NwXldX8SWbPt5biJhnTpHJCzF5nSymcv4hcOxiCrOpXmgOvFYGpAY729KODF+5e1OLqPbJ8ApiwPu/peQ==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.22.tgz",
+      "integrity": "sha512-K1QwTu7GCK+nKOVRBp5HY9jt3DXOfPGPr6WRDrPImkcJRelG9UTx2cAtK1liXmibRrzJlTWOwqgWT3k2XnS62w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -6209,13 +6238,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.20.tgz",
-      "integrity": "sha512-ruUTCUGKhe6TvDM3/gKjX9v7D5cWbiuawFE6aF/cFmNO79R/zMjrFFVoueDM8FRw8yXqnREb0jFkYF1LUxnDNA==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.22.tgz",
+      "integrity": "sha512-wTZOBkzH+ItPuZ3ZPa9lynBsdMp6kQ9zbjVPYEtSBG7UulGjg2kQiAnUjgyG4SlntpTce5bOmXAPvE4sguXjpA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -6232,39 +6261,39 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.7.tgz",
-      "integrity": "sha512-QFk31Gq4Wr+Ve9ilMiFGGrSjGZQBilV0cgTN1zubD98Bx65fsNrh8++Biy/9mjNKRaqHFbZBw5baAcQvOmW8OQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.9.tgz",
+      "integrity": "sha512-7Z6N+uzkWM7+xsE+3rJdhdG/+mQgejOVqspoW+w0AbSZnL6nq5tGMEVASaYVWbkoSzecABWwmludO2evU3d31g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1"
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.8.tgz",
-      "integrity": "sha512-GamytM0a3fLh8xjgWbGb/DmDA1SmW6sc6ZyfiiWL1my2NAkV6mrTEKMOA4LSK2gB43uf8vcOS7Hp/LeVjIqLwg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.10.tgz",
+      "integrity": "sha512-kWTxRF8zHjQOn2TJs+XttLioBih6bdc5CcosXIzZsrTY383PXI35DuhIllZKu7CdXFi2rz2BWPN9l0dPsvrQOA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1"
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.20.tgz",
-      "integrity": "sha512-il2TG7xDlfiLE3cnOCxfDfrwvsiSmXjVd26hvf4tdzHvdisgLiEjbN6mi51/TnlSQ+2Qc69+9jIq3ws93nhS2w==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.22.tgz",
+      "integrity": "sha512-5Fxt1L9vh3rAKqjYwqsjU4DZsEvY/2Gll+QkqR4yEpy6wvzLxdSgFhUcxfDAOtO4BEoTreWoznC0phagwLU5Kw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -6272,34 +6301,34 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.3.6.tgz",
-      "integrity": "sha512-go5DXxasCIZvztWapYPUSFXg7GceDSQPM1ew3MahFF7degA5kfIVe5kB4KAlARXt83fApyEczvE1H4bh0HLObA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.3.8.tgz",
+      "integrity": "sha512-b2BudQY/Si4Y2a0PdZZL6BeJtl8llgeZa7U2j47aaJSCeAl1e4UI7y8a9bSkO3o/ZbZrgT5muy/34JbsjfIWxA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^2.4.5",
-        "@inquirer/confirm": "^3.1.20",
-        "@inquirer/editor": "^2.1.20",
-        "@inquirer/expand": "^2.1.20",
-        "@inquirer/input": "^2.2.7",
-        "@inquirer/number": "^1.0.8",
-        "@inquirer/password": "^2.1.20",
-        "@inquirer/rawlist": "^2.2.2",
-        "@inquirer/search": "^1.0.5",
-        "@inquirer/select": "^2.4.5"
+        "@inquirer/checkbox": "^2.4.7",
+        "@inquirer/confirm": "^3.1.22",
+        "@inquirer/editor": "^2.1.22",
+        "@inquirer/expand": "^2.1.22",
+        "@inquirer/input": "^2.2.9",
+        "@inquirer/number": "^1.0.10",
+        "@inquirer/password": "^2.1.22",
+        "@inquirer/rawlist": "^2.2.4",
+        "@inquirer/search": "^1.0.7",
+        "@inquirer/select": "^2.4.7"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.2.2.tgz",
-      "integrity": "sha512-U4OsvqjdLB6nmf5ZDshPYMq0b+qd6JWxTrvRTiMfwUY6cFxkR9YWKarLXFhndf7tawQ8f3DwU9P9wryDc2ESSA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.2.4.tgz",
+      "integrity": "sha512-pb6w9pWrm7EfnYDgQObOurh2d2YH07+eDo3xQBsNAM2GRhliz6wFXGi1thKQ4bN6B0xDd6C3tBsjdr3obsCl3Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/type": "^1.5.2",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -6307,14 +6336,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.0.5.tgz",
-      "integrity": "sha512-25nyVAbO0NwFZTXP/cW++W1QGHlHY+hmsehMM1sPKvp4wYcxMQcm6xNCor0bU2Pv/L33IkPV/NV9SuJyFC85EQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.0.7.tgz",
+      "integrity": "sha512-p1wpV+3gd1eST/o5N3yQpYEdFNCzSP0Klrl+5bfD3cTTz8BGG6nf4Z07aBW0xjlKIj1Rp0y3x/X4cZYi6TfcLw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
+        "@inquirer/core": "^9.0.10",
         "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/type": "^1.5.2",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -6322,14 +6351,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.5.tgz",
-      "integrity": "sha512-DbCthH3l7vrrK+Ewll3bgzxC3dzMle8xkWYta4if31p9NOmFNhZKhSfdYMjaOtGFBCUEwo4D5LMgN6sPKgUWIw==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.7.tgz",
+      "integrity": "sha512-JH7XqPEkBpNWp3gPCqWqY8ECbyMoFcCZANlL6pV9hf59qK6dGmkOlx1ydyhY+KZ0c5X74+W6Mtp+nm2QX0/MAQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.0.8",
+        "@inquirer/core": "^9.0.10",
         "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/type": "^1.5.2",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -6338,9 +6367,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.1.tgz",
-      "integrity": "sha512-m3YgGQlKNS0BM+8AFiJkCsTqHEFCWn6s/Rqye3mYwvqY6LdfUv12eSwbsgNzrYyrLXiy7IrrjDLPysaSBwEfhw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.2.tgz",
+      "integrity": "sha512-w9qFkumYDCNyDZmNQjf/n6qQuvQ4dMC3BJesY4oF+yr0CxR5vxujflAVeIcS6U336uzi9GM0kAfZlLrZ9UTkpA==",
       "license": "MIT",
       "dependencies": {
         "mute-stream": "^1.0.0"
@@ -7055,23 +7084,23 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
     "node_modules/@libsql/client": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.8.1.tgz",
-      "integrity": "sha512-xGg0F4iTDFpeBZ0r4pA6icGsYa5rG6RAG+i/iLDnpCAnSuTqEWMDdPlVseiq4Z/91lWI9jvvKKiKpovqJ1kZWA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.9.0.tgz",
+      "integrity": "sha512-mT+91wtb8pxK9SWd566D5W2VUCemksUMqICRBtf0WXiS7XzNcQhWyrwYOnVrVmTSze/SCCsNNEKIkCRwk/pr2Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@libsql/core": "^0.8.1",
+        "@libsql/core": "^0.9.0",
         "@libsql/hrana-client": "^0.6.2",
         "js-base64": "^3.7.5",
-        "libsql": "^0.3.10",
+        "libsql": "^0.4.1",
         "promise-limit": "^2.7.0"
       }
     },
     "node_modules/@libsql/core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.8.1.tgz",
-      "integrity": "sha512-u6nrj6HZMTPsgJ9EBhLzO2uhqhlHQJQmVHV+0yFLvfGf3oSP8w7TjZCNUgu1G8jHISx6KFi7bmcrdXW9lRt++A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-rCsS/EC32K8ARjDQJGqauGZmkR6orOOY4I7898PyQ/mmltAkMwRgz5kjEmYRZ42o7mP0ayJfbw28qgv7SRFEgg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7079,26 +7108,28 @@
       }
     },
     "node_modules/@libsql/darwin-arm64": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.3.19.tgz",
-      "integrity": "sha512-rmOqsLcDI65zzxlUOoEiPJLhqmbFsZF6p4UJQ2kMqB+Kc0Rt5/A1OAdOZ/Wo8fQfJWjR1IbkbpEINFioyKf+nQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.4.1.tgz",
+      "integrity": "sha512-XICT9/OyU8Aa9Iv1xZIHgvM09n/1OQUk3VC+s5uavzdiGHrDMkOWzN47JN7/FiMa/NWrcgoEiDMk3+e7mE53Ig==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@libsql/darwin-x64": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.3.19.tgz",
-      "integrity": "sha512-q9O55B646zU+644SMmOQL3FIfpmEvdWpRpzubwFc2trsa+zoBlSkHuzU9v/C+UNoPHQVRMP7KQctJ455I/h/xw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.4.1.tgz",
+      "integrity": "sha512-pSKxhRrhu4SsTD+IBRZXcs1SkwMdeAG1tv6Z/Ctp/sOEYrgkU8MDKLqkOr9NsmwpK4S0+JdwjkLMyhTkct/5TQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -7160,65 +7191,70 @@
       }
     },
     "node_modules/@libsql/linux-arm64-gnu": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.3.19.tgz",
-      "integrity": "sha512-mgeAUU1oqqh57k7I3cQyU6Trpdsdt607eFyEmH5QO7dv303ti+LjUvh1pp21QWV6WX7wZyjeJV1/VzEImB+jRg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.4.1.tgz",
+      "integrity": "sha512-9lpvb24tO2qZd9nq5dlq3ESA3hSKYWBIK7lJjfiCM6f7a70AUwBY9QoPJV9q4gILIyVnR1YBGrlm50nnb+dYgw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@libsql/linux-arm64-musl": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.3.19.tgz",
-      "integrity": "sha512-VEZtxghyK6zwGzU9PHohvNxthruSxBEnRrX7BSL5jQ62tN4n2JNepJ6SdzXp70pdzTfwroOj/eMwiPt94gkVRg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.4.1.tgz",
+      "integrity": "sha512-lyxi+lFxE+NcBRDMQCxCtDg3c4WcKAbc9u63d5+B23Vm+UgphD9XY4seu+tGrBy1MU2tuNVix7r9S7ECpAaVrA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@libsql/linux-x64-gnu": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.3.19.tgz",
-      "integrity": "sha512-2t/J7LD5w2f63wGihEO+0GxfTyYIyLGEvTFEsMO16XI5o7IS9vcSHrxsvAJs4w2Pf907uDjmc7fUfMg6L82BrQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.4.1.tgz",
+      "integrity": "sha512-psvuQ3UFBEmDFV8ZHG+WkUHIJiWv+elZ+zIPvOVedlIKdxG1O+8WthWUAhFHOGnbiyzc4sAZ4c3de1oCvyHxyQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@libsql/linux-x64-musl": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.3.19.tgz",
-      "integrity": "sha512-BLsXyJaL8gZD8+3W2LU08lDEd9MIgGds0yPy5iNPp8tfhXx3pV/Fge2GErN0FC+nzt4DYQtjL+A9GUMglQefXQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.4.1.tgz",
+      "integrity": "sha512-PDidJ3AhGDqosGg3OAZzGxMFIbnuOALya4BoezJKl667AFv3x7BBQ30H81Mngsq3Fh8RkJkXSdWfL91+Txb1iA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@libsql/win32-x64-msvc": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.3.19.tgz",
-      "integrity": "sha512-ay1X9AobE4BpzG0XPw1gplyLZPGHIgJOovvW23gUrukRegiUP62uzhpRbKNogLlUOynyXeq//prHgPXiebUfWg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.4.1.tgz",
+      "integrity": "sha512-IdODVqV/PrdOnHA/004uWyorZQuRsB7U7bCRCE3vXgABj3eJLJGc6cv2C6ksEaEoVxJbD8k53H4VVAGrtYwXzQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -7576,7 +7612,8 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
       "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "13.4.13",
@@ -8307,6 +8344,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
       "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -8323,6 +8361,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.2.tgz",
       "integrity": "sha512-in5wwt6chDBcUv1Lw1+QzZxN9fBffi+qOixfb65yK4sDuKG7zAUO9HAFqmVzsZM3N+3tTyvZjtnDXePpvp007Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-retry": "^3.0.14",
@@ -8342,6 +8381,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
       "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
@@ -8425,6 +8465,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
       "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
@@ -8438,6 +8479,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
       "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -8453,6 +8495,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
       "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8463,6 +8506,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8475,6 +8519,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
       "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
@@ -8489,6 +8534,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
       "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
@@ -8507,6 +8553,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.14.tgz",
       "integrity": "sha512-7ZaWZJOjUxa5hgmuMspyt8v/zVsh0GXYuF7OvCmdcbVa/xbnKQoYC+uYKunAqRGTkxjOyuOCw9rmFUFOqqC0eQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/protocol-http": "^4.1.0",
@@ -8531,6 +8578,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8540,6 +8588,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
       "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8553,6 +8602,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
       "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8566,6 +8616,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
       "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
@@ -8596,6 +8647,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
       "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8634,6 +8686,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
       "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8647,6 +8700,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
       "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0"
       },
@@ -8659,6 +8713,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
       "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8672,6 +8727,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
       "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
         "@smithy/protocol-http": "^4.1.0",
@@ -8691,6 +8747,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.12.tgz",
       "integrity": "sha512-wtm8JtsycthkHy1YA4zjIh2thJgIQ9vGkoR639DBx5lLlLNU0v4GARpQZkr2WjXue74nZ7MiTSWfVrLkyD8RkA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
@@ -8719,6 +8776,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
       "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^3.0.3",
         "@smithy/types": "^3.3.0",
@@ -8730,6 +8788,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
       "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
@@ -8744,6 +8803,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
       "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -8753,6 +8813,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
       "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8765,6 +8826,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
         "tslib": "^2.6.2"
@@ -8778,6 +8840,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
       "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8790,6 +8853,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.14.tgz",
       "integrity": "sha512-0iwTgKKmAIf+vFLV8fji21Jb2px11ktKVxbX6LIDPAUJyWQqGqBVfwba7xwa1f2FZUoolYQgLvxQEpJycXuQ5w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
         "@smithy/smithy-client": "^3.1.12",
@@ -8806,6 +8870,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.14.tgz",
       "integrity": "sha512-e9uQarJKfXApkTMMruIdxHprhcXivH1flYCe8JRDTzkkLx8dA3V5J8GZlST9yfDiRWkJpZJlUXGN9Rc9Ade3OQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.5",
         "@smithy/credential-provider-imds": "^3.2.0",
@@ -8824,6 +8889,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
       "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
@@ -8850,6 +8916,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
       "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -8863,6 +8930,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
       "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^3.0.3",
         "@smithy/types": "^3.3.0",
@@ -8877,6 +8945,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
       "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/node-http-handler": "^3.1.4",
@@ -8907,6 +8976,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
       "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
@@ -9356,9 +9426,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.6.tgz",
-      "integrity": "sha512-FZxyao9eQks1MRmUshgsZTmlg/HB2oXK5fghkoWJm/1CU2q2kaJlVDll2as5j+rmWiwkp0Gidlq8wlXcEEAO+g==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.11.tgz",
+      "integrity": "sha512-AB+qc45UrJrDfbhPKcUXk+9z/NmFfYYwJT6G7/iur0fCse9kXjx45gi40+u/O2zgarG/30/zV6E3ps8fUvjh7g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -9374,16 +9444,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.7.6",
-        "@swc/core-darwin-x64": "1.7.6",
-        "@swc/core-linux-arm-gnueabihf": "1.7.6",
-        "@swc/core-linux-arm64-gnu": "1.7.6",
-        "@swc/core-linux-arm64-musl": "1.7.6",
-        "@swc/core-linux-x64-gnu": "1.7.6",
-        "@swc/core-linux-x64-musl": "1.7.6",
-        "@swc/core-win32-arm64-msvc": "1.7.6",
-        "@swc/core-win32-ia32-msvc": "1.7.6",
-        "@swc/core-win32-x64-msvc": "1.7.6"
+        "@swc/core-darwin-arm64": "1.7.11",
+        "@swc/core-darwin-x64": "1.7.11",
+        "@swc/core-linux-arm-gnueabihf": "1.7.11",
+        "@swc/core-linux-arm64-gnu": "1.7.11",
+        "@swc/core-linux-arm64-musl": "1.7.11",
+        "@swc/core-linux-x64-gnu": "1.7.11",
+        "@swc/core-linux-x64-musl": "1.7.11",
+        "@swc/core-win32-arm64-msvc": "1.7.11",
+        "@swc/core-win32-ia32-msvc": "1.7.11",
+        "@swc/core-win32-x64-msvc": "1.7.11"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -9395,9 +9465,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.6.tgz",
-      "integrity": "sha512-6lYHey84ZzsdtC7UuPheM4Rm0Inzxm6Sb8U6dmKc4eCx8JL0LfWG4LC5RsdsrTxnjTsbriWlnhZBffh8ijUHIQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.11.tgz",
+      "integrity": "sha512-HRQv4qIeMBPThZ6Y/4yYW52rGsS6yrpusvuxLGyoFo45Y0y12/V2yXkOIA/0HIQyrqoUAxn1k4zQXpPaPNCmnw==",
       "cpu": [
         "arm64"
       ],
@@ -9412,9 +9482,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.6.tgz",
-      "integrity": "sha512-Fyl+8aH9O5rpx4O7r2KnsPpoi32iWoKOYKiipeTbGjQ/E95tNPxbmsz4yqE8Ovldcga60IPJ5OKQA3HWRiuzdw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.11.tgz",
+      "integrity": "sha512-vtMQj0F3oYwDu5yhO7SKDRg1XekRSi6/TbzHAbBXv+dBhlGGvcZZynT1H90EVFTv+7w7Sh+lOFvRv5Z4ZTcxow==",
       "cpu": [
         "x64"
       ],
@@ -9429,9 +9499,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.6.tgz",
-      "integrity": "sha512-2WxYTqFaOx48GKC2cbO1/IntA+w+kfCFy436Ij7qRqqtV/WAvTM9TC1OmiFbqq436rSot52qYmX8fkwdB5UcLQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.11.tgz",
+      "integrity": "sha512-mHtzWKxhtyreI4CSxs+3+ENv8t/Qo35WFoYG66qHEgJz/Z2Lh6jv1E+MYgHdYwnpQHgHbdvAco7HsBu/Dt6xXw==",
       "cpu": [
         "arm"
       ],
@@ -9446,9 +9516,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.6.tgz",
-      "integrity": "sha512-TBEGMSe0LhvPe4S7E68c7VzgT3OMu4VTmBLS7B2aHv4v8uZO92Khpp7L0WqgYU1y5eMjk+XLDLi4kokiNHv/Hg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.11.tgz",
+      "integrity": "sha512-FRwe/x0GfXSQjGP2lIk+NO0pUFS/lI/RorCLBPiK808EVE9JTbh9DKCc/4Bbb4jgScAjNkrFCUVObQYl3YKmpA==",
       "cpu": [
         "arm64"
       ],
@@ -9463,9 +9533,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.6.tgz",
-      "integrity": "sha512-QI8QGL0HGT42tj7F1A+YAzhGkJjUcvvTfI1e2m704W0Enl2/UIK9v5D1zvQzYwusRyKuaQfbeBRYDh0NcLOGLg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.11.tgz",
+      "integrity": "sha512-GY/rs0+GUq14Gbnza90KOrQd/9yHd5qQMii5jcSWcUCT5A8QTa8kiicsM2NxZeTJ69xlKmT7sLod5l99lki/2A==",
       "cpu": [
         "arm64"
       ],
@@ -9480,9 +9550,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.6.tgz",
-      "integrity": "sha512-61AYVzhjuNQAVIKKWOJu3H0/pFD28RYJGxnGg3YMhvRLRyuWNyY5Nyyj2WkKcz/ON+g38Arlz00NT1LDIViRLg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.11.tgz",
+      "integrity": "sha512-QDkGRwSPmp2RBOlSs503IUXlWYlny8DyznTT0QuK0ML2RpDFlXWU94K/EZhS0RBEUkMY/W51OacM8P8aS/dkCg==",
       "cpu": [
         "x64"
       ],
@@ -9497,9 +9567,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.6.tgz",
-      "integrity": "sha512-hQFznpfLK8XajfAAN9Cjs0w/aVmO7iu9VZvInyrTCRcPqxV5O+rvrhRxKvC1LRMZXr5M6JRSRtepp5w+TK4kAw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.11.tgz",
+      "integrity": "sha512-SBEfKrXy6zQ6ksnyxw1FaCftrIH4fLfA81xNnKb7x/6iblv7Ko6H0aK3P5C86jyqF/82+ONl9C7ImGkUFQADig==",
       "cpu": [
         "x64"
       ],
@@ -9514,9 +9584,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.6.tgz",
-      "integrity": "sha512-Aqsd9afykVMuekzjm4X4TDqwxmG4CrzoOSFe0hZrn9SMio72l5eAPnMtYoe5LsIqtjV8MNprLfXaNbjHjTegmA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.11.tgz",
+      "integrity": "sha512-a2Y4xxEsLLYHJN7sMnw9+YQJDi3M1BxEr9hklfopPuGGnYLFNnx5CypH1l9ReijEfWjIAHNi7pq3m023lzW1Hg==",
       "cpu": [
         "arm64"
       ],
@@ -9531,9 +9601,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.6.tgz",
-      "integrity": "sha512-9h0hYnOeRVNeQgHQTvD1Im67faNSSzBZ7Adtxyu9urNLfBTJilMllFd2QuGHlKW5+uaT6ZH7ZWDb+c/enx7Lcg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.11.tgz",
+      "integrity": "sha512-ZbZFMwZO+j8ulhegJ7EhJ/QVZPoQ5qc30ylJQSxizizTJaen71Q7/13lXWc6ksuCKvg6dUKrp/TPgoxOOtSrFA==",
       "cpu": [
         "ia32"
       ],
@@ -9548,9 +9618,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.6.tgz",
-      "integrity": "sha512-izeoB8glCSe6IIDQmrVm6bvR9muk9TeKgmtY7b6l1BwL4BFnTUk4dMmpbntT90bEVQn3JPCaPtUG4HfL8VuyuA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.11.tgz",
+      "integrity": "sha512-IUohZedSJyDu/ReEBG/mqX6uG29uA7zZ9z6dIAF+p6eFxjXmh9MuHryyM+H8ebUyoq/Ad3rL+rUCksnuYNnI0w==",
       "cpu": [
         "x64"
       ],
@@ -10430,12 +10500,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
-      "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.11.1"
+        "undici-types": "~6.18.2"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -10456,9 +10526,9 @@
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
       "license": "MIT"
     },
     "node_modules/@types/nunjucks": {
@@ -12557,7 +12627,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "6.2.1",
@@ -20200,13 +20271,13 @@
       "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
     },
     "node_modules/inquirer": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.1.6.tgz",
-      "integrity": "sha512-TDqkT2B9MpzzsuJYi139mJDmhRwE9iJejdIy4hWIDmBkmkg8aKB0O4F2/Dz1Zex77zyqm9GrYK1xFhlD6yn4zg==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.1.8.tgz",
+      "integrity": "sha512-syxGpOzLyqVeZi1KDBjRTnCn5PiGWySGHP0BbqXbqsEK0ckkZk3egAepEWslUjZXj0rhkUapVXM/IpADWe4D6w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "^5.3.6",
-        "@inquirer/type": "^1.5.1",
+        "@inquirer/prompts": "^5.3.8",
+        "@inquirer/type": "^1.5.2",
         "@types/mute-stream": "^0.0.4",
         "ansi-escapes": "^4.3.2",
         "mute-stream": "^1.0.0",
@@ -22401,6 +22472,37 @@
       }
     },
     "node_modules/libsql": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.4.1.tgz",
+      "integrity": "sha512-qZlR9Yu1zMBeLChzkE/cKfoKV3Esp9cn9Vx5Zirn4AVhDWPcjYhKwbtJcMuHehgk3mH+fJr9qW+3vesBWbQpBg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32"
+      ],
+      "devOptional": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2",
+        "libsql": "^0.3.19"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.4.1",
+        "@libsql/darwin-x64": "0.4.1",
+        "@libsql/linux-arm64-gnu": "0.4.1",
+        "@libsql/linux-arm64-musl": "0.4.1",
+        "@libsql/linux-x64-gnu": "0.4.1",
+        "@libsql/linux-x64-musl": "0.4.1",
+        "@libsql/win32-x64-msvc": "0.4.1"
+      }
+    },
+    "node_modules/libsql/node_modules/libsql": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.3.19.tgz",
       "integrity": "sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==",
@@ -22410,6 +22512,7 @@
         "wasm32"
       ],
       "devOptional": true,
+      "license": "MIT",
       "os": [
         "darwin",
         "linux",
@@ -22429,6 +22532,104 @@
         "@libsql/linux-x64-musl": "0.3.19",
         "@libsql/win32-x64-msvc": "0.3.19"
       }
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/darwin-arm64": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.3.19.tgz",
+      "integrity": "sha512-rmOqsLcDI65zzxlUOoEiPJLhqmbFsZF6p4UJQ2kMqB+Kc0Rt5/A1OAdOZ/Wo8fQfJWjR1IbkbpEINFioyKf+nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/darwin-x64": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.3.19.tgz",
+      "integrity": "sha512-q9O55B646zU+644SMmOQL3FIfpmEvdWpRpzubwFc2trsa+zoBlSkHuzU9v/C+UNoPHQVRMP7KQctJ455I/h/xw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.3.19.tgz",
+      "integrity": "sha512-mgeAUU1oqqh57k7I3cQyU6Trpdsdt607eFyEmH5QO7dv303ti+LjUvh1pp21QWV6WX7wZyjeJV1/VzEImB+jRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.3.19.tgz",
+      "integrity": "sha512-VEZtxghyK6zwGzU9PHohvNxthruSxBEnRrX7BSL5jQ62tN4n2JNepJ6SdzXp70pdzTfwroOj/eMwiPt94gkVRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.3.19.tgz",
+      "integrity": "sha512-2t/J7LD5w2f63wGihEO+0GxfTyYIyLGEvTFEsMO16XI5o7IS9vcSHrxsvAJs4w2Pf907uDjmc7fUfMg6L82BrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-x64-musl": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.3.19.tgz",
+      "integrity": "sha512-BLsXyJaL8gZD8+3W2LU08lDEd9MIgGds0yPy5iNPp8tfhXx3pV/Fge2GErN0FC+nzt4DYQtjL+A9GUMglQefXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/libsql/node_modules/libsql/node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.3.19.tgz",
+      "integrity": "sha512-ay1X9AobE4BpzG0XPw1gplyLZPGHIgJOovvW23gUrukRegiUP62uzhpRbKNogLlUOynyXeq//prHgPXiebUfWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/lilconfig": {
       "version": "3.1.2",
@@ -32300,9 +32501,10 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
     },
     "node_modules/winston": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.1.tgz",
-      "integrity": "sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
     "node-sql-parser": "^5.2.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.623.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.631.0",
     "@azure/identity": "^4.4.1",
-    "@eslint/js": "^9.8.0",
-    "@libsql/client": "^0.8.1",
+    "@eslint/js": "^9.9.0",
+    "@libsql/client": "^0.9.0",
     "@swc/cli": "^0.4.0",
-    "@swc/core": "^1.7.6",
+    "@swc/core": "^1.7.11",
     "@swc/jest": "^0.2.36",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/async": "^3.2.24",
@@ -104,7 +104,7 @@
     "drizzle-kit": "^0.23.1",
     "esbuild": "^0.23.0",
     "eslint": "^8.57.0",
-    "eslint-plugin-jest": "^28.6.0",
+    "eslint-plugin-jest": "28.6.0",
     "eslint-plugin-unused-imports": "^3.2.0",
     "jest": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
@@ -119,7 +119,7 @@
     "zod-to-json-schema": "^3.23.2"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.25.0",
+    "@anthropic-ai/sdk": "^0.26.0",
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@googleapis/sheets": "^9.0.0",
     "ajv": "^8.17.1",
@@ -146,12 +146,12 @@
     "fast-xml-parser": "^4.4.1",
     "fastest-levenshtein": "^1.0.16",
     "glob": "^10.4.3",
-    "inquirer": "^10.1.6",
+    "inquirer": "^10.1.8",
     "js-yaml": "^4.1.0",
     "mathjs": "^13.0.3",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
-    "openai": "^4.54.0",
+    "openai": "^4.55.7",
     "opener": "^1.5.2",
     "proxy-agent": "^6.4.0",
     "python-shell": "^5.0.0",
@@ -162,7 +162,7 @@
     "socket.io": "^4.7.5",
     "tiny-invariant": "^1.3.3",
     "uuid": "^10.0.0",
-    "winston": "^3.13.1",
+    "winston": "^3.14.2",
     "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
- Upgrade @anthropic-ai/sdk from 0.25.0 to 0.26.0
- Upgrade @aws-sdk/client-bedrock-runtime from 3.623.0 to 3.631.0
- Upgrade @eslint/js from 9.8.0 to 9.9.0
- Upgrade @libsql/client from 0.8.1 to 0.9.0
- Upgrade @swc/core from 1.7.6 to 1.7.11
- Upgrade inquirer from 10.1.6 to 10.1.8
- Upgrade openai from 4.54.0 to 4.55.7
- Upgrade winston from 3.13.1 to 3.14.2
- Pin eslint-plugin-jest to 28.6.0