### PR TITLE
feat: package import support improvements

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -6,7 +6,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { distance as levenshtein } from 'fastest-levenshtein';
 import fs from 'fs';
 import * as rouge from 'js-rouge';
-import yaml, { load } from 'js-yaml';
+import yaml from 'js-yaml';
 import { type Option as sqlParserOption } from 'node-sql-parser';
 import util from 'node:util';
 import path from 'path';

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -6,7 +6,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { distance as levenshtein } from 'fastest-levenshtein';
 import fs from 'fs';
 import * as rouge from 'js-rouge';
-import yaml from 'js-yaml';
+import yaml, { load } from 'js-yaml';
 import { type Option as sqlParserOption } from 'node-sql-parser';
 import util from 'node:util';
 import path from 'path';
@@ -31,6 +31,7 @@ import {
 } from '../matchers';
 import type { OpenAiChatCompletionProvider } from '../providers/openai';
 import { validateFunctionCall } from '../providers/openaiUtil';
+import { isPackagePath, loadFromPackage } from '../providers/packageParser';
 import { parseChatPrompt } from '../providers/shared';
 import { runPython } from '../python/pythonUtils';
 import { runPythonCode } from '../python/wrapper';
@@ -338,6 +339,16 @@ export async function runAssertion({
       } else {
         renderedValue = processFileReference(renderedValue);
       }
+    } else if (isPackagePath(renderedValue)) {
+      const basePath = cliState.basePath || '';
+      const requiredModule = await loadFromPackage(renderedValue, basePath);
+      if (typeof requiredModule !== 'function') {
+        throw new Error(
+          `Assertion malformed: ${renderedValue} must be a function. Received: ${typeof requiredModule}`,
+        );
+      }
+
+      valueFromScript = await Promise.resolve(requiredModule(output, context));
     } else {
       // It's a normal string value
       renderedValue = nunjucks.renderString(renderedValue, test.vars || {});

--- a/src/providers/packageParser.ts
+++ b/src/providers/packageParser.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import dedent from 'dedent';
-import fs from 'fs';
+import { createRequire } from 'node:module';
 import path from 'path';
 import { importModule } from '../esm';
 import logger from '../logger';
@@ -12,49 +12,44 @@ function getValue<T extends object, K extends string>(obj: T, path: K): any {
   }, obj);
 }
 
+export function isPackagePath(path: any): path is string {
+  return typeof path === 'string' && path.startsWith('package:');
+}
+
+export async function loadFromPackage(packageInstancePath: string, basePath: string): Promise<any> {
+  const [, packageName, entityName] = packageInstancePath.split(':');
+
+  if (!packageName || !entityName) {
+    throw new Error(
+      `Invalid package format: ${packageInstancePath}. Expected format: package:packageName:exportedClassOrFunction`,
+    );
+  }
+
+  try {
+    const require = createRequire(path.resolve(basePath));
+    const filePath = require.resolve(packageName);
+    const module = await importModule(filePath);
+    const entity = getValue(module, entityName ?? 'default');
+
+    if (!entity) {
+      logger.error(dedent`
+        Could not find entity: ${chalk.bold(entityName)} in module: ${chalk.bold(filePath)}.
+      `);
+      process.exit(1);
+    }
+
+    return entity;
+  } catch {
+    throw new Error(`Package not found: ${packageName}. Make sure it's installed in ${basePath}`);
+  }
+}
+
 export async function parsePackageProvider(
   providerPath: string,
   basePath: string,
   options: ProviderOptions,
 ): Promise<ApiProvider> {
-  const [, packageName, providerName] = providerPath.split(':');
-
-  if (!packageName || !providerName) {
-    throw new Error(
-      `Invalid package provider format: ${providerPath}. Expected format: package:packageName:providerName`,
-    );
-  }
-
-  const modulePath = path.join(basePath, 'node_modules', packageName);
-  const pkgPath = path.join(modulePath, 'package.json');
-
-  if (!fs.existsSync(pkgPath)) {
-    throw new Error(`Package not found: ${packageName}. Make sure it's installed in ${basePath}`);
-  }
-
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
-    name: string;
-    main?: string;
-  };
-
-  if (!pkg.main) {
-    logger.error(dedent`
-      Could not determine main entry in package.json: ${chalk.bold(pkgPath)}.
-
-      ${chalk.white(dedent`Please check your package.json and ensure the property 'main' is correctly specified.`)}
-    `);
-    process.exit(1);
-  }
-
-  const module = await importModule(path.join(modulePath, pkg.main));
-  const Provider = getValue(module, providerName);
-
-  if (!Provider) {
-    logger.error(dedent`
-      Could not find provider: ${chalk.bold(providerName)} in module: ${chalk.bold(modulePath)}.
-    `);
-    process.exit(1);
-  }
+  const Provider = await loadFromPackage(providerPath, basePath);
 
   return new Provider(options);
 }

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { createRequire } from 'node:module';
 import * as path from 'path';
 import { renderPrompt, resolveVariables, runExtensionHook } from '../src/evaluatorHelpers';
 import type { Prompt } from '../src/types';
