### PR TITLE
feat(http): add support for raw requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "fastest-levenshtein": "^1.0.16",
         "glob": "^10.4.3",
         "groq-sdk": "^0.7.0",
+        "http-z": "^7.1.1",
         "inquirer": "^10.2.2",
         "js-rouge": "3.0.0",
         "js-yaml": "^4.1.0",
@@ -18550,6 +18551,18 @@
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "peer": true
+    },
+    "node_modules/http-z": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/http-z/-/http-z-7.1.1.tgz",
+      "integrity": "sha512-Vt2tRLs8d4YqEj7p8oyXwiZGd+8UnyhwfgiLCGktDxcXZ9gLn3M5IKRC3WQacogrhLNANfg1vky+S9lV0O9uBA==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=8"
+      }
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "@azure/identity": "^4.0.0",
     "@azure/openai-assistants": "^1.0.0-beta.5",
     "@ibm-generative-ai/node-sdk": "^2.0.6",
+    "@playwright/browser-chromium": "^1.47.2",
     "@smithy/node-http-handler": "^3.1.1",
     "google-auth-library": "^9.7.0",
     "langfuse": "^3.7.0",
     "node-sql-parser": "^5.2.0",
-    "playwright": "^1.47.2",
-    "@playwright/browser-chromium": "^1.47.2"
+    "playwright": "^1.47.2"
   },
   "devDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.654.0",
@@ -159,6 +159,7 @@
     "fastest-levenshtein": "^1.0.16",
     "glob": "^10.4.3",
     "groq-sdk": "^0.7.0",
+    "http-z": "^7.1.1",
     "inquirer": "^10.2.2",
     "js-rouge": "3.0.0",
     "js-yaml": "^4.1.0",

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -77,7 +77,7 @@ providers:
   - id: https
     config:
       request: file://path/to/request.txt
-      responseParser: 'json.choices[0].text'
+      responseParser: 'json.text'
 ```
 
 ### Nested objects
@@ -151,6 +151,26 @@ Extracts the message content from this response:
     }
   ]
 }
+```
+
+## Parsing a text response
+
+If your API responds with a text response, you can use the `responseParser` property to set a Javascript snippet that manipulates the provided `text` object.
+
+For example, this `responseParser` configuration:
+
+```yaml
+providers:
+  - id: 'https://example.com/api'
+    config:
+      # ...
+      responseParser: 'text.slice(11)'
+```
+
+Extracts the message content "hello world" from this response:
+
+```
+Assistant: hello world
 ```
 
 ## Query parameters

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -40,6 +40,46 @@ tests:
 
 If not specified, HTTP POST with content-type application/json is assumed.
 
+## Sending a raw HTTP request
+
+You can also send a raw HTTP request by specifying the `request` property in the provider configuration. This allows you to have full control over the request, including headers and body.
+
+Here's an example of how to use the raw HTTP request feature:
+
+```yaml
+providers:
+  - id: https
+    config:
+      request: |
+        POST /v1/completions HTTP/1.1
+        Host: api.example.com
+        Content-Type: application/json
+        Authorization: Bearer {{api_key}}
+
+        {
+          "model": "llama3.1-405b-base",
+          "prompt": "{{prompt}}",
+          "max_tokens": 100
+        }
+      responseParser: 'json.text'
+```
+
+In this example:
+
+1. The `request` property contains a raw HTTP request, including the method, path, headers, and body.
+2. You can use template variables like `{{api_key}}` and `{{prompt}}` within the raw request. These will be replaced with actual values when the request is sent.
+3. The `responseParser` property is used to extract the desired information from the JSON response.
+
+You can also load the raw request from an external file using the `file://` prefix:
+
+```yaml
+providers:
+  - id: https
+    config:
+      request: file://path/to/request.txt
+      responseParser: 'json.choices[0].text'
+```
+
 ### Nested objects
 
 Nested objects are supported and should be passed to the `dump` function.
@@ -159,6 +199,7 @@ Supported config options:
 | Option         | Type                     | Description                                                                                                                                   |
 | -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | url            | string                   | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                       |
