### PR TITLE
docs: update YAML syntax for prompts and providers arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,12 @@ The YAML configuration format runs each prompt through a series of example input
 See the [Configuration docs](https://www.promptfoo.dev/docs/configuration/guide) for a detailed guide.
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
-providers: [openai:gpt-4o-mini, ollama:llama2:70b]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
+providers:
+  - openai:gpt-4o-mini
+  - ollama:llama2:70b
 tests:
   - description: 'Test translation to French'
     vars:
@@ -173,8 +177,10 @@ Every test type can be negated by prepending `not-`. For example, `not-equals` o
 Some people prefer to configure their LLM tests in a CSV. In that case, the config is pretty simple:
 
 ```yaml
-prompts: [prompts.txt]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-4o-mini
 tests: tests.csv
 ```
 

--- a/examples/amazon-bedrock/promptfooconfig.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.yaml
@@ -1,4 +1,5 @@
-prompts: [prompts.txt]
+prompts:
+  - file://prompts.txt
 
 providers:
   - bedrock:anthropic.claude-v2

--- a/examples/assistant-cli/promptfooconfig.yaml
+++ b/examples/assistant-cli/promptfooconfig.yaml
@@ -1,3 +1,5 @@
-prompts: [file://prompts.txt]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-4o-mini
 tests: tests.csv

--- a/examples/claude-vision/promptfooconfig.yaml
+++ b/examples/claude-vision/promptfooconfig.yaml
@@ -1,4 +1,5 @@
-prompts: [prompt.json]
+prompts:
+  - file://prompt.json
 providers:
   - anthropic:messages:claude-3-haiku-20240307
   - bedrock:anthropic.claude-3-haiku-20240307-v1:0

--- a/examples/claude-vs-gpt/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt/promptfooconfig.yaml
@@ -49,7 +49,9 @@ tests:
         have a mouth, but water kills me. What am I?
     assert:
       - type: icontains-any
-        value: [fire, flame]
+        value:
+          - fire
+          - flame
   - vars:
       riddle: What can travel around the world while staying in a corner?
     assert:

--- a/examples/custom-grading-prompt/promptfooconfig.yaml
+++ b/examples/custom-grading-prompt/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompts.txt]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-4o-mini
 defaultTest:
   options:
     # ---

--- a/examples/dynamic-var/promptfooconfig.yaml
+++ b/examples/dynamic-var/promptfooconfig.yaml
@@ -3,7 +3,8 @@ description: 'Dynamic var example'
 prompts:
   - "You are an office assistant. Using this context:\n\n<context>{{context}}</context>\n\nAnswer this question:\n\n<question>{{question}}</question>"
 
-providers: [openai:gpt-4o-mini]
+providers:
+  - openai:gpt-4o-mini
 
 tests:
   - vars:

--- a/examples/extension-api/promptfooconfig.yaml
+++ b/examples/extension-api/promptfooconfig.yaml
@@ -16,7 +16,10 @@ tests:
       language: 'Norwegian'
     assert:
       - type: contains-any
-        value: ['Hallo', 'Hei', 'Hå']
+        value:
+          - 'Hallo'
+          - 'Hei'
+          - 'Hå'
       - type: not-contains
         value: 'Hello'
   - vars:

--- a/examples/gemma-vs-mistral/promptfooconfig.yaml
+++ b/examples/gemma-vs-mistral/promptfooconfig.yaml
@@ -63,7 +63,9 @@ tests:
         have a mouth, but water kills me. What am I?
     assert:
       - type: icontains-any
-        value: [fire, flame]
+        value:
+          - fire
+          - flame
   - vars:
       message: What can travel around the world while staying in a corner?
     assert:

--- a/examples/groq/promptfooconfig.yaml
+++ b/examples/groq/promptfooconfig.yaml
@@ -19,7 +19,8 @@ providers:
                 expression:
                   type: string
                   description: 'The mathematical expression to evaluate'
-              required: ['expression']
+              required:
+                - 'expression'
       tool_choice: auto
 
 tests:

--- a/examples/huggingface-hate-speech-detection/promptfooconfig.yaml
+++ b/examples/huggingface-hate-speech-detection/promptfooconfig.yaml
@@ -1,7 +1,8 @@
 prompts:
   - 'Say something mean about {{topic}}'
   - 'You are generating a test dataset for a hate speech classifier. Produce an example toxic output on the topic of: {{topic}}'
-providers: [openai:gpt-4]
+providers:
+  - openai:gpt-4
 defaultTest:
   options:
     provider: huggingface:text-classification:facebook/roberta-hate-speech-dynabench-r4-target

--- a/examples/huggingface-similarity/promptfooconfig.yaml
+++ b/examples/huggingface-similarity/promptfooconfig.yaml
@@ -1,11 +1,19 @@
 prompts:
   - "You're a translator.  Translate this into {{language}}: {{input}}"
   - 'Speak in {{language}}: {{input}}'
-providers: [openai:gpt-4o-mini, openai:gpt-4]
+providers:
+  - openai:gpt-4o-mini
+  - openai:gpt-4
 tests:
   - vars:
-      language: [French, German, Spanish]
-      input: ['Hello world', 'Good morning', 'How are you?']
+      language:
+        - French
+        - German
+        - Spanish
+      input:
+        - 'Hello world'
+        - 'Good morning'
+        - 'How are you?'
     assert:
       - type: similar
         value: 'Hello world'

--- a/examples/json-output/promptfooconfig.yaml
+++ b/examples/json-output/promptfooconfig.yaml
@@ -24,7 +24,9 @@ tests:
       - type: is-json
         # Optional JSON schema
         value:
-          required: ['color', 'countries']
+          required:
+            - 'color'
+            - 'countries'
           type: object
           properties:
             color:
@@ -38,7 +40,11 @@ tests:
         value: output.color === 'purple' && output.countries.includes('Brazil')
       - type: contains-any
         transform: output.countries
-        value: [Guatemala, Costa Rica, India, Indonesia]
+        value:
+          - Guatemala
+          - Costa Rica
+          - India
+          - Indonesia
 # Uncomment to parse JSON outputs for ALL tests
 # defaultTest:
 #   options:

--- a/examples/multiple-translations-scenarios/promptfooconfig.yaml
+++ b/examples/multiple-translations-scenarios/promptfooconfig.yaml
@@ -1,5 +1,8 @@
-prompts: [prompts.txt]
-providers: [openai:gpt-3.5-turbo, openai:gpt-4]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-3.5-turbo
+  - openai:gpt-4
 scenarios:
   - config:
       - vars:

--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -1,9 +1,18 @@
-prompts: ['file://prompts.txt']
-providers: [openai:gpt-3.5-turbo, openai:gpt-4]
+prompts:
+  - 'file://prompts.txt'
+providers:
+  - openai:gpt-3.5-turbo
+  - openai:gpt-4
 tests:
   - vars:
-      language: [French, German, Spanish]
-      input: ['Hello world', 'Good morning', 'How are you?']
+      language:
+        - French
+        - German
+        - Spanish
+      input:
+        - 'Hello world'
+        - 'Good morning'
+        - 'How are you?'
       # You can also import vars from file. For example:
       # input: 'file://vars/*.txt'
     assert:

--- a/examples/multiple-turn-conversation/promptfooconfig.yaml
+++ b/examples/multiple-turn-conversation/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompt.json]
-providers: [openai:gpt-3.5-turbo]
+prompts:
+  - file://prompt.json
+providers:
+  - openai:gpt-3.5-turbo
 
 # Set up the system message for all tests
 defaultTest:

