### PR TITLE
fix(docker): link peer dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk update && apk add --no-cache python3 build-base
 # Envars are read in from src/web/nextui/.env.production
 RUN echo "*** Building with env vars from .env.production"
 
-RUN npm install
+RUN npm install --install-links
 RUN npm run build
 
 WORKDIR /app/src/web/nextui


### PR DESCRIPTION
- Add --install-links flag to npm install command in Dockerfile
- Ensures peer dependencies listed in package.json are installed in Docker container

Resolves issue with missing peer dependencies in node_modules within Docker image.

[Reference](https://discord.com/channels/1153767083381903389/1277236581790515221/1278374025726529629)