### PR TITLE
Add costs for OpenAI model "gpt-4o-2024-08-06"

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -37,6 +37,13 @@ const OPENAI_CHAT_MODELS = [
       output: 12 / 1e6,
     },
   })),
+  ...['gpt-4o-2024-08-06'].map((model) => ({
+    id: model,
+    cost: {
+      input: 2.5 / 1e6,
+      output: 10 / 1e6,
+    },
+  })),
   ...['gpt-4o', 'gpt-4o-2024-05-13'].map((model) => ({
     id: model,
     cost: {


### PR DESCRIPTION
Based on: https://openai.com/api/pricing/

**gpt-4o**
$5.00 / 1M input tokens
$15.00 / 1M output tokens

**gpt-4o-2024-08-06**
$2.50 / 1M input tokens
$10.00 / 1M output tokens

**gpt-4o-2024-05-13**
$5.00 / 1M input tokens
$15.00 / 1M output tokens
