### PR TITLE
chore(providers): render provider label using Nunjucks

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -457,7 +457,7 @@ export async function loadApiProvider(
   }
   ret.transform = options.transform;
   ret.delay = options.delay;
-  ret.label ||= options.label;
+  ret.label ||= getNunjucksEngine().renderString(options.label || '', {});
   return ret;
 }
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1567,4 +1567,15 @@ config:
     expect(mockExit).toHaveBeenCalledWith(1);
     mockExit.mockRestore();
   });
+
+  it('renders label using Nunjucks', async () => {
+    process.env.someVariable = 'foo';
+    const providerOptions = {
+      id: 'openai:chat:gpt-4o',
+      config: {},
+      label: '{{ env.someVariable }}',
+    };
+    const provider = await loadApiProvider('openai:chat:gpt-4o', { options: providerOptions });
+    expect(provider.label).toBe('foo');
+  });
 });


### PR DESCRIPTION
Relates to #1552 https://github.com/promptfoo/promptfoo/issues/1552#issuecomment-2380343802 

- Update loadApiProvider to use Nunjucks for rendering the label
