### PR TITLE
docs: update model references from gpt-3.5-turbo to gpt-4o-mini

### DIFF
--- a/examples/dbrx-benchmark/promptfooconfig.yaml
+++ b/examples/dbrx-benchmark/promptfooconfig.yaml
@@ -8,7 +8,7 @@ providers:
   - id: openrouter:mistralai/mixtral-8x7b-instruct
     config:
       temperature: 0
-  - id: openai:gpt-3.5-turbo-0125
+  - id: openai:gpt-4o-mini
     config:
       temperature: 0
 

--- a/examples/gpt-4o-vs-4o-mini/README.md
+++ b/examples/gpt-4o-vs-4o-mini/README.md
@@ -9,5 +9,5 @@ promptfoo eval
 Full command-line equivalent:
 
 ```
-promptfoo eval --prompts prompts.txt --providers openai:gpt-3.5-turbo openai:gpt-4
+promptfoo eval --prompts prompts.txt --providers openai:gpt-4o openai:gpt-4o-mini
 ```

--- a/examples/json-output/promptfooconfig.yaml
+++ b/examples/json-output/promptfooconfig.yaml
@@ -4,7 +4,7 @@ prompts:
   - 'Output a JSON object that contains the keys `color` and `countries`, describing the following object: {{item}}'
 
 providers:
-  - openai:chat:gpt-3.5-turbo
+  - openai:chat:gpt-4o-mini
 
 tests:
   - vars:

--- a/examples/multiple-translations-scenarios/promptfooconfig.yaml
+++ b/examples/multiple-translations-scenarios/promptfooconfig.yaml
@@ -1,8 +1,8 @@
 prompts:
   - file://prompts.txt
 providers:
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
 scenarios:
   - config:
       - vars:

--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -1,8 +1,8 @@
 prompts:
   - 'file://prompts.txt'
 providers:
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
 tests:
   - vars:
       language:

--- a/examples/multiple-turn-conversation/promptfooconfig.yaml
+++ b/examples/multiple-turn-conversation/promptfooconfig.yaml
@@ -1,7 +1,7 @@
 prompts:
   - file://prompt.json
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 
 # Set up the system message for all tests
 defaultTest:

--- a/examples/named-metrics/promptfooconfig.yaml
+++ b/examples/named-metrics/promptfooconfig.yaml
@@ -3,7 +3,7 @@ prompts:
   - 'Say this as though you are a seafarer from the 17th century: {{body}}'
 
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 
 derivedMetrics:
   - name: DoubleConsistency

--- a/examples/node-package/full-eval.js
+++ b/examples/node-package/full-eval.js
@@ -54,8 +54,8 @@ const customFunction = (prompt, context) => {
 customFunction.label = 'My custom function';
 
 const providers = [
-  // Call the OpenAI API GPT 3.5
-  'openai:gpt-3.5-turbo',
+  // Call the OpenAI API GPT 4o Mini
+  'openai:gpt-4o-mini',
 
   // Or use a custom function.
   customFunction,

--- a/examples/nunjucks-custom-filters/promptfooconfig.yaml
+++ b/examples/nunjucks-custom-filters/promptfooconfig.yaml
@@ -1,7 +1,7 @@
 prompts:
   - file://prompts.txt
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 nunjucksFilters:
   allcaps: ./allcaps.js
 tests:

--- a/examples/ollama-comparison/promptfooconfig.yaml
+++ b/examples/ollama-comparison/promptfooconfig.yaml
@@ -15,7 +15,7 @@ providers:
       - llama_prompt
     config:
       num_predict: 1024
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-4o-mini
     prompts:
       - openai_prompt
 

--- a/examples/openai-chat-history/promptfooconfig.yaml
+++ b/examples/openai-chat-history/promptfooconfig.yaml
@@ -1,7 +1,7 @@
 prompts:
   - file://prompt.json
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 
 # Set up the conversation history
 defaultTest:

--- a/examples/openai-eval-factuality/promptfooconfig.yaml
+++ b/examples/openai-eval-factuality/promptfooconfig.yaml
@@ -1,5 +1,5 @@
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 prompts:
   - file://prompts/name_capitals_concise.txt
   - file://prompts/name_capitals_verbose.txt

--- a/examples/python-provider/provider.py
+++ b/examples/python-provider/provider.py
@@ -19,7 +19,7 @@ def call_api(prompt, options, context):
                 "content": prompt,
             },
         ],
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
     )
 
     return {"output": chat_completion.choices[0].message.content}

