### PR TITLE
feat(anthropic): add support for create message headers (prompt caching)

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -20,10 +20,17 @@ export ANTHROPIC_API_KEY=your_api_key_here
 
 ### Supported Parameters
 
-| Config Property | Environment Variable | Description                                    |
-| --------------- | -------------------- | ---------------------------------------------- |
-| apiKey          | ANTHROPIC_API_KEY    | Your API key from Anthropic                    |
-| apiBaseUrl      | ANTHROPIC_BASE_URL   | The base URL for requests to the Anthropic API |
+| Config Property | Environment Variable  | Description                                                       |
+| --------------- | --------------------- | ----------------------------------------------------------------- |
+| apiKey          | ANTHROPIC_API_KEY     | Your API key from Anthropic                                       |
+| apiBaseUrl      | ANTHROPIC_BASE_URL    | The base URL for requests to the Anthropic API                    |
+| temperature     | ANTHROPIC_TEMPERATURE | Controls the randomness of the output (default: 0)                |
+| max_tokens      | ANTHROPIC_MAX_TOKENS  | The maximum length of the generated text (default: 1024)          |
+| top_p           | -                     | Controls nucleus sampling, affecting the randomness of the output |
+| top_k           | -                     | Only sample from the top K options for each subsequent token      |
+| tools           | -                     | An array of tool or function definitions for the model to call    |
+| tool_choice     | -                     | An object specifying the tool to call                             |
+| headers         | -                     | Additional headers to be sent with the API request                |
 
 ## Latest API (Messages)
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -126,10 +126,7 @@ export function parseMessages(messages: string) {
   ]);
   // Convert from OpenAI to Anthropic format
   const systemMessage = chats.find((m) => m.role === 'system')?.content;
-  const system =
-    typeof systemMessage === 'string'
-      ? [{ type: 'text' as const, text: systemMessage }]
-      : systemMessage;
+  const system = typeof systemMessage === 'string' ? systemMessage : undefined;
   const extractedMessages: Anthropic.MessageParam[] = chats
     .filter((m) => m.role === 'user' || m.role === 'assistant')
     .map((m) => {
@@ -247,7 +244,7 @@ export class AnthropicMessagesProvider implements ApiProvider {
 
     try {
       const response = await this.anthropic.messages.create(params, {
-        headers: this.config.headers,
+        ...(this.config.headers ? { headers: this.config.headers } : {}),
       });
 
       logger.debug(`Anthropic Messages API response: ${JSON.stringify(response)}`);

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -68,24 +68,28 @@ describe('Anthropic', () => {
 
       const result = await provider.callApi('What is the forecast in San Francisco?');
       expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
-      expect(provider.anthropic.messages.create).toHaveBeenNthCalledWith(1, {
-        model: 'claude-3-opus-20240229',
-        max_tokens: 1024,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              {
-                text: 'What is the forecast in San Francisco?',
-                type: 'text',
-              },
-            ],
-          },
-        ],
-        tools,
-        temperature: 0,
-        stream: false,
-      });
+      expect(provider.anthropic.messages.create).toHaveBeenNthCalledWith(
+        1,
+        {
+          model: 'claude-3-opus-20240229',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  text: 'What is the forecast in San Francisco?',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+          tools,
+          temperature: 0,
+          stream: false,
+        },
+        {},
+      );
 
       expect(result).toMatchObject({
         cost: undefined,
@@ -126,25 +130,29 @@ describe('Anthropic', () => {
 
       await provider.callApi('What is the forecast in San Francisco?');
       expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
-      expect(provider.anthropic.messages.create).toHaveBeenNthCalledWith(1, {
-        model: 'claude-3-opus-20240229',
-        max_tokens: 1024,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              {
-                text: 'What is the forecast in San Francisco?',
-                type: 'text',
-              },
-            ],
-          },
-        ],
-        tools,
-        tool_choice: toolChoice,
-        temperature: 0,
-        stream: false,
-      });
+      expect(provider.anthropic.messages.create).toHaveBeenNthCalledWith(
+        1,
+        {
+          model: 'claude-3-opus-20240229',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  text: 'What is the forecast in San Francisco?',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+          tools,
+          tool_choice: toolChoice,
+          temperature: 0,
+          stream: false,
+        },
+        {},
+      );
 
       provider.config.tool_choice = undefined;
     });


### PR DESCRIPTION
This PR adds support for the `headers` property in an anthropic provider config.  This enables [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).