### PR TITLE
chore: replace node-fetch with native fetch API

### DIFF
--- a/examples/claude-vs-gpt-image/prompt.js
+++ b/examples/claude-vs-gpt-image/prompt.js
@@ -6,7 +6,7 @@
  *
  * Note: For simplicity and to avoid dependencies, this example uses the built-in
  * 'https' module. In a production environment, use more robust libraries like
- * node-fetch or axios for better error handling and features.
+ * axios for better error handling and features.
  */
 
 const https = require('https');

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "js-yaml": "^4.1.0",
         "mathjs": "^13.2.0",
         "node-cache": "^5.1.2",
-        "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.4",
         "openai": "^4.68.1",
         "opener": "^1.5.2",
@@ -94,7 +93,6 @@
         "@types/inquirer": "^9.0.7",
         "@types/jest": "^29.5.13",
         "@types/js-yaml": "^4.0.9",
-        "@types/node-fetch": "^2.6.11",
         "@types/nunjucks": "^3.2.6",
         "@types/opener": "^1.4.3",
         "@types/semver": "^7.5.8",
@@ -22698,6 +22696,28 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -28792,6 +28812,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
       "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -30319,6 +30340,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -30758,6 +30780,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
       "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
       "dependencies": {
         "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,7 @@
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:app\""
   },
   "overrides": {
-    "uri-js": "npm:uri-js-replace",
-    "node-fetch": {
-      "whatwg-url": "14.x"
-    }
+    "uri-js": "npm:uri-js-replace"
   },
   "peerDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.602.0",
@@ -106,7 +103,6 @@
     "@types/inquirer": "^9.0.7",
     "@types/jest": "^29.5.13",
     "@types/js-yaml": "^4.0.9",
-    "@types/node-fetch": "^2.6.11",
     "@types/nunjucks": "^3.2.6",
     "@types/opener": "^1.4.3",
     "@types/semver": "^7.5.8",
@@ -175,7 +171,6 @@
     "js-yaml": "^4.1.0",
     "mathjs": "^13.2.0",
     "node-cache": "^5.1.2",
-    "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.4",
     "openai": "^4.68.1",
     "opener": "^1.5.2",

