### PR TITLE
feat: make config `prompts` optional

### DIFF
--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -327,6 +327,10 @@ Translate this to {{language}}: {{body | allcaps}}
 
 In this example, the `body` variable is passed through the `allcaps` filter before it's used in the prompt. This means that the text will be transformed to uppercase.
 
+### Default prompt
+
+If `prompts` is not defined in the config, then by default Promptfoo will use a "passthrough" prompt: `{{prompt}}`. This prompt simply passes through content of the `prompt` variable.
+
 ## Tests File
 
 If you have a lot of tests, you can optionally keep them separate from the main config file.

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,6 +172,24 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
     ret.redteam.strategies = ret.strategies;
     delete ret.strategies;
   }
+  if (!ret.prompts) {
+    logger.debug(`Setting default prompt because there is no \`prompts\` field`);
+    const hasAnyPrompt =
+      // Allow any string
+      typeof ret.tests === 'string' ||
+      // Check the array for `prompt` vars
+      (Array.isArray(ret.tests) &&
+        ret.tests.some(
+          (test) => typeof test === 'object' && Object.keys(test.vars || {}).includes('prompt'),
+        ));
+
+    if (!hasAnyPrompt) {
+      logger.warn(
+        `Warning: Expected top-level "prompts" property in config or a test variable named "prompt"`,
+      );
+    }
+    ret.prompts = ['{{prompt}}'];
+  }
   return ret;
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -870,4 +870,24 @@ describe('readConfig', () => {
       },
     });
   });
+
+  it('should set default prompt when no prompts are provided', async () => {
+    const mockConfig = {
+      description: 'Test config',
+      providers: ['openai:gpt-4o'],
+      tests: [
+        { vars: { someVar: 'value', prompt: 'abc' } },
+        { vars: { anotherVar: 'anotherValue', prompt: 'yo mama' } },
+      ],
+    };
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockConfig));
+    jest.spyOn(path, 'parse').mockReturnValue({ ext: '.json' } as any);
+
+    const result = await readConfig('config.json');
+
+    expect(result).toEqual({
+      ...mockConfig,
+      prompts: ['{{prompt}}'],
+    });
+  });
 });


### PR DESCRIPTION
Did it better than #1686 with the same pattern from #1689 

warns the user if there isn't a `prompt` test var