### PR TITLE
fix(redteam): fix modifier handling in PluginBase

### DIFF
--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -111,7 +111,10 @@ export abstract class PluginBase {
   }
 
   private appendModifiers(template: string): string {
-    if (Object.keys(this.modifiers).length === 0) {
+    if (
+      Object.keys(this.modifiers).length === 0 ||
+      Object.values(this.modifiers).every((value) => typeof value !== 'string' || value === '')
+    ) {
       return template;
     }
 

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -113,15 +113,13 @@ export abstract class PluginBase {
   private appendModifiers(template: string): string {
     if (
       Object.keys(this.modifiers).length === 0 ||
-      Object.values(this.modifiers).every(
-        (value) => typeof value === 'undefined' || (typeof value === 'string' && value === ''),
-      )
+      Object.values(this.modifiers).every((value) => typeof value === 'undefined' || value === '')
     ) {
       return template;
     }
 
     const modifierSection = Object.entries(this.modifiers)
-      .filter(([key, value]) => typeof value === 'string' && value !== '')
+      .filter(([key, value]) => typeof value !== 'undefined' && value !== '')
       .map(([key, value]) => `${key}: ${value}`)
       .join('\n');
 

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -121,6 +121,7 @@ export abstract class PluginBase {
     }
 
     const modifierSection = Object.entries(this.modifiers)
+      .filter(([key, value]) => typeof value === 'string' && value !== '')
       .map(([key, value]) => `${key}: ${value}`)
       .join('\n');
 

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -113,7 +113,9 @@ export abstract class PluginBase {
   private appendModifiers(template: string): string {
     if (
       Object.keys(this.modifiers).length === 0 ||
-      Object.values(this.modifiers).every((value) => typeof value !== 'string' || value === '')
+      Object.values(this.modifiers).every(
+        (value) => typeof value === 'undefined' || (typeof value === 'string' && value === ''),
+      )
     ) {
       return template;
     }

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -199,6 +199,31 @@ describe('PluginBase', () => {
     );
     expect(new Set(result.map((r) => r.vars?.testVar)).size).toBe(5);
   });
+
+  describe('appendModifiers', () => {
+    it('should not append modifiers when all modifier values are undefined or empty strings', async () => {
+      const plugin = new TestPlugin(provider, 'test purpose', 'testVar', {
+        modifier1: undefined as any,
+        modifier2: '',
+      });
+      await plugin.generateTests(1);
+      expect(provider.callApi).toHaveBeenCalledWith(expect.not.stringContaining('<Modifiers>'));
+      expect(provider.callApi).toHaveBeenCalledWith(expect.not.stringContaining('modifier1'));
+      expect(provider.callApi).toHaveBeenCalledWith(expect.not.stringContaining('modifier2'));
+    });
+
+    it('should append modifiers when at least one modifier has a non-empty value', async () => {
+      const plugin = new TestPlugin(provider, 'test purpose', 'testVar', {
+        modifier1: undefined as any,
+        modifier2: 'value2',
+      });
+
+      await plugin.generateTests(1);
+      expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('<Modifiers>'));
+      expect(provider.callApi).toHaveBeenCalledWith(expect.not.stringContaining('modifier1'));
+      expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('modifier2: value2'));
+    });
+  });
 });
 
 class TestGrader extends RedteamModelGrader {


### PR DESCRIPTION
- Update appendModifiers method to skip empty or undefined modifiers
- Add filter to exclude empty or undefined modifiers when creating modifierSection
- Add tests to verify correct handling of empty and undefined modifiers