### PR TITLE
fix: remove prompt-extraction from base plugins

### DIFF
--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -80,7 +80,6 @@ export const BASE_PLUGINS = [
   'hijacking',
   'overreliance',
   'politics',
-  'prompt-extraction',
 ] as const;
 export type BasePlugin = (typeof BASE_PLUGINS)[number];
 


### PR DESCRIPTION
It's already in `ADDITIONAL_PLUGINS`, which is causing it to appear twice, and can't go in default (base) plugins because it requires configuration.