### PR TITLE
chore(providers): support file:// syntax for Python providers

### DIFF
--- a/examples/python-provider/promptfooconfig.yaml
+++ b/examples/python-provider/promptfooconfig.yaml
@@ -2,13 +2,13 @@ prompts:
   - 'Write a very concise funny tweet about {{topic}}'
 
 providers:
-  - id: python:provider.py # defaults to call_api function
+  - id: file://provider.py # defaults to call_api function
     config:
       someOption: foobar
 
-  - id: python:provider.py:some_other_function
+  - id: file://provider.py:some_other_function
 
-  - id: python:provider.py:async_provider
+  - id: file://provider.py:async_provider
     label: async provider
 
 tests:

--- a/examples/rag-full/promptfooconfig.with-asserts.yaml
+++ b/examples/rag-full/promptfooconfig.with-asserts.yaml
@@ -4,11 +4,11 @@ prompts:
   - '{{question}}'
 
 providers:
-  - id: python:retrieve.py
+  - id: file://retrieve.py
     label: RAG retrieval small
     config:
       topK: 5
-  - id: python:retrieve.py
+  - id: file://retrieve.py
     label: RAG retrieval big
     config:
       topK: 10

--- a/examples/rag-full/promptfooconfig.yaml
+++ b/examples/rag-full/promptfooconfig.yaml
@@ -4,7 +4,7 @@ prompts:
   - '{{question}}'
 
 providers:
-  - python:retrieve.py
+  - id: file://retrieve.py
 
 tests:
   - vars:

--- a/examples/rag-full/promptfooconfig.yaml
+++ b/examples/rag-full/promptfooconfig.yaml
@@ -4,7 +4,7 @@ prompts:
   - '{{question}}'
 
 providers:
-  - id: file://retrieve.py
+  - file://retrieve.py
 
 tests:
   - vars:

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -284,7 +284,7 @@ All assertion types can be used in `__expected`. The column supports exactly one
 
 - `is-json` and `contains-json` are supported directly, and do not require any value
 - `fn` indicates `javascript` type. For example: `fn:output.includes('foo')`
-- `file://` indicates an external file. For example: `file://custom_assertion.py` or `file://customAssertion.js`
+- `file://` indicates an external file relative to your config. For example: `file://custom_assertion.py` or `file://customAssertion.js`
 - `similar` takes a threshold value. For example: `similar(0.8):hello world`
 - `grade` indicates `llm-rubric`. For example: `grade: does not mention being an AI`
 - By default, `__expected` will use type `equals`

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -284,7 +284,7 @@ All assertion types can be used in `__expected`. The column supports exactly one
 
 - `is-json` and `contains-json` are supported directly, and do not require any value
 - `fn` indicates `javascript` type. For example: `fn:output.includes('foo')`
-- `python` indicates `python` type. For example: `python:file://custom_assertion.py`
+- `file://` indicates an external file. For example: `file://custom_assertion.py` or `file://customAssertion.js`
 - `similar` takes a threshold value. For example: `similar(0.8):hello world`
 - `grade` indicates `llm-rubric`. For example: `grade: does not mention being an AI`
 - By default, `__expected` will use type `equals`

--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -70,7 +70,7 @@ First, create `promptfooconfig.yaml`. We'll use a placeholder prompt with a sing
 prompts:
   - '{{ query }}'
 providers:
-  - 'python: retrieve.py'
+  - id: file://retrieve.py
 tests:
   - vars:
       query: What is our reimbursement policy?
@@ -100,9 +100,9 @@ In order to compare multiple vector databases in your evaluation, create retriev
 
 ```yaml
 providers:
-  - 'python: retrieve_pinecone.py'
-  - 'python: retrieve_milvus.py'
-  - 'python: retrieve_pgvector.py'
+  - id: file://retrieve_pinecone.py
+  - id: file://retrieve_milvus.py
+  - id: file://retrieve_pgvector.py
 ```
 
 Running the eval with `promptfoo eval` will create a comparison view between Pinecone, Milvus, and PGVector:
