### PR TITLE
chore: move skip logic to generate

### DIFF
--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -49,14 +49,14 @@ export async function doGenerateRedteam(options: Partial<RedteamCliGenerateOptio
 
   // Check for updates to the config file and decide whether to generate
   let shouldGenerate = options.force;
-  if (!shouldGenerate && fs.existsSync(outputPath)) {
+  if (!options.force && fs.existsSync(outputPath)) {
     const redteamContent = yaml.load(fs.readFileSync(outputPath, 'utf8')) as any;
     const storedHash = redteamContent.metadata?.configHash;
     const currentHash = getConfigHash(configPath);
 
-    if (storedHash !== currentHash) {
-      shouldGenerate = true;
-    }
+    shouldGenerate = storedHash !== currentHash;
+  } else {
+    shouldGenerate = true;
   }
 
   if (!shouldGenerate) {

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -42,6 +42,7 @@ export interface RedteamCliGenerateOptions extends CommonOptions {
   envFile?: string;
   maxConcurrency?: number;
   output?: string;
+  force?: boolean;
   write: boolean;
 }
 


### PR DESCRIPTION
Right now the logic is in `run`, which works great for `run` but it would be nice if `generate` didn't regenerate unnecessarily too.