### PR TITLE
fix: pass isRedteam from eval database model

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -912,7 +912,8 @@ class Evaluator {
       hasAnyPass: this.evalRecord.prompts.some(
         (p) => p.metrics?.testPassCount && p.metrics.testPassCount > 0,
       ),
-      //isRedteam: Boolean(testSuite.redteam),
+      // FIXME(ian): Does this work?  I think redteam is only on the config, not testSuite.
+      // isRedteam: Boolean(testSuite.redteam),
     });
     return this.evalRecord;
   }

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -473,6 +473,7 @@ export async function getSummaryOfLatestEvals(
       description: evalsTable.description,
       numTests: sql`COUNT(DISTINCT ${evalResultsTable.testIdx})`.as('numTests'),
       datasetId: evalsToDatasetsTable.datasetId,
+      isRedteam: sql<boolean>`json_type(${evalsTable.config}, '$.redteam') IS NOT NULL`,
     })
     .from(evalsTable)
     .leftJoin(evalsToDatasetsTable, eq(evalsTable.id, evalsToDatasetsTable.evalId))
@@ -494,6 +495,7 @@ export async function getSummaryOfLatestEvals(
     description: result.description,
     numTests: (result.numTests as number) || 0,
     datasetId: result.datasetId,
+    isRedteam: result.isRedteam,
   }));
 
   const endTime = performance.now();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -73,7 +73,6 @@ export function createApp() {
         return {
           ...meta,
           label: meta.description ? `${meta.description} (${meta.evalId})` : meta.evalId,
-          isRedTeam: meta.isRedteam,
         };
       }),
     });


### PR DESCRIPTION
attaches missing `isRedteam` field.  fixes the /report view, for example