### PR TITLE
feat(webui): display custom namedScores

### DIFF
--- a/src/assertions/AssertionsResult.ts
+++ b/src/assertions/AssertionsResult.ts
@@ -70,6 +70,14 @@ export class AssertionsResult {
       this.namedScores[metric] = (this.namedScores[metric] || 0) + result.score;
     }
 
+    if (result.namedScores) {
+      Object.entries(result.namedScores).forEach(([metricName, score]) => {
+        if (metricName !== metric) {
+          this.namedScores[metricName] = (this.namedScores[metricName] || 0) + score;
+        }
+      });
+    }
+
     if (result.tokensUsed) {
       this.tokensUsed.total += result.tokensUsed.total || 0;
       this.tokensUsed.prompt += result.tokensUsed.prompt || 0;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -402,6 +402,7 @@ class Evaluator {
               cached: 0,
             },
             namedScores: {},
+            namedScoresCount: {},
             cost: 0,
           },
         };
@@ -653,6 +654,7 @@ class Evaluator {
       metrics.score += row.score;
       for (const [key, value] of Object.entries(row.namedScores)) {
         metrics.namedScores[key] = (metrics.namedScores[key] || 0) + value;
+        metrics.namedScoresCount[key] = (metrics.namedScoresCount[key] || 0) + 1;
       }
 
       if (testSuite.derivedMetrics) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,6 +156,7 @@ export const CompletedPromptSchema = PromptSchema.extend({
       totalLatencyMs: z.number(),
       tokenUsage: TokenUsageSchema,
       namedScores: z.record(z.string(), z.number()),
+      namedScoresCount: z.record(z.string(), z.number()),
       cost: z.number(),
     })
     .optional(),

--- a/src/web/nextui/src/app/eval/CustomMetrics.tsx
+++ b/src/web/nextui/src/app/eval/CustomMetrics.tsx
@@ -5,12 +5,14 @@ const NUM_METRICS_TO_DISPLAY_ABOVE_FOLD = 10;
 
 interface CustomMetricsProps {
   lookup: Record<string, number>;
+  counts?: Record<string, number>;
   metricTotals?: Record<string, number>;
   onSearchTextChange?: (searchText: string) => void;
 }
 
 const CustomMetrics: React.FC<CustomMetricsProps> = ({
   lookup,
+  counts,
   metricTotals,
   onSearchTextChange,
 }) => {
@@ -36,6 +38,11 @@ const CustomMetrics: React.FC<CustomMetricsProps> = ({
               <>
                 {((score / metricTotals[metric]) * 100).toFixed(2)}% ({score.toFixed(2)}/
                 {metricTotals[metric].toFixed(2)})
+              </>
+            ) : counts && counts[metric] ? (
+              <>
+                {(score / counts[metric]).toFixed(2)} ({score.toFixed(2)}/
+                {counts[metric].toFixed(2)})
               </>
             ) : (
               score.toFixed(2)

--- a/src/web/nextui/src/app/eval/ResultsTable.tsx
+++ b/src/web/nextui/src/app/eval/ResultsTable.tsx
@@ -494,6 +494,7 @@ function ResultsTable({
                     Object.keys(prompt.metrics.namedScores).length > 0 ? (
                       <CustomMetrics
                         lookup={prompt.metrics.namedScores}
+                        counts={prompt.metrics.namedScoresCount}
                         metricTotals={metricTotals}
                         onSearchTextChange={onSearchTextChange}
                       />


### PR DESCRIPTION
Addresses issue raised in https://github.com/promptfoo/promptfoo/issues/1626

Given a custom assertion that sets some `namedScores` such as:
```
def get_assert(output, context):
    return {
      'pass': True,
      'score': 0.11,
      'reason': 'Looks good to me',
      'namedScores': {
         'answer_similarity': 0.12,
         'answer_correctness': 0.13,
         'answer_relevancy': 0.14,
      }
    }
```

Render something like:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/3bce25ea-632e-43fa-9c12-ed2536bc69c7">

Note that [docs](https://www.promptfoo.dev/docs/configuration/expected-outputs/python/) indicate `named_scores` is the correct field name but currently only snake case is supported.

It might be interesting to allow different types of aggregation and formatting of top-level metrics. This also does not support `namedScores` that are nested in `GradingResults.componentResults`.