### PR TITLE
chore(openai): improve support for structured outputs

### DIFF
--- a/examples/openai-structured-output/README.md
+++ b/examples/openai-structured-output/README.md
@@ -1,0 +1,28 @@
+# OpenAI Structured Output Example
+
+This example demonstrates how to use OpenAI's new Structured Outputs feature with JSON schemas to ensure model outputs adhere to a specific structure.
+
+## Key Features
+
+- Utilizes the `gpt-4o` model supporting Structured Outputs
+- Implements a JSON schema for analyzing customer support queries
+- Demonstrates the `response_format` parameter with a `json_schema`
+
+## How it Works
+
+1. The prompt asks the model to analyze a customer support query.
+2. The response is structured according to a predefined JSON schema, including fields like query summary, category, sentiment, urgency, and suggested actions.
+
+## Running the Example
+
+To run:
+
+```bash
+promptfoo eval
+```
+
+This executes tests defined in `promptfooconfig.yaml`, covering various customer support scenarios and validating the model's output.
+
+## Note
+
+For more details, refer to the [OpenAI announcement](https://openai.com/index/introducing-structured-outputs-in-the-api/).

--- a/examples/openai-structured-output/promptfooconfig.yaml
+++ b/examples/openai-structured-output/promptfooconfig.yaml
@@ -1,0 +1,159 @@
+description: 'OpenAI Structured Output Example'
+prompts:
+  - 'Analyze the following customer support query: "{{query}}"'
+
+providers:
+  - id: openai:chat:gpt-4o-2024-08-06
+    config: &structured_output_config
+      response_format:
+        type: json_schema
+        json_schema:
+          name: customer_support_analysis
+          strict: true
+          schema:
+            type: object
+            properties:
+              query_summary:
+                type: string
+                description: "A brief summary of the customer's query"
+              category:
+                type: string
+                enum:
+                  [
+                    'billing',
+                    'technical_issue',
+                    'product_inquiry',
+                    'complaint',
+                    'feature_request',
+                    'other',
+                  ]
+                description: "The main category of the customer's query"
+              sentiment:
+                type: string
+                enum: ['positive', 'neutral', 'negative']
+                description: "The overall sentiment of the customer's query"
+              urgency:
+                type: string
+                enum: ['1', '2', '3', '4', '5']
+                description: 'The urgency level of the query, where 1 is lowest and 5 is highest'
+              suggested_actions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      description: 'A specific action to be taken'
+                    priority:
+                      type: string
+                      enum: ['low', 'medium', 'high']
+                  required: ['action', 'priority']
+                  additionalProperties: false
+              estimated_resolution_time:
+                type: string
+                description: "Estimated time to resolve the query (e.g., '2 hours', '1 day')"
+            required:
+              [
+                'query_summary',
+                'category',
+                'sentiment',
+                'urgency',
+                'suggested_actions',
+                'estimated_resolution_time',
+              ]
+            additionalProperties: false
+  - id: openai:chat:gpt-4o-mini
+    config: *structured_output_config
+
+tests:
+  - vars:
+      query: "I've been charged twice for my subscription this month. Can you please refund the extra charge?"
+    assert:
+      - type: is-json
+        metric: ValidJSON
+      - type: javascript
+        value: |
+          output.category === 'billing'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'negative'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) >= 3
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.length > 0 && output.suggested_actions.some(action => action.action.toLowerCase().includes('refund'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's issue about being charged twice?"
+        metric: SummaryAccuracy
+
+  - vars:
+      query: "How do I change my password? I can't find the option in my account settings."
+    assert:
+      - type: is-json
+        metric: ValidJSON
+      - type: javascript
+        value: output.category === 'technical_issue'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'neutral'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) <= 3
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('password'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's issue about changing their password?"
+        metric: SummaryAccuracy
+
+  - vars:
+      query: "I love your new feature! It's made my work so much easier. Any plans to expand on it?"
+    assert:
+      - type: is-json
+        metric: ValidJSON
+      - type: javascript
+        value: output.category === 'feature_request'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'positive'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) <= 2
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('feedback'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's positive feedback and interest in feature expansion?"
+        metric: SummaryAccuracy
+
+  - vars:
+      query: "Your product is terrible and never works! I want a full refund and I'm cancelling my account!"
+    assert:
+      - type: is-json
+        metric: ValidJSON
+      - type: javascript
+        value: output.category === 'complaint'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'negative'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: |
+          output.urgency === '5'
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.priority === 'high')
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's severe complaint and refund request?"
+        metric: SummaryAccuracy
+
+derivedMetrics:
+  - name: 'OverallAccuracy'
+    value: '(CategoryAccuracy + SentimentAccuracy + UrgencyAccuracy + ActionRelevance + SummaryAccuracy) / 5'
+  - name: 'ResponseQuality'
+    value: '(ValidJSON + OverallAccuracy) / 2'

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -1,5 +1,5 @@
 prompts:
-  - 'What is the weather like in {{city}}?'
+  - 'Analyze the following customer support query: "{{query}}"'
 
 providers:
   - id: openai:chat:gpt-4o-2024-08-06
@@ -7,53 +7,148 @@ providers:
       response_format:
         type: json_schema
         json_schema:
-          name: weather_response
+          name: customer_support_analysis
           strict: true
           schema:
             type: object
             properties:
-              temperature:
-                type: number
-              description:
+              query_summary:
                 type: string
-              unit:
+                description: "A brief summary of the customer's query"
+              category:
                 type: string
-                enum: [celsius, fahrenheit]
-            required: [temperature, description, unit]
+                enum:
+                  [
+                    'billing',
+                    'technical_issue',
+                    'product_inquiry',
+                    'complaint',
+                    'feature_request',
+                    'other',
+                  ]
+                description: "The main category of the customer's query"
+              sentiment:
+                type: string
+                enum: ['positive', 'neutral', 'negative']
+                description: "The overall sentiment of the customer's query"
+              urgency:
+                type: string
+                enum: ['1', '2', '3', '4', '5']
+                description: 'The urgency level of the query, where 1 is lowest and 5 is highest'
+              suggested_actions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      description: 'A specific action to be taken'
+                    priority:
+                      type: string
+                      enum: ['low', 'medium', 'high']
+                  required: ['action', 'priority']
+                  additionalProperties: false
+              estimated_resolution_time:
+                type: string
+                description: "Estimated time to resolve the query (e.g., '2 hours', '1 day')"
+            required:
+              [
+                'query_summary',
+                'category',
+                'sentiment',
+                'urgency',
+                'suggested_actions',
+                'estimated_resolution_time',
+              ]
             additionalProperties: false
 
 tests:
   - vars:
-      city: Boston
+      query: "I've been charged twice for my subscription this month. Can you please refund the extra charge?"
     assert:
       - type: is-json
-        value:
-          required:
-            - 'temperature'
-            - 'description'
-            - 'unit'
-          type: object
-          properties:
-            temperature:
-              type: number
-            description:
-              type: string
-            unit:
-              type: string
-              enum: [celsius, fahrenheit]
+        metric: ValidJSON
       - type: javascript
-        value: typeof output.temperature === 'number' && typeof output.description === 'string' && ['celsius', 'fahrenheit'].includes(output.unit)
+        value: output.category === 'billing'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'negative'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) >= 3
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.length > 0 && output.suggested_actions.some(action => action.action.toLowerCase().includes('refund'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's issue about being charged twice?"
+        metric: SummaryAccuracy
 
   - vars:
-      city: New York
+      query: "How do I change my password? I can't find the option in my account settings."
     assert:
       - type: is-json
+        metric: ValidJSON
       - type: javascript
-        value: Object.keys(output).length === 3
+        value: output.category === 'technical_issue'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'neutral'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) <= 3
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('password'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's issue about changing their password?"
+        metric: SummaryAccuracy
 
   - vars:
-      city: Paris
+      query: "I love your new feature! It's made my work so much easier. Any plans to expand on it?"
     assert:
       - type: is-json
+        metric: ValidJSON
       - type: javascript
-        value: output.unit === 'celsius'
+        value: output.category === 'feature_request'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'positive'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: parseInt(output.urgency) <= 2
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('feedback'))
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's positive feedback and interest in feature expansion?"
+        metric: SummaryAccuracy
+
+  - vars:
+      query: "Your product is terrible and never works! I want a full refund and I'm cancelling my account!"
+    assert:
+      - type: is-json
+        metric: ValidJSON
+      - type: javascript
+        value: output.category === 'complaint'
+        metric: CategoryAccuracy
+      - type: javascript
+        value: output.sentiment === 'negative'
+        metric: SentimentAccuracy
+      - type: javascript
+        value: output.urgency === '5'
+        metric: UrgencyAccuracy
+      - type: javascript
+        value: output.suggested_actions.some(action => action.priority === 'high')
+        metric: ActionRelevance
+      - type: llm-rubric
+        value: "Does the query summary accurately reflect the customer's severe complaint and refund request?"
+        metric: SummaryAccuracy
+
+derivedMetrics:
+  - name: 'OverallAccuracy'
+    value: '(CategoryAccuracy + SentimentAccuracy + UrgencyAccuracy + ActionRelevance + SummaryAccuracy) / 5'
+  - name: 'ResponseQuality'
+    value: '(ValidJSON + OverallAccuracy) / 2'

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -1,156 +1,69 @@
 prompts:
-  - 'Analyze the following customer support query: "{{query}}"'
+  - 'What is the weather like in {{city}}?'
 
 providers:
-  - id: openai:chat:gpt-4o-2024-08-06
+  - id: openai:chat:gpt-4o-mini
     config:
-      response_format:
-        type: json_schema
-        json_schema:
-          name: customer_support_analysis
-          strict: true
-          schema:
-            type: object
-            properties:
-              query_summary:
-                type: string
-                description: "A brief summary of the customer's query"
-              category:
-                type: string
-                enum:
-                  [
-                    'billing',
-                    'technical_issue',
-                    'product_inquiry',
-                    'complaint',
-                    'feature_request',
-                    'other',
-                  ]
-                description: "The main category of the customer's query"
-              sentiment:
-                type: string
-                enum: ['positive', 'neutral', 'negative']
-                description: "The overall sentiment of the customer's query"
-              urgency:
-                type: string
-                enum: ['1', '2', '3', '4', '5']
-                description: 'The urgency level of the query, where 1 is lowest and 5 is highest'
-              suggested_actions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    action:
-                      type: string
-                      description: 'A specific action to be taken'
-                    priority:
-                      type: string
-                      enum: ['low', 'medium', 'high']
-                  required: ['action', 'priority']
-                  additionalProperties: false
-              estimated_resolution_time:
-                type: string
-                description: "Estimated time to resolve the query (e.g., '2 hours', '1 day')"
-            required:
-              [
-                'query_summary',
-                'category',
-                'sentiment',
-                'urgency',
-                'suggested_actions',
-                'estimated_resolution_time',
-              ]
-            additionalProperties: false
+      tools:
+        [
+          {
+            'type': 'function',
+            'function':
+              {
+                'name': 'get_current_weather',
+                'description': 'Get the current weather in a given location',
+                'parameters':
+                  {
+                    'type': 'object',
+                    'properties':
+                      {
+                        'location':
+                          {
+                            'type': 'string',
+                            'description': 'The city and state, e.g. San Francisco, CA',
+                          },
+                        'unit': { 'type': 'string', 'enum': ['celsius', 'fahrenheit'] },
+                      },
+                    'required': ['location'],
+                  },
+              },
+          },
+        ]
 
 tests:
   - vars:
-      query: "I've been charged twice for my subscription this month. Can you please refund the extra charge?"
+      city: Boston
     assert:
       - type: is-json
-        metric: ValidJSON
+      - type: is-valid-openai-tools-call
       - type: javascript
-        value: |
-          output.category === 'billing'
-        metric: CategoryAccuracy
+        value: output[0].function.name === 'get_current_weather'
       - type: javascript
-        value: output.sentiment === 'negative'
-        metric: SentimentAccuracy
-      - type: javascript
-        value: parseInt(output.urgency) >= 3
-        metric: UrgencyAccuracy
-      - type: javascript
-        value: output.suggested_actions.length > 0 && output.suggested_actions.some(action => action.action.toLowerCase().includes('refund'))
-        metric: ActionRelevance
-      - type: llm-rubric
-        value: "Does the query summary accurately reflect the customer's issue about being charged twice?"
-        metric: SummaryAccuracy
+        value: JSON.parse(output[0].function.arguments).location === 'Boston, MA'
 
   - vars:
-      query: "How do I change my password? I can't find the option in my account settings."
+      city: New York
+    options:
+      # Transform is a cleaner way to pick out specific properties.
+      # This transform returns only the 'name' property
+      transform: output[0].function.name
     assert:
-      - type: is-json
-        metric: ValidJSON
-      - type: javascript
-        value: output.category === 'technical_issue'
-        metric: CategoryAccuracy
-      - type: javascript
-        value: output.sentiment === 'neutral'
-        metric: SentimentAccuracy
-      - type: javascript
-        value: parseInt(output.urgency) <= 3
-        metric: UrgencyAccuracy
-      - type: javascript
-        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('password'))
-        metric: ActionRelevance
-      - type: llm-rubric
-        value: "Does the query summary accurately reflect the customer's issue about changing their password?"
-        metric: SummaryAccuracy
+      - type: equals
+        value: get_current_weather
 
   - vars:
