### PR TITLE
chore: Support AWS sessionToken and profile for authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,8 @@
         "promptfoo": "dist/src/main.js"
       },
       "devDependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.682.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.686.0",
+        "@aws-sdk/credential-provider-sso": "^3.686.0",
         "@azure/identity": "^4.5.0",
         "@eslint/js": "^9.14.0",
         "@libsql/client": "^0.14.0",
@@ -139,6 +140,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.602.0",
+        "@aws-sdk/credential-provider-sso": "^3.686.0",
         "@azure/identity": "^4.0.0",
         "@azure/openai-assistants": "^1.0.0-beta.5",
         "@fal-ai/serverless-client": "^0.14.3",
@@ -680,6 +682,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -811,54 +814,55 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.682.0.tgz",
-      "integrity": "sha512-8dPaXEACiwxm47RltmhckwlfwucX9+orKF9UZVPQlvYOo8M7mTxRtTuNq711iwz5dhXI1S3eXR0vQisjT6Ekaw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.686.0.tgz",
+      "integrity": "sha512-m00XFJPhNCPb/s9EcmzfvuOVaD/E9g8DTkme9S+nxHzwIAH27BZ/6EQ+ne+jCre/V8KVrBwm4pFWPlyxgxKpLw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.682.0",
-        "@aws-sdk/client-sts": "3.682.0",
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-node": "3.682.0",
-        "@aws-sdk/middleware-host-header": "3.679.0",
-        "@aws-sdk/middleware-logger": "3.679.0",
-        "@aws-sdk/middleware-recursion-detection": "3.679.0",
-        "@aws-sdk/middleware-user-agent": "3.682.0",
-        "@aws-sdk/region-config-resolver": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@aws-sdk/util-endpoints": "3.679.0",
-        "@aws-sdk/util-user-agent-browser": "3.679.0",
-        "@aws-sdk/util-user-agent-node": "3.682.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/eventstream-serde-browser": "^3.0.10",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
-        "@smithy/eventstream-serde-node": "^3.0.9",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/client-sts": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/eventstream-serde-browser": "^3.0.11",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.8",
+        "@smithy/eventstream-serde-node": "^3.0.10",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -867,47 +871,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
-      "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.686.0.tgz",
+      "integrity": "sha512-D8huL2BSHNP9QdQrqPcx4DCJXcG/vrPimNbymgCBgnYyS1HNs11Hu27ZPrbWCZFC8n/bvfXGXOhm8WAHOi4Vtw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/middleware-host-header": "3.679.0",
-        "@aws-sdk/middleware-logger": "3.679.0",
-        "@aws-sdk/middleware-recursion-detection": "3.679.0",
-        "@aws-sdk/middleware-user-agent": "3.682.0",
-        "@aws-sdk/region-config-resolver": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@aws-sdk/util-endpoints": "3.679.0",
-        "@aws-sdk/util-user-agent-browser": "3.679.0",
-        "@aws-sdk/util-user-agent-node": "3.682.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -916,48 +921,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
-      "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.686.0.tgz",
+      "integrity": "sha512-bV8yw1tpEj9WOVEnIJTcHPmTqikGccvh9RCg9ohc5DVKLajt/pUF4b+8dDyqNrEijUqlpDDwpSnh1GFhfe298A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-node": "3.682.0",
-        "@aws-sdk/middleware-host-header": "3.679.0",
-        "@aws-sdk/middleware-logger": "3.679.0",
-        "@aws-sdk/middleware-recursion-detection": "3.679.0",
-        "@aws-sdk/middleware-user-agent": "3.682.0",
-        "@aws-sdk/region-config-resolver": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@aws-sdk/util-endpoints": "3.679.0",
-        "@aws-sdk/util-user-agent-browser": "3.679.0",
-        "@aws-sdk/util-user-agent-node": "3.682.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -965,53 +971,54 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.682.0"
+        "@aws-sdk/client-sts": "^3.686.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
-      "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.686.0.tgz",
+      "integrity": "sha512-WVyOYdK3w7RhK6UrA2MY8KPIbcZ88BGIoKmRhcOXdIUC8CLL1UIECgdRthFXOU+MBqDPFS+VeF+COk0CpRhE8Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.682.0",
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-node": "3.682.0",
-        "@aws-sdk/middleware-host-header": "3.679.0",
-        "@aws-sdk/middleware-logger": "3.679.0",
-        "@aws-sdk/middleware-recursion-detection": "3.679.0",
-        "@aws-sdk/middleware-user-agent": "3.682.0",
-        "@aws-sdk/region-config-resolver": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@aws-sdk/util-endpoints": "3.679.0",
-        "@aws-sdk/util-user-agent-browser": "3.679.0",
-        "@aws-sdk/util-user-agent-node": "3.682.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/client-sso-oidc": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-node": "3.686.0",
+        "@aws-sdk/middleware-host-header": "3.686.0",
+        "@aws-sdk/middleware-logger": "3.686.0",
+        "@aws-sdk/middleware-recursion-detection": "3.686.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/region-config-resolver": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@aws-sdk/util-user-agent-browser": "3.686.0",
+        "@aws-sdk/util-user-agent-node": "3.686.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/core": "^2.5.1",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/hash-node": "^3.0.8",
+        "@smithy/invalid-dependency": "^3.0.8",
+        "@smithy/middleware-content-length": "^3.0.10",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-retry": "^3.0.25",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.25",
+        "@smithy/util-defaults-mode-node": "^3.0.25",
+        "@smithy/util-endpoints": "^2.1.4",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -1020,20 +1027,21 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.679.0.tgz",
-      "integrity": "sha512-CS6PWGX8l4v/xyvX8RtXnBisdCa5+URzKd0L6GvHChype9qKUVxO/Gg6N/y43Hvg7MNWJt9FBPNWIxUB+byJwg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.686.0.tgz",
+      "integrity": "sha512-Xt3DV4DnAT3v2WURwzTxWQK34Ew+iiLzoUoguvLaZrVMFOqMMrwVjP+sizqIaHp1j7rGmFcN5I8saXnsDLuQLA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/core": "^2.4.8",
-        "@smithy/node-config-provider": "^3.1.8",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/node-config-provider": "^3.1.9",
         "@smithy/property-provider": "^3.1.7",
