### PR TITLE
chore: azureopenai -> azure

### DIFF
--- a/examples/azure-openai-assistant/promptfooconfig.yaml
+++ b/examples/azure-openai-assistant/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Write a tweet about {{topic}}'
 
 providers:
-  - id: azureopenai:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
+  - id: azure:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
     config:
       apiHost: aliothopenai-assistants.openai.azure.com
 

--- a/examples/azure-openai/promptfooconfig.yaml
+++ b/examples/azure-openai/promptfooconfig.yaml
@@ -3,7 +3,7 @@ prompts:
   - 'Generate one very interesting fact about {{topic}}'
 
 providers:
-  - id: azureopenai:chat:gpt-35-turbo-deployment1
+  - id: azure:chat:gpt-35-turbo-deployment1
     config:
       apiHost: 'your-org.openai.azure.com'
 
@@ -21,6 +21,6 @@ tests:
       - type: similar
         value: Bananas are naturally radioactive.
         provider:
-          id: azureopenai:embeddings:ada-deployment1
+          id: azure:embeddings:ada-deployment1
           config:
             apiHost: 'your-org.openai.azure.com'

--- a/site/docs/guides/azure-vs-openai.md
+++ b/site/docs/guides/azure-vs-openai.md
@@ -30,7 +30,7 @@ Additionally, make sure you have the following environment variables set:
 
 ```sh
 OPENAI_API_KEY='...'
-AZURE_OPENAI_API_KEY='...'
+AZURE_API_KEY='...'
 ```
 
 ## Step 1: Set up the models
@@ -46,7 +46,7 @@ Edit your `promptfooconfig.yaml` to include both OpenAI and Azure OpenAI as prov
 ```yaml
 providers:
   - id: openai:chat:gpt-4o-mini
-  - id: azureopenai:chat:my-gpt-4o-mini-deployment
+  - id: azure:chat:my-gpt-4o-mini-deployment
     config:
       apiHost: myazurehost.openai.azure.com
 ```
@@ -63,7 +63,7 @@ providers:
     config:
       temperature: 0
       max_tokens: 128
-  - id: azureopenai:chat:my-gpt-4o-mini-deployment
+  - id: azure:chat:my-gpt-4o-mini-deployment
     config:
       apiHost: your_azure_openai_host
       temperature: 0

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -4,19 +4,19 @@ sidebar_position: 20
 
 # Azure
 
-The `azureopenai` provider is an interface to OpenAI through Azure. It behaves the same as the [OpenAI provider](/docs/providers/openai).
+The `azure` provider is an interface to Azure. It shares configuration settings with the [OpenAI provider](/docs/providers/openai).
 
 ## Setup
 
-There are two ways to authenticate with Azure OpenAI:
+There are two ways to authenticate with Azure:
 
 ### Option 1: API Key Authentication
 
-Set the `AZURE_OPENAI_API_KEY` environment variable and configure your deployment:
+Set the `AZURE_API_KEY` environment variable and configure your deployment:
 
 ```yaml
 providers:
-  - id: azureopenai:chat:deploymentNameHere
+  - id: azure:chat:deploymentNameHere
     config:
       apiHost: 'xxxxxxxx.openai.azure.com'
 ```
@@ -38,61 +38,61 @@ Then configure your deployment:
 
 ```yaml
 providers:
-  - id: azureopenai:chat:deploymentNameHere
+  - id: azure:chat:deploymentNameHere
     config:
       apiHost: 'xxxxxxxx.openai.azure.com'
 ```
 
 ## Provider Types
 
-- `azureopenai:chat:<deployment name>` - uses the given deployment (for chat endpoints such as gpt-35-turbo, gpt-4)
-- `azureopenai:completion:<deployment name>` - uses the given deployment (for completion endpoints such as gpt-35-instruct)
+- `azure:chat:<deployment name>` - uses the given deployment (for chat endpoints such as gpt-35-turbo, gpt-4)
+- `azure:completion:<deployment name>` - uses the given deployment (for completion endpoints such as gpt-35-instruct)
 
 ## Environment Variables
 
 The Azure OpenAI provider supports the following environment variables:
 
-| Environment Variable           | Config Key           | Description                        | Required |
-| ------------------------------ | -------------------- | ---------------------------------- | -------- |
-| `AZURE_OPENAI_API_KEY`         | `apiKey`             | Your Azure OpenAI API key          | No\*     |
-| `AZURE_OPENAI_API_HOST`        | `apiHost`            | API host                           | No       |
-| `AZURE_OPENAI_API_BASE_URL`    | `apiBaseUrl`         | API base URL                       | No       |
-| `AZURE_OPENAI_BASE_URL`        | `apiBaseUrl`         | Alternative API base URL           | No       |
-| `AZURE_OPENAI_DEPLOYMENT_NAME` | -                    | Default deployment name            | Yes      |
-| `AZURE_CLIENT_ID`              | `azureClientId`      | Azure AD application client ID     | No\*     |
-| `AZURE_CLIENT_SECRET`          | `azureClientSecret`  | Azure AD application client secret | No\*     |
-| `AZURE_TENANT_ID`              | `azureTenantId`      | Azure AD tenant ID                 | No\*     |
-| `AZURE_AUTHORITY_HOST`         | `azureAuthorityHost` | Azure AD authority host            | No       |
-| `AZURE_TOKEN_SCOPE`            | `azureTokenScope`    | Azure AD token scope               | No       |
+| Environment Variable    | Config Key           | Description                        | Required |
+| ----------------------- | -------------------- | ---------------------------------- | -------- |
+| `AZURE_API_KEY`         | `apiKey`             | Your Azure OpenAI API key          | No\*     |
+| `AZURE_API_HOST`        | `apiHost`            | API host                           | No       |
+| `AZURE_API_BASE_URL`    | `apiBaseUrl`         | API base URL                       | No       |
+| `AZURE_BASE_URL`        | `apiBaseUrl`         | Alternative API base URL           | No       |
+| `AZURE_DEPLOYMENT_NAME` | -                    | Default deployment name            | Yes      |
+| `AZURE_CLIENT_ID`       | `azureClientId`      | Azure AD application client ID     | No\*     |
+| `AZURE_CLIENT_SECRET`   | `azureClientSecret`  | Azure AD application client secret | No\*     |
+| `AZURE_TENANT_ID`       | `azureTenantId`      | Azure AD tenant ID                 | No\*     |
+| `AZURE_AUTHORITY_HOST`  | `azureAuthorityHost` | Azure AD authority host            | No       |
+| `AZURE_TOKEN_SCOPE`     | `azureTokenScope`    | Azure AD token scope               | No       |
 
