### PR TITLE
chore: support config object in javascript and python assertions

### DIFF
--- a/examples/javascript-assert-external/promptfooconfig.yaml
+++ b/examples/javascript-assert-external/promptfooconfig.yaml
@@ -8,6 +8,8 @@ defaultTest:
   assert:
     - type: javascript
       value: file://assert.js
+      config:
+        foo: bar
 
 tests:
   - vars:

--- a/site/docs/configuration/expected-outputs/javascript.md
+++ b/site/docs/configuration/expected-outputs/javascript.md
@@ -143,14 +143,22 @@ assert:
   - type: javascript
     value: file://relative/path/to/script.js
     config:
-      foo: bar
+      maximumOutputSize: 10
 ```
 
-The Javascript file must export an assertion function. The context object passed into the assertion contains the optional configuration, some Here's an example:
+The Javascript file must export an assertion function. Here's an example:
 
 ```js
 module.exports = (output, context) => {
-  return output.length > 10 && context.config.foo === 'bar';
+  return output.length > 10;
+};
+```
+
+This is an example of an assertion that uses data from a configuration defined in the assertion's YML file:
+
+```js
+module.exports = (output, context) => {
+  return output.length > context.config.maximumOutputSize;
 };
 ```
 

--- a/site/docs/configuration/expected-outputs/javascript.md
+++ b/site/docs/configuration/expected-outputs/javascript.md
@@ -158,7 +158,7 @@ This is an example of an assertion that uses data from a configuration defined i
 
 ```js
 module.exports = (output, context) => {
-  return output.length > context.config.maximumOutputSize;
+  return output.length <= context.config.maximumOutputSize;
 };
 ```
 

--- a/site/docs/configuration/expected-outputs/javascript.md
+++ b/site/docs/configuration/expected-outputs/javascript.md
@@ -142,13 +142,15 @@ To reference an external file, use the `file://` prefix:
 assert:
   - type: javascript
     value: file://relative/path/to/script.js
+    config:
+      foo: bar
 ```
 
-The Javascript file must export an assertion function. Here's an example:
+The Javascript file must export an assertion function. The context object passed into the assertion contains the optional configuration, some Here's an example:
 
 ```js
 module.exports = (output, context) => {
-  return output.length > 10;
+  return output.length > 10 && context.config.foo === 'bar';
 };
 ```
 

--- a/site/docs/configuration/expected-outputs/python.md
+++ b/site/docs/configuration/expected-outputs/python.md
@@ -78,6 +78,8 @@ To reference an external file, use the `file://` prefix:
 assert:
   - type: python
     value: file://relative/path/to/script.py
+    config:
+      outputLengthLimit: 10
 ```
 
 This file will be called with an `output` string and an `AssertContext` object (see above).
@@ -98,6 +100,15 @@ def get_assert(output: str, context) -> Union[bool, float, Dict[str, Any]]:
       'score': 0.6,
       'reason': 'Looks good to me',
     }
+```
+
+This is an example of an assertion that uses data from a configuration defined in the assertion's YML file:
+
+```py
+from typing import Dict, Union
+
+def get_assert(output: str, context) -> Union[bool, float, Dict[str, Any]]:
+    return output.length() <= context.get('config', {}).get('outputLengthLimit', 0)
 ```
 
 You can also return nested metrics and assertions via a `GradingResult` object:

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -356,6 +356,7 @@
                                     "properties": {
                                       "type": {},
                                       "value": {},
+                                      "config": {},
                                       "threshold": {
                                         "type": "number"
                                       },

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -356,7 +356,10 @@
                                     "properties": {
                                       "type": {},
                                       "value": {},
-                                      "config": {},
+                                      "config": {
+                                        "type": "object",
+                                        "additionalProperties": {}
+                                      },
                                       "threshold": {
                                         "type": "number"
                                       },

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -313,6 +313,7 @@ export async function runAssertion({
     vars: test.vars || {},
     test,
     logProbs,
+    ...(assertion.config ? { config: assertion.config } : {}),
   };
 
   // Render assertion values

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,6 +369,9 @@ export const AssertionSchema = z.object({
   // The expected value, if applicable
   value: z.custom<AssertionValue>().optional(),
 
+  // An external object that is passed to the assertion for custom javascript asserts
+  config: z.any().optional(),
+
   // The threshold value, only applicable for similarity (cosine distance)
   threshold: z.number().optional(),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,8 +369,9 @@ export const AssertionSchema = z.object({
   // The expected value, if applicable
   value: z.custom<AssertionValue>().optional(),
 
-  // An external object that is passed to the assertion for custom javascript asserts
-  config: z.any().optional(),
+  // An external mapping of arbitrary strings to values that is passed
+  // to the assertion for custom javascript asserts
+  config: z.record(z.string(), z.any()).optional(),
 
   // The threshold value, only applicable for similarity (cosine distance)
   threshold: z.number().optional(),

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -618,6 +618,14 @@ describe('runAssertion', () => {
     value: 'output.length * 10',
   };
 
+  const javascriptBooleanAssertionWithConfig: Assertion = {
+    type: 'javascript',
+    value: 'output.length <= context.config.maximumOutputSize',
+    config: {
+      maximumOutputSize: 20,
+    },
+  };
+
   const javascriptStringAssertionWithNumberAndThreshold: Assertion = {
     type: 'javascript',
     value: 'output.length * 10',
@@ -1582,6 +1590,40 @@ describe('runAssertion', () => {
       pass: true,
       score: output.length * 10,
       reason: 'Assertion passed',
+    });
+  });
+
+  it('should pass when javascript returns an output string that is smaller than the maximum size threshold', async () => {
+    const output = 'Expected output';
+
+    const result: GradingResult = await runAssertion({
+      prompt: 'Some prompt',
+      provider: new OpenAiChatCompletionProvider('gpt-4'),
+      assertion: javascriptBooleanAssertionWithConfig,
+      test: {} as AtomicTestCase,
+      providerResponse: { output },
+    });
+    expect(result).toMatchObject({
+      pass: true,
+      score: 1.0,
+      reason: 'Assertion passed',
+    });
+  });
+
+  it('should fail when javascript returns an output string that is larger than the maximum size threshold', async () => {
+    const output = 'Expected output with some extra characters';
+
+    const result: GradingResult = await runAssertion({
+      prompt: 'Some prompt',
+      provider: new OpenAiChatCompletionProvider('gpt-4'),
+      assertion: javascriptBooleanAssertionWithConfig,
+      test: {} as AtomicTestCase,
+      providerResponse: { output },
+    });
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: expect.stringContaining('Custom function returned false'),
     });
   });
 


### PR DESCRIPTION
Partially addresses: #1701. We still need to add support for assertion sets.

Manually verified by logging the loaded assertion and the context object and also writing a custom assertion using the `promptfooconfig.yml` based on the `javascript-assert-external` example. The correct solution is to support loading / mocking the load of an actual promptfooconfig which has a custom config for assertions.