### PR TITLE
fix(app): resolve undefined version display in InfoModal

### DIFF
--- a/src/app/src/components/InfoModal.test.tsx
+++ b/src/app/src/components/InfoModal.test.tsx
@@ -17,7 +17,7 @@ describe('InfoModal', () => {
   });
 
   it('displays the correct version', () => {
-    process.env.PROMPTFOO_VERSION = '1.0.0';
+    process.env.VITE_PROMPTFOO_VERSION = '1.0.0';
     render(<InfoModal open={true} onClose={mockOnClose} />);
     expect(screen.getByText('Version 1.0.0')).toBeInTheDocument();
   });

--- a/src/app/src/components/InfoModal.tsx
+++ b/src/app/src/components/InfoModal.tsx
@@ -65,15 +65,17 @@ export default function InfoModal<T extends { open: boolean; onClose: () => void
             }}
             target="_blank"
           >
-            <Typography variant="subtitle2">Version {import.meta.env.PROMPTFOO_VERSION}</Typography>
+            <Typography variant="subtitle2">
+              Version {import.meta.env.VITE_PROMPTFOO_VERSION}
+            </Typography>
           </Link>
         </Stack>
       </DialogTitle>
       <DialogContent>
         <Typography variant="body2" gutterBottom>
-          Promptfoo is a MIT licensed open-source tool for evaluating LLMs. We make it easy to track
-          the performance of your models and prompts over time with automated support for dataset
-          generation and grading.
+          Promptfoo is a MIT licensed open-source tool for evaluating and red-teaming LLMs. We make
+          it easy to track the performance of your models and prompts over time with automated
+          support for dataset generation and grading.
         </Typography>
         <Stack spacing={2} mt={2}>
           {links.map((item, index) => (

--- a/src/app/src/vite-env.d.ts
+++ b/src/app/src/vite-env.d.ts
@@ -4,7 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_PUBLIC_PROMPTFOO_SHARE_API_URL: string;
   readonly VITE_PUBLIC_PROMPTFOO_APP_SHARE_URL: string;
   readonly VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL: string;
-  readonly PROMPTFOO_VERSION: string;
+  readonly VITE_PROMPTFOO_VERSION: string;
   readonly VITE_PUBLIC_HOSTED: string;
   // more env variables...
 }

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import packageJson from '../../package.json';
 
 const API_PORT = process.env.API_PORT || '15500';
 
@@ -44,5 +45,8 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     globals: true,
+  },
+  define: {
+    'import.meta.env.VITE_PROMPTFOO_VERSION': JSON.stringify(packageJson.version),
   },
 });


### PR DESCRIPTION
- Replace PROMPTFOO_VERSION with VITE_PROMPTFOO_VERSION in vite-env.d.ts
- Update InfoModal.tsx to use VITE_PROMPTFOO_VERSION, fixing undefined display
- Adjust InfoModal.test.tsx to set VITE_PROMPTFOO_VERSION for testing
- Modify vite.config.ts to inject VITE_PROMPTFOO_VERSION from package.json
- Update InfoModal description to include "red-teaming LLMs"

This fix ensures the correct version is displayed in the InfoModal, resolving the issue where it previously showed as undefined.