-      query: "I love your new feature! It's made my work so much easier. Any plans to expand on it?"
+      city: Paris
     assert:
-      - type: is-json
-        metric: ValidJSON
-      - type: javascript
-        value: output.category === 'feature_request'
-        metric: CategoryAccuracy
-      - type: javascript
-        value: output.sentiment === 'positive'
-        metric: SentimentAccuracy
-      - type: javascript
-        value: parseInt(output.urgency) <= 2
-        metric: UrgencyAccuracy
-      - type: javascript
-        value: output.suggested_actions.some(action => action.action.toLowerCase().includes('feedback'))
-        metric: ActionRelevance
-      - type: llm-rubric
-        value: "Does the query summary accurately reflect the customer's positive feedback and interest in feature expansion?"
-        metric: SummaryAccuracy
+      - type: equals
+        value: get_current_weather
+        # Transform is a cleaner way to pick out specific properties.
+        # This transform returns only the 'name' property
+        transform: output[0].function.name
+      - type: similar
+        value: Paris, France
+        threshold: 0.5
+        # This transform returns only the parsed location argument.
+        transform: JSON.parse(output[0].function.arguments).location
 
   - vars:
-      query: "Your product is terrible and never works! I want a full refund and I'm cancelling my account!"
-    assert:
-      - type: is-json
-        metric: ValidJSON
-      - type: javascript
-        value: output.category === 'complaint'
-        metric: CategoryAccuracy
-      - type: javascript
-        value: output.sentiment === 'negative'
-        metric: SentimentAccuracy
-      - type: javascript
-        value: |
-          output.urgency === '5'
-        metric: UrgencyAccuracy
-      - type: javascript
-        value: output.suggested_actions.some(action => action.priority === 'high')
-        metric: ActionRelevance
-      - type: llm-rubric
-        value: "Does the query summary accurately reflect the customer's severe complaint and refund request?"
-        metric: SummaryAccuracy
-
-derivedMetrics:
-  - name: 'OverallAccuracy'
-    value: '(CategoryAccuracy + SentimentAccuracy + UrgencyAccuracy + ActionRelevance + SummaryAccuracy) / 5'
-  - name: 'ResponseQuality'
-    value: '(ValidJSON + OverallAccuracy) / 2'
+      city: Mars

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -69,7 +69,8 @@ tests:
       - type: is-json
         metric: ValidJSON
       - type: javascript
