### PR TITLE
chore(providers): support response_format in prompt config in openai provider

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -57,29 +57,29 @@ providers:
 
 Supported parameters include:
 
-| Parameter               | Description                                                                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiBaseUrl`            | The base URL of the OpenAI API, please also read `OPENAI_BASE_URL` below.                                                                                       |
-| `apiHost`               | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                       |
-| `apiKey`                | Your OpenAI API key, equivalent to `OPENAI_API_KEY` environment variable                                                                                        |
-| `apiKeyEnvar`           | An environment variable that contains the API key                                                                                                               |
-| `best_of`               | Controls the number of alternative outputs to generate and select from.                                                                                         |
-| `frequency_penalty`     | Applies a penalty to frequent tokens, making them less likely to appear in the output.                                                                          |
-| `function_call`         | Controls whether the AI should call functions. Can be either 'none', 'auto', or an object with a `name` that specifies the function to call.                    |
-| `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                               |
-| `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                            |
-| `headers`               | Additional headers to include in the request.                                                                                                                   |
-| `max_tokens`            | Controls the maximum length of the output in tokens.                                                                                                            |
-| `organization`          | Your OpenAI organization key.                                                                                                                                   |
-| `passthrough`           | Additional parameters to pass through to the API.                                                                                                               |
-| `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                   |
-| `response_format`       | Specifies the desired output format, including `json_object` and `json_schema`                                                                                  |
-| `seed`                  | Seed used for deterministic output.                                                                                                                             |
-| `stop`                  | Defines a list of tokens that signal the end of the output.                                                                                                     |
-| `temperature`           | Controls the randomness of the AI's output. Higher values (close to 1) make the output more random, while lower values (close to 0) make it more deterministic. |
-| `tool_choice`           | Controls whether the AI should use a tool. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)       |
-| `tools`                 | Allows you to define custom tools. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)               |
-| `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                   |
+| Parameter               | Description                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiBaseUrl`            | The base URL of the OpenAI API, please also read `OPENAI_BASE_URL` below.                                                                                                             |
+| `apiHost`               | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                                             |
+| `apiKey`                | Your OpenAI API key, equivalent to `OPENAI_API_KEY` environment variable                                                                                                              |
+| `apiKeyEnvar`           | An environment variable that contains the API key                                                                                                                                     |
+| `best_of`               | Controls the number of alternative outputs to generate and select from.                                                                                                               |
+| `frequency_penalty`     | Applies a penalty to frequent tokens, making them less likely to appear in the output.                                                                                                |
+| `function_call`         | Controls whether the AI should call functions. Can be either 'none', 'auto', or an object with a `name` that specifies the function to call.                                          |
+| `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                                                     |
+| `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                  |
+| `headers`               | Additional headers to include in the request.                                                                                                                                         |
+| `max_tokens`            | Controls the maximum length of the output in tokens.                                                                                                                                  |
+| `organization`          | Your OpenAI organization key.                                                                                                                                                         |
+| `passthrough`           | Additional parameters to pass through to the API.                                                                                                                                     |
+| `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                                         |
+| `response_format`       | Specifies the desired output format, including `json_object` and `json_schema`. Can also be specified in the prompt config. If specified in both, the prompt config takes precedence. |
+| `seed`                  | Seed used for deterministic output.                                                                                                                                                   |
+| `stop`                  | Defines a list of tokens that signal the end of the output.                                                                                                                           |
+| `temperature`           | Controls the randomness of the AI's output. Higher values (close to 1) make the output more random, while lower values (close to 0) make it more deterministic.                       |
+| `tool_choice`           | Controls whether the AI should use a tool. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                             |
+| `tools`                 | Allows you to define custom tools. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                     |
+| `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                                         |
 
 Here are the type declarations of `config` parameters:
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -504,6 +504,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       ? undefined
       : (this.config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0));
 
+    const responseFormat = context?.prompt.config?.response_format || this.config.response_format;
+
     const body = {
       model: this.modelName,
       messages,
@@ -530,10 +532,10 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         ? { tools: maybeLoadFromExternalFile(renderVarsInObject(this.config.tools, context?.vars)) }
         : {}),
       ...(this.config.tool_choice ? { tool_choice: this.config.tool_choice } : {}),
-      ...(this.config.response_format
+      ...(responseFormat
         ? {
             response_format: maybeLoadFromExternalFile(
-              renderVarsInObject(this.config.response_format, context?.vars),
+              renderVarsInObject(responseFormat, context?.vars),
             ),
           }
         : {}),

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1130,13 +1130,108 @@ describe('call provider apis', () => {
       expect(result.tokenUsage).toEqual({ total: 5, prompt: 2, completion: 3 });
     });
   });
