### PR TITLE
fix: handle basic auth credentials in fetch requests

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -28,6 +28,7 @@ import type {
   RunEvalOptions,
   TestSuite,
 } from './types';
+import { sleep } from './util/time';
 import { transform, TransformInputType } from './util/transform';
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
@@ -229,13 +230,13 @@ class Evaluator {
       });
 
       if (!response.cached) {
-        let sleep = provider.delay ?? delay;
-        if (!sleep) {
-          sleep = getEnvInt('PROMPTFOO_DELAY_MS', 0);
+        let sleepMs = provider.delay ?? delay;
+        if (!sleepMs) {
+          sleepMs = getEnvInt('PROMPTFOO_DELAY_MS', 0);
         }
-        if (sleep) {
-          logger.debug(`Sleeping for ${sleep}ms`);
-          await new Promise((resolve) => setTimeout(resolve, sleep));
+        if (sleepMs) {
+          logger.debug(`Sleeping for ${sleepMs}ms`);
+          await sleep(sleepMs);
         }
       }
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,6 +2,7 @@ import { ProxyAgent } from 'proxy-agent';
 import invariant from 'tiny-invariant';
 import { getEnvInt, getEnvBool } from './envars';
 import logger from './logger';
+import { sleep } from './util/time';
 
 export async function fetchWithProxy(
   url: RequestInfo,
@@ -108,7 +109,7 @@ export async function handleRateLimit(response: Response): Promise<void> {
   }
 
   logger.debug(`Rate limited, waiting ${waitTime}ms before retry`);
-  await new Promise((resolve) => setTimeout(resolve, waitTime));
+  await sleep(waitTime);
 }
 
 export async function fetchWithRetries(
@@ -141,7 +142,7 @@ export async function fetchWithRetries(
     } catch (error) {
       lastError = error;
       const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());
-      await new Promise((resolve) => setTimeout(resolve, waitTime));
+      await sleep(waitTime);
     }
   }
   throw new Error(`Request failed after ${retries} retries: ${(lastError as Error).message}`);

--- a/src/providers/azureopenai.ts
+++ b/src/providers/azureopenai.ts
@@ -18,6 +18,7 @@ import type {
   ProviderResponse,
 } from '../types';
 import { maybeLoadFromExternalFile, renderVarsInObject } from '../util';
+import { sleep } from '../util/time';
 import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase, calculateCost } from './shared';
 
 interface AzureOpenAiCompletionOptions {
@@ -728,7 +729,7 @@ export class AzureOpenAiAssistantProvider extends AzureOpenAiGenericProvider {
         run = await this.assistantsClient.submitToolOutputsToRun(run.threadId, run.id, toolOutputs);
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(1000);
 
       logger.debug(`Calling Azure API, getting thread run ${run.id} status`);
       run = await this.assistantsClient.getRun(run.threadId, run.id);

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -18,6 +18,7 @@ import type {
 import { renderVarsInObject } from '../util';
 import { maybeLoadFromExternalFile } from '../util';
 import { safeJsonStringify } from '../util/json';
+import { sleep } from '../util/time';
 import type { OpenAiFunction, OpenAiTool } from './openaiUtil';
 import { calculateCost, REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase } from './shared';
 
@@ -823,7 +824,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
         continue;
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(1000);
 
       logger.debug(`Calling OpenAI API, getting thread run ${run.id} status`);
       try {

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -15,6 +15,7 @@ import type { AtomicTestCase, GradingResult } from '../../types';
 import { maybeLoadFromExternalFile } from '../../util';
 import { retryWithDeduplication, sampleArray } from '../../util/generation';
 import { getNunjucksEngine } from '../../util/templates';
+import { sleep } from '../../util/time';
 import { loadRedteamProvider } from '../providers/shared';
 import { removePrefix } from '../util';
 
@@ -82,7 +83,7 @@ export abstract class RedteamPluginBase {
       const { output: generatedPrompts, error } = await this.provider.callApi(finalTemplate);
       if (delayMs > 0) {
         logger.debug(`Delaying for ${delayMs}ms`);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        await sleep(delayMs);
       }
 
       if (error) {

--- a/src/redteam/plugins/harmful.ts
+++ b/src/redteam/plugins/harmful.ts
@@ -5,6 +5,7 @@ import { PromptfooHarmfulCompletionProvider } from '../../providers/promptfoo';
 import type { ApiProvider, Assertion, TestCase } from '../../types';
 import type { AtomicTestCase, GradingResult } from '../../types';
 import { retryWithDeduplication, sampleArray } from '../../util/generation';
+import { sleep } from '../../util/time';
 import {
   HARM_PLUGINS,
   LLAMA_GUARD_ENABLED_CATEGORIES,
@@ -254,7 +255,7 @@ async function generateTestsForCategory(
       results.push(result);
       if (delayMs > 0) {
         logger.debug(`Delaying for ${delayMs}ms`);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        await sleep(delayMs);
       }
     }
     return results.map((result) => createTestCase(injectVar, result.output || '', harmCategory));

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -1,3 +1,5 @@
 export function getCurrentTimestamp() {
   return Math.floor(new Date().getTime() / 1000);
 }
+
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -10,7 +10,6 @@ import {
 import logger from '../src/logger';
 import { sleep } from '../src/util/time';
 
-// Mock all time-based functions
 jest.mock('../src/util/time', () => ({
   sleep: jest.fn().mockResolvedValue(undefined),
 }));

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,0 +1,112 @@
+import { ProxyAgent } from 'proxy-agent';
+import { fetchWithProxy, fetchWithTimeout } from '../src/fetch';
+import logger from '../src/logger';
+
+jest.mock('proxy-agent');
+jest.mock('../src/logger');
+jest.mock('../src/envars', () => ({
+  ...jest.requireActual('../src/envars'),
+  getEnvInt: jest.fn().mockReturnValue(100),
+  getEnvBool: jest.fn().mockReturnValue(false),
+}));
+
+function createMockResponse(options: Partial<Response> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    redirected: false,
+    type: 'basic',
+    url: 'https://example.com',
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(''),
+    blob: () => Promise.resolve(new Blob()),
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    formData: () => Promise.resolve(new FormData()),
+    bodyUsed: false,
+    body: null,
+    clone() {
+      return createMockResponse(this);
+    },
+    ...options,
+  };
+}
+
+describe('fetchWithProxy', () => {
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockImplementation();
+    jest.mocked(ProxyAgent).mockClear();
+  });
+
+  it('should handle URLs with basic auth credentials', async () => {
+    const url = 'https://username:password@example.com/api';
+    const options = { headers: { 'Content-Type': 'application/json' } };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        },
+      }),
+    );
+  });
+
+  it('should handle URLs without auth credentials', async () => {
+    const url = 'https://example.com/api';
+    const options = { headers: { 'Content-Type': 'application/json' } };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+  });
+
+  it('should handle invalid URLs gracefully', async () => {
+    const invalidUrl = 'not-a-url';
+    await fetchWithProxy(invalidUrl);
+
+    expect(logger.debug).toHaveBeenCalledWith('URL parsing failed in fetchWithProxy');
+    expect(global.fetch).toHaveBeenCalledWith(invalidUrl, expect.any(Object));
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'fetch').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should resolve when fetch completes before timeout', async () => {
+    const mockResponse = createMockResponse({ ok: true });
+    jest.mocked(global.fetch).mockImplementationOnce(() => Promise.resolve(mockResponse));
+
+    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
+    await expect(fetchPromise).resolves.toBe(mockResponse);
+  });
+
+  it('should reject when request times out', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 6000)));
+
+    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
+    jest.advanceTimersByTime(5000);
+
+    await expect(fetchPromise).rejects.toThrow('Request timed out after 5000 ms');
+  });
+});

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -56,6 +56,10 @@ describe('fetchWithProxy', () => {
     jest.mocked(ProxyAgent).mockClear();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should handle URLs with basic auth credentials', async () => {
     const url = 'https://username:password@example.com/api';
     const options = { headers: { 'Content-Type': 'application/json' } };
@@ -153,20 +157,6 @@ describe('fetchWithProxy', () => {
       expect.objectContaining({
         headers: {
           Authorization: 'Basic OnBhc3N3b3Jk',
-        },
-      }),
-    );
-  });
-
-  it('should handle URLs with empty credentials', async () => {
-    const url = 'https://:@example.com/api';
-    await fetchWithProxy(url);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Basic Og==', // Base64 encoded ':' (empty username and password)
         },
       }),
     );

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -158,6 +158,57 @@ describe('fetchWithProxy', () => {
       }),
     );
   });
