### PR TITLE
feat: --filter-sample on eval to randomly sample

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -36,6 +36,7 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 | `-n, --filter-first-n <number>`     | Only run the first N tests                                                      |
 | `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern                      |
 | `--filter-providers <providers>`    | Only run tests with these providers                                             |
+| `--filter-sample <number>`          | Only run a random sample of N tests                                             |
 | `--filter-targets <targets>`        | Only run tests with these targets                                               |
 | `--grader <provider>`               | Model that will grade outputs                                                   |
 | `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                          |

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -883,6 +883,10 @@
               "type": "integer",
               "exclusiveMinimum": 0
             },
+            "filterSample": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
             "filterPattern": {
               "type": "string"
             },

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -135,6 +135,7 @@ export async function doEval(
       firstN: cmdObj.filterFirstN,
       pattern: cmdObj.filterPattern,
       failing: cmdObj.filterFailing,
+      sample: cmdObj.filterSample,
     });
 
     if (
@@ -496,6 +497,7 @@ export function evalCommand(
       '--filter-providers, --filter-targets <providers>',
       'Only run tests with these providers (regex match)',
     )
+    .option('--filter-sample <number>', 'Only run a random sample of N tests')
     .option('--filter-failing <path>', 'Path to json output file')
 
     // Output configuration

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -3,6 +3,7 @@ import { filterFailingTests } from './filterFailingTests';
 
 interface Args {
   firstN?: string | number;
+  sample?: string | number;
   pattern?: string;
   failing?: string;
 }
@@ -20,7 +21,7 @@ export async function filterTests(testSuite: TestSuite, args: Args): Promise<Tes
     return tests;
   }
 
-  const { firstN, pattern, failing } = args;
+  const { firstN, pattern, failing, sample } = args;
   let newTests: NonNullable<Tests>;
 
   if (failing) {
@@ -41,6 +42,22 @@ export async function filterTests(testSuite: TestSuite, args: Args): Promise<Tes
     }
 
     newTests = newTests.slice(0, count);
+  }
+
+  if (sample) {
+    const count = typeof sample === 'number' ? sample : Number.parseInt(sample, 10);
+
+    if (Number.isNaN(count)) {
+      throw new Error(`sample must be a number, got: ${sample}`);
+    }
+
+    // Fisher-Yates shuffle and take first n elements
+    const shuffled = [...newTests];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    newTests = shuffled.slice(0, count);
   }
 
   return newTests;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,7 @@ export const CommandLineOptionsSchema = z.object({
   watch: z.boolean().optional(),
   filterFailing: z.string().optional(),
   filterFirstN: z.coerce.number().int().positive().optional(),
+  filterSample: z.coerce.number().int().positive().optional(),
   filterPattern: z.string().optional(),
   filterProviders: z.string().optional(),
   filterTargets: z.string().optional(),

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -546,6 +546,7 @@ export async function resolveConfigs(
           firstN: cmdObj.filterFirstN,
           pattern: cmdObj.filterPattern,
           failing: cmdObj.filterFailing,
+          sample: cmdObj.filterSample,
         },
       );
       invariant(filteredTests, 'filteredTests are undefined');

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -62,4 +62,45 @@ describe('filterTests', () => {
       expect(result).not.toBe(tests);
     });
   });
+
+  describe('sample', () => {
+    it('should return the requested number of random tests', async () => {
+      const result = await filterTests(testSuite, { sample: 2 });
+
+      expect(result).toHaveLength(2);
+      // Each result should be one of the original tests
+      result?.forEach((test) => {
+        expect(tests).toContain(test);
+      });
+    });
+
+    it('accepts sample as string', async () => {
+      const result = await filterTests(testSuite, { sample: '2' });
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('throws an exception when sample is not a number', async () => {
+      await expect(() => filterTests(testSuite, { sample: 'NOPE' })).rejects.toEqual(
+        new Error('sample must be a number, got: NOPE'),
+      );
+    });
+
+    it('returns all tests when sample size exceeds test count', async () => {
+      const result = await filterTests(testSuite, { sample: 10 });
+
+      expect(result).toHaveLength(tests.length);
+      result?.forEach((test) => {
+        expect(tests).toContain(test);
+      });
+    });
+
+    it('can combine with pattern filter', async () => {
+      const result = await filterTests(testSuite, { sample: 1, pattern: 'ey$' });
+
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(1);
+      expect(result?.[0].description).toMatch(/ey$/);
+    });
+  });
 });


### PR DESCRIPTION
Adds `--filter-sample <number>` to take a random sample

Related to #740 