--- a/examples/replicate-lifeboat/promptfooconfig.yaml
+++ b/examples/replicate-lifeboat/promptfooconfig.yaml
@@ -2,7 +2,7 @@ prompts:
   - 'Respond to the user concisely: {{message}}'
 
 providers:
-  - id: openai:chat:gpt-3.5-turbo
+  - id: openai:chat:gpt-4o-mini
     config:
       apiKey: '...'
       temperature: 0.01

--- a/examples/simple-csv/README.md
+++ b/examples/simple-csv/README.md
@@ -7,5 +7,5 @@ promptfoo eval
 Here's the full command:
 
 ```
-promptfoo eval --prompts prompts.txt --tests tests.csv --providers openai:gpt-3.5-turbo
+promptfoo eval --prompts prompts.txt --tests tests.csv --providers openai:gpt-4o-mini
 ```

--- a/examples/simple-csv/promptfooconfig.yaml
+++ b/examples/simple-csv/promptfooconfig.yaml
@@ -2,5 +2,5 @@ description: A translator built with LLM
 prompts:
   - file://prompts.txt
 providers:
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 tests: file://tests.csv

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -73,7 +73,7 @@ By default, `llm-rubric` uses GPT-4 for grading. You can override this in severa
 1. Using the `--grader` CLI option:
 
    ```sh
-   promptfoo eval --grader openai:gpt-3.5-turbo
+   promptfoo eval --grader openai:gpt-4o-mini
    ```
 
 2. Using `test.options` or `defaultTest.options`:
@@ -81,7 +81,7 @@ By default, `llm-rubric` uses GPT-4 for grading. You can override this in severa
    ```yaml
    defaultTest:
      options:
-       provider: openai:gpt-3.5-turbo
+       provider: openai:gpt-4o-mini
      assert:
        - description: Evaluate output using LLM
          assert:
@@ -97,7 +97,7 @@ By default, `llm-rubric` uses GPT-4 for grading. You can override this in severa
        assert:
          - type: llm-rubric
             value: Is written in a professional tone
-            provider: openai:gpt-3.5-turbo
+            provider: openai:gpt-4o-mini
    ```
 
 ### Customizing the rubric prompt

