### PR TITLE
fix: redteam aliases

### DIFF
--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -5,7 +5,6 @@ import {
   COLLECTIONS,
   HARM_PLUGINS,
   PII_PLUGINS,
-  ALIASED_PLUGIN_MAPPINGS,
 } from '../../src/redteam/constants';
 import {
   RedteamGenerateOptionsSchema,

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -5,6 +5,7 @@ import {
   COLLECTIONS,
   HARM_PLUGINS,
   PII_PLUGINS,
+  ALIASED_PLUGIN_MAPPINGS,
 } from '../../src/redteam/constants';
 import {
   RedteamGenerateOptionsSchema,
@@ -518,5 +519,157 @@ describe('redteamConfigSchema', () => {
       { id: 'policy', config: { policy: 'Policy A' }, numTests: 5 },
       { id: 'policy', config: { policy: 'Policy B' }, numTests: 3 },
     ]);
+  });
+
+  describe('plugin aliases', () => {
+    it('should expand high-level aliased plugin names', () => {
+      const input = {
+        plugins: ['owasp:llm'],
+        numTests: 3,
+      };
+      const result = RedteamConfigSchema.safeParse(input);
+      expect(result.success).toBe(true);
+
+      const expectedPlugins = [
+        'harmful:violent-crime',
+        'harmful:non-violent-crime',
+        'harmful:sex-crime',
+        'harmful:child-exploitation',
+        'harmful:indiscriminate-weapons',
+        'harmful:hate',
+        'harmful:self-harm',
+        'harmful:sexual-content',
+        'harmful:cybercrime',
+        'harmful:chemical-biological-weapons',
+        'harmful:illegal-drugs',
+        'harmful:copyright-violations',
+        'harmful:harassment-bullying',
+        'harmful:illegal-activities',
+        'harmful:graphic-content',
+        'harmful:unsafe-practices',
+        'harmful:radicalization',
+        'harmful:profanity',
+        'harmful:insults',
+        'harmful:privacy',
+        'harmful:intellectual-property',
+        'harmful:misinformation-disinformation',
+        'harmful:specialized-advice',
+        'pii:api-db',
+        'pii:direct',
+        'pii:session',
+        'pii:social',
+        'overreliance',
+        'hallucination',
+      ];
+
+      expect(result.data?.plugins).toEqual(
+        expect.arrayContaining(
+          expectedPlugins.map((id) => expect.objectContaining({ id, numTests: 3 })),
+        ),
+      );
+    });
+
+    it('should expand granular aliased plugin names', () => {
+      const input = {
+        plugins: ['owasp:llm:01'],
+        numTests: 3,
+      };
+      const result = RedteamConfigSchema.safeParse(input);
+      expect(result.success).toBe(true);
+
+      const expectedPlugins = [
+        'harmful:violent-crime',
+        'harmful:non-violent-crime',
+        'harmful:sex-crime',
+        'harmful:child-exploitation',
+        'harmful:indiscriminate-weapons',
+        'harmful:hate',
+        'harmful:self-harm',
+        'harmful:sexual-content',
+        'harmful:cybercrime',
+        'harmful:chemical-biological-weapons',
+        'harmful:illegal-drugs',
+        'harmful:copyright-violations',
+        'harmful:harassment-bullying',
+        'harmful:illegal-activities',
+        'harmful:graphic-content',
+        'harmful:unsafe-practices',
+        'harmful:radicalization',
+        'harmful:profanity',
+        'harmful:insults',
+        'harmful:privacy',
+        'harmful:intellectual-property',
+        'harmful:misinformation-disinformation',
+        'harmful:specialized-advice',
+      ];
+
+      expect(result.data?.plugins).toEqual(
+        expect.arrayContaining(
+          expectedPlugins.map((id) => expect.objectContaining({ id, numTests: 3 })),
+        ),
+      );
+    });
+
+    it('should expand collections within aliased plugin names', () => {
+      const input = {
+        plugins: ['nist:ai:measure:2.1'],
+        numTests: 3,
+      };
+      const result = RedteamConfigSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      const expectedPlugins = [
+        'harmful:privacy',
+        'pii:api-db',
+        'pii:direct',
+        'pii:session',
+        'pii:social',
+      ];
+      expect(result.data?.plugins).toEqual(
+        expect.arrayContaining(
+          expectedPlugins.map((id) => expect.objectContaining({ id, numTests: 3 })),
+        ),
+      );
+    });
+
+    it('should not duplicate plugins when using multiple aliased names', () => {
+      const input = {
+        plugins: ['owasp:llm:01', 'owasp:llm:02'],
+        numTests: 3,
+      };
+      const result = RedteamConfigSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      const expectedPlugins = [
+        'harmful:violent-crime',
+        'harmful:non-violent-crime',
+        'harmful:sex-crime',
+        'harmful:child-exploitation',
+        'harmful:indiscriminate-weapons',
+        'harmful:hate',
+        'harmful:self-harm',
+        'harmful:sexual-content',
+        'harmful:cybercrime',
+        'harmful:chemical-biological-weapons',
+        'harmful:illegal-drugs',
+        'harmful:copyright-violations',
+        'harmful:harassment-bullying',
+        'harmful:illegal-activities',
+        'harmful:graphic-content',
+        'harmful:unsafe-practices',
+        'harmful:radicalization',
+        'harmful:profanity',
+        'harmful:insults',
+        'harmful:privacy',
+        'harmful:intellectual-property',
+        'harmful:misinformation-disinformation',
+        'harmful:specialized-advice',
+        'overreliance',
+      ];
+      expect(result.data?.plugins).toHaveLength(expectedPlugins.length);
+      expect(result.data?.plugins).toEqual(
+        expect.arrayContaining(
+          expectedPlugins.map((id) => expect.objectContaining({ id, numTests: 3 })),
+        ),
+      );
+    });
   });
 });


### PR DESCRIPTION
Fix high-level aliases (such as `owasp:llm`) and granular aliases (such as `owasp:llm:02`).