### PR TITLE
fix: Http Provider parser

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -38,9 +38,7 @@ tests:
       language: 'French'
 ```
 
-If not specified, HTTP POST with content-type application/json is assumed if the body is an object or array.
-
-`body` can be a string or a JSON object. If the body is a string, it will be sent as a raw request body and you may have to specify a `Content-Type` header. If the body is an object, then content type is automatically set to `application/json`.
+`body` can be a string or JSON object. If the body is a string, the `Content-type` header defaults to `text/plain` unless specified otherwise. If the body is an object, then content type is automatically set to `application/json`.
 
 ### JSON Example
 

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import httpZ from 'http-z';
 import path from 'path';
 import invariant from 'tiny-invariant';
@@ -79,33 +80,51 @@ export async function createResponseParser(
   );
 }
 
-export function processBody(
-  body: Record<string, any> | string | any[] | undefined,
-  vars: Record<string, any>,
-): Record<string, any> | string | any[] | undefined {
-  if (body === undefined) {
-    return undefined;
-  }
-
-  if (typeof body === 'string') {
-    return nunjucks.renderString(body, vars);
-  }
-
-  // Handle JSON content type (objects and arrays)
-  if (Array.isArray(body)) {
-    return body.map((item) => processBody(item, vars));
-  }
-
-  if (typeof body === 'object' && body !== null) {
-    const processedBody: Record<string, any> = {};
-    for (const [key, value] of Object.entries(body)) {
-      processedBody[key] = processBody(value, vars);
+function processValue(value: any, vars: Record<string, any>): any {
+  if (typeof value === 'string') {
+    const renderedValue = nunjucks.renderString(value, vars || {});
+    try {
+      return JSON.parse(renderedValue);
+    } catch {
+      return renderedValue;
     }
-    return processedBody;
+  }
+  return value;
+}
+
+export function processJsonBody(
+  body: Record<string, any> | any[],
+  vars: Record<string, any>,
+): Record<string, any> | any[] {
+  if (Array.isArray(body)) {
+    return body.map((item) =>
+      typeof item === 'object' && item !== null
+        ? processJsonBody(item, vars)
+        : processValue(item, vars),
+    );
   }
 
-  // For any other types, return as is
-  return body;
+  const processedBody: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(body)) {
+    if (typeof value === 'object' && value !== null) {
+      processedBody[key] = processJsonBody(value, vars);
+    } else {
+      processedBody[key] = processValue(value, vars);
+    }
+  }
+  return processedBody;
+}
+
+export function processTextBody(body: string, vars: Record<string, any>): string {
+  if (body == null) {
+    return body;
+  }
+  invariant(
+    typeof body !== 'object',
+    'Expected body to be a string when content type is not application/json',
+  );
+  return nunjucks.renderString(body, vars);
 }
 
 function parseRawRequest(input: string) {
@@ -170,16 +189,19 @@ export class HttpProvider implements ApiProvider {
   }
 
   private validateContentTypeAndBody(headers: Record<string, string>, body: any): void {
-    const contentType = this.getContentType(headers);
-    if (
-      contentType &&
-      !contentType.includes('application/json') &&
-      typeof body === 'object' &&
-      body !== null
-    ) {
-      throw new Error(
-        'Content-Type is not application/json, but body is an object or array. The body must be a string if the Content-Type is not application/json.',
-      );
+    if (body != null) {
+      if (typeof body == 'object' && !contentTypeIsJson(headers)) {
+        throw new Error(
+          'Content-Type is not application/json, but body is an object or array. The body must be a string if the Content-Type is not application/json.',
+        );
+      }
+      if (typeof body === 'string' && contentTypeIsJson(headers)) {
+        console.warn(
+          chalk.yellow(
+            'Content-Type is application/json, but body is a string. This is likely to cause unexpected results. It should be an object or array.',
+          ),
+        );
+      }
     }
   }
 
@@ -225,7 +247,10 @@ export class HttpProvider implements ApiProvider {
       url: this.url,
       method: nunjucks.renderString(this.config.method || 'GET', vars),
       headers,
-      body: processBody(this.config.body, vars),
+      // We validate the content type and body with this.validateContentTypeAndBody
+      body: contentTypeIsJson(headers)
+        ? processJsonBody(this.config.body as Record<string, any> | any[], vars)
+        : processTextBody(this.config.body as string, vars),
       queryParams: this.config.queryParams
         ? Object.fromEntries(
             Object.entries(this.config.queryParams).map(([key, value]) => [

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -184,6 +184,8 @@ export class HttpProvider implements ApiProvider {
     }
     if (typeof body === 'object' && body !== null) {
       return { 'content-type': 'application/json' };
+    } else if (typeof body === 'string') {
+      return { 'content-type': 'text/plain' };
     }
     return {};
   }

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -582,10 +582,10 @@ describe('HttpProvider', () => {
       expect(result).toEqual({ 'content-type': 'application/json' });
     });
 
-    it('should return empty object for string body', () => {
+    it('should return text/plain for string body', () => {
       const provider = new HttpProvider(mockUrl, { config: { method: 'POST', body: 'test' } });
       const result = provider['getDefaultHeaders']('string body');
-      expect(result).toEqual({});
+      expect(result).toEqual({ 'content-type': 'text/plain' });
     });
   });
 
@@ -694,7 +694,7 @@ describe('HttpProvider', () => {
     );
   });
 
-  it('should not default to application/json for content-type if body is not an object', async () => {
+  it('should default to text/plain for content-type if body is not an object', async () => {
     const provider = new HttpProvider(mockUrl, {
       config: {
         method: 'POST',
@@ -715,7 +715,7 @@ describe('HttpProvider', () => {
       mockUrl,
       expect.objectContaining({
         method: 'POST',
-        headers: {},
+        headers: { 'content-type': 'text/plain' },
         body: 'test',
       }),
       expect.any(Number),
@@ -760,7 +760,7 @@ describe('HttpProvider', () => {
         mockUrl,
         expect.objectContaining({
           method: 'POST',
-          headers: {},
+          headers: { 'content-type': 'text/plain' },
           body: 'Hello world',
         }),
         expect.any(Number),

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent';
 import path from 'path';
 import { fetchWithCache } from '../../src/cache';
 import { importModule } from '../../src/esm';
-import { HttpProvider, processBody, createResponseParser } from '../../src/providers/http';
+import { HttpProvider, createResponseParser, processJsonBody } from '../../src/providers/http';
 import { maybeLoadFromExternalFile } from '../../src/util';
 
 jest.mock('../../src/cache', () => ({
@@ -363,11 +363,11 @@ describe('HttpProvider', () => {
     });
   });
 
-  describe('processBody', () => {
+  describe('processJsonBody', () => {
     it('should process simple key-value pairs', () => {
       const body = { key: 'value', prompt: '{{ prompt }}' };
       const vars = { prompt: 'test prompt' };
-      const result = processBody(body, vars);
+      const result = processJsonBody(body, vars);
       expect(result).toEqual({ key: 'value', prompt: 'test prompt' });
     });
 
@@ -379,7 +379,7 @@ describe('HttpProvider', () => {
         },
       };
       const vars = { prompt: 'test prompt' };
-      const result = processBody(body, vars);
+      const result = processJsonBody(body, vars);
       expect(result).toEqual({
         outer: {
           inner: 'test prompt',
@@ -393,7 +393,7 @@ describe('HttpProvider', () => {
         list: ['{{ prompt }}', 'static', '{{ prompt }}'],
       };
       const vars = { prompt: 'test prompt' };
-      const result = processBody(body, vars);
+      const result = processJsonBody(body, vars);
       expect(result).toEqual({
         list: ['test prompt', 'static', 'test prompt'],
       });
@@ -401,7 +401,7 @@ describe('HttpProvider', () => {
 
     it('should handle empty vars', () => {
       const body = { key: '{{ prompt }}' };
-      const result = processBody(body, {});
+      const result = processJsonBody(body, {});
       expect(result).toEqual({ key: '' });
     });
 
@@ -414,14 +414,14 @@ describe('HttpProvider', () => {
         jsonArray: '[1, 2, "{{ prompt }}"]',
       };
       const vars = { prompt: 'test prompt' };
-      const result = processBody(body, vars);
+      const result = processJsonBody(body, vars);
 
       expect(result).toEqual({
         outer: {
           inner: ['test prompt', { nestedKey: 'test prompt' }],
           static: 'value',
         },
-        jsonArray: `[1, 2, \"test prompt\"]`,
+        jsonArray: [1, 2, 'test prompt'],
       });
     });
   });
