### PR TITLE
refactor(redteam): reorganize redteam exports and add Strategies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import providers, { loadApiProvider } from './providers';
 import { loadApiProviders } from './providers';
 import { extractEntities } from './redteam/extraction/entities';
 import { extractSystemPurpose } from './redteam/extraction/purpose';
-import { Plugins as RedteamPlugins } from './redteam/plugins';
+import { Plugins } from './redteam/plugins';
+import { Strategies } from './redteam/strategies';
 import telemetry from './telemetry';
 import { readTests } from './testCases';
 import type {
@@ -128,7 +129,8 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
 const redteam = {
   extractEntities,
   extractSystemPurpose,
-  Plugins: RedteamPlugins,
+  Plugins,
+  Strategies,
 };
 
 export { assertions, cache, evaluate, providers, redteam };

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,8 +127,18 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
 }
 
 const redteam = {
+  /**
+   * @deprecated This export will be removed in a future version. Please use redteam.Extractors.extractEntities instead.
+   */
   extractEntities,
+  /**
+   * @deprecated This export will be removed in a future version. Please use redteam.Extractors.extractSystemPurpose instead.
+   */
   extractSystemPurpose,
+  Extractors: {
+    extractEntities,
+    extractSystemPurpose,
+  },
   Plugins,
   Strategies,
 };

--- a/src/redteam/strategies/index.ts
+++ b/src/redteam/strategies/index.ts
@@ -10,7 +10,7 @@ import { addMultilingual } from './multilingual';
 import { addInjections } from './promptInjections';
 import { addRot13 } from './rot13';
 
