### PR TITLE
feat(cli): add example download functionality to init command

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,7 @@ const REPO_OWNER = 'promptfoo';
 const REPO_NAME = 'promptfoo';
 const EXAMPLES_PATH = 'examples';
 
-async function downloadFile(url: string, filePath: string): Promise<void> {
+export async function downloadFile(url: string, filePath: string): Promise<void> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Failed to download file: ${response.statusText}`);
@@ -24,7 +24,7 @@ async function downloadFile(url: string, filePath: string): Promise<void> {
   await fs.writeFile(filePath, content);
 }
 
-async function downloadDirectory(dirPath: string, targetDir: string): Promise<void> {
+export async function downloadDirectory(dirPath: string, targetDir: string): Promise<void> {
   const url = `${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}/${dirPath}?ref=${VERSION}`;
   const response = await fetch(url, {
     headers: {
@@ -36,8 +36,9 @@ async function downloadDirectory(dirPath: string, targetDir: string): Promise<vo
   if (!response.ok) {
     throw new Error(`Failed to fetch directory contents: ${response.statusText}`);
   }
-
+  console.log(response);
   const contents = await response.json();
+  console.log(contents);
 
   for (const item of contents) {
     const itemPath = path.join(targetDir, item.name);
@@ -50,7 +51,7 @@ async function downloadDirectory(dirPath: string, targetDir: string): Promise<vo
   }
 }
 
-async function downloadExample(exampleName: string, targetDir: string): Promise<void> {
+export async function downloadExample(exampleName: string, targetDir: string): Promise<void> {
   try {
     await fs.mkdir(targetDir, { recursive: true });
     await downloadDirectory(exampleName, targetDir);
@@ -61,7 +62,7 @@ async function downloadExample(exampleName: string, targetDir: string): Promise<
   }
 }
 
-async function getExamplesList(): Promise<string[]> {
+export async function getExamplesList(): Promise<string[]> {
   try {
     const response = await fetch(
       `${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}?ref=${VERSION}`,
@@ -89,7 +90,7 @@ async function getExamplesList(): Promise<string[]> {
   }
 }
 
-async function selectExample(): Promise<string> {
+export async function selectExample(): Promise<string> {
   const examples = await getExamplesList();
   const choices = [
     { name: 'None (initialize with dummy files)', value: '' },

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,7 +10,6 @@ import logger from '../logger';
 import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
 
-const EXAMPLES_BASE_URL = `https://api.github.com/repos/promptfoo/promptfoo/contents/examples`;
 const GITHUB_API_BASE = 'https://api.github.com';
 const REPO_OWNER = 'promptfoo';
 const REPO_NAME = 'promptfoo';
@@ -26,7 +25,7 @@ async function downloadFile(url: string, filePath: string): Promise<void> {
 }
 
 async function downloadDirectory(dirPath: string, targetDir: string): Promise<void> {
-  const url = `${EXAMPLES_BASE_URL}/${dirPath}`;
+  const url = `${GITHUB_API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}/${dirPath}?ref=${VERSION}`;
   const response = await fetch(url, {
     headers: {
       Accept: 'application/vnd.github.v3+json',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,36 +1,157 @@
 import confirm from '@inquirer/confirm';
+import input from '@inquirer/input';
+import select from '@inquirer/select';
 import type { Command } from 'commander';
+import fs from 'fs/promises';
+import path from 'path';
 import logger from '../logger';
 import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
 
+const EXAMPLES_BASE_URL = `https://api.github.com/repos/promptfoo/promptfoo/contents/examples`;
+
+async function downloadFile(url: string, filePath: string): Promise<void> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download file: ${response.statusText}`);
+  }
+  const content = await response.text();
+  await fs.writeFile(filePath, content);
+}
+
+async function downloadDirectory(dirPath: string, targetDir: string): Promise<void> {
+  const url = `${EXAMPLES_BASE_URL}/${dirPath}`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'promptfoo-cli',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch directory contents: ${response.statusText}`);
+  }
+
+  const contents = await response.json();
+
+  for (const item of contents) {
+    const itemPath = path.join(targetDir, item.name);
+    if (item.type === 'file') {
+      await downloadFile(item.download_url, itemPath);
+    } else if (item.type === 'dir') {
+      await fs.mkdir(itemPath, { recursive: true });
+      await downloadDirectory(`${dirPath}/${item.name}`, itemPath);
+    }
+  }
+}
+
+async function downloadExample(exampleName: string, targetDir: string): Promise<void> {
+  try {
+    await fs.mkdir(targetDir, { recursive: true });
+    await downloadDirectory(exampleName, targetDir);
+  } catch (error) {
+    throw new Error(
+      `Failed to download example: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+}
+
+async function getExamplesList(): Promise<string[]> {
+  // This is a simplified version. In a real implementation, you might want to fetch this list dynamically.
+  return [
+    'simple-test',
+    'claude-vs-gpt',
+    'openai-function-call',
+    // Add more examples here
+  ];
+}
+
 export function initCommand(program: Command) {
   program
     .command('init [directory]')
-    .description('Initialize project with dummy files')
+    .description('Initialize project with dummy files or download an example')
     .option('--no-interactive', 'Do not run in interactive mode')
-    .action(async (directory: string | null, cmdObj: { interactive: boolean }) => {
-      telemetry.record('command_used', {
-        name: 'init - started',
-      });
-
-      if (directory === 'redteam' && cmdObj.interactive) {
-        const useRedteam = await confirm({
-          message:
-            'You specified "redteam" as the directory. Did you mean to write "promptfoo redteam init" instead?',
-          default: false,
+    .option('--example [name]', 'Download a specific example')
+    .action(
+      async (
+        directory: string | null,
+        cmdObj: { interactive: boolean; example?: string | boolean },
+      ) => {
+        telemetry.record('command_used', {
+          name: 'init - started',
         });
-        if (useRedteam) {
-          logger.warn('Please use "promptfoo redteam init" to initialize a red teaming project.');
-          return;
-        }
-      }
 
-      const details = await initializeProject(directory, cmdObj.interactive);
-      telemetry.record('command_used', {
-        ...details,
-        name: 'init',
-      });
-      await telemetry.send();
-    });
+        if (directory === 'redteam' && cmdObj.interactive) {
+          const useRedteam = await confirm({
+            message:
+              'You specified "redteam" as the directory. Did you mean to write "promptfoo redteam init" instead?',
+            default: false,
+          });
+          if (useRedteam) {
+            logger.warn('Please use "promptfoo redteam init" to initialize a red teaming project.');
+            return;
+          }
+        }
+
+        let exampleName: string | undefined;
+
+        if (cmdObj.example === true || (cmdObj.example === undefined && cmdObj.interactive)) {
+          // --example flag was passed without a value, or we're in interactive mode
+          const examples = await getExamplesList();
+          const choices = [
+            { name: 'None (initialize with dummy files)', value: '' },
+            ...examples.map((ex) => ({ name: ex, value: ex })),
+            { name: 'Enter custom example name', value: 'custom' },
+          ];
+
+          const selectedExample = await select({
+            message: 'Choose an example to download:',
+            choices,
+          });
+
+          if (selectedExample === 'custom') {
+            exampleName = await input({ message: 'Enter the name of the example:' });
+          } else {
+            exampleName = selectedExample;
+          }
+        } else if (typeof cmdObj.example === 'string') {
+          // --example flag was passed with a value
+          exampleName = cmdObj.example;
+        }
+
+        if (exampleName) {
+          const targetDir = path.join(directory || '.', exampleName);
+          try {
+            await downloadExample(exampleName, targetDir);
+            logger.info(`Example '${exampleName}' downloaded successfully to ${targetDir}`);
+          } catch (error) {
+            logger.error(
+              `Failed to download example: ${error instanceof Error ? error.message : error}`,
+            );
+
+            // Offer to try again or exit
+            const tryAgain = await confirm({
+              message: 'Would you like to try downloading a different example?',
+              default: true,
+            });
+
+            if (tryAgain) {
+              // Recursively call the action to start over
+              await program.commands
+                .find((cmd) => cmd.name() === 'init')
+                ?.action(directory, cmdObj);
+              return;
+            }
+          }
+        } else {
+          const details = await initializeProject(directory, cmdObj.interactive);
+          telemetry.record('command_used', {
+            ...details,
+            name: 'init',
+          });
+        }
+
+        await telemetry.send();
+      },
+    );
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -36,9 +36,7 @@ export async function downloadDirectory(dirPath: string, targetDir: string): Pro
   if (!response.ok) {
     throw new Error(`Failed to fetch directory contents: ${response.statusText}`);
   }
-  console.log(response);
   const contents = await response.json();
-  console.log(contents);
 
   for (const item of contents) {
     const itemPath = path.join(targetDir, item.name);

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -161,7 +161,6 @@ describe('init command', () => {
       if (!initCmd) {
         throw new Error('initCmd not found');
       }
-      action = initCmd.action as Function;
     });
 
     it('should set up the init command correctly', () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,0 +1,176 @@
+import { Command } from 'commander';
+import fs from 'fs/promises';
+import fetch from 'node-fetch';
+import * as init from '../../src/commands/init';
+import logger from '../../src/logger';
+
+jest.mock('../../src/commands/init', () => {
+  const actual = jest.requireActual('../../src/commands/init');
+  return {
+    ...actual,
+    downloadDirectory: jest.fn(actual.downloadDirectory),
+    downloadExample: jest.fn(actual.downloadExample),
+    getExamplesList: jest.fn(actual.getExamplesList),
+  };
+});
+
+jest.mock('fs/promises');
+jest.mock('path');
+jest.mock('node-fetch');
+jest.mock('../../src/constants');
+jest.mock('../../src/logger');
+jest.mock('../../src/onboarding');
+jest.mock('../../src/telemetry');
+jest.mock('@inquirer/confirm');
+jest.mock('@inquirer/input');
+jest.mock('@inquirer/select');
+
+describe('init command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('downloadFile', () => {
+    it('should download a file successfully', async () => {
+      const mockResponse = {
+        ok: true,
+        text: jest.fn().mockResolvedValue('file content'),
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      await init.downloadFile('https://example.com/file.txt', '/path/to/file.txt');
+
+      expect(fetch).toHaveBeenCalledWith('https://example.com/file.txt');
+      expect(fs.writeFile).toHaveBeenCalledWith('/path/to/file.txt', 'file content');
+    });
+
+    it('should throw an error if download fails', async () => {
+      const mockResponse = {
+        ok: false,
+        statusText: 'Not Found',
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      await expect(
+        init.downloadFile('https://example.com/file.txt', '/path/to/file.txt'),
+      ).rejects.toThrow('Failed to download file: Not Found');
+    });
+
+    it('should handle network errors', async () => {
+      jest.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        init.downloadFile('https://example.com/file.txt', '/path/to/file.txt'),
+      ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('downloadDirectory', () => {
+    it('should throw an error if fetching directory contents fails', async () => {
+      const mockResponse = {
+        ok: false,
+        statusText: 'Not Found',
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      await expect(init.downloadDirectory('example', '/path/to/target')).rejects.toThrow(
+        'Failed to fetch directory contents: Not Found',
+      );
+    });
+
+    it('should handle network errors', async () => {
+      jest.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+      await expect(init.downloadDirectory('example', '/path/to/target')).rejects.toThrow(
+        'Network error',
+      );
+    });
+  });
+
+  describe('downloadExample', () => {
+    it('should throw an error if directory creation fails', async () => {
+      jest.spyOn(fs, 'mkdir').mockRejectedValue(new Error('Permission denied'));
+
+      await expect(init.downloadExample('example', '/path/to/target')).rejects.toThrow(
+        'Failed to download example: Permission denied',
+      );
+    });
+
+    it('should throw an error if downloadDirectory fails', async () => {
+      jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+      jest.mocked(init.downloadDirectory).mockRejectedValue(new Error('Download failed'));
+
+      await expect(init.downloadExample('example', '/path/to/target')).rejects.toThrow(
+        'Failed to download example: Network error',
+      );
+    });
+  });
+
+  describe('getExamplesList', () => {
+    it('should return a list of examples', async () => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue([
+          { name: 'example1', type: 'dir' },
+          { name: 'example2', type: 'dir' },
+          { name: 'not-an-example', type: 'file' },
+        ]),
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      const examples = await init.getExamplesList();
+
+      expect(examples).toEqual(['example1', 'example2']);
+    });
+
+    it('should return an empty array if fetching fails', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      const examples = await init.getExamplesList();
+
+      expect(examples).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Not Found'));
+    });
+
+    it('should handle network errors', async () => {
+      jest.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+      const examples = await init.getExamplesList();
+
+      expect(examples).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Network error'));
+    });
+  });
+
+  describe('initCommand', () => {
+    let program: Command;
+
+    beforeEach(() => {
+      program = new Command();
+      init.initCommand(program);
+      const initCmd = program.commands.find((cmd) => cmd.name() === 'init');
+      if (!initCmd) {
+        throw new Error('initCmd not found');
+      }
+      action = initCmd.action as Function;
+    });
+
+    it('should set up the init command correctly', () => {
+      const initCmd = program.commands.find((cmd) => cmd.name() === 'init');
+      expect(initCmd).toBeDefined();
+      expect(initCmd?.description()).toBe(
+        'Initialize project with dummy files or download an example',
+      );
+      expect(initCmd?.options).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
This PR enhances the `init` command by adding the ability to download and set up example projects. Users can now quickly get started with the pre-configured examples on github directly from the command line.  When running the `init` command, users now have the option to download an example project:

```
promptfoo init --example
```

### Interactive Mode

1. The command will present a list of available examples to choose from (based on what was available in the examples directory associated with the release version).
2. Users can select an example from the list or choose to enter a custom example name.
3. If "None" is selected, the command will proceed with the standard initialization process.

### Non-Interactive Mode

Users can directly specify an example to download:

```
promptfoo init --example my-example-name
```

### Example Download Process

1. The selected example is downloaded from the promptfoo GitHub repository.
2. Files are saved to a new directory named after the example (e.g., `./my-example-name/`).
3. If the download fails, users are prompted to try again or choose a different example.

### Fallback Behavior

If no example is specified or if the user chooses not to download an example, the command falls back to the standard initialization process, creating dummy files as before.
