### PR TITLE
chore: check config.redteam instead of config.metadata.redteam

### DIFF
--- a/src/commands/generate/redteam.ts
+++ b/src/commands/generate/redteam.ts
@@ -156,7 +156,6 @@ export async function doGenerateRedteam(options: RedteamGenerateOptions) {
         },
       },
       tests: redteamTests,
-      metadata: { ...existingYaml.metadata, redteam: true },
       redteam: { ...(existingYaml.redteam || {}), ...updatedRedteamConfig },
     };
     writePromptfooConfig(updatedYaml, options.output);
@@ -174,7 +173,6 @@ export async function doGenerateRedteam(options: RedteamGenerateOptions) {
       },
     };
     existingConfig.tests = [...(existingConfig.tests || []), ...redteamTests];
-    existingConfig.metadata = { ...(existingConfig.metadata || {}), redteam: true };
     existingConfig.redteam = { ...(existingConfig.redteam || {}), ...updatedRedteamConfig };
     writePromptfooConfig(existingConfig, configPath);
     logger.info(`\nWrote ${redteamTests.length} new test cases to ${configPath}`);

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -550,18 +550,19 @@ export default function ResultsView({
                 Table Settings
               </Button>
             </Tooltip>
-            {config?.metadata?.redteam && (
-              <Tooltip title="View vulnerability scan report" placement="bottom">
-                <Button
-                  color="primary"
-                  variant="contained"
-                  startIcon={<EyeIcon />}
-                  onClick={() => router.push(`/report/?evalId=${evalId || defaultEvalId}`)}
-                >
-                  Vulnerability Report
-                </Button>
-              </Tooltip>
-            )}
+            {config?.redteam ||
+              (config?.metadata?.redteam && (
+                <Tooltip title="View vulnerability scan report" placement="bottom">
+                  <Button
+                    color="primary"
+                    variant="contained"
+                    startIcon={<EyeIcon />}
+                    onClick={() => router.push(`/report/?evalId=${evalId || defaultEvalId}`)}
+                  >
+                    Vulnerability Report
+                  </Button>
+                </Tooltip>
+              ))}
           </ResponsiveStack>
         </Box>
       </ResponsiveStack>

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -550,19 +550,19 @@ export default function ResultsView({
                 Table Settings
               </Button>
             </Tooltip>
-            {config?.redteam ||
-              (config?.metadata?.redteam && (
-                <Tooltip title="View vulnerability scan report" placement="bottom">
-                  <Button
-                    color="primary"
-                    variant="contained"
-                    startIcon={<EyeIcon />}
-                    onClick={() => router.push(`/report/?evalId=${evalId || defaultEvalId}`)}
-                  >
-                    Vulnerability Report
-                  </Button>
-                </Tooltip>
-              ))}
+            {/* TODO: Remove config.metadata.redteam check in favor of config.redteam */}
+            {(config?.redteam || config?.metadata?.redteam) && (
+              <Tooltip title="View vulnerability scan report" placement="bottom">
+                <Button
+                  color="primary"
+                  variant="contained"
+                  startIcon={<EyeIcon />}
+                  onClick={() => router.push(`/report/?evalId=${evalId || defaultEvalId}`)}
+                >
+                  Vulnerability Report
+                </Button>
+              </Tooltip>
+            )}
           </ResponsiveStack>
         </Box>
       </ResponsiveStack>

--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -550,7 +550,7 @@ export default function ResultsView({
                 Table Settings
               </Button>
             </Tooltip>
-            {/* TODO: Remove config.metadata.redteam check in favor of config.redteam */}
+            {/* TODO(Michael): Remove config.metadata.redteam check (2024-08-18) */}
             {(config?.redteam || config?.metadata?.redteam) && (
               <Tooltip title="View vulnerability scan report" placement="bottom">
                 <Button


### PR DESCRIPTION
Now that we have the top level redteam config schema, we can check the existence of config.redteam instead of writing on config.metadata.redteam