### PR TITLE
feat: improvements to http and websocket providers

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -113,6 +113,22 @@ Extracts the message content from this response:
 }
 ```
 
+## Query parameters
+
+Query parameters can be specified in the provider config using the `queryParams` field. These will be appended to the URL as GET parameters.
+
+```yaml
+providers:
+  - id: 'https://example.com/search'
+    config:
+      // highlight-start
+      method: 'GET'
+      queryParams:
+        q: '{{prompt}}'
+        foo: 'bar'
+      // highlight-end
+```
+
 ## Using as a library
 
 If you are using promptfoo as a [node library](/docs/usage/node-package/), you can provide the equivalent provider config:
@@ -135,3 +151,20 @@ If you are using promptfoo as a [node library](/docs/usage/node-package/), you c
   }],
 }
 ```
+
+## Reference
+
+Supported config options:
+
+| Option         | Type                   | Description                                                                                                                                   |
+| -------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| url            | string                 | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                       |
+| method         | string                 | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                   |
+| headers        | Record<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                    |
+| body           | Record<string, any>    | The request body. For POST requests, this will be sent as JSON.                                                                               |
+| queryParams    | Record<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                     |
+| responseParser | string \| Function     | A function or string representation of a function to parse the response. If not provided, the entire response will be returned as the output. |
+
+Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
+
+In addition to a full URL, the provider `id` field accepts `http` or `https` as values.

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -156,14 +156,14 @@ If you are using promptfoo as a [node library](/docs/usage/node-package/), you c
 
 Supported config options:
 
-| Option         | Type                   | Description                                                                                                                                   |
-| -------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| url            | string                 | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                       |
-| method         | string                 | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                   |
-| headers        | Record<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                    |
-| body           | Record<string, any>    | The request body. For POST requests, this will be sent as JSON.                                                                               |
-| queryParams    | Record<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                     |
-| responseParser | string \| Function     | A function or string representation of a function to parse the response. If not provided, the entire response will be returned as the output. |
+| Option         | Type                     | Description                                                                                                                                   |
+| -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| url            | string                   | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                       |
+| method         | string                   | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                   |
+| headers        | Record\<string, string\> | Key-value pairs of HTTP headers to include in the request.                                                                                    |
+| body           | Record\<string, any\>    | The request body. For POST requests, this will be sent as JSON.                                                                               |
+| queryParams    | Record\<string, string\> | Key-value pairs of query parameters to append to the URL.                                                                                     |
+| responseParser | string \| Function       | A function or string representation of a function to parse the response. If not provided, the entire response will be returned as the output. |
 
 Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
 