-        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/protocol-http": "^4.1.5",
         "@smithy/signature-v4": "^4.2.0",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -1056,6 +1064,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -1064,15 +1073,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.679.0.tgz",
-      "integrity": "sha512-EdlTYbzMm3G7VUNAMxr9S1nC1qUNqhKlAxFU8E7cKsAe8Bp29CD5HAs3POc56AVo9GC4yRIS+/mtlZSmrckzUA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
+      "integrity": "sha512-osD7lPO8OREkgxPiTWmA1i6XEmOth1uW9HWWj/+A2YGCj1G/t2sHu931w4Qj9NWHYZtbTTXQYVRg+TErALV7nQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1080,20 +1090,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.679.0.tgz",
-      "integrity": "sha512-ZoKLubW5DqqV1/2a3TSn+9sSKg0T8SsYMt1JeirnuLJF0mCoYFUaWMyvxxKuxPoqvUsaycxKru4GkpJ10ltNBw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.686.0.tgz",
+      "integrity": "sha512-xyGAD/f3vR/wssUiZrNFWQWXZvI4zRm2wpHhoHA1cC2fbRMNFYtFn365yw6dU7l00ZLcdFB1H119AYIUZS7xbw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/node-http-handler": "^3.2.4",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
         "@smithy/property-provider": "^3.1.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1101,48 +1112,50 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
