### PR TITLE
chore(cli): display help for invalid args

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { listCommand } from './commands/list';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
 import { viewCommand } from './commands/view';
+import logger from './logger';
 import { runDbMigrations } from './migrate';
 import { redteamGenerateCommand } from './redteam/commands/generate';
 import { initCommand as redteamInitCommand } from './redteam/commands/init';
@@ -33,7 +34,15 @@ async function main() {
   const { defaultConfig, defaultConfigPath } = await loadDefaultConfig();
 
   const program = new Command('promptfoo');
-  program.version(version);
+  program
+    .version(version)
+    .showHelpAfterError()
+    .showSuggestionAfterError()
+    .on('option:*', function () {
+      logger.error('Invalid option(s)');
+      program.help();
+      process.exitCode = 1;
+    });
 
   // Main commands
   evalCommand(program, defaultConfig, defaultConfigPath);


### PR DESCRIPTION
Adds better error feedback for invalid options, including:
- Show help after errors
- Display suggestions for mistyped commands
- Explicit error message for invalid options