+
+  describe('OpenAiChatCompletionProvider response_format', () => {
+    it('should prioritize response_format from prompt config over provider config', async () => {
+      const providerResponseFormat = {
+        type: 'json_object' as const,
+      };
+      const promptResponseFormat = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'test_schema',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { key2: { type: 'string' } },
+            additionalProperties: false,
+          },
+        },
+      };
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
+        config: {
+          response_format: providerResponseFormat,
+        },
+      });
+
+      const mockResponse = {
+        ...defaultMockResponse,
+        text: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            choices: [{ message: { content: '{"key2": "value2"}' } }],
+            usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+          }),
+        ),
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+
+      const result = await provider.callApi('Test prompt', {
+        vars: {},
+        prompt: {
+          raw: 'Test prompt',
+          label: 'Test prompt',
+          config: {
+            response_format: promptResponseFormat,
+          },
+        },
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const fetchArgs = jest.mocked(fetch).mock.calls[0];
+      const requestBody = JSON.parse(fetchArgs[1]?.body as string);
+      expect(requestBody.response_format).toEqual(promptResponseFormat);
+
+      expect(result.output).toBe('{"key2": "value2"}');
+      expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
+    });
+
+    it('should use provider config response_format when prompt config is not provided', async () => {
+      const providerResponseFormat = {
+        type: 'json_object' as const,
+      };
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
+        config: {
+          response_format: providerResponseFormat,
+        },
+      });
+
+      const mockResponse = {
+        ...defaultMockResponse,
+        text: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            choices: [{ message: { content: '{"key1": "value1"}' } }],
+            usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+          }),
+        ),
+      };
+      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+
+      const result = await provider.callApi('Test prompt', {
+        vars: {},
+        prompt: {
+          raw: 'Test prompt',
+          label: 'Test prompt',
+        },
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const fetchArgs = jest.mocked(fetch).mock.calls[0];
+      const requestBody = JSON.parse(fetchArgs[1]?.body as string);
+      expect(requestBody.response_format).toEqual(providerResponseFormat);
+      expect(result.output).toBe('{"key1": "value1"}');
+      expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
+    });
+  });
 });
 
 describe('loadApiProvider', () => {
   it('loadApiProvider with yaml filepath', async () => {
-    const mockYamlContent = `id: 'openai:gpt-4'
-config:
-  key: 'value'`;
+    const mockYamlContent = dedent`
+    id: 'openai:gpt-4'
+    config:
+      key: 'value'`;
     jest.mocked(fs.readFileSync).mockReturnValueOnce(mockYamlContent);
 
     const provider = await loadApiProvider('file://path/to/mock-provider-file.yaml');


### PR DESCRIPTION
- Update OpenAiChatCompletionProvider to prioritize response_format from prompt config
- Add tests for response_format handling in OpenAiChatCompletionProvider
- Update OpenAI documentation to explain new response_format behavior

Here's an example of how to use the new feature in a `promptfooconfig.yaml` file:

```yaml
prompts:
  - label: 'Prompt #1'
    raw: You are a helpful math tutor. Solve {{problem}}
    config:
      response_format:
        type: json_schema
        json_schema:
          name: math_response
          strict: true
          schema:
            type: object
            properties:
              final_answer:
                type: string
              steps:
                type: array
                items:
                  type: object
                  properties:
                    explanation:
                      type: string
                    output:
                      type: string
                  required:
                    - explanation
                    - output
                  additionalProperties: false
            required:
              - steps
              - final_answer
            additionalProperties: false

providers:
  - openai:gpt-4o-mini

tests:
  - vars:
      problem: 2 + 2
```

You can also use

```yaml
prompts:
  - label: 'Prompt #1'
    raw: You are a helpful math tutor. Solve {{problem}}

providers:
  - id: openai:gpt-4o-mini
    config:
      response_format:
        json_schema:
          name: math_response
          schema:
            additionalProperties: false
            properties:
              final_answer:
                type: string
              steps:
                items:
                  additionalProperties: false
                  properties:
                    explanation:
                      type: string
                    output:
                      type: string
                  required:
                  - explanation
                  - output
                  type: object
                type: array
            required:
            - steps
            - final_answer
            type: object
          strict: true
        type: json_schema

tests:
  - vars:
      problem: 2 + 2
```

CC @noahmacca