### PR TITLE
fix(assertions): update error messages for context-relevance and context-faithfulness

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1078,7 +1078,7 @@ ${
     invariant(test.vars, 'context-relevance assertion type must have a vars object');
     invariant(
       typeof test.vars.query === 'string',
-      'context-relevance assertion type must have a question var',
+      'context-relevance assertion type must have a query var',
     );
     invariant(
       typeof test.vars.context === 'string',
@@ -1100,7 +1100,7 @@ ${
     invariant(test.vars, 'context-faithfulness assertion type must have a vars object');
     invariant(
       typeof test.vars.query === 'string',
-      'context-faithfulness assertion type must have a question var',
+      'context-faithfulness assertion type must have a query var',
     );
     invariant(
       typeof test.vars.context === 'string',


### PR DESCRIPTION
This PR addresses the issue reported in #1477, where misleading error messages were displayed for `context-relevance` and `context-faithfulness` assertions. It updates error messages to correctly refer to "query var" instead of "question var". 

Thanks so much @elsatch for reporting this issue and providing a detailed reproduction case. We appreciate your help!

Closes #1477