### PR TITLE
style: enforce object shorthand rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,7 @@ export default [
       'no-empty': 0,
       'no-unused-expressions': 'error',
       'no-useless-escape': 0,
+      'object-shorthand': 'error',
       'prefer-const': 'error',
       'unicorn/no-lonely-if': 'error',
       'unicorn/no-negated-condition': 'error',

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -182,7 +182,7 @@ export function containsXml(
   for (const xmlMatch of xmlMatches) {
     const { isValid, reason } = validateXml(xmlMatch, requiredElements);
     if (isValid) {
-      return { isValid: true, reason: reason };
+      return { isValid: true, reason };
     }
   }
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -57,7 +57,7 @@ export function deleteCommand(program: Command) {
       telemetry.maybeShowNotice();
       telemetry.record('command_used', {
         name: 'delete eval',
-        evalId: evalId,
+        evalId,
       });
       await telemetry.send();
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -57,7 +57,7 @@ export function exportCommand(program: Command) {
 
         telemetry.record('command_used', {
           name: 'export',
-          evalId: evalId,
+          evalId,
         });
         await telemetry.send();
       } catch (error) {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -66,7 +66,7 @@ export function assertionFromString(expected: string): Assertion {
     } else if (type === 'contains-json' || type === 'is-json') {
       return {
         type: fullType as AssertionType,
-        value: value,
+        value,
       };
     } else if (
       type === 'rouge-n' ||

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -830,7 +830,7 @@ class Evaluator {
     }
 
     await runExtensionHook(testSuite.extensions, 'afterAll', {
-      results: results,
+      results,
       suite: testSuite,
     });
 

--- a/src/prompts/utils.ts
+++ b/src/prompts/utils.ts
@@ -77,7 +77,7 @@ export function normalizeInput(
       */
     return Object.entries(promptPathOrGlobs).map(([raw, key]) => ({
       label: key,
-      raw: raw,
+      raw,
     }));
   }
   // numbers, booleans, etc

--- a/src/providers/ai21.ts
+++ b/src/providers/ai21.ts
@@ -134,7 +134,7 @@ export class AI21ChatCompletionProvider implements ApiProvider {
 
     const body = {
       model: this.modelName,
-      messages: messages,
+      messages,
       temperature: this.config?.temperature ?? 0.1,
       top_p: this.config?.top_p || 1,
       max_tokens: this.config?.max_tokens || 1024,

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -349,7 +349,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
     }
     const body = {
       model: this.deploymentName,
-      messages: messages,
+      messages,
       max_tokens: this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024),
       temperature: this.config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0),
       top_p: this.config.top_p ?? getEnvFloat('OPENAI_TOP_P', 1),

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -411,7 +411,7 @@ export const BEDROCK_MODEL = {
   LLAMA3: getLlamaModelHandler(LlamaVersion.V3), // Prompt format of llama3 instruct differs from llama2.
   COHERE_COMMAND: {
     params: (config: BedrockCohereCommandGenerationOptions, prompt: string, stop: string[]) => {
-      const params: any = { prompt: prompt };
+      const params: any = { prompt };
       addConfigParam(params, 'temperature', config?.temperature, process.env.COHERE_TEMPERATURE, 0);
       addConfigParam(params, 'p', config?.p, process.env.COHERE_P, 1);
       addConfigParam(params, 'k', config?.k, process.env.COHERE_K, 0);
@@ -462,7 +462,7 @@ export const BEDROCK_MODEL = {
   },
   MISTRAL: {
     params: (config: BedrockMistralGenerationOptions, prompt: string, stop: string[]) => {
-      const params: any = { prompt: prompt, stop: stop };
+      const params: any = { prompt, stop };
       addConfigParam(
         params,
         'max_tokens',

--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -53,7 +53,7 @@ export class LocalAiChatProvider extends LocalAiGenericProvider {
     const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
     const body = {
       model: this.modelName,
-      messages: messages,
+      messages,
       temperature: this.config.temperature || getEnvFloat('LOCALAI_TEMPERATURE') || 0.7,
     };
     logger.debug(`Calling LocalAI API: ${JSON.stringify(body)}`);

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -185,7 +185,7 @@ export class MistralChatCompletionProvider implements ApiProvider {
 
     const body = {
       model: this.modelName,
-      messages: messages,
+      messages,
       temperature: this.config?.temperature,
       top_p: this.config?.top_p || 1,
       max_tokens: this.config?.max_tokens || 1024,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -465,7 +465,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     const body = {
       model: this.modelName,
-      messages: messages,
+      messages,
       seed: this.config.seed || 0,
       max_tokens:
         this.config.max_tokens ?? Number.parseInt(process.env.OPENAI_MAX_TOKENS || '1024'),

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -832,7 +832,7 @@ export async function getEvalsWithPredicate(
     const createdAt = new Date(eval_.createdAt).toISOString();
     const resultWrapper: ResultsFile = {
       version: 3,
-      createdAt: createdAt,
+      createdAt,
       author: eval_.author,
       results: eval_.results,
       config: eval_.config,

--- a/src/web/nextui/src/app/eval/ResultsCharts.tsx
+++ b/src/web/nextui/src/app/eval/ResultsCharts.tsx
@@ -114,11 +114,11 @@ function HistogramChart({ table }: ChartProps) {
           },
           tooltip: {
             callbacks: {
-              title: function (context) {
+              title(context) {
                 const datasetIndex = context[0].datasetIndex;
                 return `Column ${datasetIndex + 1}`;
               },
-              label: function (context) {
+              label(context) {
                 const labelIndex = context.dataIndex;
                 const lowerBound = bins[labelIndex];
                 const upperBound = bins[labelIndex + 1];
@@ -254,7 +254,7 @@ function ScatterChart({ table }: ChartProps) {
           },
           tooltip: {
             callbacks: {
-              label: function (tooltipItem: TooltipItem<'scatter'>) {
+              label(tooltipItem: TooltipItem<'scatter'>) {
                 const row = table.body[tooltipItem.dataIndex];
                 let prompt1Text = row.outputs[0].text;
                 let prompt2Text = row.outputs[1].text;
@@ -276,7 +276,7 @@ function ScatterChart({ table }: ChartProps) {
               text: `Prompt ${xAxisPrompt + 1} Score`,
             },
             ticks: {
-              callback: function (value: string | number, index: number, values: any[]) {
+              callback(value: string | number, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';
@@ -291,7 +291,7 @@ function ScatterChart({ table }: ChartProps) {
               text: `Prompt ${yAxisPrompt + 1} Score`,
             },
             ticks: {
-              callback: function (value: string | number, index: number, values: any[]) {
+              callback(value: string | number, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';
@@ -384,7 +384,7 @@ function MetricChart({ table }: ChartProps) {
           },
           y: {
             ticks: {
-              callback: function (value: string | number, index: number, values: any[]) {
+              callback(value: string | number, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';
@@ -397,10 +397,10 @@ function MetricChart({ table }: ChartProps) {
         plugins: {
           tooltip: {
             callbacks: {
-              title: function (tooltipItem: TooltipItem<'bar'>[]) {
+              title(tooltipItem: TooltipItem<'bar'>[]) {
                 return tooltipItem[0].dataset.label;
               },
-              label: function (tooltipItem: TooltipItem<'bar'>) {
+              label(tooltipItem: TooltipItem<'bar'>) {
                 const value = tooltipItem.parsed.y;
                 return `${labels[tooltipItem.dataIndex]}: ${(value * 100).toFixed(2)}% pass rate`;
               },

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -2310,8 +2310,8 @@ describe('runAssertion', () => {
     // Expect test to pass because assertion grader takes priority
     const result: GradingResult = await runAssertion({
       prompt: 'Some prompt',
-      assertion: assertion,
-      test: test,
+      assertion,
+      test,
       providerResponse: { output },
       provider: new OpenAiChatCompletionProvider('gpt-4'),
     });
@@ -3139,7 +3139,7 @@ describe('runAssertion', () => {
         pass: false,
         score: 0,
         reason: expect.stringMatching(/XML parsing failed/),
-        assertion: assertion,
+        assertion,
       });
     });
 
@@ -3186,7 +3186,7 @@ describe('runAssertion', () => {
         pass: false,
         score: 0,
         reason: 'XML is missing required elements: analysis.color',
-        assertion: assertion,
+        assertion,
       });
     });
 
@@ -3364,7 +3364,7 @@ describe('runAssertion', () => {
         pass: false,
         score: 0,
         reason: 'No XML content found in the output',
-        assertion: assertion,
+        assertion,
       });
     });
 
@@ -3411,7 +3411,7 @@ describe('runAssertion', () => {
         pass: false,
         score: 0,
         reason: 'No valid XML content found matching the requirements',
-        assertion: assertion,
+        assertion,
       });
     });
 


### PR DESCRIPTION
Adds 'object-shorthand': 'error' to ESLint config from https://github.com/promptfoo/promptfoo/pull/1555#discussion_r1737641271