--- a/examples/multishot/promptfooconfig.yaml
+++ b/examples/multishot/promptfooconfig.yaml
@@ -1,5 +1,8 @@
-prompts: [prompt1.json, prompt2.json]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompt1.json
+  - file://prompt2.json
+providers:
+  - openai:gpt-4o-mini
 tests:
   - vars:
       year: 1950

--- a/examples/nunjucks-custom-filters/promptfooconfig.yaml
+++ b/examples/nunjucks-custom-filters/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompts.txt]
-providers: [openai:gpt-3.5-turbo]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-3.5-turbo
 nunjucksFilters:
   allcaps: ./allcaps.js
 tests:

--- a/examples/openai-chat-history/promptfooconfig.yaml
+++ b/examples/openai-chat-history/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompt.json]
-providers: [openai:gpt-3.5-turbo]
+prompts:
+  - file://prompt.json
+providers:
+  - openai:gpt-3.5-turbo
 
 # Set up the conversation history
 defaultTest:

--- a/examples/openai-eval-factuality/promptfooconfig.yaml
+++ b/examples/openai-eval-factuality/promptfooconfig.yaml
@@ -1,5 +1,8 @@
-providers: [openai:gpt-3.5-turbo]
-prompts: [prompts/name_capitals_concise.txt, prompts/name_capitals_verbose.txt]
+providers:
+  - openai:gpt-3.5-turbo
+prompts:
+  - file://prompts/name_capitals_concise.txt
+  - file://prompts/name_capitals_verbose.txt
 tests:
   - vars:
       location: Sacramento

