### PR TITLE
fix: remove failure messages from output

### DIFF
--- a/src/web/nextui/src/app/eval/DownloadMenu.tsx
+++ b/src/web/nextui/src/app/eval/DownloadMenu.tsx
@@ -112,7 +112,9 @@ function DownloadMenu() {
       .map((row) => ({
         vars: {
           ...row.test.vars,
-          output: row.outputs[0].text,
+          output: row.outputs[0].text.includes('---')
+            ? row.outputs[0].text.split('---\n')[1]
+            : row.outputs[0].text,
         },
         assert: [
           {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5d6866df-7a6d-4bcd-a04c-e3fadf0d47e0)


Downloading the human eval was including the failure messages in the output which made it unusable to run through the grader again.