### PR TITLE
fix(eval): set author from getUserEmail when creating Eval

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -463,7 +463,7 @@ export default class Eval {
   }
 }
 
-export async function getSummaryofLatestEvals(
+export async function getSummaryOfLatestEvals(
   limit: number = DEFAULT_QUERY_LIMIT,
   filterDescription?: string,
   datasetId?: string,

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -158,11 +158,9 @@ export default class Eval {
       results?: EvalResult[];
     },
   ): Promise<Eval> {
-    logger.warn(`opts: ${JSON.stringify(opts)}`);
     const createdAt = opts?.createdAt || new Date();
     const evalId = opts?.id || createEvalId(createdAt);
     const author = opts?.author || getUserEmail();
-    logger.info(`author: ${author}`);
     const db = getDb();
     await db.transaction(async (tx) => {
       await tx

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -158,9 +158,11 @@ export default class Eval {
       results?: EvalResult[];
     },
   ): Promise<Eval> {
+    logger.warn(`opts: ${JSON.stringify(opts)}`);
     const createdAt = opts?.createdAt || new Date();
     const evalId = opts?.id || createEvalId(createdAt);
     const author = opts?.author || getUserEmail();
+    logger.info(`author: ${author}`);
     const db = getDb();
     await db.transaction(async (tx) => {
       await tx

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -14,6 +14,7 @@ import {
   evalResultsTable,
   evalsToProvidersTable,
 } from '../database/tables';
+import { getUserEmail } from '../globalConfig/accounts';
 import logger from '../logger';
 import { hashPrompt } from '../prompts/utils';
 import type {
@@ -159,6 +160,7 @@ export default class Eval {
   ): Promise<Eval> {
     const createdAt = opts?.createdAt || new Date();
     const evalId = opts?.id || createEvalId(createdAt);
+    const author = opts?.author || getUserEmail();
     const db = getDb();
     await db.transaction(async (tx) => {
       await tx
@@ -166,7 +168,7 @@ export default class Eval {
         .values({
           id: evalId,
           createdAt: createdAt.getTime(),
-          author: opts?.author,
+          author,
           description: config.description,
           config,
           results: {},

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -30,7 +30,7 @@ import { getAuthor } from '../globalConfig/accounts';
 import { writeCsvToGoogleSheet } from '../googleSheets';
 import logger from '../logger';
 import { runDbMigrations } from '../migrate';
-import Eval, { createEvalId, getSummaryofLatestEvals } from '../models/eval';
+import Eval, { createEvalId, getSummaryOfLatestEvals } from '../models/eval';
 import { generateIdFromPrompt } from '../models/prompt';
 import {
   type EvalWithMetadata,
@@ -375,7 +375,7 @@ export async function listPreviousResults(
 
   const endTime = performance.now();
   const executionTime = endTime - startTime;
-  const evalResults = await getSummaryofLatestEvals(undefined, filterDescription, datasetId);
+  const evalResults = await getSummaryOfLatestEvals(undefined, filterDescription, datasetId);
   logger.debug(`listPreviousResults execution time: ${executionTime.toFixed(2)}ms`);
   const combinedResults = [...evalResults, ...mappedResults];
   return combinedResults;

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -67,8 +67,8 @@ describe('evaluator', () => {
     });
 
     it('should use default author from getUserEmail when not provided', async () => {
-      jest.mocked(getUserEmail).mockReturnValue('default@example.com');
       const mockEmail = 'default@example.com';
+      jest.mocked(getUserEmail).mockReturnValue(mockEmail);
       const config = { description: 'Test eval' };
       const renderedPrompts: Prompt[] = [
         { raw: 'Test prompt', display: 'Test prompt', label: 'Test label' },

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1,5 +1,5 @@
 import { runDbMigrations } from '../../src/migrate';
-import Eval, { getSummaryofLatestEvals } from '../../src/models/eval';
+import Eval, { getSummaryOfLatestEvals } from '../../src/models/eval';
 import EvalFactory from '../factories/evalFactory';
 
 describe('evaluator', () => {
@@ -11,7 +11,7 @@ describe('evaluator', () => {
       const eval1 = await EvalFactory.create();
       const eval2 = await EvalFactory.create();
       await EvalFactory.createOldResult();
-      const evaluations = await getSummaryofLatestEvals();
+      const evaluations = await getSummaryOfLatestEvals();
 
       expect(evaluations).toHaveLength(2);
       expect(evaluations).toContainEqual(


### PR DESCRIPTION
- Set author to opts?.author or getUserEmail() result in Eval.create method
- Add tests to cover new author assignment logic
- Update getSummaryOfLatestEvals function name (typo fix)