### PR TITLE
fix(redteam): read redteam config during redteam eval command

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,5 +1,6 @@
-process.env.OPENAI_API_KEY = 'foo';
-process.env.AZURE_OPENAI_API_KEY = 'foo';
-process.env.AZURE_OPENAI_API_HOST = 'azure.openai.host';
 process.env.ANTHROPIC_API_KEY = 'foo';
+process.env.AZURE_OPENAI_API_HOST = 'azure.openai.host';
+process.env.AZURE_OPENAI_API_KEY = 'foo';
 process.env.HF_API_TOKEN = 'foo';
+process.env.OPENAI_API_KEY = 'foo';
+delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,8 +56,15 @@ async function main() {
   generateDatasetCommand(generateCommand, defaultConfig, defaultConfigPath);
   redteamGenerateCommand(generateCommand, 'redteam', defaultConfig, defaultConfigPath);
 
+  const { defaultConfig: redteamConfig, defaultConfigPath: redteamConfigPath } =
+    await loadDefaultConfig(undefined, 'redteam');
+
   redteamInitCommand(redteamBaseCommand);
-  evalCommand(redteamBaseCommand, defaultConfig, defaultConfigPath);
+  evalCommand(
+    redteamBaseCommand,
+    redteamConfig ?? defaultConfig,
+    redteamConfigPath ?? defaultConfigPath,
+  );
   redteamGenerateCommand(redteamBaseCommand, 'generate', defaultConfig, defaultConfigPath);
   redteamRunCommand(redteamBaseCommand);
   redteamReportCommand(redteamBaseCommand);

--- a/src/util/config/default.ts
+++ b/src/util/config/default.ts
@@ -14,18 +14,23 @@ export const configCache = new Map<
  * Loads the default configuration file from the specified directory.
  *
  * @param dir - The directory to search for configuration files. Defaults to the current working directory.
+ * @param configName - The name of the configuration file to load. Defaults to 'promptfooconfig'.
  * @returns A promise that resolves to an object containing the default configuration and its file path.
  * The default configuration is partial, and the file path may be undefined if no configuration is found.
  */
-export async function loadDefaultConfig(dir?: string): Promise<{
+export async function loadDefaultConfig(
+  dir?: string,
+  configName: string = 'promptfooconfig',
+): Promise<{
   defaultConfig: Partial<UnifiedConfig>;
   defaultConfigPath: string | undefined;
 }> {
   dir = dir || process.cwd();
 
   // Check if the result is already cached
-  if (configCache.has(dir)) {
-    return configCache.get(dir)!;
+  const cacheKey = `${dir}:${configName}`;
+  if (configCache.has(cacheKey)) {
+    return configCache.get(cacheKey)!;
   }
 
   let defaultConfig: Partial<UnifiedConfig> = {};
@@ -35,7 +40,7 @@ export async function loadDefaultConfig(dir?: string): Promise<{
   const extensions = ['yaml', 'yml', 'json', 'cjs', 'cts', 'js', 'mjs', 'mts', 'ts'];
 
   for (const ext of extensions) {
-    const configPath = path.join(dir, `promptfooconfig.${ext}`);
+    const configPath = path.join(dir, `${configName}.${ext}`);
     const maybeConfig = await maybeReadConfig(configPath);
     if (maybeConfig) {
       defaultConfig = maybeConfig;
@@ -45,6 +50,6 @@ export async function loadDefaultConfig(dir?: string): Promise<{
   }
 
   const result = { defaultConfig, defaultConfigPath };
-  configCache.set(dir, result);
+  configCache.set(cacheKey, result);
   return result;
 }


### PR DESCRIPTION
- Update loadDefaultConfig to accept custom config name
- Use 'redteam' config for redteam eval command if available
