### PR TITLE
fix: include vars in python provider cache key

### DIFF
--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -54,7 +54,7 @@ export class PythonProvider implements ApiProvider {
     const fileHash = sha256(fs.readFileSync(absPath, 'utf-8'));
     const cacheKey = `python:${this.scriptPath}:${apiType}:${fileHash}:${prompt}:${JSON.stringify(
       this.options,
-    )}`;
+    )}:${JSON.stringify(context?.vars)}`;
     const cache = await getCache();
     let cachedResult;
 


### PR DESCRIPTION
Related to #1492