-\* Either `AZURE_OPENAI_API_KEY` OR the combination of `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` must be provided.
+\* Either `AZURE_API_KEY` OR the combination of `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` must be provided.
 
-Note: For API URLs, you only need to set one of `AZURE_OPENAI_API_HOST`, `AZURE_OPENAI_API_BASE_URL`, or `AZURE_OPENAI_BASE_URL`. If multiple are set, the provider will use them in that order of preference.
+Note: For API URLs, you only need to set one of `AZURE_API_HOST`, `AZURE_API_BASE_URL`, or `AZURE_BASE_URL`. If multiple are set, the provider will use them in that order of preference.
 
 ### Default Deployment
 
-If `AZURE_OPENAI_DEPLOYMENT_NAME` is set, it will be automatically used as the default deployment when no other provider is configured. This makes Azure OpenAI the default provider when:
+If `AZURE_DEPLOYMENT_NAME` is set, it will be automatically used as the default deployment when no other provider is configured. This makes Azure OpenAI the default provider when:
 
 1. No OpenAI API key is present (`OPENAI_API_KEY` is not set)
 2. Azure authentication is configured (either via API key or client credentials)
-3. `AZURE_OPENAI_DEPLOYMENT_NAME` is set
+3. `AZURE_DEPLOYMENT_NAME` is set
 
 For example, if you have these environment variables set:
 
 ```bash
-AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4
-AZURE_OPENAI_API_KEY=your-api-key
-AZURE_OPENAI_API_HOST=your-host.openai.azure.com
+AZURE_DEPLOYMENT_NAME=gpt-4
+AZURE_API_KEY=your-api-key
+AZURE_API_HOST=your-host.openai.azure.com
 ```
 
 Or these client credential environment variables:
 
 ```bash
-AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4
+AZURE_DEPLOYMENT_NAME=gpt-4
 AZURE_CLIENT_ID=your-client-id
 AZURE_CLIENT_SECRET=your-client-secret
 AZURE_TENANT_ID=your-tenant-id
-AZURE_OPENAI_API_HOST=your-host.openai.azure.com
+AZURE_API_HOST=your-host.openai.azure.com
 ```
 
 Then Azure OpenAI will be used as the default provider for all operations including:
@@ -112,7 +112,7 @@ The YAML configuration can override environment variables and set additional par
 
 ```yaml
 providers:
-  - id: azureopenai:chat:deploymentNameHere
+  - id: azure:chat:deploymentNameHere
     config:
       apiHost: 'xxxxxxxx.openai.azure.com'
       # Authentication (Option 1: API Key)
@@ -146,7 +146,7 @@ Then set the following configuration variables:
 
 ```yaml
 providers:
-  - id: azureopenai:chat:deploymentNameHere
+  - id: azure:chat:deploymentNameHere
     config:
       apiHost: 'xxxxxxxx.openai.azure.com'
       azureClientId: 'your-azure-client-id'
