### PR TITLE
chore(cli): warn users about unknown arguments after 'eval' command

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -469,9 +469,7 @@ export function evalCommand(
         return;
       }
       if (command.args.length > 0) {
-        logger.warn(
-          `Unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]}?`,
-        );
+        logger.warn(`Unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]}?`);
       }
 
       if (validatedOpts.help) {

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -455,8 +455,7 @@ export function evalCommand(
     .option('--description <description>', 'Description of the eval run')
     .option('--verbose', 'Show debug logs', defaultConfig?.commandLineOptions?.verbose)
     .option('--no-progress-bar', 'Do not show progress bar')
-
-    .action(async (opts: EvalCommandOptions) => {
+    .action(async (opts: EvalCommandOptions, command: Command) => {
       let validatedOpts: z.infer<typeof EvalCommandSchema>;
       try {
         validatedOpts = EvalCommandSchema.parse(opts);
@@ -468,6 +467,11 @@ export function evalCommand(
         `);
         process.exitCode = 1;
         return;
+      }
+      if (command.args.length > 0) {
+        logger.warn(
+          `unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]} or --config ${command.args[0]}?`,
+        );
       }
 
       if (validatedOpts.help) {

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -470,7 +470,7 @@ export function evalCommand(
       }
       if (command.args.length > 0) {
         logger.warn(
-          `unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]} or --config ${command.args[0]}?`,
+          `Unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]}?`,
         );
       }
 


### PR DESCRIPTION
This commit adds a warning message when users provide unexpected arguments after the 'eval' command. It suggests that they might have meant to use the '-c' or '--config' option instead.

Relates to https://github.com/promptfoo/promptfoo/issues/1895