### PR TITLE
chore: improve ui for plugin configs

### DIFF
--- a/src/app/src/pages/redteam/setup/components/PluginConfigDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginConfigDialog.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import type { Plugin } from '@promptfoo/redteam/constants';
+import type { LocalPluginConfig } from '../types';
+
+interface PluginConfigDialogProps {
+  open: boolean;
+  plugin: Plugin | null;
+  config: LocalPluginConfig[string];
+  onClose: () => void;
+  onSave: (plugin: Plugin, config: LocalPluginConfig[string]) => void;
+}
+
+export default function PluginConfigDialog({
+  open,
+  plugin,
+  config,
+  onClose,
+  onSave,
+}: PluginConfigDialogProps) {
+  const [localConfig, setLocalConfig] = useState<LocalPluginConfig[string]>(config || {});
+
+  const handleArrayInputChange = (key: string, index: number, value: string) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      [key]: [...((prev[key] as string[]) || [])].map((item, i) => (i === index ? value : item)),
+    }));
+  };
+
+  const addArrayItem = (key: string) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      [key]: [...((prev[key] as string[]) || []), ''],
+    }));
+  };
+
+  const removeArrayItem = (key: string, index: number) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      [key]: ((prev[key] as string[]) || []).filter((_, i) => i !== index),
+    }));
+  };
+
+  const renderConfigInputs = () => {
+    if (!plugin) {
+      return null;
+    }
+
+    switch (plugin) {
+      case 'policy':
+      case 'prompt-extraction':
+        const key = plugin === 'policy' ? 'policy' : 'systemPrompt';
+        return (
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label={plugin === 'policy' ? 'Policy' : 'System Prompt'}
+            variant="outlined"
+            margin="normal"
+            value={localConfig[key] || ''}
+            onChange={(e) => setLocalConfig({ ...localConfig, [key]: e.target.value })}
+          />
+        );
+      case 'bfla':
+      case 'bola':
+      case 'ssrf':
+        const arrayKey =
+          plugin === 'bfla'
+            ? 'targetIdentifiers'
+            : plugin === 'bola'
+              ? 'targetSystems'
+              : 'targetUrls';
+        return (
+          <>
+            {((localConfig[arrayKey] as string[]) || ['']).map((item: string, index: number) => (
+              <Box key={index} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                <TextField
+                  fullWidth
+                  label={`${arrayKey} ${index + 1}`}
+                  variant="outlined"
+                  value={item}
+                  onChange={(e) => handleArrayInputChange(arrayKey, index, e.target.value)}
+                  sx={{ mr: 1 }}
+                />
+                <IconButton onClick={() => removeArrayItem(arrayKey, index)} size="small">
+                  <RemoveIcon />
+                </IconButton>
+              </Box>
+            ))}
+            <Button
+              startIcon={<AddIcon />}
+              onClick={() => addArrayItem(arrayKey)}
+              variant="outlined"
+              size="small"
+              sx={{ mt: 1 }}
+            >
+              New
+            </Button>
+          </>
+        );
+      case 'indirect-prompt-injection':
+        return (
+          <TextField
+            fullWidth
+            label="Indirect Injection Variable"
+            variant="outlined"
+            margin="normal"
+            value={localConfig.indirectInjectionVar || ''}
+            onChange={(e) =>
+              setLocalConfig({ ...localConfig, indirectInjectionVar: e.target.value })
+            }
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Configure {plugin}</DialogTitle>
+      <DialogContent>{renderConfigInputs()}</DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={() => {
+            if (plugin) {
+              onSave(plugin, localConfig);
+              onClose();
+            }
+          }}
+          variant="contained"
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -1,11 +1,10 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import AddIcon from '@mui/icons-material/Add';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
-import RemoveIcon from '@mui/icons-material/Remove';
 import SearchIcon from '@mui/icons-material/Search';
+import SettingsIcon from '@mui/icons-material/Settings';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -14,7 +13,6 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Checkbox from '@mui/material/Checkbox';
-import Collapse from '@mui/material/Collapse';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
@@ -41,6 +39,7 @@ import {
 } from '@promptfoo/redteam/constants';
 import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import type { LocalPluginConfig } from '../types';
+import PluginConfigDialog from './PluginConfigDialog';
 import PresetCard from './PresetCard';
 
 interface PluginsProps {
@@ -56,6 +55,7 @@ const ErrorFallback = ({ error }: { error: Error }) => (
 );
 
 const PLUGINS_REQUIRING_CONFIG = ['policy', 'prompt-extraction', 'indirect-prompt-injection'];
+const PLUGINS_SUPPORTING_CONFIG = ['bfla', 'bola', 'ssrf', ...PLUGINS_REQUIRING_CONFIG];
 
 export default function Plugins({ onNext, onBack }: PluginsProps) {
   const { config, updateConfig } = useRedTeamConfig();
@@ -65,6 +65,8 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
   });
   const [searchTerm, setSearchTerm] = useState('');
   const [pluginConfig, setPluginConfig] = useState<LocalPluginConfig>({});
+  const [configDialogOpen, setConfigDialogOpen] = useState(false);
+  const [selectedConfigPlugin, setSelectedConfigPlugin] = useState<Plugin | null>(null);
 
   useEffect(() => {
     updateConfig('plugins', Array.from(selectedPlugins));
@@ -86,6 +88,11 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
           ...prevConfig,
           [plugin]: {},
         }));
+        // Automatically open config dialog for plugins that require config
+        if (PLUGINS_REQUIRING_CONFIG.includes(plugin)) {
+          setSelectedConfigPlugin(plugin);
+          setConfigDialogOpen(true);
+        }
       }
       return newSet;
     });