@@ -176,7 +176,7 @@ The easiest way to do this for _all_ your test cases is to add the [`defaultTest
 defaultTest:
   options:
     provider:
-      id: azureopenai:chat:gpt-4-deployment-name
+      id: azure:chat:gpt-4-deployment-name
       config:
         apiHost: 'xxxxxxx.openai.azure.com'
 ```
@@ -189,7 +189,7 @@ assert:
   - type: llm-rubric
     value: Do not mention that you are an AI or chat assistant
     provider:
-      id: azureopenai:chat:xxxx
+      id: azure:chat:xxxx
       config:
         apiHost: 'xxxxxxx.openai.azure.com'
 ```
@@ -203,17 +203,13 @@ tests:
       # ...
     options:
       provider:
-        id: azureopenai:chat:xxxx
+        id: azure:chat:xxxx
         config:
           apiHost: 'xxxxxxx.openai.azure.com'
     assert:
       - type: llm-rubric
         value: Do not mention that you are an AI or chat assistant
 ```
-
-:::note
-The `maybeEmitAzureOpenAiWarning` function in the implementation will warn you if you're using model-graded assertions with Azure providers without specifying an override.
-:::
 
 ### Similarity
 
@@ -225,7 +221,7 @@ You may also specify `deployment_id` and `dataSources`, used to integrate with t
 
 ```yaml
 providers:
-  - id: azureopenai:chat:deploymentNameHere
+  - id: azure:chat:deploymentNameHere
     config:
       apiHost: 'xxxxxxxx.openai.azure.com'
       deployment_id: 'abc123'
@@ -293,7 +289,7 @@ Next, record the assistant ID and set up your provider like so:
 
 ```yaml
 providers:
-  - id: azureopenai:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
+  - id: azure:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
     config:
       apiHost: yourdeploymentname.openai.azure.com
 ```
@@ -307,7 +303,7 @@ prompts:
   - 'Write a tweet about {{topic}}'
 
 providers:
-  - id: azureopenai:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
+  - id: azure:assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
     config:
       apiHost: yourdeploymentname.openai.azure.com
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -81,7 +81,43 @@
                             "AZURE_OPENAI_API_KEY": {
                               "type": "string"
                             },
+                            "AZURE_API_BASE_URL": {
+                              "type": "string"
+                            },
+                            "AZURE_API_HOST": {
+                              "type": "string"
+                            },
+                            "AZURE_API_KEY": {
+                              "type": "string"
+                            },
+                            "AZURE_DEPLOYMENT_NAME": {
+                              "type": "string"
+                            },
+                            "AZURE_EMBEDDING_DEPLOYMENT_NAME": {
+                              "type": "string"
+                            },
                             "AZURE_OPENAI_BASE_URL": {
+                              "type": "string"
+                            },
+                            "AZURE_OPENAI_DEPLOYMENT_NAME": {
+                              "type": "string"
+                            },
+                            "AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME": {
+                              "type": "string"
+                            },
+                            "AZURE_CLIENT_SECRET": {
+                              "type": "string"
+                            },
+                            "AZURE_CLIENT_ID": {
+                              "type": "string"
+                            },
+                            "AZURE_TENANT_ID": {
+                              "type": "string"
+                            },
+                            "AZURE_AUTHORITY_HOST": {
+                              "type": "string"
+                            },
+                            "AZURE_TOKEN_SCOPE": {
                               "type": "string"
                             },
                             "BAM_API_HOST": {
@@ -96,7 +132,13 @@
                             "CLOUDFLARE_API_KEY": {
                               "type": "string"
                             },
+                            "PROMPTFOO_REMOTE_GENERATION_URL": {
+                              "type": "string"
+                            },
                             "COHERE_API_KEY": {
+                              "type": "string"
+                            },
+                            "FAL_KEY": {
                               "type": "string"
                             },
                             "GOOGLE_API_HOST": {
@@ -160,6 +202,15 @@
                               "type": "string"
                             },
                             "VERTEX_REGION": {
+                              "type": "string"
+                            },
+                            "WATSONX_AI_APIKEY": {
+                              "type": "string"
+                            },
+                            "WATSONX_AI_PROJECT_ID": {
+                              "type": "string"
+                            },
+                            "WATSONX_AI_BEARER_TOKEN": {
                               "type": "string"
                             }
                           },

--- a/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
+++ b/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
@@ -70,8 +70,8 @@ const ConfigureEnvButton: React.FC = () => {
                 label="Azure API key"
                 fullWidth
                 margin="normal"
-                value={env.AZURE_OPENAI_API_KEY}
-                onChange={(e) => setEnv({ ...env, AZURE_OPENAI_API_KEY: e.target.value })}
+                value={env.AZURE_API_KEY || env.AZURE_OPENAI_API_KEY}
+                onChange={(e) => setEnv({ ...env, AZURE_API_KEY: e.target.value })}
               />
             </AccordionDetails>
           </Accordion>

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -139,6 +139,8 @@ export type EnvVars = {
   AZURE_TENANT_ID?: string;
   AZURE_AUTHORITY_HOST?: string;
   AZURE_TOKEN_SCOPE?: string;
+  AZURE_DEPLOYMENT_NAME?: string;
+  AZURE_EMBEDDING_DEPLOYMENT_NAME?: string;
   AZURE_OPENAI_DEPLOYMENT_NAME?: string;
   AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME?: string;
 } & EnvOverrides;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -13,7 +13,7 @@ import { renderPrompt, runExtensionHook } from './evaluatorHelpers';
 import logger from './logger';
 import type Eval from './models/eval';
 import { generateIdFromPrompt } from './models/prompt';
-import { maybeEmitAzureOpenAiWarning } from './providers/azureopenaiUtil';
+import { maybeEmitAzureOpenAiWarning } from './providers/azureUtil';
 import { generatePrompts } from './suggestions';
 import telemetry from './telemetry';
 import type {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -14,11 +14,11 @@ import {
 import { AI21ChatCompletionProvider } from './providers/ai21';
 import { AnthropicCompletionProvider, AnthropicMessagesProvider } from './providers/anthropic';
 import {
-  AzureOpenAiAssistantProvider,
-  AzureOpenAiChatCompletionProvider,
-  AzureOpenAiCompletionProvider,
-  AzureOpenAiEmbeddingProvider,
-} from './providers/azureopenai';
+  AzureAssistantProvider,
+  AzureChatCompletionProvider,
+  AzureCompletionProvider,
+  AzureEmbeddingProvider,
+} from './providers/azure';
 import { BAMChatProvider, BAMEmbeddingProvider } from './providers/bam';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './providers/bedrock';
 import { BrowserProvider } from './providers/browser';
@@ -176,23 +176,20 @@ export async function loadApiProvider(
       );
       ret = new OpenAiChatCompletionProvider(modelType, providerOptions);
     }
-  } else if (providerPath.startsWith('azureopenai:')) {
+  } else if (providerPath.startsWith('azure:') || providerPath.startsWith('azureopenai:')) {
     // Load Azure OpenAI module
     const splits = providerPath.split(':');
     const modelType = splits[1];
     const deploymentName = splits[2];
 
     if (modelType === 'chat') {
-      ret = new AzureOpenAiChatCompletionProvider(deploymentName, providerOptions);
+      ret = new AzureChatCompletionProvider(deploymentName, providerOptions);
     } else if (modelType === 'assistant') {
-      ret = new AzureOpenAiAssistantProvider(deploymentName, providerOptions);
+      ret = new AzureAssistantProvider(deploymentName, providerOptions);
     } else if (modelType === 'embedding' || modelType === 'embeddings') {
-      ret = new AzureOpenAiEmbeddingProvider(
-        deploymentName || 'text-embedding-ada-002',
-        providerOptions,
-      );
+      ret = new AzureEmbeddingProvider(deploymentName || 'text-embedding-ada-002', providerOptions);
     } else if (modelType === 'completion') {
-      ret = new AzureOpenAiCompletionProvider(deploymentName, providerOptions);
+      ret = new AzureCompletionProvider(deploymentName, providerOptions);
     } else {
       throw new Error(
         `Unknown Azure OpenAI model type: ${modelType}. Use one of the following providers: azureopenai:chat:<model name>, azureopenai:assistant:<assistant id>, azureopenai:completion:<model name>`,
@@ -593,10 +590,17 @@ export default {
   MistralChatCompletionProvider,
   MistralEmbeddingProvider,
   AI21ChatCompletionProvider,
-  AzureOpenAiAssistantProvider,
-  AzureOpenAiChatCompletionProvider,
-  AzureOpenAiCompletionProvider,
-  AzureOpenAiEmbeddingProvider,
+  AzureAssistantProvider,
+  AzureChatCompletionProvider,
+  AzureCompletionProvider,
+  AzureEmbeddingProvider,
+
+  // Backwards compatibility for Azure rename 2024-11-09 / 0.96.0
+  AzureOpenAiAssistantProvider: AzureAssistantProvider,
+  AzureOpenAiChatCompletionProvider: AzureChatCompletionProvider,
+  AzureOpenAiCompletionProvider: AzureCompletionProvider,
+  AzureOpenAiEmbeddingProvider: AzureEmbeddingProvider,
+
   AwsBedrockCompletionProvider,
   AwsBedrockEmbeddingProvider,
   BrowserProvider,

--- a/src/providers/adaline.gateway.ts
+++ b/src/providers/adaline.gateway.ts
@@ -35,11 +35,7 @@ import type {
 } from '../types';
 import { safeJsonStringify } from '../util/json';
 import { AnthropicMessagesProvider, calculateAnthropicCost } from './anthropic';
-import {
-  AzureOpenAiChatCompletionProvider,
-  AzureOpenAiEmbeddingProvider,
-  calculateAzureOpenAICost,
-} from './azureopenai';
+import { AzureChatCompletionProvider, AzureEmbeddingProvider, calculateAzureCost } from './azure';
 import { GroqProvider } from './groq';
 import {
   OpenAiChatCompletionProvider,
@@ -234,7 +230,7 @@ export class AdalineGatewayEmbeddingProvider extends AdalineGatewayGenericProvid
         });
       } else if (this.providerName === 'azureopenai') {
         const provider = new GatewayAzure();
-        const parentClass = new AzureOpenAiEmbeddingProvider(this.modelName, this.providerOptions);
+        const parentClass = new AzureEmbeddingProvider(this.modelName, this.providerOptions);
         gatewayEmbeddingModel = provider.embeddingModel({
           apiKey: await parentClass.getApiKey(),
           deploymentId: this.modelName,
@@ -473,10 +469,7 @@ export class AdalineGatewayChatProvider extends AdalineGatewayGenericProvider {
         });
       } else if (this.providerName === 'azureopenai') {
         const provider = new GatewayAzure();
-        const parentClass = new AzureOpenAiChatCompletionProvider(
-          this.modelName,
-          this.providerOptions,
-        );
+        const parentClass = new AzureChatCompletionProvider(this.modelName, this.providerOptions);
         const apiKey = await parentClass.getApiKey();
         gatewayChatModel = provider.chatModel({
           apiKey,
@@ -670,7 +663,7 @@ export class AdalineGatewayChatProvider extends AdalineGatewayGenericProvider {
           response.response.usage?.completionTokens,
         );
       } else if (this.providerName === 'azureopenai') {
-        cost = calculateAzureOpenAICost(
+        cost = calculateAzureCost(
           this.modelName,
           {},
           response.response.usage?.promptTokens,

--- a/src/providers/azure.ts
+++ b/src/providers/azure.ts
@@ -21,7 +21,7 @@ import { maybeLoadFromExternalFile, renderVarsInObject } from '../util';
 import { sleep } from '../util/time';
 import { REQUEST_TIMEOUT_MS, parseChatPrompt, toTitleCase, calculateCost } from './shared';
 
-interface AzureOpenAiCompletionOptions {
+interface AzureCompletionOptions {
   // Azure identity params
   azureClientId?: string;
   azureClientSecret?: string;
@@ -69,7 +69,7 @@ interface AzureOpenAiCompletionOptions {
   passthrough?: object;
 }
 
-const AZURE_OPENAI_MODELS = [
+const AZURE_MODELS = [
   {
     id: 'gpt-4o-2024-08-06',
     cost: {
@@ -178,9 +178,9 @@ const AZURE_OPENAI_MODELS = [
   },
 ];
 
-export function calculateAzureOpenAICost(
+export function calculateAzureCost(
   modelName: string,
-  config: AzureOpenAiCompletionOptions,
+  config: AzureCompletionOptions,
   promptTokens?: number,
   completionTokens?: number,
 ): number | undefined {
@@ -189,21 +189,21 @@ export function calculateAzureOpenAICost(
     { cost: undefined },
     promptTokens,
     completionTokens,
-    AZURE_OPENAI_MODELS,
+    AZURE_MODELS,
   );
 }
 
-export class AzureOpenAiGenericProvider implements ApiProvider {
+export class AzureGenericProvider implements ApiProvider {
   deploymentName: string;
   apiHost?: string;
   apiBaseUrl?: string;
 
-  config: AzureOpenAiCompletionOptions;
+  config: AzureCompletionOptions;
   env?: EnvOverrides;
 
   constructor(
     deploymentName: string,
-    options: { config?: AzureOpenAiCompletionOptions; id?: string; env?: EnvOverrides } = {},
+    options: { config?: AzureCompletionOptions; id?: string; env?: EnvOverrides } = {},
   ) {
     const { config, id, env } = options;
     this.env = env;
@@ -211,11 +211,18 @@ export class AzureOpenAiGenericProvider implements ApiProvider {
     this.deploymentName = deploymentName;
 
     this.apiHost =
-      config?.apiHost || env?.AZURE_OPENAI_API_HOST || getEnvString('AZURE_OPENAI_API_HOST');
+      config?.apiHost ||
+      // These and similar OPENAI envars: Backwards compatibility for Azure rename 2024-11-09 / 0.96.0
+      env?.AZURE_API_HOST ||
+      env?.AZURE_OPENAI_API_HOST ||
+      getEnvString('AZURE_API_HOST') ||
+      getEnvString('AZURE_OPENAI_API_HOST');
     this.apiBaseUrl =
       config?.apiBaseUrl ||
+      env?.AZURE_API_BASE_URL ||
       env?.AZURE_OPENAI_API_BASE_URL ||
       env?.AZURE_OPENAI_BASE_URL ||
+      getEnvString('AZURE_API_BASE_URL') ||
       getEnvString('AZURE_OPENAI_API_BASE_URL') ||
       getEnvString('AZURE_OPENAI_BASE_URL');
 
@@ -232,6 +239,8 @@ export class AzureOpenAiGenericProvider implements ApiProvider {
           ? process.env[this.config.apiKeyEnvar] ||
             this.env?.[this.config.apiKeyEnvar as keyof EnvOverrides]
           : undefined) ||
+        this.env?.AZURE_API_KEY ||
+        getEnvString('AZURE_API_KEY') ||
         this.env?.AZURE_OPENAI_API_KEY ||
         getEnvString('AZURE_OPENAI_API_KEY');
 
@@ -269,7 +278,7 @@ export class AzureOpenAiGenericProvider implements ApiProvider {
       }
 
       throw new Error(
-        'Azure OpenAI authentication failed. Please provide either an API key via AZURE_OPENAI_API_KEY or client credentials via AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID',
+        'Azure authentication failed. Please provide either an API key via AZURE_API_KEY or client credentials via AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID',
       );
     }
     return this._cachedApiKey;
@@ -287,7 +296,7 @@ export class AzureOpenAiGenericProvider implements ApiProvider {
   }
 
   id(): string {
-    return `azureopenai:${this.deploymentName}`;
+    return `azure:${this.deploymentName}`;
   }
 
   toString(): string {
@@ -304,7 +313,7 @@ export class AzureOpenAiGenericProvider implements ApiProvider {
   }
 }
 
-export class AzureOpenAiEmbeddingProvider extends AzureOpenAiGenericProvider {
+export class AzureEmbeddingProvider extends AzureGenericProvider {
   async callEmbeddingApi(text: string): Promise<ProviderEmbeddingResponse> {
     const apiKey = await this.getApiKey();
     if (!apiKey) {
@@ -381,7 +390,7 @@ export class AzureOpenAiEmbeddingProvider extends AzureOpenAiGenericProvider {
   }
 }
 
-export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
+export class AzureCompletionProvider extends AzureGenericProvider {
   async callApi(
     prompt: string,
     context?: CallApiContextParams,
@@ -390,7 +399,7 @@ export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
     const apiKey = await this.getApiKey();
     if (!apiKey) {
       throw new Error(
-        'Azure OpenAI API key is not set. Set AZURE_OPENAI_API_KEY environment variable or pass it as an argument to the constructor.',
+        'Azure OpenAI API key is not set. Set AZURE_API_KEY environment variable or pass it as an argument to the constructor.',
       );
     }
     if (!this.getApiBaseUrl()) {
@@ -457,7 +466,7 @@ export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
               prompt: data.usage.prompt_tokens,
               completion: data.usage.completion_tokens,
             },
-        cost: calculateAzureOpenAICost(
+        cost: calculateAzureCost(
           this.deploymentName,
           this.config,
           data.usage?.prompt_tokens,
@@ -472,7 +481,7 @@ export class AzureOpenAiCompletionProvider extends AzureOpenAiGenericProvider {
   }
 }
 
-export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvider {
+export class AzureChatCompletionProvider extends AzureGenericProvider {
   getOpenAiBody(
     prompt: string,
     context?: CallApiContextParams,
@@ -541,7 +550,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
     const apiKey = await this.getApiKey();
     if (!apiKey) {
       throw new Error(
-        'Azure OpenAI API key is not set. Set AZURE_OPENAI_API_KEY environment variable or pass it as an argument to the constructor.',
+        'Azure OpenAI API key is not set. Set AZURE_API_KEY environment variable or pass it as an argument to the constructor.',
       );
     }
     if (!this.getApiBaseUrl()) {
@@ -615,7 +624,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
             },
         cached,
         logProbs,
-        cost: calculateAzureOpenAICost(
+        cost: calculateAzureCost(
           this.deploymentName,
           this.config,
           data.usage?.prompt_tokens,
@@ -630,7 +639,7 @@ export class AzureOpenAiChatCompletionProvider extends AzureOpenAiGenericProvide
   }
 }
 
-type AzureOpenAiAssistantOptions = AzureOpenAiCompletionOptions &
+type AzureAssistantOptions = AzureCompletionOptions &
   Partial<AssistantCreationOptions> & {
     /**
      * If set, automatically call these functions when the assistant activates
@@ -640,14 +649,14 @@ type AzureOpenAiAssistantOptions = AzureOpenAiCompletionOptions &
   };
 
 // See https://learn.microsoft.com/en-us/javascript/api/overview/azure/openai-assistants-readme?view=azure-node-preview
-export class AzureOpenAiAssistantProvider extends AzureOpenAiGenericProvider {
-  assistantConfig: AzureOpenAiAssistantOptions;
+export class AzureAssistantProvider extends AzureGenericProvider {
+  assistantConfig: AzureAssistantOptions;
   assistantsClient: AssistantsClient | undefined;
   private initializationPromise: Promise<void> | null = null;
 
   constructor(
     deploymentName: string,
-    options: { config?: AzureOpenAiAssistantOptions; id?: string; env?: EnvOverrides } = {},
+    options: { config?: AzureAssistantOptions; id?: string; env?: EnvOverrides } = {},
   ) {
     super(deploymentName, options);
     this.assistantConfig = options.config || {};

--- a/src/providers/azureUtil.ts
+++ b/src/providers/azureUtil.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { MODEL_GRADED_ASSERTION_TYPES } from '../assertions';
 import logger from '../logger';
 import type { TestCase, TestSuite } from '../types';
-import { AzureOpenAiChatCompletionProvider, AzureOpenAiCompletionProvider } from './azureopenai';
+import { AzureChatCompletionProvider, AzureCompletionProvider } from './azure';
 import {
   OpenAiAssistantProvider,
   OpenAiChatCompletionProvider,
@@ -11,8 +11,7 @@ import {
 
 export function maybeEmitAzureOpenAiWarning(testSuite: TestSuite, tests: TestCase[]) {
   const hasAzure = testSuite.providers.some(
-    (p) =>
-      p instanceof AzureOpenAiChatCompletionProvider || p instanceof AzureOpenAiCompletionProvider,
+    (p) => p instanceof AzureChatCompletionProvider || p instanceof AzureCompletionProvider,
   );
   const hasOpenAi = testSuite.providers.some(
     (p) =>

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -7,7 +7,7 @@ import {
   DefaultSuggestionsProvider as AnthropicSuggestionsProvider,
   DefaultLlmRubricProvider as AnthropicLlmRubricProvider,
 } from './anthropic';
-import { AzureOpenAiChatCompletionProvider, AzureOpenAiEmbeddingProvider } from './azureopenai';
+import { AzureChatCompletionProvider, AzureEmbeddingProvider } from './azure';
 import {
   DefaultEmbeddingProvider as OpenAiEmbeddingProvider,
   DefaultGradingJsonProvider as OpenAiGradingJsonProvider,
@@ -38,7 +38,11 @@ export async function getDefaultProviders(env?: EnvOverrides): Promise<DefaultPr
     !env?.OPENAI_API_KEY &&
     (getEnvString('ANTHROPIC_API_KEY') || env?.ANTHROPIC_API_KEY);
 
-  const hasAzureApiKey = getEnvString('AZURE_OPENAI_API_KEY') || env?.AZURE_OPENAI_API_KEY;
+  const hasAzureApiKey =
+    getEnvString('AZURE_OPENAI_API_KEY') ||
+    env?.AZURE_OPENAI_API_KEY ||
+    getEnvString('AZURE_API_KEY') ||
+    env?.AZURE_API_KEY;
   const hasAzureClientCreds =
     (getEnvString('AZURE_CLIENT_ID') || env?.AZURE_CLIENT_ID) &&
     (getEnvString('AZURE_CLIENT_SECRET') || env?.AZURE_CLIENT_SECRET) &&
@@ -48,6 +52,7 @@ export async function getDefaultProviders(env?: EnvOverrides): Promise<DefaultPr
     !getEnvString('OPENAI_API_KEY') &&
     !env?.OPENAI_API_KEY &&
     (hasAzureApiKey || hasAzureClientCreds) &&
+    (getEnvString('AZURE_DEPLOYMENT_NAME') || env?.AZURE_DEPLOYMENT_NAME) &&
     (getEnvString('AZURE_OPENAI_DEPLOYMENT_NAME') || env?.AZURE_OPENAI_DEPLOYMENT_NAME);
 
   if (preferAzure) {
@@ -63,8 +68,8 @@ export async function getDefaultProviders(env?: EnvOverrides): Promise<DefaultPr
       env?.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME ||
       deploymentName;
 
-    const azureProvider = new AzureOpenAiChatCompletionProvider(deploymentName, { env });
-    const azureEmbeddingProvider = new AzureOpenAiEmbeddingProvider(embeddingDeploymentName, {
+    const azureProvider = new AzureChatCompletionProvider(deploymentName, { env });
+    const azureEmbeddingProvider = new AzureEmbeddingProvider(embeddingDeploymentName, {
       env,
     });
 

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -107,6 +107,7 @@ export interface ProviderClassificationResponse {
   classification?: Record<string, number>;
 }
 
+// Note: sync with validators/providers.ts
 export type EnvOverrides = {
   AI21_API_BASE_URL?: string;
   AI21_API_KEY?: string;
@@ -115,6 +116,11 @@ export type EnvOverrides = {
   AZURE_OPENAI_API_BASE_URL?: string;
   AZURE_OPENAI_API_HOST?: string;
   AZURE_OPENAI_API_KEY?: string;
+  AZURE_API_BASE_URL?: string;
+  AZURE_API_HOST?: string;
+  AZURE_API_KEY?: string;
+  AZURE_DEPLOYMENT_NAME?: string;
+  AZURE_EMBEDDING_DEPLOYMENT_NAME?: string;
   AZURE_OPENAI_BASE_URL?: string;
   AZURE_OPENAI_DEPLOYMENT_NAME?: string;
   AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME?: string;

--- a/src/validators/providers.ts
+++ b/src/validators/providers.ts
@@ -13,6 +13,7 @@ import type {
 import { PromptSchema } from './prompts';
 import { NunjucksFilterMapSchema, TokenUsageSchema } from './shared';
 
+// Note: sync with types/providers.ts
 export const ProviderEnvOverridesSchema = z.object({
   AI21_API_BASE_URL: z.string().optional(),
   AI21_API_KEY: z.string().optional(),
@@ -21,12 +22,26 @@ export const ProviderEnvOverridesSchema = z.object({
   AZURE_OPENAI_API_BASE_URL: z.string().optional(),
   AZURE_OPENAI_API_HOST: z.string().optional(),
   AZURE_OPENAI_API_KEY: z.string().optional(),
+  AZURE_API_BASE_URL: z.string().optional(),
+  AZURE_API_HOST: z.string().optional(),
+  AZURE_API_KEY: z.string().optional(),
+  AZURE_DEPLOYMENT_NAME: z.string().optional(),
+  AZURE_EMBEDDING_DEPLOYMENT_NAME: z.string().optional(),
   AZURE_OPENAI_BASE_URL: z.string().optional(),
+  AZURE_OPENAI_DEPLOYMENT_NAME: z.string().optional(),
+  AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: z.string().optional(),
+  AZURE_CLIENT_SECRET: z.string().optional(),
+  AZURE_CLIENT_ID: z.string().optional(),
+  AZURE_TENANT_ID: z.string().optional(),
+  AZURE_AUTHORITY_HOST: z.string().optional(),
+  AZURE_TOKEN_SCOPE: z.string().optional(),
   BAM_API_HOST: z.string().optional(),
   BAM_API_KEY: z.string().optional(),
   CLOUDFLARE_ACCOUNT_ID: z.string().optional(),
   CLOUDFLARE_API_KEY: z.string().optional(),
+  PROMPTFOO_REMOTE_GENERATION_URL: z.string().optional(),
   COHERE_API_KEY: z.string().optional(),
+  FAL_KEY: z.string().optional(),
   GOOGLE_API_HOST: z.string().optional(),
   GOOGLE_API_KEY: z.string().optional(),
   GROQ_API_KEY: z.string().optional(),
@@ -48,6 +63,9 @@ export const ProviderEnvOverridesSchema = z.object({
   VERTEX_PROJECT_ID: z.string().optional(),
   VERTEX_PUBLISHER: z.string().optional(),
   VERTEX_REGION: z.string().optional(),
+  WATSONX_AI_APIKEY: z.string().optional(),
+  WATSONX_AI_PROJECT_ID: z.string().optional(),
+  WATSONX_AI_BEARER_TOKEN: z.string().optional(),
 });
 
 export const ProviderOptionsSchema = z

--- a/test/providers/azure.test.ts
+++ b/test/providers/azure.test.ts
@@ -1,7 +1,7 @@
-import { AzureOpenAiCompletionProvider } from '../../src/providers/azureopenai';
-import { AzureOpenAiGenericProvider } from '../../src/providers/azureopenai';
-import { AzureOpenAiChatCompletionProvider } from '../../src/providers/azureopenai';
-import { maybeEmitAzureOpenAiWarning } from '../../src/providers/azureopenaiUtil';
+import { AzureCompletionProvider } from '../../src/providers/azure';
+import { AzureGenericProvider } from '../../src/providers/azure';
+import { AzureChatCompletionProvider } from '../../src/providers/azure';
+import { maybeEmitAzureOpenAiWarning } from '../../src/providers/azureUtil';
 import { HuggingfaceTextGenerationProvider } from '../../src/providers/huggingface';
 import { OpenAiCompletionProvider } from '../../src/providers/openai';
 import type { TestSuite, TestCase, CallApiContextParams } from '../../src/types';
@@ -26,7 +26,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
 
   it('should not emit warning when Azure provider is used alone, but no model graded eval', () => {
     const testSuite: TestSuite = {
-      providers: [new AzureOpenAiCompletionProvider('foo')],
+      providers: [new AzureCompletionProvider('foo')],
       defaultTest: {},
       prompts: [],
     };
@@ -41,7 +41,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
 
   it('should emit warning when Azure provider is used alone, but with model graded eval', () => {
     const testSuite: TestSuite = {
-      providers: [new AzureOpenAiCompletionProvider('foo')],
+      providers: [new AzureCompletionProvider('foo')],
       defaultTest: {},
       prompts: [],
     };
@@ -56,10 +56,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
 
   it('should emit warning when Azure provider used with non-OpenAI provider', () => {
     const testSuite: TestSuite = {
-      providers: [
-        new AzureOpenAiCompletionProvider('foo'),
-        new HuggingfaceTextGenerationProvider('bar'),
-      ],
+      providers: [new AzureCompletionProvider('foo'), new HuggingfaceTextGenerationProvider('bar')],
       defaultTest: {},
       prompts: [],
     };
@@ -74,7 +71,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
 
   it('should not emit warning when Azure providers are used with a default provider set', () => {
     const testSuite: TestSuite = {
-      providers: [new AzureOpenAiCompletionProvider('foo')],
+      providers: [new AzureCompletionProvider('foo')],
       defaultTest: { options: { provider: 'azureopenai:....' } },
       prompts: [],
     };
@@ -89,7 +86,7 @@ describe('maybeEmitAzureOpenAiWarning', () => {
 
   it('should not emit warning when both Azure and OpenAI providers are used', () => {
     const testSuite: TestSuite = {
-      providers: [new AzureOpenAiCompletionProvider('foo'), new OpenAiCompletionProvider('bar')],
+      providers: [new AzureCompletionProvider('foo'), new OpenAiCompletionProvider('bar')],
       defaultTest: {},
       prompts: [],
     };
@@ -110,42 +107,42 @@ describe('AzureOpenAiGenericProvider', () => {
     });
 
     it('should return apiBaseUrl if set', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {
+      const provider = new AzureGenericProvider('test-deployment', {
         config: { apiBaseUrl: 'https://custom.azure.com' },
       });
       expect(provider.getApiBaseUrl()).toBe('https://custom.azure.com');
     });
 
     it('should return apiBaseUrl without trailing slash if set', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {
+      const provider = new AzureGenericProvider('test-deployment', {
         config: { apiBaseUrl: 'https://custom.azure.com/' },
       });
       expect(provider.getApiBaseUrl()).toBe('https://custom.azure.com');
     });
 
     it('should construct URL from apiHost without protocol', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {
+      const provider = new AzureGenericProvider('test-deployment', {
         config: { apiHost: 'api.azure.com' },
       });
       expect(provider.getApiBaseUrl()).toBe('https://api.azure.com');
     });
 
     it('should remove protocol from apiHost if present', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {
+      const provider = new AzureGenericProvider('test-deployment', {
         config: { apiHost: 'https://api.azure.com' },
       });
       expect(provider.getApiBaseUrl()).toBe('https://api.azure.com');
     });
 
     it('should remove trailing slash from apiHost if present', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {
+      const provider = new AzureGenericProvider('test-deployment', {
         config: { apiHost: 'api.azure.com/' },
       });
       expect(provider.getApiBaseUrl()).toBe('https://api.azure.com');
     });
 
     it('should return undefined if neither apiBaseUrl nor apiHost is set', () => {
-      const provider = new AzureOpenAiGenericProvider('test-deployment', {});
+      const provider = new AzureGenericProvider('test-deployment', {});
       expect(provider.getApiBaseUrl()).toBeUndefined();
     });
   });
@@ -153,10 +150,10 @@ describe('AzureOpenAiGenericProvider', () => {
 
 describe('AzureOpenAiChatCompletionProvider', () => {
   describe('config merging', () => {
-    let provider: AzureOpenAiChatCompletionProvider;
+    let provider: AzureChatCompletionProvider;
 
     beforeEach(() => {
-      provider = new AzureOpenAiChatCompletionProvider('test-deployment', {
+      provider = new AzureChatCompletionProvider('test-deployment', {
         config: {
           apiHost: 'test.azure.com',
           apiKey: 'test-key',

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -9,10 +9,7 @@ import { importModule } from '../../src/esm';
 import logger from '../../src/logger';
 import { loadApiProvider, loadApiProviders } from '../../src/providers';
 import { AnthropicCompletionProvider } from '../../src/providers/anthropic';
-import {
-  AzureOpenAiChatCompletionProvider,
-  AzureOpenAiCompletionProvider,
-} from '../../src/providers/azureopenai';
+import { AzureChatCompletionProvider, AzureCompletionProvider } from '../../src/providers/azure';
 import { AwsBedrockCompletionProvider } from '../../src/providers/bedrock';
 import {
   CloudflareAiChatCompletionProvider,
@@ -385,7 +382,7 @@ describe('call provider apis', () => {
     };
     mockFetch.mockResolvedValue(mockResponse);
 
-    const provider = new AzureOpenAiCompletionProvider('text-davinci-003');
+    const provider = new AzureCompletionProvider('text-davinci-003');
     const result = await provider.callApi('Test prompt');
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -405,7 +402,7 @@ describe('call provider apis', () => {
     };
     mockFetch.mockResolvedValue(mockResponse);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
+    const provider = new AzureChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
@@ -440,7 +437,7 @@ describe('call provider apis', () => {
     };
     mockFetch.mockResolvedValue(mockResponse);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini', {
+    const provider = new AzureChatCompletionProvider('gpt-4o-mini', {
       config: { dataSources },
     });
     const result = await provider.callApi(
@@ -469,7 +466,7 @@ describe('call provider apis', () => {
     };
     mockFetch.mockResolvedValue(mockResponse);
 
-    const provider = new AzureOpenAiChatCompletionProvider('gpt-4o-mini');
+    const provider = new AzureChatCompletionProvider('gpt-4o-mini');
     const result = await provider.callApi(
       JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
     );
@@ -1292,12 +1289,12 @@ describe('loadApiProvider', () => {
 
   it('loadApiProvider with azureopenai:completion:modelName', async () => {
     const provider = await loadApiProvider('azureopenai:completion:text-davinci-003');
-    expect(provider).toBeInstanceOf(AzureOpenAiCompletionProvider);
+    expect(provider).toBeInstanceOf(AzureCompletionProvider);
   });
 
   it('loadApiProvider with azureopenai:chat:modelName', async () => {
     const provider = await loadApiProvider('azureopenai:chat:gpt-3.5-turbo');
-    expect(provider).toBeInstanceOf(AzureOpenAiChatCompletionProvider);
+    expect(provider).toBeInstanceOf(AzureChatCompletionProvider);
   });
 
   it('loadApiProvider with anthropic:completion', async () => {


### PR DESCRIPTION
The Azure provider supports more than just OpenAI, so let's just call it `azure`.  We're still supporting all the old configs and envars for backwards compatibility.