### PR TITLE
feat(redteam): support multiple policies in redteam config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cSpell.words": ["redteam"]
 }

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -163,11 +163,11 @@ export async function synthesize({
   logger.debug(`System purpose: ${purpose}`);
 
   const testCases: TestCaseWithPlugin[] = [];
-  for (const { key: pluginId, action } of Plugins) {
-    const plugin = plugins.find((p) => p.id === pluginId);
-    if (plugin) {
+  for (const plugin of plugins) {
+    const { action } = Plugins.find((p) => p.key === plugin.id) || {};
+    if (action) {
       updateProgress();
-      logger.debug(`Generating tests for ${pluginId}...`);
+      logger.debug(`Generating tests for ${plugin.id}...`);
       const pluginTests = await action(redteamProvider, purpose, injectVar, plugin.numTests, {
         language,
         ...(plugin.config || {}),
@@ -177,11 +177,13 @@ export async function synthesize({
           ...t,
           metadata: {
             ...(t.metadata || {}),
-            pluginId,
+            pluginId: plugin.id,
           },
         })),
       );
-      logger.debug(`Added ${pluginTests.length} ${pluginId} test cases`);
+      logger.debug(`Added ${pluginTests.length} ${plugin.id} test cases`);
+    } else {
+      logger.warn(`Plugin ${plugin.id} not registered, skipping`);
     }
   }
 

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -40,6 +40,9 @@ export async function synthesize({
   entities: string[];
   testCases: TestCaseWithPlugin[];
 }> {
+  if (prompts.length === 0) {
+    throw new Error('Prompts array cannot be empty');
+  }
   validateStrategies(strategies);
 
   let redteamProvider: ApiProvider;

--- a/src/types/redteam.ts
+++ b/src/types/redteam.ts
@@ -50,7 +50,7 @@ export interface SynthesizeOptions {
   numTests: number;
   language: string;
   plugins: { id: string; numTests: number; config?: Record<string, any> }[];
-  prompts: string[];
+  prompts: [string, ...string[]];
   provider?: ApiProvider | ProviderOptions | string;
   purpose?: string;
   strategies: { id: string }[];

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -1,0 +1,146 @@
+import logger from '../../src/logger';
+import { loadApiProvider } from '../../src/providers';
+import { extractEntities } from '../../src/redteam/extraction/entities';
+import { extractSystemPurpose } from '../../src/redteam/extraction/purpose';
+import { synthesize } from '../../src/redteam/index';
+import { Plugins } from '../../src/redteam/plugins';
+
+jest.mock('../../src/logger');
+jest.mock('../../src/providers');
+jest.mock('../../src/redteam/extraction/entities');
+jest.mock('../../src/redteam/extraction/purpose');
+
+jest.mock('process', () => ({
+  ...jest.requireActual('process'),
+  exit: jest.fn(),
+}));
+
+describe('synthesize', () => {
+  const mockProvider = {
+    callApi: jest.fn(),
+    generate: jest.fn(),
+    id: () => 'test-provider',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(extractEntities).mockResolvedValue(['entity1', 'entity2']);
+    jest.mocked(extractSystemPurpose).mockResolvedValue('Test purpose');
+    jest.mocked(loadApiProvider).mockResolvedValue(mockProvider);
+    jest.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process.exit called with code ${code}`);
+    });
+  });
+
+  it('should use provided purpose and entities if given', async () => {
+    const result = await synthesize({
+      entities: ['custom-entity'],
+      language: 'en',
+      numTests: 1,
+      plugins: [{ id: 'test-plugin', numTests: 1 }],
+      prompts: ['Test prompt'],
+      purpose: 'Custom purpose',
+      strategies: [],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        entities: ['custom-entity'],
+        purpose: 'Custom purpose',
+      }),
+    );
+    expect(extractEntities).not.toHaveBeenCalled();
+    expect(extractSystemPurpose).not.toHaveBeenCalled();
+  });
+
+  it('should extract purpose and entities if not provided', async () => {
+    await synthesize({
+      language: 'english',
+      numTests: 1,
+      plugins: [{ id: 'test-plugin', numTests: 1 }],
+      prompts: ['Test prompt'],
+      strategies: [],
+    });
+
+    expect(extractEntities).toHaveBeenCalledWith(expect.any(Object), ['Test prompt']);
+    expect(extractSystemPurpose).toHaveBeenCalledWith(expect.any(Object), ['Test prompt']);
+  });
+
+  it('should use the provided API provider if given', async () => {
+    const customProvider = { callApi: jest.fn(), generate: jest.fn(), id: () => 'custom-provider' };
+    await synthesize({
+      language: 'en',
+      numTests: 1,
+      plugins: [{ id: 'test-plugin', numTests: 1 }],
+      prompts: ['Test prompt'],
+      provider: customProvider,
+      strategies: [],
+    });
+
+    expect(loadApiProvider).not.toHaveBeenCalled();
+  });
+
+  it('should load the default provider if not provided', async () => {
+    await synthesize({
+      language: 'en',
+      numTests: 1,
+      plugins: [{ id: 'test-plugin', numTests: 1 }],
+      prompts: ['Test prompt'],
+      strategies: [],
+    });
+
+    expect(loadApiProvider).toHaveBeenCalledWith('openai:chat:gpt-4o', {
+      options: { config: { temperature: 0.5 } },
+    });
+  });
+
+  it('should generate test cases for each plugin', async () => {
+    const mockPluginAction = jest.fn().mockResolvedValue([{ test: 'case' }]);
+    jest.spyOn(Plugins, 'find').mockReturnValue({ action: mockPluginAction, key: 'mockPlugin' });
+
+    const result = await synthesize({
+      language: 'en',
+      numTests: 1,
+      plugins: [
+        { id: 'plugin1', numTests: 2 },
+        { id: 'plugin2', numTests: 3 },
+      ],
+      prompts: ['Test prompt'],
+      strategies: [],
+    });
+
+    expect(mockPluginAction).toHaveBeenCalledTimes(2);
+    expect(result.testCases).toEqual([
+      expect.objectContaining({ metadata: expect.objectContaining({ pluginId: 'plugin1' }) }),
+      expect.objectContaining({ metadata: expect.objectContaining({ pluginId: 'plugin2' }) }),
+    ]);
+  });
+
+  it('should warn about unregistered plugins', async () => {
+    jest.spyOn(Plugins, 'find').mockReturnValue(undefined);
+
+    await synthesize({
+      language: 'en',
+      numTests: 1,
+      plugins: [{ id: 'unregistered-plugin', numTests: 1 }],
+      prompts: ['Test prompt'],
+      strategies: [],
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith('Plugin unregistered-plugin not registered, skipping');
+  });
+
+  it('should call process.exit when invalid strategies are provided', async () => {
+    await expect(
+      synthesize({
+        language: 'en',
+        numTests: 1,
+        plugins: [{ id: 'test-plugin', numTests: 1 }],
+        prompts: ['Test prompt'],
+        strategies: [{ id: 'invalid-strategy' }],
+      }),
+    ).rejects.toThrow('Process.exit called with code 1');
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
- Add check for empty prompts array in synthesize function
- Update plugin iteration logic to support multiple policies
- Add warning for unregistered plugins
- Update SynthesizeOptions type to ensure non-empty prompts array
- Add unit tests for new functionality
- Update VSCode settings to include 'redteam' in spell check