--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -215,7 +215,7 @@ interface TestSuiteConfig {
   // Optional description of what you're trying to test
   description?: string;
 
-  // One or more LLM APIs to use, for example: openai:gpt-3.5-turbo, openai:gpt-4, localai:chat:vicuna
+  // One or more LLM APIs to use, for example: openai:gpt-4o-mini, openai:gpt-4o, localai:chat:vicuna
   providers: ProviderId | ProviderFunction | (ProviderId | ProviderOptionsMap | ProviderOptions)[];
 
   // One or more prompts

--- a/site/docs/guides/azure-vs-openai.md
+++ b/site/docs/guides/azure-vs-openai.md
@@ -45,8 +45,8 @@ Edit your `promptfooconfig.yaml` to include both OpenAI and Azure OpenAI as prov
 
 ```yaml
 providers:
-  - id: openai:chat:gpt-3.5-turbo
-  - id: azureopenai:chat:my-gpt-35-turbo-deployment
+  - id: openai:chat:gpt-4o-mini
+  - id: azureopenai:chat:my-gpt-4o-mini-deployment
     config:
       apiHost: myazurehost.openai.azure.com
 ```
@@ -59,11 +59,11 @@ For each provider, you may configure additional parameters such as `temperature`
 
 ```yaml
 providers:
-  - id: openai:chat:gpt-3.5-turbo
+  - id: openai:chat:gpt-4o-mini
     config:
       temperature: 0
       max_tokens: 128
-  - id: azureopenai:chat:my-gpt-35-turbo-deployment
+  - id: azureopenai:chat:my-gpt-4o-mini-deployment
     config:
       apiHost: your_azure_openai_host
       temperature: 0

--- a/site/docs/guides/evaluate-llm-temperature.md
+++ b/site/docs/guides/evaluate-llm-temperature.md
@@ -134,13 +134,13 @@ Set a constant seed in the provider config:
 ```yaml
 providers:
   - id: openai:gpt-4o-mini
-    label: openai-gpt-3.5-turbo-lowtemp
+    label: openai-gpt-4o-mini-lowtemp
     config:
       temperature: 0.2
       // highlight-next-line
       seed: 0
   - id: openai:gpt-4o-mini
-    label: openai-gpt-3.5-turbo-hightemp
+    label: openai-gpt-4o-mini-hightemp
     config:
       temperature: 0.9
       // highlight-next-line

--- a/site/docs/guides/evaluate-replicate-lifeboat.md
+++ b/site/docs/guides/evaluate-replicate-lifeboat.md
@@ -33,7 +33,7 @@ prompts:
   - 'Respond to the user concisely: {{message}}'
 
 providers:
-  - id: openai:chat:gpt-3.5-turbo
+  - id: openai:chat:gpt-4o-mini
     config:
       apiKey: 'your_openai_api_key'
       temperature: 0.01

--- a/site/docs/guides/gemini-vs-gpt.md
+++ b/site/docs/guides/gemini-vs-gpt.md
@@ -36,8 +36,8 @@ Edit the `promptfooconfig.yaml` file to include the `gemini-pro` model from Goog
 ```yaml title=promptfooconfig.yaml
 providers:
   - vertex:gemini-pro
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
 ```
 
 ## Step 2: Set up the prompts
@@ -59,10 +59,10 @@ prompts:
 providers:
   - id: vertex:gemini-pro
     prompts: gemini_prompt
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-4o-mini
     prompts:
       - gpt_prompt
-  - id: openai:gpt-4
+  - id: openai:gpt-4o
     prompts:
       - gpt_prompt
 ```

--- a/site/docs/guides/gpt-3.5-vs-gpt-4.md
+++ b/site/docs/guides/gpt-3.5-vs-gpt-4.md
@@ -31,8 +31,8 @@ Edit `promptfooconfig.yaml` to include GPT-3.5 and GPT-4:
 
 ```yaml title=promptfooconfig.yaml
 providers:
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
 ```
 
 ## Step 2: Crafting the prompts
@@ -125,8 +125,8 @@ Finally, we'll use `defaultTest` to clean things up a bit and apply global `late
 
 ```yaml
 providers:
-  - openai:gpt-3.5-turbo
-  - openai:gpt-4
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
 
 prompts:
   - 'Solve this riddle: {{riddle}}'

--- a/site/docs/guides/llama2-uncensored-benchmark-ollama.md
+++ b/site/docs/guides/llama2-uncensored-benchmark-ollama.md
@@ -39,7 +39,7 @@ Now let's start editing `promptfooconfig.yaml`. First, we'll add the list of mod
 providers:
   - ollama:llama2
   - ollama:llama2-uncensored
-  - openai:gpt-3.5-turbo
+  - openai:gpt-4o-mini
 ```
 
 These [providers](/docs/providers) reference the built-in Ollama models.
@@ -82,7 +82,7 @@ providers:
   - id: ollama:llama2-uncensored
     prompts:
       - llama_prompt
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-4o-mini
     prompts:
       - openai_prompt
 ```
@@ -129,7 +129,7 @@ providers:
   - id: ollama:llama2-uncensored
     prompts:
     - llama_prompt
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-4o-mini
     prompts:
     - openai_prompt
 ```
@@ -183,7 +183,7 @@ providers:
   - id: ollama:llama2-uncensored
     prompts:
     - llama_prompt
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-4o-mini
     prompts:
     - openai_prompt
 ```

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -561,11 +561,11 @@ describe('getGradingProvider', () => {
   it('should return the correct provider when provider is a string', async () => {
     const provider = await getGradingProvider(
       'text',
-      'openai:chat:gpt-3.5-turbo-foobar',
+      'openai:chat:gpt-4o-mini-foobar',
       DefaultGradingProvider,
     );
     // ok for this not to match exactly when the string is parsed
-    expect(provider?.id()).toBe('openai:gpt-3.5-turbo-foobar');
+    expect(provider?.id()).toBe('openai:gpt-4o-mini-foobar');
   });
 
   it('should return the correct provider when provider is an ApiProvider', async () => {
@@ -579,14 +579,14 @@ describe('getGradingProvider', () => {
 
   it('should return the correct provider when provider is ProviderOptions', async () => {
     const providerOptions = {
-      id: 'openai:chat:gpt-3.5-turbo-foobar',
+      id: 'openai:chat:gpt-4o-mini-foobar',
       config: {
         apiKey: 'abc123',
         temperature: 3.1415926,
       },
     };
     const provider = await getGradingProvider('text', providerOptions, DefaultGradingProvider);
-    expect(provider?.id()).toBe('openai:chat:gpt-3.5-turbo-foobar');
+    expect(provider?.id()).toBe('openai:chat:gpt-4o-mini-foobar');
   });
 
   it('should return the default provider when provider is not provided', async () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -139,7 +139,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
+    const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
@@ -162,7 +162,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
+    const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt 2' }]),
     );
@@ -193,7 +193,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo');
+    const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
@@ -220,7 +220,7 @@ describe('call provider apis', () => {
       temperature: 3.1415926,
       max_tokens: 201,
     };
-    const provider = new OpenAiChatCompletionProvider('gpt-3.5-turbo', { config });
+    const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', { config });
     const prompt = 'Test prompt';
     await provider.callApi(prompt);
 
@@ -266,7 +266,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo');
+    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
@@ -301,7 +301,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo', {
+    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini', {
       config: { dataSources },
     });
     const result = await provider.callApi(
@@ -330,7 +330,7 @@ describe('call provider apis', () => {
     };
     jest.mocked(fetch).mockResolvedValue(mockResponse as never);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-3.5-turbo');
+    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -342,14 +342,14 @@ describe('redteamConfigSchema', () => {
 
   it('should accept a provider string', () => {
     const input = {
-      provider: 'openai:gpt-3.5-turbo',
+      provider: 'openai:gpt-4o-mini',
       plugins: ['overreliance'],
       strategies: ['jailbreak'],
     };
     expect(RedteamConfigSchema.safeParse(input)).toEqual({
       success: true,
       data: {
-        provider: 'openai:gpt-3.5-turbo',
+        provider: 'openai:gpt-4o-mini',
         plugins: [{ id: 'overreliance', numTests: undefined }],
         strategies: [{ id: 'jailbreak' }],
       },

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -28,7 +28,7 @@ describe('AssertionSchema', () => {
       value: 'expected value',
       threshold: 0.8,
       weight: 2,
-      provider: 'openai:gpt-3.5-turbo',
+      provider: 'openai:gpt-4o-mini',
       rubricPrompt: 'Custom rubric prompt',
       metric: 'similarity_score',
       transform: 'toLowerCase()',


### PR DESCRIPTION
This commit updates various configuration files and examples to use the
gpt-4o-mini model instead of gpt-3.5-turbo. It also updates some references
to gpt-4 to gpt-4o. This change affects multiple files across the project,
including configuration files, documentation, and test cases.