### PR TITLE
fix: Navigating directly to an eval

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { IS_RUNNING_LOCALLY } from '@app/constants';
 import { useStore as useMainStore } from '@app/stores/evalConfig';
 import { callApi } from '@app/utils/api';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -136,27 +137,31 @@ export default function ResultsView({
   };
 
   const handleShareButtonClick = async () => {
-    setShareLoading(true);
-
-    try {
-      const response = await callApi('/results/share', {
-        method: 'POST',
-        body: JSON.stringify({ id: currentEvalId }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      const { url } = await response.json();
-      if (response.ok) {
-        setShareUrl(url);
-        setShareModalOpen(true);
-      } else {
+    if (IS_RUNNING_LOCALLY) {
+      setShareLoading(true);
+      try {
+        const response = await callApi('/results/share', {
+          method: 'POST',
+          body: JSON.stringify({ id: currentEvalId }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const { url } = await response.json();
+        if (response.ok) {
+          setShareUrl(url);
+          setShareModalOpen(true);
+        } else {
+          alert('Sorry, something went wrong.');
+        }
+      } catch {
         alert('Sorry, something went wrong.');
+      } finally {
+        setShareLoading(false);
       }
-    } catch {
-      alert('Sorry, something went wrong.');
-    } finally {
-      setShareLoading(false);
+    } else {
+      setShareUrl(`${window.location.host}/eval/?evalId=${currentEvalId}`);
+      setShareModalOpen(true);
     }
   };
 

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  base: './',
+  base: process.env.VITE_PUBLIC_BASENAME || '/',
   plugins: [react(), nodePolyfills()] as PluginOption[],
   resolve: {
     alias: {


### PR DESCRIPTION
Navigating directly to an eval like `http://localhost:8500/eval/eval-17m-2024-10-16T19%3A31%3A03` wouldn't load because it was trying to load the assets from `http://localhost:8500/eval/index.js` instead of `http://localhost:8500/index.js`