### PR TITLE
fix(share): update eval author to logged-in user when sharing

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -77,22 +77,7 @@ export async function createShareableUrl(
   evalRecord: Eval,
   showAuth: boolean = false,
 ): Promise<string | null> {
-  if (cloudConfig.isEnabled()) {
-    const loggedInEmail = getUserEmail();
-    invariant(loggedInEmail, 'User email is not set');
-    const evalAuthor = evalRecord.author;
-    if (evalAuthor !== loggedInEmail) {
-      logger.warn(
-        `Warning: Changing eval author from ${evalAuthor} to logged-in user ${loggedInEmail}`,
-      );
-    }
-    evalRecord.author = loggedInEmail;
-    await evalRecord.save();
-  } else if (
-    process.stdout.isTTY &&
-    !isCI() &&
-    !getEnvBool('PROMPTFOO_DISABLE_SHARE_EMAIL_REQUEST')
-  ) {
+  if (process.stdout.isTTY && !isCI() && !getEnvBool('PROMPTFOO_DISABLE_SHARE_EMAIL_REQUEST')) {
     let email = getUserEmail();
     if (!email) {
       email = await input({
@@ -113,6 +98,17 @@ export async function createShareableUrl(
   if (cloudConfig.isEnabled()) {
     apiBaseUrl = cloudConfig.getApiHost();
     url = `${apiBaseUrl}/results`;
+
+    const loggedInEmail = getUserEmail();
+    invariant(loggedInEmail, 'User email is not set');
+    const evalAuthor = evalRecord.author;
+    if (evalAuthor !== loggedInEmail) {
+      logger.warn(
+        `Warning: Changing eval author from ${evalAuthor} to logged-in user ${loggedInEmail}`,
+      );
+    }
+    evalRecord.author = loggedInEmail;
+    await evalRecord.save();
   } else {
     apiBaseUrl =
       typeof evalRecord.config.sharing === 'object'


### PR DESCRIPTION
- If sharing for the first time and no email is set, write the email to the eval. 
- When sharing an eval in cloud mode, automatically update the author to match the logged-in user's email. 
- Show a warning if the author is being changed from a different email address. - let's discuss this I am not sure about the behavior pattern 
