### PR TITLE
feat(templates): allow Nunjucks templating in grader context

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -36,7 +36,7 @@ import type {
 import { extractJsonObjects } from './util/json';
 import { getNunjucksEngine } from './util/templates';
 
-const nunjucks = getNunjucksEngine();
+const nunjucks = getNunjucksEngine(undefined, false, true);
 
 function cosineSimilarity(vecA: number[], vecB: number[]) {
   if (vecA.length !== vecB.length) {

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -2,11 +2,20 @@ import nunjucks from 'nunjucks';
 import { getEnvBool } from '../envars';
 import type { NunjucksFilterMap } from '../types';
 
+/**
+ * Get a Nunjucks engine instance with optional filters and configuration.
+ * @param filters - Optional map of custom Nunjucks filters.
+ * @param throwOnUndefined - Whether to throw an error on undefined variables.
+ * @param isGrader - Whether this engine is being used in a grader context.
+ * Nunjucks is always enabled in grader mode.
+ * @returns A configured Nunjucks environment.
+ */
 export function getNunjucksEngine(
   filters?: NunjucksFilterMap,
   throwOnUndefined: boolean = false,
+  isGrader: boolean = false,
 ): nunjucks.Environment {
-  if (getEnvBool('PROMPTFOO_DISABLE_TEMPLATING')) {
+  if (!isGrader && getEnvBool('PROMPTFOO_DISABLE_TEMPLATING')) {
     return {
       renderString: (template: string) => template,
     } as unknown as nunjucks.Environment;


### PR DESCRIPTION
- Add `isGrader` parameter to `getNunjucksEngine` function
- Always enable Nunjucks in grader context, regardless of PROMPTFOO_DISABLE_TEMPLATING
- Update tests to cover new functionality
- Related to issue #1405