### PR TITLE
fix(openai): refusals are not failures

### DIFF
--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -198,6 +198,7 @@ interface ProviderResponse {
   cached?: boolean;
   cost?: number; // required for cost assertion
   logProbs?: number[]; // required for perplexity assertion
+  isRefusal?: boolean; // the provider has explicitly refused to generate a response
 }
 ```
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -587,6 +587,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         return {
           output: message.refusal,
           tokenUsage: getTokenUsage(data, cached),
+          isRefusal: true,
         };
       }
       let output = '';

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -585,7 +585,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       const message = data.choices[0].message;
       if (message.refusal) {
         return {
-          error: `Model refused to generate a response: ${message.refusal}`,
+          output: message.refusal,
           tokenUsage: getTokenUsage(data, cached),
         };
       }

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -86,6 +86,7 @@ export interface ProviderResponse {
   raw?: string | any;
   output?: string | any;
   tokenUsage?: TokenUsage;
+  isRefusal?: boolean;
 }
 
 export interface ProviderEmbeddingResponse {

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -305,8 +305,9 @@ describe('call provider apis', () => {
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(result.error).toBe('Model refused to generate a response: Content policy violation');
+    expect(result.output).toBe('Content policy violation');
     expect(result.tokenUsage).toEqual({ total: 5, prompt: 5, completion: 0 });
+    expect(result.isRefusal).toBe(true);
   });
 
   it('OpenAiChatCompletionProvider callApi with function tool callbacks', async () => {


### PR DESCRIPTION
Let's just pass through the response so the end user can decide what to pass/fail