### PR TITLE
fix: only set redteam on combined configs when necessary

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -268,13 +268,15 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
     );
   }
 
-  const redteam: UnifiedConfig['redteam'] = {
-    plugins: [],
-    strategies: [],
-  };
-
+  let redteam: UnifiedConfig['redteam'] | undefined;
   for (const config of configs) {
     if (config.redteam) {
+      if (!redteam) {
+        redteam = {
+          plugins: [],
+          strategies: [],
+        };
+      }
       for (const redteamKey of Object.keys(config.redteam) as Array<keyof typeof redteam>) {
         if (['entities', 'plugins', 'strategies'].includes(redteamKey)) {
           if (Array.isArray(config.redteam[redteamKey])) {
@@ -406,7 +408,6 @@ export async function resolveConfigs(
   cmdObj: Partial<CommandLineOptions>,
   defaultConfig: Partial<UnifiedConfig>,
 ): Promise<{ testSuite: TestSuite; config: Partial<UnifiedConfig>; basePath: string }> {
-  // Config parsing
   let fileConfig: Partial<UnifiedConfig> = {};
   const configPaths = cmdObj.config;
   if (configPaths) {

--- a/test/util.config.load.test.ts.ts
+++ b/test/util.config.load.test.ts.ts
@@ -475,6 +475,62 @@ describe('combineConfigs', () => {
     );
     consoleSpy.mockRestore();
   });
+
+  it('should only set redteam config when at least one individual config has redteam settings', async () => {
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(
+        JSON.stringify({
+          description: 'Config without redteam',
+          providers: ['provider1'],
+        }),
+      )
+      .mockReturnValueOnce(
+        JSON.stringify({
+          description: 'Config with redteam',
+          providers: ['provider2'],
+          redteam: {
+            plugins: ['plugin1'],
+            strategies: ['strategy1'],
+          },
+        }),
+      )
+      .mockReturnValueOnce(
+        JSON.stringify({
+          description: 'Another config without redteam',
+          providers: ['provider3'],
+        }),
+      );
+
+    const result = await combineConfigs(['config1.json', 'config2.json', 'config3.json']);
+
+    expect(result.redteam).toBeDefined();
+    expect(result.redteam).toEqual({
+      plugins: ['plugin1'],
+      strategies: ['strategy1'],
+    });
+  });
+
+  it('should not set redteam config when no individual configs have redteam settings', async () => {
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(
+        JSON.stringify({
+          description: 'Config without redteam',
+          providers: ['provider1'],
+        }),
+      )
+      .mockReturnValueOnce(
+        JSON.stringify({
+          description: 'Another config without redteam',
+          providers: ['provider2'],
+        }),
+      );
+
+    const result = await combineConfigs(['config1.json', 'config2.json']);
+
+    expect(result.redteam).toBeUndefined();
+  });
 });
 
 describe('dereferenceConfig', () => {


### PR DESCRIPTION
Related to #1866.  This was causing an empty `redteam` to be set on _any_ combined configs, which leads to cli/ui treating the eval like a redteam when it shouldn't.