### PR TITLE
add Adaline Gateway OpenAI integration and documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "site"
       ],
       "dependencies": {
+        "@adaline/gateway": "^0.22.0",
+        "@adaline/open-router": "^0.6.0",
+        "@adaline/openai": "^0.19.0",
+        "@adaline/together-ai": "^0.6.0",
+        "@adaline/types": "^0.14.0",
         "@anthropic-ai/sdk": "^0.29.0",
         "@apidevtools/json-schema-ref-parser": "^11.7.2",
         "@emotion/react": "^11.13.3",
@@ -141,6 +146,102 @@
         "playwright": "^1.47.2",
         "playwright-extra": "^4.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2"
+      }
+    },
+    "node_modules/@adaline/gateway": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@adaline/gateway/-/gateway-0.22.0.tgz",
+      "integrity": "sha512-OfpfWXYg2S6i1iAHL4hRESjI7GbxlSywZH2j6u4ATX7KlF4EFbhjHcO8H05JZTuF7bA4KNqGXPijjCEkkoucvw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "axios": "^1.7.2",
+        "crypto-js": "^4.2.0",
+        "dotenv": "^16.4.5",
+        "env-paths": "^3.0.0",
+        "lodash": "^4.17.21",
+        "lru-cache": "^11.0.1",
+        "proxy-agent": "^6.4.0",
+        "uuid": "^10.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adaline/gateway/node_modules/lru-cache": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@adaline/open-router": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@adaline/open-router/-/open-router-0.6.0.tgz",
+      "integrity": "sha512-DYpxPTq2PamLEmw7RpPP4Xm9S4ofyp4x42KNYocT9un2eNNulMHtVptRmdEwjTaGu18P0+CfK/388xgjmMNLNQ==",
+      "dependencies": {
+        "@adaline/provider": "0.16.0",
+        "@adaline/types": "0.14.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adaline/openai": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@adaline/openai/-/openai-0.19.0.tgz",
+      "integrity": "sha512-2HAX8zDc2VOyYUixCs3JGaA0VqekWMOK7firLQr2E2EMy8rwyj4HERsjJDQf8Dxo3Hu+Twh44s65K0OZ7hJA3g==",
+      "dependencies": {
+        "@adaline/provider": "0.16.0",
+        "@adaline/types": "0.14.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adaline/provider": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@adaline/provider/-/provider-0.16.0.tgz",
+      "integrity": "sha512-jqXlViGoDxK6KO030tD8YjlMf54DohKw0V1jWtffyhSWNMnbIurUM//JYE/SH0F7LYQOuvxi0zpiraH5WgLpHg==",
+      "dependencies": {
+        "@adaline/types": "0.14.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adaline/together-ai": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@adaline/together-ai/-/together-ai-0.6.0.tgz",
+      "integrity": "sha512-H1ErVUeFjOvlAjANd5hL1hsR9oFMhgMD4fa5Avvpnbf+IZLIcvI33UomrnYXudfl9CjZkbrC6D8ey7ElczH9iA==",
+      "dependencies": {
+        "@adaline/provider": "0.16.0",
+        "@adaline/types": "0.14.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adaline/types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@adaline/types/-/types-0.14.0.tgz",
+      "integrity": "sha512-PxkpKIUwIqqbsjRlm3WDXMtAsIccTdipKLKjbvcqaJAhGeXfz8wyF9ANJ5RQPPmT+HK8lYYBfYxPdnOe58l5Nw==",
+      "dependencies": {
+        "json-schema": "^0.4.0",
+        "jsonschema": "^1.4.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -575,7 +676,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -600,7 +700,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -611,7 +710,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -623,7 +721,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -636,7 +733,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -1160,7 +1256,6 @@
       "version": "3.667.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
       "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
@@ -7290,6 +7385,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -8008,7 +8119,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -8229,7 +8339,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
       "integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
@@ -8328,7 +8437,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
@@ -8406,7 +8514,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
       "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8418,7 +8525,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.7.tgz",
       "integrity": "sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^3.5.0",
@@ -8478,7 +8584,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
       "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
@@ -11194,6 +11299,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -13394,6 +13509,11 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
     "node_modules/crypto-random-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
@@ -15526,6 +15646,17 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -20525,6 +20656,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -20568,6 +20704,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jsonwebtoken": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
     "zod-to-json-schema": "^3.23.3"
   },
   "dependencies": {
+    "@adaline/gateway": "^0.22.0",
+    "@adaline/open-router": "^0.6.0",
+    "@adaline/openai": "^0.19.0",
+    "@adaline/together-ai": "^0.6.0",
+    "@adaline/types": "^0.14.0",
     "@anthropic-ai/sdk": "^0.29.0",
     "@apidevtools/json-schema-ref-parser": "^11.7.2",
     "@emotion/react": "^11.13.3",

--- a/site/docs/integrations/gateway.md
+++ b/site/docs/integrations/gateway.md
@@ -1,0 +1,675 @@
+# Gateway
+
+The Gateway provides a unified interface for interacting with various AI Providers, allowing you to easily interact with chat and embedding models.
+
+Gateway can handle concurrent requests with retries on failure, exponential backoff on all other errors, and rate limiting on model rate limits, request timeouts. Gateway also has an in-built LRU cache as well as allows user to specify their own cache. 
+
+Gateway supports various providers such as OpenAI, Anthropic, Gemini, Groq, Azure, AWS Bedrock, etc. Gateway uses HTTP Requests to interact with the model providers. 
+
+Gateway has unified input and output types for prompts and embedding inputs that work across providers. Gateway also allows for users to use provider specific inputs and convert them into Gateway's unified types. 
+
+This is usage guide uses two independent packages -- `@adaline/gateway` and `@adaline/openai` to demonstrate Gateway. First we talk about the Provider package aka `@adaline/openai` that let's user perform provider specific logic and transformations. Then we talk about the actual Gateway package aka `@adaline/gateway` that let's user make actual Chat and Embedding calls.
+
+# OpenAI Provider Usage Guide
+
+## Installation
+
+```bash
+npm install @adaline/openai
+```
+
+## Initialization
+
+```typescript
+import { OpenAI } from "@adaline/openai";
+
+const openai = new OpenAI();
+```
+
+## Chat and Embedding Models
+
+### List available chat models
+
+```typescript
+const chatModels = openai.chatModelLiterals();
+console.log(chatModels);
+```
+
+```output
+[
+  "gpt-3.5-turbo",
+  "gpt-3.5-turbo-0125",
+  "gpt-3.5-turbo-1106",
+  "gpt-4-0125-preview",
+  "gpt-4-0613",
+  "gpt-4-1106-preview",
+  "gpt-4-turbo-2024-04-09",
+  "gpt-4-turbo-preview",
+  "gpt-4-turbo",
+  "gpt-4",
+  "gpt-4o-2024-08-06",
+  "gpt-4o-mini",
+  "gpt-4o",
+  "o1-mini",
+  "o1-preview"
+]
+```
+
+### List available embedding models
+
+```typescript
+const embeddingModels = openai.embeddingModelLiterals();
+console.log(embeddingModels);
+```
+
+```output
+[
+  "text-embedding-ada-002",
+  "text-embedding-3-small",
+  "text-embedding-3-large",
+]
+```
+
+### Create a chat model instance
+
+The model instance is used by Gateway to make API requests to the specified model according to the options provided.
+
+```typescript
+const chatModel = openai.chatModel({
+  modelName: "gpt-4-turbo-preview",                         // required
+  apiKey: "your-api-key-here",                              // required
+  baseUrl: "https://your-custom-endpoint.com",              // optional
+  organization: "your-openai-business-organization",        // optional
+});
+```
+* You can specify a custom base URL for API requests. For eg. if the `baseUrl` specified is `https://your-custom-endpoint.com`, API requests for chat model will call `https://your-custom-endpoint.com/chat/completions`.
+* You can specify a Business Organization to be included in API request headers.
+
+### Create an embedding model instance
+
+```typescript
+const embeddingModel = openai.embeddingModel({
+  modelName: "text-embedding-3-large",                      // required
+  apiKey: "your-api-key-here",                              // required
+  baseUrl: "https://your-custom-endpoint.com",              // optional
+});
+```
+* You can specify a custom base URL for API requests. For eg. if the `baseUrl` specified is `https://your-custom-endpoint.com`, API requests for embedding model will call `https://your-custom-endpoint.com/embeddings`.
+
+### Transform Model Request
+
+`transformModelRequest()` method converts requests in OpenAI native format into Gateway's unified types. A User can either create their Gateway request in Gateway's unified types from scratch that will work across providers or they can convert their provider native request into Gateway's unified types using `transformModelRequest()` method and then invoke Gateway. 
+
+```typescript
+// OpenAI format
+const openAiRequest = {
+  // required fields
+  messages: [
+    { role: 'system', content: [{ type: 'text', text: 'Reply consisely and like a teacher' }] },
+    { role: 'user', content: [{ type: 'text', text: 'What is 3 + 1?' }] },
+    { role: 'assistant', content: [{ type: 'text', text: '3 + 1 = 4' }] },
+    { role: 'user', content: [
+        { type: 'image_url', image_url: { url: "some-url", detail: "high" } },
+        { type: 'text', text: 'Solve the linear equation in the image' }
+      ] 
+    },
+  ],
+  // optional fields, all other Open AI fields
+  max_tokens: 400,
+  temperature: 0.95,
+  logprobs: true,
+  seed: 98322,
+};
+
+const chatModel = openai.chatModel({
+  modelName: "gpt-4-turbo-preview",
+  apiKey: "your-api-key-here",
+});
+const gatewayRequest = chatModel.transformModelRequest(openAiRequest)
+```
+
+```json
+// Gateway's unified types
+{
+  "config": {
+    "seed": 98322,
+    "maxTokens": 400,
+    "temperature": 0.95,
+    "logProbs": true
+  },
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "modality": "text",
+          "value": "Reply consisely and like a teacher"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "modality": "text",
+          "value": "What is 3 + 1?"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "modality": "text",
+          "value": "3 + 1 = 4"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "modality": "image",
+          "detail": "high",
+          "value": {
+            "type": "url",
+            "url": "some-url"
+          }
+        },
+        {
+          "modality": "text",
+          "value": "Solve the linear equation in the image"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+```typescript
+// OpenAI format
+const openAiRequest = {
+  // required fields
+  messages: [
+    { role: "system", content: "you are a delivery date finding agent, you will be given an order id for this." },
+    { role: "user", content: [{ type: "text", text: "What is the delivery date of order_id 'hg2345ds-lkj34' ?" }] },
+  ],
+  // optional fields
+  max_tokens: 800,
+  tool_choice: "required",
+  tools: [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_delivery_date",
+            "description": "Get the delivery date for a customer's order. Call this whenever you need to know the delivery date, for example when a customer asks 'Where is my package'",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "order_id": {
+                        "type": "string",
+                        "description": "The customer's order ID."
+                    }
+                },
+                "required": ["order_id"],
+                "additionalProperties": false
+            }
+        }
+    }
+  ]
+};
+
+const chatModel = openai.chatModel({
+  modelName: "gpt-4-turbo-preview",
+  apiKey: "your-api-key-here",
+});
+const gatewayRequest = chatModel.transformModelRequest(openAiRequest)
+```
+
+```json
+// Gateway's unified types
+{
+  "config": {
+    "toolChoice": "required",
+    "maxTokens": 800
+  },
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "modality": "text",
+          "value": "you are a delivery date finding agent, you will be given an order id for this."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "modality": "text",
+          "value": "What is the delivery date of order_id 'hg2345ds-lkj34-435jnkl' ?"
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "definition": {
+        "schema": {
+          "name": "get_delivery_date",
+          "description": "Get the delivery date for a customer's order. Call this whenever you need to know the delivery date, for example when a customer asks 'Where is my package'",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order_id": {
+                "type": "string",
+                "description": "The customer's order ID."
+              }
+            },
+            "required": [
+              "order_id"
+            ],
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+```typescript
+const openAiRequest = {
+  // required fields
+  input: [
+    "some-text-for-embedding-1",
+    "some-text-for-embedding-2",
+  ],
+  // optional fields
+  encoding_format: "base64",
+};
+
+const embeddingModel = openai.embeddingModel({
+  modelName: "text-embedding-3-large",
+  apiKey: "your-api-key-here",
+});
+const gatewayRequest = embeddingModel.transformModelRequest(openAiRequest)
+```
+
+```json
+// Gateway's unified types
+{
+  "config": {
+    "encodingFormat": "base64"
+  },
+  "embeddingRequests": {
+    "modality": "text",
+    "requests": [
+      "some-text-for-embedding-1",
+      "some-text-for-embedding-2"
+    ]
+  }
+}
+```
+
+
+# Gateway usage guide
+
+## Installation
+
+```bash
+npm install @adaline/gateway
+```
+
+## Initialization
+
+### Concurrency, Retry, Timeout
+
+A single gateway instance can be used to concurrently run requests across provider and models
+
+```typescript
+import { Gateway } from "@adaline/gateway";
+
+const gateway = new Gateway({
+  // optional queue options
+  queueOptions: {
+    maxConcurrentTasks: 8,
+    retryCount: 4,
+    retry: {
+      initialDelay: 5000,
+      exponentialFactor: 2,
+    },
+    timeout: 120000, 
+  },
+});
+```
+
+`queueOptions` allows user to control how the Gateway processes requests. It includes the following properties: 
+* `maxConcurrentTasks`: Specifies the maximum number of requests that can be processed concurrently.
+* `retryCount`: Defines how many times a task should be retried if it fails for any status code.
+* `retry`: Configures the retry behavior. If the failure status code is '429' aka model rate limit exceeded, Gateway will try to parse the response headers from the model and delay the next request until the rate limit has been reset. For all other status codes, Gateway uses a exponential backoff.
+  * `initialDelay`: The delay in milliseconds before the first retry.
+  * `exponentialFactor`: The factor by which the delay increases with each subsequent retry. Here, it's set to `2`, meaning the delay will double with each retry attempt. 
+* `timeout`: Specifies the maximum time in milliseconds that the Gateway will wait for a request to complete before timing out.
+
+
+### Caching
+
+Gateway has an in-built LRU cache. Gateway's cache key is made up of 'model url', 'model name' and 'model request'.
+
+```typescript
+import { Gateway } from "@adaline/gateway";
+
+// no cache provided, use internal LRU cache
+const gateway = new Gateway({});
+```
+
+Gateway allow it's user to specify their own cache. Access for Gateway to read / write user's cache by implementing the `GatewayCache` interface.
+
+```typescript
+import type { Cache as GatewayCache } from '@adaline/gateway';
+
+class GatewayCachePlugin<T> implements GatewayCache<T> {
+    
+    async get(key: string): Promise<T | undefined> {
+      // your custom caching logic
+      // use the given key and return the value found in cache for cache hit
+      // or return undefined for cache miss
+    }
+
+    async set(key: string, value: T): Promise<void> {
+      // your custom caching logic
+      // use the given key and value to set in your cache
+    }
+
+    // Gateway will never invoke this method
+    async delete(key: string): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    // Gateway will never invoke this method
+    async clear(): Promise<void> {
+        throw new Error('Not implemented');
+    }
+};
+
+import { Gateway } from "@adaline/gateway";
+
+const gateway = new Gateway({
+  completeChatCache: new GatewayCachePlugin(),
+  getEmbeddingsCache: new GatewayCachePlugin(),
+});
+```
+
+## Complete Chat
+
+```typescript
+import { Gateway } from "@adaline/gateway";
+import { OpenAI } from "@adaline/openai";
+
+const gateway = new Gateway({});
+const openai = new OpenAI();
+
+const openAiRequest = {
+  messages: [
+    { role: "system", content: [{ type: "text", text: "Reply consisely and like a teacher" }] },
+    { role: "user", content: [{ type: "text", text: "What is 3 + 1?" }] },
+    { role: "assistant", content: [{ type: "text", text: "3 + 1 = 4" }] },
+    { role: "user", content: [
+        { type: "image_url", image_url: { url: "https://hs.sbcounty.gov/cn/Photo%20Gallery/_w/Sample%20Picture%20-%20Koala_jpg.jpg", detail: "high" } },
+        { type: "text", text: "Solve the linear equation in the image" }
+      ] 
+    },
+  ],
+  max_tokens: 400,
+  temperature: 0.95,
+  seed: 98322,
+};
+
+const model = openai.chatModel({
+  modelName: "gpt-4o",
+  apiKey: "your-api-key-here",
+});
+const gatewayRequest = model.transformModelRequest(openAiRequest)
+
+const request = {
+  model: model,
+  config: gatewayRequest.config,
+  messages: gatewayRequest.messages,
+};
+
+async function testCompleteChat() {
+  const response = await gateway.completeChat(request, {
+    enableCache: false, // optional, default is true
+  });
+  // response.request is the request to model in Gateway's unified types
+  // response.response is the response from the model in Gateway's unified types
+  // response.cache is whether response was cache or not
+  // response.latencyInMs is the gateway calculated latency 
+  // response.provider.request is the actual HTTP request to model 
+  // response.provider.response is the actual HTTP response from the model 
+  console.log(JSON.stringify(response.response.provider.response, null, 2));
+}
+
+testCompleteChat();
+```
+
+```json
+{
+  "data": {
+    "id": "chatcmpl-A8lFCRHkYLgfsVHENJPvtmzkzQO3D",
+    "object": "chat.completion",
+    "created": 1726651594,
+    "model": "gpt-4o-2024-05-13",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "This image does not contain a linear equation. Instead, it shows a picture of a koala. If you have a linear equation you need help solving, please provide the equation in text form!",
+          "refusal": null
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 474,
+      "completion_tokens": 39,
+      "total_tokens": 513,
+      "completion_tokens_details": {
+        "reasoning_tokens": 0
+      }
+    },
+    "system_fingerprint": "fp_8dd226ca9c"
+  },
+  "headers": {
+    "date": "Wed, 18 Sep 2024 09:26:35 GMT",
+    "content-type": "application/json",
+    "transfer-encoding": "chunked",
+    "connection": "close",
+    "access-control-expose-headers": "X-Request-ID",
+    "openai-organization": "your-openai-org",
+    "openai-processing-ms": "2439",
+    "openai-version": "2020-10-01",
+    "strict-transport-security": "max-age=15552000; includeSubDomains; preload",
+    "x-ratelimit-limit-requests": "10000",
+    "x-ratelimit-limit-tokens": "30000000",
+    "x-ratelimit-remaining-requests": "9999",
+    "x-ratelimit-remaining-tokens": "29998807",
+    "x-ratelimit-reset-requests": "6ms",
+    "x-ratelimit-reset-tokens": "2ms",
+    "x-request-id": "req_af1dcfbc6c5903fe30c48bf10352915a",
+    "cf-cache-status": "DYNAMIC",
+    "set-cookie": "__cf_bm=jlhCFfrsI0VF.S2pk7sWLnyE.UaTeIuJBhWbo8ThFEo-1726651595-1.0.1.1-QGpdXu7lKtesKkM2m80Y8WuvUXfMQ1TzHlHoGIoR0QvkLg78RjGtZTSdx0.1X0wRtCvCPLqrtXn_M1AlkVy1Uw; path=/; expires=Wed, 18-Sep-24 09:56:35 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=8mT4fgFaRnJIOm45VTYetdkyx3wLTXoIiWWnTqE3f2w-1726651595443-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+    "x-content-type-options": "nosniff",
+    "server": "cloudflare",
+    "cf-ray": "8c504b87cbe5ba36-SEA",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "status": {
+    "code": 200,
+    "text": "OK"
+  }
+}
+```
+
+## Embeddings
+
+```typescript
+import { Gateway } from "@adaline/gateway";
+import { OpenAI } from "@adaline/openai";
+
+const gateway = new Gateway({});
+const openai = new OpenAI();
+
+const openAiRequest = {
+  // required fields
+  input: [
+    "Hello world",
+    "When the going gets tough, the tough get going. or something like that. or the tough pivots",
+  ],
+  // optional fields
+  encoding_format: "base64",
+};
+
+const model = openai.embeddingModel({
+  modelName: "text-embedding-3-large",
+  apiKey: "your-api-key",
+});
+const gatewayRequest = model.transformModelRequest(openAiRequest)
+
+
+const request = {
+  model: model,
+  config: gatewayRequest.config,
+  embeddingRequests: gatewayRequest.embeddingRequests,
+};
+
+async function testGetEmbeddings() {
+  const response = await gateway.getEmbeddings(request, {
+    enableCache: false, // optional, default is true
+  });
+  // response.request is the request to model in Gateway's unified types
+  // response.response is the response from the model in Gateway's unified types
+  // response.cache is whether response was cache or not
+  // response.latencyInMs is the gateway calculated latency 
+  // response.provider.request is the actual HTTP request to model 
+  // response.provider.response is the actual HTTP response from the model 
+  console.log(JSON.stringify(response.response.provider.response, null, 2));
+}
+
+testGetEmbeddings();
+```
+
+```json
+{
+  "data": {
+    "object": "list",
+    "data": [
+      {
+        "object": "embedding",
+        "index": 0,
+        "embedding": "bDUPvNEuJ7xFZMs7sNcBPa+UB ... bO3xQqLveX9u6" // minified base64
+      },
+      {
+        "object": "embedding",
+        "index": 1,
+        "embedding": "NxYFveE6CLyxc0q87bsrPVSZbj ... 9ULyA3wk8" //minified base64
+      }
+    ],
+    "model": "text-embedding-3-large",
+    "usage": {
+      "prompt_tokens": 23,
+      "total_tokens": 23
+    }
+  },
+  "headers": {
+    "date": "Wed, 18 Sep 2024 09:31:22 GMT",
+    "content-type": "application/json",
+    "transfer-encoding": "chunked",
+    "connection": "close",
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "X-Request-ID",
+    "openai-model": "text-embedding-3-large",
+    "openai-organization": "your-openai-org",
+    "openai-processing-ms": "62",
+    "openai-version": "2020-10-01",
+    "strict-transport-security": "max-age=15552000; includeSubDomains; preload",
+    "x-ratelimit-limit-requests": "10000",
+    "x-ratelimit-limit-tokens": "10000000",
+    "x-ratelimit-remaining-requests": "9999",
+    "x-ratelimit-remaining-tokens": "9999975",
+    "x-ratelimit-reset-requests": "6ms",
+    "x-ratelimit-reset-tokens": "0s",
+    "x-request-id": "req_c7a4a9c39f1baa78312351ca6fc51e28",
+    "cf-cache-status": "DYNAMIC",
+    "set-cookie": "__cf_bm=n7eZtr5NGj98pC10N7e4G_1iFuMVNaPTxFEYMFaZVrU-1726651882-1.0.1.1-QHmeJ4SNNFXmDHse4z5PYDTEu.hwVaOzLiKAFPAZ7gVMfQgdC2KEP4J8ZzWAcr1NdC8ECTTzrJvx6ikc1LGQwg; path=/; expires=Wed, 18-Sep-24 10:01:22 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=kP_84ZnbpJOXVmsHCdamZXCbDX.cItrmt18thfqPyM0-1726651882995-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+    "x-content-type-options": "nosniff",
+    "server": "cloudflare",
+    "cf-ray": "8c505299dec975d3-SEA",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "status": {
+    "code": 200,
+    "text": "OK"
+  }
+}
+```
+
+## Run concurrent requests
+
+```typescript
+import { Gateway, CompleteChatHandlerResponseType } from "@adaline/gateway";
+import { OpenAI } from "@adaline/openai";
+
+const gateway = new Gateway({
+  queueOptions: {
+    maxConcurrentTasks: 8,
+    retryCount: 4,
+    retry: {
+      initialDelay: 5000,
+      exponentialFactor: 2,
+    },
+    timeout: 120000, 
+  },
+});
+const openai = new OpenAI();
+const model = openai.chatModel({
+  modelName: "gpt-4o",
+  apiKey: "your-api-key",
+});
+
+const doCompleteChat = async (request): Promise<CompleteChatHandlerResponseType> => {
+  return await gateway.completeChat({
+    model: model,
+    config: request.config,
+    messages: request.messages,
+    tools: request.tools,
+  });
+};
+
+async function testConcurrentCompleteChat() {
+  const requests = [] // your custom request generation logic
+
+  const promises: Promise<CompleteChatHandlerResponseType>[] = [];
+
+  requests.forEach(request => {
+    promises.push(doCompleteChat(request));
+  });
+
+  const results = await Promise.allSettled(promises);
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      console.log(JSON.stringify(result.value.response, null, 2));
+    } else {
+      console.log(result.reason);
+    }
+  }
+}
+
+testConcurrentCompleteChat();
+```

--- a/src/cache.gateway.ts
+++ b/src/cache.gateway.ts
@@ -1,0 +1,26 @@
+import type { Cache as GatewayCache } from '@adaline/gateway';
+
+import { getCache } from './cache';
+
+export class GatewayCachePlugin<T> implements GatewayCache<T> {
+    
+    async get(key: string): Promise<T | undefined> {
+        const cache = await getCache();
+        return cache.get(key);
+    }
+
+    async set(key: string, value: T): Promise<void> {
+        const cache = await getCache();
+        cache.set(key, value);
+    }
+
+    // Gateway will never invoke this method
+    async delete(key: string): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    // Gateway will never invoke this method
+    async clear(): Promise<void> {
+        throw new Error('Not implemented');
+    }
+};

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -1,3 +1,4 @@
+import type { Gateway } from '@adaline/gateway';
 import type winston from 'winston';
 import type { Prompt } from './prompts';
 import type { NunjucksFilterMap, TokenUsage } from './shared';
@@ -36,6 +37,7 @@ export interface CallApiContextParams {
   fetchWithCache?: any;
   filters?: NunjucksFilterMap;
   getCache?: any;
+  gateway?: Gateway;
   logger?: winston.Logger;
   originalProvider?: ApiProvider;
   prompt: Prompt;


### PR DESCRIPTION
### Notes:
* Update `CallApiContextParams` to include optional gateway object
  * Uses a single gateway object created for each eval run
  * Can handle multiple requests concurrently when running with concurrency > 1
  * Supports PromptFoo like retry, timeout, header based delay for 429 error, exponential backoff for 5XX errors, proxy-agent integration, and caching out of the box
  * Will be used to integrate with other providers in future
 * Update `openai` provider
   * use gateway based chat-completion, embedding by default
   * For unsupported calls / any exception from gateway -- fallback to native OpenAI call (existing implementation)
   * embedding calls don't reuse the gateway object because they are sequential
   * support open-router, together-ai as well with their native urls
  * Created a gateway cache plugin
    * Light wrapper over PromptFoo's existing cache implementation
    * Allows access for gateway to read / write PromptFoo's cache implementation
  * Previous PR: 
    * https://github.com/promptfoo/promptfoo/pull/1676
### Testing
* Tested with `examples/openai-tools-call/promptfooconfig.yaml`
* Tested with `examples/openai-chat-history/promptfooconfig.yaml`
* Tested with self created configs handling text, image, tool modality messages
* Tested cache implementation by firing same prompts multiple times
* Tested gateway retry, timeout, backoff, proxy-agent by tweaking gateway options
* Passing all existing openai unit tests