### PR TITLE
chore(deps): upgrade Docusaurus to version 3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34267,11 +34267,11 @@
       "license": "MIT",
       "dependencies": {
         "@calcom/embed-react": "^1.5.0",
-        "@docusaurus/core": "3.5.1",
-        "@docusaurus/plugin-content-docs": "3.5.1",
-        "@docusaurus/plugin-google-gtag": "3.5.1",
-        "@docusaurus/preset-classic": "3.5.1",
-        "@docusaurus/theme-search-algolia": "3.5.1",
+        "@docusaurus/core": "^3.5.2",
+        "@docusaurus/plugin-content-docs": "^3.5.2",
+        "@docusaurus/plugin-google-gtag": "^3.5.2",
+        "@docusaurus/preset-classic": "^3.5.2",
+        "@docusaurus/theme-search-algolia": "^3.5.2",
         "@mdx-js/react": "^3.0.1",
         "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "^5.16.7",
@@ -34283,7 +34283,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.5.1",
+        "@docusaurus/module-type-aliases": "^3.5.2",
         "@tsconfig/docusaurus": "^2.0.3",
         "typescript": "^5.5.4"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -17,11 +17,11 @@
   },
   "dependencies": {
     "@calcom/embed-react": "^1.5.0",
-    "@docusaurus/core": "3.5.1",
-    "@docusaurus/plugin-content-docs": "3.5.1",
-    "@docusaurus/plugin-google-gtag": "3.5.1",
-    "@docusaurus/preset-classic": "3.5.1",
-    "@docusaurus/theme-search-algolia": "3.5.1",
+    "@docusaurus/core": "^3.5.2",
+    "@docusaurus/plugin-content-docs": "^3.5.2",
+    "@docusaurus/plugin-google-gtag": "^3.5.2",
+    "@docusaurus/preset-classic": "^3.5.2",
+    "@docusaurus/theme-search-algolia": "^3.5.2",
     "@mdx-js/react": "^3.0.1",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "^5.16.7",
@@ -33,7 +33,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.1",
+    "@docusaurus/module-type-aliases": "^3.5.2",
     "@tsconfig/docusaurus": "^2.0.3",
     "typescript": "^5.5.4"
   },


### PR DESCRIPTION
- Update @docusaurus/core from 3.5.1 to ^3.5.2
- Update @docusaurus/plugin-content-docs from 3.5.1 to ^3.5.2
- Update @docusaurus/plugin-google-gtag from 3.5.1 to ^3.5.2
- Update @docusaurus/preset-classic from 3.5.1 to ^3.5.2
- Update @docusaurus/theme-search-algolia from 3.5.1 to ^3.5.2
- Update @docusaurus/module-type-aliases from 3.5.1 to ^3.5.2