+
+  it('should handle URLs with empty credentials', async () => {
+    const url = 'https://:@example.com/api';
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Basic Og==', // Base64 encoded ':' (empty username and password)
+        },
+      }),
+    );
+  });
+
+  it('should handle URLs with only username', async () => {
+    const url = 'https://username@example.com/api';
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Basic dXNlcm5hbWU6', // Base64 encoded 'username:'
+        },
+      }),
+    );
+  });
+
+  it('should preserve existing headers when adding Authorization from URL credentials', async () => {
+    const url = 'https://username:password@example.com/api';
+    const options = {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'value',
+      },
+    };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Custom-Header': 'value',
+          Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        },
+      }),
+    );
+  });
 });
 
 describe('fetchWithTimeout', () => {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -98,7 +98,7 @@ describe('fetchWithProxy', () => {
     await fetchWithProxy(invalidUrl);
 
     expect(logger.debug).toHaveBeenCalledWith(
-      'URL parsing failed in fetchWithProxy: TypeError: Invalid URL',
+      expect.stringMatching(/URL parsing failed in fetchWithProxy: TypeError/),
     );
     expect(global.fetch).toHaveBeenCalledWith(invalidUrl, expect.any(Object));
   });


### PR DESCRIPTION
Now that we use native fetch API (since #1968), URLs with embedded credentials
are rejected. This change properly handles basic auth by:

- Extracting credentials from URLs before making requests
- Converting to Authorization header format
- Removing credentials from URL to comply with fetch spec

- In addition, it increases test coverage of fetch.ts to 100%

Relates to #2012

CC @tan-z-tan