### PR TITLE
fix: hosted load shared eval

### DIFF
--- a/src/web/nextui/src/app/eval/Eval.tsx
+++ b/src/web/nextui/src/app/eval/Eval.tsx
@@ -122,9 +122,10 @@ export default function Eval({
       setAuthor(preloadedData.data.author || null);
       setLoaded(true);
     } else if (fetchId) {
-      console.log('Eval init: Fetching eval from remote server', fetchId);
+      console.log('Eval init: Fetching eval', fetchId);
       const run = async () => {
-        const url = `${REMOTE_API_BASE_URL}/api/eval/${fetchId}`;
+        const host = IS_RUNNING_LOCALLY ? REMOTE_API_BASE_URL : '';
+        const url = `${host}/api/eval/${fetchId}`;
         console.log('Fetching eval from remote server', url);
         const response = await fetch(url);
         if (!response.ok) {


### PR DESCRIPTION
If we're long running locally it means we're running in a hosted server, load the eval from local instead of a potential fallback url of promptfoo.dev