--- a/scripts/generateCitation.ts
+++ b/scripts/generateCitation.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import yaml from 'js-yaml';
-import fetch from 'node-fetch';
 import path from 'path';
 
 /**

--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -70,8 +70,6 @@ See also: [ProviderResponse](/docs/configuration/reference/#providerresponse)
 Here's an example of a custom API provider that returns a predefined output along with token usage:
 
 ```javascript
-import fetch from 'node-fetch';
-
 class CustomApiProvider {
   constructor(options) {
     // Provider ID can be overridden by the config file (e.g. when using multiple of the same provider)

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,6 @@ import cacheManager from 'cache-manager';
 import type { Cache } from 'cache-manager';
 import fsStore from 'cache-manager-fs-hash';
 import fs from 'fs';
-import type { RequestInfo, RequestInit } from 'node-fetch';
 import path from 'path';
 import { getEnvBool, getEnvString, getEnvInt } from './envars';
 import { fetchWithRetries } from './fetch';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import dedent from 'dedent';
 import fs from 'fs/promises';
-import fetch from 'node-fetch';
 import path from 'path';
 import { VERSION } from '../constants';
 import { getEnvString } from '../envars';

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-import type { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { ProxyAgent } from 'proxy-agent';
 import invariant from 'tiny-invariant';
 import { getEnvInt, getEnvBool } from './envars';
@@ -9,9 +7,9 @@ export async function fetchWithProxy(
   url: RequestInfo,
   options: RequestInit = {},
 ): Promise<Response> {
-  options.agent = new ProxyAgent({
+  (options as any).agent = new ProxyAgent({
     rejectUnauthorized: false, // Don't check SSL cert
-  }) as unknown as RequestInit['agent'];
+  });
   return fetch(url, options);
 }
 
@@ -30,7 +28,7 @@ export function fetchWithTimeout(
 
     fetchWithProxy(url, {
       ...options,
-      signal: signal as never, // AbortSignal type is not exported by node-fetch 2.x
+      signal,
     })
       .then((response) => {
         clearTimeout(timeoutId);
@@ -70,9 +68,9 @@ async function handleRateLimit(response: Response): Promise<void> {
 
 export async function fetchWithRetries(
   url: RequestInfo,
-  options: RequestInit = {},
+  options: RequestInit,
   timeout: number,
-  retries: number = 4,
+  retries: number = 3,
 ): Promise<Response> {
   let lastError;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -7,10 +7,10 @@ export async function fetchWithProxy(
   url: RequestInfo,
   options: RequestInit = {},
 ): Promise<Response> {
-  (options as any).agent = new ProxyAgent({
+  const agent = new ProxyAgent({
     rejectUnauthorized: false, // Don't check SSL cert
   });
-  return fetch(url, options);
+  return fetch(url, { ...options, agent } as RequestInit);
 }
 
 export function fetchWithTimeout(
@@ -68,9 +68,9 @@ async function handleRateLimit(response: Response): Promise<void> {
 
 export async function fetchWithRetries(
   url: RequestInfo,
-  options: RequestInit,
+  options: RequestInit = {},
   timeout: number,
-  retries: number = 3,
+  retries: number = 4,
 ): Promise<Response> {
   let lastError;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);

--- a/src/integrations/portkey.ts
+++ b/src/integrations/portkey.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import invariant from 'tiny-invariant';
 import { getEnvString } from '../envars';
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -134,7 +134,6 @@ def call_api(prompt, options, context):
 
 export const JAVASCRIPT_PROVIDER = `// Learn more about building a JavaScript provider: https://promptfoo.dev/docs/providers/custom-api
 // customApiProvider.js
-import fetch from 'node-fetch';
 
 class CustomApiProvider {
   constructor(options) {

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -1,5 +1,4 @@
 import type { Cache } from 'cache-manager';
-import fetch from 'node-fetch';
 import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -1,5 +1,4 @@
 import type { Cache } from 'cache-manager';
-import fetch from 'node-fetch';
 import Replicate from 'replicate';
 import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString, getEnvFloat, getEnvInt } from '../envars';

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,6 +1,5 @@
 import input from '@inquirer/input';
 import chalk from 'chalk';
-import type { Response } from 'node-fetch';
 import { URL } from 'url';
 import { SHARE_API_BASE_URL, SHARE_VIEW_BASE_URL, DEFAULT_SHARE_VIEW_BASE_URL } from './constants';
 import { getEnvBool, isCI } from './envars';

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -1,6 +1,5 @@
 import dedent from 'dedent';
 import * as fs from 'fs';
-import { Response } from 'node-fetch';
 import * as path from 'path';
 import {
   containsXml,

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,24 +1,23 @@
-import type { Response } from 'node-fetch';
-import fetch from 'node-fetch';
 import { fetchWithCache, disableCache, enableCache, clearCache } from '../src/cache';
 
-jest.mock('node-fetch');
-const mockedFetch = jest.mocked(fetch);
+jest.mock('node:fetch');
 
-const mockedFetchResponse = (ok: boolean, response: object) => {
+const mockedFetch = jest.mocked(jest.fn());
+global.fetch = mockedFetch;
+
+const mockedFetchResponse = (ok: boolean, response: object): Response => {
+  const responseText = JSON.stringify(response);
   return {
     ok,
-    status: 200,
-    text: () => Promise.resolve(JSON.stringify(response)),
-    headers: {
-      get: (name: string) => {
-        if (name === 'content-type') {
-          return 'application/json';
-        }
-        return null;
-      },
-    },
-  } as unknown as Response;
+    status: ok ? 200 : 400,
+    statusText: ok ? 'OK' : 'Bad Request',
+    text: () => Promise.resolve(responseText),
+    json: () => Promise.resolve(response),
+    headers: new Headers({
+      'content-type': 'application/json',
+    }),
+    // Add other methods and properties as needed
+  } as Response;
 };
 
 describe('fetchWithCache', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,7 +1,5 @@
 import { fetchWithCache, disableCache, enableCache, clearCache } from '../src/cache';
 
-jest.mock('node:fetch');
-
 const mockedFetch = jest.mocked(jest.fn());
 global.fetch = mockedFetch;
 
@@ -16,7 +14,6 @@ const mockedFetchResponse = (ok: boolean, response: object): Response => {
     headers: new Headers({
       'content-type': 'application/json',
     }),
-    // Add other methods and properties as needed
   } as Response;
 };
 

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -6,7 +6,6 @@ import { runDbMigrations } from '../src/migrate';
 import Eval from '../src/models/eval';
 import type { ApiProvider, TestSuite, Prompt } from '../src/types';
 
-jest.mock('node-fetch', () => jest.fn());
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -4,7 +4,6 @@ import { renderPrompt, resolveVariables, runExtensionHook } from '../src/evaluat
 import type { Prompt } from '../src/types';
 import { transform } from '../src/util/transform';
 
-jest.mock('node-fetch', () => jest.fn());
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import child_process from 'child_process';
 import dedent from 'dedent';
 import * as fs from 'fs';
-import fetch from 'node-fetch';
 import * as path from 'path';
 import Stream from 'stream';
 import { clearCache, disableCache, enableCache } from '../src/cache';
@@ -71,7 +70,6 @@ jest.mock('glob', () => ({
   globSync: jest.fn(),
 }));
 
-jest.mock('node-fetch', () => jest.fn());
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));
@@ -125,12 +123,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -146,14 +144,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -169,14 +167,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt 2' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output 2');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -184,7 +182,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Test prompt 2' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result2.output).toBe('Test output 2');
     expect(result2.tokenUsage).toEqual({ total: 10, cached: 10 });
   });
@@ -200,14 +198,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -217,7 +215,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(result2.output).toBe('Test output');
     expect(result2.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -233,7 +231,7 @@ describe('call provider apis', () => {
     const prompt = 'Test prompt';
     await provider.callApi(prompt);
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
         body: expect.stringMatching(`temperature\":3.1415926`),
@@ -254,7 +252,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
       config: {
@@ -280,7 +278,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Get me a person' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toEqual({ name: 'John', age: 30 });
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -296,14 +294,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Generate inappropriate content' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.error).toBe('Model refused to generate a response: Content policy violation');
     expect(result.tokenUsage).toEqual({ total: 5, prompt: 5, completion: 0 });
   });
@@ -333,7 +331,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const mockWeatherFunction = jest.fn().mockResolvedValue('Sunny, 25°C');
 
@@ -364,7 +362,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: "What's the weather in New York?" }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(mockWeatherFunction).toHaveBeenCalledWith('{"location":"New York"}');
     expect(result.output).toBe('Sunny, 25°C');
     expect(result.tokenUsage).toEqual({ total: 15, prompt: 10, completion: 5 });
@@ -380,12 +378,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new AzureOpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -400,14 +398,14 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -435,7 +433,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini', {
       config: { dataSources },
@@ -447,7 +445,7 @@ describe('call provider apis', () => {
       ]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test response');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -464,14 +462,14 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -487,12 +485,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new LlamaProvider('llama.cpp');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
   });
 
@@ -510,12 +508,12 @@ describe('call provider apis', () => {
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:35.117166Z","response":" blue","done":false}
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:41.695299Z","done":true,"context":[1,29871,1,13,9314],"total_duration":10411943458,"load_duration":458333,"sample_count":217,"sample_duration":154566000,"prompt_eval_count":11,"prompt_eval_duration":3334582000,"eval_count":216,"eval_duration":6905134000}`),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OllamaCompletionProvider('llama');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Great question! The sky appears blue');
   });
 
@@ -531,12 +529,12 @@ describe('call provider apis', () => {
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.324309782Z","message":{"role":"assistant","content":".","images":null},"done":false}
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.337165395Z","done":true,"total_duration":1486443841,"load_duration":1280794143,"prompt_eval_count":35,"prompt_eval_duration":142384000,"eval_count":6,"eval_duration":61912000}`),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new OllamaChatProvider('llama');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe(' Because of Rayleigh scattering.');
   });
 
@@ -549,12 +547,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new WebhookProvider('http://example.com/webhook');
     const result = await provider.callApi('Test prompt');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
   });
 
@@ -567,12 +565,12 @@ describe('call provider apis', () => {
         ...defaultMockResponse,
         text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
-      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
       const provider = new HuggingfaceTextGenerationProvider('gpt2');
       const result = await provider.callApi('Test prompt');
 
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('Test output');
     });
   });
@@ -582,12 +580,12 @@ describe('call provider apis', () => {
       ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
     const result = await provider.callEmbeddingApi('Test text');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
   });
 
@@ -608,12 +606,12 @@ describe('call provider apis', () => {
       ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify(mockClassification)),
     };
-    jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
     const provider = new HuggingfaceTextClassificationProvider('foo');
     const result = await provider.callClassificationApi('Test text');
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result.classification).toEqual({
       nothate: 0.9,
       hate: 0.1,
@@ -624,8 +622,6 @@ describe('call provider apis', () => {
     beforeAll(() => {
       enableCache();
     });
-
-    const fetchMock = jest.mocked(fetch);
     const cloudflareMinimumConfig: Required<
       Pick<ICloudflareProviderBaseConfig, 'accountId' | 'apiKey'>
     > = {
@@ -663,16 +659,16 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        fetchMock.mockResolvedValue(mockResponse as never);
+        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
         const result = await provider.callApi(PROMPT);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(result.output).toBe(responsePayload.result.response);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
 
         const resultFromCache = await provider.callApi(PROMPT);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(resultFromCache.output).toBe(responsePayload.result.response);
         expect(resultFromCache.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -699,15 +695,15 @@ describe('call provider apis', () => {
             ok: true,
           };
 
-          fetchMock.mockResolvedValue(mockResponse as never);
+          global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
           const result = await provider.callApi(PROMPT);
 
-          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(global.fetch).toHaveBeenCalledTimes(1);
           expect(result.output).toBe(responsePayload.result.response);
           expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
 
           const resultFromCache = await provider.callApi(PROMPT);
-          expect(fetch).toHaveBeenCalledTimes(2);
+          expect(global.fetch).toHaveBeenCalledTimes(2);
           expect(resultFromCache.output).toBe(responsePayload.result.response);
           expect(resultFromCache.tokenUsage).toEqual(tokenUsageDefaultResponse);
         } finally {
@@ -732,7 +728,7 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        fetchMock.mockResolvedValue(mockResponse as never);
+        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
         const result = await provider.callApi(PROMPT);
 
         expect(result.error).toContain(JSON.stringify(responsePayload.errors));
@@ -775,27 +771,25 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        fetchMock.mockResolvedValue(mockResponse as never);
+        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
         await cfProvider.callApi(PROMPT);
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock.mock.calls).toHaveLength(1);
-        const [url, options] = fetchMock.mock.calls[0] ?? [undefined, {}];
-        const { body, headers, method } = options as RequestInit;
-        expect(url).toContain(cloudflareChatConfig.accountId);
-        expect(method).toBe('POST');
-        expect(headers && 'Authorization' in headers ? headers['Authorization'] : '').toContain(
-          cloudflareChatConfig.apiKey,
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.stringMatching(`"prompt":"${PROMPT}"`),
+          }),
         );
-        const hydratedBody = typeof body === 'string' ? JSON.parse(body) : body;
-        expect(hydratedBody.prompt).toBe(PROMPT);
 
         const {
           accountId: _accountId,
           apiKey: _apiKey,
           ...passThroughConfig
         } = cloudflareChatConfig;
-        const { prompt: _prompt, ...bodyWithoutPrompt } = hydratedBody;
+        const { prompt: _prompt, ...bodyWithoutPrompt } = JSON.parse(
+          jest.mocked(global.fetch).mock.calls[0][1].body as string,
+        );
         expect(bodyWithoutPrompt).toEqual(passThroughConfig);
       });
     });
@@ -820,10 +814,10 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        fetchMock.mockResolvedValue(mockResponse as never);
+        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
         const result = await provider.callApi('Test chat prompt');
 
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(result.output).toBe(responsePayload.result.response);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -851,10 +845,10 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        fetchMock.mockResolvedValue(mockResponse as never);
+        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
         const result = await provider.callEmbeddingApi('Create embeddings from this');
 
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(result.embedding).toEqual(responsePayload.result.data[0]);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -953,7 +947,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -985,7 +979,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Add 5 and 6');
 
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('11');
       expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
     });
@@ -1021,7 +1015,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -1072,7 +1066,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Add 5 and 6, then multiply 2 and 3');
 
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('11\n6');
       expect(result.tokenUsage).toEqual({ total: 15, prompt: 7, completion: 8 });
     });
@@ -1098,7 +1092,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      jest.mocked(fetch).mockResolvedValue(mockResponse as never);
+      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -1125,7 +1119,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Call the error function');
 
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result.output).toEqual({ arguments: '{}', name: 'errorFunction' });
       expect(result.tokenUsage).toEqual({ total: 5, prompt: 2, completion: 3 });
     });

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -99,6 +99,9 @@ jest.mock('../src/logger', () => ({
   warn: jest.fn(),
 }));
 
+const mockFetch = jest.mocked(jest.fn());
+global.fetch = mockFetch;
+
 const defaultMockResponse = {
   status: 200,
   statusText: 'OK',
@@ -123,12 +126,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -144,14 +147,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -167,14 +170,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt 2' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output 2');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -182,7 +185,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Test prompt 2' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result2.output).toBe('Test output 2');
     expect(result2.tokenUsage).toEqual({ total: 10, cached: 10 });
   });
@@ -198,14 +201,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -215,7 +218,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(result2.output).toBe('Test output');
     expect(result2.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -231,7 +234,7 @@ describe('call provider apis', () => {
     const prompt = 'Test prompt';
     await provider.callApi(prompt);
 
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
         body: expect.stringMatching(`temperature\":3.1415926`),
@@ -252,7 +255,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
       config: {
@@ -278,7 +281,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: 'Get me a person' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toEqual({ name: 'John', age: 30 });
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -294,14 +297,14 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Generate inappropriate content' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.error).toBe('Model refused to generate a response: Content policy violation');
     expect(result.tokenUsage).toEqual({ total: 5, prompt: 5, completion: 0 });
   });
@@ -331,7 +334,7 @@ describe('call provider apis', () => {
       ),
       ok: true,
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const mockWeatherFunction = jest.fn().mockResolvedValue('Sunny, 25°C');
 
@@ -362,7 +365,7 @@ describe('call provider apis', () => {
       JSON.stringify([{ role: 'user', content: "What's the weather in New York?" }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockWeatherFunction).toHaveBeenCalledWith('{"location":"New York"}');
     expect(result.output).toBe('Sunny, 25°C');
     expect(result.tokenUsage).toEqual({ total: 15, prompt: 10, completion: 5 });
@@ -378,12 +381,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -398,14 +401,14 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -433,7 +436,7 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini', {
       config: { dataSources },
@@ -445,7 +448,7 @@ describe('call provider apis', () => {
       ]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test response');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
   });
@@ -462,14 +465,14 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
     expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
 
@@ -485,12 +488,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new LlamaProvider('llama.cpp');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
   });
 
@@ -508,12 +511,12 @@ describe('call provider apis', () => {
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:35.117166Z","response":" blue","done":false}
 {"model":"llama2:13b","created_at":"2023-08-08T21:50:41.695299Z","done":true,"context":[1,29871,1,13,9314],"total_duration":10411943458,"load_duration":458333,"sample_count":217,"sample_duration":154566000,"prompt_eval_count":11,"prompt_eval_duration":3334582000,"eval_count":216,"eval_duration":6905134000}`),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OllamaCompletionProvider('llama');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Great question! The sky appears blue');
   });
 
@@ -529,12 +532,12 @@ describe('call provider apis', () => {
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.324309782Z","message":{"role":"assistant","content":".","images":null},"done":false}
 {"model":"orca-mini","created_at":"2023-12-16T01:46:19.337165395Z","done":true,"total_duration":1486443841,"load_duration":1280794143,"prompt_eval_count":35,"prompt_eval_duration":142384000,"eval_count":6,"eval_duration":61912000}`),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new OllamaChatProvider('llama');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe(' Because of Rayleigh scattering.');
   });
 
@@ -547,12 +550,12 @@ describe('call provider apis', () => {
         }),
       ),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new WebhookProvider('http://example.com/webhook');
     const result = await provider.callApi('Test prompt');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.output).toBe('Test output');
   });
 
@@ -565,12 +568,12 @@ describe('call provider apis', () => {
         ...defaultMockResponse,
         text: jest.fn().mockResolvedValue(JSON.stringify(mockedData)),
       };
-      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+      mockFetch.mockResolvedValue(mockResponse);
 
       const provider = new HuggingfaceTextGenerationProvider('gpt2');
       const result = await provider.callApi('Test prompt');
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('Test output');
     });
   });
@@ -580,12 +583,12 @@ describe('call provider apis', () => {
       ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5])),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new HuggingfaceFeatureExtractionProvider('distilbert-base-uncased');
     const result = await provider.callEmbeddingApi('Test text');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
   });
 
@@ -606,12 +609,12 @@ describe('call provider apis', () => {
       ...defaultMockResponse,
       text: jest.fn().mockResolvedValue(JSON.stringify(mockClassification)),
     };
-    global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+    mockFetch.mockResolvedValue(mockResponse);
 
     const provider = new HuggingfaceTextClassificationProvider('foo');
     const result = await provider.callClassificationApi('Test text');
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.classification).toEqual({
       nothate: 0.9,
       hate: 0.1,
@@ -659,16 +662,16 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+        mockFetch.mockResolvedValue(mockResponse);
         const result = await provider.callApi(PROMPT);
 
-        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         expect(result.output).toBe(responsePayload.result.response);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
 
         const resultFromCache = await provider.callApi(PROMPT);
 
-        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         expect(resultFromCache.output).toBe(responsePayload.result.response);
         expect(resultFromCache.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -695,15 +698,15 @@ describe('call provider apis', () => {
             ok: true,
           };
 
-          global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+          mockFetch.mockResolvedValue(mockResponse);
           const result = await provider.callApi(PROMPT);
 
-          expect(global.fetch).toHaveBeenCalledTimes(1);
+          expect(mockFetch).toHaveBeenCalledTimes(1);
           expect(result.output).toBe(responsePayload.result.response);
           expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
 
           const resultFromCache = await provider.callApi(PROMPT);
-          expect(global.fetch).toHaveBeenCalledTimes(2);
+          expect(mockFetch).toHaveBeenCalledTimes(2);
           expect(resultFromCache.output).toBe(responsePayload.result.response);
           expect(resultFromCache.tokenUsage).toEqual(tokenUsageDefaultResponse);
         } finally {
@@ -728,7 +731,7 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+        mockFetch.mockResolvedValue(mockResponse);
         const result = await provider.callApi(PROMPT);
 
         expect(result.error).toContain(JSON.stringify(responsePayload.errors));
@@ -771,11 +774,11 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+        mockFetch.mockResolvedValue(mockResponse);
         await cfProvider.callApi(PROMPT);
 
-        expect(global.fetch).toHaveBeenCalledTimes(1);
-        expect(global.fetch).toHaveBeenCalledWith(
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
             body: expect.stringMatching(`"prompt":"${PROMPT}"`),
@@ -788,7 +791,7 @@ describe('call provider apis', () => {
           ...passThroughConfig
         } = cloudflareChatConfig;
         const { prompt: _prompt, ...bodyWithoutPrompt } = JSON.parse(
-          jest.mocked(global.fetch).mock.calls[0][1].body as string,
+          jest.mocked(mockFetch).mock.calls[0][1].body as string,
         );
         expect(bodyWithoutPrompt).toEqual(passThroughConfig);
       });
@@ -814,10 +817,10 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+        mockFetch.mockResolvedValue(mockResponse);
         const result = await provider.callApi('Test chat prompt');
 
-        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         expect(result.output).toBe(responsePayload.result.response);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -845,10 +848,10 @@ describe('call provider apis', () => {
           ok: true,
         };
 
-        global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+        mockFetch.mockResolvedValue(mockResponse);
         const result = await provider.callEmbeddingApi('Create embeddings from this');
 
-        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         expect(result.embedding).toEqual(responsePayload.result.data[0]);
         expect(result.tokenUsage).toEqual(tokenUsageDefaultResponse);
       });
@@ -947,7 +950,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+      mockFetch.mockResolvedValue(mockResponse);
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -979,7 +982,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Add 5 and 6');
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('11');
       expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
     });
@@ -1015,7 +1018,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+      mockFetch.mockResolvedValue(mockResponse);
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -1066,7 +1069,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Add 5 and 6, then multiply 2 and 3');
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.output).toBe('11\n6');
       expect(result.tokenUsage).toEqual({ total: 15, prompt: 7, completion: 8 });
     });
@@ -1092,7 +1095,7 @@ describe('call provider apis', () => {
         ),
         ok: true,
       };
-      global.fetch = jest.mocked(jest.fn(() => Promise.resolve(mockResponse)));
+      mockFetch.mockResolvedValue(mockResponse);
 
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
         config: {
@@ -1119,7 +1122,7 @@ describe('call provider apis', () => {
 
       const result = await provider.callApi('Call the error function');
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.output).toEqual({ arguments: '{}', name: 'errorFunction' });
       expect(result.tokenUsage).toEqual({ total: 5, prompt: 2, completion: 3 });
     });

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -14,8 +14,7 @@ const mockedFetchResponse = (ok: boolean, response: object, headers: object = {}
       'content-type': 'application/json',
       ...headers,
     }),
-    // Add other methods and properties as needed
-  } as unknown as Response;
+  } as Response;
 };
 
 const mockedSetTimeout = (reqTimeout: number) =>

--- a/test/server/providers.test.ts
+++ b/test/server/providers.test.ts
@@ -13,8 +13,6 @@ describe('providersRouter', () => {
   it('should parse and load the provider, then call callApi', async () => {
     const mockCallApi = jest.fn().mockResolvedValue({ output: 'Mocked response' });
     jest.spyOn(httpProvider.HttpProvider.prototype, 'callApi').mockImplementation(mockCallApi);
-
-    // Add this mock for the fetch call
     jest.mocked(fetch).mockResolvedValue({
       json: jest.fn().mockResolvedValue({
         changes_needed: true,
@@ -22,7 +20,20 @@ describe('providersRouter', () => {
         changes_needed_suggestions: ['Test suggestion 1', 'Test suggestion 2'],
       }),
       ok: true,
-    } as unknown as Response);
+      headers: new Headers(),
+      redirected: false,
+      status: 200,
+      statusText: 'OK',
+      type: 'basic',
+      url: 'http://example.com',
+      clone: jest.fn(),
+      body: null,
+      bodyUsed: false,
+      arrayBuffer: jest.fn(),
+      blob: jest.fn(),
+      formData: jest.fn(),
+      text: jest.fn(),
+    } as Response);
     const testProvider = {
       id: 'http://example.com/api',
       config: {

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -17,7 +17,6 @@ import {
 } from '../src/testCases';
 import type { AssertionType, TestCase, TestCaseWithVarsFile } from '../src/types';
 
-jest.mock('node-fetch', () => jest.fn());
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));


### PR DESCRIPTION
Now that the minimum supported version is node 18, we can remove the node-fetch dependency and related types

- Updates fetch calls to use global fetch API
- Adjust mocking in tests to use global fetch
- Update error handling and response processing for native fetch
- Remove node-fetch from package.json and package-lock.json