### PR TITLE
fix: use redteam provider in extractions

### DIFF
--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -168,20 +168,6 @@ describe('synthesize', () => {
 
       expect(loadApiProvider).not.toHaveBeenCalled();
     });
-
-    it('should load the default provider if not provided', async () => {
-      await synthesize({
-        language: 'en',
-        numTests: 1,
-        plugins: [{ id: 'test-plugin', numTests: 1 }],
-        prompts: ['Test prompt'],
-        strategies: [],
-      });
-
-      expect(loadApiProvider).toHaveBeenCalledWith('openai:chat:gpt-4o', {
-        options: { config: { temperature: 0.5 } },
-      });
-    });
   });
 
   // Plugin and strategy tests


### PR DESCRIPTION
uses the new `loadRedteamProvider` to respect `redteam.provider` config