### PR TITLE
fix: rate limiting handling

### DIFF
--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -8,6 +8,7 @@ const mockedFetch = jest.mocked(fetch);
 const mockedFetchResponse = (ok: boolean, response: object) => {
   return {
     ok,
+    status: 200,
     text: () => Promise.resolve(JSON.stringify(response)),
     headers: {
       get: (name: string) => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -92,6 +92,14 @@ jest.mock('../src/database', () => ({
 }));
 jest.mock('../src/logger');
 
+const defaultMockResponse = {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    get: jest.fn().mockReturnValue(null),
+  },
+};
+
 describe('call provider apis', () => {
   afterEach(async () => {
     jest.clearAllMocks();
@@ -100,6 +108,7 @@ describe('call provider apis', () => {
 
   it('OpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ text: 'Test output' }],
@@ -119,6 +128,7 @@ describe('call provider apis', () => {
 
   it('OpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ message: { content: 'Test output' } }],
@@ -141,6 +151,7 @@ describe('call provider apis', () => {
 
   it('OpenAiChatCompletionProvider callApi with caching', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ message: { content: 'Test output 2' } }],
@@ -171,6 +182,7 @@ describe('call provider apis', () => {
 
   it('OpenAiChatCompletionProvider callApi with cache disabled', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ message: { content: 'Test output' } }],
@@ -224,6 +236,7 @@ describe('call provider apis', () => {
 
   it('AzureOpenAiCompletionProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ text: 'Test output' }],
@@ -243,6 +256,7 @@ describe('call provider apis', () => {
 
   it('AzureOpenAiChatCompletionProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ message: { content: 'Test output' } }],
@@ -273,6 +287,7 @@ describe('call provider apis', () => {
       },
     ];
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [
@@ -305,6 +320,7 @@ describe('call provider apis', () => {
     disableCache();
 
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           choices: [{ message: { content: 'Test output' } }],
@@ -328,6 +344,7 @@ describe('call provider apis', () => {
 
   it('LlamaProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           content: 'Test output',
@@ -345,6 +362,7 @@ describe('call provider apis', () => {
 
   it('OllamaCompletionProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn()
         .mockResolvedValue(`{"model":"llama2:13b","created_at":"2023-08-08T21:50:34.898068Z","response":"Gre","done":false}
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:34.929199Z","response":"at","done":false}
@@ -367,6 +385,7 @@ describe('call provider apis', () => {
 
   it('OllamaChatProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn()
         .mockResolvedValue(`{"model":"orca-mini","created_at":"2023-12-16T01:46:19.263682972Z","message":{"role":"assistant","content":" Because","images":null},"done":false}
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.275143974Z","message":{"role":"assistant","content":" of","images":null},"done":false}
@@ -387,6 +406,7 @@ describe('call provider apis', () => {
 
   it('WebhookProvider callApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(
         JSON.stringify({
           output: 'Test output',
@@ -408,6 +428,7 @@ describe('call provider apis', () => {
   ])('HuggingfaceTextGenerationProvider callApi with %s', (format, mockedData) => {
     it('returns expected output', async () => {
       const mockResponse = {
+        ...defaultMockResponse,
         text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
       jest.mocked(fetch).mockResolvedValue(mockResponse as never);
@@ -422,6 +443,7 @@ describe('call provider apis', () => {
 
   it('HuggingfaceFeatureExtractionProvider callEmbeddingApi', async () => {
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
@@ -447,6 +469,7 @@ describe('call provider apis', () => {
       ],
     ];
     const mockResponse = {
+      ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify(mockClassification)),
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
@@ -499,6 +522,7 @@ describe('call provider apis', () => {
           },
         };
         const mockResponse = {
+          ...defaultMockResponse,
           text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
           ok: true,
         };
@@ -534,6 +558,7 @@ describe('call provider apis', () => {
             },
           };
           const mockResponse = {
+            ...defaultMockResponse,
             text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
             ok: true,
           };
@@ -566,6 +591,7 @@ describe('call provider apis', () => {
           messages: [],
         };
         const mockResponse = {
+          ...defaultMockResponse,
           text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
           ok: true,
         };
@@ -608,6 +634,7 @@ describe('call provider apis', () => {
           },
         };
         const mockResponse = {
+          ...defaultMockResponse,
           text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
           ok: true,
         };
@@ -652,6 +679,7 @@ describe('call provider apis', () => {
           },
         };
         const mockResponse = {
+          ...defaultMockResponse,
           text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
           ok: true,
         };
@@ -682,6 +710,7 @@ describe('call provider apis', () => {
         };
 
         const mockResponse = {
+          ...defaultMockResponse,
           text: jest.fn().mockResolvedValue(JSON.stringify(responsePayload)),
           ok: true,
         };

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -1,0 +1,134 @@
+import type { Response } from 'node-fetch';
+import fetch from 'node-fetch';
+import { fetchWithRetries } from '../src/fetch';
+
+jest.mock('node-fetch');
+
+const mockedFetch = jest.mocked(fetch);
+
+const mockedFetchResponse = (
+  ok: boolean,
+  response: object,
+  headers: Record<string, string> = {},
+) => {
+  return {
+    ok,
+    status: ok ? 200 : 429,
+    statusText: ok ? 'OK' : 'Too Many Requests',
+    data: response,
+    headers: {
+      get: (name: string) => {
+        if (name === 'content-type') {
+          return 'application/json';
+        }
+        if (headers[name] !== undefined) {
+          return headers[name];
+        }
+        return null;
+      },
+    },
+  } as unknown as Response;
+};
+
+const mockedSetTimeout = (reqTimeout: number) =>
+  jest.spyOn(global, 'setTimeout').mockImplementation((cb: Function, ms?: number) => {
+    if (ms !== reqTimeout) {
+      cb();
+    }
+    return 0 as any;
+  });
+
+describe('fetchWithRetries', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    mockedFetch.mockReset();
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch data', async () => {
+    const url = 'https://api.example.com/data';
+    const response = { data: 'test data' };
+
+    mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
+
+    const result = await fetchWithRetries(url, {}, 1000);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ data: response });
+  });
+
+  it('should retry after given time if rate limited, using X-Limit headers', async () => {
+    const url = 'https://api.example.com/data';
+    const response = { data: 'test data' };
+    const rateLimitReset = 47_000;
+    const timeout = 1234;
+    const now = Date.now();
+
+    const setTimoutMock = mockedSetTimeout(timeout);
+
+    mockedFetch
+      .mockResolvedValueOnce(
+        mockedFetchResponse(false, response, {
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': `${(now + rateLimitReset) / 1000}`,
+        }),
+      )
+      .mockResolvedValueOnce(mockedFetchResponse(true, response));
+
+    const result = await fetchWithRetries(url, {}, timeout);
+    const waitTime = setTimoutMock.mock.calls[1][1];
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(waitTime).toBeGreaterThan(rateLimitReset);
+    expect(waitTime).toBeLessThanOrEqual(rateLimitReset + 1000);
+    expect(result).toMatchObject({ data: response });
+  });
+
+  it('should retry after given time if rate limited, using status and Retry-After', async () => {
+    const url = 'https://api.example.com/data';
+    const response = { data: 'test data' };
+    const retryAfter = 15;
+    const timeout = 1234;
+
+    const setTimoutMock = mockedSetTimeout(timeout);
+
+    mockedFetch
+      .mockResolvedValueOnce(
+        mockedFetchResponse(false, response, { 'Retry-After': String(retryAfter) }),
+      )
+      .mockResolvedValueOnce(mockedFetchResponse(true, response));
+
+    const result = await fetchWithRetries(url, {}, timeout);
+    const waitTime = setTimoutMock.mock.calls[1][1];
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(waitTime).toBe(retryAfter * 1000);
+    expect(result).toMatchObject({ data: response });
+  });
+
+  it('should retry after default wait time if rate limited and wait time not found', async () => {
+    const url = 'https://api.example.com/data';
+    const response = { data: 'test data' };
+    const timeout = 1234;
+
+    const setTimoutMock = mockedSetTimeout(timeout);
+
+    mockedFetch
+      .mockResolvedValueOnce(mockedFetchResponse(false, response))
+      .mockResolvedValueOnce(mockedFetchResponse(true, response));
+
+    const result = await fetchWithRetries(url, {}, timeout);
+    const waitTime = setTimoutMock.mock.calls[1][1];
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(waitTime).toBe(60_000);
+    expect(result).toMatchObject({ data: response });
+  });
+});


### PR DESCRIPTION
I improved the rate limiting detection and handling logic, to also rely on status code and standard `Retry-After` header.

After some testing, it turned out that there was also a bug preventing the existing logic to be called at all, so hitting rate limits just resulted in an error.

I added some unit test to check that the new behavior works as intended.