### PR TITLE
fix: update cloud share URL path from 'results' to 'eval'

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -167,7 +167,7 @@ export async function createShareableUrl(
   let fullUrl = SHARE_VIEW_BASE_URL;
   if (cloudConfig.isEnabled()) {
     appBaseUrl = cloudConfig.getAppUrl();
-    fullUrl = `${appBaseUrl}/results/${evalId}`;
+    fullUrl = `${appBaseUrl}/eval/${evalId}`;
   } else {
     const appBaseUrl =
       typeof evalRecord.config.sharing === 'object'

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -1,6 +1,15 @@
-import { stripAuthFromUrl } from '../src/share';
+import { cloudConfig } from '../src/globalConfig/cloud';
+import type Eval from '../src/models/eval';
+import { stripAuthFromUrl, createShareableUrl } from '../src/share';
 
 jest.mock('../src/logger');
+jest.mock('../src/globalConfig/cloud');
+jest.mock('../src/fetch', () => ({
+  fetchWithProxy: jest.fn().mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue({ id: 'mock-eval-id' }),
+  }),
+}));
 
 describe('stripAuthFromUrl', () => {
   it('removes username and password from URL', () => {
@@ -35,5 +44,24 @@ describe('stripAuthFromUrl', () => {
     const input = 'http://user:pass@192.168.1.1:8080/path';
     const expected = 'http://192.168.1.1:8080/path';
     expect(stripAuthFromUrl(input)).toBe(expected);
+  });
+});
+
+describe('createShareableUrl', () => {
+  it('creates correct URL for cloud config', async () => {
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(true);
+    jest.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');
+    jest.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+    jest.mocked(cloudConfig.getApiKey).mockReturnValue('mock-api-key');
+
+    const mockEval: Partial<Eval> = {
+      config: {},
+      useOldResults: jest.fn().mockReturnValue(false),
+      loadResults: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await createShareableUrl(mockEval as Eval);
+
+    expect(result).toBe('https://app.example.com/eval/mock-eval-id');
   });
 });


### PR DESCRIPTION
The URL path for shared evaluation results in cloud mode has been updated
from '/results/' to '/eval/' to maintain consistency with the non-cloud
sharing URL structure.