### PR TITLE
fix(assertions): fix latencyMs comparison with undefined to allow 0 ms latency

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1288,7 +1288,7 @@ ${
     if (!assertion.threshold) {
       throw new Error('Latency assertion must have a threshold in milliseconds');
     }
-    if (!latencyMs) {
+    if (latencyMs === undefined) {
       throw new Error(
         'Latency assertion does not support cached results. Rerun the eval with --no-cache',
       );


### PR DESCRIPTION
Context: https://github.com/promptfoo/promptfoo/issues/1667

and https://github.com/promptfoo/promptfoo/blob/main/src/evaluator.ts#L277

0 ms latency happens when the provider run is blazingly fast