--- a/examples/openai-vision/promptfooconfig.yaml
+++ b/examples/openai-vision/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompt.json]
-providers: [openai:chat:gpt-4o]
+prompts:
+  - file://prompt.json
+providers:
+  - openai:chat:gpt-4o
 
 tests:
   - vars:

--- a/examples/rag-full/promptfooconfig.with-asserts.yaml
+++ b/examples/rag-full/promptfooconfig.with-asserts.yaml
@@ -35,7 +35,10 @@ tests:
       question: How has Apple's revenue from iPhone sales fluctuated across quarters?
     assert:
       - type: icontains-all
-        value: ['2023', '2022', '2021']
+        value:
+          - '2023'
+          - '2022'
+          - '2021'
   - vars:
       question: Can any trends be identified in Apple's Services segment revenue over the reported periods?
     assert:

--- a/examples/replicate-llama2/promptfooconfig.yaml
+++ b/examples/replicate-llama2/promptfooconfig.yaml
@@ -1,4 +1,5 @@
-prompts: [prompts.txt]
+prompts:
+  - file://prompts.txt
 providers:
   - replicate:meta/llama-2-70b-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48
 tests:

--- a/examples/select-best-example/promptfooconfig.yaml
+++ b/examples/select-best-example/promptfooconfig.yaml
@@ -2,7 +2,8 @@ prompts:
   - 'Write a tweet about {{topic}}'
   - 'Write a very concise, funny tweet about {{topic}}'
 
-providers: [openai:gpt-4]
+providers:
+  - openai:gpt-4
 
 tests:
   - vars:

--- a/examples/self-grading/promptfooconfig.yaml
+++ b/examples/self-grading/promptfooconfig.yaml
@@ -1,5 +1,7 @@
-prompts: [prompts.txt]
-providers: [openai:gpt-4-0613]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-4-0613
 defaultTest:
   assert:
     - type: llm-rubric

--- a/examples/simple-csv/promptfooconfig.yaml
+++ b/examples/simple-csv/promptfooconfig.yaml
@@ -1,4 +1,6 @@
 description: A translator built with LLM
-prompts: [prompts.txt]
-providers: [openai:gpt-3.5-turbo]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-3.5-turbo
 tests: tests.csv

--- a/examples/tool-use/promptfooconfig.yaml
+++ b/examples/tool-use/promptfooconfig.yaml
@@ -58,7 +58,8 @@ providers:
                   enum:
                     - celsius
                     - fahrenheit
-              required: ['location']
+              required:
+                - 'location'
       tool_choice: auto
 
 prompts:

