### PR TITLE
chore: redteam onboarding updates

### DIFF
--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -47,7 +47,7 @@ Edit the config to set up the prompt and the LLM you want to test:
 prompts:
   - 'Act as a travel agent and help the user plan their trip. User query: {{query}}'
 
-providers:
+targets:
   - openai:gpt-4o-mini
 ```
 
@@ -143,18 +143,18 @@ function getPrompt(context) {
 }
 ```
 
-## Step 2: Configure your LLM providers
+## Step 2: Configure your targets
 
-LLMs are configured with the `providers` property in `promptfooconfig.yaml`. An LLM provider can be a known LLM API (such as OpenAI, Anthropic, Ollama, etc.) or a custom RAG or agent flow you've built yourself.
+LLMs are configured with the `targets` property in `promptfooconfig.yaml`. An LLM target can be a known LLM API (such as OpenAI, Anthropic, Ollama, etc.) or a custom RAG or agent flow you've built yourself.
 
 ### LLM APIs
 
 Promptfoo supports [many LLM providers](/docs/providers) including OpenAI, Anthropic, Mistral, Azure, Groq, Perplexity, Cohere, and more. In most cases all you need to do is set the appropriate API key environment variable.
 
-You should choose at least one provider. If desired, set multiple in order to compare their performance in the red team eval. In this example, we’re comparing performance of GPT, Claude, and Llama:
+You should choose at least one target. If desired, set multiple in order to compare their performance in the red team eval. In this example, we’re comparing performance of GPT, Claude, and Llama:
 
 ```yaml
-providers:
+targets:
   - openai:gpt-4o
   - anthropic:messages:claude-3-5-sonnet-20240620
   - ollama:chat:llama3.1:70b
@@ -167,7 +167,7 @@ To learn more, find your preferred LLM provider [here](/docs/providers).
 If you have a custom RAG or agent flow, you can include them in your project like this:
 
 ```yaml
-providers:
+targets:
   # JS is natively supported
   - file:///path/to/js_agent.js
   # Python requires the `python:` directive
@@ -190,7 +190,7 @@ To learn more, see:
 In order to pentest a live API endpoint, set the provider id to a URL. This will send an HTTP request to the endpoint. It expects that the LLM or agent output will be in the HTTP response.
 
 ```yaml
-providers:
+targets:
   - id: 'https://example.com/generate'
     config:
       method: 'POST'
@@ -243,10 +243,10 @@ For more information, see [Overriding the LLM grader](/docs/configuration/expect
 Now that you've configured everything, the next step is to generate the red teaming inputs. This is done by running the `promptfoo redteam generate` command:
 
 ```sh
-npx promptfoo@latest redteam generate -w
+npx promptfoo@latest redteam generate
 ```
 
-This command works by reading your prompts and providers, and then generating a set of adversarial inputs that stress-test your prompts/models in a variety of situations. Test generation usually takes about 5 minutes.
+This command works by reading your prompts and targets, and then generating a set of adversarial inputs that stress-test your prompts/models in a variety of situations. Test generation usually takes about 5 minutes.
 
 The adversarial tests include:
 
@@ -294,7 +294,7 @@ It also tests for a variety of harmful input and output scenarios from the [ML C
 By default, all of the above will be included in the redteam. To use specific types of tests, use `--plugins`:
 
 ```yaml
-npx promptfoo@latest redteam generate -w --plugins 'harmful,jailbreak,hijacking'
+npx promptfoo@latest redteam generate --plugins 'harmful,jailbreak,hijacking'
 ```
 
 The following plugins are enabled by default:
@@ -326,7 +326,7 @@ The adversarial test cases will be written to `promptfooconfig.yaml`.
 Now that all the red team tests are ready, run the eval:
 
 ```
-npx promptfoo@latest eval
+npx promptfoo@latest eval -c redteam.yaml
 ```
 
 This will take a while, usually ~15 minutes or so depending on how many plugins you have chosen.

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -20,6 +20,12 @@ npx promptfoo@latest redteam init
 The redteam configuration uses the following YAML structure:
 
 ```yaml
+targets:
+  - openai:gpt-4o
+
+prompts:
+  - 'Your prompt template here: {{variable}}'
+
 redteam:
   plugins: Array<string | { id: string, numTests?: number, config?: Record<string, any> }>
   strategies: Array<string | { id: string }>
@@ -28,11 +34,6 @@ redteam:
   provider: string | ProviderOptions
   purpose: string
   language: string
