### PR TITLE
fix: Only persist custom API url in local storage if it's set through the UI

### DIFF
--- a/src/app/src/components/ApiSettingsModal.tsx
+++ b/src/app/src/components/ApiSettingsModal.tsx
@@ -14,7 +14,7 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
   open,
   onClose,
 }: T) {
-  const { apiBaseUrl, setApiBaseUrl } = useApiConfig();
+  const { apiBaseUrl, setApiBaseUrl, enablePersistApiBaseUrl } = useApiConfig();
   const [tempApiBaseUrl, setTempApiBaseUrl] = useState(apiBaseUrl || '');
 
   useEffect(() => {
@@ -27,6 +27,7 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
 
   const handleSave = () => {
     setApiBaseUrl(tempApiBaseUrl);
+    enablePersistApiBaseUrl();
     onClose();
   };
 

--- a/src/app/src/stores/apiConfig.ts
+++ b/src/app/src/stores/apiConfig.ts
@@ -6,6 +6,8 @@ export interface ApiConfig {
   setApiBaseUrl: (apiBaseUrl: string) => void;
   fetchingPromise: Promise<Response> | null;
   setFetchingPromise: (fetchingPromise: Promise<Response> | null) => void;
+  persistApiBaseUrl: boolean;
+  enablePersistApiBaseUrl: () => void;
 }
 
 const useApiConfig = create<ApiConfig>()(
@@ -13,12 +15,16 @@ const useApiConfig = create<ApiConfig>()(
     (set) => ({
       apiBaseUrl: import.meta.env.VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL || '',
       setApiBaseUrl: (apiBaseUrl: string) => set({ apiBaseUrl }),
+      persistApiBaseUrl: false,
+      enablePersistApiBaseUrl: () => set({ persistApiBaseUrl: true }),
       fetchingPromise: null,
       setFetchingPromise: (fetchingPromise: Promise<Response> | null) => set({ fetchingPromise }),
     }),
     {
       name: 'api-config-storage',
-      partialize: (state) => ({ apiBaseUrl: state.apiBaseUrl }) as Partial<ApiConfig>,
+      partialize: (state) => {
+        return state.persistApiBaseUrl ? { apiBaseUrl: state.apiBaseUrl } : {};
+      },
     },
   ),
 );


### PR DESCRIPTION
Persisting this all the time creates weird side effects if you're developing and testing env variables, etc...