### PR TITLE
chore(cli): improve validation for extension hooks

### DIFF
--- a/examples/extension-api/hooks.py
+++ b/examples/extension-api/hooks.py
@@ -6,13 +6,16 @@ individual evaluations, as well as running setup and teardown commands.
 """
 
 import logging
+import os
 from datetime import datetime
 
 # Set up logging only if it hasn't been set up already
 if not logging.getLogger().handlers:
+    current_dir = os.path.dirname(os.path.abspath(__file__))
     log_filename = f"promptfoo_run_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+    log_path = os.path.join(current_dir, log_filename)
     logging.basicConfig(
-        filename=log_filename,
+        filename=log_path,
         level=logging.INFO,
         format="%(asctime)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -48,7 +48,7 @@ import {
   type TestCase,
   isGradingResult,
 } from './types';
-import { isJavascriptFile } from './util';
+import { isJavascriptFile } from './util/file';
 import { extractJsonObjects } from './util/json';
 import { getNunjucksEngine } from './util/templates';
 import { transform } from './util/transform';

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -129,11 +129,12 @@ export async function doEval(
 
     const testSuiteSchema = TestSuiteSchema.safeParse(testSuite);
     if (!testSuiteSchema.success) {
+      const validationError = fromError(testSuiteSchema.error);
       logger.warn(
         chalk.yellow(dedent`
       TestSuite Schema Validation Error:
       
-        ${JSON.stringify(testSuiteSchema.error.format())}
+        ${validationError.toString()}
       
       Please review your promptfooconfig.yaml configuration.`),
       );

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -8,7 +8,8 @@ import { importModule } from './esm';
 import logger from './logger';
 import { runPython } from './python/pythonUtils';
 import type { ApiProvider, NunjucksFilterMap, Prompt } from './types';
-import { isJavascriptFile, renderVarsInObject } from './util';
+import { renderVarsInObject } from './util';
+import { isJavascriptFile } from './util/file';
 import { getNunjucksEngine } from './util/templates';
 import { transform } from './util/transform';
 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -8,7 +8,8 @@ import type {
   TestSuite,
   ProviderOptions,
 } from '../types';
-import { isJavascriptFile, parsePathOrGlob } from '../util';
+import { parsePathOrGlob } from '../util';
+import { isJavascriptFile } from '../util/file';
 import { processJsFile } from './processors/javascript';
 import { processJsonFile } from './processors/json';
 import { processJsonlFile } from './processors/jsonl';

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -76,7 +76,7 @@ import type {
   ProviderOptions,
   ProviderOptionsMap,
 } from './types/providers';
-import { isJavascriptFile } from './util';
+import { isJavascriptFile } from './util/file';
 import { getNunjucksEngine } from './util/templates';
 
 // FIXME(ian): Make loadApiProvider handle all the different provider types (string, ProviderOptions, ApiProvider, etc), rather than the callers.

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -12,7 +12,7 @@ import type {
   ProviderResponse,
 } from '../types';
 import { maybeLoadFromExternalFile } from '../util';
-import { isJavascriptFile } from '../util';
+import { isJavascriptFile } from '../util/file';
 import { safeJsonStringify } from '../util/json';
 import { getNunjucksEngine } from '../util/templates';
 import { REQUEST_TIMEOUT_MS } from './shared';

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -26,7 +26,8 @@ import type {
   TestSuite,
   UnifiedConfig,
 } from '../../types';
-import { isJavascriptFile, maybeLoadFromExternalFile, readFilters } from '../../util';
+import { maybeLoadFromExternalFile, readFilters } from '../../util';
+import { isJavascriptFile } from '../../util/file';
 
 export async function dereferenceConfig(rawConfig: UnifiedConfig): Promise<UnifiedConfig> {
   if (getEnvBool('PROMPTFOO_DISABLE_REF_PARSER')) {

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if a file is a JavaScript or TypeScript file based on its extension.
+ *
+ * @param filePath - The path of the file to check.
+ * @returns True if the file has a JavaScript or TypeScript extension, false otherwise.
+ */
+export function isJavascriptFile(filePath: string): boolean {
+  return /\.(js|cjs|mjs|ts|cts|mts)$/.test(filePath);
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -52,19 +52,10 @@ import {
 } from '../types';
 import { getConfigDirectoryPath } from './config/manage';
 import { sha256 } from './createHash';
+import { isJavascriptFile } from './file';
 import { getNunjucksEngine } from './templates';
 
 const DEFAULT_QUERY_LIMIT = 100;
-
-/**
- * Checks if a file is a JavaScript or TypeScript file based on its extension.
- *
- * @param filePath - The path of the file to check.
- * @returns True if the file has a JavaScript or TypeScript extension, false otherwise.
- */
-export function isJavascriptFile(filePath: string): boolean {
-  return /\.(js|cjs|mjs|ts|cts|mts)$/.test(filePath);
-}
 
 const outputToSimpleString = (output: EvaluateTableOutput) => {
   const passFailText = output.pass ? '[PASS]' : '[FAIL]';

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -3,7 +3,7 @@ import cliState from '../cliState';
 import { importModule } from '../esm';
 import { runPython } from '../python/pythonUtils';
 import type { Prompt, Vars } from '../types';
-import { isJavascriptFile } from './';
+import { isJavascriptFile } from './file';
 
 export type TransformContext = {
   vars?: Vars;

--- a/test/util.file.test.ts
+++ b/test/util.file.test.ts
@@ -1,0 +1,34 @@
+import { isJavascriptFile } from '../src/util/file';
+
+describe('util', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isJavascriptFile', () => {
+    it('should return true for JavaScript files', () => {
+      expect(isJavascriptFile('file.js')).toBe(true);
+      expect(isJavascriptFile('file.cjs')).toBe(true);
+      expect(isJavascriptFile('file.mjs')).toBe(true);
+    });
+
+    it('should return true for TypeScript files', () => {
+      expect(isJavascriptFile('file.ts')).toBe(true);
+      expect(isJavascriptFile('file.cts')).toBe(true);
+      expect(isJavascriptFile('file.mts')).toBe(true);
+    });
+
+    it('should return false for non-JavaScript/TypeScript files', () => {
+      expect(isJavascriptFile('file.txt')).toBe(false);
+      expect(isJavascriptFile('file.py')).toBe(false);
+      expect(isJavascriptFile('file.jsx')).toBe(false);
+      expect(isJavascriptFile('file.tsx')).toBe(false);
+    });
+
+    it('should handle paths with directories', () => {
+      expect(isJavascriptFile('/path/to/file.js')).toBe(true);
+      expect(isJavascriptFile('C:\\path\\to\\file.ts')).toBe(true);
+      expect(isJavascriptFile('/path/to/file.txt')).toBe(false);
+    });
+  });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -6,7 +6,6 @@ import * as googleSheets from '../src/googleSheets';
 import type { ApiProvider, EvaluateResult, EvaluateTable, TestCase } from '../src/types';
 import {
   maybeLoadFromExternalFile,
-  isJavascriptFile,
   parsePathOrGlob,
   providerToIdentifier,
   readFilters,
@@ -168,33 +167,6 @@ describe('maybeLoadFromExternalFile', () => {
 describe('util', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  describe('isJavascriptFile', () => {
-    it('should return true for JavaScript files', () => {
-      expect(isJavascriptFile('file.js')).toBe(true);
-      expect(isJavascriptFile('file.cjs')).toBe(true);
-      expect(isJavascriptFile('file.mjs')).toBe(true);
-    });
-
-    it('should return true for TypeScript files', () => {
-      expect(isJavascriptFile('file.ts')).toBe(true);
-      expect(isJavascriptFile('file.cts')).toBe(true);
-      expect(isJavascriptFile('file.mts')).toBe(true);
-    });
-
-    it('should return false for non-JavaScript/TypeScript files', () => {
-      expect(isJavascriptFile('file.txt')).toBe(false);
-      expect(isJavascriptFile('file.py')).toBe(false);
-      expect(isJavascriptFile('file.jsx')).toBe(false);
-      expect(isJavascriptFile('file.tsx')).toBe(false);
-    });
-
-    it('should handle paths with directories', () => {
-      expect(isJavascriptFile('/path/to/file.js')).toBe(true);
-      expect(isJavascriptFile('C:\\path\\to\\file.ts')).toBe(true);
-      expect(isJavascriptFile('/path/to/file.txt')).toBe(false);
-    });
   });
 
   describe('writeOutput', () => {


### PR DESCRIPTION
- Add refined validation for extension paths in TestSuiteSchema
- Move isJavascriptFile function to separate file for better organization
- Update import statements across multiple files to use new isJavascriptFile location
- Add new tests for TestSuiteSchema extensions field validation
- Create separate test file for isJavascriptFile function
- Improve error message display for TestSuite schema validation errors