-
-prompts:
-  - 'Your prompt template here: {{variable}}'
-providers:
-  - openai:gpt-4o
 ```
 
 ### Configuration Fields
@@ -438,7 +439,7 @@ You can force 100% local generation by setting the `PROMPTFOO_DISABLE_REDTEAM_RE
 To use the `openai:chat:gpt-4o-mini` model, you can override the provider on the command line:
 
 ```sh
-npx promptfoo@latest redteam generate -w --provider openai:chat:gpt-4o-mini
+npx promptfoo@latest redteam generate --provider openai:chat:gpt-4o-mini
 ```
 
 Or in the config:
@@ -473,7 +474,7 @@ Disabling remote generation may result in lower quality adversarial inputs. For 
 
 If you need to use a custom provider for generation, you can still benefit from our remote service by leaving `PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION` set to `false` (the default). This allows you to use a custom provider for your target model while still leveraging our optimized generation service for creating adversarial inputs.
 
-### Custom Providers
+### Custom Providers/Targets
 
 In some cases your target application may require custom requests or setups.
 
@@ -485,7 +486,7 @@ In some cases your target application may require custom requests or setups.
 For example, to send a customized HTTP request, use a [HTTP Provider](/docs/providers/http/):
 
 ```yaml
-providers:
+targets:
   - id: 'https://example.com/generate'
     config:
       method: 'POST'
@@ -503,7 +504,7 @@ Alternatively, you can use a custom [Python](/docs/providers/python/), [Javascri
 For example, let's create a Python provider. Your config would look like this:
 
 ```yaml
-providers:
+targets:
   - id: 'python:send_redteam.py'
     label: 'Test script 1' # Optional display label
 ```
@@ -594,17 +595,14 @@ def call_api(prompt, options, context):
 
 ### Passthrough prompts
 
-In most cases, if you're handling the prompting in a script, you can just make `prompt` passthrough the variable in your `promptfooconfig.yaml`.
+If you just want to send the entire adversarial input as-is to your target, omit the `prompts` field.
 
 In this case, be sure to specify a `purpose`, because the redteam generator can no longer infer the purpose from your prompt. The purpose is used to tailor the adversarial inputs:
 
 ```yaml
-prompts:
-  - '{{query}}' # Just send the query as-is to the provider
-
 purpose: 'Act as a travel agent with a focus on European holidays'
 
-providers:
+targets:
   - python:send_redteam.py
 
 redteam:

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -476,10 +476,10 @@ If you need to use a custom provider for generation, you can still benefit from 
 
 ### Custom Providers/Targets
 
-In some cases your target application may require custom requests or setups.
+Promptfoo is very flexible and allows you to configure almost any code or API, with dozens of [providers](/docs/providers) supported out of the box.
 
-- **Custom**: See how to call your existing [Javascript](/docs/providers/custom-api), [Python](/docs/providers/python), [any other executable](/docs/providers/custom-script) or [API endpoint](/docs/providers/http).
-- **APIs**: See setup instructions for [OpenAI](/docs/providers/openai), [Azure](/docs/providers/azure), [Anthropic](/docs/providers/anthropic), [Mistral](/docs/providers/mistral), [HuggingFace](/docs/providers/huggingface), [AWS Bedrock](/docs/providers/aws-bedrock), and [more](/docs/providers).
+- **Public APIs**: See setup instructions for [OpenAI](/docs/providers/openai), [Azure](/docs/providers/azure), [Anthropic](/docs/providers/anthropic), [Mistral](/docs/providers/mistral), [HuggingFace](/docs/providers/huggingface), [AWS Bedrock](/docs/providers/aws-bedrock), and many [more](/docs/providers).
+- **Custom**: In some cases your target application may require customized setups. See how to call your existing [Javascript](/docs/providers/custom-api), [Python](/docs/providers/python), [any other executable](/docs/providers/custom-script) or [API endpoint](/docs/providers/http).
 
 #### HTTP requests
 

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -63,14 +63,14 @@ Edit the config to set up the prompt(s) and the LLM(s) you want to test:
 prompts:
   - 'Act as a travel agent and help the user plan their trip. User query: {{query}}'
 
