### PR TITLE
fix(openai): don't set openai chat completion seed=0 by default

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -371,7 +371,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
     const body = {
       model: this.modelName,
       prompt,
-      seed: this.config.seed || 0,
+      seed: this.config.seed,
       max_tokens: this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024),
       temperature: this.config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0),
       top_p: this.config.top_p ?? getEnvFloat('OPENAI_TOP_P', 1),
@@ -466,7 +466,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     const body = {
       model: this.modelName,
       messages,
-      seed: this.config.seed || 0,
+      seed: this.config.seed,
       max_tokens:
         this.config.max_tokens ?? Number.parseInt(process.env.OPENAI_MAX_TOKENS || '1024'),
       temperature:


### PR DESCRIPTION
It seems openai now supports seeds for reproducible responses. The code before this commit sets the openai chatcompletion seed to 0 by default resulting in repeated tests always having the same outcome. I'm pretty new to promptfoo but I'm guessing that is not intentional when using the `--repeat` cli option for instance. It might be due to the fact that seeds are in beta at openai and their behaviour has changed. see https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed

The patch suggested makes not providing a seed value work as expected (non-deterministic outcome). But I did not dive very deep into the code to check if it might break anything. I'm opening this pull request just to report.