### PR TITLE
fix(provider): fal prompt config overrides

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import type {
   Scenario,
 } from './types';
 import { readFilters, writeMultipleOutputs, writeOutput } from './util';
+import { PromptSchema } from './validators/prompts';
 
 export * from './types';
 
@@ -56,6 +57,8 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
             };
           } else if (typeof promptInput === 'string') {
             return readPrompts(promptInput);
+          } else if (typeof promptInput === 'object') {
+            return PromptSchema.parse(promptInput);
           } else {
             return {
               raw: JSON.stringify(promptInput),

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,13 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
             };
           } else if (typeof promptInput === 'string') {
             return readPrompts(promptInput);
-          } else if (typeof promptInput === 'object') {
+          }
+          try {
             return PromptSchema.parse(promptInput);
-          } else {
+          } catch (error) {
+            console.warn(
+              `Prompt input is not a valid prompt schema: ${error}\nFalling back to serialized JSON as raw prompt.`,
+            );
             return {
               raw: JSON.stringify(promptInput),
               label: JSON.stringify(promptInput),

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -42,7 +42,7 @@ class FalProvider<Input = any> implements ApiProvider {
     return `[fal.ai Inference Provider ${this.modelName}]`;
   }
 
-  async callApi(prompt: string): Promise<ProviderResponse> {
+  async callApi(prompt: string, context: any): Promise<ProviderResponse> {
     if (!this.apiKey) {
       throw new Error(
         'fal.ai API key is not set. Set the FAL_KEY environment variable or or add `apiKey` to the provider config.',
@@ -56,6 +56,7 @@ class FalProvider<Input = any> implements ApiProvider {
     const input = {
       prompt,
       ...this.input,
+      ...(context.prompt?.config ?? {}),
     };
     const cacheKey = `fal:${this.modelName}:${JSON.stringify(input)}`;
     if (isCacheEnabled()) {


### PR DESCRIPTION
**Notes:**

1. The fal provider now handles config per prompt correctly using the `context.prompt`
2. When passing a prompt object via the Web UI YAML editor, the format described here is being passed as a serialized `string` and the prompt object with the config is lost and not present on the context.

cc @mldangelo 