### PR TITLE
chore(providers): support AWS credentials in config file for bedrock provider

### DIFF
--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -38,6 +38,8 @@ The `bedrock` lets you use Amazon Bedrock in your evals. This is a common way to
          region: 'us-west-2'
          temperature: 0.7
          max_tokens: 256
+         accessKeyId: YOUR_ACCESS_KEY_ID
+         secretAccessKey: YOUR_SECRET_ACCESS_KEY
    ```
 
 ## Example

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -35,11 +35,11 @@ The `bedrock` lets you use Amazon Bedrock in your evals. This is a common way to
    providers:
      - id: bedrock:anthropic.claude-3-5-sonnet-20240620-v1:0
        config:
-         region: 'us-west-2'
-         temperature: 0.7
-         max_tokens: 256
          accessKeyId: YOUR_ACCESS_KEY_ID
          secretAccessKey: YOUR_SECRET_ACCESS_KEY
+         region: 'us-west-2'
+         max_tokens: 256
+         temperature: 0.7
    ```
 
 ## Example

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -18,8 +18,8 @@ import { outputFromMessage, parseMessages } from './anthropic';
 import { parseChatPrompt } from './shared';
 
 interface BedrockOptions {
-  region?: string;
   accessKeyId?: string;
+  region?: string;
   secretAccessKey?: string;
 }
 
@@ -232,7 +232,7 @@ export const formatPromptLlama2Chat = (messages: LlamaMessage[]): string => {
     return '';
   }
 
-  let formattedPrompt = ' ';
+  let formattedPrompt = '<s>';
   let systemMessageIncluded = false;
 
   for (let i = 0; i < messages.length; i++) {
@@ -241,25 +241,25 @@ export const formatPromptLlama2Chat = (messages: LlamaMessage[]): string => {
     switch (message.role) {
       case 'system':
         if (!systemMessageIncluded) {
-          formattedPrompt += `  <<SYS>>\n${message.content.trim()}\n<</SYS>>\n\n`;
+          formattedPrompt += `[INST] <<SYS>>\n${message.content.trim()}\n<</SYS>>\n\n`;
           systemMessageIncluded = true;
         }
         break;
 
       case 'user':
         if (i === 0 && !systemMessageIncluded) {
-          formattedPrompt += `  ${message.content.trim()}  `;
+          formattedPrompt += `[INST] ${message.content.trim()} [/INST]`;
         } else if (i === 0 && systemMessageIncluded) {
-          formattedPrompt += `${message.content.trim()}  `;
+          formattedPrompt += `${message.content.trim()} [/INST]`;
         } else if (i > 0 && messages[i - 1].role === 'assistant') {
-          formattedPrompt += `  ${message.content.trim()}  `;
+          formattedPrompt += `<s>[INST] ${message.content.trim()} [/INST]`;
         } else {
-          formattedPrompt += `${message.content.trim()}  `;
+          formattedPrompt += `${message.content.trim()} [/INST]`;
         }
         break;
 
       case 'assistant':
-        formattedPrompt += ` ${message.content.trim()}  `;
+        formattedPrompt += ` ${message.content.trim()} </s>`;
         break;
 
       default:


### PR DESCRIPTION
Updates BedrockOptions interface to include accessKeyId and secretAccessKey. Relates to #1935. CC @zhlmmc