### PR TITLE
chore(redteam): attempt to reuse existing server for redteam init

### DIFF
--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -67,7 +67,7 @@ We particularly welcome contributions in the following areas:
    This will run the express server on port 15500 and the web UI on port 3000.
    Both the API and UI will be automatically reloaded when you make changes.
 
-   Note: The developement experience is a little bit different than how it runs in production. In development, the web UI is served using a Vite server. In all other environments, the front end is built and served as a static site via the Express server.
+   Note: The development experience is a little bit different than how it runs in production. In development, the web UI is served using a Vite server. In all other environments, the front end is built and served as a static site via the Express server.
 
 If you're not sure where to start, check out our [good first issues](https://github.com/promptfoo/promptfoo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or join our [Discord community](https://discord.gg/gHPS9jjfbs) for guidance.
 

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
 import { DEFAULT_PORT } from '../constants';
-import { BrowserBehavior, startServer } from '../server/server';
+import { startServer } from '../server/server';
 import telemetry from '../telemetry';
 import { setupEnv } from '../util';
 import { setConfigDirectoryPath } from '../util/config/manage';
+import { BrowserBehavior } from '../util/server';
 
 export function viewCommand(program: Command) {
   program

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { DEFAULT_PORT } from '../constants';
 import { BrowserBehavior, startServer } from '../server/server';
 import telemetry from '../telemetry';
 import { setupEnv } from '../util';
@@ -8,7 +9,7 @@ export function viewCommand(program: Command) {
   program
     .command('view [directory]')
     .description('Start browser ui')
-    .option('-p, --port <number>', 'Port number', '15500')
+    .option('-p, --port <number>', 'Port number', DEFAULT_PORT.toString())
     .option('-y, --yes', 'Skip confirmation and auto-open the URL')
     .option('-n, --no', 'Skip confirmation and do not open the URL')
     .option('--filter-description <pattern>', 'Filter evals by description using a regex pattern')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export const SHARE_VIEW_BASE_URL =
   process.env.PROMPTFOO_REMOTE_APP_BASE_URL ||
   DEFAULT_SHARE_VIEW_BASE_URL;
 
+export const DEFAULT_PORT = Number.parseInt(process.env.API_PORT || '15500');
+
 // Maximum width for terminal outputs.
 export const TERMINAL_MAX_WIDTH =
   process?.stdout?.isTTY && process?.stdout?.columns && process?.stdout?.columns > 10

--- a/src/redteam/commands/init.ts
+++ b/src/redteam/commands/init.ts
@@ -669,6 +669,7 @@ export function initCommand(program: Command) {
       ) => {
         setupEnv(opts.envPath);
         try {
+          // Check if we're in a non-GUI environment
           const hasDisplay =
             process.env.DISPLAY || process.platform === 'win32' || process.platform === 'darwin';
           const useGui = opts.gui && hasDisplay;

--- a/src/redteam/commands/init.ts
+++ b/src/redteam/commands/init.ts
@@ -14,11 +14,11 @@ import { DEFAULT_PORT } from '../../constants';
 import { getUserEmail, setUserEmail } from '../../globalConfig/accounts';
 import { readGlobalConfig, writeGlobalConfigPartial } from '../../globalConfig/globalConfig';
 import logger from '../../logger';
-import { BrowserBehavior } from '../../server/server';
 import { startServer } from '../../server/server';
 import telemetry, { type EventProperties } from '../../telemetry';
 import type { ProviderOptions, RedteamPluginObject } from '../../types';
 import { setupEnv } from '../../util';
+import { BrowserBehavior } from '../../util/server';
 import { checkServerRunning, openBrowser } from '../../util/server';
 import { extractVariablesFromTemplate, getNunjucksEngine } from '../../util/templates';
 import {

--- a/src/redteam/commands/report.ts
+++ b/src/redteam/commands/report.ts
@@ -32,8 +32,7 @@ export function redteamReportCommand(program: Command) {
           setConfigDirectoryPath(directory);
         }
 
-        const browserBehavior = BrowserBehavior.OPEN_TO_REPORT;
-        await startServer(cmdObj.port, browserBehavior, cmdObj.filterDescription);
+        await startServer(cmdObj.port, BrowserBehavior.OPEN_TO_REPORT, cmdObj.filterDescription);
       },
     );
 }

--- a/src/redteam/commands/report.ts
+++ b/src/redteam/commands/report.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
 import { DEFAULT_PORT } from '../../constants';
-import { BrowserBehavior, startServer } from '../../server/server';
+import { startServer } from '../../server/server';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
 import { setConfigDirectoryPath } from '../../util/config/manage';
+import { BrowserBehavior } from '../../util/server';
 
 export function redteamReportCommand(program: Command) {
   program

--- a/src/redteam/commands/report.ts
+++ b/src/redteam/commands/report.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { DEFAULT_PORT } from '../../constants';
 import { BrowserBehavior, startServer } from '../../server/server';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
@@ -8,7 +9,7 @@ export function redteamReportCommand(program: Command) {
   program
     .command('report [directory]')
     .description('Start browser ui and open to report')
-    .option('-p, --port <number>', 'Port number', '15500')
+    .option('-p, --port <number>', 'Port number', DEFAULT_PORT.toString())
     .option('--filter-description <pattern>', 'Filter evals by description using a regex pattern')
     .option('--env-file, --env-path <path>', 'Path to .env file')
     .action(

--- a/src/redteam/commands/setup.ts
+++ b/src/redteam/commands/setup.ts
@@ -1,9 +1,10 @@
 import type { Command } from 'commander';
 import { DEFAULT_PORT } from '../../constants';
-import { BrowserBehavior, startServer } from '../../server/server';
+import { startServer } from '../../server/server';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
 import { setConfigDirectoryPath } from '../../util/config/manage';
+import { BrowserBehavior } from '../../util/server';
 
 export function redteamSetupCommand(program: Command) {
   program

--- a/src/redteam/commands/setup.ts
+++ b/src/redteam/commands/setup.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { DEFAULT_PORT } from '../../constants';
 import { BrowserBehavior, startServer } from '../../server/server';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
@@ -8,7 +9,7 @@ export function redteamSetupCommand(program: Command) {
   program
     .command('setup [configDirectory]')
     .description('Start browser ui and open to redteam setup')
-    .option('-p, --port <number>', 'Port number', '15500')
+    .option('-p, --port <number>', 'Port number', DEFAULT_PORT.toString())
     .option('--filter-description <pattern>', 'Filter evals by description using a regex pattern')
     .option('--env-file, --env-path <path>', 'Path to .env file')
     .action(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,4 +2,4 @@ import { DEFAULT_PORT } from '../constants';
 import { BrowserBehavior, startServer } from './server';
 
 // start server
-startServer(Number.parseInt(process.env.API_PORT || DEFAULT_PORT.toString()), BrowserBehavior.SKIP);
+startServer(DEFAULT_PORT, BrowserBehavior.SKIP);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
+import { DEFAULT_PORT } from '../constants';
 import { BrowserBehavior, startServer } from './server';
 
 // start server
-startServer(Number.parseInt(process.env.API_PORT || '15500'), BrowserBehavior.SKIP);
+startServer(Number.parseInt(process.env.API_PORT || DEFAULT_PORT.toString()), BrowserBehavior.SKIP);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PORT } from '../constants';
-import { BrowserBehavior, startServer } from './server';
+import { BrowserBehavior } from '../util/server';
+import { startServer } from './server';
 
 // start server
 startServer(DEFAULT_PORT, BrowserBehavior.SKIP);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -31,6 +31,7 @@ import {
   getLatestEval,
   getStandaloneEvals,
 } from '../util';
+import { BrowserBehavior } from '../util/server';
 import { openBrowser } from '../util/server';
 import { configsRouter } from './routes/configs';
 import { evalRouter } from './routes/eval';
@@ -40,14 +41,6 @@ import { userRouter } from './routes/user';
 
 // Prompts cache
 let allPrompts: PromptWithMetadata[] | null = null;
-
-export enum BrowserBehavior {
-  ASK = 0,
-  OPEN = 1,
-  SKIP = 2,
-  OPEN_TO_REPORT = 3,
-  OPEN_TO_REDTEAM_CREATE = 4,
-}
 
 export function createApp() {
   const app = express();

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -4,12 +4,6 @@ import { VERSION, DEFAULT_PORT } from '../constants';
 import logger from '../logger';
 import { BrowserBehavior } from '../server/server';
 
-// Map behavior to paths with proper type checking
-const BEHAVIOR_PATHS: Partial<Record<BrowserBehavior, string>> = {
-  [BrowserBehavior.OPEN_TO_REPORT]: '/report',
-  [BrowserBehavior.OPEN_TO_REDTEAM_CREATE]: '/redteam/setup',
-} as const;
-
 export async function checkServerRunning(port = DEFAULT_PORT): Promise<boolean> {
   try {
     const response = await fetch(`http://localhost:${port}/health`);
@@ -26,6 +20,13 @@ export async function openBrowser(
   port = DEFAULT_PORT,
 ): Promise<void> {
   const baseUrl = `http://localhost:${port}`;
+  // Map behavior to paths with proper type checking
+  const BEHAVIOR_PATHS: Partial<Record<BrowserBehavior, string>> = {
+    [BrowserBehavior.OPEN_TO_REPORT]: '/report',
+    [BrowserBehavior.OPEN_TO_REDTEAM_CREATE]: '/redteam/setup',
+  } as const;
+
+  logger.warn(`Opening browser to ${baseUrl}${BEHAVIOR_PATHS[browserBehavior]}`);
   const path = BEHAVIOR_PATHS[browserBehavior] ?? '';
   const url = `${baseUrl}${path}`;
 

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -1,0 +1,55 @@
+import opener from 'opener';
+import readline from 'readline';
+import { VERSION, DEFAULT_PORT } from '../constants';
+import logger from '../logger';
+import { BrowserBehavior } from '../server/server';
+
+// Map behavior to paths with proper type checking
+const BEHAVIOR_PATHS: Partial<Record<BrowserBehavior, string>> = {
+  [BrowserBehavior.OPEN_TO_REPORT]: '/report',
+  [BrowserBehavior.OPEN_TO_REDTEAM_CREATE]: '/redteam/setup',
+} as const;
+
+export async function checkServerRunning(port = DEFAULT_PORT): Promise<boolean> {
+  try {
+    const response = await fetch(`http://localhost:${port}/health`);
+    const data = await response.json();
+    return data.status === 'OK' && data.version === VERSION;
+  } catch (err) {
+    logger.debug(`Failed to check server health: ${String(err)}`);
+    return false;
+  }
+}
+
+export async function openBrowser(
+  browserBehavior: BrowserBehavior,
+  port = DEFAULT_PORT,
+): Promise<void> {
+  const baseUrl = `http://localhost:${port}`;
+  const path = BEHAVIOR_PATHS[browserBehavior] ?? '';
+  const url = `${baseUrl}${path}`;
+
+  const doOpen = async () => {
+    try {
+      logger.info('Press Ctrl+C to stop the server');
+      await opener(url);
+    } catch (err) {
+      logger.error(`Failed to open browser: ${String(err)}`);
+    }
+  };
+
+  if (browserBehavior === BrowserBehavior.ASK) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question('Open URL in browser? (y/N): ', async (answer) => {
+      if (answer.toLowerCase().startsWith('y')) {
+        await doOpen();
+      }
+      rl.close();
+    });
+  } else if (browserBehavior !== BrowserBehavior.SKIP) {
+    await doOpen();
+  }
+}

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -2,7 +2,14 @@ import opener from 'opener';
 import readline from 'readline';
 import { VERSION, DEFAULT_PORT } from '../constants';
 import logger from '../logger';
-import { BrowserBehavior } from '../server/server';
+
+export enum BrowserBehavior {
+  ASK = 0,
+  OPEN = 1,
+  SKIP = 2,
+  OPEN_TO_REPORT = 3,
+  OPEN_TO_REDTEAM_CREATE = 4,
+}
 
 export async function checkServerRunning(port = DEFAULT_PORT): Promise<boolean> {
   try {

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -37,15 +37,22 @@ export async function openBrowser(
   };
 
   if (browserBehavior === BrowserBehavior.ASK) {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    rl.question('Open URL in browser? (y/N): ', async (answer) => {
-      if (answer.toLowerCase().startsWith('y')) {
-        await doOpen();
+    return new Promise((resolve, reject) => {
+      try {
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        rl.question('Open URL in browser? (y/N): ', async (answer) => {
+          if (answer.toLowerCase().startsWith('y')) {
+            await doOpen();
+          }
+          rl.close();
+          resolve();
+        });
+      } catch (err) {
+        reject(err);
       }
-      rl.close();
     });
   } else if (browserBehavior !== BrowserBehavior.SKIP) {
     await doOpen();

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -20,15 +20,12 @@ export async function openBrowser(
   port = DEFAULT_PORT,
 ): Promise<void> {
   const baseUrl = `http://localhost:${port}`;
-  // Map behavior to paths with proper type checking
-  const BEHAVIOR_PATHS: Partial<Record<BrowserBehavior, string>> = {
-    [BrowserBehavior.OPEN_TO_REPORT]: '/report',
-    [BrowserBehavior.OPEN_TO_REDTEAM_CREATE]: '/redteam/setup',
-  } as const;
-
-  logger.warn(`Opening browser to ${baseUrl}${BEHAVIOR_PATHS[browserBehavior]}`);
-  const path = BEHAVIOR_PATHS[browserBehavior] ?? '';
-  const url = `${baseUrl}${path}`;
+  let url = baseUrl;
+  if (browserBehavior === BrowserBehavior.OPEN_TO_REPORT) {
+    url = `${baseUrl}/report`;
+  } else if (browserBehavior === BrowserBehavior.OPEN_TO_REDTEAM_CREATE) {
+    url = `${baseUrl}/redteam/setup`;
+  }
 
   const doOpen = async () => {
     try {

--- a/test/util/server.test.ts
+++ b/test/util/server.test.ts
@@ -1,0 +1,144 @@
+import opener from 'opener';
+import { VERSION, DEFAULT_PORT } from '../../src/constants';
+import logger from '../../src/logger';
+import { BrowserBehavior } from '../../src/server/server';
+import { checkServerRunning, openBrowser } from '../../src/util/server';
+
+jest.mock('opener');
+jest.mock('../../src/logger');
+jest.mock('readline');
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('server utilities', () => {
+  let mockReadline: { question: jest.Mock; close: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockReadline = {
+      question: jest.fn(),
+      close: jest.fn(),
+    };
+    const readline = jest.requireMock('readline');
+    readline.createInterface.mockReturnValue(mockReadline);
+  });
+
+  describe('checkServerRunning', () => {
+    it('returns true when server is running with matching version', async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ status: 'OK', version: VERSION }),
+      });
+
+      const result = await checkServerRunning(DEFAULT_PORT);
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}/health`);
+    });
+
+    it('returns false when server returns non-OK status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ status: 'ERROR', version: VERSION }),
+      });
+
+      const result = await checkServerRunning();
+      expect(result).toBe(false);
+    });
+
+    it('returns false when server version does not match', async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ status: 'OK', version: '0.0.0' }),
+      });
+
+      const result = await checkServerRunning();
+      expect(result).toBe(false);
+    });
+
+    it('returns false and logs debug message when fetch fails', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'));
+
+      const result = await checkServerRunning();
+      expect(result).toBe(false);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to check server health'),
+      );
+    });
+
+    it('uses default port when not specified', async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ status: 'OK', version: VERSION }),
+      });
+
+      await checkServerRunning();
+      expect(mockFetch).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}/health`);
+    });
+  });
+
+  describe('openBrowser', () => {
+    it('opens browser directly with OPEN behavior', async () => {
+      await openBrowser(BrowserBehavior.OPEN);
+      expect(opener).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}`);
+      expect(logger.info).toHaveBeenCalledWith('Press Ctrl+C to stop the server');
+    });
+
+    it('opens report page with OPEN_TO_REPORT behavior', async () => {
+      await openBrowser(BrowserBehavior.OPEN_TO_REPORT);
+      expect(opener).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}/report`);
+    });
+
+    it('opens redteam setup with OPEN_TO_REDTEAM_CREATE behavior', async () => {
+      await openBrowser(BrowserBehavior.OPEN_TO_REDTEAM_CREATE);
+      expect(opener).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}/redteam/setup`);
+    });
+
+    it('does not open browser with SKIP behavior', async () => {
+      await openBrowser(BrowserBehavior.SKIP);
+      expect(opener).not.toHaveBeenCalled();
+    });
+
+    it('prompts user with ASK behavior and opens on yes', async () => {
+      mockReadline.question.mockImplementationOnce((_, callback) => {
+        callback('y');
+      });
+
+      await openBrowser(BrowserBehavior.ASK);
+
+      expect(mockReadline.question).toHaveBeenCalledWith(
+        'Open URL in browser? (y/N): ',
+        expect.any(Function),
+      );
+      expect(opener).toHaveBeenCalledWith(`http://localhost:${DEFAULT_PORT}`);
+      expect(mockReadline.close).toHaveBeenCalledWith();
+    });
+
+    it('prompts user with ASK behavior and skips on no', async () => {
+      mockReadline.question.mockImplementationOnce((_, callback) => {
+        callback('n');
+      });
+
+      await openBrowser(BrowserBehavior.ASK);
+
+      expect(mockReadline.question).toHaveBeenCalledWith(
+        'Open URL in browser? (y/N): ',
+        expect.any(Function),
+      );
+      expect(opener).not.toHaveBeenCalled();
+      expect(mockReadline.close).toHaveBeenCalledWith();
+    });
+
+    it('handles opener errors gracefully', async () => {
+      jest.mocked(opener).mockImplementation(() => {
+        throw new Error('Failed to open browser');
+      });
+
+      await openBrowser(BrowserBehavior.OPEN);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to open browser'));
+    });
+
+    it('uses custom port when specified', async () => {
+      const customPort = 3000;
+      await openBrowser(BrowserBehavior.OPEN, customPort);
+      expect(opener).toHaveBeenCalledWith(`http://localhost:${customPort}`);
+    });
+  });
+});

--- a/test/util/server.test.ts
+++ b/test/util/server.test.ts
@@ -1,7 +1,7 @@
 import opener from 'opener';
 import { VERSION, DEFAULT_PORT } from '../../src/constants';
 import logger from '../../src/logger';
-import { BrowserBehavior } from '../../src/server/server';
+import { BrowserBehavior } from '../../src/util/server';
 import { checkServerRunning, openBrowser } from '../../src/util/server';
 
 jest.mock('opener');


### PR DESCRIPTION
- Add server health check to detect running instance
- Open browser to redteam setup if server exists
- Start new server only if needed
- Use DEFAULT_PORT consistently across commands