### PR TITLE
fix(webui): restore token usage display

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -265,24 +265,26 @@ function EvalOutputCell({
     costDisplay = <span>${output.cost.toPrecision(2)}</span>;
   }
 
-  if (output.tokenUsage?.cached) {
+  console.info(`output: ${JSON.stringify(output, null, 2)}`);
+
+  if (output.response.tokenUsage?.cached) {
     tokenUsageDisplay = (
       <span>
         {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-          output.tokenUsage.cached,
+          output.response.tokenUsage.cached,
         )}{' '}
         (cached)
       </span>
     );
-  } else if (output.tokenUsage?.total) {
+  } else if (output.response.tokenUsage?.total) {
     const promptTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.tokenUsage.prompt ?? 0,
+      output.response.tokenUsage.prompt ?? 0,
     );
     const completionTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.tokenUsage.completion ?? 0,
+      output.response.tokenUsage.completion ?? 0,
     );
     const totalTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.tokenUsage.total,
+      output.response.tokenUsage.total ?? 0,
     );
 
     tokenUsageDisplay = (

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -265,26 +265,24 @@ function EvalOutputCell({
     costDisplay = <span>${output.cost.toPrecision(2)}</span>;
   }
 
-  console.info(`output: ${JSON.stringify(output, null, 2)}`);
-
-  if (output.response.tokenUsage?.cached) {
+  if (output.response?.tokenUsage?.cached) {
     tokenUsageDisplay = (
       <span>
         {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-          output.response.tokenUsage.cached,
+          output.response?.tokenUsage?.cached ?? 0,
         )}{' '}
         (cached)
       </span>
     );
-  } else if (output.response.tokenUsage?.total) {
+  } else if (output.response?.tokenUsage?.total) {
     const promptTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response.tokenUsage.prompt ?? 0,
+      output.response?.tokenUsage?.prompt ?? 0,
     );
     const completionTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response.tokenUsage.completion ?? 0,
+      output.response?.tokenUsage?.completion ?? 0,
     );
     const totalTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response.tokenUsage.total ?? 0,
+      output.response?.tokenUsage?.total ?? 0,
     );
 
     tokenUsageDisplay = (

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -141,7 +141,7 @@ export default class EvalResult {
   error?: string | null;
   success: boolean;
   score: number;
-  response: ProviderResponse | null;
+  response: ProviderResponse | undefined;
   gradingResult: GradingResult | null;
   namedScores: Record<string, number>;
   provider: ProviderOptions;
@@ -181,7 +181,7 @@ export default class EvalResult {
     this.error = opts.error;
     this.score = opts.score;
     this.success = opts.success;
-    this.response = opts.response;
+    this.response = opts.response || undefined;
     this.gradingResult = opts.gradingResult;
     this.namedScores = opts.namedScores || {};
     this.provider = opts.provider;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,6 +225,7 @@ export interface EvaluateTableOutput {
   gradingResult?: GradingResult | null;
   cost: number;
   metadata?: Record<string, any>;
+  response: ProviderResponse | null;
 }
 
 export interface EvaluateTableRow {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,7 +225,7 @@ export interface EvaluateTableOutput {
   gradingResult?: GradingResult | null;
   cost: number;
   metadata?: Record<string, any>;
-  response: ProviderResponse | null;
+  response?: ProviderResponse;
 }
 
 export interface EvaluateTableRow {

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -126,14 +126,10 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     prompt.metrics.assertFailCount +=
       result.gradingResult?.componentResults?.filter((r) => !r.pass).length || 0;
     prompt.metrics.totalLatencyMs += result.latencyMs || 0;
-    // @ts-expect-error
-    prompt.metrics.tokenUsage.cached += result.providerResponse?.tokenUsage?.cached || 0;
-    // @ts-expect-error
-    prompt.metrics.tokenUsage.completion += result.providerResponse?.tokenUsage?.completion || 0;
-    // @ts-expect-error
-    prompt.metrics.tokenUsage.prompt += result.providerResponse?.tokenUsage?.prompt || 0;
-    // @ts-expect-error
-    prompt.metrics.tokenUsage.total += result.providerResponse?.tokenUsage?.total || 0;
+    prompt.metrics.tokenUsage!.cached! += result.response?.tokenUsage?.cached || 0;
+    prompt.metrics.tokenUsage!.completion! += result.response?.tokenUsage?.completion || 0;
+    prompt.metrics.tokenUsage!.prompt! += result.response?.tokenUsage?.prompt || 0;
+    prompt.metrics.tokenUsage!.total! += result.response?.tokenUsage?.total || 0;
     prompt.metrics.cost += result.cost || 0;
     prompt.metrics.namedScores = eval_.prompts[result.promptIdx]?.metrics?.namedScores || {};
     prompt.metrics.namedScoresCount =

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -101,6 +101,7 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     row.outputs[result.promptIdx] = {
       id: result.id || `${result.testIdx}-${result.promptIdx}`,
       ...result,
+      response: result.response || null,
       text: resultText || '',
       prompt: result.prompt.raw,
       provider: result.provider?.label || result.provider?.id || 'unknown provider',

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -101,7 +101,6 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     row.outputs[result.promptIdx] = {
       id: result.id || `${result.testIdx}-${result.promptIdx}`,
       ...result,
-      response: result.response || null,
       text: resultText || '',
       prompt: result.prompt.raw,
       provider: result.provider?.label || result.provider?.id || 'unknown provider',

--- a/src/util/exportToFile/index.ts
+++ b/src/util/exportToFile/index.ts
@@ -1,6 +1,6 @@
 import type Eval from '../../models/eval';
 import type EvalResult from '../../models/evalResult';
-import type { EvaluateTableRow } from '../../types';
+import type { EvaluateTableOutput, EvaluateTableRow } from '../../types';
 
 export function getHeaderForTable(eval_: Eval) {
   const varsForHeader = new Set<string>();
@@ -44,7 +44,7 @@ export function getHeaderForTable(eval_: Eval) {
   };
 }
 
-function convertEvalResultToTableCell(result: EvalResult) {
+function convertEvalResultToTableCell(result: EvalResult): EvaluateTableOutput {
   let resultText: string | undefined;
   const failReasons = (result.gradingResult?.componentResults || [])
     .filter((result) => (result ? !result.pass : false))


### PR DESCRIPTION
* Update token usage access path to use response.tokenUsage
* Fix type definitions for EvalResult response property
* Add non-null assertions for tokenUsage metrics
* Update EvaluateTableOutput interface to include response

Relates to  #2142