### PR TITLE
refactor(providers): centralize cost calculation logic

### DIFF
--- a/src/providers/ai21.ts
+++ b/src/providers/ai21.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import type { ApiProvider, EnvOverrides, ProviderResponse, TokenUsage } from '../types';
-import { REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
+import { calculateCost, REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
 
 const AI21_CHAT_MODELS = [
   {
@@ -47,24 +47,13 @@ function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
   return {};
 }
 
-function calculateCost(
+function calculateAI21Cost(
   modelName: string,
   config: AI21ChatCompletionOptions,
   promptTokens?: number,
   completionTokens?: number,
 ): number | undefined {
-  if (!promptTokens || !completionTokens) {
-    return undefined;
-  }
-
-  const model = AI21_CHAT_MODELS.find((m) => m.id === modelName);
-  if (!model || !model.cost) {
-    return undefined;
-  }
-
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
-  return inputCost * promptTokens + outputCost * completionTokens || undefined;
+  return calculateCost(modelName, config, promptTokens, completionTokens, AI21_CHAT_MODELS);
 }
 
 export class AI21ChatCompletionProvider implements ApiProvider {
@@ -185,7 +174,7 @@ export class AI21ChatCompletionProvider implements ApiProvider {
       output: data.choices[0].message.content,
       tokenUsage: getTokenUsage(data, cached),
       cached,
-      cost: calculateCost(
+      cost: calculateAI21Cost(
         this.modelName,
         this.config,
         data.usage?.prompt_tokens,

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -1,8 +1,70 @@
 import yaml from 'js-yaml';
 import { getEnvBool, getEnvInt } from '../envars';
 
+/**
+ * The default timeout for API requests in milliseconds.
+ */
 export const REQUEST_TIMEOUT_MS = getEnvInt('REQUEST_TIMEOUT_MS', 300_000);
 
+interface ModelCost {
+  input: number;
+  output: number;
+}
+
+interface ProviderModel {
+  id: string;
+  cost?: ModelCost;
+}
+
+interface ProviderConfig {
+  cost?: number;
+}
+
+/**
+ * Calculates the cost of an API call based on the model and token usage.
+ *
+ * @param {string} modelName The name of the model used.
+ * @param {ProviderConfig} config The provider configuration.
+ * @param {number | undefined} promptTokens The number of tokens in the prompt.
+ * @param {number | undefined} completionTokens The number of tokens in the completion.
+ * @param {ProviderModel[]} models An array of available models with their costs.
+ * @returns {number | undefined} The calculated cost, or undefined if it can't be calculated.
+ */
+export function calculateCost(
+  modelName: string,
+  config: ProviderConfig,
+  promptTokens: number | undefined,
+  completionTokens: number | undefined,
+  models: ProviderModel[],
+): number | undefined {
+  if (
+    !Number.isFinite(promptTokens) ||
+    !Number.isFinite(completionTokens) ||
+    typeof promptTokens === 'undefined' ||
+    typeof completionTokens === 'undefined'
+  ) {
+    return undefined;
+  }
+
+  const model = models.find((m) => m.id === modelName);
+  if (!model || !model.cost) {
+    return undefined;
+  }
+
+  const inputCost = config.cost ?? model.cost.input;
+  const outputCost = config.cost ?? model.cost.output;
+  return inputCost * promptTokens + outputCost * completionTokens || undefined;
+}
+
+/**
+ * Parses a chat prompt string into a structured format.
+ *
+ * @template T The expected return type of the parsed prompt.
+ * @param {string} prompt The input prompt string to parse.
+ * @param {T} defaultValue The default value to return if parsing fails.
+ * @returns {T} The parsed prompt or the default value.
+ * @throws {Error} If the prompt is invalid YAML or JSON (when required).
+ */
 export function parseChatPrompt<T>(prompt: string, defaultValue: T): T {
   const trimmedPrompt = prompt.trim();
   if (trimmedPrompt.startsWith('- role:')) {
@@ -30,46 +92,12 @@ export function parseChatPrompt<T>(prompt: string, defaultValue: T): T {
   }
 }
 
+/**
+ * Converts a string to title case.
+ *
+ * @param {string} str The input string to convert.
+ * @returns {string} The input string converted to title case.
+ */
 export function toTitleCase(str: string) {
   return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
-}
-
-interface ModelCost {
-  input: number;
-  output: number;
-}
-
-interface ProviderModel {
-  id: string;
-  cost?: ModelCost;
-}
-
-interface ProviderConfig {
-  cost?: number;
-}
-
-export function calculateCost(
-  modelName: string,
-  config: ProviderConfig,
-  promptTokens: number | undefined,
-  completionTokens: number | undefined,
-  models: ProviderModel[],
-): number | undefined {
-  if (
-    !Number.isFinite(promptTokens) ||
-    !Number.isFinite(completionTokens) ||
-    typeof promptTokens === 'undefined' ||
-    typeof completionTokens === 'undefined'
-  ) {
-    return undefined;
-  }
-
-  const model = models.find((m) => m.id === modelName);
-  if (!model || !model.cost) {
-    return undefined;
-  }
-
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
-  return inputCost * promptTokens + outputCost * completionTokens || undefined;
 }

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -33,3 +33,43 @@ export function parseChatPrompt<T>(prompt: string, defaultValue: T): T {
 export function toTitleCase(str: string) {
   return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 }
+
+interface ModelCost {
+  input: number;
+  output: number;
+}
+
+interface ProviderModel {
+  id: string;
+  cost?: ModelCost;
+}
+
+interface ProviderConfig {
+  cost?: number;
+}
+
+export function calculateCost(
+  modelName: string,
+  config: ProviderConfig,
+  promptTokens: number | undefined,
+  completionTokens: number | undefined,
+  models: ProviderModel[],
+): number | undefined {
+  if (
+    !Number.isFinite(promptTokens) ||
+    !Number.isFinite(completionTokens) ||
+    typeof promptTokens === 'undefined' ||
+    typeof completionTokens === 'undefined'
+  ) {
+    return undefined;
+  }
+
+  const model = models.find((m) => m.id === modelName);
+  if (!model || !model.cost) {
+    return undefined;
+  }
+
+  const inputCost = config.cost ?? model.cost.input;
+  const outputCost = config.cost ?? model.cost.output;
+  return inputCost * promptTokens + outputCost * completionTokens || undefined;
+}

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -1,4 +1,4 @@
-import { getEnvString, getEnvBool, getEnvInt, getEnvFloat } from '../src/envars';
+import { getEnvString, getEnvBool, getEnvInt, getEnvFloat, isCI } from '../src/envars';
 
 describe('envars', () => {
   const originalEnv = process.env;
@@ -46,6 +46,35 @@ describe('envars', () => {
       expect(getEnvBool('PROMPTFOO_CACHE_ENABLED', true)).toBe(true);
       expect(getEnvBool('PROMPTFOO_CACHE_ENABLED', false)).toBe(false);
     });
+
+    it('should return true for uppercase truthy string values', () => {
+      ['TRUE', 'YES', 'YUP', 'YEPPERS'].forEach((value) => {
+        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(true);
+      });
+    });
+
+    it('should return false for any other string values', () => {
+      ['maybe', 'enabled', 'on'].forEach((value) => {
+        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
+      });
+    });
+
+    it('should return true when the environment variable is set to "1"', () => {
+      process.env.PROMPTFOO_CACHE_ENABLED = '1';
+      expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(true);
+    });
+
+    it('should return false when the environment variable is set to "0"', () => {
+      process.env.PROMPTFOO_CACHE_ENABLED = '0';
+      expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
+    });
+
+    it('should return false when no default value is provided and the environment variable is not set', () => {
+      delete process.env.PROMPTFOO_CACHE_ENABLED;
+      expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
+    });
   });
 
   describe('getEnvInt', () => {
@@ -62,6 +91,31 @@ describe('envars', () => {
     it('should return the default value for a non-existing environment variable', () => {
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT', 100)).toBe(100);
     });
+
+    it('should floor a floating-point number in the environment variable', () => {
+      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '42.7';
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(42);
+    });
+
+    it('should handle negative numbers', () => {
+      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '-42';
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(-42);
+    });
+
+    it('should return undefined for empty string', () => {
+      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '';
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBeUndefined();
+    });
+
+    it('should return the default value when the environment variable is undefined', () => {
+      delete process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT;
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT', 100)).toBe(100);
+    });
+
+    it('should return undefined when no default value is provided and the environment variable is not set', () => {
+      delete process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT;
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBeUndefined();
+    });
   });
 
   describe('getEnvFloat', () => {
@@ -77,6 +131,76 @@ describe('envars', () => {
 
     it('should return the default value for a non-existing environment variable', () => {
       expect(getEnvFloat('OPENAI_TEMPERATURE', 2.718)).toBe(2.718);
+    });
+
+    it('should handle integer values', () => {
+      process.env.OPENAI_TEMPERATURE = '42';
+      expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(42);
+    });
+
+    it('should handle negative numbers', () => {
+      process.env.OPENAI_TEMPERATURE = '-3.14';
+      expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(-3.14);
+    });
+
+    it('should return undefined for empty string', () => {
+      process.env.OPENAI_TEMPERATURE = '';
+      expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
+    });
+
+    it('should return the default value when the environment variable is undefined', () => {
+      delete process.env.OPENAI_TEMPERATURE;
+      expect(getEnvFloat('OPENAI_TEMPERATURE', 2.718)).toBe(2.718);
+    });
+
+    it('should return undefined when no default value is provided and the environment variable is not set', () => {
+      delete process.env.OPENAI_TEMPERATURE;
+      expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
+    });
+  });
+
+  describe('isCI', () => {
+    const ciEnvironments = [
+      'CI',
+      'GITHUB_ACTIONS',
+      'TRAVIS',
+      'CIRCLECI',
+      'JENKINS',
+      'GITLAB_CI',
+      'APPVEYOR',
+      'CODEBUILD_BUILD_ID',
+      'TF_BUILD',
+      'BITBUCKET_COMMIT',
+      'BUDDY',
+      'BUILDKITE',
+      'TEAMCITY_VERSION',
+    ];
+
+    beforeEach(() => {
+      // Clear all CI-related environment variables before each test
+      ciEnvironments.forEach((env) => delete process.env[env]);
+    });
+
+    it('should return false when no CI environment variables are set', () => {
+      expect(isCI()).toBe(false);
+    });
+
+    ciEnvironments.forEach((env) => {
+      it(`should return true when ${env} is set to 'true'`, () => {
+        process.env[env] = 'true';
+        expect(isCI()).toBe(true);
+      });
+
+      it(`should return false when ${env} is set to 'false'`, () => {
+        process.env[env] = 'false';
+        expect(isCI()).toBe(false);
+      });
+    });
+
+    it('should return true if any CI environment variable is set to true', () => {
+      process.env.GITHUB_ACTIONS = 'true';
+      process.env.TRAVIS = 'false';
+      expect(isCI()).toBe(true);
     });
   });
 });

--- a/test/providers.anthropic.test.ts
+++ b/test/providers.anthropic.test.ts
@@ -5,7 +5,7 @@ import {
   AnthropicCompletionProvider,
   AnthropicLlmRubricProvider,
   AnthropicMessagesProvider,
-  calculateCost,
+  calculateAnthropicCost,
   outputFromMessage,
   parseMessages,
 } from '../src/providers/anthropic';
@@ -407,21 +407,21 @@ describe('Anthropic', () => {
     });
   });
 
-  describe('calculateCost', () => {
+  describe('calculateAnthropicCost', () => {
     it('should calculate cost for valid input and output tokens', () => {
-      const cost = calculateCost('claude-3-opus-20240229', { cost: 0.015 }, 100, 200);
+      const cost = calculateAnthropicCost('claude-3-opus-20240229', { cost: 0.015 }, 100, 200);
 
       expect(cost).toBe(4.5); // (0.015 * 100) + (0.075 * 200)
     });
 
     it('should return undefined for missing model', () => {
-      const cost = calculateCost('non-existent-model', { cost: 0.015 });
+      const cost = calculateAnthropicCost('non-existent-model', { cost: 0.015 });
 
       expect(cost).toBeUndefined();
     });
 
     it('should return undefined for missing tokens', () => {
-      const cost = calculateCost('claude-3-opus-20240229', { cost: 0.015 });
+      const cost = calculateAnthropicCost('claude-3-opus-20240229', { cost: 0.015 });
 
       expect(cost).toBeUndefined();
     });

--- a/test/providers.shared.test.ts
+++ b/test/providers.shared.test.ts
@@ -1,9 +1,5 @@
 import { getEnvBool } from '../src/envars';
-import {
-  parseChatPrompt,
-  toTitleCase,
-  calculateCost,
-} from '../src/providers/shared';
+import { parseChatPrompt, toTitleCase, calculateCost } from '../src/providers/shared';
 
 jest.mock('../src/envars');
 

--- a/test/providers.shared.test.ts
+++ b/test/providers.shared.test.ts
@@ -1,0 +1,115 @@
+import { getEnvBool } from '../src/envars';
+import {
+  parseChatPrompt,
+  toTitleCase,
+  calculateCost,
+} from '../src/providers/shared';
+
+jest.mock('../src/envars');
+
+describe('Shared Provider Functions', () => {
+  describe('parseChatPrompt', () => {
+    it('should parse YAML prompt', () => {
+      const yamlPrompt = `
+        - role: user
+          content: Hello
+        - role: assistant
+          content: Hi there!
+      `;
+      const result = parseChatPrompt(yamlPrompt, []);
+      expect(result).toEqual([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ]);
+    });
+
+    it('should parse JSON prompt', () => {
+      const jsonPrompt = JSON.stringify([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ]);
+      const result = parseChatPrompt(jsonPrompt, []);
+      expect(result).toEqual([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ]);
+    });
+
+    it('should return default value for non-YAML, non-JSON prompt', () => {
+      const defaultValue = [{ role: 'user', content: 'Default' }];
+      const result = parseChatPrompt('Just a regular string', defaultValue);
+      expect(result).toEqual(defaultValue);
+    });
+
+    it('should throw error for invalid YAML', () => {
+      const invalidYaml = '- role: user\n  content: :\n';
+      expect(() => parseChatPrompt(invalidYaml, [])).toThrow(
+        'Chat Completion prompt is not a valid YAML string',
+      );
+    });
+
+    it('should throw error for invalid JSON when PROMPTFOO_REQUIRE_JSON_PROMPTS is true', () => {
+      jest.mocked(getEnvBool).mockReturnValue(true);
+      const invalidJson = '"role": "user", "content": "Hello" }'; // Missing array brackets
+      expect(() => parseChatPrompt(invalidJson, [])).toThrow(
+        'Chat Completion prompt is not a valid JSON string',
+      );
+    });
+
+    it('should throw error for invalid JSON when prompt starts with { or [', () => {
+      jest.mocked(getEnvBool).mockReturnValue(false);
+      const invalidJson = '{ "invalid: "json" }';
+      expect(() => parseChatPrompt(invalidJson, [])).toThrow(
+        'Chat Completion prompt is not a valid JSON string',
+      );
+    });
+  });
+
+  describe('toTitleCase', () => {
+    it('should convert string to title case', () => {
+      expect(toTitleCase('hello world')).toBe('Hello World');
+      expect(toTitleCase('UPPERCASE STRING')).toBe('Uppercase String');
+      expect(toTitleCase('mixed CASE string')).toBe('Mixed Case String');
+    });
+
+    it('should handle empty string', () => {
+      expect(toTitleCase('')).toBe('');
+    });
+
+    it('should handle single word', () => {
+      expect(toTitleCase('word')).toBe('Word');
+    });
+  });
+
+  describe('calculateCost', () => {
+    const models = [
+      { id: 'model1', cost: { input: 0.001, output: 0.002 } },
+      { id: 'model2', cost: { input: 0.003, output: 0.004 } },
+    ];
+
+    it('should calculate cost correctly', () => {
+      const cost = calculateCost('model1', {}, 1000, 500, models);
+      expect(cost).toBe(2); // (0.001 * 1000) + (0.002 * 500)
+    });
+
+    it('should use config cost if provided', () => {
+      const cost = calculateCost('model1', { cost: 0.005 }, 1000, 500, models);
+      expect(cost).toBe(7.5); // (0.005 * 1000) + (0.005 * 500)
+    });
+
+    it('should return undefined if model not found', () => {
+      const cost = calculateCost('nonexistent', {}, 1000, 500, models);
+      expect(cost).toBeUndefined();
+    });
+
+    it('should return undefined if tokens are not finite', () => {
+      expect(calculateCost('model1', {}, Number.NaN, 500, models)).toBeUndefined();
+      expect(calculateCost('model1', {}, 1000, Infinity, models)).toBeUndefined();
+    });
+
+    it('should return undefined if tokens are undefined', () => {
+      expect(calculateCost('model1', {}, undefined, 500, models)).toBeUndefined();
+      expect(calculateCost('model1', {}, 1000, undefined, models)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
- Move common cost calculation logic to shared.ts
- Update AI21, Anthropic, Mistral, and OpenAI providers to use shared calculateCost function
- Add tests for shared calculateCost function