-      "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.686.0.tgz",
+      "integrity": "sha512-90yr47QsduNiuVizMaJ2GctXZfp/z6s9eSk8ryMxMEJ2zJtaQHmJXIxaNnXj5Kh7V+HhCK7rYu58eyhZvz2Seg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-env": "3.679.0",
-        "@aws-sdk/credential-provider-http": "3.679.0",
-        "@aws-sdk/credential-provider-process": "3.679.0",
-        "@aws-sdk/credential-provider-sso": "3.682.0",
-        "@aws-sdk/credential-provider-web-identity": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/credential-provider-imds": "^3.2.4",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.682.0"
+        "@aws-sdk/client-sts": "^3.686.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
-      "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.686.0.tgz",
+      "integrity": "sha512-d5etJJD5rE3ALxrZag80EuFYI+tmJrS4E4dvFNRCosVFKvIC89VVpVY0W+OaA0J+D4FD3OzBwxan31BQAW3IyA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.679.0",
-        "@aws-sdk/credential-provider-http": "3.679.0",
-        "@aws-sdk/credential-provider-ini": "3.682.0",
-        "@aws-sdk/credential-provider-process": "3.679.0",
-        "@aws-sdk/credential-provider-sso": "3.682.0",
-        "@aws-sdk/credential-provider-web-identity": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/credential-provider-env": "3.686.0",
+        "@aws-sdk/credential-provider-http": "3.686.0",
+        "@aws-sdk/credential-provider-ini": "3.686.0",
+        "@aws-sdk/credential-provider-process": "3.686.0",
+        "@aws-sdk/credential-provider-sso": "3.686.0",
+        "@aws-sdk/credential-provider-web-identity": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/credential-provider-imds": "^3.2.4",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1150,16 +1163,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.679.0.tgz",
-      "integrity": "sha512-u/p4TV8kQ0zJWDdZD4+vdQFTMhkDEJFws040Gm113VHa/Xo1SYOjbpvqeuFoz6VmM0bLvoOWjxB9MxnSQbwKpQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.686.0.tgz",
+      "integrity": "sha512-sXqaAgyzMOc+dm4CnzAR5Q6S9OWVHyZjLfW6IQkmGjqeQXmZl24c4E82+w64C+CTkJrFLzH1VNOYp1Hy5gE6Qw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1167,52 +1181,75 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
-      "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.686.0.tgz",
+      "integrity": "sha512-bGDFRcqpGUe2YBL5gmRZTLcxGwbtFd916JsdqmNgJwhhlOXPF6nqjGil5ZYruS3AMPy0BMntnG0Mvn/ZbusT/A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.682.0",
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/token-providers": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/client-sso": "3.686.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/token-providers": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.679.0.tgz",
-      "integrity": "sha512-a74tLccVznXCaBefWPSysUcLXYJiSkeUmQGtalNgJ1vGkE36W5l/8czFiiowdWdKWz7+x6xf0w+Kjkjlj42Ung==",
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.686.0.tgz",
+      "integrity": "sha512-9oL4kTCSePFmyKPskibeiOXV6qavPZ63/kXM9Wh9V6dTSvBtLeNnMxqGvENGKJcTdIgtoqyqA6ET9u0PJ5IRIg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/types": "3.686.0",
         "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.679.0"
