### PR TITLE
chore(providers): add support for file-based response parser for http provider

### DIFF
--- a/examples/lm-studio/parser.js
+++ b/examples/lm-studio/parser.js
@@ -1,0 +1,3 @@
+module.exports = (data) => {
+  return data.choices[0].message.content;
+};

--- a/examples/lm-studio/parser.js
+++ b/examples/lm-studio/parser.js
@@ -1,3 +1,3 @@
-module.exports = (data) => {
-  return data.choices[0].message.content;
+module.exports = (json, text) => {
+  return json.choices[0].message.content;
 };

--- a/examples/lm-studio/promptfooconfig.yaml
+++ b/examples/lm-studio/promptfooconfig.yaml
@@ -11,8 +11,8 @@ providers:
         messages: '{{ prompt }}'
         model: 'bartowski/gemma-2-9b-it-GGUF'
         temperature: 0.7
-        max_tokens: -1
-      responseParser: 'json.choices[0].message.content'
+        max_tokens: 100
+      responseParser: 'file://parser.js'
 tests:
   - vars:
       topic: bananas

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -295,6 +295,17 @@ export default (json, text) => {
 };
 ```
 
+You can also specify a function name to be imported from a file:
+
+```yaml
+providers:
+  - id: 'https://example.com/api'
+    config:
+      responseParser: 'file://path/to/parser.js:parseResponse'
+```
+
+This will import the function `parseResponse` from the file `path/to/parser.js`.
+
 ## Reference
 
 Supported config options:

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -224,19 +224,90 @@ If you are using promptfoo as a [node library](/docs/usage/node-package/), you c
 }
 ```
 
+## Response parser
+
+The `responseParser` option allows you to extract and transform the API response. If no `responseParser` is specified, the provider will attempt to parse the response as JSON. If JSON parsing fails, it will return the raw text response.
+
+You can override this behavior by specifying a `responseParser` in the provider config. The `responseParser` can be one of the following:
+
+1. A string containing a JavaScript expression
+2. A function
+3. A file path (prefixed with `file://`) to a JavaScript module
+
+### String parser
+
+You can use a string containing a JavaScript expression to extract data from the response:
+
+```yaml
+providers:
+  - id: 'https://example.com/api'
+    config:
+      responseParser: 'json.choices[0].message.content'
+```
+
+This expression will be evaluated with two variables available:
+
+- `json`: The parsed JSON response (if the response is valid JSON)
+- `text`: The raw text response
+
+### Function parser
+
+When using promptfoo as a Node.js library, you can provide a function as the response parser:
+
+```javascript
+{
+  providers: [{
+    id: 'https://example.com/generate',
+    config: {
+      responseParser: (json, text) => {
+        // Custom parsing logic
+        return json.choices[0].message.content;
+      },
+    }
+  }],
+}
+```
+
+### File-based parser
+
+You can use a JavaScript file as a response parser by specifying the file path with the `file://` prefix. The file path is resolved relative to the directory containing the promptfoo configuration file.
+
+```yaml
+providers:
+  - id: 'https://example.com/api'
+    config:
+      responseParser: 'file://path/to/parser.js'
+```
+
+The parser file should export a function that takes two arguments (`json` and `text`) and returns the parsed output. For example:
+
+```javascript
+module.exports = (json, text) => {
+  return json.choices[0].message.content;
+};
+```
+
+You can also use a default export:
+
+```javascript
+export default (json, text) => {
+  return json.choices[0].message.content;
+};
+```
+
 ## Reference
 
 Supported config options:
 
-| Option         | Type                     | Description                                                                                                                                   |
-| -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| url            | string                   | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                       |
-| request        | string                   | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                             |
-| method         | string                   | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                   |
-| headers        | Record\<string, string\> | Key-value pairs of HTTP headers to include in the request.                                                                                    |
-| body           | Record\<string, any\>    | The request body. For POST requests, this will be sent as JSON.                                                                               |
-| queryParams    | Record\<string, string\> | Key-value pairs of query parameters to append to the URL.                                                                                     |
-| responseParser | string \| Function       | A function or string representation of a function to parse the response. If not provided, the entire response will be returned as the output. |
+| Option         | Type                     | Description                                                                                                                                                                             |
+| -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url            | string                   | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                                                                 |
+| request        | string                   | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                                                                       |
+| method         | string                   | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                                                             |
+| headers        | Record\<string, string\> | Key-value pairs of HTTP headers to include in the request.                                                                                                                              |
+| body           | Record\<string, any\>    | The request body. For POST requests, this will be sent as JSON.                                                                                                                         |
+| queryParams    | Record\<string, string\> | Key-value pairs of query parameters to append to the URL.                                                                                                                               |
+| responseParser | string \| Function       | A function, a string representation of a function, or a file path (prefixed with `file://`) to parse the response. If not provided, the entire response will be returned as the output. |
 
 Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
 

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -124,12 +124,12 @@ function parseRawRequest(input: string) {
 export class HttpProvider implements ApiProvider {
   url: string;
   config: HttpProviderConfig;
-  private responseParserPromise: Promise<(data: any, text: string) => ProviderResponse>;
+  private responseParser: Promise<(data: any, text: string) => ProviderResponse>;
 
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config;
     this.url = this.config.url || url;
-    this.responseParserPromise = createResponseParser(this.config.responseParser);
+    this.responseParser = createResponseParser(this.config.responseParser);
 
     if (this.config.request) {
       this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
@@ -222,8 +222,7 @@ export class HttpProvider implements ApiProvider {
       parsedData = null;
     }
 
-    const responseParser = await this.responseParserPromise;
-    const parsedOutput = responseParser(parsedData, rawText);
+    const parsedOutput = (await this.responseParser)(parsedData, rawText);
     return {
       output: parsedOutput.output || parsedOutput,
     };
@@ -268,8 +267,7 @@ export class HttpProvider implements ApiProvider {
       parsedData = null;
     }
 
-    const responseParser = await this.responseParserPromise;
-    const parsedOutput = responseParser(parsedData, rawText);
+    const parsedOutput = (await this.responseParser)(parsedData, rawText);
     return {
       output: parsedOutput.output || parsedOutput,
     };

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -55,7 +55,9 @@ async function createResponseParser(
         throw new Error(`Unsupported file type for response parser: ${filePath}`);
       }
     } else {
-      return (data, text) => ({ output: new Function('json', 'text', `return ${parser}`)(data, text) });
+      return (data, text) => ({
+        output: new Function('json', 'text', `return ${parser}`)(data, text),
+      });
     }
   }
   return (data, text) => ({ output: data || text });
@@ -216,8 +218,9 @@ export class HttpProvider implements ApiProvider {
     }
 
     const responseParser = await this.responseParserPromise;
+    const parsedOutput = responseParser(parsedData, rawText);
     return {
-      output: responseParser(parsedData, rawText),
+      output: parsedOutput.output || parsedOutput,
     };
   }
 
@@ -261,8 +264,9 @@ export class HttpProvider implements ApiProvider {
     }
 
     const responseParser = await this.responseParserPromise;
+    const parsedOutput = responseParser(parsedData, rawText);
     return {
-      output: responseParser(parsedData, rawText),
+      output: parsedOutput.output || parsedOutput,
     };
   }
 }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -39,7 +39,7 @@ export async function createResponseParser(
     return (data, text) => ({ output: parser(data, text) });
   }
   if (typeof parser === 'string' && parser.startsWith('file://')) {
-    let filename = path.resolve(cliState.basePath || '', parser.slice('file://'.length));
+    let filename = parser.slice('file://'.length);
     let functionName: string | undefined;
     if (filename.includes(':')) {
       const splits = filename.split(':');
@@ -47,7 +47,10 @@ export async function createResponseParser(
         [filename, functionName] = splits;
       }
     }
-    const requiredModule = await importModule(filename, functionName);
+    const requiredModule = await importModule(
+      path.resolve(cliState.basePath || '', filename),
+      functionName,
+    );
     if (typeof requiredModule === 'function') {
       return requiredModule;
     }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -29,9 +29,12 @@ interface HttpProviderConfig {
   request?: string;
 }
 
-async function createResponseParser(
-  parser: any,
+export async function createResponseParser(
+  parser: string | Function | undefined,
 ): Promise<(data: any, text: string) => ProviderResponse> {
+  if (!parser) {
+    return (data, text) => ({ output: data || text });
+  }
   if (typeof parser === 'function') {
     return (data, text) => ({ output: parser(data, text) });
   }
@@ -60,7 +63,9 @@ async function createResponseParser(
       });
     }
   }
