### PR TITLE
fix: normalize prompts when reading configs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -272,36 +272,33 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
   };
 
   const seenPrompts = new Set<string | Prompt>();
-  const addSeenPrompt = (prompt: string | Prompt) => {
-    if (typeof prompt === 'string') {
-      seenPrompts.add(prompt);
-    } else if (typeof prompt === 'object' && prompt.id) {
-      seenPrompts.add(prompt);
-    } else {
-      throw new Error('Invalid prompt object');
-    }
-  };
-  configs.forEach((config, idx) => {
+  for (const [idx, config] of configs.entries()) {
     if (typeof config.prompts === 'string') {
       invariant(Array.isArray(prompts), 'Cannot mix string and map-type prompts');
       const absolutePrompt = makeAbsolute(configPaths[idx], config.prompts);
-      addSeenPrompt(absolutePrompt);
+      seenPrompts.add(absolutePrompt);
     } else if (Array.isArray(config.prompts)) {
       invariant(Array.isArray(prompts), 'Cannot mix configs with map and array-type prompts');
-      config.prompts.forEach((prompt) => {
+      logger.warn(`config.prompts: ${JSON.stringify(config.prompts)}`);
+      const parsedPrompts = await readPrompts(config.prompts, path.dirname(configPaths[idx]));
+      logger.error(`parsedPrompts: ${JSON.stringify(parsedPrompts)}`);
+      for (const prompt of parsedPrompts) {
         invariant(
           typeof prompt === 'string' ||
             (typeof prompt === 'object' && typeof prompt.raw === 'string'),
           'Invalid prompt',
         );
-        addSeenPrompt(makeAbsolute(configPaths[idx], prompt as string | Prompt));
-      });
+        seenPrompts.add(prompt as Prompt);
+      }
     } else {
       // Object format such as { 'prompts/prompt1.txt': 'foo', 'prompts/prompt2.txt': 'bar' }
-      invariant(typeof prompts === 'object', 'Cannot mix configs with map and array-type prompts');
+      invariant(
+        typeof prompts === 'object',
+        'Cannot mix configs with map and array-type prompts',
+      );
       prompts = { ...prompts, ...config.prompts };
     }
-  });
+  }
   if (Array.isArray(prompts)) {
     prompts.push(...Array.from(seenPrompts));
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -246,15 +246,17 @@ export async function readConfigs(configPaths: string[]): Promise<UnifiedConfig>
     }
   }
 
-  const seenPrompts = new Set<string | Prompt>();
+  const seenPrompts = new Map<string, Prompt>();
   for (const [idx, config] of configs.entries()) {
     const parsedPrompts = await readPrompts(config.prompts, path.dirname(configPaths[idx]));
     for (const prompt of parsedPrompts) {
-      seenPrompts.add(prompt as Prompt);
-      logger.warn(`Prompt ${prompt.label} is duplicated in config ${configPaths[idx]}`);
+      const key = typeof prompt === 'string' ? prompt : prompt.raw;
+      if (!seenPrompts.has(key)) {
+        seenPrompts.set(key, prompt as Prompt);
+      }
     }
   }
