### PR TITLE
fix: validate config after dereferencing

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -152,14 +152,14 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
   const ext = path.parse(configPath).ext;
   if (ext === '.json' || ext === '.yaml' || ext === '.yml') {
     const rawConfig = yaml.load(fs.readFileSync(configPath, 'utf-8'));
-
-    const validationResult = UnifiedConfigSchema.safeParse(rawConfig);
+    const dereferencedConfig = await dereferenceConfig(rawConfig as UnifiedConfig);
+    const validationResult = UnifiedConfigSchema.safeParse(dereferencedConfig);
     if (!validationResult.success) {
       logger.warn(
         `Invalid configuration file ${configPath}:\n${fromError(validationResult.error).message}`,
       );
     }
-    ret = await dereferenceConfig(rawConfig as UnifiedConfig);
+    ret = dereferencedConfig;
   } else if (isJavascriptFile(configPath)) {
     const imported = await importModule(configPath);
     const validationResult = UnifiedConfigSchema.safeParse(imported);

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1,5 +1,4 @@
 import $RefParser from '@apidevtools/json-schema-ref-parser';
-import dedent from 'dedent';
 import * as fs from 'fs';
 import { globSync } from 'glob';
 import yaml from 'js-yaml';
@@ -941,132 +940,50 @@ describe('readConfig', () => {
   });
 
   it('should resolve YAML references before validation', async () => {
-    const mockFiles: Record<string, string> = {
-      'config.yaml': dedent`
-        description: test_config
-        prompts:
-          - test {{text}}
-        providers:
-          - $ref: defaultParams.yaml#/model
-        temperature: 1
-        tests:
-          - vars:
-              text: test text`,
-      'defaultParams.yaml': `
-        model: echo`,
+    const mockConfig = {
+      description: 'test_config',
+      prompts: ['test {{text}}'],
+      providers: [{ $ref: 'defaultParams.yaml#/model' }],
+      temperature: 1,
+      tests: [{ vars: { text: 'test text' } }],
     };
 
-    jest.spyOn($RefParser.prototype, 'dereference').mockImplementation(async function (schema) {
-      const resolveRefs = (obj: any): any => {
-        if (typeof obj !== 'object' || obj === null) {
-          return obj;
-        }
-
-        if (obj.$ref && typeof obj.$ref === 'string') {
-          const [filePath, pointer] = obj.$ref.split('#/');
-          const fileContent = yaml.load(mockFiles[filePath]);
-          return pointer
-            .split('/')
-            .reduce((acc: Record<string, unknown>, key: string) => acc[key], fileContent);
-        }
-
-        if (Array.isArray(obj)) {
-          return obj.map(resolveRefs);
-        }
-
-        return Object.fromEntries(
-          Object.entries(obj).map(([key, value]) => [key, resolveRefs(value)]),
-        );
-      };
-
-      return resolveRefs(schema);
-    });
-
-    jest.mocked(fs.readFileSync).mockImplementation((path: fs.PathOrFileDescriptor) => {
-      if (typeof path === 'string') {
-        return mockFiles[path.split('/').pop()!] || '';
-      }
-      return '';
-    });
-
-    jest.mocked(fs.existsSync).mockImplementation((path: fs.PathOrFileDescriptor) => {
-      if (typeof path === 'string') {
-        const fileName = path.split('/').pop()!;
-        return fileName in mockFiles;
-      }
-      return false;
-    });
-
-    const result = await readConfig('config.yaml');
-    expect(result).toEqual({
+    const dereferencedConfig = {
       description: 'test_config',
       prompts: ['test {{text}}'],
       providers: ['echo'],
       temperature: 1,
-      tests: [
-        {
-          vars: {
-            text: 'test text',
-          },
-        },
-      ],
-    });
+      tests: [{ vars: { text: 'test text' } }],
+    };
 
+    jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(mockConfig));
+    jest.spyOn($RefParser.prototype, 'dereference').mockResolvedValue(dereferencedConfig);
+
+    const result = await readConfig('config.yaml');
+    expect(result).toEqual(dereferencedConfig);
     expect(fs.readFileSync).toHaveBeenCalledWith('config.yaml', 'utf-8');
   });
 
   it('should throw validation error for invalid dereferenced config', async () => {
-    const mockFiles: Record<string, string> = {
-      'config.yaml': dedent`
-        description: invalid_config
-        prompts:
-          - test prompt
-        providers:
-          - $ref: defaultParams.yaml#/invalidKey`,
-      'defaultParams.yaml': `
-        invalidKey: 
-          invalid: true  # This will fail validation as it's not a valid provider format
-        `,
+    const mockConfig = {
+      description: 'invalid_config',
+      prompts: ['test prompt'],
+      providers: [{ $ref: 'defaultParams.yaml#/invalidKey' }],
     };
 
-    jest.spyOn($RefParser.prototype, 'dereference').mockImplementation(async function (schema) {
-      const resolveRefs = (obj: any): any => {
-        if (typeof obj !== 'object' || obj === null) {
-          return obj;
-        }
+    const dereferencedConfig = {
+      description: 'invalid_config',
+      prompts: ['test prompt'],
+      providers: [{ invalid: true }], // This will fail validation
+    };
 
-        if (obj.$ref && typeof obj.$ref === 'string') {
-          const [filePath, pointer] = obj.$ref.split('#/');
-          const fileContent = yaml.load(mockFiles[filePath]);
-          return pointer
-            .split('/')
-            .reduce((acc: Record<string, unknown>, key: string) => acc[key], fileContent);
-        }
-
-        if (Array.isArray(obj)) {
-          return obj.map(resolveRefs);
-        }
-
-        return Object.fromEntries(
-          Object.entries(obj).map(([key, value]) => [key, resolveRefs(value)]),
-        );
-      };
-
-      return resolveRefs(schema);
-    });
-
-    jest.mocked(fs.readFileSync).mockImplementation((path: fs.PathOrFileDescriptor) => {
-      if (typeof path === 'string') {
-        const fileName = path.split('/').pop()!;
-        return mockFiles[fileName] || '';
-      }
-      return '';
-    });
-
+    jest.mocked(fs.readFileSync).mockReturnValue(yaml.dump(mockConfig));
+    jest.spyOn($RefParser.prototype, 'dereference').mockResolvedValue(dereferencedConfig);
     jest.mocked(fs.existsSync).mockReturnValue(true);
     const loggerSpy = jest.spyOn(logger, 'warn').mockImplementation();
 
     await readConfig('config.yaml');
+
     expect(loggerSpy).toHaveBeenCalledWith(
       'Invalid configuration file config.yaml:\nValidation error: Unrecognized key(s) in object: \'invalid\' at "providers[0]"',
     );

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1012,7 +1012,6 @@ describe('readConfig', () => {
       ],
     });
 
-    // Verify readFileSync was called for config.yaml
     expect(fs.readFileSync).toHaveBeenCalledWith('config.yaml', 'utf-8');
   });
 
@@ -1056,7 +1055,6 @@ describe('readConfig', () => {
       return resolveRefs(schema);
     });
 
-    // Mock the file system reads
     jest.mocked(fs.readFileSync).mockImplementation((path: fs.PathOrFileDescriptor) => {
       if (typeof path === 'string') {
         const fileName = path.split('/').pop()!;


### PR DESCRIPTION
The schema validation was happening before  resolution, causing false validation errors for valid  usage in providers configuration.

This change:
- Moves schema validation after dereferencing
- Adds tests to verify  resolution in YAML configs
- Ensures validation errors are properly reported

Related to #2125