### PR TITLE
chore: Fix AWS default region to match documentation

### DIFF
--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -765,7 +765,7 @@ export abstract class AwsBedrockGenericProvider {
       this.config?.region ||
       this.env?.AWS_BEDROCK_REGION ||
       getEnvString('AWS_BEDROCK_REGION') ||
-      'us-west-2'
+      'us-east-1'
     );
   }
 }


### PR DESCRIPTION
The AWS Bedrock docs have `us-east-1` as the default region in two instances. [1] and [2]

Fix the ADS Bedrock provider code to use the `us-east-1` as the default region. `us-east-1` is generally assumed the default instead of the `us-west-2`.

1. https://github.com/promptfoo/promptfoo/blob/1a919fc1fab8d81002c4a6e06d322aa50d3de8b9/site/docs/providers/aws-bedrock.md?plain=1#L58
2. https://github.com/promptfoo/promptfoo/blob/1a919fc1fab8d81002c4a6e06d322aa50d3de8b9/site/docs/providers/aws-bedrock.md?plain=1#L68