@@ -10,6 +11,15 @@ jest.mock('proxy-agent', () => ({
 jest.mock('glob', () => ({
   globSync: jest.fn(),
 }));
+
+jest.mock('node:module', () => {
+  const mockRequire: NodeJS.Require = {
+    resolve: jest.fn() as unknown as NodeJS.RequireResolve,
+  } as unknown as NodeJS.Require;
+  return {
+    createRequire: jest.fn().mockReturnValue(mockRequire),
+  };
+});
 
 jest.mock('fs', () => ({
   readFileSync: jest.fn(),
@@ -116,6 +126,32 @@ describe('renderPrompt', () => {
 
     const renderedPrompt = await renderPrompt(prompt, vars, evaluateOptions);
     expect(renderedPrompt).toBe('Test prompt with Dynamic value for var1 and var2 and var3');
+  });
+
+  it('should load external js package in renderPrompt and execute the exported function', async () => {
+    const prompt = toPrompt('Test prompt with {{ var1 }}');
+    const vars = {
+      var1: 'package:@promptfoo/fake:testFunction',
+    };
+    const evaluateOptions = {};
+
+    const require = createRequire('');
+    jest.spyOn(require, 'resolve').mockReturnValueOnce('/node_modules/@promptfoo/fake/index.js');
+
+    jest.doMock(
+      path.resolve('/node_modules/@promptfoo/fake/index.js'),
+      () => {
+        return {
+          testFunction: (varName: any, prompt: any, vars: any) => ({
+            output: `Dynamic value for ${varName}`,
+          }),
+        };
+      },
+      { virtual: true },
+    );
+
+    const renderedPrompt = await renderPrompt(prompt, vars, evaluateOptions);
+    expect(renderedPrompt).toBe('Test prompt with Dynamic value for var1');
   });
 
   it('should load external json files in renderPrompt and parse the JSON content', async () => {

--- a/test/providers/packageParser.test.ts
+++ b/test/providers/packageParser.test.ts
@@ -1,10 +1,14 @@
-import fs from 'fs';
+import { createRequire } from 'node:module';
 import path from 'path';
 import { importModule } from '../../src/esm';
-import { parsePackageProvider } from '../../src/providers/packageParser';
+import { parsePackageProvider, loadFromPackage } from '../../src/providers/packageParser';
 import type { ProviderOptions } from '../../src/types/providers';
 
-jest.mock('fs');
+jest.mock('node:module', () => {
+  return {
+    createRequire: jest.fn(() => jest.fn((path: string) => path)),
+  };
+});
 jest.mock('../../src/esm', () => ({
   importModule: jest.fn(async (modulePath: string, functionName?: string) => {
     const mockModule = {
@@ -19,22 +23,102 @@ jest.mock('../../src/esm', () => ({
 }));
 jest.mock('../../src/logger');
 
+describe('isPackagePath', () => {
+  it('should return true for package paths', () => {
+    expect(loadFromPackage('package:packageName:exportedClassOrFunction', '/mock/base/path')).toBe(
+      true,
+    );
+  });
+
+  it('should return false for non-package paths', () => {
+    expect(loadFromPackage('notAPackagePath', '/mock/base/path')).toBe(false);
+  });
+});
+
+describe('loadFromPackage', () => {
+  const mockBasePath = '/mock/base/path';
+  const mockPackageName = 'testpackage';
+  const mockFunctionName = 'getVariable';
+  const mockProviderPath = `package:${mockPackageName}:${mockFunctionName}`;
+  const mockRequire: NodeJS.Require = {
+    resolve: jest.fn() as unknown as NodeJS.RequireResolve,
+  } as unknown as NodeJS.Require;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully parse a valid package', async () => {
+    const mockFunction = jest.fn();
+
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    jest.mocked(mockRequire.resolve).mockReturnValue(mockPackagePath);
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
+    jest.mocked(importModule).mockResolvedValue({ getVariable: mockFunction });
+
+    const result = await loadFromPackage(mockProviderPath, mockBasePath);
+
+    expect(result).toBe(mockFunction);
+    result('test');
+    expect(mockFunction).toHaveBeenCalledWith('test');
+    expect(importModule).toHaveBeenCalledWith(mockPackagePath);
+  });
+
+  it('should throw an error for invalid provider format', async () => {
+    await expect(loadFromPackage('invalid:format', mockBasePath)).rejects.toThrow(
+      'Invalid package format: invalid:format. Expected format: package:packageName:exportedClassOrFunction',
+    );
+  });
+
+  it('should throw an error if package is not found', async () => {
+    jest.mocked(mockRequire.resolve).mockImplementationOnce(() => {
+      throw new Error('Cannot find module');
+    });
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
+
+    await expect(loadFromPackage(mockProviderPath, mockBasePath)).rejects.toThrow(
+      `Package not found: ${mockPackageName}. Make sure it's installed in ${mockBasePath}`,
+    );
+  });
+
+  it('should handle nested provider names', async () => {
+    const mockModule = {
+      nested: {
+        getVariable: jest.fn(),
+      },
+    };
+
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    jest.mocked(mockRequire.resolve).mockReturnValue(mockPackagePath);
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
+    jest.mocked(importModule).mockResolvedValue(mockModule);
+
+    const result = await loadFromPackage(
+      `package:${mockPackageName}:nested.getVariable`,
+      mockBasePath,
+    );
+
+    expect(result).toBe(mockModule.nested.getVariable);
+    result('test input');
+    expect(mockModule.nested.getVariable).toHaveBeenCalledWith('test input');
+  });
+});
+
 describe('parsePackageProvider', () => {
   const mockBasePath = '/mock/base/path';
   const mockPackageName = 'testpackage';
   const mockProviderName = 'Provider';
   const mockProviderPath = `package:${mockPackageName}:${mockProviderName}`;
   const mockOptions: ProviderOptions = { config: {} };
+  const mockRequire: NodeJS.Require = {
+    resolve: jest.fn() as unknown as NodeJS.RequireResolve,
+  } as unknown as NodeJS.Require;
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should successfully parse a valid package provider', async () => {
-    const mockPackageJson = {
-      name: mockPackageName,
-      main: 'index.js',
-    };
     const mockProvider = class {
       options: any;
       constructor(options: any) {
@@ -42,49 +126,35 @@ describe('parsePackageProvider', () => {
       }
     };
 
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockPackageJson));
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    jest.mocked(mockRequire.resolve).mockReturnValue(mockPackagePath);
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
     jest.mocked(importModule).mockResolvedValue({ Provider: mockProvider });
 
     const result = await parsePackageProvider(mockProviderPath, mockBasePath, mockOptions);
 
     expect(result).toBeInstanceOf(mockProvider);
-    expect(fs.existsSync).toHaveBeenCalledWith(
-      path.join(mockBasePath, 'node_modules', mockPackageName, 'package.json'),
-    );
-    expect(importModule).toHaveBeenCalledWith(
-      path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js'),
-    );
+    expect(importModule).toHaveBeenCalledWith(mockPackagePath);
   });
 
   it('should throw an error for invalid provider format', async () => {
     await expect(parsePackageProvider('invalid:format', mockBasePath, mockOptions)).rejects.toThrow(
-      'Invalid package provider format: invalid:format. Expected format: package:packageName:providerName',
+      'Invalid package format: invalid:format. Expected format: package:packageName:exportedClassOrFunction',
     );
   });
 
   it('should throw an error if package is not found', async () => {
-    jest.mocked(fs.existsSync).mockReturnValue(false);
+    jest.mocked(mockRequire.resolve).mockImplementationOnce(() => {
+      throw new Error('Cannot find module');
+    });
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
 
     await expect(parsePackageProvider(mockProviderPath, mockBasePath, mockOptions)).rejects.toThrow(
       `Package not found: ${mockPackageName}. Make sure it's installed in ${mockBasePath}`,
     );
   });
 
-  it('should throw an error if package.json cannot be parsed', async () => {
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest.mocked(fs.readFileSync).mockReturnValue('invalid json');
-
-    await expect(parsePackageProvider(mockProviderPath, mockBasePath, mockOptions)).rejects.toThrow(
-      /Unexpected token/,
-    );
-  });
-
   it('should handle nested provider names', async () => {
-    const mockPackageJson = {
-      name: mockPackageName,
-      main: 'index.js',
-    };
     const mockModule = {
       nested: {
         Provider: class {
@@ -96,8 +166,9 @@ describe('parsePackageProvider', () => {
       },
     };
 
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockPackageJson));
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    jest.mocked(mockRequire.resolve).mockReturnValue(mockPackagePath);
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
     jest.mocked(importModule).mockResolvedValue(mockModule);
 
     const result = await parsePackageProvider(
@@ -110,14 +181,11 @@ describe('parsePackageProvider', () => {
   });
 
   it('should pass options to the provider constructor', async () => {
-    const mockPackageJson = {
-      name: mockPackageName,
-      main: 'index.js',
-    };
     const MockProvider = jest.fn();
 
-    jest.mocked(fs.existsSync).mockReturnValue(true);
-    jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockPackageJson));
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    jest.mocked(mockRequire.resolve).mockReturnValue(mockPackagePath);
+    jest.mocked(createRequire).mockReturnValue(mockRequire);
     jest.mocked(importModule).mockResolvedValue({ Provider: MockProvider });
 
     await parsePackageProvider(mockProviderPath, mockBasePath, mockOptions);

--- a/test/providers/packageParser.test.ts
+++ b/test/providers/packageParser.test.ts
@@ -1,7 +1,11 @@
 import { createRequire } from 'node:module';
 import path from 'path';
 import { importModule } from '../../src/esm';
-import { parsePackageProvider, loadFromPackage } from '../../src/providers/packageParser';
+import {
+  parsePackageProvider,
+  loadFromPackage,
+  isPackagePath,
+} from '../../src/providers/packageParser';
 import type { ProviderOptions } from '../../src/types/providers';
 
 jest.mock('node:module', () => {
@@ -25,13 +29,11 @@ jest.mock('../../src/logger');
 
 describe('isPackagePath', () => {
   it('should return true for package paths', () => {
-    expect(loadFromPackage('package:packageName:exportedClassOrFunction', '/mock/base/path')).toBe(
-      true,
-    );
+    expect(isPackagePath('package:packageName:exportedClassOrFunction')).toBe(true);
   });
 
   it('should return false for non-package paths', () => {
-    expect(loadFromPackage('notAPackagePath', '/mock/base/path')).toBe(false);
+    expect(isPackagePath('notAPackagePath')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Previously the `package:` provider was only looking at `${basePath}/node_modules/package.json` but Node.js module resolution logic is actually much more complicated. `require.resolve` handles this lookup much better as it contains all of the logic. There is an equivalent for ESM called `import.meta.resolve` but it's still not stable so as a result I opted for using `createRequire` to create a require instance specifically for that `basePath` and then leverage `require.resolve` from that instance. This fix was needed especially when working with a monorepo with multiple packages where the package you want to use might not be at the same level as your config.

Additionally I ported that same functionality to both variable definition and JavaScript assertions. With this change both of these should be valid:

```yml
defaultVars:
  example: package:@dkundel/demo:getSessionVariable

tests:
  - vars:
      prompt: Ahoy!
    assert:
      - type: javascript
        value: package:@dkundel/demo:isNauticalGreeting
```