### PR TITLE
fix: resolve foreign key constraint in deleteAllEvals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "Dedup",
     "deduped",
     "envars",
+    "Evals",
     "Groq",
     "mitigations",
     "openai",

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -923,7 +923,15 @@ export async function deleteEval(evalId: string) {
 
 export async function deleteAllEvals() {
   const db = getDb();
-  await db.delete(evals).run();
+  await db.transaction(async (tx) => {
+    // Delete related records first
+    await tx.delete(evalsToPrompts).run();
+    await tx.delete(evalsToDatasets).run();
+    await tx.delete(evalsToTags).run();
+
+    // Now delete all evals
+    await tx.delete(evals).run();
+  });
 }
 
 export async function readFilters(


### PR DESCRIPTION
Relates to: https://github.com/promptfoo/promptfoo/issues/1578
 
This change allows the 'npx promptfoo delete eval all' command to
successfully delete all evaluations without encountering a foreign key
constraint error.

Thank you @pbackx for finding the issue!