### PR TITLE
fix(providers): dynamically import fal-ai serverless client

### DIFF
--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -1,4 +1,3 @@
-import * as fal from '@fal-ai/serverless-client';
 import type { Cache } from 'cache-manager';
 import fetch from 'node-fetch';
 import { getCache, isCacheEnabled } from '../cache';
@@ -16,6 +15,9 @@ class FalProvider<Input = any> implements ApiProvider {
   apiKey?: string;
   config: FalProviderOptions;
   input: Input;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  private fal: typeof import('@fal-ai/serverless-client') | null = null;
 
   constructor(
     modelType: 'image',
@@ -66,7 +68,11 @@ class FalProvider<Input = any> implements ApiProvider {
       cached = response !== undefined;
     }
 
-    fal.config({
+    if (!this.fal) {
+      this.fal = await import('@fal-ai/serverless-client');
+    }
+
+    this.fal.config({
       credentials: this.apiKey,
       fetch: fetch as any, // TODO fix type incompatibility
     });
@@ -90,7 +96,11 @@ class FalProvider<Input = any> implements ApiProvider {
   }
 
   async runInference<Result = any>(input: Input): Promise<Result> {
-    const result = await fal.subscribe(this.modelName, {
+    if (!this.fal) {
+      this.fal = await import('@fal-ai/serverless-client');
+    }
+
+    const result = await this.fal.subscribe(this.modelName, {
       input,
     });
     return result as Result;


### PR DESCRIPTION
This PR addresses issue #1847 where promptfoo fails to start without explicitly installing @fal-ai/serverless-client. The changes include:

- Removing static import of @fal-ai/serverless-client
- Adding dynamic import of the client when needed
- Initializing the `fal` property in the constructor
- Updating `runInference` and `generateImage` methods to use dynamic import (async methods are not allowed in the constructor)

To test this change, use the following configuration:

```yaml
prompts:
  - a cat
providers:
  - id: fal:image:fal-ai/flux/schnell
```

Then run:

```
promptfoo eval
```

CC @tomquist @drochetti