+        "@aws-sdk/client-sso-oidc": "^3.686.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.686.0.tgz",
+      "integrity": "sha512-40UqCpPxyHCXDP7CGd9JIOZDgDZf+u1OyLaGBpjQJlz1HYuEsIWnnbTe29Yg3Ah/Zc3g4NBWcUdlGVotlnpnDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.686.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.679.0.tgz",
-      "integrity": "sha512-y176HuQ8JRY3hGX8rQzHDSbCl9P5Ny9l16z4xmaiLo+Qfte7ee4Yr3yaAKd7GFoJ3/Mhud2XZ37fR015MfYl2w==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
+      "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1220,13 +1257,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.679.0.tgz",
-      "integrity": "sha512-0vet8InEj7nvIvGKk+ch7bEF5SyZ7Us9U7YTEgXPrBNStKeRUsgwRm0ijPWWd0a3oz2okaEwXsFl7G/vI0XiEA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
+      "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1234,14 +1272,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.679.0.tgz",
-      "integrity": "sha512-sQoAZFsQiW/LL3DfKMYwBoGjYDEnMbA9WslWN8xneCmBAwKo6IcSksvYs23PP8XMIoBGe2I2J9BSr654XWygTQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
+      "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1249,17 +1288,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
-      "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.686.0.tgz",
+      "integrity": "sha512-/GRU68H5J66OD2a/RtX5s2ECtXTlMq6NneLlzcx0mIWnZ2VRMS2vFW2j2jrBEPJ5Y5us1/lK/fbun6gNo3qh7Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/types": "3.679.0",
-        "@aws-sdk/util-endpoints": "3.679.0",
-        "@smithy/core": "^2.4.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@aws-sdk/util-endpoints": "3.686.0",
+        "@smithy/core": "^2.5.1",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1267,48 +1307,30 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.679.0.tgz",
-      "integrity": "sha512-Ybx54P8Tg6KKq5ck7uwdjiKif7n/8g1x+V0V9uTjBjRWqaIgiqzXwKWoPj6NCNkE7tJNtqI4JrNxp/3S3HvmRw==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
+      "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.679.0.tgz",
-      "integrity": "sha512-1/+Zso/x2jqgutKixYFQEGli0FELTgah6bm7aB+m2FAWH4Hz7+iMUsazg6nSWm714sG9G3h5u42Dmpvi9X6/hA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.679.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.679.0.tgz",
-      "integrity": "sha512-NwVq8YvInxQdJ47+zz4fH3BRRLC6lL+WLkvr242PVBbUOLRyK/lkwHlfiKUoeVIMyK5NF+up6TRg71t/8Bny6Q==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
+      "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1316,14 +1338,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.679.0.tgz",
-      "integrity": "sha512-YL6s4Y/1zC45OvddvgE139fjeWSKKPgLlnfrvhVL7alNyY9n7beR4uhoDpNrt5mI6sn9qiBF17790o+xLAXjjg==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
+      "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-endpoints": "^2.1.3",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-endpoints": "^2.1.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1343,27 +1366,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.679.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.679.0.tgz",
-      "integrity": "sha512-CusSm2bTBG1kFypcsqU8COhnYc6zltobsqs3nRrvYqYaOqtMnuE46K4XTWpnzKgwDejgZGOE+WYyprtAxrPvmQ==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
+      "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
-      "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+      "version": "3.686.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.686.0.tgz",
+      "integrity": "sha512-XXUhZPeacJt5BmWc0qNXA4/yyQGXPmFcTOFe5aqXuZbhtTCNVJ0fPQHFip37iGSHCg8eAFykiBn9W8hD4swolQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.682.0",
-        "@aws-sdk/types": "3.679.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/middleware-user-agent": "3.686.0",
+        "@aws-sdk/types": "3.686.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8129,25 +8154,27 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.6.tgz",
-      "integrity": "sha512-SBiOYPBH+5wOyPS7lfI150ePfGLhnp/eTu5RnV9xvhGvRiKfnl6HzRK9wehBph+il8FxS9KTeadx7Rcmf1GLPQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
+      "integrity": "sha512-kVSXScIiRN7q+s1x7BrQtZ1Aa9hvvP9FeCqCdBxv37GimIHgBCOnZ5Ip80HLt0DhnAKpiobFdGqTFgbaJNrazA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.10.tgz",
-      "integrity": "sha512-1i9aMY6Pl/SmA6NjvidxnfBLHMPzhKu2BP148pEt5VwhMdmXn36PE2kWKGa9Hj8b0XGtCTRucpCncylevCtI7g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.11.tgz",
+      "integrity": "sha512-Pd1Wnq3CQ/v2SxRifDUihvpXzirJYbbtXfEnnLV/z0OGCTx/btVX74P86IgrZkjOydOASBGXdPpupYQI+iO/6A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.9",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8155,12 +8182,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.7.tgz",
-      "integrity": "sha512-eVzhGQBPEqXXYHvIUku0jMTxd4gDvenRzUQPTmKVWdRvp9JUCKrbAXGQRYiGxUYq9+cqQckRm0wq3kTWnNtDhw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.8.tgz",
+      "integrity": "sha512-zkFIG2i1BLbfoGQnf1qEeMqX0h5qAznzaZmMVNnvPZz9J5AWBPkOMckZWPedGUPcVITacwIdQXoPcdIQq5FRcg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8168,13 +8196,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.9.tgz",
-      "integrity": "sha512-JE0Guqvt0xsmfQ5y1EI342/qtJqznBv8cJqkHZV10PwC8GWGU5KNgFbQnsVCcX+xF+qIqwwfRmeWoJCjuOLmng==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.10.tgz",
+      "integrity": "sha512-hjpU1tIsJ9qpcoZq9zGHBJPBOeBGYt+n8vfhDwnITPhEre6APrvqq/y3XMDEGUT2cWQ4ramNqBPRbx3qn55rhw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.9",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8182,13 +8211,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.9.tgz",
-      "integrity": "sha512-bydfgSisfepCufw9kCEnWRxqxJFzX/o8ysXWv+W9F2FIyiaEwZ/D8bBKINbh4ONz3i05QJ1xE7A5OKYvgJsXaw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
+      "integrity": "sha512-ewG1GHbbqsFZ4asaq40KmxCmXO+AFSM1b+DcO2C03dyJj/ZH71CiTg853FSE/3SHK9q3jiYQIFjlGSwfxQ9kww==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.6",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-codec": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8196,14 +8226,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
-      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
@@ -8669,19 +8700,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
-      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^4.1.5",
-        "@smithy/querystring-builder": "^3.0.8",
-        "@smithy/types": "^3.6.0",
-        "@smithy/util-base64": "^3.0.0",
-        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-uri-escape": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.602.0",
+    "@aws-sdk/credential-provider-sso": "^3.686.0",
     "@azure/identity": "^4.0.0",
     "@azure/openai-assistants": "^1.0.0-beta.5",
     "@fal-ai/serverless-client": "^0.14.3",
