### PR TITLE
chore(providers): add pricing information for Azure OpenAI models

### DIFF
--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -183,7 +183,7 @@ export function calculateAzureOpenAICost(
   promptTokens?: number,
   completionTokens?: number,
 ): number | undefined {
-  return calculateCost(modelName, config as { cost: number }, promptTokens, completionTokens, AZURE_OPENAI_MODELS);
+  return calculateCost(modelName, { cost: undefined }, promptTokens, completionTokens, AZURE_OPENAI_MODELS);
 }
 
 export class AzureOpenAiGenericProvider implements ApiProvider {

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -18,7 +18,7 @@ import type {
   ProviderResponse,
 } from '../types';
 import { maybeLoadFromExternalFile, renderVarsInObject } from '../util';
-import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase } from './shared';
+import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase, calculateCost } from './shared';
 
 interface AzureOpenAiCompletionOptions {
   // Azure identity params
@@ -66,6 +66,124 @@ interface AzureOpenAiCompletionOptions {
   seed?: number;
 
   passthrough?: object;
+}
+
+const AZURE_OPENAI_MODELS = [
+  {
+    id: 'gpt-4o-2024-08-06',
+    cost: {
+      input: 2.5 / 1000000,
+      output: 10 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-4o',
+    cost: {
+      input: 5 / 1000000,
+      output: 15 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-4o-mini',
+    cost: {
+      input: 0.15 / 1000000,
+      output: 0.6 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-3.5-turbo-0125',
+    cost: {
+      input: 0.5 / 1000000,
+      output: 1.5 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-3.5-turbo-instruct',
+    cost: {
+      input: 1.5 / 1000000,
+      output: 2 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-4',
+    cost: {
+      input: 30 / 1000000,
+      output: 60 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-4-32k',
+    cost: {
+      input: 60 / 1000000,
+      output: 120 / 1000000,
+    },
+  },
+  {
+    id: 'babbage-002',
+    cost: {
+      input: 0.4 / 1000000,
+      output: 0.4 / 1000000,
+    },
+  },
+  {
+    id: 'davinci-002',
+    cost: {
+      input: 2 / 1000000,
+      output: 2 / 1000000,
+    },
+  },
+  {
+    id: 'text-embedding-ada-002',
+    cost: {
+      input: 0.1 / 1000000,
+      output: 0.1 / 1000000,
+    },
+  },
+  {
+    id: 'text-embedding-3-large',
+    cost: {
+      input: 0.13 / 1000000,
+      output: 0.13 / 1000000,
+    },
+  },
+  {
+    id: 'text-embedding-3-small',
+    cost: {
+      input: 0.02 / 1000000,
+      output: 0.02 / 1000000,
+    },
+  },
+  // Legacy models
+  {
+    id: 'gpt-3.5-turbo-0301',
+    cost: {
+      input: 2 / 1000000,
+      output: 2 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-3.5-turbo-0613',
+    cost: {
+      input: 1.5 / 1000000,
+      output: 2 / 1000000,
+    },
+  },
+  {
+    id: 'gpt-3.5-turbo-1106',
+    cost: {
+      input: 1 / 1000000,
+      output: 2 / 1000000,
+    },
+  },
+];
+
+export function calculateAzureOpenAICost(
+  modelName: string,
+  config: AzureOpenAiCompletionOptions,
+  promptTokens?: number,
+  completionTokens?: number,
+): number | undefined {
+  return calculateCost(modelName, config as { cost: number }, promptTokens, completionTokens, AZURE_OPENAI_MODELS);
 }
 
 export class AzureOpenAiGenericProvider implements ApiProvider {
@@ -319,6 +437,12 @@ export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
               prompt: data.usage.prompt_tokens,
               completion: data.usage.completion_tokens,
             },
+        cost: calculateAzureOpenAICost(
+          this.deploymentName,
+          this.config,
+          data.usage?.prompt_tokens,
+          data.usage?.completion_tokens,
+        ),
       };
     } catch (err) {
       return {
@@ -450,6 +574,12 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
             },
         cached,
         logProbs,
+        cost: calculateAzureOpenAICost(
+          this.deploymentName,
+          this.config,
+          data.usage?.prompt_tokens,
+          data.usage?.completion_tokens,
+        ),
       };
     } catch (err) {
       return {

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -183,7 +183,13 @@ export function calculateAzureOpenAICost(
   promptTokens?: number,
   completionTokens?: number,
 ): number | undefined {
-  return calculateCost(modelName, { cost: undefined }, promptTokens, completionTokens, AZURE_OPENAI_MODELS);
+  return calculateCost(
+    modelName,
+    { cost: undefined },
+    promptTokens,
+    completionTokens,
+    AZURE_OPENAI_MODELS,
+  );
 }
 
 export class AzureOpenAiGenericProvider implements ApiProvider {


### PR DESCRIPTION
This commit adds pricing information for Azure OpenAI models. Note that all prices are based on East US. We don't currently support regions. Prices are taken from [this](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/) page.

- Add AZURE_OPENAI_MODELS constant with pricing details
- Implement calculateAzureOpenAICost function
- Update AzureOpenAiCompletionProvider and AzureOpenAiChatCompletionProvider
  to include cost calculation in their responses

Relates to #1660