@@ -326,8 +326,8 @@ prompts: [prompt1.txt, prompt2.txt]
 
 # Test different retrieval and generation methods to find the best
 providers:
-  - python: retrieve_and_generate_v1.py
-  - python: retrieve_and_generate_v2.py
+  - file://retrieve_and_generate_v1.py
+  - file://retrieve_and_generate_v2.py
 
 tests:
   # ...

--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -70,7 +70,7 @@ First, create `promptfooconfig.yaml`. We'll use a placeholder prompt with a sing
 prompts:
   - '{{ query }}'
 providers:
-  - id: file://retrieve.py
+  - file://retrieve.py
 tests:
   - vars:
       query: What is our reimbursement policy?
@@ -100,9 +100,9 @@ In order to compare multiple vector databases in your evaluation, create retriev
 
 ```yaml
 providers:
-  - id: file://retrieve_pinecone.py
-  - id: file://retrieve_milvus.py
-  - id: file://retrieve_pgvector.py
+  - file://retrieve_pinecone.py
+  - file://retrieve_milvus.py
+  - file://retrieve_pgvector.py
 ```
 
 Running the eval with `promptfoo eval` will create a comparison view between Pinecone, Milvus, and PGVector:

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -169,8 +169,8 @@ If you have a custom RAG or agent flow, you can include them in your project lik
 ```yaml
 targets:
   # JS and Python are natively supported
-  - file:///path/to/js_agent.js
-  - file://python_agent.py
+  - file://path/to/js_agent.js
+  - file://path/to/python_agent.py
   # Any executable can be run with the `exec:` directive
   - exec:/path/to/shell_agent
   # HTTP requests can be made with the `webhook:` directive

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -168,10 +168,9 @@ If you have a custom RAG or agent flow, you can include them in your project lik
 
 ```yaml
 targets:
-  # JS is natively supported
+  # JS and Python are natively supported
   - file:///path/to/js_agent.js
-  # Python requires the `python:` directive
-  - python:/path/to/python_agent.py
+  - file://python_agent.py
   # Any executable can be run with the `exec:` directive
   - exec:/path/to/shell_agent
   # HTTP requests can be made with the `webhook:` directive

--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -33,6 +33,12 @@ Here's an example of a Python script that could be used with the Python provider
 import json
 
 def call_api(prompt: str, options: Dict[str, Any], context: Dict[str, Any]) -> ProviderResponse:
+    # Note: The prompt may be in JSON format, so you might need to parse it.
+    # For example, if the prompt is a JSON string representing a conversation:
+    # prompt = '[{"role": "user", "content": "Hello, world!"}]'
+    # You would parse it like this:
+    # prompt = json.loads(prompt)
+
     # The 'options' parameter contains additional configuration for the API call.
     config = options.get('config', None)
     additional_option = config.get('additionalOption', None)

--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -12,7 +12,7 @@ To configure the Python provider, you need to specify the path to your Python sc
 
 ```yaml
 providers:
-  - id: 'python:my_script.py'
+  - id: 'file://my_script.py'
     label: 'Test script 1' # Optional display label for this provider
     config:
       additionalOption: 123
@@ -24,7 +24,7 @@ Your Python script should implement a function that accepts a prompt, options, a
 
 - The `ProviderResponse` must include an `output` field containing the result of the API call.
 - Optionally, it can include an `error` field if something goes wrong, and a `tokenUsage` field to report the number of tokens used.
-- By default, supported functions are `call_api`, `call_embedding_api`, and `call_classification_api`. To override the function name, specify the script like so: `python:my_script.py:function_name`
+- By default, supported functions are `call_api`, `call_embedding_api`, and `call_classification_api`. To override the function name, specify the script like so: `file://my_script.py:function_name`
 
 Here's an example of a Python script that could be used with the Python provider, which includes handling for the prompt, options, and context:
 