-  const prompts: UnifiedConfig['prompts'] = Array.from(seenPrompts);
+  const prompts: UnifiedConfig['prompts'] = Array.from(seenPrompts.values());
 
   // Combine all configs into a single UnifiedConfig
   const combinedConfig: UnifiedConfig = {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,8 +3,9 @@ import { globSync } from 'glob';
 import * as path from 'path';
 import cliState from '../src/cliState';
 import { dereferenceConfig, readConfigs, resolveConfigs } from '../src/config';
+import { readPrompts } from '../src/prompts';
 import { readTests } from '../src/testCases';
-import type { UnifiedConfig } from '../src/types';
+import type { Prompt, UnifiedConfig } from '../src/types';
 import { maybeLoadFromExternalFile } from '../src/util';
 
 jest.mock('../src/database', () => ({
@@ -54,6 +55,12 @@ jest.mock('../src/testCases', () => {
     readTests: jest.fn(originalModule.readTests),
   };
 });
+
+// At the top of the file, update the mock
+jest.mock('../src/prompts', () => ({
+  ...jest.requireActual('../src/prompts'),
+  readPrompts: jest.fn(),
+}));
 
 describe('readConfigs', () => {
   beforeEach(() => {
@@ -135,16 +142,38 @@ describe('readConfigs', () => {
       throw new Error('File does not exist');
     });
 
+    // Update the mock implementation
+    jest
+      .mocked(readPrompts)
+      .mockImplementation((prompts) =>
+        Promise.resolve(
+          Array.isArray(prompts)
+            ? prompts.map(
+                (p): Prompt =>
+                  typeof p === 'string'
+                    ? { raw: p, config: undefined, label: p }
+                    : { raw: p.raw || '', config: p.config || {}, label: p.label || '' },
+              )
+            : typeof prompts === 'string'
+              ? [{ raw: prompts, config: {}, label: prompts }]
+              : Object.entries(prompts).map(
+                  ([key, value]): Prompt => ({ raw: value, config: {}, label: key }),
+                ),
+        ),
+      );
+
     const config1Result = await readConfigs(['config1.json']);
     expect(config1Result).toEqual({
       description: 'test1',
       tags: { tag1: 'value1' },
       providers: ['provider1'],
-      prompts: [{
-        raw: 'prompt1',
-        config: undefined, 
-        label: 'prompt1',
-      }],
+      prompts: [
+        {
+          raw: 'prompt1',
+          config: undefined,
+          label: 'prompt1',
+        },
+      ],
       extensions: [],
       tests: ['test1'],
       scenarios: ['scenario1'],
@@ -173,11 +202,13 @@ describe('readConfigs', () => {
       description: 'test2',
       tags: {},
       providers: ['provider2'],
-      prompts: [{
-        raw: 'prompt2',
-        config: undefined,
-        label: 'prompt2',
-      }],
+      prompts: [
+        {
+          raw: 'prompt2',
+          config: undefined,
+          label: 'prompt2',
+        },
+      ],
       extensions: [],
       tests: ['test2'],
       scenarios: ['scenario2'],
@@ -208,15 +239,18 @@ describe('readConfigs', () => {
       description: 'test1, test2',
       tags: { tag1: 'value1' },
       providers: ['provider1', 'provider2'],
-      prompts: [{
-        raw: 'prompt1',
-        config: undefined,
-        label: 'prompt1',
-      }, {
-        raw: 'prompt2',
-        config: undefined,
-        label: 'prompt2',
-      }],
+      prompts: [
+        {
+          raw: 'prompt1',
+          config: undefined,
+          label: 'prompt1',
+        },
+        {
+          raw: 'prompt2',
+          config: undefined,
+          label: 'prompt2',
+        },
+      ],
       tests: ['test1', 'test2'],
       extensions: [],
       scenarios: ['scenario1', 'scenario2'],
@@ -252,79 +286,53 @@ describe('readConfigs', () => {
     );
   });
 
-  it('makeAbsolute should resolve file:// syntax and plaintext prompts', async () => {
+  fit('de-duplicates prompts when reading configs', async () => {
     jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest
-      .mocked(fs.readFileSync)
-      .mockImplementation(
-        (
-          path: fs.PathOrFileDescriptor,
-          options?: fs.ObjectEncodingOptions | BufferEncoding | null,
-        ): string | Buffer => {
-          if (typeof path === 'string' && path === 'config1.json') {
-            return JSON.stringify({
-              description: 'test1',
-              prompts: ['file://prompt1.txt', 'prompt2'],
-            });
-          } else if (typeof path === 'string' && path === 'config2.json') {
-            return JSON.stringify({
-              description: 'test2',
-              prompts: ['file://prompt3.txt', 'prompt4'],
-            });
-          }
-          return Buffer.from(''); // Return an empty Buffer instead of null
-        },
-      );
+    jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob].flat());
+    jest.mocked(fs.readFileSync).mockImplementation((path: fs.PathOrFileDescriptor) => {
+      if (typeof path === 'string' && path === 'config1.json') {
+        return JSON.stringify({
+          description: 'test1',
+          prompts: ['prompt1', 'file://prompt2.txt', 'prompt3'],
+        });
+      } else if (typeof path === 'string' && path === 'config2.json') {
+        return JSON.stringify({
+          description: 'test2',
+          prompts: ['prompt3', 'file://prompt2.txt', 'prompt4'],
+        });
+      }
+      return Buffer.from('');
+    });
+
+    // Update the mock implementation
+    jest.mocked(readPrompts).mockImplementation((prompts) =>
+      Promise.resolve(
+        Array.isArray(prompts)
+          ? prompts.map(
+              (p): Prompt =>
+                typeof p === 'string'
+                  ? {
+                      raw: p.startsWith('file://') ? `${p} content` : p,
+                      config: undefined,
+                      label: p.startsWith('file://') ? p.slice(7) : p,
+                    }
+                  : { raw: p.raw || '', config: p.config || {}, label: p.label || '' },
+            )
+          : typeof prompts === 'string'
+            ? [{ raw: prompts, config: {}, label: prompts }]
+            : Object.entries(prompts).map(
+                ([key, value]): Prompt => ({ raw: value, config: {}, label: key }),
+              ),
+      ),
+    );
 
     const configPaths = ['config1.json', 'config2.json'];
     const result = await readConfigs(configPaths);
-
     expect(result.prompts).toEqual([
-      {
-        raw: 'prompt1',
-        config: undefined,
-        label: 'prompt1',
-      },
-      {
-        raw: 'prompt2',
-        config: undefined,
-        label: 'prompt2',
-      },
-    ]);
-  });
-
-  it('de-duplicates prompts when reading configs', async () => {
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest
-      .mocked(fs.readFileSync)
-      .mockImplementation(
-        (
-          path: fs.PathOrFileDescriptor,
-          options?: fs.ObjectEncodingOptions | BufferEncoding | null,
-        ): string | Buffer => {
-          if (typeof path === 'string' && path === 'config1.json') {
-            return JSON.stringify({
-              description: 'test1',
-              prompts: ['prompt1', 'file://prompt2.txt', 'prompt3'],
-            });
-          } else if (typeof path === 'string' && path === 'config2.json') {
-            return JSON.stringify({
-              description: 'test2',
-              prompts: ['prompt3', 'file://prompt2.txt', 'prompt4'],
-            });
-          }
-          return Buffer.from(''); // Return an empty Buffer instead of null
-        },
-      );
-
-    const configPaths = ['config1.json', 'config2.json'];
-    const result = await readConfigs(configPaths);
-
-    expect(result.prompts).toEqual([
-      'prompt1',
-      `file://${path.resolve(path.dirname(configPaths[0]), 'prompt2.txt')}`,
-      'prompt3',
-      'prompt4',
+      { config: undefined, label: 'prompt1', raw: 'prompt1' },
+      { config: undefined, label: 'prompt2.txt', raw: 'file://prompt2.txt content' },
+      { config: undefined, label: 'prompt3', raw: 'prompt3' },
+      { config: undefined, label: 'prompt4', raw: 'prompt4' },
     ]);
   });
 
@@ -333,11 +341,13 @@ describe('readConfigs', () => {
       defaultTest: {
         metadata: { key1: 'value1' },
       },
+      prompts: ['prompt1'],
     };
     const config2 = {
       defaultTest: {
         metadata: { key2: 'value2' },
       },
+      prompts: ['prompt2'],
     };
 
     jest
@@ -356,9 +366,11 @@ describe('readConfigs', () => {
   it('combines extensions from multiple configs', async () => {
     const config1 = {
       extensions: ['extension1', 'extension2'],
+      prompts: ['prompt1'],
     };
     const config2 = {
       extensions: ['extension3'],
+      prompts: ['prompt2'],
     };
 
     jest
@@ -375,9 +387,11 @@ describe('readConfigs', () => {
   it('handles configs without extensions', async () => {
     const config1 = {
       description: 'Config without extensions',
+      prompts: ['prompt1'],
     };
     const config2 = {
       extensions: ['extension1'],
+      prompts: ['prompt2'],
     };
 
     jest
@@ -396,11 +410,13 @@ describe('readConfigs', () => {
       .mockReturnValueOnce(
         JSON.stringify({
           extensions: ['extension1'],
+          prompts: ['prompt1'],
         }),
       )
       .mockReturnValueOnce(
         JSON.stringify({
           extensions: ['extension2'],
+          prompts: ['prompt2'],
         }),
       );
 
@@ -421,11 +437,13 @@ describe('readConfigs', () => {
       .mockReturnValueOnce(
         JSON.stringify({
           extensions: ['extension1', 'extension2'],
+          prompts: ['prompt1'],
         }),
       )
       .mockReturnValueOnce(
         JSON.stringify({
           description: 'Config without extensions',
+          prompts: ['prompt2'],
         }),
       );
 
@@ -652,6 +670,26 @@ describe('resolveConfigs', () => {
       }),
     );
 
+    // Mock readPrompts to handle string input
+    jest
+      .mocked(readPrompts)
+      .mockImplementation((prompts) =>
+        Promise.resolve(
+          Array.isArray(prompts)
+            ? prompts.map(
+                (p): Prompt =>
+                  typeof p === 'string'
+                    ? { raw: p, config: undefined, label: p }
+                    : { raw: p.raw || '', config: p.config || {}, label: p.label || '' },
+              )
+            : typeof prompts === 'string'
+              ? [{ raw: prompts, config: {}, label: prompts }]
+              : Object.entries(prompts).map(
+                  ([key, value]): Prompt => ({ raw: value, config: {}, label: key }),
+                ),
+        ),
+      );
+
     await resolveConfigs(cmdObj, defaultConfig);
 
     expect(cliState.basePath).toBe(path.dirname('config.json'));
@@ -688,37 +726,55 @@ describe('resolveConfigs', () => {
 
     jest.mocked(globSync).mockReturnValue(['config.json']);
 
+    // Update the mock implementation
+    jest
+      .mocked(readPrompts)
+      .mockImplementation((prompts) =>
+        Promise.resolve(
+          Array.isArray(prompts)
+            ? prompts.map(
+                (p): Prompt =>
+                  typeof p === 'string'
+                    ? { raw: p, config: undefined, label: p }
+                    : { raw: p.raw || '', config: p.config || {}, label: p.label || '' },
+              )
+            : typeof prompts === 'string'
+              ? [{ raw: prompts, config: {}, label: prompts }]
+              : Object.entries(prompts).map(
+                  ([key, value]): Prompt => ({ raw: value, config: {}, label: key }),
+                ),
+        ),
+      );
+
     const { testSuite } = await resolveConfigs(cmdObj, defaultConfig);
 
     expect(maybeLoadFromExternalFile).toHaveBeenCalledWith(['file://scenarios.yaml']);
     expect(maybeLoadFromExternalFile).toHaveBeenCalledWith('file://tests.yaml');
-    expect(testSuite).toEqual(
-      expect.objectContaining({
-        prompts: [
-          {
-            raw: prompt,
-            label: prompt,
-            config: undefined,
-          },
-        ],
-        providers: expect.arrayContaining([
-          expect.objectContaining({
-            modelName: 'gpt-4',
-          }),
-        ]),
-        scenarios: ['file://scenarios.yaml'],
-        tests: externalTests,
-        defaultTest: {
-          assert: [],
-          metadata: {},
-          options: {},
-          vars: {},
+    expect(testSuite).toMatchObject({
+      prompts: [
+        {
+          raw: prompt,
+          label: prompt,
+          config: {},
         },
-        derivedMetrics: undefined,
-        extensions: [],
-        nunjucksFilters: {},
-        providerPromptMap: {},
-      }),
-    );
+      ],
+      providers: expect.arrayContaining([
+        expect.objectContaining({
+          modelName: 'gpt-4',
+        }),
+      ]),
+      scenarios: ['file://scenarios.yaml'],
+      tests: externalTests,
+      defaultTest: {
+        assert: [],
+        metadata: {},
+        options: {},
+        vars: {},
+      },
+      derivedMetrics: undefined,
+      extensions: [],
+      nunjucksFilters: {},
+      providerPromptMap: {},
+    });
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -140,7 +140,11 @@ describe('readConfigs', () => {
       description: 'test1',
       tags: { tag1: 'value1' },
       providers: ['provider1'],
-      prompts: ['prompt1'],
+      prompts: [{
+        raw: 'prompt1',
+        config: undefined, 
+        label: 'prompt1',
+      }],
       extensions: [],
       tests: ['test1'],
       scenarios: ['scenario1'],
@@ -169,7 +173,11 @@ describe('readConfigs', () => {
       description: 'test2',
       tags: {},
       providers: ['provider2'],
-      prompts: ['prompt2'],
+      prompts: [{
+        raw: 'prompt2',
+        config: undefined,
+        label: 'prompt2',
+      }],
       extensions: [],
       tests: ['test2'],
       scenarios: ['scenario2'],
@@ -200,7 +208,15 @@ describe('readConfigs', () => {
       description: 'test1, test2',
       tags: { tag1: 'value1' },
       providers: ['provider1', 'provider2'],
-      prompts: ['prompt1', 'prompt2'],
+      prompts: [{
+        raw: 'prompt1',
+        config: undefined,
+        label: 'prompt1',
+      }, {
+        raw: 'prompt2',
+        config: undefined,
+        label: 'prompt2',
+      }],
       tests: ['test1', 'test2'],
       extensions: [],
       scenarios: ['scenario1', 'scenario2'],
@@ -264,10 +280,16 @@ describe('readConfigs', () => {
     const result = await readConfigs(configPaths);
 
     expect(result.prompts).toEqual([
-      `file://${path.resolve(path.dirname(configPaths[0]), 'prompt1.txt')}`,
-      'prompt2',
-      `file://${path.resolve(path.dirname(configPaths[1]), 'prompt3.txt')}`,
-      'prompt4',
+      {
+        raw: 'prompt1',
+        config: undefined,
+        label: 'prompt1',
+      },
+      {
+        raw: 'prompt2',
+        config: undefined,
+        label: 'prompt2',
+      },
     ]);
   });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -286,7 +286,7 @@ describe('readConfigs', () => {
     );
   });
 
-  fit('de-duplicates prompts when reading configs', async () => {
+  it('de-duplicates prompts when reading configs', async () => {
     jest.mocked(fs.existsSync).mockReturnValue(true);
     jest.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob].flat());
     jest.mocked(fs.readFileSync).mockImplementation((path: fs.PathOrFileDescriptor) => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -142,7 +142,6 @@ describe('readConfigs', () => {
       throw new Error('File does not exist');
     });
 
-    // Update the mock implementation
     jest
       .mocked(readPrompts)
       .mockImplementation((prompts) =>
@@ -304,7 +303,6 @@ describe('readConfigs', () => {
       return Buffer.from('');
     });
 
-    // Update the mock implementation
     jest.mocked(readPrompts).mockImplementation((prompts) =>
       Promise.resolve(
         Array.isArray(prompts)
@@ -726,7 +724,6 @@ describe('resolveConfigs', () => {
 
     jest.mocked(globSync).mockReturnValue(['config.json']);
 
-    // Update the mock implementation
     jest
       .mocked(readPrompts)
       .mockImplementation((prompts) =>


### PR DESCRIPTION
This normalizes our prompts earlier when reading the config. It does not narrow the type yet. This fixes issue with prompt-labels example not working correctly and an issue reported via email. 