### PR TITLE
fix(providers): handle system messages correctly for bedrock Claude models

### DIFF
--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -3,12 +3,20 @@ description: 'Claude vs GPT Image Analysis'
 
 prompts:
   - ./prompt.py:format_image_prompt
+  - ./prompt.js:formatImagePrompt
 
 providers:
   - id: bedrock:anthropic.claude-3-sonnet-20240229-v1:0
   - id: anthropic:messages:claude-3-5-sonnet-20241022
+  - id: openai:gpt-4o
+    label: custom label for gpt-4o
 
 tests:
   - vars:
       image_url: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Great_Wave_off_Kanagawa2.jpg/640px-Great_Wave_off_Kanagawa2.jpg
       label: Great Wave off Kanagawa
+
+defaultTest:
+  assert:
+    - type: llm-rubric
+      value: Is a detailed description of the image '{{label}}'

--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -3,19 +3,12 @@ description: 'Claude vs GPT Image Analysis'
 
 prompts:
   - ./prompt.py:format_image_prompt
-  - ./prompt.js:formatImagePrompt
 
 providers:
   - id: bedrock:anthropic.claude-3-sonnet-20240229-v1:0
   - id: anthropic:messages:claude-3-5-sonnet-20241022
-  - id: openai:gpt-4o
-    label: custom label for gpt-4o
 
 tests:
   - vars:
       image_url: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Great_Wave_off_Kanagawa2.jpg/640px-Great_Wave_off_Kanagawa2.jpg
       label: Great Wave off Kanagawa
-
-assert:
-  - type: icontains
-    value: '{{label}}'

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -423,7 +423,8 @@ export const BEDROCK_MODEL = {
             content: Array.isArray(msg.content)
               ? msg.content
               : [{ type: 'text', text: msg.content }],
-          }));
+          })).filter((msg) => msg.role !== 'system');
+          systemPrompt = parsed.find((msg) => msg.role === 'system')?.content;
         } else {
           const { system, extractedMessages } = parseMessages(prompt);
           messages = extractedMessages;
@@ -434,6 +435,9 @@ export const BEDROCK_MODEL = {
         messages = extractedMessages;
         systemPrompt = system;
       }
+
+      logger.warn(`\n\n\nUsing system prompt: ${systemPrompt}`);
+      logger.warn(`Using messages: ${JSON.stringify(messages, null, 2)}`);
 
       const params: any = { messages };
       addConfigParam(

--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -418,12 +418,14 @@ export const BEDROCK_MODEL = {
       try {
         const parsed = JSON.parse(prompt);
         if (Array.isArray(parsed)) {
-          messages = parsed.map((msg) => ({
-            role: msg.role,
-            content: Array.isArray(msg.content)
-              ? msg.content
-              : [{ type: 'text', text: msg.content }],
-          })).filter((msg) => msg.role !== 'system');
+          messages = parsed
+            .map((msg) => ({
+              role: msg.role,
+              content: Array.isArray(msg.content)
+                ? msg.content
+                : [{ type: 'text', text: msg.content }],
+            }))
+            .filter((msg) => msg.role !== 'system');
           systemPrompt = parsed.find((msg) => msg.role === 'system')?.content;
         } else {
           const { system, extractedMessages } = parseMessages(prompt);
@@ -435,9 +437,6 @@ export const BEDROCK_MODEL = {
         messages = extractedMessages;
         systemPrompt = system;
       }
-
-      logger.warn(`\n\n\nUsing system prompt: ${systemPrompt}`);
-      logger.warn(`Using messages: ${JSON.stringify(messages, null, 2)}`);
 
       const params: any = { messages };
       addConfigParam(

--- a/test/providers/bedrock.test.ts
+++ b/test/providers/bedrock.test.ts
@@ -267,10 +267,6 @@ describe('AwsBedrockGenericProvider', () => {
 
       expect(params.messages).toEqual([
         {
-          role: 'system',
-          content: [{ type: 'text', text: 'You are a helpful assistant.' }],
-        },
-        {
           role: 'user',
           content: [
             { type: 'text', text: 'Describe this image:' },
@@ -285,6 +281,7 @@ describe('AwsBedrockGenericProvider', () => {
           ],
         },
       ]);
+      expect(params.system).toBe('You are a helpful assistant.');
     });
   });
 


### PR DESCRIPTION
Relates to #2136

To test, rerun `examples/claude-vs-gpt-image/promptfooconfig.yaml`

CC @maximcherny