### PR TITLE
fix: smarter caching in exec provider

### DIFF
--- a/src/providers/scriptCompletion.ts
+++ b/src/providers/scriptCompletion.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import invariant from 'tiny-invariant';
 import { getCache, isCacheEnabled } from '../cache';
 import logger from '../logger';
@@ -27,71 +30,95 @@ export class ScriptCompletionProvider implements ApiProvider {
   }
 
   async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
-    const cacheKey = `exec:${this.scriptPath}:${prompt}:${JSON.stringify(this.options)}`;
-    const cache = await getCache();
-    let cachedResult;
+    const fileHashes: string[] = [];
 
-    if (isCacheEnabled()) {
-      cachedResult = await cache.get(cacheKey);
+    // Parse all filepaths out of the command string
+    const scriptParts = this.scriptPath.match(/[^\s"']+|"([^"]*)"|'([^']*)'/g) || [];
+    for (const part of scriptParts) {
+      // Remove quotes if present
+      const cleanPart = part.replace(/^['"]|['"]$/g, '');
+      if (fs.existsSync(cleanPart) && fs.statSync(cleanPart).isFile()) {
+        const fileContent = fs.readFileSync(cleanPart);
+        const fileHash = crypto.createHash('sha256').update(fileContent).digest('hex');
+        fileHashes.push(fileHash);
+        logger.debug(`File hash for ${cleanPart}: ${fileHash}`);
+      }
     }
 
-    if (cachedResult) {
-      logger.debug(`Returning cached result for script ${this.scriptPath}: ${cachedResult}`);
-      return JSON.parse(cachedResult as string);
-    } else {
-      return new Promise<ProviderResponse>((resolve, reject) => {
-        const scriptPartsRegex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
-        let match;
-        const scriptParts = [];
+    if (fileHashes.length === 0) {
+      logger.warn(`Could not find any valid files in the command: ${this.scriptPath}`);
+    }
 
-        while ((match = scriptPartsRegex.exec(this.scriptPath)) !== null) {
-          // If it's a quoted match, push the first group (ignoring the quotes)
-          if (match[1]) {
-            scriptParts.push(match[1]);
-          } else if (match[2]) {
-            // If it's a single-quoted match, push the second group (ignoring the quotes)
-            scriptParts.push(match[2]);
-          } else {
-            // Otherwise, push the whole match
-            scriptParts.push(match[0]);
-          }
+    const cacheKey = `exec:${this.scriptPath}:${fileHashes.join(':')}:${prompt}:${JSON.stringify(this.options)}`;
+
+    let cachedResult;
+    if (fileHashes.length > 0 && isCacheEnabled()) {
+      const cache = await getCache();
+      cachedResult = await cache.get(cacheKey);
+
+      if (cachedResult) {
+        logger.debug(`Returning cached result for script ${this.scriptPath}: ${cachedResult}`);
+        return JSON.parse(cachedResult as string);
+      }
+    } else if (fileHashes.length === 0 && isCacheEnabled()) {
+      logger.warn(
+        `Could not hash any files for command ${this.scriptPath}, caching will not be used`,
+      );
+    }
+
+    return new Promise<ProviderResponse>((resolve, reject) => {
+      const scriptPartsRegex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
+      let match;
+      const scriptParts = [];
+
+      while ((match = scriptPartsRegex.exec(this.scriptPath)) !== null) {
+        // If it's a quoted match, push the first group (ignoring the quotes)
+        if (match[1]) {
+          scriptParts.push(match[1]);
+        } else if (match[2]) {
+          // If it's a single-quoted match, push the second group (ignoring the quotes)
+          scriptParts.push(match[2]);
+        } else {
+          // Otherwise, push the whole match
+          scriptParts.push(match[0]);
         }
-        const command = scriptParts.shift();
-        invariant(command, 'No command found in script path');
-        // These are not useful in the shell
-        delete context?.fetchWithCache;
-        delete context?.getCache;
-        delete context?.logger;
-        const scriptArgs = scriptParts.concat([
-          prompt,
-          safeJsonStringify(this.options || {}),
-          safeJsonStringify(context || {}),
-        ]);
-        const options = this.options?.config.basePath ? { cwd: this.options.config.basePath } : {};
+      }
+      const command = scriptParts.shift();
+      invariant(command, 'No command found in script path');
+      // These are not useful in the shell
+      delete context?.fetchWithCache;
+      delete context?.getCache;
+      delete context?.logger;
+      const scriptArgs = scriptParts.concat([
+        prompt,
+        safeJsonStringify(this.options || {}),
+        safeJsonStringify(context || {}),
+      ]);
+      const options = this.options?.config.basePath ? { cwd: this.options.config.basePath } : {};
 
-        execFile(command, scriptArgs, options, async (error, stdout, stderr) => {
-          if (error) {
-            logger.debug(`Error running script ${this.scriptPath}: ${error.message}`);
-            reject(error);
+      execFile(command, scriptArgs, options, async (error, stdout, stderr) => {
+        if (error) {
+          logger.debug(`Error running script ${this.scriptPath}: ${error.message}`);
+          reject(error);
+          return;
+        }
+        const standardOutput = stripText(String(stdout).trim());
+        const errorOutput = stripText(String(stderr).trim());
+        if (errorOutput) {
+          logger.debug(`Error output from script ${this.scriptPath}: ${errorOutput}`);
+          if (!standardOutput) {
+            reject(new Error(errorOutput));
             return;
           }
-          const standardOutput = stripText(String(stdout).trim());
-          const errorOutput = stripText(String(stderr).trim());
-          if (errorOutput) {
-            logger.debug(`Error output from script ${this.scriptPath}: ${errorOutput}`);
-            if (!standardOutput) {
-              reject(new Error(errorOutput));
-              return;
-            }
-          }
-          logger.debug(`Output from script ${this.scriptPath}: ${standardOutput}`);
-          const result = { output: standardOutput };
-          if (isCacheEnabled()) {
-            await cache.set(cacheKey, JSON.stringify(result));
-          }
-          resolve(result);
-        });
+        }
+        logger.debug(`Output from script ${this.scriptPath}: ${standardOutput}`);
+        const result = { output: standardOutput };
+        if (fileHashes.length > 0 && isCacheEnabled()) {
+          const cache = await getCache();
+          await cache.set(cacheKey, JSON.stringify(result));
+        }
+        resolve(result);
       });
-    }
+    });
   }
 }

--- a/src/providers/scriptCompletion.ts
+++ b/src/providers/scriptCompletion.ts
@@ -1,7 +1,6 @@
 import { execFile } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
-import path from 'path';
 import invariant from 'tiny-invariant';
 import { getCache, isCacheEnabled } from '../cache';
 import logger from '../logger';

--- a/test/providers.scriptCompletion.test.ts
+++ b/test/providers.scriptCompletion.test.ts
@@ -1,0 +1,83 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import { parseScriptParts, getFileHashes } from '../src/providers/scriptCompletion';
+
+jest.mock('fs');
+jest.mock('crypto');
+
+describe('parseScriptParts', () => {
+  it('should parse script parts correctly', () => {
+    const scriptPath = `node script.js "arg with 'spaces'" 'another arg' simple_arg`;
+    const result = parseScriptParts(scriptPath);
+    expect(result).toEqual(['node', 'script.js', "arg with 'spaces'", 'another arg', 'simple_arg']);
+  });
+
+  it('should handle script path with no arguments', () => {
+    const scriptPath = '/bin/bash script.sh';
+    const result = parseScriptParts(scriptPath);
+    expect(result).toEqual(['/bin/bash', 'script.sh']);
+  });
+});
+
+describe('getFileHashes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return file hashes for existing files', () => {
+    const scriptParts = ['file1.js', 'file2.js', 'nonexistent.js'];
+    const mockFileContent1 = 'content1';
+    const mockFileContent2 = 'content2';
+    const mockHash1 = 'hash1';
+    const mockHash2 = 'hash2';
+
+    jest.mocked(fs.existsSync).mockImplementation((path) => path !== 'nonexistent.js');
+    jest.mocked(fs.statSync).mockReturnValue({
+      isFile: () => true,
+      isDirectory: () => false,
+      isBlockDevice: () => false,
+      isCharacterDevice: () => false,
+      isSymbolicLink: () => false,
+      isFIFO: () => false,
+      isSocket: () => false,
+    } as fs.Stats);
+    jest.mocked(fs.readFileSync).mockImplementation((path) => {
+      if (path === 'file1.js') {
+        return mockFileContent1;
+      }
+      if (path === 'file2.js') {
+        return mockFileContent2;
+      }
+      throw new Error('File not found');
+    });
+
+    const mockHashUpdate = {
+      update: jest.fn().mockReturnThis(),
+      digest: jest.fn(),
+    } as unknown as crypto.Hash;
+    jest
+      .mocked(mockHashUpdate.digest)
+      .mockReturnValueOnce(mockHash1)
+      .mockReturnValueOnce(mockHash2);
+    jest.mocked(crypto.createHash).mockReturnValue(mockHashUpdate);
+
+    const result = getFileHashes(scriptParts);
+
+    expect(result).toEqual([mockHash1, mockHash2]);
+    expect(fs.existsSync).toHaveBeenCalledTimes(3);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(crypto.createHash).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return an empty array for non-existent files', () => {
+    const scriptParts = ['nonexistent1.js', 'nonexistent2.js'];
+    jest.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = getFileHashes(scriptParts);
+
+    expect(result).toEqual([]);
+    expect(fs.existsSync).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(crypto.createHash).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Instead of blindly caching based on the payload, we also include a hash of any files we find in the exec string.

A string like this:
```
/bin/bash test.sh --foo bar
```

Will attempt to include both `/bin/bash` and `test.sh` in the hash.