### PR TITLE
feat: Respect max text length in Markdown cells

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -396,7 +396,9 @@ function ResultsTable({
               cell: (info: CellContext<EvaluateTableRow, string>) => {
                 const value = info.getValue();
                 const truncatedValue =
-                  value.length > maxTextLength ? `${value.slice(0, maxTextLength)}...` : value;
+                  value.length > maxTextLength
+                    ? `${value.substring(0, maxTextLength - 3).trim()}...`
+                    : value;
                 return (
                   <div className="cell">
                     {renderMarkdown ? (

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -395,10 +395,12 @@ function ResultsTable({
               ),
               cell: (info: CellContext<EvaluateTableRow, string>) => {
                 const value = info.getValue();
+                const truncatedValue =
+                  value.length > maxTextLength ? `${value.slice(0, maxTextLength)}...` : value;
                 return (
                   <div className="cell">
                     {renderMarkdown ? (
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
                     ) : (
                       <TruncatedText text={value} maxLength={maxTextLength} />
                     )}


### PR DESCRIPTION
Implements #2046 

I tested this by running an eval that had long cells and ensuring that when I checked the "Render model outputs as Markdown" box that it respected that limit. This enabled me to see Markdown links for my evals that had large inputs.

Open to any feedback, and thanks for the quick response on the original issue!