### PR TITLE
fix: providers config for redteam when not using OpenAI

### DIFF
--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -112,7 +112,9 @@ export async function synthesize({
   if (isApiProvider(provider)) {
     redteamProvider = provider;
   } else if (isProviderOptions(provider)) {
-    redteamProvider = await loadApiProvider(provider.id || REDTEAM_MODEL, provider);
+    redteamProvider = await loadApiProvider(provider.id || REDTEAM_MODEL, {
+      options: provider
+    });
   } else {
     redteamProvider = await loadApiProvider(REDTEAM_MODEL, {
       options: { config: { temperature: 0.5 } },

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -113,7 +113,7 @@ export async function synthesize({
     redteamProvider = provider;
   } else if (isProviderOptions(provider)) {
     redteamProvider = await loadApiProvider(provider.id || REDTEAM_MODEL, {
-      options: provider
+      options: provider,
     });
   } else {
     redteamProvider = await loadApiProvider(REDTEAM_MODEL, {


### PR DESCRIPTION
I am using Azure OpenAI  and when testing the redteam features I noticed that when passing a different provider for the redteam configuration similar to:

```yaml
redteam:
  numTests: 1

  provider:
    id: azureopenai:chat:gpt-4o-2024-05-13
    config:
      apiHost:  myendpoint.openai.azure.com 
```    

and running `redteam generate`  I would get an `undefined` host.
```
ason: getaddrinfo ENOTFOUND undefined░░░░ 0% | ETA: 0s | 0/3Error in extraction: API call error: Error: Request failed after 4 retries: request to https://undefined/openai/deployments/gpt-4o-2024-05-13/chat/completions?api-version=2023-12-01-preview failed, re
/Users/alexrrr/projects/promptfoo/src/redteam/extraction/util.ts:14
    throw new Error(`Failed to perform extraction: ${error}`);
```

This is simply of a bug on how `loadApiProvider` is invoked.

BTW: the option of passing a different provider for redteam is not documented and I only found out when looking at the code. I'll try to add a PR for the documentation when I get a chance later.

