### PR TITLE
chore(cli): warn on unsupported test format

### DIFF
--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -222,6 +222,14 @@ export async function readTests(
         ret.push(await readTest(globOrTest, basePath));
       }
     }
+  } else {
+    logger.warn(dedent`
+      Warning: Unsupported 'tests' format in promptfooconfig.yaml.
+      Expected: string, string[], or TestCase[], but received: ${typeof tests}
+
+      Please check your configuration file and ensure the 'tests' field is correctly formatted.
+      For more information, visit: https://promptfoo.dev/docs/configuration/reference/#test-case
+    `);
   }
 
   if (

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -4,6 +4,7 @@ import { globSync } from 'glob';
 import yaml from 'js-yaml';
 import { testCaseFromCsvRow } from '../src/csv';
 import { fetchCsvFromGoogleSheet } from '../src/googleSheets';
+import logger from '../src/logger';
 import { loadApiProvider } from '../src/providers';
 import {
   generatePersonasPrompt,
@@ -454,6 +455,17 @@ describe('readTests', () => {
       vars: { var1: 'value3', var2: 'value4' },
       assert: [{ type: 'equals', value: 'expected2' }],
     });
+  });
+
+  it('should log a warning for unsupported test format', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn');
+    const unsupportedTests = { invalid: 'format' };
+
+    await readTests(unsupportedTests as any);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Warning: Unsupported 'tests' format in promptfooconfig.yaml."),
+    );
+    warnSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Resolves discord issue. In the future we should validate the config and throw an error. 