### PR TITLE
chore: add promptfoo Guru link on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/typpo/promptfoo/main.yml)](https://github.com/promptfoo/promptfoo/actions/workflows/main.yml)
 ![MIT license](https://img.shields.io/github/license/promptfoo/promptfoo)
 [![Discord](https://github.com/user-attachments/assets/2092591a-ccc5-42a7-aeb6-24a2808950fd)](https://discord.gg/gHPS9jjfbs)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20promptfoo%20Guru-006BFF)](https://gurubase.io/g/promptfoo)
 
 `promptfoo` is a tool for testing, evaluating, and red-teaming LLM apps.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [promptfoo Guru](https://gurubase.io/g/promptfoo) to Gurubase. promptfoo Guru uses the data from this repo and data from the [docs](https://www.promptfoo.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "promptfoo Guru", which highlights that promptfoo now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable promptfoo Guru in Gurubase, just let me know that's totally fine.
