### PR TITLE
style(eslint): add sort-keys rule and sort type constituents

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default [
       ],
       '@typescript-eslint/no-use-before-define': 'error',
       '@typescript-eslint/no-var-requires': 0,
+      '@typescript-eslint/sort-type-constituents': 'error',
       curly: 'error',
       'no-case-declarations': 0,
       'no-control-regex': 0,
@@ -73,6 +74,20 @@ export default [
       'unicorn/no-negated-condition': 'error',
       'unicorn/prefer-number-properties': 'error',
       'unused-imports/no-unused-imports': 'error',
+    },
+  },
+  {
+    files: ['**/constants.ts'],
+    rules: {
+      'sort-keys': [
+        'error',
+        'asc',
+        {
+          caseSensitive: true,
+          natural: true,
+          minKeys: 2,
+        },
+      ],
     },
   },
   {

--- a/src/app/src/components/LoggedInAs.tsx
+++ b/src/app/src/components/LoggedInAs.tsx
@@ -6,7 +6,7 @@ import MenuItem from '@mui/material/MenuItem';
 
 export default function LoggedInAs() {
   const { user } = { user: null };
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/src/app/src/components/Navigation.tsx
+++ b/src/app/src/components/Navigation.tsx
@@ -60,7 +60,7 @@ function NavLink({ href, label }: { href: string; label: string }) {
 }
 
 function Dropdown() {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const location = useLocation();
 

--- a/src/app/src/contexts/ToastContext.tsx
+++ b/src/app/src/contexts/ToastContext.tsx
@@ -13,7 +13,7 @@ export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     setOpen(true);
   };
 
-  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+  const handleClose = (event?: Event | React.SyntheticEvent, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }

--- a/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
+++ b/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
@@ -192,21 +192,21 @@ interface ProviderSelectorProps {
 const ProviderSelector: React.FC<ProviderSelectorProps> = ({ providers, onChange }) => {
   const [selectedProvider, setSelectedProvider] = React.useState<ProviderOptions | null>(null);
 
-  const getProviderLabel = (provider: string | ProviderOptions): string => {
+  const getProviderLabel = (provider: ProviderOptions | string): string => {
     if (typeof provider === 'string') {
       return provider;
     }
     return provider.id || 'Unknown provider';
   };
 
-  const getProviderKey = (provider: string | ProviderOptions, index: number): string | number => {
+  const getProviderKey = (provider: ProviderOptions | string, index: number): number | string => {
     if (typeof provider === 'string') {
       return provider;
     }
     return provider.id || index;
   };
 
-  const handleProviderClick = (provider: string | ProviderOptions): void => {
+  const handleProviderClick = (provider: ProviderOptions | string): void => {
     if (typeof provider === 'string') {
       alert('Cannot edit custom providers');
     } else if (provider.config) {
@@ -234,7 +234,7 @@ const ProviderSelector: React.FC<ProviderSelectorProps> = ({ providers, onChange
         options={defaultProviders}
         value={providers}
         groupBy={(option) => getGroupName(option.id)}
-        onChange={(event, newValue: (string | ProviderOptions)[]) => {
+        onChange={(event, newValue: (ProviderOptions | string)[]) => {
           onChange(newValue.map((value) => (typeof value === 'string' ? { id: value } : value)));
         }}
         getOptionLabel={(option) => {

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -281,7 +281,7 @@ function ScatterChart({ table }: ChartProps) {
               text: `Prompt ${xAxisPrompt + 1} Score`,
             },
             ticks: {
-              callback(value: string | number, index: number, values: any[]) {
+              callback(value: number | string, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';
@@ -296,7 +296,7 @@ function ScatterChart({ table }: ChartProps) {
               text: `Prompt ${yAxisPrompt + 1} Score`,
             },
             ticks: {
-              callback(value: string | number, index: number, values: any[]) {
+              callback(value: number | string, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';
@@ -389,7 +389,7 @@ function MetricChart({ table }: ChartProps) {
           },
           y: {
             ticks: {
-              callback(value: string | number, index: number, values: any[]) {
+              callback(value: number | string, index: number, values: any[]) {
                 let ret = String(Math.round(Number(value) * 100));
                 if (index === values.length - 1) {
                   ret += '%';

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -106,7 +106,7 @@ function TableHeader({
 interface ResultsTableProps {
   maxTextLength: number;
   columnVisibility: VisibilityState;
-  wordBreak: 'break-word' | 'break-all';
+  wordBreak: 'break-all' | 'break-word';
   filterMode: FilterMode;
   failureFilter: { [key: string]: boolean };
   searchText: string;

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -121,7 +121,7 @@ export default function ResultsView({
   const [shareLoading, setShareLoading] = React.useState(false);
 
   // State for anchor element
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
   const currentEvalId = evalId || defaultEvalId || 'default';
 

--- a/src/app/src/pages/eval/components/ResultsViewSettingsModal.tsx
+++ b/src/app/src/pages/eval/components/ResultsViewSettingsModal.tsx
@@ -19,8 +19,8 @@ const MemoizedSlider = React.memo(
     onChangeCommitted,
   }: {
     value: number;
-    onChange: (event: Event | React.SyntheticEvent, value: number | number[]) => void;
-    onChangeCommitted: (event: Event | React.SyntheticEvent, value: number | number[]) => void;
+    onChange: (event: Event | React.SyntheticEvent, value: number[] | number) => void;
+    onChangeCommitted: (event: Event | React.SyntheticEvent, value: number[] | number) => void;
   }) => (
     <Slider
       min={25}
@@ -72,14 +72,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
   );
 
   const handleSliderChange = useCallback(
-    (_event: Event | React.SyntheticEvent, value: number | number[]) => {
+    (_event: Event | React.SyntheticEvent, value: number[] | number) => {
       setLocalMaxTextLength(value as number);
     },
     [],
   );
 
   const handleSliderChangeCommitted = useCallback(
-    (_event: Event | React.SyntheticEvent, value: number | number[]) => {
+    (_event: Event | React.SyntheticEvent, value: number[] | number) => {
       const newValue = value === 1001 ? Number.POSITIVE_INFINITY : (value as number);
       setMaxTextLength(newValue);
     },

--- a/src/app/src/pages/eval/components/TruncatedText.tsx
+++ b/src/app/src/pages/eval/components/TruncatedText.tsx
@@ -17,7 +17,7 @@ function textLength(node: React.ReactNode): number {
 }
 
 export interface TruncatedTextProps {
-  text: string | number | React.ReactNode;
+  text: React.ReactNode | number | string;
   maxLength: number;
 }
 

--- a/src/app/src/pages/eval/components/store.ts
+++ b/src/app/src/pages/eval/components/store.ts
@@ -42,8 +42,8 @@ interface TableState {
 
   maxTextLength: number;
   setMaxTextLength: (maxTextLength: number) => void;
-  wordBreak: 'break-word' | 'break-all';
-  setWordBreak: (wordBreak: 'break-word' | 'break-all') => void;
+  wordBreak: 'break-all' | 'break-word';
+  setWordBreak: (wordBreak: 'break-all' | 'break-word') => void;
   showInferenceDetails: boolean;
   setShowInferenceDetails: (showInferenceDetails: boolean) => void;
   renderMarkdown: boolean;
@@ -90,7 +90,7 @@ export const useStore = create<TableState>()(
       maxTextLength: 250,
       setMaxTextLength: (maxTextLength: number) => set(() => ({ maxTextLength })),
       wordBreak: 'break-word',
-      setWordBreak: (wordBreak: 'break-word' | 'break-all') => set(() => ({ wordBreak })),
+      setWordBreak: (wordBreak: 'break-all' | 'break-word') => set(() => ({ wordBreak })),
       showInferenceDetails: true,
       setShowInferenceDetails: (showInferenceDetails: boolean) =>
         set(() => ({ showInferenceDetails })),

--- a/src/app/src/pages/eval/components/types.ts
+++ b/src/app/src/pages/eval/components/types.ts
@@ -1,3 +1,3 @@
-export type FilterMode = 'all' | 'failures' | 'different' | 'highlights';
+export type FilterMode = 'all' | 'different' | 'failures' | 'highlights';
 
 export * from '@promptfoo/types';

--- a/src/app/src/pages/progress/Progress.tsx
+++ b/src/app/src/pages/progress/Progress.tsx
@@ -22,7 +22,7 @@ export default function Cols() {
   const [cols, setCols] = useState<StandaloneEval[]>([]);
   const [sortField, setSortField] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [page, setPage] = React.useState(1);
   const [filter, setFilter] = useState({ evalId: '', datasetId: '', provider: '', promptId: '' });
 

--- a/src/app/src/pages/redteam/dashboard/components/Dashboard.tsx
+++ b/src/app/src/pages/redteam/dashboard/components/Dashboard.tsx
@@ -53,7 +53,7 @@ export default function Dashboard() {
     { date: string; resolved: number }[]
   >([]);
   const [activeChart, setActiveChart] = useState<
-    'attackSuccess' | 'issuesResolved' | 'applicationSuccess'
+    'applicationSuccess' | 'attackSuccess' | 'issuesResolved'
   >('attackSuccess');
   const [applicationAttackSuccessData, setApplicationAttackSuccessData] = useState<
     ApplicationAttackSuccessDataPoint[]

--- a/src/app/src/pages/redteam/dashboard/components/DashboardCharts.tsx
+++ b/src/app/src/pages/redteam/dashboard/components/DashboardCharts.tsx
@@ -14,8 +14,8 @@ interface DashboardChartsProps {
   attackSuccessRateData: AttackSuccessRateDataPoint[];
   issuesResolvedData: IssuesResolvedDataPoint[];
   applicationAttackSuccessData: ApplicationAttackSuccessDataPoint[];
-  activeChart: 'attackSuccess' | 'issuesResolved' | 'applicationSuccess';
-  setActiveChart: (value: 'attackSuccess' | 'issuesResolved' | 'applicationSuccess') => void;
+  activeChart: 'applicationSuccess' | 'attackSuccess' | 'issuesResolved';
+  setActiveChart: (value: 'applicationSuccess' | 'attackSuccess' | 'issuesResolved') => void;
 }
 
 export default function DashboardCharts({

--- a/src/app/src/pages/redteam/dashboard/components/MetricCard.tsx
+++ b/src/app/src/pages/redteam/dashboard/components/MetricCard.tsx
@@ -9,9 +9,9 @@ import Typography from '@mui/material/Typography';
 interface MetricCardProps {
   title: string;
   value: string;
-  trend?: 'up' | 'down' | 'flat';
+  trend?: 'down' | 'flat' | 'up';
   trendValue?: string;
-  sentiment?: 'good' | 'bad' | 'flat';
+  sentiment?: 'bad' | 'flat' | 'good';
   subtitle?: string;
 }
 

--- a/src/app/src/pages/redteam/dashboard/components/utils.ts
+++ b/src/app/src/pages/redteam/dashboard/components/utils.ts
@@ -5,7 +5,7 @@ export function calculateTrend(current: number, previous: number, increaseIsBad:
   const difference = current - previous;
   const percentChange = difference / previous;
 
-  let direction: 'up' | 'down' | 'flat';
+  let direction: 'down' | 'flat' | 'up';
   if (percentChange > 0.01) {
     direction = 'up';
   } else if (percentChange < -0.01) {
@@ -14,7 +14,7 @@ export function calculateTrend(current: number, previous: number, increaseIsBad:
     direction = 'flat';
   }
 
-  let sentiment: 'good' | 'bad' | 'flat';
+  let sentiment: 'bad' | 'flat' | 'good';
   if (increaseIsBad) {
     sentiment = direction === 'up' ? 'bad' : direction === 'down' ? 'good' : 'flat';
   } else {

--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
@@ -40,7 +40,7 @@ function getPromptDisplayString(prompt: string): string {
   return prompt;
 }
 
-function getOutputDisplay(output: string | object) {
+function getOutputDisplay(output: object | string) {
   if (typeof output === 'string') {
     return output;
   }

--- a/src/app/src/pages/redteam/report/components/TestSuites.tsx
+++ b/src/app/src/pages/redteam/report/components/TestSuites.tsx
@@ -83,7 +83,7 @@ const TestSuites: React.FC<{
   };
 
   const [order, setOrder] = React.useState<'asc' | 'desc'>('asc');
-  const [orderBy, setOrderBy] = React.useState<'passRate' | 'severity' | 'default'>('default');
+  const [orderBy, setOrderBy] = React.useState<'default' | 'passRate' | 'severity'>('default');
   const handleSort = (property: 'passRate' | 'severity') => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -93,7 +93,7 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
 
   const handlePresetSelect = (preset: {
     name: string;
-    plugins: Set<Plugin> | ReadonlySet<Plugin>;
+    plugins: ReadonlySet<Plugin> | Set<Plugin>;
   }) => {
     if (preset.name === 'Custom') {
       setIsCustomMode(true);
@@ -125,7 +125,7 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
     });
   }, [searchTerm]);
 
-  const presets: { name: string; plugins: Set<Plugin> | ReadonlySet<Plugin> }[] = [
+  const presets: { name: string; plugins: ReadonlySet<Plugin> | Set<Plugin> }[] = [
     { name: 'Default', plugins: DEFAULT_PLUGINS },
     {
       name: 'NIST',

--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -31,11 +31,11 @@ export default function Review() {
     URL.revokeObjectURL(url);
   };
 
-  const getPluginLabel = (plugin: string | RedteamPlugin) => {
+  const getPluginLabel = (plugin: RedteamPlugin | string) => {
     return typeof plugin === 'string' ? plugin : plugin.id;
   };
 
-  const getStrategyLabel = (strategy: string | RedteamStrategy) => {
+  const getStrategyLabel = (strategy: RedteamStrategy | string) => {
     return typeof strategy === 'string' ? strategy : strategy.id;
   };
 

--- a/src/app/src/pages/redteam/setup/components/YamlPreview.tsx
+++ b/src/app/src/pages/redteam/setup/components/YamlPreview.tsx
@@ -101,7 +101,7 @@ export default function YamlPreview({ config }: YamlPreviewProps) {
   const validateAndImportYaml = (yamlString: string) => {
     try {
       const parsedYaml = yaml.load(yamlString) as UnifiedConfig & {
-        targets?: (string | ProviderOptions)[];
+        targets?: (ProviderOptions | string)[];
       };
       // Add more detailed validation here
       if (!parsedYaml.description || !parsedYaml.prompts || !parsedYaml.targets) {

--- a/src/app/src/pages/redteam/setup/types.ts
+++ b/src/app/src/pages/redteam/setup/types.ts
@@ -15,7 +15,7 @@ export interface ProviderOptions {
   id: string;
   label?: string;
   config: {
-    type?: 'http' | 'websocket' | 'browser';
+    type?: 'browser' | 'http' | 'websocket';
     // HTTP/WebSocket specific options
     url?: string;
     method?: string;
@@ -39,7 +39,7 @@ export interface ProviderOptions {
 }
 
 export interface BrowserStep {
-  action: 'navigate' | 'click' | 'type' | 'extract' | 'screenshot' | 'wait' | 'waitForNewChildren';
+  action: 'click' | 'extract' | 'navigate' | 'screenshot' | 'type' | 'wait' | 'waitForNewChildren';
   args?: {
     url?: string;
     selector?: string;
@@ -89,6 +89,6 @@ export interface LocalPluginConfig {
     targetSystems?: string[];
     indirectInjectionVar?: string;
     targetUrls?: string[];
-    [key: string]: string | string[] | undefined;
+    [key: string]: string[] | string | undefined;
   };
 }

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -78,7 +78,7 @@ const ajv = createAjv();
 
 const nunjucks = getNunjucksEngine();
 
-function coerceString(value: string | object): string {
+function coerceString(value: object | string): string {
   if (typeof value === 'string') {
     return value;
   }
@@ -92,7 +92,7 @@ function handleRougeScore(
   output: string,
   inverted: boolean,
 ): GradingResult {
-  const fnName = baseType[baseType.length - 1] as 'n' | 'l' | 's';
+  const fnName = baseType[baseType.length - 1] as 'l' | 'n' | 's';
   const rougeMethod = rouge[fnName];
   const score = rougeMethod(output, expected, {});
   const pass = score >= (assertion.threshold || 0.75) != inverted;
@@ -304,7 +304,7 @@ export async function runAssertion({
 
   // Render assertion values
   let renderedValue = assertion.value;
-  let valueFromScript: string | boolean | number | GradingResult | object | undefined;
+  let valueFromScript: GradingResult | boolean | number | object | string | undefined;
   if (typeof renderedValue === 'string') {
     if (renderedValue.startsWith('file://')) {
       const basePath = cliState.basePath || '';
@@ -743,7 +743,7 @@ export async function runAssertion({
 
   if (baseType === 'javascript') {
     try {
-      const validateResult = async (result: any): Promise<boolean | number | GradingResult> => {
+      const validateResult = async (result: any): Promise<GradingResult | boolean | number> => {
         result = await Promise.resolve(result);
         if (typeof result === 'boolean' || typeof result === 'number' || isGradingResult(result)) {
           return result;
@@ -783,7 +783,7 @@ export async function runAssertion({
        */
       renderedValue = renderedValue.trimEnd();
 
-      let result: boolean | number | GradingResult;
+      let result: GradingResult | boolean | number;
       if (typeof valueFromScript === 'undefined') {
         const functionBody = renderedValue.includes('\n')
           ? renderedValue
@@ -834,7 +834,7 @@ ${renderedValue}`,
   if (baseType === 'python') {
     invariant(typeof renderedValue === 'string', 'python assertion must have a string value');
     try {
-      let result: string | number | boolean | object | GradingResult | undefined;
+      let result: GradingResult | boolean | number | object | string | undefined;
       if (typeof valueFromScript === 'undefined') {
         const isMultiline = renderedValue.includes('\n');
         let indentStyle = '    ';
@@ -1135,7 +1135,7 @@ ${
     if (promptToModerate[0] === '[' || promptToModerate[0] === '{') {
       // Try to extract the last user message from OpenAI-style prompts.
       try {
-        const parsedPrompt = parseChatPrompt<null | { role: string; content: string }[]>(
+        const parsedPrompt = parseChatPrompt<{ role: string; content: string }[] | null>(
           promptToModerate,
           null,
         );

--- a/src/assertions/validateAssertions.ts
+++ b/src/assertions/validateAssertions.ts
@@ -23,7 +23,7 @@ function validateAssertSet(assertion: object, test: TestCase) {
   }
 }
 
-export function validateAssertions(tests: TestCase<Record<string, string | object | string[]>>[]) {
+export function validateAssertions(tests: TestCase<Record<string, string[] | object | string>>[]) {
   for (const test of tests) {
     if (test.assert) {
       for (const assertion of test.assert) {

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -58,7 +58,7 @@ function showRedteamProviderLabelMissingWarning(testSuite: TestSuite) {
 }
 
 export async function doEval(
-  cmdObj: Partial<CommandLineOptions & Command>,
+  cmdObj: Partial<Command & CommandLineOptions>,
   defaultConfig: Partial<UnifiedConfig>,
   defaultConfigPath: string | undefined,
   evaluateOptions: EvaluateOptions,
@@ -546,7 +546,7 @@ export function evalCommand(
       }
 
       doEval(
-        validatedOpts as Partial<CommandLineOptions & Command>,
+        validatedOpts as Partial<Command & CommandLineOptions>,
         defaultConfig,
         defaultConfigPath,
         evaluateOptions,

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -2,7 +2,7 @@ import type { TestSuite } from '../../types';
 import { filterFailingTests } from './filterFailingTests';
 
 interface Args {
-  firstN?: string | number;
+  firstN?: number | string;
   pattern?: string;
   failing?: string;
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -102,7 +102,7 @@ export async function selectExample(): Promise<string> {
 
 async function handleExampleDownload(
   directory: string | null,
-  example: string | boolean | undefined,
+  example: boolean | string | undefined,
 ): Promise<string | undefined> {
   let exampleName: string | undefined;
 
@@ -158,7 +158,7 @@ async function handleExampleDownload(
 
 interface InitCommandOptions {
   interactive: boolean;
-  example: string | boolean | undefined;
+  example: boolean | string | undefined;
 }
 
 export function initCommand(program: Command) {

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -32,7 +32,7 @@ export function shareCommand(program: Command) {
     .action(
       async (
         evalId: string | undefined,
-        cmdObj: { yes: boolean; envPath?: string; showAuth: boolean } & Command,
+        cmdObj: Command & { yes: boolean; envPath?: string; showAuth: boolean },
       ) => {
         setupEnv(cmdObj.envPath);
         telemetry.record('command_used', {
@@ -40,7 +40,7 @@ export function shareCommand(program: Command) {
         });
         await telemetry.send();
 
-        let eval_: Eval | undefined | null = null;
+        let eval_: Eval | null | undefined = null;
         if (evalId) {
           eval_ = await Eval.findById(evalId);
         } else {

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -16,14 +16,14 @@ export function viewCommand(program: Command) {
     .action(
       async (
         directory: string | undefined,
-        cmdObj: {
+        cmdObj: Command & {
           port: number;
           yes: boolean;
           no: boolean;
           apiBaseUrl?: string;
           envPath?: string;
           filterDescription?: string;
-        } & Command,
+        },
       ) => {
         setupEnv(cmdObj.envPath);
         telemetry.record('command_used', {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -123,7 +123,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
   const vars: Record<string, string> = {};
   const asserts: Assertion[] = [];
   const options: TestCase['options'] = {};
-  let providerOutput: string | object | undefined;
+  let providerOutput: object | string | undefined;
   let description: string | undefined;
   let metric: string | undefined;
   let threshold: number | undefined;

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -1,8 +1,8 @@
 import type { EnvOverrides } from './types';
 
 // Define the supported environment variables and their types
-export type EnvVars = {
-  LOG_LEVEL?: 'error' | 'warn' | 'info' | 'debug';
+export type EnvVars = EnvOverrides & {
+  LOG_LEVEL?: 'debug' | 'error' | 'info' | 'warn';
   NEXT_PUBLIC_PROMPTFOO_BASE_URL?: string;
   NEXT_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL?: string;
   PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY?: number;
@@ -12,7 +12,7 @@ export type EnvVars = {
   PROMPTFOO_CACHE_MAX_SIZE?: number;
   PROMPTFOO_CACHE_PATH?: string;
   PROMPTFOO_CACHE_TTL?: number;
-  PROMPTFOO_CACHE_TYPE?: 'memory' | 'disk';
+  PROMPTFOO_CACHE_TYPE?: 'disk' | 'memory';
   PROMPTFOO_CONFIG_DIR?: string;
   PROMPTFOO_DELAY_MS?: number;
   PROMPTFOO_DISABLE_AJV_STRICT_MODE?: boolean;
@@ -131,7 +131,7 @@ export type EnvVars = {
   BUDDY?: boolean;
   BUILDKITE?: boolean;
   TEAMCITY_VERSION?: boolean;
-} & EnvOverrides;
+};
 
 type EnvVarKey = keyof EnvVars;
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -58,10 +58,10 @@ export function isAllowedPrompt(prompt: Prompt, allowedPrompts: string[] | undef
 }
 
 export function generateVarCombinations(
-  vars: Record<string, string | string[] | any>,
-): Record<string, string | any[]>[] {
+  vars: Record<string, string[] | any | string>,
+): Record<string, any[] | string>[] {
   const keys = Object.keys(vars);
-  const combinations: Record<string, string | any[]>[] = [{}];
+  const combinations: Record<string, any[] | string>[] = [{}];
 
   for (const key of keys) {
     let values: any[] = [];
@@ -105,9 +105,9 @@ class Evaluator {
   stats: EvaluateStats;
   conversations: Record<
     string,
-    { prompt: string | object; input: string; output: string | object }[]
+    { prompt: object | string; input: string; output: object | string }[]
   >;
-  registers: Record<string, string | object>;
+  registers: Record<string, object | string>;
 
   constructor(testSuite: TestSuite, evalRecord: Eval, options: EvaluateOptions) {
     this.testSuite = testSuite;
@@ -485,11 +485,11 @@ class Evaluator {
 
     // Prepare vars
     const varNames: Set<string> = new Set();
-    const varsWithSpecialColsRemoved: Record<string, string | string[] | object>[] = [];
+    const varsWithSpecialColsRemoved: Record<string, string[] | object | string>[] = [];
     const inputTransformDefault = testSuite?.defaultTest?.options?.transformVars;
     for (const testCase of tests) {
       if (testCase.vars) {
-        const varWithSpecialColsRemoved: Record<string, string | string[] | object> = {};
+        const varWithSpecialColsRemoved: Record<string, string[] | object | string> = {};
         const inputTransformForIndividualTest = testCase.options?.transformVars;
         const inputTransform = inputTransformForIndividualTest || inputTransformDefault;
         if (inputTransform) {

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -14,8 +14,8 @@ import { getNunjucksEngine } from './util/templates';
 import { transform } from './util/transform';
 
 export function resolveVariables(
-  variables: Record<string, string | object>,
-): Record<string, string | object> {
+  variables: Record<string, object | string>,
+): Record<string, object | string> {
   let resolved = true;
   const regex = /\{\{\s*(\w+)\s*\}\}/; // Matches {{variableName}}, {{ variableName }}, etc.
 
@@ -47,7 +47,7 @@ export function resolveVariables(
 
 export async function renderPrompt(
   prompt: Prompt,
-  vars: Record<string, string | object>,
+  vars: Record<string, object | string>,
   nunjucksFilters?: NunjucksFilterMap,
   provider?: ApiProvider,
 ): Promise<string> {
@@ -98,7 +98,7 @@ export async function renderPrompt(
         vars[varName] = pythonScriptOutput.output.trim();
       } else if (fileExtension === 'yaml' || fileExtension === 'yml') {
         vars[varName] = JSON.stringify(
-          yaml.load(fs.readFileSync(filePath, 'utf8')) as string | object,
+          yaml.load(fs.readFileSync(filePath, 'utf8')) as object | string,
         );
       } else {
         vars[varName] = fs.readFileSync(filePath, 'utf8').trim();

--- a/src/integrations/helicone.ts
+++ b/src/integrations/helicone.ts
@@ -22,7 +22,7 @@ export interface ResultSuccess<T> {
   error: null;
 }
 
-export type Result<T, K> = ResultSuccess<T> | ResultError<K>;
+export type Result<T, K> = ResultError<K> | ResultSuccess<T>;
 
 const buildFilter = (majorVersion?: number, minorVersion?: number): any => {
   const filter: any = {};

--- a/src/integrations/langfuse.ts
+++ b/src/integrations/langfuse.ts
@@ -12,7 +12,7 @@ const langfuse = new Langfuse(langfuseParams);
 export async function getPrompt(
   id: string,
   vars: Record<string, any>,
-  type: 'text' | 'chat' | undefined,
+  type: 'chat' | 'text' | undefined,
   version?: number,
 ): Promise<string> {
   let prompt;

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -47,7 +47,7 @@ function cosineSimilarity(vecA: number[], vecB: number[]) {
   return dotProduct / (vecAMagnitude * vecBMagnitude);
 }
 
-function fromVars(vars?: Record<string, string | object>) {
+function fromVars(vars?: Record<string, object | string>) {
   if (!vars) {
     return {};
   }
@@ -334,7 +334,7 @@ export function renderLlmRubricPrompt(
   rubric: string,
   llmOutput: string,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ) {
   let rubricPrompt = grading?.rubricPrompt || DEFAULT_GRADING_PROMPT;
 
@@ -353,7 +353,7 @@ export async function matchesLlmRubric(
   rubric: string,
   llmOutput: string,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -418,7 +418,7 @@ export async function matchesFactuality(
   expected: string,
   output: string,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -514,7 +514,7 @@ export async function matchesClosedQa(
   expected: string,
   output: string,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   if (!grading) {
     throw new Error(
@@ -674,7 +674,7 @@ export async function matchesContextRecall(
   groundTruth: string,
   threshold: number,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   const textProvider = await getAndCheckProvider(
     'text',
@@ -773,7 +773,7 @@ export async function matchesContextFaithfulness(
   context: string,
   threshold: number,
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>> {
   const textProvider = await getAndCheckProvider(
     'text',
@@ -854,7 +854,7 @@ export async function matchesSelectBest(
   criteria: string,
   outputs: string[],
   grading?: GradingConfig,
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ): Promise<Omit<GradingResult, 'assertion'>[]> {
   invariant(
     outputs.length >= 2,

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -365,7 +365,7 @@ export default class Eval {
     this.results = await EvalResult.findManyByEvalId(this.id);
   }
 
-  async getResults(): Promise<EvaluateResult[] | EvalResult[]> {
+  async getResults(): Promise<EvalResult[] | EvaluateResult[]> {
     if (this.useOldResults()) {
       invariant(this.oldResults, 'Old results not found');
       return this.oldResults.results;
@@ -373,7 +373,7 @@ export default class Eval {
     await this.loadResults();
     return this.results;
   }
-  async toEvaluateSummary(): Promise<EvaluateSummaryV3 | EvaluateSummaryV2> {
+  async toEvaluateSummary(): Promise<EvaluateSummaryV2 | EvaluateSummaryV3> {
     if (this.useOldResults()) {
       invariant(this.oldResults, 'Old results not found');
       return {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -249,7 +249,7 @@ function recordOnboardingStep(step: string, properties: EventProperties = {}) {
  * Iterate through user choices and determine if the user has selected a provider that needs an API key
  * but has not set and API key in their environment.
  */
-export function reportProviderAPIKeyWarnings(providerChoices: (string | object)[]): string[] {
+export function reportProviderAPIKeyWarnings(providerChoices: (object | string)[]): string[] {
   const ids = providerChoices.map((c) => (typeof c === 'object' ? (c as any).id : c));
 
   const map: Record<string, keyof EnvOverrides> = {
@@ -302,7 +302,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
 
   // Rest of the onboarding flow
   const prompts: string[] = [];
-  const providers: (string | object)[] = [];
+  const providers: (object | string)[] = [];
   let action: string;
   let language: string;
 
@@ -351,7 +351,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
       });
     }
 
-    const choices: { name: string; value: (string | object)[] }[] = [
+    const choices: { name: string; value: (object | string)[] }[] = [
       { name: `I'll choose later`, value: ['openai:gpt-4o-mini', 'openai:gpt-4o'] },
       {
         name: '[OpenAI] GPT 4o, GPT 4o-mini, GPT-3.5, ...',
@@ -445,7 +445,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
      * The potential of the object type here is given by the agent action conditional
      * for openai as a value choice
      */
-    const providerChoices: (string | object)[] = (
+    const providerChoices: (object | string)[] = (
       await checkbox({
         message: 'Which model providers would you like to use?',
         choices,

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -172,7 +172,7 @@ export async function processPrompt(
  * @returns Promise resolving to an array of processed prompts.
  */
 export async function readPrompts(
-  promptPathOrGlobs: string | (string | Partial<Prompt>)[] | Record<string, string>,
+  promptPathOrGlobs: (Partial<Prompt> | string)[] | Record<string, string> | string,
   basePath: string = '',
 ): Promise<Prompt[]> {
   logger.debug(`Reading prompts from ${JSON.stringify(promptPathOrGlobs)}`);

--- a/src/prompts/processors/javascript.ts
+++ b/src/prompts/processors/javascript.ts
@@ -3,7 +3,7 @@ import { importModule } from '../../esm';
 import type { ApiProvider, Prompt, PromptFunctionContext } from '../../types';
 
 export const transformContext = (context: {
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   provider?: ApiProvider;
   config?: Record<string, any>;
 }): PromptFunctionContext => {

--- a/src/prompts/processors/python.ts
+++ b/src/prompts/processors/python.ts
@@ -18,7 +18,7 @@ export const pythonPromptFunction = async (
   filePath: string,
   functionName: string,
   context: {
-    vars: Record<string, string | object>;
+    vars: Record<string, object | string>;
     provider?: ApiProvider;
     config?: Record<string, any>;
   },
@@ -46,7 +46,7 @@ export const pythonPromptFunction = async (
 export const pythonPromptFunctionLegacy = async (
   filePath: string,
   context: {
-    vars: Record<string, string | object>;
+    vars: Record<string, object | string>;
     provider?: ApiProvider;
     config?: Record<string, any>;
   },

--- a/src/prompts/utils.ts
+++ b/src/prompts/utils.ts
@@ -39,7 +39,7 @@ export function maybeFilePath(str: string): boolean {
  * @throws If the input is invalid or empty.
  */
 export function normalizeInput(
-  promptPathOrGlobs: string | (string | Partial<Prompt>)[] | Record<string, string>,
+  promptPathOrGlobs: (Partial<Prompt> | string)[] | Record<string, string> | string,
 ): Partial<Prompt>[] {
   if (
     !promptPathOrGlobs ||

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -120,7 +120,7 @@ export function parseMessages(messages: string): {
     .filter((line) => line);
   let system: Anthropic.TextBlockParam[] | undefined;
   const extractedMessages: Anthropic.MessageParam[] = [];
-  let currentRole: 'user' | 'assistant' | null = null;
+  let currentRole: 'assistant' | 'user' | null = null;
   let currentContent: string[] = [];
 
   const pushMessage = () => {

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -51,7 +51,7 @@ interface AzureOpenAiCompletionOptions {
     description?: string;
     parameters: any;
   }[];
-  function_call?: 'none' | 'auto' | { name: string };
+  function_call?: 'auto' | 'none' | { name: string };
   tools?: {
     type: string;
     function: {
@@ -60,7 +60,7 @@ interface AzureOpenAiCompletionOptions {
       parameters: any;
     };
   }[];
-  tool_choice?: 'none' | 'auto' | { type: 'function'; function?: { name: string } };
+  tool_choice?: 'auto' | 'none' | { type: 'function'; function?: { name: string } };
   response_format?: { type: 'json_object' };
   stop?: string[];
   seed?: number;

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -79,7 +79,7 @@ interface BedrockCohereCommandGenerationOptions extends BedrockOptions {
 interface BedrockCohereCommandRGenerationOptions extends BedrockOptions {
   message?: string;
   chat_history?: Array<{
-    role: 'USER' | 'CHATBOT';
+    role: 'CHATBOT' | 'USER';
     message: string;
   }>;
   documents?: Array<{
@@ -125,7 +125,7 @@ interface BedrockCohereCommandRGenerationOptions extends BedrockOptions {
 interface CohereCommandRRequestParams {
   message: string;
   chat_history: {
-    role: 'USER' | 'CHATBOT';
+    role: 'CHATBOT' | 'USER';
     message: string;
   }[];
   documents?: {
@@ -191,7 +191,7 @@ interface IBedrockModel {
   output: (responseJson: any) => any;
 }
 
-export function parseValue(value: string | number, defaultValue: any) {
+export function parseValue(value: number | string, defaultValue: any) {
   if (typeof defaultValue === 'number') {
     if (typeof value === 'string') {
       return Number.isNaN(Number.parseFloat(value)) ? defaultValue : Number.parseFloat(value);
@@ -205,7 +205,7 @@ export function addConfigParam(
   params: any,
   key: string,
   configValue: any,
-  envValue?: string | number | undefined,
+  envValue?: number | string | undefined,
   defaultValue?: any,
 ) {
   if (configValue !== undefined || envValue !== undefined || defaultValue !== undefined) {
@@ -222,7 +222,7 @@ export enum LlamaVersion {
 }
 
 export interface LlamaMessage {
-  role: 'system' | 'user' | 'assistant';
+  role: 'assistant' | 'system' | 'user';
   content: string;
 }
 

--- a/src/providers/browser.ts
+++ b/src/providers/browser.ts
@@ -21,7 +21,7 @@ interface BrowserAction {
 
 interface BrowserProviderConfig {
   steps: BrowserAction[];
-  responseParser?: string | Function;
+  responseParser?: Function | string;
   timeoutMs?: number;
   headless?: boolean;
   cookies?:

--- a/src/providers/cloudflare-ai.ts
+++ b/src/providers/cloudflare-ai.ts
@@ -20,7 +20,7 @@ import { REQUEST_TIMEOUT_MS, parseChatPrompt } from './shared';
  */
 type ICloudflareParamsToIgnore = keyof Pick<
   Cloudflare.Workers.AI.AIRunParams.TextGeneration,
-  'messages' | 'prompt' | 'raw' | 'stream' | 'account_id'
+  'account_id' | 'messages' | 'prompt' | 'raw' | 'stream'
 >;
 
 export type ICloudflareProviderBaseConfig = {
@@ -58,7 +58,7 @@ export type IBuildCloudflareResponse<SuccessData extends Record<string, unknown>
   | { success: false; errors: unknown[]; messages: unknown[] };
 
 abstract class CloudflareAiGenericProvider implements ApiProvider {
-  abstract readonly modelType: 'embedding' | 'chat' | 'completion';
+  abstract readonly modelType: 'chat' | 'completion' | 'embedding';
 
   deploymentName: string;
   public readonly config: ICloudflareProviderConfig;
@@ -339,9 +339,9 @@ export class CloudflareAiChatCompletionProvider extends CloudflareAiGenericProvi
   ): Promise<ProviderResponse> {
     const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
-    const body: { [K in keyof ICloudflareTextGenerationOptions]: any } & {
+    const body: {
       messages: { role: string; content: string }[];
-    } = {
+    } & { [K in keyof ICloudflareTextGenerationOptions]: any } = {
       messages,
       max_tokens: this.config.max_tokens,
       temperature: this.config.temperature,

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -52,7 +52,7 @@ export class GolangProvider implements ApiProvider {
   private async executeGolangScript(
     prompt: string,
     context: CallApiContextParams | undefined,
-    apiType: 'call_api' | 'call_embedding_api' | 'call_classification_api',
+    apiType: 'call_api' | 'call_classification_api' | 'call_embedding_api',
   ): Promise<any> {
     const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
     logger.debug(`Computing file hash for script ${absPath}`);

--- a/src/providers/groq.ts
+++ b/src/providers/groq.ts
@@ -25,7 +25,7 @@ interface GroqCompletionOptions {
       parameters?: Record<string, any>;
     };
   }>;
-  tool_choice?: 'none' | 'auto' | { type: 'function'; function: { name: string } };
+  tool_choice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
   functionToolCallbacks?: Record<string, (arg: string) => Promise<string>>;
   systemPrompt?: string;
 }
@@ -65,7 +65,7 @@ export class GroqProvider implements ApiProvider {
     context?: CallApiContextParams,
     options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [
+    const messages: Array<{ role: 'assistant' | 'system' | 'user'; content: string }> = [
       {
         role: 'system',
         content: this.config.systemPrompt || 'You are a helpful assistant.',

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -24,9 +24,9 @@ interface HttpProviderConfig {
   url?: string;
   method?: string;
   headers?: Record<string, string>;
-  body?: Record<string, any> | string | any[];
+  body?: any[] | Record<string, any> | string;
   queryParams?: Record<string, string>;
-  responseParser?: string | Function;
+  responseParser?: Function | string;
   request?: string;
 }
 
@@ -43,7 +43,7 @@ function contentTypeIsJson(headers: Record<string, string> | undefined) {
 }
 
 export async function createResponseParser(
-  parser: string | Function | undefined,
+  parser: Function | string | undefined,
 ): Promise<(data: any, text: string) => ProviderResponse> {
   if (!parser) {
     return (data, text) => ({ output: data || text });
@@ -93,9 +93,9 @@ function processValue(value: any, vars: Record<string, any>): any {
 }
 
 function processObjects(
-  body: Record<string, any> | any[],
+  body: any[] | Record<string, any>,
   vars: Record<string, any>,
-): Record<string, any> | any[] {
+): any[] | Record<string, any> {
   if (Array.isArray(body)) {
     return body.map((item) =>
       typeof item === 'object' && item !== null
@@ -117,9 +117,9 @@ function processObjects(
 }
 
 export function processJsonBody(
-  body: Record<string, any> | any[],
+  body: any[] | Record<string, any>,
   vars: Record<string, any>,
-): Record<string, any> | any[] {
+): any[] | Record<string, any> {
   // attempting to process a string as a stringifiedJSON object
   if (typeof body === 'string') {
     body = processValue(body, vars);
@@ -266,7 +266,7 @@ export class HttpProvider implements ApiProvider {
       headers,
       // We validate the content type and body with this.validateContentTypeAndBody
       body: contentTypeIsJson(headers)
-        ? processJsonBody(this.config.body as Record<string, any> | any[], vars)
+        ? processJsonBody(this.config.body as any[] | Record<string, any>, vars)
         : processTextBody(this.config.body as string, vars),
       queryParams: this.config.queryParams
         ? Object.fromEntries(

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -80,7 +80,7 @@ export class HuggingfaceTextGenerationProvider implements ApiProvider {
         return options;
       },
       {} as Partial<
-        Record<keyof HuggingfaceTextGenerationOptions, number | boolean | string | undefined>
+        Record<keyof HuggingfaceTextGenerationOptions, boolean | number | string | undefined>
       >,
     );
   }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -147,7 +147,7 @@ export class OllamaCompletionProvider implements ApiProvider {
           return options;
         },
         {} as Partial<
-          Record<keyof OllamaCompletionOptions, number | boolean | string[] | undefined>
+          Record<keyof OllamaCompletionOptions, string[] | boolean | number | undefined>
         >,
       ),
     };
@@ -241,7 +241,7 @@ export class OllamaChatProvider implements ApiProvider {
           return options;
         },
         {} as Partial<
-          Record<keyof OllamaCompletionOptions, number | boolean | string[] | undefined>
+          Record<keyof OllamaCompletionOptions, string[] | boolean | number | undefined>
         >,
       ),
     };

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -144,9 +144,9 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
   presence_penalty?: number;
   best_of?: number;
   functions?: OpenAiFunction[];
-  function_call?: 'none' | 'auto' | { name: string };
+  function_call?: 'auto' | 'none' | { name: string };
   tools?: OpenAiTool[];
-  tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function?: { name: string } };
+  tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; function?: { name: string } };
   response_format?:
     | {
         type: 'json_object';
@@ -682,10 +682,10 @@ type OpenAiAssistantOptions = OpenAiSharedOptions & {
   metadata?: object[];
   temperature?: number;
   toolChoice?:
-    | 'none'
     | 'auto'
-    | { type: 'function'; function?: { name: string } }
-    | { type: 'file_search' };
+    | 'none'
+    | { type: 'file_search' }
+    | { type: 'function'; function?: { name: string } };
   attachments?: OpenAI.Beta.Threads.Message.Attachment[];
 };
 
@@ -957,11 +957,11 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
           n: 1,
           size:
             ((this.config.size || process.env.OPENAI_IMAGE_SIZE) as
-              | '1024x1024'
               | '256x256'
               | '512x512'
-              | '1792x1024'
+              | '1024x1024'
               | '1024x1792'
+              | '1792x1024'
               | undefined) || '1024x1024',
         });
       } catch (error) {

--- a/src/providers/openaiUtil.ts
+++ b/src/providers/openaiUtil.ts
@@ -17,7 +17,7 @@ export interface OpenAiTool {
 export function validateFunctionCall(
   functionCall: { arguments: string; name: string },
   functions?: OpenAiFunction[],
-  vars?: Record<string, string | object>,
+  vars?: Record<string, object | string>,
 ) {
   // Parse function call and validate it against schema
   const interpolatedFunctions = maybeLoadFromExternalFile(

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -88,7 +88,7 @@ interface PromptfooChatCompletionOptions {
   id?: string;
   jsonOnly: boolean;
   preferSmallModel: boolean;
-  task: 'crescendo' | 'iterative' | 'iterative:image' | 'iterative:tree';
+  task: 'crescendo' | 'iterative:image' | 'iterative:tree' | 'iterative';
 }
 
 export class PromptfooChatCompletionProvider implements ApiProvider {

--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -48,7 +48,7 @@ export class PythonProvider implements ApiProvider {
   private async executePythonScript(
     prompt: string,
     context: CallApiContextParams | undefined,
-    apiType: 'call_api' | 'call_embedding_api' | 'call_classification_api',
+    apiType: 'call_api' | 'call_classification_api' | 'call_embedding_api',
   ): Promise<any> {
     const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
     logger.debug(`Computing file hash for script ${absPath}`);

--- a/src/providers/vertex.ts
+++ b/src/providers/vertex.ts
@@ -84,7 +84,7 @@ interface VertexCompletionOptions {
 
   toolConfig?: {
     functionCallingConfig?: {
-      mode?: 'MODE_UNSPECIFIED' | 'AUTO' | 'ANY' | 'NONE';
+      mode?: 'ANY' | 'AUTO' | 'MODE_UNSPECIFIED' | 'NONE';
       allowedFunctionNames?: string[];
     };
   };

--- a/src/providers/vertexUtil.ts
+++ b/src/providers/vertexUtil.ts
@@ -2,14 +2,14 @@ import type { GoogleAuth } from 'google-auth-library';
 import { z } from 'zod';
 import logger from '../logger';
 
-type Probability = 'NEGLIGIBLE' | 'LOW' | 'MEDIUM' | 'HIGH';
+type Probability = 'HIGH' | 'LOW' | 'MEDIUM' | 'NEGLIGIBLE';
 
 interface SafetyRating {
   category:
+    | 'HARM_CATEGORY_DANGEROUS_CONTENT'
     | 'HARM_CATEGORY_HARASSMENT'
     | 'HARM_CATEGORY_HATE_SPEECH'
-    | 'HARM_CATEGORY_SEXUALLY_EXPLICIT'
-    | 'HARM_CATEGORY_DANGEROUS_CONTENT';
+    | 'HARM_CATEGORY_SEXUALLY_EXPLICIT';
   probability: Probability;
   blocked: boolean;
 }
@@ -25,7 +25,7 @@ interface PartFunctionCall {
   };
 }
 
-type Part = PartText | PartFunctionCall;
+type Part = PartFunctionCall | PartText;
 
 interface Content {
   parts: Part[];
@@ -34,7 +34,7 @@ interface Content {
 
 interface Candidate {
   content: Content;
-  finishReason?: 'FINISH_REASON_STOP' | 'STOP' | 'SAFETY';
+  finishReason?: 'FINISH_REASON_STOP' | 'SAFETY' | 'STOP';
   safetyRatings: SafetyRating[];
 }
 
@@ -72,9 +72,9 @@ interface GeminiBlockedResponse {
 }
 
 export type GeminiApiResponse = (
-  | GeminiResponseData
-  | GeminiErrorResponse
   | GeminiBlockedResponse
+  | GeminiErrorResponse
+  | GeminiResponseData
 )[];
 
 export interface Palm2ApiResponse {
@@ -144,7 +144,7 @@ export function maybeCoerceToGeminiFormat(contents: any): {
   ) {
     // This looks like an OpenAI chat format
     coercedContents = contents.map((item) => ({
-      role: item.role as 'user' | 'model' | undefined,
+      role: item.role as 'model' | 'user' | undefined,
       parts: [{ text: item.content }],
     }));
     coerced = true;

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -358,7 +358,7 @@ export class WatsonXProvider implements ApiProvider {
     return `[Watsonx Provider ${this.modelName}]`;
   }
 
-  async getAuth(): Promise<IamAuthenticator | BearerTokenAuthenticator> {
+  async getAuth(): Promise<BearerTokenAuthenticator | IamAuthenticator> {
     const { IamAuthenticator, BearerTokenAuthenticator } = await import('ibm-cloud-sdk-core');
 
     const apiKey =

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -15,7 +15,7 @@ const nunjucks = getNunjucksEngine();
 interface WebSocketProviderConfig {
   messageTemplate: string;
   url?: string;
-  responseParser?: string | Function;
+  responseParser?: Function | string;
   timeoutMs?: number;
 }
 

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -87,7 +87,7 @@ export async function validatePythonPath(pythonPath: string, isExplicit: boolean
 export async function runPython(
   scriptPath: string,
   method: string,
-  args: (string | number | object | undefined)[],
+  args: (number | object | string | undefined)[],
   options: { pythonExecutable?: string } = {},
 ): Promise<any> {
   const absPath = path.resolve(scriptPath);

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -14,7 +14,7 @@ import { runPython } from './pythonUtils';
 export async function runPythonCode(
   code: string,
   method: string,
-  args: (string | object | undefined)[],
+  args: (object | string | undefined)[],
 ): Promise<any> {
   const tempFilePath = path.join(
     os.tmpdir(),

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -246,7 +246,7 @@ export async function doGenerateRedteam(options: Partial<RedteamCliGenerateOptio
 
 export function redteamGenerateCommand(
   program: Command,
-  command: 'redteam' | 'generate',
+  command: 'generate' | 'redteam',
   defaultConfig: Partial<UnifiedConfig>,
   defaultConfigPath: string | undefined,
 ) {

--- a/src/redteam/commands/init.ts
+++ b/src/redteam/commands/init.ts
@@ -247,7 +247,7 @@ export async function redteamInit(directory: string | undefined) {
     );
   }
 
-  let providers: (string | ProviderOptions)[];
+  let providers: (ProviderOptions | string)[];
   let writeChatPy = false;
   if (useCustomProvider) {
     if (redTeamChoice === 'http_endpoint' || redTeamChoice === 'not_sure') {

--- a/src/redteam/commands/report.ts
+++ b/src/redteam/commands/report.ts
@@ -14,12 +14,12 @@ export function redteamReportCommand(program: Command) {
     .action(
       async (
         directory: string | undefined,
-        cmdObj: {
+        cmdObj: Command & {
           port: number;
           apiBaseUrl?: string;
           envPath?: string;
           filterDescription?: string;
-        } & Command,
+        },
       ) => {
         setupEnv(cmdObj.envPath);
         telemetry.record('command_used', {

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -62,7 +62,7 @@ async function doRedteamRun(options: RedteamRunOptions) {
       write: true, // Write results to database
       filterProviders: options.filterProviders,
       filterTargets: options.filterTargets,
-    } as Partial<CommandLineOptions & Command>,
+    } as Partial<Command & CommandLineOptions>,
     defaultConfig,
     redteamPath,
     {

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -29,35 +29,28 @@ export const LLAMA_GUARD_ENABLED_CATEGORIES = [
 export const COLLECTIONS = ['default', 'harmful', 'pii'] as const;
 export type Collection = (typeof COLLECTIONS)[number];
 
+// MLCommons harm categories - https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-guard-2/
+// Harmbench taxonomy - https://arxiv.org/pdf/2402.04249
 export const UNALIGNED_PROVIDER_HARM_PLUGINS = {
-  // MLCommons harm categories
-  // https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-guard-2/
-  'harmful:child-exploitation': 'Child Exploitation',
-  'harmful:hate': 'Hate',
-  'harmful:indiscriminate-weapons': 'Indiscriminate Weapons',
-  'harmful:non-violent-crime': 'Non-Violent Crimes',
-  'harmful:self-harm': 'Self-Harm',
-  'harmful:sex-crime': 'Sex Crimes',
-  'harmful:sexual-content': 'Sexual Content',
-  'harmful:violent-crime': 'Violent Crimes',
-
-  // Harmbench taxonomy
-  // https://arxiv.org/pdf/2402.04249
   'harmful:chemical-biological-weapons': 'Chemical & Biological Weapons',
+  'harmful:child-exploitation': 'Child Exploitation',
   'harmful:copyright-violations': 'Copyright Violations - Copyrighted text',
   'harmful:cybercrime': 'Cybercrime & Unauthorized Intrusion - Hacking and Malware',
   'harmful:graphic-content': 'Graphic & age-restricted content',
   'harmful:harassment-bullying': 'Harassment & Bullying',
+  'harmful:hate': 'Hate',
   'harmful:illegal-activities': 'Illegal Activities - Fraud & scams',
   'harmful:illegal-drugs': 'Illegal Drugs',
-  'harmful:unsafe-practices': 'Promotion of unsafe practices',
-
-  // Other
+  'harmful:indiscriminate-weapons': 'Indiscriminate Weapons',
   'harmful:insults': 'Insults and personal attacks',
+  'harmful:non-violent-crime': 'Non-Violent Crimes',
   'harmful:profanity': 'Requests containing profanity',
   'harmful:radicalization': 'Radicalization',
-
-  // Commented out
+  'harmful:self-harm': 'Self-Harm',
+  'harmful:sex-crime': 'Sex Crimes',
+  'harmful:sexual-content': 'Sexual Content',
+  'harmful:unsafe-practices': 'Promotion of unsafe practices',
+  'harmful:violent-crime': 'Violent Crimes',
   //'harmful:privacy-violations': 'Privacy violations & data exploitation',  // redundant with MLCommons category
   //'locale_specific_illegal (e.g. hate speech in Germany, alcohol in Saudi Arabia)',
   //'scam_fraud_creation',
@@ -115,12 +108,12 @@ export const CONFIG_REQUIRED_PLUGINS = ['policy'] as const;
 export type ConfigRequiredPlugin = (typeof CONFIG_REQUIRED_PLUGINS)[number];
 
 export type Plugin =
-  | Collection
-  | HarmPlugin
-  | PIIPlugin
-  | BasePlugin
   | AdditionalPlugin
-  | ConfigRequiredPlugin;
+  | BasePlugin
+  | Collection
+  | ConfigRequiredPlugin
+  | HarmPlugin
+  | PIIPlugin;
 
 export const DEFAULT_PLUGINS: ReadonlySet<Plugin> = new Set([
   ...COLLECTIONS,
@@ -394,7 +387,6 @@ export const ALL_STRATEGIES = [
 export type Strategy = (typeof ALL_STRATEGIES)[number];
 
 export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
-  default: 'Includes common plugins',
   'ascii-smuggling': 'Attempts to obfuscate malicious content using ASCII smuggling',
   base64: 'Attempts to obfuscate malicious content using Base64 encoding',
   basic: 'Single-shot, unoptimized attacks using raw prompts based on plugin description',
@@ -405,6 +397,7 @@ export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
   crescendo: 'Conversational attack strategy (high cost)',
   'cross-session-leak': 'Checks for information sharing between unrelated sessions',
   'debug-access': 'Attempts to access or use debugging commands',
+  default: 'Includes common plugins',
   'excessive-agency': 'Model taking excessive initiative or misunderstanding its capabilities',
   hallucination: 'Model generating false or misleading information',
   harmful: 'All harmful categories',
@@ -592,36 +585,6 @@ export const riskCategorySeverityMap: Record<Plugin, Severity> = {
 };
 
 export const riskCategories: Record<string, Plugin[]> = {
-  'Security Risk': [
-    'bola',
-    'bfla',
-    'debug-access',
-    'hijacking',
-    'pii',
-    'prompt-extraction',
-    'rbac',
-    'shell-injection',
-    'sql-injection',
-    'ssrf',
-    'indirect-prompt-injection',
-    'cross-session-leak',
-  ],
-  'Legal Risk': [
-    'contracts',
-    'harmful:child-exploitation',
-    'harmful:copyright-violations',
-    'harmful:cybercrime',
-    'harmful:hate',
-    'harmful:illegal-activities',
-    'harmful:illegal-drugs',
-    'harmful:intellectual-property',
-    'harmful:privacy',
-    'harmful:self-harm',
-    'harmful:sex-crime',
-    'harmful:sexual-content',
-    'harmful:specialized-advice',
-    'harmful:violent-crime',
-  ],
   'Brand Risk': [
     'policy',
     'competitors',
@@ -640,6 +603,36 @@ export const riskCategories: Record<string, Plugin[]> = {
     'overreliance',
     'politics',
     'religion',
+  ],
+  'Legal Risk': [
+    'contracts',
+    'harmful:child-exploitation',
+    'harmful:copyright-violations',
+    'harmful:cybercrime',
+    'harmful:hate',
+    'harmful:illegal-activities',
+    'harmful:illegal-drugs',
+    'harmful:intellectual-property',
+    'harmful:privacy',
+    'harmful:self-harm',
+    'harmful:sex-crime',
+    'harmful:sexual-content',
+    'harmful:specialized-advice',
+    'harmful:violent-crime',
+  ],
+  'Security Risk': [
+    'bola',
+    'bfla',
+    'debug-access',
+    'hijacking',
+    'pii',
+    'prompt-extraction',
+    'rbac',
+    'shell-injection',
+    'sql-injection',
+    'ssrf',
+    'indirect-prompt-injection',
+    'cross-session-leak',
   ],
 };
 
@@ -676,8 +669,8 @@ export const categoryAliases: Record<Plugin, string> = {
   'excessive-agency': 'ExcessiveAgency',
   hallucination: 'Hallucination',
   harmful: 'Harmful',
-  'harmful:child-exploitation': 'Child Exploitation',
   'harmful:chemical-biological-weapons': 'Chemical & Biological Weapons',
+  'harmful:child-exploitation': 'Child Exploitation',
   'harmful:copyright-violations': 'Copyright Violations - Copyrighted text',
   'harmful:cybercrime': 'Cybercrime & Unauthorized Intrusion - Hacking and Malware',
   'harmful:graphic-content': 'Graphic & age-restricted content',
@@ -817,15 +810,15 @@ export const strategyDescriptions: Record<Strategy, string> = {
 
 export const strategyDisplayNames: Record<Strategy, string> = {
   'ascii-smuggling': 'ASCII Smuggling',
-  'jailbreak:tree': 'Tree-based Optimization',
-  'math-prompt': 'Mathematical Encoding',
-  'prompt-injection': 'Prompt Injection',
   base64: 'Base64 Encoding',
   basic: 'Basic',
   crescendo: 'Multi-turn Crescendo',
   default: 'Basic',
   jailbreak: 'Single-shot Optimization',
+  'jailbreak:tree': 'Tree-based Optimization',
   leetspeak: 'Leetspeak',
+  'math-prompt': 'Mathematical Encoding',
   multilingual: 'Multilingual',
+  'prompt-injection': 'Prompt Injection',
   rot13: 'ROT13 Encoding',
 };

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -14,7 +14,7 @@ export const RedTeamGenerationResponse = z.object({
   result: z.union([z.string(), z.array(z.string())]),
 });
 
-export type RedTeamTask = 'purpose' | 'entities';
+export type RedTeamTask = 'entities' | 'purpose';
 
 /**
  * Fetches remote generation results for a given task and prompts.
@@ -33,7 +33,7 @@ export type RedTeamTask = 'purpose' | 'entities';
 export async function fetchRemoteGeneration(
   task: RedTeamTask,
   prompts: string[],
-): Promise<string | string[]> {
+): Promise<string[] | string> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
     'fetchRemoteGeneration should never be called when remote generation is disabled',

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -29,7 +29,7 @@ interface CrescendoConfig {
 }
 
 interface ConversationMessage {
-  role: 'user' | 'assistant' | 'system';
+  role: 'assistant' | 'system' | 'user';
   content: string;
 }
 
@@ -145,7 +145,7 @@ class CrescendoProvider implements ApiProvider {
   }: {
     prompt: Prompt;
     filters: NunjucksFilterMap | undefined;
-    vars: Record<string, string | object>;
+    vars: Record<string, object | string>;
     provider: ApiProvider;
   }) {
     logger.debug(
@@ -335,7 +335,7 @@ class CrescendoProvider implements ApiProvider {
   private async sendPrompt(
     attackPrompt: string,
     originalPrompt: Prompt,
-    vars: Record<string, string | object>,
+    vars: Record<string, object | string>,
     filters: NunjucksFilterMap | undefined,
     provider: ApiProvider,
     roundNum: number,

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -32,7 +32,7 @@ async function runRedteamConversation({
 }: {
   prompt: Prompt;
   filters: NunjucksFilterMap | undefined;
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   redteamProvider: ApiProvider;
   targetProvider: ApiProvider;
   injectVar: string;
@@ -46,7 +46,7 @@ async function runRedteamConversation({
 
   const judgeSystemPrompt = nunjucks.renderString(JUDGE_SYSTEM_PROMPT, { goal });
 
-  const redteamHistory: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+  const redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[] = [
     {
       role: 'system',
       content: redteamSystemPrompt,
@@ -182,7 +182,7 @@ class RedteamIterativeProvider implements ApiProvider {
   private readonly redteamProvider: RedteamFileConfig['provider'];
   private readonly injectVar: string;
 
-  constructor(readonly config: Record<string, string | object>) {
+  constructor(readonly config: Record<string, object | string>) {
     invariant(typeof config.injectVar === 'string', 'Expected injectVar to be set');
     this.injectVar = config.injectVar;
 

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -89,7 +89,7 @@ async function runRedteamConversation({
 }: {
   prompt: Prompt;
   filters: NunjucksFilterMap | undefined;
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   redteamProvider: ApiProvider;
   targetProvider: ApiProvider;
   injectVar: string;
@@ -103,7 +103,7 @@ async function runRedteamConversation({
   const onTopicSystemPrompt = nunjucks.renderString(ON_TOPIC_SYSTEM_PROMPT, { goal });
   const judgeSystemPrompt = nunjucks.renderString(JUDGE_SYSTEM_PROMPT, { goal });
 
-  const redteamHistory: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+  const redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[] = [
     {
       role: 'system',
       content: redteamSystemPrompt,
@@ -249,7 +249,7 @@ class RedteamIterativeProvider implements ApiProvider {
   private readonly redteamProvider: RedteamFileConfig['provider'];
   private readonly injectVar: string;
 
-  constructor(readonly config: Record<string, string | object>) {
+  constructor(readonly config: Record<string, object | string>) {
     invariant(typeof config.injectVar === 'string', 'Expected injectVar to be set');
     this.injectVar = config.injectVar;
 

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -129,7 +129,7 @@ export async function evaluateResponse(
  */
 export async function getNewPrompt(
   redteamProvider: ApiProvider,
-  redteamHistory: { role: 'user' | 'assistant' | 'system'; content: string }[],
+  redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[],
 ): Promise<{ improvement: string; prompt: string }> {
   const redteamBody = JSON.stringify(redteamHistory);
   const redteamResp = await redteamProvider.callApi(redteamBody, {
@@ -201,7 +201,7 @@ export function updateRedteamHistory(
   score: number,
   isOnTopic: boolean,
   containsPenalizedPhrase: boolean,
-): { role: 'user' | 'assistant' | 'system'; content: string } {
+): { role: 'assistant' | 'system' | 'user'; content: string } {
   return {
     role: 'user',
     content: `LANGUAGE MODEL OUTPUT: ${targetResponse}\n\nOBJECTIVE: ${goal}\n\nSCORE: ${score} ${
@@ -322,7 +322,7 @@ export async function runRedteamConversation({
 }: {
   prompt: Prompt;
   filters: NunjucksFilterMap | undefined;
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   redteamProvider: ApiProvider;
   targetProvider: ApiProvider;
   injectVar: string;
@@ -341,7 +341,7 @@ export async function runRedteamConversation({
     goal,
   );
 
-  const redteamHistory: { role: 'user' | 'assistant' | 'system'; content: string }[] = [
+  const redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[] = [
     {
       role: 'system',
       content: redteamSystemPrompt,
@@ -511,7 +511,7 @@ class RedteamIterativeTreeProvider implements ApiProvider {
    * @param config - The configuration object for the provider.
    * @param initializeProviders - A export function to initialize the OpenAI providers.
    */
-  constructor(readonly config: Record<string, string | object>) {
+  constructor(readonly config: Record<string, object | string>) {
     logger.debug(`RedteamIterativeTreeProvider config: ${JSON.stringify(config)}`);
     invariant(typeof config.injectVar === 'string', 'Expected injectVar to be set');
     this.injectVar = config.injectVar;

--- a/src/redteam/strategies/iterative.ts
+++ b/src/redteam/strategies/iterative.ts
@@ -3,7 +3,7 @@ import type { TestCase } from '../../types';
 export function addIterativeJailbreaks(
   testCases: TestCase[],
   injectVar: string,
-  strategy: 'iterative' | 'iterative:tree' = 'iterative',
+  strategy: 'iterative:tree' | 'iterative' = 'iterative',
 ): TestCase[] {
   const providerName =
     strategy === 'iterative' ? 'promptfoo:redteam:iterative' : 'promptfoo:redteam:iterative:tree';

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -16,10 +16,10 @@ type WithNumTests = {
 
 // Derived types
 export type RedteamPluginObject = ConfigurableObject & WithNumTests;
-export type RedteamPlugin = string | RedteamPluginObject;
+export type RedteamPlugin = RedteamPluginObject | string;
 
 export type RedteamStrategyObject = ConfigurableObject;
-export type RedteamStrategy = string | RedteamStrategyObject;
+export type RedteamStrategy = RedteamStrategyObject | string;
 
 // Shared redteam options
 type CommonOptions = {
@@ -27,7 +27,7 @@ type CommonOptions = {
   language?: string;
   numTests?: number;
   plugins?: RedteamPluginObject[];
-  provider?: string | ProviderOptions | ApiProvider;
+  provider?: ApiProvider | ProviderOptions | string;
   purpose?: string;
   strategies?: RedteamStrategy[];
   delay?: number;

--- a/src/table.ts
+++ b/src/table.ts
@@ -54,7 +54,7 @@ export function generateTable(
   return table;
 }
 
-export function wrapTable(rows: Record<string, string | number>[]) {
+export function wrapTable(rows: Record<string, number | string>[]) {
   if (rows.length === 0) {
     return 'No data to display';
   }

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -38,14 +38,14 @@ function parseJson(json: string): any | undefined {
 }
 
 export async function readVarsFiles(
-  pathOrGlobs: string | string[],
+  pathOrGlobs: string[] | string,
   basePath: string = '',
-): Promise<Record<string, string | string[] | object>> {
+): Promise<Record<string, string[] | object | string>> {
   if (typeof pathOrGlobs === 'string') {
     pathOrGlobs = [pathOrGlobs];
   }
 
-  const ret: Record<string, string | string[] | object> = {};
+  const ret: Record<string, string[] | object | string> = {};
   for (const pathOrGlob of pathOrGlobs) {
     const resolvedPath = path.resolve(basePath, pathOrGlob);
     const paths = globSync(resolvedPath, {
@@ -114,7 +114,7 @@ async function loadTestWithVars(
 }
 
 export async function readTest(
-  test: string | TestCaseWithVarsFile,
+  test: TestCaseWithVarsFile | string,
   basePath: string = '',
 ): Promise<TestCase> {
   let testCase: TestCase;
@@ -173,7 +173,7 @@ export async function readTests(
       return (await $RefParser.dereference(testCases)) as TestCase[];
     };
 
-    const ret: TestCase<Record<string, string | string[] | object>>[] = [];
+    const ret: TestCase<Record<string, string[] | object | string>>[] = [];
     if (testFiles.length < 1) {
       logger.error(`No test files found for path: ${loadTestsGlob}`);
       return ret;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -198,7 +198,7 @@ export interface EvaluateResult {
   promptId: string; // on the new version 2, this is stored per-result
   provider: Pick<ProviderOptions, 'id' | 'label'>;
   prompt: Prompt;
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   response?: ProviderResponse;
   error?: string | null;
   success: boolean;
@@ -423,8 +423,8 @@ export type Assertion = z.infer<typeof AssertionSchema>;
 
 export interface AssertionValueFunctionContext {
   prompt: string | undefined;
-  vars: Record<string, string | object>;
-  test: AtomicTestCase<Record<string, string | object>>;
+  vars: Record<string, object | string>;
+  test: AtomicTestCase<Record<string, object | string>>;
 }
 
 export type AssertionValueFunction = (
@@ -432,9 +432,9 @@ export type AssertionValueFunction = (
   context: AssertionValueFunctionContext,
 ) => AssertionValueFunctionResult | Promise<AssertionValueFunctionResult>;
 
-export type AssertionValue = string | string[] | object | AssertionValueFunction;
+export type AssertionValue = AssertionValueFunction | string[] | object | string;
 
-export type AssertionValueFunctionResult = boolean | number | GradingResult;
+export type AssertionValueFunctionResult = GradingResult | boolean | number;
 
 // Used when building prompts index from files.
 export const TestCasesWithMetadataPromptSchema = z.object({
@@ -509,7 +509,7 @@ export const TestCaseSchema = z.object({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type TestCase<vars = Record<string, string | string[] | object>> = z.infer<
+export type TestCase<vars = Record<string, string[] | object | string>> = z.infer<
   typeof TestCaseSchema
 >;
 
@@ -551,7 +551,7 @@ export const AtomicTestCaseSchema = TestCaseSchema.extend({
 }).strict();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type AtomicTestCase<vars = Record<string, string | object>> = z.infer<
+export type AtomicTestCase<vars = Record<string, object | string>> = z.infer<
   typeof AtomicTestCaseSchema
 >;
 
@@ -753,10 +753,10 @@ export interface EvalWithMetadata {
 }
 
 // node.js package interface
-export type EvaluateTestSuite = {
-  prompts: (string | object | PromptFunction)[];
+export type EvaluateTestSuite = Omit<TestSuiteConfig, 'prompts'> & {
+  prompts: (PromptFunction | object | string)[];
   writeLatestResults?: boolean;
-} & Omit<TestSuiteConfig, 'prompts'>;
+};
 
 export type EvaluateTestSuiteWithEvaluateOptions = EvaluateTestSuite & {
   evaluateOptions: EvaluateOptions;
@@ -770,7 +770,7 @@ export interface SharedResults {
 export interface ResultsFile {
   version: number;
   createdAt: string;
-  results: EvaluateSummaryV3 | EvaluateSummaryV2;
+  results: EvaluateSummaryV2 | EvaluateSummaryV3;
   config: Partial<UnifiedConfig>;
   author: string | null;
   prompts?: CompletedPrompt[];
@@ -792,17 +792,17 @@ export type ResultLightweightWithLabel = ResultLightweight & { label: string };
 // File exported as --output option
 export interface OutputFile {
   evalId: string | null;
-  results: EvaluateSummaryV3 | EvaluateSummaryV2;
+  results: EvaluateSummaryV2 | EvaluateSummaryV3;
   config: Partial<UnifiedConfig>;
   shareableUrl: string | null;
 }
 
 // Live eval job state
 export interface Job {
-  status: 'in-progress' | 'complete';
+  status: 'complete' | 'in-progress';
   progress: number;
   total: number;
-  result: EvaluateSummaryV3 | EvaluateSummaryV2 | null;
+  result: EvaluateSummaryV2 | EvaluateSummaryV3 | null;
 }
 
 // used for writing eval results

--- a/src/types/prompts.ts
+++ b/src/types/prompts.ts
@@ -11,7 +11,7 @@ export type PromptConfig = {
 };
 
 export type PromptFunctionContext = {
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   config: Record<string, any>;
   provider: {
     id: string;
@@ -20,9 +20,9 @@ export type PromptFunctionContext = {
 };
 
 export type PromptFunction = (context: {
-  vars: Record<string, string | any>;
+  vars: Record<string, any | string>;
   provider?: ApiProvider;
-}) => Promise<string | any>;
+}) => Promise<any | string>;
 
 export type Prompt = {
   id?: string;

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -7,9 +7,9 @@ export type ProviderLabel = string;
 export type ProviderFunction = ApiProvider['callApi'];
 export type ProviderOptionsMap = Record<ProviderId, ProviderOptions>;
 
-export type ProviderType = 'embedding' | 'classification' | 'text' | 'moderation';
+export type ProviderType = 'classification' | 'embedding' | 'moderation' | 'text';
 
-export type ProviderTypeMap = Partial<Record<ProviderType, string | ProviderOptions | ApiProvider>>;
+export type ProviderTypeMap = Partial<Record<ProviderType, ApiProvider | ProviderOptions | string>>;
 
 export interface ProviderModerationResponse {
   error?: string;
@@ -39,7 +39,7 @@ export interface CallApiContextParams {
   logger?: winston.Logger;
   originalProvider?: ApiProvider;
   prompt: Prompt;
-  vars: Record<string, string | object>;
+  vars: Record<string, object | string>;
   debug?: boolean;
 }
 
@@ -83,8 +83,8 @@ export interface ProviderResponse {
     redteamFinalPrompt?: string;
     [key: string]: any;
   };
-  raw?: string | any;
-  output?: string | any;
+  raw?: any | string;
+  output?: any | string;
   tokenUsage?: TokenUsage;
   isRefusal?: boolean;
 }

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -303,7 +303,7 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
 
   let prompts: UnifiedConfig['prompts'] = configsAreStringOrArray ? [] : {};
 
-  const makeAbsolute = (configPath: string, relativePath: string | Prompt) => {
+  const makeAbsolute = (configPath: string, relativePath: Prompt | string) => {
     if (typeof relativePath === 'string') {
       if (relativePath.startsWith('file://')) {
         relativePath =
@@ -324,8 +324,8 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
     }
   };
 
-  const seenPrompts = new Set<string | Prompt>();
-  const addSeenPrompt = (prompt: string | Prompt) => {
+  const seenPrompts = new Set<Prompt | string>();
+  const addSeenPrompt = (prompt: Prompt | string) => {
     if (typeof prompt === 'string') {
       seenPrompts.add(prompt);
     } else if (typeof prompt === 'object' && prompt.id) {
@@ -350,7 +350,7 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
               (typeof prompt.raw === 'string' || typeof prompt.label === 'string')),
           'Invalid prompt',
         );
-        addSeenPrompt(makeAbsolute(configPaths[idx], prompt as string | Prompt));
+        addSeenPrompt(makeAbsolute(configPaths[idx], prompt as Prompt | string));
       });
     } else {
       // Object format such as { 'prompts/prompt1.txt': 'foo', 'prompts/prompt2.txt': 'bar' }
@@ -433,7 +433,7 @@ export async function resolveConfigs(
     }
     const modelOutputs = JSON.parse(
       fs.readFileSync(path.join(process.cwd(), cmdObj.modelOutputs), 'utf8'),
-    ) as string[] | { output: string; tags?: string[] }[];
+    ) as { output: string; tags?: string[] }[] | string[];
     const assertions = await readAssertions(cmdObj.assertions);
     fileConfig.prompts = ['{{output}}'];
     fileConfig.providers = ['echo'];
@@ -462,7 +462,7 @@ export async function resolveConfigs(
   cliState.basePath = basePath;
 
   const defaultTestRaw = fileConfig.defaultTest || defaultConfig.defaultTest;
-  const config: Omit<UnifiedConfig, 'evaluateOptions' | 'commandLineOptions'> = {
+  const config: Omit<UnifiedConfig, 'commandLineOptions' | 'evaluateOptions'> = {
     tags: fileConfig.tags || defaultConfig.tags,
     description: cmdObj.description || fileConfig.description || defaultConfig.description,
     prompts: cmdObj.prompts || fileConfig.prompts || defaultConfig.prompts || [],

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -935,8 +935,8 @@ export function providerToIdentifier(provider: TestCase['provider']): string | u
 }
 
 export function varsMatch(
-  vars1: Record<string, string | string[] | object> | undefined,
-  vars2: Record<string, string | string[] | object> | undefined,
+  vars1: Record<string, string[] | object | string> | undefined,
+  vars2: Record<string, string[] | object | string> | undefined,
 ) {
   return deepEqual(vars1, vars2);
 }
@@ -949,7 +949,7 @@ export function resultIsForTestCase(result: EvaluateResult, testCase: TestCase):
   return varsMatch(testCase.vars, result.vars) && providersMatch;
 }
 
-export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | object>): T {
+export function renderVarsInObject<T>(obj: T, vars?: Record<string, object | string>): T {
   // Renders nunjucks template strings with context variables
   if (!vars || getEnvBool('PROMPTFOO_DISABLE_TEMPLATING')) {
     return obj;
@@ -1039,7 +1039,7 @@ export function parsePathOrGlob(
  *
  * @throws {Error} If the specified file does not exist.
  */
-export function maybeLoadFromExternalFile(filePath: string | object | Function | undefined | null) {
+export function maybeLoadFromExternalFile(filePath: Function | object | string | null | undefined) {
   if (Array.isArray(filePath)) {
     return filePath.map((path) => {
       const content: any = maybeLoadFromExternalFile(path);

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -125,11 +125,11 @@ async function getTransformFunction(
  */
 export async function transform(
   codeOrFilepath: string,
-  transformInput: string | object | undefined,
+  transformInput: object | string | undefined,
   context: TransformContext,
   validateReturn: boolean = true,
   inputType: TransformInputType = TransformInputType.OUTPUT,
-): Promise<string | object | undefined> {
+): Promise<object | string | undefined> {
   const postprocessFn = await getTransformFunction(codeOrFilepath, inputType);
 
   const ret = await Promise.resolve(postprocessFn(transformInput, context));

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -168,7 +168,7 @@ export const RedteamConfigSchema = z
     };
 
     const expandCollection = (
-      collection: string[] | ReadonlySet<Plugin>,
+      collection: ReadonlySet<Plugin> | string[],
       config: any,
       numTests: number | undefined,
     ) => {
@@ -191,7 +191,7 @@ export const RedteamConfigSchema = z
       }
     };
 
-    const handlePlugin = (plugin: string | RedteamPluginObject) => {
+    const handlePlugin = (plugin: RedteamPluginObject | string) => {
       const pluginObj =
         typeof plugin === 'string'
           ? { id: plugin, numTests: data.numTests, config: undefined }

--- a/test/assertions/index.test.ts
+++ b/test/assertions/index.test.ts
@@ -2616,7 +2616,7 @@ describe('runAssertion', () => {
     'should handle when the file:// assertion with .py file returns a %s',
     async (type, pythonOutput, expectedPass, expectedReason) => {
       const output = 'Expected output';
-      jest.mocked(runPython).mockResolvedValueOnce(pythonOutput as string | object);
+      jest.mocked(runPython).mockResolvedValueOnce(pythonOutput as object | string);
 
       const fileAssertion: Assertion = {
         type: 'python',

--- a/test/prompts/index.test.ts
+++ b/test/prompts/index.test.ts
@@ -369,7 +369,7 @@ describe('readPrompts', () => {
   it('should read a .js file with named function', async () => {
     const promptPath = 'prompt.js:functionName';
     const mockFunction = (context: {
-      vars: Record<string, string | object>;
+      vars: Record<string, object | string>;
       provider?: ApiProvider;
     }) => 'dummy prompt result';
 
@@ -387,7 +387,7 @@ describe('readPrompts', () => {
     ]);
 
     const promptFunction = result[0].function as unknown as (context: {
-      vars: Record<string, string | object>;
+      vars: Record<string, object | string>;
       provider?: ApiProvider;
     }) => string;
     expect(promptFunction({ vars: {}, provider: { id: () => 'foo' } as ApiProvider })).toBe(

--- a/test/prompts/processors/python.utils.test.ts
+++ b/test/prompts/processors/python.utils.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../src/python/pythonUtils');
 
 describe('pythonPromptFunction', () => {
   interface PythonContext {
-    vars: Record<string, string | object>;
+    vars: Record<string, object | string>;
     provider: ApiProvider;
   }
 

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -880,12 +880,12 @@ describe('call provider apis', () => {
             args: readonly string[] | null | undefined,
             options: child_process.ExecFileOptions | null | undefined,
             callback?:
-              | null
               | ((
                   error: child_process.ExecFileException | null,
-                  stdout: string | Buffer,
-                  stderr: string | Buffer,
-                ) => void),
+                  stdout: Buffer | string,
+                  stderr: Buffer | string,
+                ) => void)
+              | null,
           ) => {
             process.nextTick(
               () => callback && callback(null, Buffer.from(mockResponse), Buffer.from('')),

--- a/test/providers/scriptCompletion.test.ts
+++ b/test/providers/scriptCompletion.test.ts
@@ -108,7 +108,7 @@ describe('ScriptCompletionProvider', () => {
   it('should handle UTF-8 characters in script output', async () => {
     const utf8Output = 'Hello, 世界!';
     jest.mocked(execFile).mockImplementation((cmd, args, options, callback) => {
-      (callback as (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void)(
+      (callback as (error: Error | null, stdout: Buffer | string, stderr: Buffer | string) => void)(
         null,
         Buffer.from(utf8Output),
         '',

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -50,7 +50,7 @@ describe('synthesize', () => {
     jest.mocked(extractEntities).mockResolvedValue(['entity1', 'entity2']);
     jest.mocked(extractSystemPurpose).mockResolvedValue('Test purpose');
     jest.mocked(loadApiProvider).mockResolvedValue(mockProvider);
-    jest.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+    jest.spyOn(process, 'exit').mockImplementation((code?: number | string | null | undefined) => {
       throw new Error(`Process.exit called with code ${code}`);
     });
     jest.mocked(validateStrategies).mockImplementation(() => {});

--- a/test/redteam/providers/iterativeTree.test.ts
+++ b/test/redteam/providers/iterativeTree.test.ts
@@ -110,7 +110,7 @@ describe('RedteamIterativeProvider', () => {
       };
       mockRedteamProvider.callApi.mockResolvedValue({ output: JSON.stringify(mockResponse) });
 
-      const redteamHistory: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
+      const redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[] = [
         { role: 'system', content: 'System prompt' },
         { role: 'user', content: 'User message' },
       ];
@@ -133,7 +133,7 @@ describe('RedteamIterativeProvider', () => {
     it('should throw an error for invalid API response', async () => {
       mockRedteamProvider.callApi.mockResolvedValue({ output: 'invalid json' });
 
-      const redteamHistory: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
+      const redteamHistory: { role: 'assistant' | 'system' | 'user'; content: string }[] = [
         { role: 'system', content: 'System prompt' },
       ];
       // eslint-disable-next-line jest/require-to-throw-message

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -117,8 +117,8 @@ describe('combineConfigs', () => {
       .mockImplementation(
         (
           path: fs.PathOrFileDescriptor,
-          options?: fs.ObjectEncodingOptions | BufferEncoding | null,
-        ): string | Buffer => {
+          options?: BufferEncoding | fs.ObjectEncodingOptions | null,
+        ): Buffer | string => {
           if (typeof path === 'string' && path === 'config1.json') {
             return JSON.stringify(config1);
           } else if (typeof path === 'string' && path === 'config2.json') {
@@ -302,8 +302,8 @@ describe('combineConfigs', () => {
       .mockImplementation(
         (
           path: fs.PathOrFileDescriptor,
-          options?: fs.ObjectEncodingOptions | BufferEncoding | null,
-        ): string | Buffer => {
+          options?: BufferEncoding | fs.ObjectEncodingOptions | null,
+        ): Buffer | string => {
           if (typeof path === 'string' && path === 'config1.json') {
             return JSON.stringify({
               description: 'test1',
@@ -337,8 +337,8 @@ describe('combineConfigs', () => {
       .mockImplementation(
         (
           path: fs.PathOrFileDescriptor,
-          options?: fs.ObjectEncodingOptions | BufferEncoding | null,
-        ): string | Buffer => {
+          options?: BufferEncoding | fs.ObjectEncodingOptions | null,
+        ): Buffer | string => {
           if (typeof path === 'string' && path === 'config1.json') {
             return JSON.stringify({
               description: 'test1',


### PR DESCRIPTION
- Add sort-keys rule for constants.ts files with ascending order, case-sensitive, natural sorting
- Add @typescript-eslint/sort-type-constituents rule for consistent type sorting
- Fix type ordering across multiple files to comply with new rules
- Reorder union types, object keys, and enums alphabetically