@@ -736,5 +736,209 @@ describe('HttpProvider', () => {
     await expect(provider.callApi('test prompt')).rejects.toThrow(
       'Content-Type is not application/json, but body is an object or array',
     );
+  });
+
+  describe('Content-Type and body handling', () => {
+    it('should render string body when content-type is not set', async () => {
+      const provider = new HttpProvider(mockUrl, {
+        config: {
+          method: 'POST',
+          body: 'Hello {{ prompt }}',
+        },
+      });
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      await provider.callApi('world');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        mockUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {},
+          body: 'Hello world',
+        }),
+        expect.any(Number),
+        'text',
+        undefined,
+      );
+    });
+
+    it('should default to JSON when content-type is not set and body is an object', async () => {
+      const provider = new HttpProvider(mockUrl, {
+        config: {
+          method: 'POST',
+          body: { key: 'test' },
+        },
+      });
+
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      await provider.callApi('test');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        mockUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ key: 'test' }),
+        }),
+        expect.any(Number),
+        'text',
+        undefined,
+      );
+    });
+
+    it('should render object body when content-type is application/json', async () => {
+      const provider = new HttpProvider(mockUrl, {
+        config: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: { key: '{{ prompt }}' },
+        },
+      });
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      await provider.callApi('test');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        mockUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ key: 'test' }),
+        }),
+        expect.any(Number),
+        'text',
+        undefined,
+      );
+    });
+
+    it('should render nested object variables correctly when content-type is application/json', async () => {
+      const provider = new HttpProvider(mockUrl, {
+        config: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            details: {
+              names: '{{ names | dump }}',
+            },
+          },
+        },
+      });
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const vars = {
+        names: [
+          { firstName: 'Jane', lastName: 'Smith' },
+          { firstName: 'John', lastName: 'Doe' },
+        ],
+      };
+
+      await provider.callApi('test', { vars, prompt: { raw: 'test', label: 'test' } });
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        mockUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            details: {
+              names: vars.names,
+            },
+          }),
+        }),
+        expect.any(Number),
+        'text',
+        undefined,
+      );
+    });
+
+    it('should render nested array variables correctly when content-type is application/json', async () => {
+      const provider = new HttpProvider(mockUrl, {
+        config: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: [
+            {
+              id: 1,
+              details: {
+                names: '{{ names | dump }}',
+              },
+            },
+            {
+              id: 2,
+              details: {
+                names: '{{ names | dump }}',
+              },
+            },
+          ],
+        },
+      });
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const vars = {
+        names: [
+          { firstName: 'Jane', lastName: 'Smith' },
+          { firstName: 'John', lastName: 'Doe' },
+        ],
+      };
+
+      await provider.callApi('test', { vars, prompt: { raw: 'test', label: 'test' } });
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        mockUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify([
+            {
+              id: 1,
+              details: {
+                names: vars.names,
+              },
+            },
+            {
+              id: 2,
+              details: {
+                names: vars.names,
+              },
+            },
+          ]),
+        }),
+        expect.any(Number),
+        'text',
+        undefined,
+      );
+    });
   });
 });


### PR DESCRIPTION
This should fix our http providing parser:



| **Headers**                  | **Body**                   | **Result**                                                                                          |
|------------------------------|----------------------------|------------------------------------------------------------------------------------------------------|
| Not set                      | Object or Array            | Headers will be set to `application/json`.                                                           |
| Not set                      | String                     | Headers will be set to `text/plain`.                                                                 |
| `application/json`           | String                     | **Warning in Console**: `Content-Type is application/json, but body is a string. This is likely to cause unexpected results. It should be an object or array.` |
| Anything that is not `application/json`       | Object or Array            | **Raises Error**: `Content-Type is not application/json, but body is an object or array. The body must be a string if the Content-Type is not application/json.` |
