### PR TITLE
refactor(redteam): aliase `generate redteam` to `redteam generate`.

### DIFF
--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -58,7 +58,7 @@ You can specify your redteam configuration directly in `promptfooconfig.yaml`. S
 Then create adversarial test cases:
 
 ```sh
-npx promptfoo@latest generate redteam -w
+npx promptfoo@latest redteam generate -w
 ```
 
 The `-w` option overwrites the `promptfooconfig.yaml` file to include the newly generated test cases.
@@ -238,10 +238,10 @@ For more information, see [Overriding the LLM grader](/docs/configuration/expect
 
 ## Step 3: Generate adversarial test cases
 
-Now that you've configured everything, the next step is to generate the red teaming inputs. This is done by running the `promptfoo generate redteam` command:
+Now that you've configured everything, the next step is to generate the red teaming inputs. This is done by running the `promptfoo redteam generate` command:
 
 ```sh
-npx promptfoo@latest generate redteam -w
+npx promptfoo@latest redteam generate -w
 ```
 
 This command works by reading your prompts and providers, and then generating a set of adversarial inputs that stress-test your prompts/models in a variety of situations. Test generation usually takes about 5 minutes.
@@ -292,7 +292,7 @@ It also tests for a variety of harmful input and output scenarios from the [ML C
 By default, all of the above will be included in the redteam. To use specific types of tests, use `--plugins`:
 
 ```yaml
-npx promptfoo@latest generate redteam -w --plugins 'harmful,jailbreak,hijacking'
+npx promptfoo@latest redteam generate -w --plugins 'harmful,jailbreak,hijacking'
 ```
 
 The following plugins are enabled by default:

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -5,7 +5,7 @@ sidebar_label: 'Configuration'
 
 # Redteam Configuration
 
-The `redteam` section in your `promptfooconfig.yaml` file is used when generating redteam tests via `promptfoo generate redteam`. It allows you to specify the plugins and other parameters of your redteam tests.
+The `redteam` section in your `promptfooconfig.yaml` file is used when generating redteam tests via `promptfoo redteam generate`. It allows you to specify the plugins and other parameters of your redteam tests.
 
 ## Getting Started
 
@@ -212,7 +212,7 @@ policy: >
 To see a complete list of available plugins, run:
 
 ```bash
-promptfoo generate redteam --help
+promptfoo redteam generate --help
 ```
 
 ### Strategies
@@ -274,7 +274,7 @@ A common use case is to use a [custom HTTP endpoint](/docs/providers/http/) or [
 To use the `openai:chat:gpt-4o-mini` model, you can override the provider on the command line:
 
 ```sh
-npx promptfoo@latest generate redteam -w --provider openai:chat:gpt-4o-mini
+npx promptfoo@latest redteam generate -w --provider openai:chat:gpt-4o-mini
 ```
 
 Or in the config:

--- a/site/docs/red-team/index.md
+++ b/site/docs/red-team/index.md
@@ -144,7 +144,7 @@ Learn more about [prompt formats](/docs/configuration/parameters/#prompts).
 The `init` step will do this for you automatically, but in case you'd like to manually re-generate your adversarial inputs:
 
 ```sh
-npx promptfoo@latest generate redteam -w
+npx promptfoo@latest redteam generate -w
 ```
 
 This will generate several hundred adversarial inputs across many categories of potential harm.
@@ -152,10 +152,10 @@ This will generate several hundred adversarial inputs across many categories of 
 You can reduce the number of test cases by setting the specific [plugins](/docs/guides/llm-redteaming#step-3-generate-adversarial-test-cases) you want to run. For example, to only generate harmful inputs:
 
 ```sh
-npx promptfoo@latest generate redteam -w --plugins harmful
+npx promptfoo@latest redteam generate -w --plugins harmful
 ```
 
-Run `npx promptfoo@latest generate redteam --help` to see all available plugins.
+Run `npx promptfoo@latest redteam generate --help` to see all available plugins.
 
 #### Changing the provider
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -199,7 +199,7 @@ promptfoo generate dataset -c my_config.yaml -o new_tests.yaml -i 'All test case
 While in beta, this feature depends on OpenAI and requires the `OPENAI_API_KEY` environment variable.
 :::
 
-## `promptfoo generate redteam`
+## `promptfoo redteam generate`
 
 BETA: Generate adversarial test cases to challenge your prompts and models.
 
@@ -228,13 +228,13 @@ providers:
 This command will generate adversarial test cases and write them to the file:
 
 ```sh
-promptfoo generate redteam -w
+promptfoo redteam generate -w
 ```
 
 This command overrides the system purpose and the variable to inject adversarial user input:
 
 ```sh
-promptfoo generate redteam -w --purpose 'Travel agent that helps users plan trips' --injectVar 'message'
+promptfoo redteam generate -w --purpose 'Travel agent that helps users plan trips' --injectVar 'message'
 ```
 
 :::danger

--- a/src/commands/generate/redteam.ts
+++ b/src/commands/generate/redteam.ts
@@ -197,11 +197,12 @@ export async function doGenerateRedteam(options: RedteamGenerateOptions) {
 
 export function generateRedteamCommand(
   program: Command,
+  command: 'redteam' | 'generate',
   defaultConfig: Partial<UnifiedConfig>,
   defaultConfigPath: string | undefined,
 ) {
   program
-    .command('redteam')
+    .command(command) // generate or redteam depending on if called from redteam or generate
     .description('Generate adversarial test cases')
     .option('-c, --config [path]', 'Path to configuration file. Defaults to promptfooconfig.yaml')
     .option('-o, --output [path]', 'Path to output file')

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -336,7 +336,7 @@ export async function redteamInit(directory: string | undefined) {
       '\n' +
         chalk.blue(
           'To generate test cases later, use the command: ' +
-            chalk.bold('promptfoo generate redteam'),
+            chalk.bold('promptfoo redteam generate'),
         ),
     );
   }

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -345,10 +345,8 @@ export async function redteamInit(directory: string | undefined) {
   await telemetry.send();
 }
 
-export function redteamCommand(program: Command) {
-  const redteamCommand = program.command('redteam').description('Red team LLM applications');
-
-  redteamCommand
+export function initRedteamCommand(program: Command) {
+  program
     .command('init [directory]')
     .description('Initialize red teaming project')
     .action(async (directory: string | undefined) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { generateRedteamCommand } from './commands/generate/redteam';
 import { importCommand } from './commands/import';
 import { initCommand } from './commands/init';
 import { listCommand } from './commands/list';
-import { redteamCommand } from './commands/redteam';
+import { initRedteamCommand } from './commands/redteam';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
 import { versionCommand } from './commands/version';
@@ -72,7 +72,6 @@ async function main() {
   importCommand(program);
   initCommand(program);
   listCommand(program);
-  redteamCommand(program);
   shareCommand(program);
   showCommand(program);
   versionCommand(program);
@@ -80,7 +79,11 @@ async function main() {
 
   const generateCommand = program.command('generate').description('Generate synthetic data');
   generateDatasetCommand(generateCommand, defaultConfig, defaultConfigPath);
-  generateRedteamCommand(generateCommand, defaultConfig, defaultConfigPath);
+  generateRedteamCommand(generateCommand, 'redteam', defaultConfig, defaultConfigPath);
+
+  const redteamBaseCommand = program.command('redteam').description('Red team LLM applications');
+  initRedteamCommand(redteamBaseCommand);
+  generateRedteamCommand(redteamBaseCommand, 'generate', defaultConfig, defaultConfigPath);
 
   if (!process.argv.slice(2).length) {
     program.outputHelp();

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -53,7 +53,7 @@ export const RedteamStrategySchema = z.union([
 ]);
 
 /**
- * Schema for `promptfoo generate redteam` command options
+ * Schema for `promptfoo redteam generate` command options
  */
 export const RedteamGenerateOptionsSchema = z.object({
   cache: z.boolean().describe('Whether to use caching'),


### PR DESCRIPTION
# Refactor Redteam and Generate Commands

This PR aliases `generate redteam` to `redteam generate`.

## Testing

- [ ]  `promptfoo generate dataset`
- [ ]  `promptfoo generate redteam`
- [ ]  `promptfoo redteam init`
- [ ]  `promptfoo redteam generate`