-        value: output.category === 'billing'
+        value: |
+          output.category === 'billing'
         metric: CategoryAccuracy
       - type: javascript
         value: output.sentiment === 'negative'
@@ -138,7 +139,8 @@ tests:
         value: output.sentiment === 'negative'
         metric: SentimentAccuracy
       - type: javascript
-        value: output.urgency === '5'
+        value: |
+          output.urgency === '5'
         metric: UrgencyAccuracy
       - type: javascript
         value: output.suggested_actions.some(action => action.priority === 'high')

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -2,68 +2,58 @@ prompts:
   - 'What is the weather like in {{city}}?'
 
 providers:
-  - id: openai:chat:gpt-4o-mini
+  - id: openai:chat:gpt-4o-2024-08-06
     config:
-      tools:
-        [
-          {
-            'type': 'function',
-            'function':
-              {
-                'name': 'get_current_weather',
-                'description': 'Get the current weather in a given location',
-                'parameters':
-                  {
-                    'type': 'object',
-                    'properties':
-                      {
-                        'location':
-                          {
-                            'type': 'string',
-                            'description': 'The city and state, e.g. San Francisco, CA',
-                          },
-                        'unit': { 'type': 'string', 'enum': ['celsius', 'fahrenheit'] },
-                      },
-                    'required': ['location'],
-                  },
-              },
-          },
-        ]
+      response_format:
+        type: json_schema
+        json_schema:
+          name: weather_response
+          strict: true
+          schema:
+            type: object
+            properties:
+              temperature:
+                type: number
+              description:
+                type: string
+              unit:
+                type: string
+                enum: [celsius, fahrenheit]
+            required: [temperature, description, unit]
+            additionalProperties: false
 
 tests:
   - vars:
       city: Boston
     assert:
       - type: is-json