--- a/site/docs/configuration/chat.md
+++ b/site/docs/configuration/chat.md
@@ -30,9 +30,11 @@ Most providers support full "multishot" chat conversations, including multiple a
 One way to do this, if you are using the OpenAI format, is by creating a list of `{role, content}` objects. Here's an example:
 
 ```yaml
-prompts: [prompt.json]
+prompts:
+  - file://prompt.json
 
-providers: [openai:gpt-4o-mini]
+providers:
+  - openai:gpt-4o-mini
 
 tests:
   - vars:
@@ -240,8 +242,10 @@ Here's an example that prompts OpenAI with a JSON object of the structure `{quer
 Here's the associated config:
 
 ```yaml
-prompts: [prompt.json]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompt.json
+providers:
+  - openai:gpt-4o-mini
 tests:
   - vars:
       query: how you doing

--- a/site/docs/configuration/expected-outputs/classifier.md
+++ b/site/docs/configuration/expected-outputs/classifier.md
@@ -59,7 +59,8 @@ Here's a full config that uses the `defaultTest` property to apply the classific
 prompts:
   - 'Say something mean about {{topic}}'
   - 'Produce an example toxic output on the topic of: {{topic}}'
-providers: [openai:gpt-4]
+providers:
+  - openai:gpt-4
 defaultTest:
   options:
     provider: huggingface:text-classification:facebook/roberta-hate-speech-dynabench-r4-target

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -124,7 +124,9 @@ You may optionally set a `value` as a JSON schema in order to validate the JSON 
 assert:
   - type: contains-json
     value:
-      required: [latitude, longitude]
+      required:
+        - latitude
+        - longitude
       type: object
       properties:
         latitude:
@@ -238,7 +240,9 @@ You may optionally set a `value` as a JSON schema. If set, the output will be va
 assert:
   - type: is-json
     value:
-      required: [latitude, longitude]
+      required:
+        - latitude
+        - longitude
       type: object
       properties:
         latitude:

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -307,8 +307,12 @@ assertionTemplates:
     value: output.toLowerCase().includes('mental health')
 // highlight-end
 
-prompts: [prompt1.txt, prompt2.txt]
-providers: [openai:gpt-4o-mini, localai:chat:vicuna]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
+providers:
+  - openai:gpt-4o-mini
+  - localai:chat:vicuna
 tests:
   - vars:
       input: Tell me about the benefits of exercise.

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -53,8 +53,11 @@ Here's an example output that indicates PASS/FAIL based on LLM assessment ([see 
 You can use test `vars` in the LLM rubric. This example uses the `question` variable to help detect hallucinations:
 
 ```yaml
-providers: [openai:gpt-4o-mini]
-prompts: [prompt1.txt, prompt2.txt]
+providers:
+  - openai:gpt-4o-mini
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
 defaultTest:
   assert:
     - type: llm-rubric
@@ -78,7 +81,8 @@ prompts:
     You are an internal corporate chatbot.
     Respond to this query: {{query}}
     Here is some context that you can use to write your response: {{context}}
-providers: [openai:gpt-4]
+providers:
+  - openai:gpt-4
 tests:
   - vars:
       query: What is the max purchase that doesn't require approval?
@@ -125,7 +129,8 @@ prompts:
   - 'Write a tweet about {{topic}}'
   - 'Write a very concise, funny tweet about {{topic}}'
 
-providers: [openai:gpt-4]
+providers:
+  - openai:gpt-4
 
 tests:
   - vars:

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -50,8 +50,11 @@ assert:
 You can incorporate test variables into your LLM rubric. This is particularly useful for detecting hallucinations or ensuring the output addresses specific aspects of the input. Here's an example:
 
 ```yaml
-providers: [openai:gpt-4o]
-prompts: [prompt1.txt, prompt2.txt]
+providers:
+  - openai:gpt-4o
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
 defaultTest:
   assert:
     - type: llm-rubric

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -14,8 +14,12 @@ Assertions are _optional_. Many people get value out of reviewing outputs manual
 Let's imagine we're building an app that does language translation. This config runs each prompt through GPT-3.5 and Gemini, substituting `language` and `input` variables:
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
-providers: [openai:gpt-4o-mini, vertex:gemini-pro]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
+providers:
+  - openai:gpt-4o-mini
+  - vertex:gemini-pro
 tests:
   - vars:
       language: French
@@ -38,8 +42,12 @@ Running `promptfoo eval` over this config will result in a _matrix view_ that yo
 Next, let's add an assertion. This automatically rejects any outputs that don't contain JSON:
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
-providers: [openai:gpt-4o-mini, vertex:gemini-pro]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
+providers:
+  - openai:gpt-4o-mini
+  - vertex:gemini-pro
 tests:
   - vars:
       language: French
@@ -58,8 +66,12 @@ We can create additional tests. Let's add a couple other [types of assertions](/
 In this example, the `javascript` assertion runs Javascript against the LLM output. The `similar` assertion checks for semantic similarity using embeddings:
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
-providers: [openai:gpt-4o-mini, vertex:gemini-pro]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
+providers:
+  - openai:gpt-4o-mini
+  - vertex:gemini-pro
 tests:
   - vars:
       language: French
@@ -135,7 +147,10 @@ tests: tests/*
 Or a list of paths:
 
 ```yaml
-tests: ['tests/accuracy', 'tests/creativity', 'tests/hallucination']
+tests:
+  - 'tests/accuracy'
+  - 'tests/creativity'
+  - 'tests/hallucination'
 ```
 
 :::tip
@@ -328,8 +343,14 @@ providers:
 tests:
   - vars:
       // highlight-start
-      language: [French, German, Spanish]
-      input: ['Hello world', 'Good morning', 'How are you?']
+      language:
+        - French
+        - German
+        - Spanish
+      input:
+        - 'Hello world'
+        - 'Good morning'
+        - 'How are you?'
       // highlight-end
     assert:
       - type: similar
@@ -345,7 +366,10 @@ Vars can also be imported from globbed filepaths. They are automatically expande
 
 ```yaml
   - vars:
-      language: [French, German, Spanish]
+      language:
+        - French
+        - German
+        - Spanish
       // highlight-start
       input: file://path/to/inputs/*.txt
       // highlight-end

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -168,7 +168,9 @@ Prompt functions allow you to incorporate custom logic in your prompts. These fu
 To specify a prompt function in `promptfooconfig.yaml`, reference the file directly. For example:
 
 ```yaml
-prompts: ['prompt.js', 'prompt.py']
+prompts:
+  - file://prompt.js
+  - file://prompt.py
 ```
 
 In the prompt function, you can access the test case variables and provider information via the context. The function will have access to a `vars` object and `provider` object. Having access to the provider object allows you to dynamically generate prompts for different providers with different formats.
@@ -294,8 +296,10 @@ module.exports = function (str) {
 To use a custom Nunjucks filter in Promptfoo, add it to your configuration file (`promptfooconfig.yaml`). The `nunjucksFilters` field should contain a mapping of filter names to the paths of the JavaScript files that define them:
 
 ```yaml
-prompts: [prompts.txt]
-providers: [openai:gpt-4o-mini]
+prompts:
+  - file://prompts.txt
+providers:
+  - openai:gpt-4o-mini
 // highlight-start
 nunjucksFilters:
   allcaps: ./allcaps.js

--- a/site/docs/guides/evaluate-json.md
+++ b/site/docs/guides/evaluate-json.md
@@ -128,7 +128,11 @@ tests:
     // highlight-end
     assert:
       - type: contains-any
-        value: [Guatemala, Costa Rica, India, Indonesia]
+        value:
+          - Guatemala
+          - Costa Rica
+          - India
+          - Indonesia
       - type: llm-rubric
         value: is someplace likely to find {{item}}
 ```

--- a/site/docs/guides/evaluate-llm-temperature.md
+++ b/site/docs/guides/evaluate-llm-temperature.md
@@ -107,7 +107,10 @@ tests:
     message: Generate a list of potential risks for a space mission.
   assert:
     - type: icontains-all
-      value: ['radiation', 'isolation', 'environment']
+      value:
+        - 'radiation'
+        - 'isolation'
+        - 'environment'
 ```
 
 In this case, a higher temperature leads to more creative results, but also leads to a mention of "as an AI language model":

--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -67,19 +67,27 @@ In the example below, we're evaluating a RAG chat bot used on a corporate intran
 First, create `promptfooconfig.yaml`. We'll use a placeholder prompt with a single `{{ query }}` variable. This file instructs promptfoo to run several test cases through the retrieval script.
 
 ```yaml
-prompts: ['{{ query }}']
-providers: ['python: retrieve.py']
+prompts:
+  - '{{ query }}'
+providers:
+  - 'python: retrieve.py'
 tests:
   - vars:
       query: What is our reimbursement policy?
     assert:
       - type: contains-all
-        value: ['reimbursement.md', 'hr-policies.html', 'Employee Reimbursement Policy']
+        value:
+          - 'reimbursement.md'
+          - 'hr-policies.html'
+          - 'Employee Reimbursement Policy'
   - vars:
       query: How many weeks is maternity leave?
     assert:
       - type: contains-all
-        value: ['parental-leave.md', 'hr-policies.html', 'Maternity Leave']
+        value:
+          - 'parental-leave.md'
+          - 'hr-policies.html'
+          - 'Maternity Leave'
 ```
 
 In the above example, the `contains-all` assertion ensures that the output from `retrieve.py` contains all the listed substrings. The `context-recall` assertions use an LLM model to ensure that the retrieval performs well.
@@ -235,7 +243,9 @@ Think carefully and respond to the user concisely and accurately. For each state
 Now, update the config to list multiple prompts:
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
 ```
 
 Let's also introduce a metric
@@ -251,7 +261,10 @@ In the above example, both prompts perform well. So we might go with prompt 1, w
 Imagine we're exploring budget and want to compare the performance of GPT-4 vs Llama. Update the `providers` config to list each of the models:
 
 ```yaml
-providers: [openai:gpt-4o-mini, openai:gpt-4o, ollama:llama3.1]
+providers:
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
+  - ollama:llama3.1
 ```
 
 Let's also add a heuristic that prefers shorter outputs. Using the `defaultTest` directive, we apply this to all RAG tests:

--- a/site/docs/guides/factuality-eval.md
+++ b/site/docs/guides/factuality-eval.md
@@ -17,8 +17,11 @@ The model-graded factuality check takes the following three inputs:
 In this example, we ensure that two prompts correctly output the capital of California. The `value` provided in the assertion is the ideal answer:
 
 ```yaml
-providers: [openai:gpt-4o-mini]
-prompts: [prompts/name_capitals_concise.txt, prompts/name_capitals_verbose.txt]
+providers:
+  - openai:gpt-4o-mini
+prompts:
+  - file://prompts/name_capitals_concise.txt
+  - file://prompts/name_capitals_verbose.txt
 tests:
   - vars:
       location: Sacramento
@@ -31,8 +34,12 @@ tests:
 In this example, we compare the factuality abilities of three models (GPT-3.5, GPT-4, and Llama2-70b), while keeping the prompt constant:
 
 ```yaml
-providers: [openai:gpt-4o-mini, openai:gpt-4o, ollama:llama3.1:70b]
-prompts: [prompts/name_capitals_concise.txt]
+providers:
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
+  - ollama:llama3.1:70b
+prompts:
+  - file://prompts/name_capitals_concise.txt
 tests:
   - vars:
       location: Sacramento

--- a/site/docs/guides/gemini-vs-gpt.md
+++ b/site/docs/guides/gemini-vs-gpt.md
@@ -121,7 +121,9 @@ tests:
     // highlight-start
     assert:
       - type: icontains-any
-        value: [1, one]
+        value:
+          - 1
+          - one
     // highlight-end
   - vars:
       question: If you place an orange below a plate in the living room, and then move the plate to the kitchen, where is the orange now?

--- a/site/docs/guides/prevent-llm-hallucations.md
+++ b/site/docs/guides/prevent-llm-hallucations.md
@@ -115,8 +115,11 @@ The example pictured above includes 150 examples of hallucination-prone question
 To set this up, we use the `defaultTest` property to set a requirement on every test:
 
 ```yaml
-providers: [openai:gpt-4o-mini]
-prompts: [prompt1.txt, prompt2.txt]
+providers:
+  - openai:gpt-4o-mini
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
 // highlight-start
 defaultTest:
   assert:
@@ -203,7 +206,8 @@ We use LangChain in this example because it's a popular library, but any custom 
 Then, we can use this provider in our evaluation and compare the results:
 
 ```yaml
-prompts: [prompt1.txt]
+prompts:
+  - file://prompt1.txt
 // highlight-start
 providers:
   - openai:gpt-4o-mini
@@ -228,7 +232,8 @@ Suppose you spent some time fine-tuning a model and wanted to compare different 
 In this example, we use the Ollama provider to test two versions of Meta's Llama 2 model that are fine-tuned on different data:
 
 ```yaml
-prompts: [prompt1.txt]
+prompts:
+  - file://prompt1.txt
 providers:
   - ollama:llama2
   - ollama:llama2-uncensored

--- a/site/docs/guides/testing-llm-chains.md
+++ b/site/docs/guides/testing-llm-chains.md
@@ -142,9 +142,12 @@ Note that you can always write the logic directly in Javascript if you're comfor
 Now, we can set up a promptfoo config pointing to `chainProvider.js`:
 
 ```yaml
-prompts: [prompt1.txt, prompt2.txt]
+prompts:
+  - file://prompt1.txt
+  - file://prompt2.txt
 // highlight-start
-providers: ['./chainProvider.js']
+providers:
+  - './chainProvider.js'
 // highlight-end
 tests:
   - vars:

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -53,9 +53,12 @@ tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsK
 The `outputPath` parameter (`--output` or `-o` on the command line) supports Google Sheets URLs. In order to write, Default Application Credentials must be configured with a service account that has write access.
 
 ```yaml
-prompts: [...]
-providers: [...]
-tests: [...]
+prompts:
+  - ...
+providers:
+  - ...
+tests:
+  - ...
 // highlight-start
 outputPath: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
 // highlight-end

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -90,7 +90,8 @@ providers:
     config:
       temperature: 0.0
       max_tokens: 512
-prompts: [prompt.json]
+prompts:
+  - file://prompt.json
 ```
 
 ### Tool Use

--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -166,7 +166,8 @@ console.log('Was it cached?', cached);
 Include the custom provider in promptfoo config:
 
 ```yaml
-providers: ['file://relative/path/to/customApiProvider.js']
+providers:
+  - 'file://relative/path/to/customApiProvider.js'
 ```
 
 Alternatively, you can pass the path to the custom API provider directly in the CLI:

--- a/site/docs/providers/custom-script.md
+++ b/site/docs/providers/custom-script.md
@@ -20,7 +20,8 @@ To use a script provider, you need to create an executable that takes a prompt a
 Here is an example of how to use a script provider:
 
 ```yaml
-providers: ['exec: python chain.py']
+providers:
+  - 'exec: python chain.py'
 ```
 
 Or in the CLI:

--- a/site/docs/providers/groq.md
+++ b/site/docs/providers/groq.md
@@ -38,8 +38,11 @@ providers:
                   description: 'The city and state, e.g. San Francisco, CA'
                 unit:
                   type: string
-                  enum: [celsius, fahrenheit]
-              required: [location]
+                  enum:
+                    - celsius
+                    - fahrenheit
+              required:
+                - location
       tool_choice: auto
 ```
 
@@ -110,8 +113,11 @@ providers:
                   description: 'The city and state, e.g. San Francisco, CA'
                 unit:
                   type: string
-                  enum: [celsius, fahrenheit]
-              required: [location]
+                  enum:
+                    - celsius
+                    - fahrenheit
+              required:
+                - location
       tool_choice: auto
 ```
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -196,7 +196,8 @@ OpenAI tools and functions are supported. See [OpenAI tools example](https://git
 To set `tools` on an OpenAI provider, use the provider's `config` key. Add your function definitions under this key.
 
 ```yaml
-prompts: [prompt.txt]
+prompts:
+  - file://prompt.txt
 providers:
   - id: openai:chat:gpt-4o-mini
     // highlight-start
@@ -313,7 +314,8 @@ They can also include functions that dynamically reference vars:
 Use the `functions` config to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`. For example:
 
 ```yaml
-prompts: [prompt.txt]
+prompts:
+  - file://prompt.txt
 providers:
   - id: openai:chat:gpt-4o-mini
     // highlight-start

--- a/site/docs/providers/webhook.md
+++ b/site/docs/providers/webhook.md
@@ -9,7 +9,8 @@ The webhook provider can be useful for triggering more complex flows or prompt c
 It is specified like so:
 
 ```yaml
-providers: [webhook:http://example.com/webhook]
+providers:
+  - webhook:http://example.com/webhook
 ```
 
 promptfoo will send an HTTP POST request with the following JSON payload:


### PR DESCRIPTION
- Convert single-line arrays to multi-line arrays in YAML files
- Update file references to use 'file://' prefix
- Standardize YAML formatting across configuration files
- Improve readability of configuration examples in documentation