-interface Strategy {
+export interface Strategy {
   key: string;
   action: (
     testCases: TestCaseWithPlugin[],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,12 +5,12 @@ describe('index.ts exports', () => {
     'assertions',
     'cache',
     'evaluate',
-    'providers',
-    'redteam',
     'generateTable',
     'isApiProvider',
     'isGradingResult',
     'isProviderOptions',
+    'providers',
+    'redteam',
   ];
 
   const expectedSchemaExports = [
@@ -46,20 +46,27 @@ describe('index.ts exports', () => {
   });
 
   it('should not have unexpected exports', () => {
-    const actualExports = Object.keys(index).filter((key) => key !== 'default');
-    const expectedExports = [...expectedNamedExports, ...expectedSchemaExports];
+    const actualExports = Object.keys(index)
+      .filter((key) => key !== 'default')
+      .sort();
+    const expectedExports = [...expectedNamedExports, ...expectedSchemaExports].sort();
     expect(actualExports).toHaveLength(expectedExports.length);
-    expect(actualExports).toEqual(expect.arrayContaining(expectedExports));
+    expect(actualExports).toEqual(expectedExports);
   });
 
   it('redteam should have expected properties', () => {
-    expect(index.redteam).toHaveProperty('Extractors');
-    expect(index.redteam).toHaveProperty('Plugins');
-    expect(index.redteam).toHaveProperty('Strategies');
-    expect(index.redteam).toHaveProperty('extractEntities');
-    expect(index.redteam).toHaveProperty('extractSystemPurpose');
-    expect(index.redteam.Extractors).toHaveProperty('extractEntities');
-    expect(index.redteam.Extractors).toHaveProperty('extractSystemPurpose');
+    expect(index.redteam).toEqual(
+      expect.objectContaining({
+        Extractors: expect.objectContaining({
+          extractEntities: expect.anything(),
+          extractSystemPurpose: expect.anything(),
+        }),
+        Plugins: expect.anything(),
+        Strategies: expect.anything(),
+        extractEntities: expect.anything(),
+        extractSystemPurpose: expect.anything(),
+      }),
+    );
   });
 
   it('default export should match named exports', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -56,7 +56,8 @@ describe('index.ts exports', () => {
     expect(index.redteam).toHaveProperty('Extractors');
     expect(index.redteam).toHaveProperty('Plugins');
     expect(index.redteam).toHaveProperty('Strategies');
-
+    expect(index.redteam).toHaveProperty('extractEntities');
+    expect(index.redteam).toHaveProperty('extractSystemPurpose');
     expect(index.redteam.Extractors).toHaveProperty('extractEntities');
     expect(index.redteam.Extractors).toHaveProperty('extractSystemPurpose');
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,77 @@
+import * as index from '../src/index';
+
+describe('index.ts exports', () => {
+  const expectedNamedExports = [
+    'assertions',
+    'cache',
+    'evaluate',
+    'providers',
+    'redteam',
+    'generateTable',
+    'isApiProvider',
+    'isGradingResult',
+    'isProviderOptions',
+  ];
+
+  const expectedSchemaExports = [
+    'AssertionSchema',
+    'AtomicTestCaseSchema',
+    'BaseAssertionTypesSchema',
+    'CommandLineOptionsSchema',
+    'CompletedPromptSchema',
+    'DerivedMetricSchema',
+    'OutputConfigSchema',
+    'OutputFileExtension',
+    'ScenarioSchema',
+    'TestCaseSchema',
+    'TestCaseWithVarsFileSchema',
+    'TestCasesWithMetadataPromptSchema',
+    'TestCasesWithMetadataSchema',
+    'TestSuiteConfigSchema',
+    'TestSuiteSchema',
+    'UnifiedConfigSchema',
+    'VarsSchema',
+  ];
+
+  it('should export all expected named modules', () => {
+    expectedNamedExports.forEach((exportName) => {
+      expect(index).toHaveProperty(exportName);
+    });
+  });
+
+  it('should export all expected schemas', () => {
+    expectedSchemaExports.forEach((exportName) => {
+      expect(index).toHaveProperty(exportName);
+    });
+  });
+
+  it('should not have unexpected exports', () => {
+    const actualExports = Object.keys(index).filter(key => key !== 'default');
+    const expectedExports = [...expectedNamedExports, ...expectedSchemaExports];
+    expect(actualExports).toHaveLength(expectedExports.length);
+    expect(actualExports).toEqual(expect.arrayContaining(expectedExports));
+  });
+
+  it('redteam should have expected properties', () => {
+    const expectedRedteamProps = [
+      'extractEntities',
+      'extractSystemPurpose',
+      'Plugins',
+      'Strategies',
+    ];
+
+    expectedRedteamProps.forEach((prop) => {
+      expect(index.redteam).toHaveProperty(prop);
+    });
+  });
+
+  it('default export should match named exports', () => {
+    expect(index.default).toEqual({
+      assertions: index.assertions,
+      cache: index.cache,
+      evaluate: index.evaluate,
+      providers: index.providers,
+      redteam: index.redteam,
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,23 +46,19 @@ describe('index.ts exports', () => {
   });
 
   it('should not have unexpected exports', () => {
-    const actualExports = Object.keys(index).filter(key => key !== 'default');
+    const actualExports = Object.keys(index).filter((key) => key !== 'default');
     const expectedExports = [...expectedNamedExports, ...expectedSchemaExports];
     expect(actualExports).toHaveLength(expectedExports.length);
     expect(actualExports).toEqual(expect.arrayContaining(expectedExports));
   });
 
   it('redteam should have expected properties', () => {
-    const expectedRedteamProps = [
-      'extractEntities',
-      'extractSystemPurpose',
-      'Plugins',
-      'Strategies',
-    ];
+    expect(index.redteam).toHaveProperty('Extractors');
+    expect(index.redteam).toHaveProperty('Plugins');
+    expect(index.redteam).toHaveProperty('Strategies');
 
-    expectedRedteamProps.forEach((prop) => {
-      expect(index.redteam).toHaveProperty(prop);
-    });
+    expect(index.redteam.Extractors).toHaveProperty('extractEntities');
+    expect(index.redteam.Extractors).toHaveProperty('extractSystemPurpose');
   });
 
   it('default export should match named exports', () => {


### PR DESCRIPTION
- Move extractEntities and extractSystemPurpose into Extractors object
- Add Strategies to redteam exports
- Deprecate direct exports of extractEntities and extractSystemPurpose
- Update imports and rename RedteamPlugins to Plugins
- Add unit tests for new redteam structure