### PR TITLE
refactor(assertions): move utility functions to separate file

### DIFF
--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -13,8 +13,7 @@ export function getFinalTest(test: TestCase, assertion: Assertion) {
 
   // Assertion provider overrides test provider
   ret.options = ret.options || {};
-  // NOTE: Clone does not copy functions so we set the provider again
-  ret.options.provider = assertion.provider || test?.options?.provider;
+  ret.options.provider = assertion.provider || ret.options.provider;
   ret.options.rubricPrompt = assertion.rubricPrompt || ret.options.rubricPrompt;
   return Object.freeze(ret);
 }

--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+import path from 'path';
+import Clone from 'rfdc';
+import cliState from '../cliState';
+import { type Assertion, type TestCase } from '../types';
+
+const clone = Clone();
+
+export function getFinalTest(test: TestCase, assertion: Assertion) {
+  // Deep copy
+  const ret = clone(test);
+
+  // Assertion provider overrides test provider
+  ret.options = ret.options || {};
+  // NOTE: Clone does not copy functions so we set the provider again
+  ret.options.provider = assertion.provider || test?.options?.provider;
+  ret.options.rubricPrompt = assertion.rubricPrompt || ret.options.rubricPrompt;
+  return Object.freeze(ret);
+}
+
+export function processFileReference(fileRef: string): object | string {
+  const basePath = cliState.basePath || '';
+  const filePath = path.resolve(basePath, fileRef.slice('file://'.length));
+  const fileContent = fs.readFileSync(filePath, 'utf8');
+  const extension = path.extname(filePath);
+  if (['.json', '.yaml', '.yml'].includes(extension)) {
+    return yaml.load(fileContent) as object;
+  } else if (extension === '.txt') {
+    return fileContent.trim();
+  } else {
+    throw new Error(`Unsupported file type: ${filePath}`);
+  }
+}

--- a/test/assertions.utils.test.ts
+++ b/test/assertions.utils.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { processFileReference } from '../src/assertions';
+import { processFileReference, getFinalTest } from '../src/assertions/utils';
 import cliState from '../src/cliState';
+import type { TestCase, Assertion, ApiProvider } from '../src/types';
 
 jest.mock('fs');
 jest.mock('path');
@@ -51,5 +52,65 @@ describe('processFileReference', () => {
     jest.mocked(path.extname).mockReturnValue('.unsupported');
 
     expect(() => processFileReference('file://test.unsupported')).toThrow('Unsupported file type');
+  });
+});
+
+describe('getFinalTest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should correctly merge test and assertion data', () => {
+    const mockApiProvider: ApiProvider = {
+      id: () => 'mockProvider',
+      callApi: jest.fn(),
+    };
+
+    const testCase: TestCase = {
+      vars: { var1: 'value1' },
+      options: {
+        provider: {
+          id: () => 'testProvider',
+          callApi: jest.fn(),
+        },
+      },
+    };
+
+    const assertion: Assertion = {
+      type: 'equals',
+      value: 'expected value',
+      provider: mockApiProvider,
+      rubricPrompt: 'custom rubric prompt',
+    };
+
+    const result = getFinalTest(testCase, assertion);
+
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(result.options?.provider).toBe(mockApiProvider);
+    expect(result.options?.rubricPrompt).toBe('custom rubric prompt');
+    expect(result.vars).toEqual({ var1: 'value1' });
+    expect(testCase.options?.provider?.id()).toBe('testProvider');
+    expect(typeof result.options?.provider?.callApi).toBe('function');
+  });
+
+  it('should use test provider when assertion provider is not provided', () => {
+    const testCase: TestCase = {
+      options: {
+        provider: {
+          id: () => 'testProvider',
+          callApi: jest.fn(),
+        },
+      },
+    };
+
+    const assertion: Assertion = {
+      type: 'equals',
+      value: 'expected value',
+    };
+
+    const result = getFinalTest(testCase, assertion);
+
+    expect(result.options?.provider?.id()).toBe('testProvider');
+    expect(typeof result.options?.provider?.callApi).toBe('function');
   });
 });

--- a/test/assertions.utils.test.ts
+++ b/test/assertions.utils.test.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { processFileReference, getFinalTest } from '../src/assertions/utils';
+import { processFileReference } from '../src/assertions/utils';
 import cliState from '../src/cliState';
-import type { TestCase, Assertion, ApiProvider } from '../src/types';
 
 jest.mock('fs');
 jest.mock('path');
@@ -52,65 +51,5 @@ describe('processFileReference', () => {
     jest.mocked(path.extname).mockReturnValue('.unsupported');
 
     expect(() => processFileReference('file://test.unsupported')).toThrow('Unsupported file type');
-  });
-});
-
-describe('getFinalTest', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should correctly merge test and assertion data', () => {
-    const mockApiProvider: ApiProvider = {
-      id: () => 'mockProvider',
-      callApi: jest.fn(),
-    };
-
-    const testCase: TestCase = {
-      vars: { var1: 'value1' },
-      options: {
-        provider: {
-          id: () => 'testProvider',
-          callApi: jest.fn(),
-        },
-      },
-    };
-
-    const assertion: Assertion = {
-      type: 'equals',
-      value: 'expected value',
-      provider: mockApiProvider,
-      rubricPrompt: 'custom rubric prompt',
-    };
-
-    const result = getFinalTest(testCase, assertion);
-
-    expect(Object.isFrozen(result)).toBe(true);
-    expect(result.options?.provider).toBe(mockApiProvider);
-    expect(result.options?.rubricPrompt).toBe('custom rubric prompt');
-    expect(result.vars).toEqual({ var1: 'value1' });
-    expect(testCase.options?.provider?.id()).toBe('testProvider');
-    expect(typeof result.options?.provider?.callApi).toBe('function');
-  });
-
-  it('should use test provider when assertion provider is not provided', () => {
-    const testCase: TestCase = {
-      options: {
-        provider: {
-          id: () => 'testProvider',
-          callApi: jest.fn(),
-        },
-      },
-    };
-
-    const assertion: Assertion = {
-      type: 'equals',
-      value: 'expected value',
-    };
-
-    const result = getFinalTest(testCase, assertion);
-
-    expect(result.options?.provider?.id()).toBe('testProvider');
-    expect(typeof result.options?.provider?.callApi).toBe('function');
   });
 });


### PR DESCRIPTION
- Move getFinalTest and processFileReference to new file src/assertions/utils.ts
- Update imports in src/assertions/index.ts to use new utils file
- Adjust import paths in test files to reflect new structure
