### PR TITLE
chore(cli): improve type safety and validation in eval command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,8 @@
         "uuid": "^10.0.0",
         "winston": "^3.14.2",
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-validation-error": "^3.4.0"
       },
       "bin": {
         "pf": "dist/src/main.js",
@@ -31148,6 +31149,18 @@
       "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
       "peerDependencies": {
         "zod": "^3.23.3"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -180,7 +180,8 @@
     "uuid": "^10.0.0",
     "winston": "^3.14.2",
     "ws": "^8.18.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zod-validation-error": "^3.4.0"
   },
   "madge": {
     "detectiveOptions": {

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -766,13 +766,17 @@
               }
             },
             "maxConcurrency": {
-              "type": "string"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "repeat": {
-              "type": "string"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "delay": {
-              "type": "string"
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
             },
             "vars": {
               "type": "string"
@@ -799,7 +803,8 @@
               "type": "string"
             },
             "tableCellMaxLength": {
-              "type": "string"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "write": {
               "type": "boolean"
@@ -823,7 +828,8 @@
               "type": "string"
             },
             "filterFirstN": {
-              "type": "string"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "filterPattern": {
               "type": "string"

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -79,7 +79,7 @@ export async function doEval(
 
     ({ config, testSuite, basePath: _basePath } = await resolveConfigs(cmdObj, defaultConfig));
 
-    let maxConcurrency = cmdObj.maxConcurrency ?? Number.NaN;
+    let maxConcurrency = cmdObj.maxConcurrency;
     const delay = cmdObj.delay ?? 0;
 
     if (delay > 0) {
@@ -99,8 +99,7 @@ export async function doEval(
 
     const options: EvaluateOptions = {
       showProgressBar: getLogLevel() === 'debug' ? false : cmdObj.progressBar,
-      maxConcurrency:
-        !Number.isNaN(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : undefined,
+      maxConcurrency,
       repeat,
       delay: !Number.isNaN(delay) && delay > 0 ? delay : undefined,
       ...evaluateOptions,

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -70,7 +70,8 @@ export async function doEval(
       setLogLevel('debug');
     }
     const iterations = cmdObj.repeat ?? Number.NaN;
-    const repeat = !Number.isNaN(iterations) && iterations > 0 ? iterations : 1;
+    const repeat = Number.isSafeInteger(cmdObj.repeat) && iterations > 0 ? iterations : 1;
+
     if (!cmdObj.cache || repeat > 1) {
       logger.info('Cache is disabled.');
       disableCache();

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -5,6 +5,8 @@ import dedent from 'dedent';
 import fs from 'fs';
 import * as path from 'path';
 import invariant from 'tiny-invariant';
+import { z } from 'zod';
+import { fromError } from 'zod-validation-error';
 import { disableCache } from '../cache';
 import cliState from '../cliState';
 import { getEnvFloat, getEnvInt, getEnvBool } from '../envars';
@@ -22,6 +24,7 @@ import type {
   UnifiedConfig,
 } from '../types';
 import { OutputFileExtension, TestSuiteSchema } from '../types';
+import { CommandLineOptionsSchema } from '../types';
 import { maybeLoadFromExternalFile } from '../util';
 import {
   migrateResultsFromFileSystemToDatabase,
@@ -34,6 +37,14 @@ import { loadDefaultConfig } from '../util/config/default';
 import { resolveConfigs } from '../util/config/load';
 import { filterProviders } from './eval/filterProviders';
 import { filterTests } from './eval/filterTests';
+
+const EvalCommandSchema = CommandLineOptionsSchema.extend({
+  help: z.boolean().optional(),
+  interactiveProviders: z.boolean().optional(),
+  remote: z.boolean().optional(),
+}).partial();
+
+type EvalCommandOptions = z.infer<typeof EvalCommandSchema>;
 
 export async function doEval(
   cmdObj: Partial<CommandLineOptions & Command>,
@@ -58,7 +69,7 @@ export async function doEval(
     if (cmdObj.verbose) {
       setLogLevel('debug');
     }
-    const iterations = Number.parseInt(cmdObj.repeat || '', 10);
+    const iterations = cmdObj.repeat ?? Number.NaN;
     const repeat = !Number.isNaN(iterations) && iterations > 0 ? iterations : 1;
     if (!cmdObj.cache || repeat > 1) {
       logger.info('Cache is disabled.');
@@ -67,8 +78,8 @@ export async function doEval(
 
     ({ config, testSuite, basePath: _basePath } = await resolveConfigs(cmdObj, defaultConfig));
 
-    let maxConcurrency = Number.parseInt(cmdObj.maxConcurrency || '', 10);
-    const delay = Number.parseInt(cmdObj.delay || '', 0);
+    let maxConcurrency = cmdObj.maxConcurrency ?? Number.NaN;
+    const delay = cmdObj.delay ?? 0;
 
     if (delay > 0) {
       maxConcurrency = 1;
@@ -138,7 +149,7 @@ export async function doEval(
 
     if (cmdObj.table && getLogLevel() !== 'debug') {
       // Output CLI table
-      const table = generateTable(summary, Number.parseInt(cmdObj.tableCellMaxLength || '', 10));
+      const table = generateTable(summary, cmdObj.tableCellMaxLength);
 
       logger.info('\n' + table.toString());
       if (summary.table.body.length > 25) {
@@ -436,13 +447,26 @@ export function evalCommand(
     .option('--verbose', 'Show debug logs', defaultConfig?.commandLineOptions?.verbose)
     .option('--no-progress-bar', 'Do not show progress bar')
 
-    .action(async (opts) => {
-      if (opts.help) {
+    .action(async (opts: EvalCommandOptions) => {
+      let validatedOpts: z.infer<typeof EvalCommandSchema>;
+      try {
+        validatedOpts = EvalCommandSchema.parse(opts);
+      } catch (err) {
+        const validationError = fromError(err);
+        logger.error(dedent`
+        Invalid command options:
+        ${validationError.toString()}
+        `);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (validatedOpts.help) {
         evalCmd.help();
         return;
       }
 
-      if (opts.interactiveProviders) {
+      if (validatedOpts.interactiveProviders) {
         logger.warn(
           chalk.yellow(dedent`
           Warning: The --interactive-providers option has been removed.
@@ -454,11 +478,11 @@ export function evalCommand(
         process.exit(2);
       }
 
-      if (opts.remote) {
+      if (validatedOpts.remote) {
         cliState.remote = true;
       }
 
-      for (const maybeFilePath of opts.output ?? []) {
+      for (const maybeFilePath of validatedOpts.output ?? []) {
         const { data: extension } = OutputFileExtension.safeParse(
           maybeFilePath.split('.').pop()?.toLowerCase(),
         );
@@ -468,15 +492,19 @@ export function evalCommand(
         );
       }
 
-      if (opts.config !== undefined) {
-        const configPaths: string[] = Array.isArray(opts.config) ? opts.config : [opts.config];
+      if (validatedOpts.config !== undefined) {
+        const configPaths: string[] = Array.isArray(validatedOpts.config)
+          ? validatedOpts.config
+          : [validatedOpts.config];
         for (const configPath of configPaths) {
           if (fs.existsSync(configPath) && fs.statSync(configPath).isDirectory()) {
             const { defaultConfig: dirConfig, defaultConfigPath: newConfigPath } =
               await loadDefaultConfig(configPath);
             if (newConfigPath) {
-              opts.config = opts.config.filter((path: string) => path !== configPath);
-              opts.config.push(newConfigPath);
+              validatedOpts.config = validatedOpts.config.filter(
+                (path: string) => path !== configPath,
+              );
+              validatedOpts.config.push(newConfigPath);
               defaultConfig = { ...defaultConfig, ...dirConfig };
             } else {
               logger.warn(`No configuration file found in directory: ${configPath}`);
@@ -485,7 +513,12 @@ export function evalCommand(
         }
       }
 
-      doEval(opts, defaultConfig, defaultConfigPath, evaluateOptions);
+      doEval(
+        validatedOpts as Partial<CommandLineOptions & Command>,
+        defaultConfig,
+        defaultConfigPath,
+        evaluateOptions,
+      );
     });
 
   return evalCmd;

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -2,7 +2,7 @@ import type { TestSuite } from '../../types';
 import { filterFailingTests } from './filterFailingTests';
 
 interface Args {
-  firstN?: string;
+  firstN?: string | number;
   pattern?: string;
   failing?: string;
 }
@@ -34,7 +34,7 @@ export async function filterTests(testSuite: TestSuite, args: Args): Promise<Tes
   }
 
   if (firstN) {
-    const count = Number.parseInt(firstN);
+    const count = typeof firstN === 'number' ? firstN : Number.parseInt(firstN);
 
     if (Number.isNaN(count)) {
       throw new Error(`firstN must be a number, got: ${firstN}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,9 +27,9 @@ export const CommandLineOptionsSchema = z.object({
   output: z.array(z.string()),
 
   // Shared with EvaluateOptions
-  maxConcurrency: z.string(),
-  repeat: z.string(),
-  delay: z.string(),
+  maxConcurrency: z.coerce.number().int().positive().optional(),
+  repeat: z.coerce.number().int().positive().optional(),
+  delay: z.coerce.number().int().nonnegative().optional(),
 
   // Command line only
   vars: z.string().optional(),
@@ -39,7 +39,7 @@ export const CommandLineOptionsSchema = z.object({
   modelOutputs: z.string().optional(),
   verbose: z.boolean().optional(),
   grader: z.string().optional(),
-  tableCellMaxLength: z.string().optional(),
+  tableCellMaxLength: z.coerce.number().int().positive().optional(),
   write: z.boolean().optional(),
   cache: z.boolean().optional(),
   table: z.boolean().optional(),
@@ -47,7 +47,7 @@ export const CommandLineOptionsSchema = z.object({
   progressBar: z.boolean().optional(),
   watch: z.boolean().optional(),
   filterFailing: z.string().optional(),
-  filterFirstN: z.string().optional(),
+  filterFirstN: z.coerce.number().int().positive().optional(),
   filterPattern: z.string().optional(),
   filterProviders: z.string().optional(),
   var: z.record(z.string()).optional(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export const CommandLineOptionsSchema = z.object({
   // Shared with EvaluateOptions
   maxConcurrency: z.coerce.number().int().positive().optional(),
   repeat: z.coerce.number().int().positive().optional(),
-  delay: z.coerce.number().int().nonnegative().optional(),
+  delay: z.coerce.number().int().nonnegative().default(0),
 
   // Command line only
   vars: z.string().optional(),


### PR DESCRIPTION
Adds Zod schema to validate CLI options following a support issue reported this morning. Also introduces a lightweight library for making Zod errors human-readable.

Open questions:
- Should we log a warning and continue instead of returning early? (This approach might be safer)