### PR TITLE
chore: add `promptfoo redteam plugins` command to list plugins

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -66,7 +66,9 @@ Plugins are specified as an array of either strings (plugin IDs) or objects with
 
 If `numTests` is not specified for a plugin, it will use the global `numTests` value.
 
-#### Available Plugin Categories
+#### Available Plugins
+
+To see the list of available plugins on the command line, run `promptfoo redteam plugins`.
 
 #### Harmful Plugins
 

--- a/src/commands/redteam.ts
+++ b/src/commands/redteam.ts
@@ -505,7 +505,7 @@ export async function redteamInit(directory: string | undefined) {
   }
 }
 
-export function initRedteamCommand(program: Command) {
+export function initCommand(program: Command) {
   program
     .command('init [directory]')
     .description('Initialize red teaming project')
@@ -530,6 +530,28 @@ export function initRedteamCommand(program: Command) {
         } else {
           throw err;
         }
+      }
+    });
+}
+
+export function pluginsCommand(program: Command) {
+  program
+    .command('plugins')
+    .description('List all available plugins')
+    .option('--ids-only', 'Show only plugin IDs without descriptions')
+    .option('--default', 'Show only the default plugins')
+    .action(async (options) => {
+      const pluginsToShow = options.default ? DEFAULT_PLUGINS : ALL_PLUGINS;
+
+      if (options.idsOnly) {
+        pluginsToShow.forEach((plugin) => {
+          logger.info(plugin);
+        });
+      } else {
+        pluginsToShow.forEach((plugin) => {
+          const description = subCategoryDescriptions[plugin] || 'No description available';
+          logger.info(`${chalk.blue.bold(plugin)}: ${description}`);
+        });
       }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,10 @@ import { generateRedteamCommand } from './commands/generate/redteam';
 import { importCommand } from './commands/import';
 import { initCommand } from './commands/init';
 import { listCommand } from './commands/list';
-import { initRedteamCommand } from './commands/redteam';
+import {
+  initCommand as redteamInitCommand,
+  pluginsCommand as redteamPluginsCommand,
+} from './commands/redteam';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
 import { versionCommand } from './commands/version';
@@ -78,7 +81,8 @@ async function main() {
   generateRedteamCommand(generateCommand, 'redteam', defaultConfig, defaultConfigPath);
 
   const redteamBaseCommand = program.command('redteam').description('Red team LLM applications');
-  initRedteamCommand(redteamBaseCommand);
+  redteamInitCommand(redteamBaseCommand);
+  redteamPluginsCommand(redteamBaseCommand);
   generateRedteamCommand(redteamBaseCommand, 'generate', defaultConfig, defaultConfigPath);
 
   if (!process.argv.slice(2).length) {


### PR DESCRIPTION
`promptfoo redteam plugins`: list plugins and their descriptions
`promptfoo redteam plugins --ids-only`: one plugin id per line
`promptfoo redteam plugins --default`: show default plugins only