@@ -190,121 +197,9 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
     return true;
   }, [selectedPlugins, pluginConfig]);
 
-  const handleArrayInputChange = useCallback(
-    (plugin: string, key: string, index: number, value: string) => {
-      setPluginConfig((prevConfig) => {
-        const pluginConfig = prevConfig[plugin] || {};
-        const newArray = [...((pluginConfig[key] as string[]) || [])];
-        newArray[index] = value;
-        return {
-          ...prevConfig,
-          [plugin]: {
-            ...pluginConfig,
-            [key]: newArray,
-          },
-        };
-      });
-    },
-    [],
-  );
-
-  const addArrayItem = useCallback((plugin: string, key: string) => {
-    setPluginConfig((prevConfig) => {
-      const pluginConfig = prevConfig[plugin] || {};
-      return {
-        ...prevConfig,
-        [plugin]: {
-          ...pluginConfig,
-          [key]: [...((pluginConfig[key] as string[]) || []), ''],
-        },
-      };
-    });
-  }, []);
-
-  const removeArrayItem = useCallback((plugin: string, key: string, index: number) => {
-    setPluginConfig((prevConfig) => {
-      const pluginConfig = prevConfig[plugin] || {};
-      const currentArray = pluginConfig[key] as string[] | undefined;
-      return {
-        ...prevConfig,
-        [plugin]: {
-          ...pluginConfig,
-          [key]: currentArray?.filter((_, i) => i !== index) || [],
-        },
-      };
-    });
-  }, []);
-
-  const renderPluginConfig = (plugin: Plugin) => {
-    const config = pluginConfig[plugin] || {};
-
-    switch (plugin) {
-      case 'policy':
-      case 'prompt-extraction':
-        const key = plugin === 'policy' ? 'policy' : 'systemPrompt';
-        return (
-          <TextField
-            fullWidth
-            multiline
-            rows={4}
-            label={plugin === 'policy' ? 'Policy' : 'System Prompt'}
-            variant="outlined"
-            margin="normal"
-            value={config[key] || ''}
-            onChange={(e) => updatePluginConfig(plugin, { [key]: e.target.value })}
-          />
-        );
-      case 'bfla':
-      case 'bola':
-      case 'ssrf':
-        const arrayKey =
-          plugin === 'bfla'
-            ? 'targetIdentifiers'
-            : plugin === 'bola'
-              ? 'targetSystems'
-              : 'targetUrls';
-        return (
-          <>
-            {((config[arrayKey] as string[]) || ['']).map((item: string, index: number) => (
-              <Box key={index} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-                <TextField
-                  fullWidth
-                  label={`${arrayKey} ${index + 1}`}
-                  variant="outlined"
-                  value={item}
-                  onChange={(e) => handleArrayInputChange(plugin, arrayKey, index, e.target.value)}
-                  sx={{ mr: 1 }}
-                />
-                <IconButton onClick={() => removeArrayItem(plugin, arrayKey, index)} size="small">
-                  <RemoveIcon />
-                </IconButton>
-              </Box>
-            ))}
-            <Button
-              startIcon={<AddIcon />}
-              onClick={() => addArrayItem(plugin, arrayKey)}
-              variant="outlined"
-              size="small"
-              sx={{ mt: 1 }}
-            >
-              Add {arrayKey}
-            </Button>
-          </>
-        );
-      case 'indirect-prompt-injection':
-        return (
-          <TextField
-            fullWidth
-            label="Indirect Injection Variable"
-            variant="outlined"
-            margin="normal"
-            value={config.indirectInjectionVar || ''}
-            onChange={(e) => updatePluginConfig(plugin, { indirectInjectionVar: e.target.value })}
-          />
-        );
-      default:
-        return null;
-    }
+  const handleConfigClick = (plugin: Plugin) => {
+    setSelectedConfigPlugin(plugin);
+    setConfigDialogOpen(true);
   };
 
   const renderPluginCategory = (category: string, plugins: readonly Plugin[]) => {
@@ -324,29 +219,55 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
             {pluginsToShow.map((plugin) => (
               <Grid item xs={12} sm={6} md={4} key={plugin}>
                 <Paper elevation={1} sx={{ p: 2, height: '100%' }}>
-                  <FormControlLabel
-                    sx={{ width: '100%' }}
-                    control={
-                      <Checkbox
-                        checked={selectedPlugins.has(plugin)}
-                        onChange={() => handlePluginToggle(plugin)}
-                        color="primary"
+                  <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1 }}>
+                      <FormControlLabel
+                        sx={{ flex: 1 }}
+                        control={
+                          <Checkbox
+                            checked={selectedPlugins.has(plugin)}
+                            onChange={() => handlePluginToggle(plugin)}
+                            color="primary"
+                          />
+                        }
+                        label={
+                          <Box>
+                            <Typography variant="subtitle1">
+                              {displayNameOverrides[plugin as keyof typeof displayNameOverrides] ||
+                                categoryAliases[plugin as keyof typeof categoryAliases] ||
+                                plugin}
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              {
+                                subCategoryDescriptions[
+                                  plugin as keyof typeof subCategoryDescriptions
+                                ]
+                              }
+                            </Typography>
+                          </Box>
+                        }
                       />
-                    }
-                    label={
-                      <Box>
-                        <Typography variant="subtitle1">
-                          {displayNameOverrides[plugin as keyof typeof displayNameOverrides] ||
-                            categoryAliases[plugin as keyof typeof categoryAliases] ||
-                            plugin}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          {subCategoryDescriptions[plugin as keyof typeof subCategoryDescriptions]}
-                        </Typography>
-                      </Box>
-                    }
-                  />
-                  <Collapse in={selectedPlugins.has(plugin)}>{renderPluginConfig(plugin)}</Collapse>
+                      {selectedPlugins.has(plugin) &&
+                        PLUGINS_SUPPORTING_CONFIG.includes(plugin) && (
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleConfigClick(plugin);
+                            }}
+                            sx={{
+                              ml: 1,
+                              color: 'action.active',
+                              '&:hover': {
+                                color: 'primary.main',
+                              },
+                            }}
+                          >
+                            <SettingsIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                    </Box>
+                  </Box>
                 </Paper>
               </Grid>
             ))}
