### PR TITLE
chore: add # requests to token usage

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -123,6 +123,7 @@ class Evaluator {
         prompt: 0,
         completion: 0,
         cached: 0,
+        numRequests: 0,
       },
     };
     this.conversations = {};
@@ -305,6 +306,7 @@ class Evaluator {
           this.stats.tokenUsage.prompt += checkResult.tokensUsed.prompt || 0;
           this.stats.tokenUsage.completion += checkResult.tokensUsed.completion || 0;
           this.stats.tokenUsage.cached += checkResult.tokensUsed.cached || 0;
+          this.stats.tokenUsage.numRequests += checkResult.tokensUsed.numRequests || 1;
         }
         ret.response = processedResponse;
         ret.gradingResult = checkResult;
@@ -316,6 +318,7 @@ class Evaluator {
         this.stats.tokenUsage.prompt += response.tokenUsage.prompt || 0;
         this.stats.tokenUsage.completion += response.tokenUsage.completion || 0;
         this.stats.tokenUsage.cached += response.tokenUsage.cached || 0;
+        this.stats.tokenUsage.numRequests += response.tokenUsage.numRequests || 1;
       }
 
       if (ret.success) {
@@ -424,6 +427,7 @@ class Evaluator {
               prompt: 0,
               completion: 0,
               cached: 0,
+              numRequests: 0,
             },
             namedScores: {},
             namedScoresCount: {},
@@ -694,6 +698,8 @@ class Evaluator {
         (metrics.tokenUsage.prompt || 0) + (row.response?.tokenUsage?.prompt || 0);
       metrics.tokenUsage.total =
         (metrics.tokenUsage.total || 0) + (row.response?.tokenUsage?.total || 0);
+      metrics.tokenUsage.numRequests =
+        (metrics.tokenUsage.numRequests || 0) + (row.response?.tokenUsage?.numRequests || 0);
       metrics.cost += row.cost || 0;
 
       await runExtensionHook(testSuite.extensions, 'afterEach', {

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -169,6 +169,7 @@ class CrescendoProvider implements ApiProvider {
       total: 0,
       prompt: 0,
       completion: 0,
+      numRequests: 0,
     };
 
     const systemPrompt = this.nunjucks.renderString(CRESCENDO_SYSTEM_PROMPT, {
@@ -210,6 +211,7 @@ class CrescendoProvider implements ApiProvider {
         totalTokenUsage.total += promptTokenUsage.total || 0;
         totalTokenUsage.prompt += promptTokenUsage.prompt || 0;
         totalTokenUsage.completion += promptTokenUsage.completion || 0;
+        totalTokenUsage.numRequests += promptTokenUsage.numRequests ?? 1;
       }
 
       const [isRefusal, refusalRationale] = await this.getRefusalScore(attackPrompt, lastResponse);

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -56,6 +56,7 @@ export default class GoatProvider implements ApiProvider {
       total: 0,
       prompt: 0,
       completion: 0,
+      numRequests: 0,
     };
 
     for (let turn = 0; turn < this.maxTurns; turn++) {
@@ -113,6 +114,9 @@ export default class GoatProvider implements ApiProvider {
         totalTokenUsage.total += targetResponse.tokenUsage.total || 0;
         totalTokenUsage.prompt += targetResponse.tokenUsage.prompt || 0;
         totalTokenUsage.completion += targetResponse.tokenUsage.completion || 0;
+        totalTokenUsage.numRequests += targetResponse.tokenUsage.numRequests ?? 1;
+      } else {
+        totalTokenUsage.numRequests += 1;
       }
     }
     return {

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -65,6 +65,7 @@ async function runRedteamConversation({
     total: 0,
     prompt: 0,
     completion: 0,
+    numRequests: 0,
   };
 
   for (let i = 0; i < NUM_ITERATIONS; i++) {
@@ -184,24 +185,40 @@ async function runRedteamConversation({
       totalTokenUsage.total += redteamResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += redteamResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += redteamResp.tokenUsage.completion || 0;
+      totalTokenUsage.numRequests =
+        (totalTokenUsage.numRequests || 0) + (redteamResp.tokenUsage.numRequests || 1);
+    } else {
+      totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
 
     if (isOnTopicResp.tokenUsage) {
       totalTokenUsage.total += isOnTopicResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += isOnTopicResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += isOnTopicResp.tokenUsage.completion || 0;
+      totalTokenUsage.numRequests =
+        (totalTokenUsage.numRequests || 0) + (isOnTopicResp.tokenUsage.numRequests || 1);
+    } else {
+      totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
 
     if (judgeResp.tokenUsage) {
       totalTokenUsage.total += judgeResp.tokenUsage.total || 0;
       totalTokenUsage.prompt += judgeResp.tokenUsage.prompt || 0;
       totalTokenUsage.completion += judgeResp.tokenUsage.completion || 0;
+      totalTokenUsage.numRequests =
+        (totalTokenUsage.numRequests || 0) + (judgeResp.tokenUsage.numRequests || 1);
+    } else {
+      totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
 
     if (targetTokenUsage) {
       totalTokenUsage.total += targetTokenUsage.total || 0;
       totalTokenUsage.prompt += targetTokenUsage.prompt || 0;
       totalTokenUsage.completion += targetTokenUsage.completion || 0;
+      totalTokenUsage.numRequests =
+        (totalTokenUsage.numRequests || 0) + (targetTokenUsage.numRequests || 1);
+    } else {
+      totalTokenUsage.numRequests = (totalTokenUsage.numRequests || 0) + 1;
     }
   }
 

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -120,6 +120,7 @@ async function runRedteamConversation({
     total: 0,
     prompt: 0,
     completion: 0,
+    numRequests: 0,
   };
 
   let targetPrompt: string | null = null;
@@ -262,6 +263,7 @@ async function runRedteamConversation({
       totalTokenUsage.total += targetTokenUsage.total || 0;
       totalTokenUsage.prompt += targetTokenUsage.prompt || 0;
       totalTokenUsage.completion += targetTokenUsage.completion || 0;
+      totalTokenUsage.numRequests += targetTokenUsage.numRequests ?? 1;
     }
   }
 

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -375,6 +375,7 @@ export async function runRedteamConversation({
     total: 0,
     prompt: 0,
     completion: 0,
+    numRequests: 0,
   };
 
   for (let depth = 0; depth < MAX_DEPTH; depth++) {
@@ -438,6 +439,7 @@ export async function runRedteamConversation({
           totalTokenUsage.total += targetTokenUsage.total || 0;
           totalTokenUsage.prompt += targetTokenUsage.prompt || 0;
           totalTokenUsage.completion += targetTokenUsage.completion || 0;
+          totalTokenUsage.numRequests += targetTokenUsage.numRequests ?? 1;
         }
 
         const containsPenalizedPhrase = PENALIZED_PHRASES.some((phrase) =>
@@ -543,6 +545,7 @@ export async function runRedteamConversation({
     totalTokenUsage.total += finalTargetTokenUsage.total || 0;
     totalTokenUsage.prompt += finalTargetTokenUsage.prompt || 0;
     totalTokenUsage.completion += finalTargetTokenUsage.completion || 0;
+    totalTokenUsage.numRequests += finalTargetTokenUsage.numRequests ?? 1;
   }
 
   logger.debug(

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -65,6 +65,9 @@ export async function getTargetResponse(
   } catch (error) {
     return {
       extractedResponse: (error as Error).message,
+      tokenUsage: {
+        numRequests: 1,
+      },
     };
   }
 
@@ -74,13 +77,19 @@ export async function getTargetResponse(
         typeof targetRespRaw.output === 'string'
           ? targetRespRaw.output
           : JSON.stringify(targetRespRaw.output),
-      tokenUsage: targetRespRaw.tokenUsage,
+      tokenUsage: {
+        ...(targetRespRaw.tokenUsage || {}),
+        numRequests: 1,
+      },
     };
   }
 
   if (targetRespRaw?.error) {
     return {
       extractedResponse: targetRespRaw.error,
+      tokenUsage: {
+        numRequests: 1,
+      },
     };
   }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -3,6 +3,7 @@ export interface TokenUsage {
   completion?: number;
   prompt?: number;
   total?: number;
+  numRequests?: number;
 }
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;

--- a/src/validators/shared.ts
+++ b/src/validators/shared.ts
@@ -5,6 +5,7 @@ export const TokenUsageSchema = z.object({
   completion: z.number().optional(),
   prompt: z.number().optional(),
   total: z.number().optional(),
+  numRequests: z.number().optional(),
 });
 
 export const NunjucksFilterMapSchema = z.record(


### PR DESCRIPTION
Used for accurate probe count in redteam report view

Note that we're not counting requests for the ancillary LLM calls in redteam providers - this is the # of requests to the target.