@@ -32,7 +32,7 @@ Here's an example of a Python script that could be used with the Python provider
 # my_script.py
 import json
 
-def call_api(prompt, options, context):
+def call_api(prompt: str, options: Dict[str, Any], context: Dict[str, Any]) -> ProviderResponse:
     # The 'options' parameter contains additional configuration for the API call.
     config = options.get('config', None)
     additional_option = config.get('additionalOption', None)
@@ -62,11 +62,11 @@ def call_api(prompt, options, context):
 
     return result
 
-def call_embedding_api(prompt):
+def call_embedding_api(prompt: str) -> ProviderEmbeddingResponse:
     # Returns ProviderEmbeddingResponse
     pass
 
-def call_classification_api(prompt):
+def call_classification_api(prompt: str) -> ProviderClassificationResponse:
     # Returns ProviderClassificationResponse
     pass
 ```
@@ -116,7 +116,7 @@ Here's an example of how you can override the Python executable using the `pytho
 
 ```yaml
 providers:
-  - id: 'python:my_script.py'
+  - id: 'file://my_script.py'
     config:
       pythonExecutable: /path/to/python3.11
 ```

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -505,7 +505,7 @@ For example, let's create a Python provider. Your config would look like this:
 
 ```yaml
 targets:
-  - id: 'python:send_redteam.py'
+  - id: 'file://send_redteam.py'
     label: 'Test script 1' # Optional display label
 ```
 
@@ -603,7 +603,7 @@ In this case, be sure to specify a `purpose`, because the redteam generator can 
 purpose: 'Act as a travel agent with a focus on European holidays'
 
 targets:
-  - python:send_redteam.py
+  - file://send_redteam.py
 
 redteam:
   numTests: 10

--- a/site/docs/red-team/rag.md
+++ b/site/docs/red-team/rag.md
@@ -435,7 +435,7 @@ This provider will handle the entire process of retrieving documents and generat
      - '{{query}}' # Use a simple passthrough prompt
 
    providers:
-     - python:rag_redteam_provider.py
+     - file://rag_redteam_provider.py
 
    redteam:
      purpose: 'Evaluate the robustness and safety of a RAG-based corporate intranet assistant'

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -42,8 +42,11 @@ export function assertionFromString(expected: string): Assertion {
       value: expected.slice(expected.startsWith('grade:') ? 6 : 11),
     };
   }