+| request        | string                   | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                             |
 | method         | string                   | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                   |
 | headers        | Record\<string, string\> | Key-value pairs of HTTP headers to include in the request.                                                                                    |
 | body           | Record\<string, any\>    | The request body. For POST requests, this will be sent as JSON.                                                                               |

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -497,6 +497,25 @@ targets:
       responseParser: 'json.output'
 ```
 
+Or, let's say you have a raw HTTP request exported from a tool like Burp Suite. Put it in a file called `request.txt`:
+
+```
+POST /api/generate HTTP/1.1
+Host: example.com
+Content-Type: application/json
+
+{"prompt": "Tell me a joke"}
+```
+
+Then, in your Promptfoo config, you can reference it like this:
+
+```yaml
+targets:
+  - id: http # or https
+    config:
+      request: file://request.txt
+```
+
 #### Custom scripts
 
 Alternatively, you can use a custom [Python](/docs/providers/python/), [Javascript](/docs/providers/custom-api/), or other [script](/docs/providers/custom-script/) in order to precisely construct your requests.

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -22,7 +22,7 @@ interface HttpProviderConfig {
   body?: Record<string, any>;
   queryParams?: Record<string, string>;
   responseParser?: string | Function;
-  rawRequest?: string;
+  request?: string;
 }
 
 function createResponseParser(parser: any): (data: any) => ProviderResponse {
@@ -98,8 +98,8 @@ export class HttpProvider implements ApiProvider {
     this.url = this.config.url || url;
     this.responseParser = createResponseParser(this.config.responseParser);
 
-    if (this.config.rawRequest) {
-      this.config.rawRequest = maybeLoadFromExternalFile(this.config.rawRequest) as string;
+    if (this.config.request) {
+      this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
     } else {
       invariant(
         this.config.body || this.config.method === 'GET',
@@ -124,7 +124,7 @@ export class HttpProvider implements ApiProvider {
       prompt,
     };
 
-    if (this.config.rawRequest) {
+    if (this.config.request) {
       return this.callApiWithRawRequest(vars);
     }
 
@@ -185,8 +185,8 @@ export class HttpProvider implements ApiProvider {
   }
 
   private async callApiWithRawRequest(vars: Record<string, any>): Promise<ProviderResponse> {
-    invariant(this.config.rawRequest, 'Expected rawRequest to be set in http provider config');
-    const renderedRequest = nunjucks.renderString(this.config.rawRequest, vars);
+    invariant(this.config.request, 'Expected request to be set in http provider config');
+    const renderedRequest = nunjucks.renderString(this.config.request, vars);
     const parsedRequest = parseRawRequest(renderedRequest.trim());
 
     const protocol = this.url.startsWith('https') ? 'https' : 'http';

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -1,8 +1,14 @@
+import dedent from 'dedent';
 import { fetchWithCache } from '../src/cache';
 import { HttpProvider, processBody } from '../src/providers/http';
+import { maybeLoadFromExternalFile } from '../src/util';
 
 jest.mock('../src/cache', () => ({
   fetchWithCache: jest.fn(),
+}));
+
+jest.mock('../src/util', () => ({
+  maybeLoadFromExternalFile: jest.fn((input) => input),
 }));
 
 describe('HttpProvider', () => {
@@ -197,6 +203,123 @@ describe('HttpProvider', () => {
       expect.any(Number),
       'json',
     );
+  });
+
+  describe('raw request', () => {
+    it('should handle a basic GET raw request', async () => {
+      const rawRequest = dedent`
+        GET /api/data HTTP/1.1
+        Host: example.com
+        User-Agent: TestAgent/1.0
+      `;
+      const provider = new HttpProvider('http', {
+        config: {
+          rawRequest,
+          responseParser: (data: any) => data,
+        },
+      });
+
+      const mockResponse = { data: { result: 'success' }, cached: false };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test prompt');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'http://example.com/api/data',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            host: 'example.com',
+            'user-agent': 'TestAgent/1.0',
+          }),
+        }),
+        expect.any(Number),
+        'json',
+      );
+      expect(result.output).toEqual({ result: 'success' });
+    });
+
+    it('should handle a POST raw request with body and variable substitution', async () => {
+      const rawRequest = dedent`
+        POST /api/submit HTTP/1.1
+        Host: example.com
+        Content-Type: application/json
+
+        {"data": "{{prompt}}"}
+      `;
+      const provider = new HttpProvider('https', {
+        config: {
+          rawRequest,
+          responseParser: (data: any) => data,
+        },
+      });
+
+      const mockResponse = { data: { result: 'received' }, cached: false };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test data');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://example.com/api/submit',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            host: 'example.com',
+            'content-type': 'application/json',
+          }),
+          body: '{"data": "test data"}',
+        }),
+        expect.any(Number),
+        'json',
+      );
+      expect(result.output).toEqual({ result: 'received' });
+    });
+
+    it('should load raw request from file if file:// prefix is used', async () => {
+      const filePath = 'file://path/to/request.txt';
+      const fileContent = dedent`
+        GET /api/data HTTP/1.1
+        Host: example.com
+      `;
+      jest.mocked(maybeLoadFromExternalFile).mockReturnValueOnce(fileContent);
+
+      const provider = new HttpProvider('https', {
+        config: {
+          rawRequest: filePath,
+          responseParser: (data: any) => data,
+        },
+      });
+
+      const mockResponse = { data: { result: 'success' }, cached: false };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test prompt');
+
+      expect(maybeLoadFromExternalFile).toHaveBeenCalledWith(filePath);
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://example.com/api/data',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            host: 'example.com',
+          }),
+        }),
+        expect.any(Number),
+        'json',
+      );
+      expect(result.output).toEqual({ result: 'success' });
+    });
+
+    it('should throw an error for invalid raw requests', async () => {
+      const provider = new HttpProvider('http', {
+        config: {
+          rawRequest: 'yo mama',
+        },
+      });
+      await expect(provider.callApi('test prompt')).rejects.toThrow(
+        'Error parsing raw HTTP request',
+      );
+    });
   });
 
   describe('processBody', () => {

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -41,7 +41,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: 'test prompt' }),
       }),
       expect.any(Number),
-      'json',
+      'text',
     );
   });
 
@@ -85,13 +85,14 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: 'test prompt' }),
       }),
       expect.any(Number),
-      'json',
+      'text',
     );
   });
 
   const testCases = [
     { parser: (data: any) => data.custom, expected: 'parsed' },
     { parser: 'json.result', expected: 'parsed' },
+    { parser: 'text', expected: JSON.stringify({ result: 'parsed', custom: 'parsed' }) },
   ];
 
   testCases.forEach(({ parser, expected }) => {
@@ -131,7 +132,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: 'test prompt' }),
       },
       expect.any(Number),
-      'json',
+      'text',
     );
   });
 
@@ -155,7 +156,7 @@ describe('HttpProvider', () => {
         body: JSON.stringify({ key: { key: 'value' } }),
       }),
       expect.any(Number),
-      'json',
+      'text',
     );
   });
 
@@ -201,7 +202,7 @@ describe('HttpProvider', () => {
         method: 'GET',
       }),
       expect.any(Number),
-      'json',
+      'text',
     );
   });
 
@@ -214,7 +215,7 @@ describe('HttpProvider', () => {
       `;
       const provider = new HttpProvider('http', {
         config: {
-          rawRequest,
+          request: rawRequest,
           responseParser: (data: any) => data,
         },
       });
