### PR TITLE
feat: Maintain session-id in http provider

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -328,6 +328,31 @@ providers:
 
 This will import the function `parseResponse` from the file `path/to/parser.js`.
 
+## Maintaining session IDs with an HTTP provider and Multi-turn redteam attacks like GOAT and Crescendo
+
+When using an HTTP provider with multi-turn redteam attacks like GOAT and Crescendo, you may need to maintain session IDs between rounds. The HTTP provider will automatically extract the session ID from the response headers and store it in the `vars` object.
+
+Create a session parser that extracts the session ID from the response headers and returns it. All of the same formats of response parsers are supported.
+
+The input to the session parser is an object with a `headers` field, which contains the response headers.
+
+`{ headers: Record<string, string> }`
+
+Simple header parser:
+
+```yaml
+sessionParser: 'headers["set-cookie"]'
+```
+
+Then you need to set the session ID in the `vars` object for the next round:
+
+```yaml
+providers:
+  - id: 'https://example.com/api'
+    headers:
+      'Cookie': '{{sessionId}}'
+```
+
 ## Reference
 
 Supported config options:

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -46,6 +46,7 @@ export type FetchWithCacheResult<T> = {
   cached: boolean;
   status: number;
   statusText: string;
+  headers?: Headers;
 };
 
 export async function fetchWithCache<T = any>(
@@ -57,6 +58,7 @@ export async function fetchWithCache<T = any>(
 ): Promise<FetchWithCacheResult<T>> {
   if (!enabled || bust) {
     const resp = await fetchWithRetries(url, options, timeout);
+
     const respText = await resp.text();
     try {
       return {
@@ -64,6 +66,7 @@ export async function fetchWithCache<T = any>(
         data: format === 'json' ? JSON.parse(respText) : respText,
         status: resp.status,
         statusText: resp.statusText,
+        headers: resp.headers,
       };
     } catch {
       throw new Error(`Error parsing response as JSON: ${respText}`);
@@ -90,6 +93,7 @@ export async function fetchWithCache<T = any>(
         data: format === 'json' ? JSON.parse(responseText) : responseText,
         status: response.status,
         statusText: response.statusText,
+        headers: response.headers,
       });
       if (!response.ok) {
         if (responseText == '') {
@@ -97,6 +101,7 @@ export async function fetchWithCache<T = any>(
             data: `Empty Response: ${response.status}: ${response.statusText}`,
             status: response.status,
             statusText: response.statusText,
+            headers: response.headers,
           });
         } else {
           errorResponse = data;
@@ -129,6 +134,7 @@ export async function fetchWithCache<T = any>(
     data: parsedResponse.data as T,
     status: parsedResponse.status,
     statusText: parsedResponse.statusText,
+    headers: parsedResponse.headers,
   };
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -46,7 +46,7 @@ export type FetchWithCacheResult<T> = {
   cached: boolean;
   status: number;
   statusText: string;
-  headers?: Headers;
+  headers?: Record<string, string>;
 };
 
 export async function fetchWithCache<T = any>(
@@ -66,7 +66,7 @@ export async function fetchWithCache<T = any>(
         data: format === 'json' ? JSON.parse(respText) : respText,
         status: resp.status,
         statusText: resp.statusText,
-        headers: resp.headers,
+        headers: Object.fromEntries(resp.headers.entries()),
       };
     } catch {
       throw new Error(`Error parsing response as JSON: ${respText}`);
@@ -88,12 +88,14 @@ export async function fetchWithCache<T = any>(
     cached = false;
     const response = await fetchWithRetries(url, options, timeout);
     const responseText = await response.text();
+    const headers = Object.fromEntries(response.headers.entries());
+
     try {
       const data = JSON.stringify({
         data: format === 'json' ? JSON.parse(responseText) : responseText,
         status: response.status,
         statusText: response.statusText,
-        headers: response.headers,
+        headers,
       });
       if (!response.ok) {
         if (responseText == '') {
@@ -101,7 +103,7 @@ export async function fetchWithCache<T = any>(
             data: `Empty Response: ${response.status}: ${response.statusText}`,
             status: response.status,
             statusText: response.statusText,
-            headers: response.headers,
+            headers,
           });
         } else {
           errorResponse = data;

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -44,7 +44,7 @@ function contentTypeIsJson(headers: Record<string, string> | undefined) {
 
 export async function createSessionParser(
   parser: string | Function | undefined,
-): Promise<(({ headers }: { headers: Headers }) => string) | null> {
+): Promise<(({ headers }: { headers: Record<string, string> }) => string) | null> {
   if (!parser) {
     return () => '';
   }
@@ -206,7 +206,9 @@ export class HttpProvider implements ApiProvider {
   url: string;
   config: HttpProviderConfig;
   private responseParser: Promise<(data: any, text: string) => ProviderResponse>;
-  private sessionParser: Promise<(({ headers }: { headers: Headers }) => string) | null>;
+  private sessionParser: Promise<
+    (({ headers }: { headers: Record<string, string> }) => string) | null
+  >;
 
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config;
@@ -360,6 +362,7 @@ export class HttpProvider implements ApiProvider {
       parsedData = null;
     }
     try {
+      console.log({ headers: response.headers });
       const parsedOutput = (await this.responseParser)(parsedData, rawText);
       ret.output = parsedOutput.output || parsedOutput;
       ret.sessionId =

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -26,6 +26,7 @@ interface HttpProviderConfig {
   body?: Record<string, any> | string | any[];
   queryParams?: Record<string, string>;
   responseParser?: string | Function;
+  sessionParser?: string | Function;
   request?: string;
 }
 
@@ -39,6 +40,45 @@ function contentTypeIsJson(headers: Record<string, string> | undefined) {
     }
     return false;
   });
+}
+
+export async function createSessionParser(
+  parser: string | Function | undefined,
+): Promise<(({ headers }: { headers: Headers }) => string) | null> {
+  if (!parser) {
+    return () => '';
+  }
+
+  if (typeof parser === 'function') {
+    return (response) => parser(response);
+  }
+  if (typeof parser === 'string' && parser.startsWith('file://')) {
+    let filename = parser.slice('file://'.length);
+    let functionName: string | undefined;
+    if (filename.includes(':')) {
+      const splits = filename.split(':');
+      if (splits[0] && isJavascriptFile(splits[0])) {
+        [filename, functionName] = splits;
+      }
+    }
+    const requiredModule = await importModule(
+      path.resolve(cliState.basePath || '', filename),
+      functionName,
+    );
+    if (typeof requiredModule === 'function') {
+      return requiredModule;
+    }
+    throw new Error(
+      `Response parser malformed: ${filename} must export a function or have a default export as a function`,
+    );
+  } else if (typeof parser === 'string') {
+    return ({ headers }) => {
+      return new Function('headers', `return headers.get('${parser}')`)(headers);
+    };
+  }
+  throw new Error(
+    `Unsupported response parser type: ${typeof parser}. Expected a function, a string starting with 'file://' pointing to a JavaScript file, or a string containing a JavaScript expression.`,
+  );
 }
 
 export async function createResponseParser(
@@ -166,11 +206,13 @@ export class HttpProvider implements ApiProvider {
   url: string;
   config: HttpProviderConfig;
   private responseParser: Promise<(data: any, text: string) => ProviderResponse>;
+  private sessionParser: Promise<(({ headers }: { headers: Headers }) => string) | null>;
 
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config;
     this.url = this.config.url || url;
     this.responseParser = createResponseParser(this.config.responseParser);
+    this.sessionParser = createSessionParser(this.config.sessionParser);
 
     if (this.config.request) {
       this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
@@ -217,13 +259,6 @@ export class HttpProvider implements ApiProvider {
         );
       }
     }
-  }
-
-  private getContentType(headers: Record<string, string>): string | undefined {
-    const contentTypeHeader = Object.keys(headers).find(
-      (key) => key.toLowerCase() === 'content-type',
-    );
-    return contentTypeHeader ? headers[contentTypeHeader] : undefined;
   }
 
   private getHeaders(
@@ -327,8 +362,13 @@ export class HttpProvider implements ApiProvider {
     try {
       const parsedOutput = (await this.responseParser)(parsedData, rawText);
       ret.output = parsedOutput.output || parsedOutput;
+      ret.sessionId =
+        response.headers && this.sessionParser !== null
+          ? (await this.sessionParser)?.({ headers: response.headers })
+          : undefined;
       return ret;
     } catch (err) {
+      logger.error(`Error parsing response: ${String(err)}`);
       ret.error = `Error parsing response: ${String(err)}`;
       return ret;
     }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -362,7 +362,6 @@ export class HttpProvider implements ApiProvider {
       parsedData = null;
     }
     try {
-      console.log({ headers: response.headers });
       const parsedOutput = (await this.responseParser)(parsedData, rawText);
       ret.output = parsedOutput.output || parsedOutput;
       ret.sessionId =

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -57,6 +57,7 @@ export default class GoatProvider implements ApiProvider {
       prompt: 0,
       completion: 0,
       numRequests: 0,
+      cached: 0,
     };
 
     for (let turn = 0; turn < this.maxTurns; turn++) {
@@ -80,6 +81,8 @@ export default class GoatProvider implements ApiProvider {
         totalTokenUsage.total += data.tokenUsage.total || 0;
         totalTokenUsage.prompt += data.tokenUsage.prompt || 0;
         totalTokenUsage.completion += data.tokenUsage.completion || 0;
+        totalTokenUsage.cached += data.tokenUsage.cached || 0;
+        totalTokenUsage.numRequests += data.tokenUsage.numRequests ?? 1;
       }
       logger.debug(
         dedent`
@@ -120,6 +123,7 @@ export default class GoatProvider implements ApiProvider {
         totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
         totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
         totalTokenUsage.numRequests += targetResponse.tokenUsage.numRequests ?? 1;
+        totalTokenUsage.cached += targetResponse.tokenUsage.cached || 0;
       } else {
         totalTokenUsage.numRequests += 1;
       }

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -99,6 +99,10 @@ export default class GoatProvider implements ApiProvider {
       const targetResponse = await targetProvider.callApi(targetPrompt, context, options);
       logger.debug(`GOAT turn ${turn} target response: ${JSON.stringify(targetResponse)}`);
 
+      if (targetResponse.sessionId) {
+        context = context ?? { vars: {}, prompt: { raw: '', label: 'target' } };
+        context.vars.sessionId = targetResponse.sessionId;
+      }
       if (targetResponse.error) {
         throw new Error(`Error from target provider: ${targetResponse.error}`);
       }
@@ -120,6 +124,8 @@ export default class GoatProvider implements ApiProvider {
         totalTokenUsage.numRequests += 1;
       }
     }
+    delete context?.vars?.sessionId;
+
     return {
       output: messages[messages.length - 1]?.content,
       metadata: {

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -129,11 +129,10 @@ async function runRedteamConversation({
       .onTopic;
     invariant(typeof isOnTopic === 'boolean', 'Expected onTopic to be a boolean');
 
-    const { extractedResponse: targetResponse, tokenUsage: targetTokenUsage } =
-      await getTargetResponse(targetProvider, targetPrompt, context, options);
+    const targetResponse = await getTargetResponse(targetProvider, targetPrompt, context, options);
     const penalizedPhrases = ['in the face of impending doom'];
     const containsPenalizedPhrase = penalizedPhrases.some((phrase) =>
-      targetResponse.toLowerCase().includes(phrase),
+      targetResponse.output.toLowerCase().includes(phrase),
     );
 
     // Calculate the score
@@ -144,7 +143,7 @@ async function runRedteamConversation({
       },
       {
         role: 'user',
-        content: targetResponse,
+        content: targetResponse.output,
       },
     ]);
     const judgeResp = await redteamProvider.callApi(judgeBody, {
@@ -167,7 +166,7 @@ async function runRedteamConversation({
 
     if (score > highestScore) {
       highestScore = score;
-      bestResponse = targetResponse;
+      bestResponse = targetResponse.output;
     }
 
     if (score >= 10) {
@@ -211,12 +210,12 @@ async function runRedteamConversation({
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
 
-    if (targetTokenUsage) {
-      totalTokenUsage.total += targetTokenUsage.total || 0;
-      totalTokenUsage.prompt += targetTokenUsage.prompt || 0;
-      totalTokenUsage.completion += targetTokenUsage.completion || 0;
+    if (targetResponse.tokenUsage) {
+      totalTokenUsage.total += targetResponse.tokenUsage.total || 0;
+      totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
+      totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
       totalTokenUsage.numRequests =
-        (totalTokenUsage.numRequests || 0) + (targetTokenUsage.numRequests || 1);
+        (totalTokenUsage.numRequests || 0) + (targetResponse.tokenUsage.numRequests || 1);
     } else {
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -66,6 +66,7 @@ async function runRedteamConversation({
     prompt: 0,
     completion: 0,
     numRequests: 0,
+    cached: 0,
   };
 
   for (let i = 0; i < NUM_ITERATIONS; i++) {
@@ -186,6 +187,7 @@ async function runRedteamConversation({
       totalTokenUsage.completion += redteamResp.tokenUsage.completion || 0;
       totalTokenUsage.numRequests =
         (totalTokenUsage.numRequests || 0) + (redteamResp.tokenUsage.numRequests || 1);
+      totalTokenUsage.cached += redteamResp.tokenUsage.cached || 0;
     } else {
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
@@ -196,6 +198,7 @@ async function runRedteamConversation({
       totalTokenUsage.completion += isOnTopicResp.tokenUsage.completion || 0;
       totalTokenUsage.numRequests =
         (totalTokenUsage.numRequests || 0) + (isOnTopicResp.tokenUsage.numRequests || 1);
+      totalTokenUsage.cached += isOnTopicResp.tokenUsage.cached || 0;
     } else {
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
@@ -206,6 +209,7 @@ async function runRedteamConversation({
       totalTokenUsage.completion += judgeResp.tokenUsage.completion || 0;
       totalTokenUsage.numRequests =
         (totalTokenUsage.numRequests || 0) + (judgeResp.tokenUsage.numRequests || 1);
+      totalTokenUsage.cached += judgeResp.tokenUsage.cached || 0;
     } else {
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
@@ -216,6 +220,7 @@ async function runRedteamConversation({
       totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
       totalTokenUsage.numRequests =
         (totalTokenUsage.numRequests || 0) + (targetResponse.tokenUsage.numRequests || 1);
+      totalTokenUsage.cached += targetResponse.tokenUsage.cached || 0;
     } else {
       totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -121,6 +121,7 @@ async function runRedteamConversation({
     prompt: 0,
     completion: 0,
     numRequests: 0,
+    cached: 0,
   };
 
   let targetPrompt: string | null = null;
@@ -133,6 +134,7 @@ async function runRedteamConversation({
       totalTokenUsage.total += redteamResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += redteamResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += redteamResp.tokenUsage.completion || 0;
+      totalTokenUsage.cached += redteamResp.tokenUsage.cached ?? 0;
     }
     if (redteamResp.error) {
       throw new Error(`Error from redteam provider: ${redteamResp.error}`);
@@ -176,6 +178,7 @@ async function runRedteamConversation({
       totalTokenUsage.total += isOnTopicResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += isOnTopicResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += isOnTopicResp.tokenUsage.completion || 0;
+      totalTokenUsage.cached += isOnTopicResp.tokenUsage.cached ?? 0;
     }
     if (isOnTopicResp.error) {
       throw new Error(`Error from redteam (onTopic) provider: ${isOnTopicResp.error}`);
@@ -216,6 +219,7 @@ async function runRedteamConversation({
         totalTokenUsage.total += visionResponse.tokenUsage.total || 0;
         totalTokenUsage.prompt += visionResponse.tokenUsage.prompt || 0;
         totalTokenUsage.completion += visionResponse.tokenUsage.completion || 0;
+        totalTokenUsage.cached += visionResponse.tokenUsage.cached ?? 0;
       }
       imageDescription = visionResponse.output;
       logger.debug(`Iteration ${i + 1}: Image description: ${imageDescription}`);
@@ -237,6 +241,7 @@ async function runRedteamConversation({
       totalTokenUsage.total += judgeResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += judgeResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += judgeResp.tokenUsage.completion || 0;
+      totalTokenUsage.cached += judgeResp.tokenUsage.cached ?? 0;
     }
     invariant(typeof judgeResp.output === 'string', 'Expected output to be a string');
     const { rating: score } = extractFirstJsonObject<{ rating: number }>(judgeResp.output);
@@ -263,6 +268,7 @@ async function runRedteamConversation({
       totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
       totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
       totalTokenUsage.numRequests += targetResponse.tokenUsage.numRequests ?? 1;
+      totalTokenUsage.cached += targetResponse.tokenUsage.cached ?? 0;
     }
   }
 

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -376,6 +376,7 @@ export async function runRedteamConversation({
     prompt: 0,
     completion: 0,
     numRequests: 0,
+    cached: 0,
   };
 
   for (let depth = 0; depth < MAX_DEPTH; depth++) {
@@ -405,6 +406,8 @@ export async function runRedteamConversation({
           totalTokenUsage.total += redteamTokenUsage.total || 0;
           totalTokenUsage.prompt += redteamTokenUsage.prompt || 0;
           totalTokenUsage.completion += redteamTokenUsage.completion || 0;
+          totalTokenUsage.numRequests += redteamTokenUsage.numRequests ?? 1;
+          totalTokenUsage.cached += redteamTokenUsage.cached || 0;
         }
 
         attempts++;
@@ -431,6 +434,8 @@ export async function runRedteamConversation({
           totalTokenUsage.total += isOnTopicTokenUsage.total || 0;
           totalTokenUsage.prompt += isOnTopicTokenUsage.prompt || 0;
           totalTokenUsage.completion += isOnTopicTokenUsage.completion || 0;
+          totalTokenUsage.cached += isOnTopicTokenUsage.cached || 0;
+          totalTokenUsage.numRequests += isOnTopicTokenUsage.numRequests ?? 1;
         }
 
         const targetResponse = await getTargetResponse(
@@ -444,6 +449,7 @@ export async function runRedteamConversation({
           totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
           totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
           totalTokenUsage.numRequests += targetResponse.tokenUsage.numRequests ?? 1;
+          totalTokenUsage.cached += targetResponse.tokenUsage.cached || 0;
         }
 
         const containsPenalizedPhrase = PENALIZED_PHRASES.some((phrase) =>
@@ -560,6 +566,7 @@ export async function runRedteamConversation({
     totalTokenUsage.prompt += finalTargetResponse.tokenUsage.prompt || 0;
     totalTokenUsage.completion += finalTargetResponse.tokenUsage.completion || 0;
     totalTokenUsage.numRequests += finalTargetResponse.tokenUsage.numRequests ?? 1;
+    totalTokenUsage.cached += finalTargetResponse.tokenUsage.cached || 0;
   }
 
   logger.debug(

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -433,23 +433,27 @@ export async function runRedteamConversation({
           totalTokenUsage.completion += isOnTopicTokenUsage.completion || 0;
         }
 
-        const { extractedResponse: targetResponse, tokenUsage: targetTokenUsage } =
-          await getTargetResponse(targetProvider, targetPrompt, context, options);
-        if (targetTokenUsage) {
-          totalTokenUsage.total += targetTokenUsage.total || 0;
-          totalTokenUsage.prompt += targetTokenUsage.prompt || 0;
-          totalTokenUsage.completion += targetTokenUsage.completion || 0;
-          totalTokenUsage.numRequests += targetTokenUsage.numRequests ?? 1;
+        const targetResponse = await getTargetResponse(
+          targetProvider,
+          targetPrompt,
+          context,
+          options,
+        );
+        if (targetResponse.tokenUsage) {
+          totalTokenUsage.total += targetResponse.tokenUsage.total || 0;
+          totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
+          totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
+          totalTokenUsage.numRequests += targetResponse.tokenUsage.numRequests ?? 1;
         }
 
         const containsPenalizedPhrase = PENALIZED_PHRASES.some((phrase) =>
-          targetResponse.toLowerCase().includes(phrase),
+          targetResponse.output.toLowerCase().includes(phrase),
         );
 
         const score = await evaluateResponse(
           redteamProvider,
           judgeSystemPrompt,
-          targetResponse,
+          targetResponse.output,
           containsPenalizedPhrase,
         );
 
@@ -483,7 +487,7 @@ export async function runRedteamConversation({
             `[Depth ${depth}, Attempt ${attempts}] Reached target score (${TARGET_SCORE}). Max score: ${maxScore}. Stopping.`,
           );
           return {
-            output: targetResponse,
+            output: targetResponse.output,
             metadata: {
               redteamFinalPrompt: targetPrompt,
             },
@@ -496,7 +500,7 @@ export async function runRedteamConversation({
             `[Depth ${depth}, Attempt ${attempts}] No improvement for ${MAX_NO_IMPROVEMENT} consecutive iterations. Max score: ${maxScore}. Stopping.`,
           );
           return {
-            output: targetResponse,
+            output: targetResponse.output,
             metadata: {
               redteamFinalPrompt: targetPrompt,
             },
@@ -509,7 +513,7 @@ export async function runRedteamConversation({
             `[Depth ${depth}, Attempt ${attempts}] Reached maximum attempts (${MAX_ATTEMPTS}). Max score: ${maxScore}. Stopping.`,
           );
           return {
-            output: targetResponse,
+            output: targetResponse.output,
             metadata: {
               redteamFinalPrompt: targetPrompt,
             },
@@ -518,7 +522,13 @@ export async function runRedteamConversation({
         }
 
         redteamHistory.push(
-          updateRedteamHistory(targetResponse, goal, score, isOnTopic, containsPenalizedPhrase),
+          updateRedteamHistory(
+            targetResponse.output,
+            goal,
+            score,
+            isOnTopic,
+            containsPenalizedPhrase,
+          ),
         );
       }
     }
@@ -539,13 +549,17 @@ export async function runRedteamConversation({
     targetProvider,
   );
 
-  const { extractedResponse: finalTargetResponse, tokenUsage: finalTargetTokenUsage } =
-    await getTargetResponse(targetProvider, finalTargetPrompt, context, options);
-  if (finalTargetTokenUsage) {
-    totalTokenUsage.total += finalTargetTokenUsage.total || 0;
-    totalTokenUsage.prompt += finalTargetTokenUsage.prompt || 0;
-    totalTokenUsage.completion += finalTargetTokenUsage.completion || 0;
-    totalTokenUsage.numRequests += finalTargetTokenUsage.numRequests ?? 1;
+  const finalTargetResponse = await getTargetResponse(
+    targetProvider,
+    finalTargetPrompt,
+    context,
+    options,
+  );
+  if (finalTargetResponse.tokenUsage) {
+    totalTokenUsage.total += finalTargetResponse.tokenUsage.total || 0;
+    totalTokenUsage.prompt += finalTargetResponse.tokenUsage.prompt || 0;
+    totalTokenUsage.completion += finalTargetResponse.tokenUsage.completion || 0;
+    totalTokenUsage.numRequests += finalTargetResponse.tokenUsage.numRequests ?? 1;
   }
 
   logger.debug(
@@ -553,7 +567,7 @@ export async function runRedteamConversation({
   );
 
   return {
-    output: finalTargetResponse,
+    output: finalTargetResponse.output,
     metadata: {
       redteamFinalPrompt: finalTargetPrompt,
     },

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -5,9 +5,9 @@ import {
   isApiProvider,
   type RedteamFileConfig,
   type ApiProvider,
-  type CallApiContextParams,
   type CallApiOptionsParams,
   type TokenUsage,
+  type CallApiContextParams,
 } from '../../types';
 import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
 

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -67,16 +67,9 @@ export async function getTargetResponse(
   options?: CallApiOptionsParams,
 ): Promise<TargetResponse> {
   let targetRespRaw;
+
   try {
-    targetRespRaw = await targetProvider.callApi(
-      targetPrompt,
-      context?.vars
-        ? {
-            vars: context.vars,
-            prompt: { raw: targetPrompt, label: 'target' },
-          }
-        : undefined,
-    );
+    targetRespRaw = await targetProvider.callApi(targetPrompt, context, options);
   } catch (error) {
     return { output: '', error: (error as Error).message, tokenUsage: { numRequests: 1 } };
   }

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -56,6 +56,7 @@ export interface ApiProvider {
   transform?: string;
   delay?: number;
   config?: any;
+  getSessionId?: () => string;
 }
 
 export interface ApiEmbeddingProvider extends ApiProvider {

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -87,6 +87,7 @@ export interface ProviderResponse {
   output?: string | any;
   tokenUsage?: TokenUsage;
   isRefusal?: boolean;
+  sessionId?: string;
 }
 
 export interface ProviderEmbeddingResponse {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -13,6 +13,7 @@ const mockedFetchResponse = (ok: boolean, response: object): Response => {
     json: () => Promise.resolve(response),
     headers: new Headers({
       'content-type': 'application/json',
+      'x-session-id': '45',
     }),
   } as Response;
 };
@@ -33,9 +34,11 @@ describe('fetchWithCache', () => {
     const result = await fetchWithCache(url, {}, 1000);
 
     expect(mockedFetch).toHaveBeenCalledTimes(1);
+
     expect(result).toEqual({
       cached: false,
       data: response,
+      headers: { 'content-type': 'application/json', 'x-session-id': '45' },
       status: 400,
       statusText: 'Bad Request',
     });
@@ -45,14 +48,22 @@ describe('fetchWithCache', () => {
     enableCache();
 
     const url = 'https://api.example.com/data';
-    const response = { data: 'test data' };
+    const response = {
+      data: 'test data',
+    };
 
     mockedFetch.mockResolvedValueOnce(mockedFetchResponse(true, response));
 
     const result = await fetchWithCache(url, {}, 1000);
 
     expect(mockedFetch).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ cached: false, data: response, status: 200, statusText: 'OK' });
+    expect(result).toEqual({
+      cached: false,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'x-session-id': '45', 'content-type': 'application/json' },
+    });
   });
 
   it('should fetch data with cache enabled after previous test', async () => {
@@ -64,7 +75,13 @@ describe('fetchWithCache', () => {
     const result = await fetchWithCache(url, {}, 1000);
 
     expect(mockedFetch).toHaveBeenCalledTimes(0);
-    expect(result).toEqual({ cached: true, data: response, status: 200, statusText: 'OK' });
+    expect(result).toEqual({
+      cached: true,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json', 'x-session-id': '45' },
+    });
   });
 
   it('should only fetch data once with cache enabled', async () => {
@@ -83,8 +100,20 @@ describe('fetchWithCache', () => {
     ]);
 
     expect(mockedFetch).toHaveBeenCalledTimes(1);
-    expect(a).toEqual({ cached: false, data: response, status: 200, statusText: 'OK' });
-    expect(b).toEqual({ cached: true, data: response, status: 200, statusText: 'OK' });
+    expect(a).toEqual({
+      cached: false,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'x-session-id': '45', 'content-type': 'application/json' },
+    });
+    expect(b).toEqual({
+      cached: true,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'x-session-id': '45', 'content-type': 'application/json' },
+    });
   });
 
   it('should fetch data without cache for a single test', async () => {
@@ -98,7 +127,13 @@ describe('fetchWithCache', () => {
     const result = await fetchWithCache(url, {}, 1000);
 
     expect(mockedFetch).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ cached: false, data: response, status: 200, statusText: 'OK' });
+    expect(result).toEqual({
+      cached: false,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json', 'x-session-id': '45' },
+    });
 
     enableCache();
   });
@@ -114,7 +149,13 @@ describe('fetchWithCache', () => {
     const result = await fetchWithCache(url, {}, 1000);
 
     expect(mockedFetch).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ cached: false, data: response, status: 200, statusText: 'OK' });
+    expect(result).toEqual({
+      cached: false,
+      data: response,
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json', 'x-session-id': '45' },
+    });
 
     enableCache();
   });

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -613,26 +613,6 @@ describe('HttpProvider', () => {
     });
   });
 
-  describe('getContentType', () => {
-    it('should return content-type if present', () => {
-      const provider = new HttpProvider(mockUrl, { config: { body: 'test' } });
-      const result = provider['getContentType']({ 'content-type': 'application/json' });
-      expect(result).toBe('application/json');
-    });
-
-    it('should return undefined if content-type is not present', () => {
-      const provider = new HttpProvider(mockUrl, { config: { body: 'test' } });
-      const result = provider['getContentType']({});
-      expect(result).toBeUndefined();
-    });
-
-    it('should be case-insensitive', () => {
-      const provider = new HttpProvider(mockUrl, { config: { body: 'test' } });
-      const result = provider['getContentType']({ 'Content-Type': 'application/json' });
-      expect(result).toBe('application/json');
-    });
-  });
-
   describe('getHeaders', () => {
     it('should combine default headers with config headers', () => {
       const provider = new HttpProvider(mockUrl, {

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -105,6 +105,7 @@ const defaultMockResponse = {
   statusText: 'OK',
   headers: {
     get: jest.fn().mockReturnValue(null),
+    entries: jest.fn().mockReturnValue([]),
   },
 };
 

--- a/test/redteam/providers/iterativeTree.test.ts
+++ b/test/redteam/providers/iterativeTree.test.ts
@@ -461,7 +461,11 @@ describe('RedteamIterativeProvider', () => {
       const options: CallApiOptionsParams = {};
       const result = await getTargetResponse(mockTargetProvider, targetPrompt, context, options);
 
-      expect(result).toEqual({ output: JSON.stringify(mockResponse), sessionId: undefined });
+      expect(result).toEqual({
+        output: JSON.stringify(mockResponse),
+        sessionId: undefined,
+        tokenUsage: { numRequests: 1 },
+      });
       expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(1);
       expect(mockTargetProvider.callApi).toHaveBeenCalledWith(targetPrompt, context, options);
     });
@@ -478,7 +482,11 @@ describe('RedteamIterativeProvider', () => {
         {} as CallApiOptionsParams,
       );
 
-      expect(result).toEqual({ output: JSON.stringify(nonStringOutput), sessionId: undefined });
+      expect(result).toEqual({
+        output: JSON.stringify(nonStringOutput),
+        sessionId: undefined,
+        tokenUsage: { numRequests: 1 },
+      });
     });
   });
 });

--- a/test/redteam/providers/iterativeTree.test.ts
+++ b/test/redteam/providers/iterativeTree.test.ts
@@ -450,7 +450,7 @@ describe('RedteamIterativeProvider', () => {
     });
 
     it('should get target response correctly', async () => {
-      const mockResponse = 'Target response';
+      const mockResponse = { output: 'Target response' };
       mockTargetProvider.callApi.mockResolvedValue({ output: mockResponse });
 
       const targetPrompt = 'Test prompt';
@@ -461,7 +461,7 @@ describe('RedteamIterativeProvider', () => {
       const options: CallApiOptionsParams = {};
       const result = await getTargetResponse(mockTargetProvider, targetPrompt, context, options);
 
-      expect(result).toMatchObject({ extractedResponse: mockResponse });
+      expect(result).toEqual({ output: JSON.stringify(mockResponse), sessionId: undefined });
       expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(1);
       expect(mockTargetProvider.callApi).toHaveBeenCalledWith(targetPrompt, context, options);
     });
@@ -478,7 +478,7 @@ describe('RedteamIterativeProvider', () => {
         {} as CallApiOptionsParams,
       );
 
-      expect(result).toMatchObject({ extractedResponse: JSON.stringify(nonStringOutput) });
+      expect(result).toEqual({ output: JSON.stringify(nonStringOutput), sessionId: undefined });
     });
   });
 });


### PR DESCRIPTION
- For multi-turn strategies we can maintain the session id for http providers.
- Only send the last message for multi-turn strategies if the providers are stateful
- Added cached-token usage to our redteam token usage.