-  if (expected.startsWith('python:')) {
-    const sliceLength = 'python:'.length;
+  if (
+    expected.startsWith('python:') ||
+    (expected.startsWith('file://') && expected.endsWith('.py'))
+  ) {
+    const sliceLength = expected.startsWith('python:') ? 'python:'.length : 'file://'.length;
     const functionBody = expected.slice(sliceLength).trim();
     return {
       type: 'python',

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -44,7 +44,7 @@ export function assertionFromString(expected: string): Assertion {
   }
   if (
     expected.startsWith('python:') ||
-    (expected.startsWith('file://') && expected.endsWith('.py'))
+    (expected.startsWith('file://') && (expected.endsWith('.py') || expected.includes('.py:')))
   ) {
     const sliceLength = expected.startsWith('python:') ? 'python:'.length : 'file://'.length;
     const functionBody = expected.slice(sliceLength).trim();

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -399,7 +399,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
       },
       {
         name: 'Local Python script',
-        value: ['python:provider.py'],
+        value: ['file://provider.py'],
       },
       {
         name: 'Local Javascript script',
@@ -465,7 +465,10 @@ export async function createDummyFiles(directory: string | null, interactive: bo
       }
 
       if (
-        providerChoices.some((choice) => typeof choice === 'string' && choice.startsWith('file://'))
+        providerChoices.some(
+          (choice) =>
+            typeof choice === 'string' && choice.startsWith('file://') && choice.endsWith('.js'),
+        )
       ) {
         fs.writeFileSync(path.join(process.cwd(), directory, 'provider.js'), JAVASCRIPT_PROVIDER);
         logger.info('⌛ Wrote provider.js');
@@ -477,7 +480,12 @@ export async function createDummyFiles(directory: string | null, interactive: bo
         logger.info('⌛ Wrote provider.sh');
       }
       if (
-        providerChoices.some((choice) => typeof choice === 'string' && choice.startsWith('python:'))
+        providerChoices.some(
+          (choice) =>
+            typeof choice === 'string' &&
+            (choice.startsWith('python:') ||
+              (choice.startsWith('file://') && choice.endsWith('.py'))),
+        )
       ) {
         fs.writeFileSync(path.join(process.cwd(), directory, 'provider.py'), PYTHON_PROVIDER);
         logger.info('⌛ Wrote provider.py');

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -124,8 +124,13 @@ export async function loadApiProvider(
     // Load script module
     const scriptPath = providerPath.split(':')[1];
     ret = new ScriptCompletionProvider(scriptPath, providerOptions);
-  } else if (providerPath.startsWith('python:')) {
-    const scriptPath = providerPath.split(':').slice(1).join(':');
+  } else if (
+    providerPath.startsWith('python:') ||
+    (providerPath.startsWith('file://') && providerPath.endsWith('.py'))
+  ) {
+    const scriptPath = providerPath.startsWith('file://')
+      ? providerPath.slice('file://'.length)
+      : providerPath.split(':').slice(1).join(':');
     ret = new PythonProvider(scriptPath, providerOptions);
   } else if (providerPath.startsWith('openai:')) {
     // Load OpenAI module

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -126,7 +126,8 @@ export async function loadApiProvider(
     ret = new ScriptCompletionProvider(scriptPath, providerOptions);
   } else if (
     providerPath.startsWith('python:') ||
-    (providerPath.startsWith('file://') && providerPath.endsWith('.py'))
+    (providerPath.startsWith('file://') &&
+      (providerPath.endsWith('.py') || providerPath.includes('.py:')))
   ) {
     const scriptPath = providerPath.startsWith('file://')
       ? providerPath.slice('file://'.length)

--- a/src/redteam/commands/init.ts
+++ b/src/redteam/commands/init.ts
@@ -257,7 +257,7 @@ export async function redteamInit(directory: string | undefined) {
         },
       ];
     } else {
-      providers = ['python:chat.py'];
+      providers = ['file://chat.py'];
     }
   } else {
     const providerChoices = [

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -310,6 +310,30 @@ describe('assertionFromString', () => {
     expect(result.value).toBe('file://file.py');
   });
 
+  it('should parse python: assertion', () => {
+    const assertion = assertionFromString('python:some_python_code');
+    expect(assertion).toEqual({
+      type: 'python',
+      value: 'some_python_code',
+    });
+  });
+
+  it(`should parse file:// prefix assertion`, () => {
+    const assertion = assertionFromString('file://script.py');
+    expect(assertion).toEqual({
+      type: 'python',
+      value: 'script.py',
+    });
+  });
+
+  it(`should parse file:// prefix assertion with function name`, () => {
+    const assertion = assertionFromString('file://script.py:function_name');
+    expect(assertion).toEqual({
+      type: 'python',
+      value: 'script.py:function_name',
+    });
+  });
+
   it('should create a javascript assertion', () => {
     const expected = 'javascript: x > 10';
 

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -1,4 +1,5 @@
-import { reportProviderAPIKeyWarnings } from '../src/onboarding';
+import fs from 'fs';
+import { createDummyFiles, reportProviderAPIKeyWarnings } from '../src/onboarding';
 
 describe('reportProviderAPIKeyWarnings', () => {
   const openaiID = 'openai:gpt-4o';
@@ -42,7 +43,6 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
-
   it('should be able to accept an object input so long as it has a valid id field', () => {
     expect(reportProviderAPIKeyWarnings([{ id: openaiID }, anthropicID])).toEqual(
       expect.arrayContaining([
@@ -59,6 +59,28 @@ describe('reportProviderAPIKeyWarnings', () => {
       expect.arrayContaining([
         expect.stringContaining('ANTHROPIC_API_KEY environment variable is not set'),
       ]),
+    );
+  });
+});
+
+describe('createDummyFiles', () => {
+  it('should create Python provider file for file:// prefix syntax', async () => {
+    const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync');
+    await createDummyFiles('file://provider.py');
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('provider.py'),
+      expect.stringContaining(
+        'def call_api(prompt: str, options: Dict[str, Any], context: Dict[str, Any]) -> ProviderResponse:',
+      ),
+    );
+  });
+
+  it('should create JavaScript provider file for file:// prefix syntax', async () => {
+    const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync');
+    await createDummyFiles('file://provider.js');
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('provider.js'),
+      expect.stringContaining('async function callApi(prompt, options, context) {'),
     );
   });
 });

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -1,24 +1,19 @@
-import fs from 'fs';
-import { createDummyFiles, reportProviderAPIKeyWarnings } from '../src/onboarding';
+import { reportProviderAPIKeyWarnings } from '../src/onboarding';
 
 describe('reportProviderAPIKeyWarnings', () => {
   const openaiID = 'openai:gpt-4o';
   const anthropicID = 'anthropic:messages:claude-3-5-sonnet-20240620';
   let oldEnv: any = {};
-
   beforeAll(() => {
     oldEnv = { ...process.env };
   });
-
   beforeEach(() => {
     process.env.OPENAI_API_KEY = '';
     process.env.ANTHROPIC_API_KEY = '';
   });
-
   afterAll(() => {
     process.env = { ...oldEnv };
   });
-
   it('should produce a warning for openai if env key is not set', () => {
     expect(reportProviderAPIKeyWarnings([openaiID])).toEqual(
       expect.arrayContaining([
@@ -26,7 +21,6 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
-
   it('should produce a warning for anthropic if env key is not set', () => {
     expect(reportProviderAPIKeyWarnings([anthropicID])).toEqual(
       expect.arrayContaining([
@@ -34,7 +28,6 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
-
   it('should produce multiple warnings for applicable providers if env keys are not set', () => {
     expect(reportProviderAPIKeyWarnings([openaiID, anthropicID])).toEqual(
       expect.arrayContaining([
@@ -51,7 +44,6 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
-
   it('should produce only warnings for applicable providers if the env keys are not set', () => {
     // Stub what would be the openai api key env variable.
     process.env.OPENAI_API_KEY = '<my-api-key>';
@@ -59,28 +51,6 @@ describe('reportProviderAPIKeyWarnings', () => {
       expect.arrayContaining([
         expect.stringContaining('ANTHROPIC_API_KEY environment variable is not set'),
       ]),
-    );
-  });
-});
-
-describe('createDummyFiles', () => {
-  it('should create Python provider file for file:// prefix syntax', async () => {
-    const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync');
-    await createDummyFiles('file://provider.py');
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('provider.py'),
-      expect.stringContaining(
-        'def call_api(prompt: str, options: Dict[str, Any], context: Dict[str, Any]) -> ProviderResponse:',
-      ),
-    );
-  });
-
-  it('should create JavaScript provider file for file:// prefix syntax', async () => {
-    const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync');
-    await createDummyFiles('file://provider.js');
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('provider.js'),
-      expect.stringContaining('async function callApi(prompt, options, context) {'),
     );
   });
 });

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -4,16 +4,20 @@ describe('reportProviderAPIKeyWarnings', () => {
   const openaiID = 'openai:gpt-4o';
   const anthropicID = 'anthropic:messages:claude-3-5-sonnet-20240620';
   let oldEnv: any = {};
+
   beforeAll(() => {
     oldEnv = { ...process.env };
   });
+
   beforeEach(() => {
     process.env.OPENAI_API_KEY = '';
     process.env.ANTHROPIC_API_KEY = '';
   });
+
   afterAll(() => {
     process.env = { ...oldEnv };
   });
+
   it('should produce a warning for openai if env key is not set', () => {
     expect(reportProviderAPIKeyWarnings([openaiID])).toEqual(
       expect.arrayContaining([
@@ -21,6 +25,7 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
+
   it('should produce a warning for anthropic if env key is not set', () => {
     expect(reportProviderAPIKeyWarnings([anthropicID])).toEqual(
       expect.arrayContaining([
@@ -28,6 +33,7 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
+
   it('should produce multiple warnings for applicable providers if env keys are not set', () => {
     expect(reportProviderAPIKeyWarnings([openaiID, anthropicID])).toEqual(
       expect.arrayContaining([
@@ -36,6 +42,7 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
+
   it('should be able to accept an object input so long as it has a valid id field', () => {
     expect(reportProviderAPIKeyWarnings([{ id: openaiID }, anthropicID])).toEqual(
       expect.arrayContaining([
@@ -44,6 +51,7 @@ describe('reportProviderAPIKeyWarnings', () => {
       ]),
     );
   });
+
   it('should produce only warnings for applicable providers if the env keys are not set', () => {
     // Stub what would be the openai api key env variable.
     process.env.OPENAI_API_KEY = '<my-api-key>';

--- a/test/providers.pythonCompletion.test.ts
+++ b/test/providers.pythonCompletion.test.ts
@@ -47,6 +47,30 @@ describe('PythonProvider', () => {
       });
       expect(provider.id()).toBe('testId');
     });
+
+    it('should initialize with python: syntax', () => {
+      const provider = new PythonProvider('python:script.py', {
+        id: 'testId',
+        config: { basePath: '/base' },
+      });
+      expect(provider.id()).toBe('testId');
+    });
+
+    it('should initialize with file:// prefix', () => {
+      const provider = new PythonProvider('file://script.py', {
+        id: 'testId',
+        config: { basePath: '/base' },
+      });
+      expect(provider.id()).toBe('testId');
+    });
+
+    it('should initialize with file:// prefix and function name', () => {
+      const provider = new PythonProvider('file://script.py:function_name', {
+        id: 'testId',
+        config: { basePath: '/base' },
+      });
+      expect(provider.id()).toBe('testId');
+    });
   });
 
   describe('callApi', () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -37,6 +37,7 @@ import {
   OpenAiCompletionProvider,
   OpenAiChatCompletionProvider,
 } from '../src/providers/openai';
+import { PythonProvider } from '../src/providers/pythonCompletion';
 import {
   ReplicateImageProvider,
   ReplicateModerationProvider,
@@ -1340,6 +1341,18 @@ config:
     const provider = await loadApiProvider('replicate:moderation:foo/bar:abc123');
     expect(provider).toBeInstanceOf(ReplicateModerationProvider);
     expect(provider.id()).toBe('replicate:foo/bar:abc123');
+  });
+
+  it('loadApiProvider with file://*.py', async () => {
+    const provider = await loadApiProvider('file://script.py:function_name');
+    expect(provider).toBeInstanceOf(PythonProvider);
+    expect(provider.id()).toBe('python:script.py:function_name');
+  });
+
+  it('loadApiProvider with python:*.py', async () => {
+    const provider = await loadApiProvider('python:script.py');
+    expect(provider).toBeInstanceOf(PythonProvider);
+    expect(provider.id()).toBe('python:script.py:default');
   });
 
   it('loadApiProvider with cloudflare-ai', async () => {


### PR DESCRIPTION
- Update configuration examples to use file:// syntax
- Modify loadApiProvider to handle file:// syntax for Python files
- Update documentation to reflect new syntax
- Add test cases for file:// syntax in Python providers
- Maintain backwards compatibility with python: syntax
