### PR TITLE
chore: resolve fast refresh warning by separating useToast hook

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,9 +39,9 @@ export default [
     },
     plugins: {
       'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
       'unused-imports': unusedImports,
       unicorn: eslintPluginUnicorn,
-      'react-refresh': reactRefresh,
     },
     rules: {
       '@typescript-eslint/ban-ts-comment': 0,
@@ -68,11 +68,11 @@ export default [
       'no-useless-escape': 0,
       'object-shorthand': 'error',
       'prefer-const': 'error',
+      'react-refresh/only-export-components': 'warn',
       'unicorn/no-lonely-if': 'error',
       'unicorn/no-negated-condition': 'error',
       'unicorn/prefer-number-properties': 'error',
       'unused-imports/no-unused-imports': 'error',
-      'react-refresh/only-export-components': 'warn',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
 import eslint from '@eslint/js';
 import jest from 'eslint-plugin-jest';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
@@ -40,6 +41,7 @@ export default [
       'react-hooks': reactHooks,
       'unused-imports': unusedImports,
       unicorn: eslintPluginUnicorn,
+      'react-refresh': reactRefresh,
     },
     rules: {
       '@typescript-eslint/no-unsafe-function-type': 0,
@@ -70,6 +72,7 @@ export default [
       'unicorn/no-negated-condition': 'error',
       'unicorn/prefer-number-properties': 'error',
       'unused-imports/no-unused-imports': 'error',
+      'react-refresh/only-export-components': 'warn',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31350,7 +31350,7 @@
         "@vitejs/plugin-react": "^4.3.2",
         "eslint": "^9.12.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-        "eslint-plugin-react-refresh": "^0.4.12",
+        "eslint-plugin-react-refresh": "^0.4.13",
         "globals": "^15.11.0",
         "jsdom": "^25.0.1",
         "typescript": "^5.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "eslint": "^9.12.0",
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+        "eslint-plugin-react-refresh": "^0.4.13",
         "eslint-plugin-unicorn": "^56.0.0",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^29.7.0",
@@ -15663,10 +15664,11 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.12.tgz",
-      "integrity": "sha512-9neVjoGv20FwYtCP6CB1dzR1vr57ZDNOXst21wd2xJ/cTlM2xLq0GWVlSNTdMn/4BtP6cHYBMCSp1wFBJ9jBsg==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.13.tgz",
+      "integrity": "sha512-f1EppwrpJRWmqDTyvAyomFVDYRtrS7iTEqv3nokETnMiMzs2SSTmKRTACce4O2p4jYyowiSMvpdwC/RLcMFhuQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "eslint": ">=7"
       }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint": "^9.12.0",
     "eslint-plugin-jest": "^28.8.3",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.13",
     "eslint-plugin-unicorn": "^56.0.0",
     "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.7.0",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -63,7 +63,7 @@
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^9.12.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-    "eslint-plugin-react-refresh": "^0.4.12",
+    "eslint-plugin-react-refresh": "^0.4.13",
     "globals": "^15.11.0",
     "jsdom": "^25.0.1",
     "typescript": "^5.6.3",

--- a/src/app/src/contexts/ToastContext.tsx
+++ b/src/app/src/contexts/ToastContext.tsx
@@ -1,22 +1,14 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { AlertColor } from '@mui/material/Alert';
 import Alert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
 
-interface ToastContextType {
+export interface ToastContextType {
   showToast: (message: string, severity?: AlertColor) => void;
 }
 
-const ToastContext = createContext<ToastContextType | undefined>(undefined);
-
-export const useToast = (): ToastContextType => {
-  const context = useContext(ToastContext);
-  if (!context) {
-    throw new Error('useToast must be used within a ToastProvider');
-  }
-  return context;
-};
+export const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
 interface ToastProviderProps {
   children: ReactNode;

--- a/src/app/src/hooks/useToast.ts
+++ b/src/app/src/hooks/useToast.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import type { ToastContextType } from '../contexts/ToastContext';
+import { ToastContext } from '../contexts/ToastContext';
+
+export const useToast = (): ToastContextType => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -8,7 +8,7 @@ import {
 import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
-import { useToast } from '@app/contexts/ToastContext';
+import { useToast } from '@app/hooks/useToast';
 import type {
   EvaluateTableRow,
   EvaluateTableOutput,


### PR DESCRIPTION
- Add eslint-plugin-react-refresh to dependencies
- Configure react-refresh plugin in eslint config
- Move useToast hook to a separate file to comply with fast refresh requirements