-      - type: is-valid-openai-tools-call
+        value:
+          required:
+            - 'temperature'
+            - 'description'
+            - 'unit'
+          type: object
+          properties:
+            temperature:
+              type: number
+            description:
+              type: string
+            unit:
+              type: string
+              enum: [celsius, fahrenheit]
       - type: javascript
-        value: output[0].function.name === 'get_current_weather'
-      - type: javascript
-        value: JSON.parse(output[0].function.arguments).location === 'Boston, MA'
+        value: typeof output.temperature === 'number' && typeof output.description === 'string' && ['celsius', 'fahrenheit'].includes(output.unit)
 
   - vars:
       city: New York
-    options:
-      # Transform is a cleaner way to pick out specific properties.
-      # This transform returns only the 'name' property
-      transform: output[0].function.name
     assert:
-      - type: equals
-        value: get_current_weather
+      - type: is-json
+      - type: javascript
+        value: Object.keys(output).length === 3
 
   - vars:
       city: Paris
     assert:
-      - type: equals
-        value: get_current_weather
-        # Transform is a cleaner way to pick out specific properties.
-        # This transform returns only the 'name' property
-        transform: output[0].function.name
-      - type: similar
-        value: Paris, France
-        threshold: 0.5
-        # This transform returns only the parsed location argument.
-        transform: JSON.parse(output[0].function.arguments).location
-
-  - vars:
-      city: Mars
+      - type: is-json
+      - type: javascript
+        value: output.unit === 'celsius'

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -73,7 +73,7 @@ Supported parameters include:
 | `organization`          | Your OpenAI organization key.                                                                                                                                   |
 | `passthrough`           | Additional parameters to pass through to the API.                                                                                                               |
 | `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                   |
-| `response_format`       | Response format restrictions.                                                                                                                                   |
+| `response_format`       | Specifies the desired output format, including `json_object` and `json_schema`                                                                                  |
 | `seed`                  | Seed used for deterministic output.                                                                                                                             |
 | `stop`                  | Defines a list of tokens that signal the end of the output.                                                                                                     |
 | `temperature`           | Controls the randomness of the AI's output. Higher values (close to 1) make the output more random, while lower values (close to 0) make it more deterministic. |

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -785,6 +785,18 @@ export async function runAssertion({
         return ret;
       }
       invariant(typeof renderedValue === 'string', 'javascript assertion must have a string value');
+
+      /**
+       * Removes trailing newline from the rendered value.
+       * This is necessary for handling multi-line string literals in YAML
+       * that are defined on a single line in the YAML file.
+       *
+       * @example
+       * value: |
+       *   output === 'true'
+       */
+      renderedValue = renderedValue.trimEnd();
+
       let result: boolean | number | GradingResult;
       if (typeof valueFromScript === 'undefined') {
         const functionBody = renderedValue.includes('\n')

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -140,7 +140,23 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
   function_call?: 'none' | 'auto' | { name: string };
   tools?: OpenAiTool[];
   tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function?: { name: string } };
-  response_format?: { type: 'json_object' };
+  response_format?:
+    | {
+        type: 'json_object';
+      }
+    | {
+        type: 'json_schema';
+        json_schema: {
+          name: string;
+          strict: boolean;
+          schema: {
+            type: 'object';
+            properties: Record<string, any>;
+            required?: string[];
+            additionalProperties: false;
+          };
+        };
+      };
   stop?: string[];
   seed?: number;
   passthrough?: object;
@@ -554,6 +570,12 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     }
     try {
       const message = data.choices[0].message;
+      if (message.refusal) {
+        return {
+          error: `Model refused to generate a response: ${message.refusal}`,
+        };
+      }
+
       let output = '';
       if (message.content && (message.function_call || message.tool_calls)) {
         output = message;
@@ -565,6 +587,15 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       const logProbs = data.choices[0].logprobs?.content?.map(
         (logProbObj: { token: string; logprob: number }) => logProbObj.logprob,
       );
+
+      // Handle structured output
+      if (this.config.response_format?.type === 'json_schema' && typeof output === 'string') {
+        try {
+          output = JSON.parse(output);
+        } catch (error) {
+          logger.error(`Failed to parse JSON output: ${error}`);
+        }
+      }
 
       // Handle function tool callbacks
       const functionCalls = message.function_call ? [message.function_call] : message.tool_calls;

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -573,6 +573,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       if (message.refusal) {
         return {
           error: `Model refused to generate a response: ${message.refusal}`,
+          tokenUsage: getTokenUsage(data, cached),
         };
       }
 


### PR DESCRIPTION
We have received several requests and issues on Discord and GitHub regarding support for OpenAI's Structured Outputs feature. This PR aims to enhance support for structured outputs in our OpenAI provider and includes a working example to help users implement this feature effectively.

## Changes

- **Add OpenAI Structured Output Example**
  - Introduced a new example in `examples/openai-structured-output/` demonstrating how to use OpenAI's Structured Outputs feature with JSON schemas.
- **Update OpenAI Provider to Handle Structured Outputs**
  - Enhanced the `OpenAiChatCompletionProvider` to support the `response_format` parameter with `json_schema` in the type (it already exists in the docs). 
  - Added handling for structured outputs by parsing JSON responses when `response_format` is set to `json_schema`.
  - Implemented checks for model refusals by detecting a `refusal` field in the response and returning an appropriate error message.
- **Improve JavaScript Assertion Handling in YAML**
  - Updated `src/assertions.ts` to trim trailing newlines from JavaScript assertions defined in YAML files.
  - This improvement enhances the handling of multi-line string literals in YAML, preventing potential issues in assertion evaluations.

## Open Questions

- **Handling of Refusals** - The current implementation for handling model refusals requires further discussion. I am not sue how to handle them and would like guidance. 