### PR TITLE
fix(providers): improve parseMessages function for anthropic

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -6,6 +6,8 @@ sidebar_position: 10
 
 This provider supports the [Anthropic Claude](https://www.anthropic.com/claude) series of models.
 
+> **Note:** Anthropic models can also be accessed through Amazon Bedrock. For information on using Anthropic models via Bedrock, please refer to our [AWS Bedrock documentation](/docs/providers/aws-bedrock).
+
 ## Setup
 
 To use Anthropic, you need to set the `ANTHROPIC_API_KEY` environment variable or specify the `apiKey` in the provider configuration.

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -86,7 +86,7 @@ Example configuration with options and prompts:
 
 ```yaml
 providers:
-  - id: anthropic:messages:claude-3-opus-20240229
+  - id: anthropic:messages:claude-3-5-sonnet-20240620
     config:
       temperature: 0.0
       max_tokens: 512
@@ -100,7 +100,7 @@ The Anthropic provider supports tool use (or function calling). Here's an exampl
 
 ```yaml
 providers:
-  - id: anthropic:messages:claude-3-opus-20240229
+  - id: anthropic:messages:claude-3-5-sonnet-20240620
     config:
       tools:
         - name: get_weather
@@ -180,9 +180,9 @@ The easiest way to do this for _all_ your test cases is to add the [`defaultTest
 defaultTest:
   options:
     provider:
-      id: anthropic:messages:claude-3-opus-20240229
+      id: anthropic:messages:claude-3-5-sonnet-20240620
       config:
-        # Provider config options
+        # optional provider config options
 ```
 
 However, you can also do this for individual assertions:
@@ -193,9 +193,9 @@ assert:
   - type: llm-rubric
     value: Do not mention that you are an AI or chat assistant
     provider:
-      id: anthropic:messages:claude-3-opus-20240229
+      id: anthropic:messages:claude-3-5-sonnet-20240620
       config:
-        # Provider config options
+        # optional provider config options
 ```
 
 Or individual tests:
@@ -207,9 +207,9 @@ tests:
       # ...
     options:
       provider:
-        id: anthropic:messages:claude-3-opus-20240229
+        id: anthropic:messages:claude-3-5-sonnet-20240620
         config:
-          # Provider config options
+          # optional provider config options
     assert:
       - type: llm-rubric
         value: Do not mention that you are an AI or chat assistant

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -116,7 +116,10 @@ interface AnthropicMessageInput {
   cache_control?: { type: 'ephemeral' };
 }
 
-export function parseMessages(messages: string) {
+export function parseMessages(messages: string): {
+  system?: Anthropic.TextBlockParam[];
+  extractedMessages: Anthropic.MessageParam[];
+} {
   // We need to be able to handle the 'system' role prompts that
   // are in the style of OpenAI's chat prompts.
   // As a result, AnthropicMessageInput is the same as Anthropic.MessageParam
@@ -139,7 +142,13 @@ export function parseMessages(messages: string) {
         return { role, content };
       }
     });
-  return { system, extractedMessages };
+  if (extractedMessages.length === 0 && system) {
+    return {
+      system: undefined,
+      extractedMessages: [{ role: 'user', content: [{ type: 'text', text: system }] }],
+    };
+  }
+  return { system: system ? [{ type: 'text', text: system }] : undefined, extractedMessages };
 }
 
 export function calculateCost(

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -4,7 +4,6 @@ import { getEnvString, getEnvFloat, getEnvInt } from '../envars';
 import logger from '../logger';
 import type { ApiProvider, EnvOverrides, ProviderResponse, TokenUsage } from '../types';
 import { maybeLoadFromExternalFile } from '../util';
-import { parseChatPrompt } from './shared';
 
 const ANTHROPIC_MODELS = [
   ...['claude-instant-1.2'].map((model) => ({
@@ -110,45 +109,55 @@ export function outputFromMessage(message: Anthropic.Messages.Message) {
     .join('\n\n');
 }
 
-interface AnthropicMessageInput {
-  role: 'user' | 'assistant' | 'system';
-  content: string | Array<Anthropic.ImageBlockParam | Anthropic.TextBlockParam>;
-  cache_control?: { type: 'ephemeral' };
-}
-
 export function parseMessages(messages: string): {
   system?: Anthropic.TextBlockParam[];
   extractedMessages: Anthropic.MessageParam[];
 } {
-  // We need to be able to handle the 'system' role prompts that
-  // are in the style of OpenAI's chat prompts.
-  // As a result, AnthropicMessageInput is the same as Anthropic.MessageParam
-  // just with the system role added on
-  const chats = parseChatPrompt<AnthropicMessageInput[]>(messages, [
-    { role: 'user' as const, content: messages },
-  ]);
-  // Convert from OpenAI to Anthropic format
-  const systemMessage = chats.find((m) => m.role === 'system')?.content;
-  const system = typeof systemMessage === 'string' ? systemMessage : undefined;
-  const extractedMessages: Anthropic.MessageParam[] = chats
-    .filter((m) => m.role === 'user' || m.role === 'assistant')
-    .map((m) => {
-      const role = m.role as 'user' | 'assistant';
-      if (typeof m.content === 'string') {
-        const content = [{ type: 'text' as const, text: m.content }];
-        return { role, content };
-      } else {
-        const content = [...m.content];
-        return { role, content };
-      }
-    });
-  if (extractedMessages.length === 0 && system) {
-    return {
-      system: undefined,
-      extractedMessages: [{ role: 'user', content: [{ type: 'text', text: system }] }],
-    };
+  const lines = messages
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line);
+  let system: Anthropic.TextBlockParam[] | undefined;
+  const extractedMessages: Anthropic.MessageParam[] = [];
+  let currentRole: 'user' | 'assistant' | null = null;
+  let currentContent: string[] = [];
+
+  const pushMessage = () => {
+    if (currentRole && currentContent.length > 0) {
+      extractedMessages.push({
+        role: currentRole,
+        content: [{ type: 'text', text: currentContent.join('\n') }],
+      });
+      currentContent = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('system:')) {
+      system = [{ type: 'text', text: line.slice(7).trim() }];
+    } else if (line.startsWith('user:') || line.startsWith('assistant:')) {
+      pushMessage();
+      currentRole = line.startsWith('user:') ? 'user' : 'assistant';
+      currentContent.push(line.slice(line.indexOf(':') + 1).trim());
+    } else if (currentRole) {
+      currentContent.push(line);
+    } else {
+      // If no role is set, assume it's a user message
+      currentRole = 'user';
+      currentContent.push(line);
+    }
   }
-  return { system: system ? [{ type: 'text', text: system }] : undefined, extractedMessages };
+
+  pushMessage();
+
+  if (extractedMessages.length === 0 && !system) {
+    extractedMessages.push({
+      role: 'user',
+      content: [{ type: 'text', text: messages.trim() }],
+    });
+  }
+
+  return { system, extractedMessages };
 }
 
 export function calculateCost(

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -673,5 +673,28 @@ describe('Anthropic', () => {
         },
       ]);
     });
+
+    it('should handle multi-line messages', () => {
+      const inputMessages = dedent`
+        user: This is a
+        multi-line
+        message
+        assistant: And this is a
+        multi-line response`;
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toBeUndefined();
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'This is a\nmulti-line\nmessage' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'And this is a\nmulti-line response' }],
+        },
+      ]);
+    });
   });
 });

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -561,16 +561,14 @@ describe('Anthropic', () => {
       const { system, extractedMessages } = parseMessages(inputMessages);
 
       expect(system).toBeUndefined();
-      expect(extractedMessages).toMatchObject([
+      expect(extractedMessages).toEqual([
         {
           role: 'user',
-          content: [
-            {
-              type: 'text',
-              text: dedent`user: What is the weather?
-                    assistant: The weather is sunny.`,
-            },
-          ],
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'The weather is sunny.' }],
         },
       ]);
     });
@@ -582,18 +580,15 @@ describe('Anthropic', () => {
 
       const { system, extractedMessages } = parseMessages(inputMessages);
 
-      expect(system).toBeUndefined();
-      expect(extractedMessages).toMatchObject([
+      expect(system).toEqual([{ type: 'text', text: 'This is a system message.' }]);
+      expect(extractedMessages).toEqual([
         {
           role: 'user',
-          content: [
-            {
-              type: 'text',
-              text: dedent`system: This is a system message.
-              user: What is the weather?
-              assistant: The weather is sunny.`,
-            },
-          ],
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'The weather is sunny.' }],
         },
       ]);
     });
@@ -604,10 +599,77 @@ describe('Anthropic', () => {
       const { system, extractedMessages } = parseMessages(inputMessages);
 
       expect(system).toBeUndefined();
-      expect(extractedMessages).toMatchObject([
+      expect(extractedMessages).toEqual([
         {
           role: 'user',
           content: [{ type: 'text', text: '' }],
+        },
+      ]);
+    });
+
+    it('should handle only system message', () => {
+      const inputMessages = 'system: This is a system message.';
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toEqual([{ type: 'text', text: 'This is a system message.' }]);
+      expect(extractedMessages).toEqual([]);
+    });
+
+    it('should handle messages with image content', () => {
+      const inputMessages = dedent`user: Here's an image: [image-1.jpg]
+        assistant: I see the image.`;
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toBeUndefined();
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: "Here's an image: [image-1.jpg]" }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'I see the image.' }],
+        },
+      ]);
+    });
+
+    it('should handle multiple messages of the same role', () => {
+      const inputMessages = dedent`
+        user: First question
+        user: Second question
+        assistant: Here's the answer`;
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toBeUndefined();
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'First question' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Second question' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: "Here's the answer" }],
+        },
+      ]);
+    });
+
+    it('should handle a single user message', () => {
+      const inputMessages = 'Hello, Claude';
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toBeUndefined();
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello, Claude' }],
         },
       ]);
     });


### PR DESCRIPTION
This PR 

- Rewrites parseMessages to correctly handle system messages, multiple roles, and multi-line content
- Update test cases to cover various scenarios including system messages, image content, and multi-line messages

Previously, the Anthropic provider could not be used to override the default text provider, either through the native Anthropic API or via Amazon Bedrock. The following configuration now works correctly:

```yaml
prompts:
  - "Write a tweet about {{topic}}"
  - "Write a very concise, funny tweet about {{topic}}"

providers:
  - id: bedrock:anthropic.claude-3-5-sonnet-20240620-v1:0
    config:
      region: "us-east-1"
      temperature: 0.7
      max_tokens: 200000

tests:
  - vars:
      topic: bananas
    assert:
      - type: select-best
        value: choose the funniest tweet
  - vars:
      topic: nyc
    assert:
      - type: select-best
        value: choose the tweet that contains the most facts

defaultTest:
  options:
    provider:
      text:
        id: bedrock:anthropic.claude-3-5-sonnet-20240620-v1:0
        # or 
        # id: anthropic:messages:claude-3-5-sonnet-20240620
        config:
          region: us-east-1
```

Previously, this configuration would fail in the main branch, particularly the `defaultTest` section specifying the Anthropic provider via Bedrock as the default text provider.