### PR TITLE
fix: use provider prompt map when running via Node package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import invariant from 'tiny-invariant';
 import assertions from './assertions';
 import * as cache from './cache';
 import { evaluate as doEvaluate } from './evaluator';
-import { readPrompts } from './prompts';
+import { readPrompts, readProviderPromptMap } from './prompts';
 import providers, { loadApiProvider } from './providers';
 import { loadApiProviders } from './providers';
 import { extractEntities } from './redteam/extraction/entities';
@@ -98,8 +98,8 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     cache.disableCache();
   }
 
-  const parsedProviderPromptMap = prompts_1.readProviderPromptMap(
-    testSuite,
+  const parsedProviderPromptMap = readProviderPromptMap(
+    testSuite as never,
     constructedTestSuite.prompts,
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,10 +98,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     cache.disableCache();
   }
 
-  const parsedProviderPromptMap = readProviderPromptMap(
-    testSuite as never,
-    constructedTestSuite.prompts,
-  );
+  const parsedProviderPromptMap = readProviderPromptMap(testSuite, constructedTestSuite.prompts);
 
   // Run the eval!
   const ret = await doEvaluate(

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
           if (typeof promptInput === 'function') {
             return {
               raw: promptInput.toString(),
-              label: promptInput.toString(),
+              label: promptInput?.name ?? promptInput.toString(),
               function: promptInput as PromptFunction,
             };
           } else if (typeof promptInput === 'string') {
@@ -98,11 +98,22 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     cache.disableCache();
   }
 
+  const parsedProviderPromptMap = prompts_1.readProviderPromptMap(
+    testSuite,
+    constructedTestSuite.prompts,
+  );
+
   // Run the eval!
-  const ret = await doEvaluate(constructedTestSuite, {
-    eventSource: 'library',
-    ...options,
-  });
+  const ret = await doEvaluate(
+    {
+      ...constructedTestSuite,
+      providerPromptMap: parsedProviderPromptMap,
+    },
+    {
+      eventSource: 'library',
+      ...options,
+    },
+  );
 
   const unifiedConfig = { ...testSuite, prompts: constructedTestSuite.prompts };
   let evalId: string | null = null;

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -28,7 +28,7 @@ export * from './grading';
  * @returns A map of provider IDs to their respective prompts.
  */
 export function readProviderPromptMap(
-  config: Partial<UnifiedConfig>,
+  config: Pick<Partial<UnifiedConfig>, 'providers'>,
   parsedPrompts: Prompt[],
 ): TestSuite['providerPromptMap'] {
   const ret: Record<string, string[]> = {};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -101,9 +101,6 @@ describe('index.ts exports', () => {
 
 describe('evaluate function', () => {
   it('should handle function prompts correctly', async () => {
-    // Mock the necessary dependencies
-
-    // Use a named function expression instead of an arrow function
     const mockPromptFunction = function testPrompt() {
       return 'Test prompt';
     };
@@ -115,8 +112,6 @@ describe('evaluate function', () => {
     };
 
     await index.evaluate(testSuite);
-
-    // Check if readProviderPromptMap was called with the correct arguments
     expect(readProviderPromptMap).toHaveBeenCalledWith(testSuite, [
       {
         raw: mockPromptFunction.toString(),
@@ -124,8 +119,6 @@ describe('evaluate function', () => {
         function: mockPromptFunction,
       },
     ]);
-
-    // Check if doEvaluate was called with the correct arguments
     expect(doEvaluate).toHaveBeenCalledWith(
       expect.objectContaining({
         prompts: [

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,9 @@
+import * as cache from '../src/cache';
 import { evaluate as doEvaluate } from '../src/evaluator';
 import * as index from '../src/index';
+import { evaluate } from '../src/index';
 import { readProviderPromptMap } from '../src/prompts';
+import { writeResultsToDatabase, writeOutput, writeMultipleOutputs } from '../src/util';
 
 jest.mock('../src/telemetry');
 jest.mock('../src/evaluator', () => {
@@ -17,6 +20,8 @@ jest.mock('../src/prompts', () => {
     readProviderPromptMap: jest.fn().mockReturnValue({}),
   };
 });
+jest.mock('../src/util');
+jest.mock('../src/cache');
 
 describe('index.ts exports', () => {
   const expectedNamedExports = [
@@ -97,6 +102,15 @@ describe('index.ts exports', () => {
       redteam: index.redteam,
     });
   });
+
+  it('should export cache with correct methods', () => {
+    expect(cache).toHaveProperty('getCache');
+    expect(cache).toHaveProperty('fetchWithCache');
+    expect(cache).toHaveProperty('enableCache');
+    expect(cache).toHaveProperty('disableCache');
+    expect(cache).toHaveProperty('clearCache');
+    expect(cache).toHaveProperty('isCacheEnabled');
+  });
 });
 
 describe('evaluate function', () => {
@@ -133,6 +147,128 @@ describe('evaluate function', () => {
       expect.objectContaining({
         eventSource: 'library',
       }),
+    );
+  });
+
+  it('should process different types of prompts correctly', async () => {
+    const testSuite = {
+      prompts: [
+        'string prompt',
+        { raw: 'object prompt' },
+        function functionPrompt() {
+          return 'function prompt';
+        },
+      ],
+      providers: [],
+    };
+    await evaluate(testSuite);
+    expect(doEvaluate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompts: expect.arrayContaining([
+          expect.any(Object),
+          expect.any(Object),
+          expect.any(Object),
+        ]),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('should resolve nested providers', async () => {
+    const testSuite = {
+      prompts: ['test prompt'],
+      providers: [],
+      tests: [{ options: { provider: 'test-provider' } }],
+    };
+    await evaluate(testSuite);
+    expect(doEvaluate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tests: expect.arrayContaining([
+          expect.objectContaining({
+            options: expect.objectContaining({
+              provider: expect.anything(),
+            }),
+          }),
+        ]),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should disable cache when specified', async () => {
+    await evaluate({ prompts: ['test'], providers: [] }, { cache: false });
+    expect(cache.disableCache).toHaveBeenCalledWith();
+  });
+
+  it('should write results to database when writeLatestResults is true', async () => {
+    const testSuite = {
+      prompts: ['test'],
+      providers: [],
+      writeLatestResults: true,
+    };
+    await evaluate(testSuite);
+    expect(writeResultsToDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({ results: expect.any(Array) }),
+      expect.objectContaining({
+        prompts: expect.arrayContaining([
+          expect.objectContaining({
+            raw: 'test',
+            label: 'test',
+          }),
+        ]),
+        providers: [],
+        writeLatestResults: true,
+      }),
+    );
+  });
+
+  it('should write output to file when outputPath is set', async () => {
+    const testSuite = {
+      prompts: ['test'],
+      providers: [],
+      outputPath: 'test.json',
+    };
+    await evaluate(testSuite);
+    expect(writeOutput).toHaveBeenCalledWith(
+      'test.json',
+      null,
+      expect.objectContaining({ results: expect.any(Array) }),
+      expect.objectContaining({
+        outputPath: 'test.json',
+        prompts: expect.arrayContaining([
+          expect.objectContaining({
+            raw: 'test',
+            label: 'test',
+          }),
+        ]),
+        providers: [],
+      }),
+      null,
+    );
+  });
+
+  it('should write multiple outputs when outputPath is an array', async () => {
+    const testSuite = {
+      prompts: ['test'],
+      providers: [],
+      outputPath: ['test1.json', 'test2.json'],
+    };
+    await evaluate(testSuite);
+    expect(writeMultipleOutputs).toHaveBeenCalledWith(
+      ['test1.json', 'test2.json'],
+      null,
+      expect.objectContaining({ results: expect.any(Array) }),
+      expect.objectContaining({
+        outputPath: ['test1.json', 'test2.json'],
+        prompts: expect.arrayContaining([
+          expect.objectContaining({
+            raw: 'test',
+            label: 'test',
+          }),
+        ]),
+        providers: [],
+      }),
+      null,
     );
   });
 });


### PR DESCRIPTION
This commit addresses issue #1785 where the provider.prompts filter was not
being used when running evaluate via the Node package. The following changes
were made:

- Import readProviderPromptMap from './prompts'
- Construct parsedProviderPromptMap using readProviderPromptMap
- Pass parsedProviderPromptMap to doEvaluate
- Update prompt label to use function name if available

This ensures that different prompts for different providers are correctly
picked up when using the evaluate function from the Node package, matching
the behavior of the CLI.

Thank you @baransu for filing this issue! 