@@ -81,7 +82,8 @@
     "puppeteer-extra-plugin-stealth": "^2.11.2"
   },
   "devDependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.682.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.686.0",
+    "@aws-sdk/credential-provider-sso": "^3.686.0",
     "@azure/identity": "^4.5.0",
     "@eslint/js": "^9.14.0",
     "@libsql/client": "^0.14.0",
@@ -134,17 +136,17 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "dependencies": {
-    "@adaline/types": "0.15.0",
-    "@adaline/provider": "0.17.0",
-    "@adaline/gateway": "0.23.0",
-    "@adaline/openai": "0.21.0",
-    "@adaline/open-router": "0.8.0",
-    "@adaline/google": "0.8.0",
-    "@adaline/vertex": "0.8.1",
-    "@adaline/azure": "0.9.1",
     "@adaline/anthropic": "0.19.0",
+    "@adaline/azure": "0.9.1",
+    "@adaline/gateway": "0.23.0",
+    "@adaline/google": "0.8.0",
     "@adaline/groq": "0.8.1",
+    "@adaline/open-router": "0.8.0",
+    "@adaline/openai": "0.21.0",
+    "@adaline/provider": "0.17.0",
     "@adaline/together-ai": "0.8.0",
+    "@adaline/types": "0.15.0",
+    "@adaline/vertex": "0.8.1",
     "@anthropic-ai/sdk": "^0.32.0",
     "@apidevtools/json-schema-ref-parser": "^11.7.2",
     "@emotion/react": "^11.13.3",

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -25,7 +25,7 @@ interface BedrockOptions {
   sessionToken?: string;
 }
 
-interface TextGenerationOptions {
+export interface TextGenerationOptions {
   maxTokenCount?: number;
   stopSequences?: Array<string>;
   temperature?: number;

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -19,10 +19,10 @@ import { parseChatPrompt } from './shared';
 
 interface BedrockOptions {
   accessKeyId?: string;
+  profile?: string;
   region?: string;
   secretAccessKey?: string;
   sessionToken?: string;
-  profile?: string;
 }
 
 interface TextGenerationOptions {

--- a/test/providers/bedrock.test.ts
+++ b/test/providers/bedrock.test.ts
@@ -48,6 +48,16 @@ jest.mock('../../src/logger', () => ({
   error: jest.fn(),
 }));
 
+class TestBedrockProvider extends AwsBedrockGenericProvider {
+  modelName = 'test-model';
+  async generateText() {
+    return { text: 'test' };
+  }
+  async generateEmbedding() {
+    return { embedding: [1, 2, 3] };
+  }
+}
+
 describe('AwsBedrockGenericProvider', () => {
   let BedrockRuntime: any;
 
@@ -334,37 +344,9 @@ describe('AwsBedrockGenericProvider', () => {
   });
 
   describe('getCredentials', () => {
-    it('should return credentials if accessKeyId and secretAccessKey are provided', () => {
-      const provider = new (class extends AwsBedrockGenericProvider {
-        constructor() {
-          super('test-model', {
-            config: {
-              accessKeyId: 'test-access-key',
-              secretAccessKey: 'test-secret-key',
-            },
-          });
-        }
-      })();
-
-      const credentials = provider.getCredentials();
-      expect(credentials).toEqual({
-        accessKeyId: 'test-access-key',
-        secretAccessKey: 'test-secret-key',
-      });
-    });
-
-    it('should return undefined if accessKeyId or secretAccessKey is missing', () => {
-      const provider = new (class extends AwsBedrockGenericProvider {
-        constructor() {
-          super('test-model', {
-            config: {
-              accessKeyId: 'test-access-key',
-            },
-          });
-        }
-      })();
-
-      const credentials = provider.getCredentials();
+    it('returns undefined when no credentials are provided', async () => {
+      const provider = new TestBedrockProvider('');
+      const credentials = await provider.getCredentials();
       expect(credentials).toBeUndefined();
     });
   });

--- a/test/providers/bedrock.test.ts
+++ b/test/providers/bedrock.test.ts
@@ -3,10 +3,11 @@ import type {
   BedrockAI21GenerationOptions,
   BedrockClaudeMessagesCompletionOptions,
   LlamaMessage,
+  TextGenerationOptions,
 } from '../../src/providers/bedrock';
+import { AwsBedrockGenericProvider } from '../../src/providers/bedrock';
 import {
   addConfigParam,
-  AwsBedrockGenericProvider,
   BEDROCK_MODEL,
   formatPromptLlama2Chat,
   formatPromptLlama3Instruct,
@@ -15,25 +16,19 @@ import {
   parseValue,
 } from '../../src/providers/bedrock';
 
-jest.mock('@aws-sdk/client-bedrock-runtime', () => {
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntime: jest.fn().mockImplementation(() => ({
+    invokeModel: jest.fn(),
+  })),
+}));
+
+const { BedrockRuntime } = jest.requireMock('@aws-sdk/client-bedrock-runtime');
+
+jest.mock('@smithy/node-http-handler', () => {
   return {
-    BedrockRuntime: jest.fn().mockImplementation(() => {
-      return {
-        invokeModel: jest.fn(),
-      };
-    }),
+    NodeHttpHandler: jest.fn(),
   };
 });
-
-jest.mock(
-  '@smithy/node-http-handler',
-  () => {
-    return {
-      NodeHttpHandler: jest.fn(),
-    };
-  },
-  { virtual: true },
-);
 
 jest.mock('proxy-agent', () => jest.fn());
 
@@ -50,27 +45,31 @@ jest.mock('../../src/logger', () => ({
 
 class TestBedrockProvider extends AwsBedrockGenericProvider {
   modelName = 'test-model';
-  async generateText() {
-    return { text: 'test' };
+
+  constructor(config: any = {}) {
+    super('test-model', { config });
   }
-  async generateEmbedding() {
-    return { embedding: [1, 2, 3] };
+
+  async getClient() {
+    return this.getBedrockInstance();
+  }
+
+  async generateText(prompt: string, options?: TextGenerationOptions): Promise<string> {
+    return '';
+  }
+
+  async generateChat(messages: any[], options?: any): Promise<any> {
+    return {};
   }
 }
 
 describe('AwsBedrockGenericProvider', () => {
-  let BedrockRuntime: any;
-
   beforeEach(() => {
-    jest.resetModules();
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    BedrockRuntime = require('@aws-sdk/client-bedrock-runtime').BedrockRuntime;
     jest.clearAllMocks();
   });
 
   afterEach(() => {
-    delete process.env.HTTP_PROXY;
-    delete process.env.HTTPS_PROXY;
+    jest.clearAllMocks();
   });
 
   it('should create Bedrock instance without proxy settings', async () => {
@@ -344,8 +343,76 @@ describe('AwsBedrockGenericProvider', () => {
   });
 
   describe('getCredentials', () => {
-    it('returns undefined when no credentials are provided', async () => {
-      const provider = new TestBedrockProvider('');
+    it('should return credentials if accessKeyId and secretAccessKey are provided', async () => {
+      const provider = new (class extends AwsBedrockGenericProvider {
+        constructor() {
+          super('test-model', {
+            config: {
+              accessKeyId: 'test-access-key',
+              secretAccessKey: 'test-secret-key',
+            },
+          });
+        }
+      })();
+
+      const credentials = await provider.getCredentials();
+      expect(credentials).toEqual({
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      });
+    });
+
+    it('should return undefined if accessKeyId or secretAccessKey is missing', async () => {
+      const provider = new (class extends AwsBedrockGenericProvider {
+        constructor() {
+          super('test-model', {
+            config: {
+              accessKeyId: 'test-access-key',
+            },
+          });
+        }
+      })();
+
+      const credentials = await provider.getCredentials();
+      expect(credentials).toBeUndefined();
+    });
+
+    it('should return credentials when accessKeyId and secretAccessKey are provided', async () => {
+      const provider = new TestBedrockProvider({
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+        sessionToken: 'test-token',
+      });
+
+      const credentials = await provider.getCredentials();
+      expect(credentials).toEqual({
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+        sessionToken: 'test-token',
+      });
+    });
+
+    it('should return SSO credential provider when profile is specified', async () => {
+      const mockSSOProvider = jest.fn();
+      jest.mock('@aws-sdk/credential-provider-sso', () => ({
+        fromSSO: (config: any) => {
+          mockSSOProvider();
+          expect(config).toEqual({ profile: 'test-profile' });
+          return 'sso-provider';
+        },
+      }));
+
+      const provider = new TestBedrockProvider({
+        profile: 'test-profile',
+      });
+
+      const credentials = await provider.getCredentials();
+      expect(mockSSOProvider).toHaveBeenCalledWith();
+      expect(credentials).toBe('sso-provider');
+    });
+
+    it('should return undefined when no credentials are provided', async () => {
+      const provider = new TestBedrockProvider({});
       const credentials = await provider.getCredentials();
       expect(credentials).toBeUndefined();
     });


### PR DESCRIPTION
Fix for #2080 

* Add sessionToken and profile as Bedrock configuration options
* Add sessionToken to credentials dictionary if key pair is present
* If profile is present, use fromSSO
* getCredentials can return an AwsCredentialIdentityProvider
* import fromSSO from aws-sdk/credential-provider-sso
