### PR TITLE
chore: use temporary file for python interprocess communication

### DIFF
--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -17,25 +17,30 @@ export async function runPython(
     os.tmpdir(),
     `promptfoo-python-input-json-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
   );
+  const outputPath = path.join(
+    os.tmpdir(),
+    `promptfoo-python-output-json-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+  );
   const pythonOptions: PythonShellOptions = {
     mode: 'text',
     pythonPath: options.pythonExecutable || process.env.PROMPTFOO_PYTHON || 'python',
     scriptPath: __dirname,
-    args: [absPath, method, tempJsonPath],
+    args: [absPath, method, tempJsonPath, outputPath],
   };
 
   try {
     await fs.writeFile(tempJsonPath, safeJsonStringify(args));
     logger.debug(`Running Python wrapper with args: ${safeJsonStringify(args)}`);
-    const results = await PythonShell.run('wrapper.py', pythonOptions);
-    logger.debug(`Python script ${absPath} returned: ${results.join('\n')}`);
+    await PythonShell.run('wrapper.py', pythonOptions);
+    const output = await fs.readFile(outputPath, 'utf-8');
+    logger.debug(`Python script ${absPath} returned: ${output}`);
     let result: { type: 'final_result'; data: any } | undefined;
     try {
-      result = JSON.parse(results[results.length - 1]);
+      result = JSON.parse(output);
     } catch (error) {
       throw new Error(
         `Invalid JSON: ${(error as Error).message} when parsing result: ${
-          results[results.length - 1]
+          output
         }\nStack Trace: ${(error as Error).stack}`,
       );
     }
@@ -59,6 +64,9 @@ export async function runPython(
   } finally {
     await fs
       .unlink(tempJsonPath)
+      .catch((error) => logger.error(`Error removing temporary file: ${error}`));
+    await fs
+      .unlink(outputPath)
       .catch((error) => logger.error(`Error removing temporary file: ${error}`));
   }
 }

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -62,11 +62,10 @@ export async function runPython(
       }`,
     );
   } finally {
-    await fs
-      .unlink(tempJsonPath)
-      .catch((error) => logger.error(`Error removing temporary file: ${error}`));
-    await fs
-      .unlink(outputPath)
-      .catch((error) => logger.error(`Error removing temporary file: ${error}`));
+    await Promise.all(
+      [tempJsonPath, outputPath].map((file) =>
+        fs.unlink(file).catch((error) => logger.error(`Error removing ${file}: ${error}`)),
+      ),
+    );
   }
 }

--- a/src/python/wrapper.py
+++ b/src/python/wrapper.py
@@ -28,8 +28,10 @@ if __name__ == "__main__":
     script_path = sys.argv[1]
     method_name = sys.argv[2]
     json_path = sys.argv[3]
+    output_path = sys.argv[4]
     with open(json_path, "r") as fp:
         data = json.load(fp)
 
     result = call_method(script_path, method_name, *data)
-    print(json.dumps({"type": "final_result", "data": result}))
+    with open(output_path, 'w') as fp:
+        fp.write(json.dumps({"type": "final_result", "data": result}))

--- a/src/python/wrapper.py
+++ b/src/python/wrapper.py
@@ -33,5 +33,5 @@ if __name__ == "__main__":
         data = json.load(fp)
 
     result = call_method(script_path, method_name, *data)
-    with open(output_path, 'w') as fp:
+    with open(output_path, "w") as fp:
         fp.write(json.dumps({"type": "final_result", "data": result}))

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -1,6 +1,4 @@
 import { promises as fs } from 'fs';
-import path from 'path';
-import os from 'os';
 import { PythonShell } from 'python-shell';
 import { runPython } from '../src/python/pythonUtils';
 import { runPythonCode } from '../src/python/wrapper';
@@ -35,16 +33,25 @@ describe('Python Wrapper', () => {
       const result = await runPython('testScript.py', 'testMethod', ['arg1', { key: 'value' }]);
 
       expect(result).toBe('test result');
-      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.objectContaining({
-        args: expect.arrayContaining([
-          expect.stringContaining('testScript.py'),
-          'testMethod',
-          expect.stringContaining('promptfoo-python-input-json'),
-          expect.stringContaining('promptfoo-python-output-json'),
-        ]),
-      }));
-      expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-input-json'), expect.any(String));
-      expect(fs.readFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-output-json'), 'utf-8');
+      expect(mockPythonShellRun).toHaveBeenCalledWith(
+        'wrapper.py',
+        expect.objectContaining({
+          args: expect.arrayContaining([
+            expect.stringContaining('testScript.py'),
+            'testMethod',
+            expect.stringContaining('promptfoo-python-input-json'),
+            expect.stringContaining('promptfoo-python-output-json'),
+          ]),
+        }),
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('promptfoo-python-input-json'),
+        expect.any(String),
+      );
+      expect(fs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining('promptfoo-python-output-json'),
+        'utf-8',
+      );
       expect(fs.unlink).toHaveBeenCalledTimes(2); // Once for input JSON, once for output JSON
     });
 
@@ -101,21 +108,29 @@ describe('Python Wrapper', () => {
       const result = await runPythonCode(code, 'main', []);
 
       expect(result).toBe('execution result');
-      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.objectContaining({
-        args: expect.arrayContaining([
-          expect.stringContaining('.py'),
-          'main',
-          expect.stringContaining('promptfoo-python-input-json'),
-          expect.stringContaining('promptfoo-python-output-json'),
-        ]),
-      }));
+      expect(mockPythonShellRun).toHaveBeenCalledWith(
+        'wrapper.py',
+        expect.objectContaining({
+          args: expect.arrayContaining([
+            expect.stringContaining('.py'),
+            'main',
+            expect.stringContaining('promptfoo-python-input-json'),
+            expect.stringContaining('promptfoo-python-output-json'),
+          ]),
+        }),
+      );
       expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining('.py'), code);
-      expect(fs.readFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-output-json'), 'utf-8');
+      expect(fs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining('promptfoo-python-output-json'),
+        'utf-8',
+      );
     });
 
     it('should clean up the temporary files after execution', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
-      jest.spyOn(fs, 'readFile').mockResolvedValue('{"type": "final_result", "data": "cleanup test"}');
+      jest
+        .spyOn(fs, 'readFile')
+        .mockResolvedValue('{"type": "final_result", "data": "cleanup test"}');
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       await runPythonCode('print("cleanup test")', 'main', []);

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -1,12 +1,20 @@
 import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
 import { PythonShell } from 'python-shell';
 import { runPython } from '../src/python/pythonUtils';
 import { runPythonCode } from '../src/python/wrapper';
 
 jest.mock('../src/esm');
 jest.mock('../src/logger');
-
 jest.mock('python-shell');
+jest.mock('fs', () => ({
+  promises: {
+    writeFile: jest.fn(),
+    readFile: jest.fn(),
+    unlink: jest.fn(),
+  },
+}));
 
 describe('Python Wrapper', () => {
   beforeEach(() => {
@@ -14,23 +22,30 @@ describe('Python Wrapper', () => {
   });
 
   describe('runPython', () => {
-    it('should correctly run a Python script with provided arguments', async () => {
+    it('should correctly run a Python script with provided arguments and read the output file', async () => {
+      const mockOutput = JSON.stringify({ type: 'final_result', data: 'test result' });
+
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'readFile').mockResolvedValue(mockOutput);
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       const mockPythonShellRun = jest.mocked(PythonShell.run);
-      mockPythonShellRun.mockResolvedValue(['{"type": "final_result", "data": "test result"}']);
+      mockPythonShellRun.mockResolvedValue([]);
 
       const result = await runPython('testScript.py', 'testMethod', ['arg1', { key: 'value' }]);
 
       expect(result).toBe('test result');
-      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
-      expect(mockPythonShellRun.mock.calls[0][1]!.args).toEqual([
-        expect.stringContaining('testScript.py'),
-        'testMethod',
-        expect.stringContaining('promptfoo-python-input-json'),
-      ]);
-      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.stringContaining('testScript.py'),
+          'testMethod',
+          expect.stringContaining('promptfoo-python-input-json'),
+          expect.stringContaining('promptfoo-python-output-json'),
+        ]),
+      }));
+      expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-input-json'), expect.any(String));
+      expect(fs.readFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-output-json'), 'utf-8');
+      expect(fs.unlink).toHaveBeenCalledTimes(2); // Once for input JSON, once for output JSON
     });
 
     it('should throw an error if the Python script execution fails', async () => {
@@ -43,44 +58,69 @@ describe('Python Wrapper', () => {
     });
 
     it('should handle Python script returning incorrect result type', async () => {
+      const mockOutput = JSON.stringify({ type: 'unexpected_result', data: 'test result' });
+
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'readFile').mockResolvedValue(mockOutput);
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       const mockPythonShellRun = jest.mocked(PythonShell.run);
-      mockPythonShellRun.mockResolvedValue([
-        '{"type": "unexpected_result", "data": "test result"}',
-      ]);
+      mockPythonShellRun.mockResolvedValue([]);
 
       await expect(runPython('testScript.py', 'testMethod', ['arg1'])).rejects.toThrow(
         'The Python script `call_api` function must return a dict with an `output`',
       );
     });
+
+    it('should handle invalid JSON in the output file', async () => {
+      jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'readFile').mockResolvedValue('Invalid JSON');
+      jest.spyOn(fs, 'unlink').mockResolvedValue();
+
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
+      mockPythonShellRun.mockResolvedValue([]);
+
+      await expect(runPython('testScript.py', 'testMethod', ['arg1'])).rejects.toThrow(
+        'Invalid JSON:',
+      );
+    });
   });
 
   describe('runPythonCode', () => {
-    it('should execute Python code from a string', async () => {
-      const mockPythonShellRun = jest.mocked(PythonShell.run);
-      mockPythonShellRun.mockResolvedValue([
-        '{"type": "final_result", "data": "execution result"}',
-      ]);
+    it('should execute Python code from a string and read the output file', async () => {
+      const mockOutput = JSON.stringify({ type: 'final_result', data: 'execution result' });
 
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'readFile').mockResolvedValue(mockOutput);
+      jest.spyOn(fs, 'unlink').mockResolvedValue();
+
+      const mockPythonShellRun = jest.mocked(PythonShell.run);
+      mockPythonShellRun.mockResolvedValue([]);
 
       const code = 'print("Hello, world!")';
       const result = await runPythonCode(code, 'main', []);
 
       expect(result).toBe('execution result');
-      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.any(Object));
+      expect(mockPythonShellRun).toHaveBeenCalledWith('wrapper.py', expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.stringContaining('.py'),
+          'main',
+          expect.stringContaining('promptfoo-python-input-json'),
+          expect.stringContaining('promptfoo-python-output-json'),
+        ]),
+      }));
       expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining('.py'), code);
+      expect(fs.readFile).toHaveBeenCalledWith(expect.stringContaining('promptfoo-python-output-json'), 'utf-8');
     });
 
-    it('should clean up the temporary file after execution', async () => {
+    it('should clean up the temporary files after execution', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValue();
+      jest.spyOn(fs, 'readFile').mockResolvedValue('{"type": "final_result", "data": "cleanup test"}');
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       await runPythonCode('print("cleanup test")', 'main', []);
 
-      expect(fs.unlink).toHaveBeenCalledTimes(2);
+      expect(fs.unlink).toHaveBeenCalledTimes(3); // Once for the temporary Python file, once for input JSON, once for output JSON
     });
   });
 });


### PR DESCRIPTION
In our application we've got lots of logging hitting stdout and is making it very difficult to use the custom python provider. This PR _attempts_ to move to using a file as the way to report results/output back to the TS layer. This should be more resilient than depending upon capturing stdout. 

I updated the tests that were failing with the change to pythonUtils.ts.