### PR TITLE
fix: Generate correct url for hosted shared evals

### DIFF
--- a/src/web/nextui/src/app/eval/ResultsView.tsx
+++ b/src/web/nextui/src/app/eval/ResultsView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { REMOTE_API_BASE_URL, REMOTE_APP_BASE_URL } from '@/../../../constants';
 import { getApiBaseUrl } from '@/api';
+import { IS_RUNNING_LOCALLY } from '@/constants';
 import { useStore as useMainStore } from '@/state/evalConfig';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -122,6 +123,8 @@ export default function ResultsView({
   // State for anchor element
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
+  const currentEvalId = evalId || defaultEvalId || 'default';
+
   // Handle menu close
   const handleMenuClose = () => {
     setAnchorEl(null);
@@ -134,26 +137,31 @@ export default function ResultsView({
 
   const handleShareButtonClick = async () => {
     setShareLoading(true);
+    let shareUrl = '';
     try {
-      const response = await fetch(`${REMOTE_API_BASE_URL}/api/eval`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          data: {
-            version: 2,
-            createdAt: new Date().toISOString(),
-            results: {
-              table,
-            },
-            config,
+      if (IS_RUNNING_LOCALLY) {
+        const response = await fetch(`${REMOTE_API_BASE_URL}/api/eval`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
           },
-        }),
-      });
+          body: JSON.stringify({
+            data: {
+              version: 2,
+              createdAt: new Date().toISOString(),
+              results: {
+                table,
+              },
+              config,
+            },
+          }),
+        });
+        const { id } = await response.json();
+        shareUrl = `${REMOTE_APP_BASE_URL}/eval/${id}`;
+      } else {
+        shareUrl = `${window.location.host}/eval/?evalId=${evalId}`;
+      }
 
-      const { id } = await response.json();
-      const shareUrl = `${REMOTE_APP_BASE_URL}/eval/${id}`;
       setShareUrl(shareUrl);
       setShareModalOpen(true);
     } catch {
@@ -249,7 +257,6 @@ export default function ResultsView({
     [hasAnyDescriptions, head.vars, head.prompts],
   );
 
-  const currentEvalId = evalId || defaultEvalId || 'default';
   const currentColumnState = columnStates[currentEvalId] || {
     selectedColumns: [],
     columnVisibility: {},


### PR DESCRIPTION
When you're running a hosted version of promptfoo, share should give you the link of your server, not share it publicly to promptfoo.dev.

Fixed Example:
<img width="783" alt="image" src="https://github.com/user-attachments/assets/e776454c-43e8-43c6-8c74-2d519414ab8c">
