### PR TITLE
fix: do not use default config when config is explicitly set

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -404,13 +404,16 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
 
 export async function resolveConfigs(
   cmdObj: Partial<CommandLineOptions>,
-  defaultConfig: Partial<UnifiedConfig>,
+  _defaultConfig: Partial<UnifiedConfig>,
 ): Promise<{ testSuite: TestSuite; config: Partial<UnifiedConfig>; basePath: string }> {
   // Config parsing
   let fileConfig: Partial<UnifiedConfig> = {};
+  let defaultConfig = _defaultConfig;
   const configPaths = cmdObj.config;
   if (configPaths) {
     fileConfig = await combineConfigs(configPaths);
+    // The user has provided a config file, so we do not want to use the default config.
+    defaultConfig = {};
   }
 
   // Standalone assertion mode

--- a/test/util.config.load.test.ts.ts
+++ b/test/util.config.load.test.ts.ts
@@ -758,6 +758,36 @@ describe('resolveConfigs', () => {
       }),
     );
   });
+
+  it('should not use default config when configs are provided', async () => {
+    const cmdObj = { config: ['config.json'] };
+    const defaultConfig = {
+      prompts: ['default prompt'],
+      defaultTest: {
+        vars: {
+          defaultVar: 'default value',
+        },
+      },
+      redteam: {
+        strategies: ['default strategy'],
+      },
+    };
+
+    jest.mocked(readConfig).mockResolvedValue({
+      prompts: ['config prompt'],
+      providers: ['openai:gpt-4'],
+    });
+
+    jest.mocked(globSync).mockReturnValue(['config.json']);
+
+    const { config } = await resolveConfigs(cmdObj, defaultConfig);
+
+    expect(config.prompts).toEqual(['config prompt']);
+    expect(config.providers).toEqual(['openai:gpt-4']);
+    expect(config.prompts).not.toEqual(defaultConfig.prompts);
+    expect(config.redteam).toBeUndefined();
+    expect(config.defaultTest).toBeUndefined();
+  });
 });
 
 describe('readConfig', () => {


### PR DESCRIPTION
Related to #1866 and a common source of confusion