### PR TITLE
refactor(redteam): extract parseGeneratedPrompts from redteam base class

### DIFF
--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -20,6 +20,37 @@ import { loadRedteamProvider } from '../providers/shared';
 import { removePrefix } from '../util';
 
 /**
+ * Parses the LLM response of generated prompts into an array of objects.
+ *
+ * @param generatedPrompts - The LLM response of generated prompts.
+ * @returns An array of { prompt: string } objects. Each of these objects represents a test case.
+ */
+export function parseGeneratedPrompts(generatedPrompts: string): { prompt: string }[] {
+  const parsePrompt = (line: string): string | null => {
+    if (!line.toLowerCase().includes('prompt:')) {
+      return null;
+    }
+    let prompt = removePrefix(line, 'Prompt');
+    // Handle numbered lists with various formats
+    prompt = prompt.replace(/^\d+[\.\)\-]?\s*-?\s*/, '');
+    // Handle quotes
+    prompt = prompt.replace(/^["'](.*)["']$/, '$1');
+    // Handle nested quotes
+    prompt = prompt.replace(/^'([^']*(?:'{2}[^']*)*)'$/, (_, p1) => p1.replace(/''/g, "'"));
+    prompt = prompt.replace(/^"([^"]*(?:"{2}[^"]*)*)"$/, (_, p1) => p1.replace(/""/g, '"'));
+    return prompt.trim();
+  };
+
+  // Split by newline or semicolon
+  const promptLines = generatedPrompts.split(/[\n;]+/);
+
+  return promptLines
+    .map(parsePrompt)
+    .filter((prompt): prompt is string => prompt !== null)
+    .map((prompt) => ({ prompt }));
+}
+
+/**
  * Abstract base class for creating plugins that generate test cases.
  */
 export abstract class RedteamPluginBase {
@@ -100,7 +131,7 @@ export abstract class RedteamPluginBase {
         );
         return [];
       }
-      return this.parseGeneratedPrompts(generatedPrompts);
+      return parseGeneratedPrompts(generatedPrompts);
     };
     const allPrompts = await retryWithDeduplication(generatePrompts, n);
     const prompts = sampleArray(allPrompts, n);
@@ -123,36 +154,10 @@ export abstract class RedteamPluginBase {
   }
 
   /**
-   * Parses the LLM response of generated prompts into an array of objects.
-   *
-   * @param generatedPrompts - The LLM response of generated prompts.
-   * @returns An array of { prompt: string } objects. Each of these objects represents a test case.
+   * Appends modifiers to the template.
+   * @param template - The template to append modifiers to.
+   * @returns The modified template.
    */
