### PR TITLE
fix(providers): add support for openai o1 max_completion_tokens

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -465,8 +465,9 @@ These OpenAI-related environment variables are supported:
 
 | Variable                       | Description                                                                                                      |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `OPENAI_TEMPERATURE`           | Temperature model parameter, defaults to 0.                                                                      |
-| `OPENAI_MAX_TOKENS`            | Max_tokens model parameter, defaults to 1024.                                                                    |
+| `OPENAI_TEMPERATURE`           | Temperature model parameter, defaults to 0. Not supported by o1-models.                                          |
+| `OPENAI_MAX_TOKENS`            | Max_tokens model parameter, defaults to 1024. Not supported by o1-models.                                        |
+| `OPENAI_MAX_COMPLETION_TOKENS` | Max_completion_tokens model parameter, defaults to 1024. Used by o1-models.                                      |
 | `OPENAI_API_HOST`              | The hostname to use (useful if you're using an API proxy). Takes priority over `OPENAI_BASE_URL`.                |
 | `OPENAI_BASE_URL`              | The base URL (protocol + hostname + port) to use, this is a more general option than `OPENAI_API_HOST`.          |
 | `OPENAI_API_KEY`               | OpenAI API key.                                                                                                  |

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -66,6 +66,7 @@ export type EnvVars = {
   OLLAMA_BASE_URL?: string;
   OPENAI_BEST_OF?: number;
   OPENAI_FREQUENCY_PENALTY?: number;
+  OPENAI_MAX_COMPLETION_TOKENS?: number;
   OPENAI_MAX_TOKENS?: number;
   OPENAI_PRESENCE_PENALTY?: number;
   OPENAI_STOP?: string;

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -478,14 +478,14 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
-    // NOTE: Special handling for O1 models which do not support max_tokens and temperature
+    // NOTE: Special handling for o1 models which do not support max_tokens and temperature
     const isO1Model = this.modelName.startsWith('o1-');
-    const maxTokens = isO1Model
-      ? undefined
-      : (this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024));
     const maxCompletionTokens = isO1Model
       ? (this.config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS', 1024))
       : undefined;
+    const maxTokens = isO1Model
+      ? undefined
+      : (this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024));
     const temperature = isO1Model
       ? undefined
       : (this.config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0));

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -130,6 +130,7 @@ interface OpenAiSharedOptions {
 
 export type OpenAiCompletionOptions = OpenAiSharedOptions & {
   temperature?: number;
+  max_completion_tokens?: number;
   max_tokens?: number;
   top_p?: number;
   frequency_penalty?: number;
@@ -477,15 +478,25 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
-    const maxTokens = this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS');
+    // NOTE: Special handling for O1 models which do not support max_tokens and temperature
+    const isO1Model = this.modelName.startsWith('o1-');
+    const maxTokens = isO1Model
+      ? undefined
+      : (this.config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024));
+    const maxCompletionTokens = isO1Model
+      ? (this.config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS', 1024))
+      : undefined;
+    const temperature = isO1Model
+      ? undefined
+      : (this.config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0));
 
     const body = {
       model: this.modelName,
       messages,
       seed: this.config.seed,
       ...(maxTokens ? { max_tokens: maxTokens } : {}),
-      temperature:
-        this.config.temperature ?? Number.parseFloat(process.env.OPENAI_TEMPERATURE || '0'),
+      ...(maxCompletionTokens ? { max_completion_tokens: maxCompletionTokens } : {}),
+      ...(temperature ? { temperature } : {}),
       top_p: this.config.top_p ?? Number.parseFloat(process.env.OPENAI_TOP_P || '1'),
       presence_penalty:
         this.config.presence_penalty ??


### PR DESCRIPTION
- Add OPENAI_MAX_COMPLETION_TOKENS to environment variables
- Implement special handling for o1 models in OpenAiChatCompletionProvider
- Update OpenAI documentation with new environment variables and model support