### PR TITLE
feat: add support for bedrock guardrails

### DIFF
--- a/examples/amazon-bedrock/promptfooconfig.titan-text.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.titan-text.yaml
@@ -3,14 +3,19 @@ prompts:
   - 'Translate to {{language}}: {{input}}'
 
 providers:
+  # https://docs.aws.amazon.com/bedrock/latest/userguide/titan-text-models.html
   - id: bedrock:amazon.titan-text-lite-v1
     config:
-      region: 'us-west-2'
+      region: 'us-east-1'
       textGenerationConfig:
         maxTokenCount: 400
         temperature: 0.3
         stopSequences: []
         topP: 0.9
+
+      # Optional guardrails
+      guardrailIdentifier: x6jfrw53f5ag
+      guardrailVersion: DRAFT
 
 tests:
   - vars:

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -248,6 +248,20 @@ defaultTest:
           region: us-east-1
 ```
 
+## Guardrails
+
+To use guardrails, set the `guardrailIdentifier` and `guardrailVersion` in the provider config.
+
+For example:
+
+```yaml
+providers:
+  - id: bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
+    config:
+      guardrailIdentifier: 'test-guardrail'
+      guardrailVersion: 1 # The version number for the guardrail. The value can also be DRAFT.
+```
+
 ## Environment Variables
 
 The following environment variables can be used to configure the Bedrock provider:


### PR DESCRIPTION
To use guardrails, set the `guardrailIdentifier` and `guardrailVersion` in the provider config.

For example:

```yaml
providers:
  - id: bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0
    config:
      guardrailIdentifier: 'test-guardrail'
      guardrailVersion: 1 # The version number for the guardrail. The value can also be DRAFT.
```