-  protected parseGeneratedPrompts(generatedPrompts: string): { prompt: string }[] {
-    const parsePrompt = (line: string): string | null => {
-      if (!line.toLowerCase().includes('prompt:')) {
-        return null;
-      }
-      let prompt = removePrefix(line, 'Prompt');
-      // Handle numbered lists with various formats
-      prompt = prompt.replace(/^\d+[\.\)\-]?\s*-?\s*/, '');
-      // Handle quotes
-      prompt = prompt.replace(/^["'](.*)["']$/, '$1');
-      // Handle nested quotes
-      prompt = prompt.replace(/^'([^']*(?:'{2}[^']*)*)'$/, (_, p1) => p1.replace(/''/g, "'"));
-      prompt = prompt.replace(/^"([^"]*(?:"{2}[^"]*)*)"$/, (_, p1) => p1.replace(/""/g, '"'));
-      return prompt.trim();
-    };
-
-    // Split by newline or semicolon
-    const promptLines = generatedPrompts.split(/[\n;]+/);
-
-    return promptLines
-      .map(parsePrompt)
-      .filter((prompt): prompt is string => prompt !== null)
-      .map((prompt) => ({ prompt }));
-  }
-
   private appendModifiers(template: string): string {
     // Take everything under "modifiers" config key
     const modifiers: Record<string, string> =

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -1,7 +1,10 @@
 import dedent from 'dedent';
 import { matchesLlmRubric } from '../../../src/matchers';
-import { RedteamPluginBase } from '../../../src/redteam/plugins/base';
-import { RedteamGraderBase } from '../../../src/redteam/plugins/base';
+import {
+  parseGeneratedPrompts,
+  RedteamGraderBase,
+  RedteamPluginBase,
+} from '../../../src/redteam/plugins/base';
 import type { ApiProvider, Assertion } from '../../../src/types';
 import type { AtomicTestCase, GradingResult } from '../../../src/types';
 import { maybeLoadFromExternalFile } from '../../../src/util';
@@ -231,57 +234,51 @@ describe('RedteamPluginBase', () => {
   });
 
   describe('parseGeneratedPrompts', () => {
-    let testPlugin: TestPlugin;
-
-    beforeEach(() => {
-      testPlugin = new TestPlugin(provider, 'test purpose', 'testVar', { language: 'English' });
-    });
-
     it('should parse simple prompts correctly', () => {
       const input = 'Prompt: Hello world\nPrompt: How are you?';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'Hello world' }, { prompt: 'How are you?' }]);
     });
 
     it('should handle prompts with quotation marks', () => {
       const input = 'Prompt: "Hello world"\nPrompt: "How are you?"';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'Hello world' }, { prompt: 'How are you?' }]);
     });
 
     it('should ignore lines without "Prompt:"', () => {
       const input = 'Prompt: Valid prompt\nInvalid line\nPrompt: Another valid prompt';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'Valid prompt' }, { prompt: 'Another valid prompt' }]);
     });
 
     it('should handle prompts with numbers', () => {
       const input = 'Prompt: 1. First prompt\nPrompt: 2. Second prompt';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'First prompt' }, { prompt: 'Second prompt' }]);
     });
 
     it('should handle prompts with colons', () => {
       const input = 'Prompt: Hello: World\nPrompt: Question: How are you?';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'Hello: World' }, { prompt: 'Question: How are you?' }]);
     });
 
     it('should handle empty input', () => {
       const input = '';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([]);
     });
 
     it('should handle input with only invalid lines', () => {
       const input = 'Invalid line 1\nInvalid line 2';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([]);
     });
 
     it('should trim whitespace from prompts', () => {
       const input = 'Prompt:    Whitespace at start and end    \nPrompt:\tTabbed prompt\t';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([
         { prompt: 'Whitespace at start and end' },
         { prompt: 'Tabbed prompt' },
@@ -290,7 +287,7 @@ describe('RedteamPluginBase', () => {
 
     it('should handle prompts with multiple lines', () => {
       const input = 'Prompt: First line\nSecond line\nPrompt: Another prompt';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'First line' }, { prompt: 'Another prompt' }]);
     });
 
@@ -304,7 +301,7 @@ describe('RedteamPluginBase', () => {
         6. Prompt: Sixth item
         7) Prompt: Seventh item
       `;
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([
         { prompt: 'First item' },
         { prompt: 'Second item' },
@@ -323,7 +320,7 @@ describe('RedteamPluginBase', () => {
         Prompt: 'Single quoted "double nested" prompt'
         Prompt: "Double quoted 'single nested' prompt"
       `;
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([
         { prompt: 'Outer "inner "nested" quote"' },
         { prompt: "Outer 'inner 'nested' quote'" },
@@ -334,7 +331,7 @@ describe('RedteamPluginBase', () => {
 
     it('should handle prompts with multiple spaces between words', () => {
       const input = 'Prompt: Multiple    spaces    between    words';
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([{ prompt: 'Multiple    spaces    between    words' }]);
     });
 
@@ -347,7 +344,7 @@ describe('RedteamPluginBase', () => {
         Prompt without colon
         Prompt: Valid prompt 3
       `;
-      const result = testPlugin['parseGeneratedPrompts'](input);
+      const result = parseGeneratedPrompts(input);
       expect(result).toEqual([
         { prompt: 'Valid prompt 1' },
         { prompt: 'Valid prompt 2' },


### PR DESCRIPTION
Move parseGeneratedPrompts from RedteamPluginBase class to standalone function and update corresponding tests. This will allow us to re-use the function in plugins that do not extend the base. 