@@ -234,7 +235,7 @@ describe('HttpProvider', () => {
           }),
         }),
         expect.any(Number),
-        'json',
+        'text',
       );
       expect(result.output).toEqual({ result: 'success' });
     });
@@ -249,7 +250,7 @@ describe('HttpProvider', () => {
       `;
       const provider = new HttpProvider('https', {
         config: {
-          rawRequest,
+          request: rawRequest,
           responseParser: (data: any) => data,
         },
       });
@@ -270,7 +271,7 @@ describe('HttpProvider', () => {
           body: '{"data": "test data"}',
         }),
         expect.any(Number),
-        'json',
+        'text',
       );
       expect(result.output).toEqual({ result: 'received' });
     });
@@ -285,7 +286,7 @@ describe('HttpProvider', () => {
 
       const provider = new HttpProvider('https', {
         config: {
-          rawRequest: filePath,
+          request: filePath,
           responseParser: (data: any) => data,
         },
       });
@@ -305,7 +306,7 @@ describe('HttpProvider', () => {
           }),
         }),
         expect.any(Number),
-        'json',
+        'text',
       );
       expect(result.output).toEqual({ result: 'success' });
     });
@@ -313,7 +314,7 @@ describe('HttpProvider', () => {
     it('should throw an error for invalid raw requests', async () => {
       const provider = new HttpProvider('http', {
         config: {
-          rawRequest: 'yo mama',
+          request: 'yo mama',
         },
       });
       await expect(provider.callApi('test prompt')).rejects.toThrow(


### PR DESCRIPTION
Allows you to do, for example:

```yaml
providers:
  - id: https
    config:
      request: |
        POST /v1/completions HTTP/1.1
        Host: api.example.com
        Content-Type: application/json
        Authorization: Bearer {{api_key}}

        {
          "model": "llama3.1-405b-base",
          "prompt": "{{prompt}}",
          "max_tokens": 100
        }
      responseParser: 'json.text'
```

Or

```yaml
providers:
  - id: https
    config:
      request: file://path/to/request.txt
      responseParser: 'json.text'
```