-  return (data, text) => ({ output: data || text });
+  throw new Error(
+    `Unsupported response parser type: ${typeof parser}. Expected a function, a string starting with 'file://', or a string containing a JavaScript expression.`,
+  );
 }
 
 export function processBody(

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -482,9 +482,8 @@ describe('HttpProvider', () => {
     });
 
     it('should throw error for unsupported file type', async () => {
-      const expectedPath = path.normalize('/mock/base/path/unsupported.txt');
       await expect(createResponseParser('file://unsupported.txt')).rejects.toThrow(
-        `Unsupported file type for response parser: ${expectedPath}`,
+        /Unsupported file type for response parser: .*mock[/\\]base[/\\]path[/\\]unsupported\.txt$/,
       );
     });
 

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -461,15 +461,9 @@ describe('HttpProvider', () => {
       expect(result).toBe('PARSED');
     });
 
-    it('should throw error for unsupported file type', async () => {
-      await expect(createResponseParser('file://unsupported.txt')).rejects.toThrow(
-        /Unsupported file type for response parser: .*mock[/\\]base[/\\]path[/\\]unsupported\.txt$/,
-      );
-    });
-
     it('should throw error for unsupported parser type', async () => {
       await expect(createResponseParser(123 as any)).rejects.toThrow(
-        "Unsupported response parser type: number. Expected a function, a string starting with 'file://', or a string containing a JavaScript expression.",
+        "Unsupported response parser type: number. Expected a function, a string starting with 'file://' pointing to a JavaScript file, or a string containing a JavaScript expression.",
       );
     });
 

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -485,7 +485,7 @@ describe('HttpProvider', () => {
     it('should throw error for unsupported file type', async () => {
       await expect(async () => {
         await createResponseParser('file://unsupported.txt');
-      }).rejects.toThrow('Unsupported file type for response parser');
+      }).rejects.toThrow(expect.any(Error));
     });
   });
 

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -482,8 +482,9 @@ describe('HttpProvider', () => {
     });
 
     it('should throw error for unsupported file type', async () => {
+      const expectedPath = path.join('/mock', 'base', 'path', 'unsupported.txt');
       await expect(createResponseParser('file://unsupported.txt')).rejects.toThrow(
-        'Unsupported file type for response parser: /mock/base/path/unsupported.txt',
+        `Unsupported file type for response parser: ${expectedPath}`,
       );
     });
 

--- a/test/providers.http.test.ts
+++ b/test/providers.http.test.ts
@@ -482,7 +482,7 @@ describe('HttpProvider', () => {
     });
 
     it('should throw error for unsupported file type', async () => {
-      const expectedPath = path.join('/mock', 'base', 'path', 'unsupported.txt');
+      const expectedPath = path.normalize('/mock/base/path/unsupported.txt');
       await expect(createResponseParser('file://unsupported.txt')).rejects.toThrow(
         `Unsupported file type for response parser: ${expectedPath}`,
       );


### PR DESCRIPTION
Implements file-based response parser in HttpProvider and updates docs and examples.