### PR TITLE
fix(providers): handle system messages correctly in anthropic parseMessages

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -124,11 +124,21 @@ export function parseMessages(messages: string): {
   try {
     const parsed = JSON.parse(messages);
     if (Array.isArray(parsed)) {
+      const systemMessage = parsed.find((msg) => msg.role === 'system');
       return {
-        extractedMessages: parsed.map((msg) => ({
-          role: msg.role,
-          content: Array.isArray(msg.content) ? msg.content : [{ type: 'text', text: msg.content }],
-        })),
+        extractedMessages: parsed
+          .filter((msg) => msg.role !== 'system')
+          .map((msg) => ({
+            role: msg.role,
+            content: Array.isArray(msg.content)
+              ? msg.content
+              : [{ type: 'text', text: msg.content }],
+          })),
+        system: systemMessage
+          ? Array.isArray(systemMessage.content)
+            ? systemMessage.content
+            : [{ type: 'text', text: systemMessage.content }]
+          : undefined,
       };
     }
   } catch {

--- a/test/providers/anthropic.test.ts
+++ b/test/providers/anthropic.test.ts
@@ -756,13 +756,10 @@ describe('Anthropic', () => {
         { role: 'assistant', content: 'I see a beautiful landscape.' },
       ]);
 
-      const { extractedMessages } = parseMessages(inputMessages);
+      const { system, extractedMessages } = parseMessages(inputMessages);
 
+      expect(system).toEqual([{ type: 'text', text: 'You are a helpful assistant.' }]);
       expect(extractedMessages).toEqual([
-        {
-          role: 'system',
-          content: [{ type: 'text', text: 'You are a helpful assistant.' }],
-        },
         {
           role: 'user',
           content: [
@@ -780,6 +777,54 @@ describe('Anthropic', () => {
         {
           role: 'assistant',
           content: [{ type: 'text', text: 'I see a beautiful landscape.' }],
+        },
+      ]);
+    });
+
+    it('should handle system messages in JSON array format', () => {
+      const inputMessages = JSON.stringify([
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Hello!' },
+        { role: 'assistant', content: 'Hi there!' },
+      ]);
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toEqual([{ type: 'text', text: 'You are a helpful assistant.' }]);
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello!' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi there!' }],
+        },
+      ]);
+    });
+
+    it('should handle system messages with array content in JSON format', () => {
+      const inputMessages = JSON.stringify([
+        {
+          role: 'system',
+          content: [
+            { type: 'text', text: 'You are a helpful assistant.' },
+            { type: 'text', text: 'Additional system context.' },
+          ],
+        },
+        { role: 'user', content: 'Hello!' },
+      ]);
+
+      const { system, extractedMessages } = parseMessages(inputMessages);
+
+      expect(system).toEqual([
+        { type: 'text', text: 'You are a helpful assistant.' },
+        { type: 'text', text: 'Additional system context.' },
+      ]);
+      expect(extractedMessages).toEqual([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello!' }],
         },
       ]);
     });


### PR DESCRIPTION
The Messages API expects system messages to be handled separately from regular messages. This change:
- Extracts system messages from the input array
- Formats system content correctly as TextBlockParams
- Filters system messages out of extractedMessages
- Updates tests to reflect the new behavior

Related to #2123