### PR TITLE
fix: bump version on fetch cache key

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -73,7 +73,7 @@ export async function fetchWithCache<T = any>(
 
   const copy = Object.assign({}, options);
   delete copy.headers;
-  const cacheKey = `fetch:${url}:${JSON.stringify(copy)}`;
+  const cacheKey = `fetch:v2:${url}:${JSON.stringify(copy)}`;
 
   let cached = true;
   let errorResponse = null;


### PR DESCRIPTION
Necessary to invalidate format change introduced in [https://github.com/promptfoo/promptfoo/commit/ff3b4f6575dbeb3bb54fb35038277582ed605a4f#diff-d027d3b9853e6bedddf63bd1[…]f2b947685108f315e4e831cdbdR88](https://github.com/promptfoo/promptfoo/commit/ff3b4f6575dbeb3bb54fb35038277582ed605a4f#diff-d027d3b9853e6bedddf63bd1d8fa67c69b4c1ff2b947685108f315e4e831cdbdR88)