-providers:
+targets:
   - openai:gpt-4o-mini
   - anthropic:messages:claude-3.5-sonnet-20240620
 ```
 
 ### Talking to your app
 
-Promptfoo can hook directly into your existing LLM app (Python, Javascript, etc), RAG or agent workflows, or send requests to your API. See [custom providers](/docs/red-team/configuration/#custom-providers) for details on setting up:
+Promptfoo can hook directly into your existing LLM app to attack targets via Python, Javascript, RAG or agent workflows, HTTP API, and more. See [custom providers](/docs/red-team/configuration/#custom-providers) for details on setting up:
 
 - [HTTP requests](/docs/red-team/configuration/#http-requests) to your API
 - [Custom Python scripts](/docs/red-team/configuration/#custom-scripts) for precise control

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -55,37 +55,52 @@ This guide describes how to get started with Promptfoo's gen AI red teaming tool
 
 The `init` command creates some placeholders, including a `promptfooconfig.yaml` file. We'll use this config file to do most of our setup.
 
-## Set the prompt & models to test
+## Attacking an API endpoint
 
-Edit the config to set up the prompt(s) and the LLM(s) you want to test:
+Edit the config to set up the target endpoint. For example:
+
+```yaml
+targets:
+  - id: 'https://example.com/generate'
+    config:
+      method: 'POST'
+      headers:
+        'Content-Type': 'application/json'
+      body:
+        myPrompt: '{{prompt}}'
+      responseParser: 'json.output'
+
+purpose: 'Budget travel agent'
+```
+
+Setting the `purpose` is optional, but it will significantly improve the quality of the generated test cases (try to be specific).
+
+For more information on configuring an HTTP target, see [HTTP requests](/docs/providers/http/).
+
+### Alternative: Test specific prompts and models
+
+If you don't have a live endpoint, you can edit the config to set the specific prompt(s) and the LLM(s) to test:
 
 ```yaml
 prompts:
   - 'Act as a travel agent and help the user plan their trip. User query: {{query}}'
+  # Paths to prompts also work:
+  # - file://path/to/prompt.txt
 
 targets:
   - openai:gpt-4o-mini
   - anthropic:messages:claude-3.5-sonnet-20240620
 ```
 
-### Talking to your app
+For more information on supported targets, see [Custom Providers](/docs/red-team/configuration/#custom-providerstargets). For more information on supported prompt formats, see [prompts](/docs/configuration/parameters/#prompts).
+
+### Alternative: Talking directly to your app
 
 Promptfoo can hook directly into your existing LLM app to attack targets via Python, Javascript, RAG or agent workflows, HTTP API, and more. See [custom providers](/docs/red-team/configuration/#custom-providers) for details on setting up:
 
 - [HTTP requests](/docs/red-team/configuration/#http-requests) to your API
 - [Custom Python scripts](/docs/red-team/configuration/#custom-scripts) for precise control
 - [Javascript](/docs/providers/custom-api/), [any executable](/docs/providers/custom-script/), local providers like [ollama](/docs/providers/ollama/), or other [provider types](/docs/providers/)
-
-### Prompting
-
-Your prompt may be [dynamic](/docs/configuration/parameters/#prompt-functions), or maybe it's constructed entirely on the application side and you just want to [pass through](/docs/red-team/configuration/#passthrough-prompts) the adversarial input. Also note that files are accepted:
-
-```yaml
-prompts:
-  - file://path/to/prompt.json
-```
-
-Learn more about [prompt formats](/docs/configuration/parameters/#prompts).
 
 ## Generate adversarial test cases
 
@@ -110,10 +125,6 @@ The `init` step will do this for you automatically, but in case you'd like to ma
 </Tabs>
 
 This will generate several hundred adversarial inputs across many categories of potential harm and save them in `redteam.yaml`.
-
-## Changing the provider (optional)
-
-By default we use OpenAI's `gpt-4o` model to generate the adversarial inputs, but we support hundreds of other models. Learn more about [setting the provider](/docs/red-team/configuration/#providers).
 
 ## Run the eval
 

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -96,7 +96,7 @@ For more information on supported targets, see [Custom Providers](/docs/red-team
 
 ### Alternative: Talking directly to your app
 
-Promptfoo can hook directly into your existing LLM app to attack targets via Python, Javascript, RAG or agent workflows, HTTP API, and more. See [custom providers](/docs/red-team/configuration/#custom-providers) for details on setting up:
+Promptfoo can hook directly into your existing LLM app to attack targets via Python, Javascript, RAG or agent workflows, HTTP API, and more. See [custom providers](/docs/red-team/configuration/#custom-providerstargets) for details on setting up:
 
 - [HTTP requests](/docs/red-team/configuration/#http-requests) to your API
 - [Custom Python scripts](/docs/red-team/configuration/#custom-scripts) for precise control

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -47,11 +47,7 @@ code p {
 }
 
 .theme-doc-sidebar-item-category-level-1 > div {
-  font-weight: bold;
-}
-
-.theme-doc-sidebar-item-link-level-1.menu__list-item {
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .navbar__brand {

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,8 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
   if (!ret.prompts) {
     logger.debug(`Setting default prompt because there is no \`prompts\` field`);
     const hasAnyPrompt =
+      // Allow no tests
+      !ret.tests ||
       // Allow any string
       typeof ret.tests === 'string' ||
       // Check the array for `prompt` vars


### PR DESCRIPTION
- Default to http provider
- Switch to using `{{prompt}}` not `{{query}}` by default
- Use `targets`, top-level `plugins` and `strategies`