### PR TITLE
ci(nexe-build): add ARM64 support for nexe builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         # TODO(Michael): Re-enable once issues are resolved, 2024-08-23
         node: ['18.x', '20.x']
         python: ['3.9']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-arm64, windows-latest, macOS-latest]
         exclude:
           # Remove when https://github.com/nodejs/node/issues/51766 is resolved
           - node: '22.x'
@@ -61,7 +61,7 @@ jobs:
   style-check:
     name: Style Check
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
   assets:
     name: Generate Assets
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
   python:
     name: Check Python
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     strategy:
       matrix:
         python-version: [3.9, 3.12]
@@ -159,7 +159,7 @@ jobs:
   docs:
     name: Build Docs
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -185,7 +185,7 @@ jobs:
   webui:
     name: webui tests
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         # TODO(Michael): Re-enable once issues are resolved, 2024-08-23
         node: ['18.x', '20.x']
         python: ['3.9']
-        os: [ubuntu-arm64, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
           # Remove when https://github.com/nodejs/node/issues/51766 is resolved
           - node: '22.x'
@@ -61,7 +61,7 @@ jobs:
   style-check:
     name: Style Check
     timeout-minutes: 5
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
   assets:
     name: Generate Assets
     timeout-minutes: 5
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
   python:
     name: Check Python
     timeout-minutes: 5
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9, 3.12]
@@ -159,7 +159,7 @@ jobs:
   docs:
     name: Build Docs
     timeout-minutes: 5
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -185,7 +185,7 @@ jobs:
   webui:
     name: webui tests
     timeout-minutes: 5
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/nexe-build.yml
+++ b/.github/workflows/nexe-build.yml
@@ -51,15 +51,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nexe
-          key: ${{ runner.os }}-${{ matrix.arch }}-nexe-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.arch }}-${{ runner.os }}-nexe-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-nexe-
+            ${{ matrix.arch }}-${{ runner.os }}-nexe-
           save-always: true
       - name: Install nexe globally
         run: npm install -g nexe
       - name: Build executable
-        run: npx nexe --build -r drizzle/ -r package.json -r "dist/**/*" -i dist/src/main.js -o promptfoo-${{ matrix.os }}-${{ matrix.arch }}
-
+        run: |
+          npx nexe --build \
+            -r drizzle/ \
+            -r package.json \
+            -r "dist/**/*" \
+            -i dist/src/main.js \
+            -o promptfoo-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'win' && '.exe' || '' }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nexe-build.yml
+++ b/.github/workflows/nexe-build.yml
@@ -29,7 +29,7 @@ jobs:
 
   nexe-build:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'x64' && 'ubuntu-latest' || 'ubuntu-arm64' }}
     timeout-minutes: 180
     continue-on-error: true
     strategy:


### PR DESCRIPTION
Update nexe-build job to use ubuntu-arm64 for ARM builds. This is because nexe does not like to build cross architecture. 