--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -84,3 +84,18 @@ If you are using promptfoo as a node library, you can provide the equivalent pro
 ```
 
 Note that when using the WebSocket provider, the connection will be opened for each API call and closed after receiving the response or when the timeout is reached.
+
+## Reference
+
+Supported config options:
+
+| Option          | Type               | Description                                                                                                                                   |
+| --------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| url             | string             | The WebSocket URL to connect to. If not provided, the `id` of the provider will be used as the URL.                                           |
+| messageTemplate | string             | A template string for the message to be sent over the WebSocket connection. Supports Nunjucks templating.                                     |
+| responseParser  | string \| Function | A function or string representation of a function to parse the response. If not provided, the entire response will be returned as the output. |
+| timeoutMs       | number             | The timeout in milliseconds for the WebSocket connection. Defaults to 10000 (10 seconds) if not specified.                                    |
+
+Note: The `messageTemplate` supports Nunjucks templating, allowing you to use the `{{prompt}}` variable or any other variables passed in the test context.
+
+In addition to a full URL, the provider `id` field accepts `ws`, `wss`, or `websocket` as values.

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -375,9 +375,20 @@ export async function loadApiProvider(
     } else {
       ret = new LocalAiChatProvider(modelType, providerOptions);
     }
-  } else if (providerPath.startsWith('http:') || providerPath.startsWith('https:')) {
+  } else if (
+    providerPath.startsWith('http:') ||
+    providerPath.startsWith('https:') ||
+    providerPath === 'http' ||
+    providerPath === 'https'
+  ) {
     ret = new HttpProvider(providerPath, providerOptions);
-  } else if (providerPath.startsWith('ws:') || providerPath.startsWith('wss:')) {
+  } else if (
+    providerPath.startsWith('ws:') ||
+    providerPath.startsWith('wss:') ||
+    providerPath === 'websocket' ||
+    providerPath === 'ws' ||
+    providerPath === 'wss'
+  ) {
     ret = new WebSocketProvider(providerPath, providerOptions);
   } else if (providerPath === 'promptfoo:redteam:iterative') {
     ret = new RedteamIterativeProvider(providerOptions.config);

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -14,10 +14,12 @@ import { REQUEST_TIMEOUT_MS } from './shared';
 const nunjucks = getNunjucksEngine();
 
 interface HttpProviderConfig {
-  method: string;
-  headers: Record<string, string>;
-  body: Record<string, any>;
-  responseParser: string | Function;
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: Record<string, any>;
+  queryParams?: Record<string, string>;
+  responseParser?: string | Function;
 }
 
 function createResponseParser(parser: any): (data: any) => ProviderResponse {
@@ -68,8 +70,8 @@ export class HttpProvider implements ApiProvider {
   responseParser: (data: any) => ProviderResponse;
 
   constructor(url: string, options: ProviderOptions) {
-    this.url = url;
     this.config = options.config;
+    this.url = this.config.url || url;
     this.responseParser = createResponseParser(this.config.responseParser);
     invariant(
       this.config.body,
@@ -93,13 +95,22 @@ export class HttpProvider implements ApiProvider {
       prompt,
     };
     const renderedConfig: Partial<HttpProviderConfig> = {
+      url: this.url,
       method: nunjucks.renderString(this.config.method || 'GET', vars),
       headers: Object.fromEntries(
         Object.entries(this.config.headers || { 'content-type': 'application/json' }).map(
           ([key, value]) => [key, nunjucks.renderString(value, vars)],
         ),
       ),
-      body: processBody(this.config.body, vars),
+      body: processBody(this.config.body || {}, vars),
+      queryParams: this.config.queryParams
+        ? Object.fromEntries(
+            Object.entries(this.config.queryParams).map(([key, value]) => [
+              key,
+              nunjucks.renderString(value, vars),
+            ]),
+          )
+        : undefined,
       responseParser: this.config.responseParser,
     };
 
@@ -108,17 +119,22 @@ export class HttpProvider implements ApiProvider {
     invariant(typeof method === 'string', 'Expected method to be a string');
     invariant(typeof headers === 'object', 'Expected headers to be an object');
 
-    logger.debug(
-      `Calling HTTP provider: ${this.url} with config: ${safeJsonStringify(renderedConfig)}`,
-    );
+    // Construct URL with query parameters for GET requests
+    let url = this.url;
+    if (renderedConfig.queryParams) {
+      const queryString = new URLSearchParams(renderedConfig.queryParams).toString();
+      url = `${url}?${queryString}`;
+    }
+
+    logger.debug(`Calling HTTP provider: ${url} with config: ${safeJsonStringify(renderedConfig)}`);
     let response;
     try {
       response = await fetchWithCache(
-        this.url,
+        url,
         {
           method: renderedConfig.method,
           headers: renderedConfig.headers,
-          body: JSON.stringify(renderedConfig.body),
+          ...(method !== 'GET' && { body: JSON.stringify(renderedConfig.body) }),
         },
         REQUEST_TIMEOUT_MS,
         'json',

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -74,7 +74,7 @@ export class HttpProvider implements ApiProvider {
     this.url = this.config.url || url;
     this.responseParser = createResponseParser(this.config.responseParser);
     invariant(
-      this.config.body,
+      this.config.body || this.config.method === 'GET',
       `Expected HTTP provider ${this.url} to have a config containing {body}, but instead got ${safeJsonStringify(
         this.config,
       )}`,
@@ -98,9 +98,10 @@ export class HttpProvider implements ApiProvider {
       url: this.url,
       method: nunjucks.renderString(this.config.method || 'GET', vars),
       headers: Object.fromEntries(
-        Object.entries(this.config.headers || { 'content-type': 'application/json' }).map(
-          ([key, value]) => [key, nunjucks.renderString(value, vars)],
-        ),
+        Object.entries(
+          this.config.headers ||
+            (this.config.method === 'GET' ? {} : { 'content-type': 'application/json' }),
+        ).map(([key, value]) => [key, nunjucks.renderString(value, vars)]),
       ),
       body: processBody(this.config.body || {}, vars),
       queryParams: this.config.queryParams

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -13,9 +13,9 @@ import { getNunjucksEngine } from '../util/templates';
 const nunjucks = getNunjucksEngine();
 
 interface WebSocketProviderConfig {
-  url: string;
   messageTemplate: string;
-  responseParser: string | Function;
+  url?: string;
+  responseParser?: string | Function;
   timeoutMs?: number;
 }
 
@@ -35,8 +35,8 @@ export class WebSocketProvider implements ApiProvider {
   responseParser: (data: any) => ProviderResponse;
 
   constructor(url: string, options: ProviderOptions) {
-    this.url = url;
     this.config = options.config as WebSocketProviderConfig;
+    this.url = this.config.url || url;
     this.responseParser = createResponseParser(this.config.responseParser);
     invariant(
       this.config.messageTemplate,


### PR DESCRIPTION
- Add `queryParams` config to http provider
- Add `url` config to http and websocket provider (benefit: enables multiple providers on the same endpoint, and enables websocket over `https`)