### PR TITLE
chore: add promptfoo version header to all requests

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,6 @@
 import { ProxyAgent } from 'proxy-agent';
 import invariant from 'tiny-invariant';
+import { VERSION } from './constants';
 import { getEnvInt, getEnvBool } from './envars';
 import logger from './logger';
 import { sleep } from './util/time';
@@ -9,7 +10,14 @@ export async function fetchWithProxy(
   options: RequestInit = {},
 ): Promise<Response> {
   let finalUrl = url;
-  const finalOptions = { ...options };
+
+  const finalOptions = {
+    ...options,
+    headers: {
+      ...options.headers,
+      'x-promptfoo-version': VERSION,
+    } as Record<string, string>,
+  };
 
   if (typeof url === 'string') {
     try {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,4 +1,5 @@
 import { ProxyAgent } from 'proxy-agent';
+import { VERSION } from '../src/constants';
 import { getEnvBool } from '../src/envars';
 import {
   fetchWithProxy,
@@ -60,6 +61,20 @@ describe('fetchWithProxy', () => {
     jest.clearAllMocks();
   });
 
+  it('should add version header to all requests', async () => {
+    const url = 'https://example.com/api';
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-promptfoo-version': VERSION,
+        }),
+      }),
+    );
+  });
+
   it('should handle URLs with basic auth credentials', async () => {
     const url = 'https://username:password@example.com/api';
     const options = { headers: { 'Content-Type': 'application/json' } };
@@ -72,6 +87,7 @@ describe('fetchWithProxy', () => {
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -88,6 +104,7 @@ describe('fetchWithProxy', () => {
       expect.objectContaining({
         headers: {
           'Content-Type': 'application/json',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -120,6 +137,7 @@ describe('fetchWithProxy', () => {
         headers: {
           Authorization: 'Bearer token123',
           'Content-Type': 'application/json',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -143,6 +161,7 @@ describe('fetchWithProxy', () => {
       expect.objectContaining({
         headers: {
           Authorization: 'Bearer token123',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -157,6 +176,7 @@ describe('fetchWithProxy', () => {
       expect.objectContaining({
         headers: {
           Authorization: 'Basic OnBhc3N3b3Jk',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -171,6 +191,7 @@ describe('fetchWithProxy', () => {
       expect.objectContaining({
         headers: {
           Authorization: 'Basic dXNlcm5hbWU6', // Base64 encoded 'username:'
+          'x-promptfoo-version': VERSION,
         },
       }),
     );
@@ -194,6 +215,7 @@ describe('fetchWithProxy', () => {
           'Content-Type': 'application/json',
           'X-Custom-Header': 'value',
           Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+          'x-promptfoo-version': VERSION,
         },
       }),
     );


### PR DESCRIPTION
Add x-promptfoo-version header to all outgoing requests to help with request tracking and debugging.

Changes:
- Add VERSION import from constants
- Add x-promptfoo-version header to all requests in fetchWithProxy
- Update tests to verify header presence in all relevant test cases