### PR TITLE
fix: keep eval id on `import`

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -20,6 +20,7 @@ export function importCommand(program: Command) {
         if (evalData.results.version === 3) {
           logger.debug('Importing v3 eval');
           const evalRecord = await Eval.create(evalData.config, evalData.results.prompts, {
+            id: evalData.id,
             createdAt: evalData.createdAt,
             author: evalData.author || 'Unknown',
           });


### PR DESCRIPTION
Related to #2108 