@@ -450,6 +371,19 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
             Next
           </Button>
         </Box>
+
+        <PluginConfigDialog
+          open={configDialogOpen}
+          plugin={selectedConfigPlugin}
+          config={selectedConfigPlugin ? pluginConfig[selectedConfigPlugin] || {} : {}}
+          onClose={() => {
+            setConfigDialogOpen(false);
+            setSelectedConfigPlugin(null);
+          }}
+          onSave={(plugin, newConfig) => {
+            updatePluginConfig(plugin, newConfig);
+          }}
+        />
       </Box>
     </ErrorBoundary>
   );

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -202,6 +202,27 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
     setConfigDialogOpen(true);
   };
 
+  const isPluginConfigured = (plugin: Plugin) => {
+    if (!PLUGINS_REQUIRING_CONFIG.includes(plugin)) {
+      return true;
+    }
+    const config = pluginConfig[plugin];
+    if (!config || Object.keys(config).length === 0) {
+      return false;
+    }
+
+    for (const key in config) {
+      const value = config[key];
+      if (Array.isArray(value) && value.length === 0) {
+        return false;
+      }
+      if (typeof value === 'string' && value.trim() === '') {
+        return false;
+      }
+    }
+    return true;
+  };
+
   const renderPluginCategory = (category: string, plugins: readonly Plugin[]) => {
     const pluginsToShow = plugins.filter((plugin) => filteredPlugins.includes(plugin));
     if (pluginsToShow.length === 0) {
@@ -218,7 +239,19 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
           <Grid container spacing={2}>
             {pluginsToShow.map((plugin) => (
               <Grid item xs={12} sm={6} md={4} key={plugin}>
-                <Paper elevation={1} sx={{ p: 2, height: '100%' }}>
+                <Paper
+                  elevation={1}
+                  sx={{
+                    p: 2,
+                    height: '100%',
+                    border: (theme) =>
+                      selectedPlugins.has(plugin) &&
+                      PLUGINS_REQUIRING_CONFIG.includes(plugin) &&
+                      !isPluginConfigured(plugin)
+                        ? `1px solid ${theme.palette.error.main}`
+                        : 'none',
+                  }}
+                >
                   <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                     <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1 }}>
                       <FormControlLabel
@@ -244,6 +277,17 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
                                 ]
                               }
                             </Typography>
+                            {selectedPlugins.has(plugin) &&
+                              PLUGINS_REQUIRING_CONFIG.includes(plugin) &&
+                              !isPluginConfigured(plugin) && (
+                                <Typography
+                                  variant="caption"
+                                  color="error"
+                                  sx={{ display: 'block', mt: 0.5 }}
+                                >
+                                  Configuration required
+                                </Typography>
+                              )}
                           </Box>
                         }
                       />
@@ -257,7 +301,11 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
                             }}
                             sx={{
                               ml: 1,
-                              color: 'action.active',
+                              color: (theme) =>
+                                PLUGINS_REQUIRING_CONFIG.includes(plugin) &&
+                                !isPluginConfigured(plugin)
+                                  ? theme.palette.error.main
+                                  : 'action.active',
                               '&:hover': {
                                 color: 'primary.main',
                               },


### PR DESCRIPTION
The changes make the plugin selection interface a bit cleaner while maintaining all functionality.

- Moved plugin configuration from inline forms to a dedicated dialog
- Added settings icon to plugins that support configuration
- Auto-opens configuration dialog for plugins that require setup
- Improved array input handling and fixed bug where clicking 'Add' did nothing 

---

<img width="785" alt="image" src="https://github.com/user-attachments/assets/4d8a2da4-fc2a-4e55-8a4d-7082eac15f26">

---

<img width="850" alt="image" src="https://github.com/user-attachments/assets/b2019196-3bed-4ed9-8d38-548a930b2fbf">

---

<img width="559" alt="image" src="https://github.com/user-attachments/assets/5a441bfe-ee93-4635-b350-bf1b369d7422">
