### PR TITLE
build: add defaults for supabase environment variables

### DIFF
--- a/src/web/nextui/next.config.js
+++ b/src/web/nextui/next.config.js
@@ -33,7 +33,8 @@ const nextConfig = {
   },
   env: {
     PROMPTFOO_VERSION: require('../../../package.json').version,
-    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.promptfoo.dev',
+    NEXT_PUBLIC_SUPABASE_URL:
+      process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.promptfoo.dev',
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'abc123',
   },
 };

--- a/src/web/nextui/next.config.js
+++ b/src/web/nextui/next.config.js
@@ -33,6 +33,8 @@ const nextConfig = {
   },
   env: {
     PROMPTFOO_VERSION: require('../../../package.json').version,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.promptfoo.dev',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'abc123',
   },
 };
 


### PR DESCRIPTION
Running `npm run build` would fail without setting supabase environment variables. These aren't required for running prompt foo locally.