### PR TITLE
fix(providers): adjust bedrock anthropic default temperature

### DIFF
--- a/examples/claude-vision/README.md
+++ b/examples/claude-vision/README.md
@@ -1,4 +1,4 @@
-Getting Started with claude3 via Anthropic and/or AWS Bedrock
+Getting Started with claude 3.5 sonnet via Anthropic and/or AWS Bedrock
 
 To get started, set your environment variables:
 

--- a/examples/claude-vision/promptfooconfig.yaml
+++ b/examples/claude-vision/promptfooconfig.yaml
@@ -3,7 +3,8 @@ prompts:
   - file://prompt.json
 providers:
   - anthropic:messages:claude-3-haiku-20240307
-  - bedrock:anthropic.claude-3-haiku-20240307-v1:0
+  - id: bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
+  - id: anthropic:messages:claude-3-5-sonnet-20241022
 
 tests:
   - assert:

--- a/examples/claude-vision/promptfooconfig.yaml
+++ b/examples/claude-vision/promptfooconfig.yaml
@@ -3,8 +3,8 @@ prompts:
   - file://prompt.json
 providers:
   - anthropic:messages:claude-3-haiku-20240307
-  - id: bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
-  - id: anthropic:messages:claude-3-5-sonnet-20241022
+  - anthropic:messages:claude-3-5-sonnet-20240620
+  - bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
 
 tests:
   - assert:

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -315,7 +315,7 @@ export const getLlamaModelHandler = (version: LlamaVersion) => {
         'temperature',
         config?.temperature,
         getEnvFloat('AWS_BEDROCK_TEMPERATURE'),
-        0.01,
+        0,
       );
       addConfigParam(params, 'top_p', config?.top_p, getEnvFloat('AWS_BEDROCK_TOP_P'), 1);
       if ([LlamaVersion.V2, LlamaVersion.V3, LlamaVersion.V3_1].includes(version)) {

--- a/test/providers/bedrock.test.ts
+++ b/test/providers/bedrock.test.ts
@@ -431,7 +431,7 @@ describe('llama', () => {
         <</SYS>>
 
         What is the capital of France? [/INST]`,
-          temperature: 0.01,
+          temperature: 0,
           top_p: 1,
           max_gen_len: 1024,
         });
@@ -447,7 +447,7 @@ describe('llama', () => {
         expect(handler.params(config, prompt)).toEqual({
           prompt:
             "<s>[INST] Hello [/INST] Hi there! How can I assist you today? </s><s>[INST] What's the weather like? [/INST]",
-          temperature: 0.01,
+          temperature: 0,
           top_p: 1,
           max_gen_len: 1024,
         });
@@ -482,7 +482,7 @@ describe('llama', () => {
         You are a helpful assistant.<|eot_id|><|start_header_id|>user<|end_header_id|>
 
         What is the capital of France?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`,
-          temperature: 0.01,
+          temperature: 0,
           top_p: 1,
           max_gen_len: 1024,
         });
@@ -503,7 +503,7 @@ describe('llama', () => {
         Hi there! How can I assist you today?<|eot_id|><|start_header_id|>user<|end_header_id|>
 
         What's the weather like?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`,
-          temperature: 0.01,
+          temperature: 0,
           top_p: 1,
           max_gen_len: 1024,
         });


### PR DESCRIPTION
Allows us to run comparisons like the one below and get the exact same output

```yaml 
# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
description: 'Bedrock vs. Anthropic Claude 3.5 Sonnet Comparison'

prompts:
  - 'Please answer the following question: {{query}}'

providers:
  - id: bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
  - id: anthropic:messages:claude-3-5-sonnet-20241022

tests:
  - vars:
      query: Generate a random sequence of 100 digits. Only output the sequence, no other text.
```