### PR TITLE
chore(providers): add openai assistant's token usage

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -878,13 +878,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
 
     return {
       output: outputBlocks.join('\n\n').trim(),
-      /*
-      tokenUsage: {
-        total: data.usage.total_tokens,
-        prompt: data.usage.prompt_tokens,
-        completion: data.usage.completion_tokens,
-      },
-      */
+      tokenUsage: getTokenUsage(run, false),
     };
   }
 }


### PR DESCRIPTION
OpenAI assistant provides tokenUsage on the run object https://platform.openai.com/docs/api-reference/runs/getRun

Passing this as an output will make the structure consistent with other openAI functions