### PR TITLE
docs: remove references to optional Supabase environment variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ env:
   OPENAI_API_KEY: xxx
   ANTHROPIC_API_KEY: xxx
   AZURE_OPENAI_API_HOST: xxx
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: xxx
-  NEXT_PUBLIC_SUPABASE_URL: https://placeholder.promptfoo.dev
   NEXT_TELEMETRY_DISABLED: 1
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -416,8 +416,6 @@ In order to build the next.js app, you'll have to set some placeholder envars (i
 DATABASE_URL="postgresql://..."
 
 NEXT_PUBLIC_PROMPTFOO_WITH_DATABASE=1
-NEXT_PUBLIC_SUPABASE_URL=https://placeholder.promptfoo.dev
-NEXT_PUBLIC_SUPABASE_ANON_KEY=abc123
 ```
 
 Then run:


### PR DESCRIPTION
These are no longer necessary now that we set default placeholders