### PR TITLE
fix: run db migrations first thing in cli

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { showCommand } from './commands/show';
 import { versionCommand } from './commands/version';
 import { viewCommand } from './commands/view';
 import { maybeReadConfig } from './config';
+import { runDbMigrations } from './migrate';
 import { type EvaluateOptions, type UnifiedConfig } from './types';
 import { checkForUpdates } from './updates';
 
@@ -48,6 +49,7 @@ export async function loadDefaultConfig(): Promise<{
 
 async function main() {
   await checkForUpdates();
+  await runDbMigrations();
 
   const program = new Command();
 


### PR DESCRIPTION
This fixes an issue where commands like `promptfoo list evals` will fail before there are any evals (previously the only other place that runs migrations is when results are written to db)

I'm a little nervous about this change in terms of adding latency, but seems ok on my system when there are no new migrations.