### PR TITLE
fix: use utf-8 encoding for python ipc

### DIFF
--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -30,7 +30,7 @@ export async function runPython(
   };
 
   try {
-    await fs.writeFile(tempJsonPath, safeJsonStringify(args));
+    await fs.writeFile(tempJsonPath, safeJsonStringify(args), 'utf-8');
     logger.debug(`Running Python wrapper with args: ${safeJsonStringify(args)}`);
     await PythonShell.run('wrapper.py', pythonOptions);
     const output = await fs.readFile(outputPath, 'utf-8');

--- a/src/python/wrapper.py
+++ b/src/python/wrapper.py
@@ -29,9 +29,9 @@ if __name__ == "__main__":
     method_name = sys.argv[2]
     json_path = sys.argv[3]
     output_path = sys.argv[4]
-    with open(json_path, "r") as fp:
+    with open(json_path, "r", encoding="utf-8") as fp:
         data = json.load(fp)
 
     result = call_method(script_path, method_name, *data)
-    with open(output_path, "w") as fp:
+    with open(output_path, "w", encoding="utf-8") as fp:
         fp.write(json.dumps({"type": "final_result", "data": result}))

--- a/test/pythonWrapper.test.ts
+++ b/test/pythonWrapper.test.ts
@@ -47,6 +47,7 @@ describe('Python Wrapper', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('promptfoo-python-input-json'),
         expect.any(String),
+        'utf-8',
       );
       expect(fs.readFile).toHaveBeenCalledWith(
         expect.stringContaining('promptfoo-python-output-json'),


### PR DESCRIPTION
Related to #1510 and #1476 

I think this was introduced by #1447 (cc @enkoder)