### PR TITLE
fix: don't always persist providers

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,7 +1,15 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { DefaultLogger, type LogWriter } from 'drizzle-orm/logger';
 import * as path from 'path';
+import logger from '../logger';
 import { getConfigDirectoryPath } from '../util/config/manage';
+
+class DrizzleLogWriter implements LogWriter {
+  write(message: string) {
+    logger.debug(`Drizzle: ${message}`);
+  }
+}
 
 let dbInstance: ReturnType<typeof drizzle> | null = null;
 
@@ -16,7 +24,8 @@ export function getDbSignalPath() {
 export function getDb() {
   if (!dbInstance) {
     const sqlite = new Database(process.env.IS_TESTING ? ':memory:' : getDbPath());
-    dbInstance = drizzle(sqlite);
+    const logger = new DefaultLogger({ writer: new DrizzleLogWriter() });
+    dbInstance = drizzle(sqlite, { logger });
   }
   return dbInstance;
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -840,7 +840,9 @@ class Evaluator {
     }
 
     await this.evalRecord.addPrompts(prompts);
-    const providers = await Provider.createMultiple(testSuite.providers);
+    const providers = await Provider.createMultiple(testSuite.providers, {
+      persist: this.evalRecord.persisted,
+    });
     await this.evalRecord.addProviders(providers);
 
     // Finish up


### PR DESCRIPTION
Evals are broken via node package unless you already have a up-to-date promptfoo db

https://x.com/yukinagae/status/1844015166859690397?t=7UaqumTY9_8lxt7jlTUjXg

To test (with brand new unmigrated config dir):

```
cd examples/node-package
PROMPTFOO_CONFIG_DIR='./pfconfig' node full-eval.js
```