### PR TITLE
chore: separate errors from assert failures

### DIFF
--- a/drizzle/0011_moaning_millenium_guard.sql
+++ b/drizzle/0011_moaning_millenium_guard.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `eval_results` ADD `failure_reason` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,699 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f2d1ba51-535b-403a-99e1-7d39801c8689",
+  "prevId": "5e481ffa-2de1-4718-9db1-a6edf93df64d",
+  "tables": {
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "configs_created_at_idx": {
+          "name": "configs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "configs_type_idx": {
+          "name": "configs_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "datasets": {
+      "name": "datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tests": {
+          "name": "tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "datasets_created_at_idx": {
+          "name": "datasets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case": {
+          "name": "test_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grading_result": {
+          "name": "grading_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "named_scores": {
+          "name": "named_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_result_eval_id_idx": {
+          "name": "eval_result_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_eval_id_evals_id_fk": {
+          "name": "eval_results_eval_id_evals_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eval_results_prompt_id_prompts_id_fk": {
+          "name": "eval_results_prompt_id_prompts_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals": {
+      "name": "evals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_created_at_idx": {
+          "name": "evals_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "evals_author_idx": {
+          "name": "evals_author_idx",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_datasets": {
+      "name": "evals_to_datasets",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_datasets_eval_id_idx": {
+          "name": "evals_to_datasets_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_datasets_dataset_id_idx": {
+          "name": "evals_to_datasets_dataset_id_idx",
+          "columns": [
+            "dataset_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_datasets_eval_id_evals_id_fk": {
+          "name": "evals_to_datasets_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_datasets_dataset_id_datasets_id_fk": {
+          "name": "evals_to_datasets_dataset_id_datasets_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_datasets_eval_id_dataset_id_pk": {
+          "columns": [
+            "eval_id",
+            "dataset_id"
+          ],
+          "name": "evals_to_datasets_eval_id_dataset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_prompts": {
+      "name": "evals_to_prompts",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_prompts_eval_id_idx": {
+          "name": "evals_to_prompts_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_prompts_prompt_id_idx": {
+          "name": "evals_to_prompts_prompt_id_idx",
+          "columns": [
+            "prompt_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_prompts_eval_id_evals_id_fk": {
+          "name": "evals_to_prompts_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evals_to_prompts_prompt_id_prompts_id_fk": {
+          "name": "evals_to_prompts_prompt_id_prompts_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_prompts_eval_id_prompt_id_pk": {
+          "columns": [
+            "eval_id",
+            "prompt_id"
+          ],
+          "name": "evals_to_prompts_eval_id_prompt_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_tags": {
+      "name": "evals_to_tags",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_tags_eval_id_idx": {
+          "name": "evals_to_tags_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_tags_tag_id_idx": {
+          "name": "evals_to_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_tags_eval_id_evals_id_fk": {
+          "name": "evals_to_tags_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_tags_tag_id_tags_id_fk": {
+          "name": "evals_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_tags_eval_id_tag_id_pk": {
+          "columns": [
+            "eval_id",
+            "tag_id"
+          ],
+          "name": "evals_to_tags_eval_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_created_at_idx": {
+          "name": "prompts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "tags_name_value_unique": {
+          "name": "tags_name_value_unique",
+          "columns": [
+            "name",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1730348380232,
       "tag": "0010_needy_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1732340901582,
+      "tag": "0011_moaning_millenium_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/examples/errors-vs-failures/README.md
+++ b/examples/errors-vs-failures/README.md
@@ -1,0 +1,1 @@
+This directory contains a custom provider that can

--- a/examples/errors-vs-failures/customProvider.js
+++ b/examples/errors-vs-failures/customProvider.js
@@ -1,0 +1,58 @@
+const promptfoo = require('../../dist/src/index.js').default;
+
+class CustomApiProvider {
+  constructor(options) {
+    // The caller may override Provider ID (e.g. when using multiple instances of the same provider)
+    this.providerId = options.id || 'custom provider';
+
+    // The config object contains any options passed to the provider in the config file.
+    this.config = options.config;
+  }
+
+  id() {
+    return this.providerId;
+  }
+
+  async callApi(prompt) {
+    if (prompt.includes('!ERROR!')) {
+      throw new Error('Forced error: ' + prompt);
+    }
+    const body = {
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+      max_tokens: Number.parseInt(this.config?.max_tokens, 10) || 1024,
+      temperature: Number.parseFloat(this.config?.temperature) || 0,
+    };
+
+    // Fetch the data from the API using promptfoo's cache. You can use your own fetch implementation if preferred.
+    const { data, cached } = await promptfoo.cache.fetchWithCache(
+      'https://api.openai.com/v1/chat/completions',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify(body),
+      },
+      10_000 /* 10 second timeout */,
+    );
+
+    const ret = {
+      output: data.choices[0].message.content,
+      tokenUsage: {
+        total: data.usage.total_tokens,
+        prompt: data.usage.prompt_tokens,
+        completion: data.usage.completion_tokens,
+      },
+    };
+    return ret;
+  }
+}
+
+module.exports = CustomApiProvider;

--- a/examples/errors-vs-failures/promptfooconfig.yaml
+++ b/examples/errors-vs-failures/promptfooconfig.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+
+description: 'Errors vs Failures'
+
+prompts:
+  - 'Tell me about {{topic}}'
+
+providers:
+  - id: file://customProvider.js
+    label: 'My custom provider'
+
+tests:
+  - vars:
+      topic: 'black holes'
+    assert:
+      # This should succeed
+      - type: not-equals
+        value: this should always pass
+  - vars:
+      # Force an error
+      topic: '!ERROR! banana slugs'
+  - vars:
+      topic: 'blue herons'
+    assert:
+      # Force a failure
+      - type: equals
+        value: this should always fail

--- a/examples/errors-vs-failures/prompts.txt
+++ b/examples/errors-vs-failures/prompts.txt
@@ -1,0 +1,3 @@
+Rephrase this in French: {{body}}
+---
+Rephrase this like a pirate: {{body}}

--- a/examples/errors-vs-failures/vars.csv
+++ b/examples/errors-vs-failures/vars.csv
@@ -1,0 +1,3 @@
+body
+Hello world
+I'm hungry

--- a/src/app/src/pages/datasets/DatasetDialog.tsx
+++ b/src/app/src/pages/datasets/DatasetDialog.tsx
@@ -62,42 +62,41 @@ export default function DatasetDialog({ openDialog, handleClose, testCase }: Dat
             {testCase?.prompts
               ?.slice((page - 1) * rowsPerPage, page * rowsPerPage)
               .sort((a, b) => b.evalId.localeCompare(a.evalId))
-              .map((promptData, index) => (
-                <TableRow key={index} hover>
-                  <TableCell>
-                    <Link to={`/eval/?evalId=${promptData.evalId}`}>{promptData.evalId}</Link>
-                  </TableCell>
-                  <TableCell style={{ minWidth: '8em' }}>
-                    <Link to={`/prompts/?id=${promptData.id}`}>{promptData.id.slice(0, 6)}</Link>
-                  </TableCell>
-                  <TableCell>
-                    {typeof promptData.prompt.metrics?.score === 'number'
-                      ? promptData.prompt.metrics.score.toFixed(2)
-                      : '-'}
-                  </TableCell>
-                  <TableCell>
-                    {typeof promptData.prompt.metrics?.testPassCount === 'number' &&
-                    typeof promptData.prompt.metrics?.testFailCount === 'number' &&
-                    promptData.prompt.metrics.testPassCount +
-                      promptData.prompt.metrics.testFailCount >
-                      0
-                      ? (
-                          (promptData.prompt.metrics.testPassCount /
-                            (promptData.prompt.metrics.testPassCount +
-                              promptData.prompt.metrics.testFailCount)) *
-                          100.0
-                        ).toFixed(2) + '%'
-                      : '-'}
-                  </TableCell>
-                  <TableCell>{promptData.prompt.metrics?.testPassCount ?? '-'}</TableCell>
-                  <TableCell>{promptData.prompt.metrics?.testFailCount ?? '-'}</TableCell>
-                  <TableCell>
-                    {promptData.prompt.raw.length > 250
-                      ? promptData.prompt.raw.slice(0, 250) + '...'
-                      : promptData.prompt.raw}
-                  </TableCell>
-                </TableRow>
-              ))}
+              .map((promptData, index) => {
+                const testPassCount = promptData.prompt.metrics?.testPassCount ?? 0;
+                const testFailCount = promptData.prompt.metrics?.testFailCount ?? 0;
+                const testErrorCount = promptData.prompt.metrics?.testErrorCount ?? 0;
+                return (
+                  <TableRow key={index} hover>
+                    <TableCell>
+                      <Link to={`/eval/?evalId=${promptData.evalId}`}>{promptData.evalId}</Link>
+                    </TableCell>
+                    <TableCell style={{ minWidth: '8em' }}>
+                      <Link to={`/prompts/?id=${promptData.id}`}>{promptData.id.slice(0, 6)}</Link>
+                    </TableCell>
+                    <TableCell>
+                      {typeof promptData.prompt.metrics?.score === 'number'
+                        ? promptData.prompt.metrics.score.toFixed(2)
+                        : '-'}
+                    </TableCell>
+                    <TableCell>
+                      {testPassCount + testFailCount + testErrorCount > 0
+                        ? (
+                            (testPassCount / (testPassCount + testFailCount + testErrorCount)) *
+                            100.0
+                          ).toFixed(2) + '%'
+                        : '-'}
+                    </TableCell>
+                    <TableCell>{testPassCount}</TableCell>
+                    <TableCell>{testFailCount}</TableCell>
+                    <TableCell>
+                      {promptData.prompt.raw.length > 250
+                        ? promptData.prompt.raw.slice(0, 250) + '...'
+                        : promptData.prompt.raw}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
           </TableBody>
         </Table>
         {Math.ceil((testCase?.prompts?.length || 0) / rowsPerPage) > 1 && (

--- a/src/app/src/pages/eval/components/DownloadMenu.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.tsx
@@ -11,6 +11,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { ResultFailureReason } from '@promptfoo/types';
 import { stringify as csvStringify } from 'csv-stringify/browser/esm/sync';
 import yaml from 'js-yaml';
 import { useStore as useResultsViewStore } from './store';
@@ -88,7 +89,14 @@ function DownloadMenu() {
     table.body.forEach((row) => {
       const rowValues = [
         ...row.vars,
-        ...row.outputs.map(({ pass, text }) => (pass ? '[PASS] ' : '[FAIL] ') + text),
+        ...row.outputs.map(
+          ({ pass, text, failureReason: failureType }) =>
+            (pass
+              ? '[PASS] '
+              : failureType === ResultFailureReason.ASSERT
+                ? '[FAIL] '
+                : '[ERROR] ') + text,
+        ),
       ];
       csvRows.push(rowValues);
     });

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import type { AssertionType, EvaluateTableOutput } from '@promptfoo/types';
+import {
+  ResultFailureReason,
+  type AssertionType,
+  type EvaluateTableOutput,
+} from '@promptfoo/types';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
@@ -39,6 +43,7 @@ describe('EvalOutputCell', () => {
       latencyMs: 100,
       namedScores: {},
       pass: true,
+      failureReason: ResultFailureReason.NONE,
       prompt: 'Test prompt',
       provider: 'test-provider',
       score: 0.8,
@@ -80,6 +85,7 @@ describe('EvalOutputCell', () => {
       latencyMs: 100,
       namedScores: {},
       pass: true,
+      failureReason: ResultFailureReason.NONE,
       prompt: 'Test prompt',
       provider: 'test-provider',
       score: 0.8,

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useShiftKey } from '@app/hooks/useShiftKey';
 import Tooltip from '@mui/material/Tooltip';
-import type { EvaluateTableOutput } from '@promptfoo/types';
+import { ResultFailureReason, type EvaluateTableOutput } from '@promptfoo/types';
 import { diffSentences, diffJson, diffWords } from 'diff';
 import remarkGfm from 'remark-gfm';
 import CustomMetrics from './CustomMetrics';
@@ -414,6 +414,7 @@ function EvalOutputCell({
   // Pass/fail badge creation
   let passCount = 0;
   let failCount = 0;
+  let errorCount = 0;
   const gradingResult = output.gradingResult;
 
   if (gradingResult) {
@@ -435,8 +436,14 @@ function EvalOutputCell({
     failCount = 1;
   }
 
+  if (output.failureReason === ResultFailureReason.ERROR) {
+    errorCount = 1;
+  }
+
   let passFailText;
-  if (failCount === 1 && passCount === 1) {
+  if (errorCount === 1) {
+    passFailText = 'ERROR';
+  } else if (failCount === 1 && passCount === 1) {
     passFailText = (
       <>
         {`${failCount} FAIL`} {`${passCount} PASS`}

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -545,7 +545,6 @@ function ResultsTable({
                   ) : null}
                 </div>
               ) : null;
-
               const providerConfig = Array.isArray(config?.providers)
                 ? config.providers[idx]
                 : undefined;
@@ -570,6 +569,13 @@ function ResultsTable({
                         <strong>{pct}% passing</strong> ({numGoodTests[idx]}/{body.length} cases)
                       </div>
                     </div>
+                    {prompt.metrics?.testErrorCount && prompt.metrics.testErrorCount > 0 ? (
+                      <div className="summary">
+                        <div className="highlight fail">
+                          <strong>Errors:</strong> {prompt.metrics?.testErrorCount || 0}
+                        </div>
+                      </div>
+                    ) : null}
                     {prompt.metrics?.namedScores &&
                     Object.keys(prompt.metrics.namedScores).length > 0 ? (
                       <CustomMetrics

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -52,6 +52,8 @@ function formatRowOutput(output: EvaluateTableOutput | string) {
       text = text.slice('[PASS]'.length);
     } else if (output.startsWith('[FAIL]')) {
       text = text.slice('[FAIL]'.length);
+    } else if (output.startsWith('[ERROR]')) {
+      text = text.slice('[ERROR]'.length);
     }
     return {
       text,

--- a/src/app/src/pages/progress/Progress.tsx
+++ b/src/app/src/pages/progress/Progress.tsx
@@ -92,6 +92,7 @@ export default function Cols() {
       calculatePassRate(col.metrics),
       col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`,
       col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`,
+      col.metrics?.testErrorCount == null ? '-' : `${col.metrics.testErrorCount}`,
       col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2),
     ]);
     return [headers]
@@ -343,7 +344,13 @@ export default function Cols() {
                   {col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`}
                 </TableCell>
                 <TableCell>
-                  {col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`}
+                  {col.metrics?.testFailCount == null
+                    ? '- ' +
+                      (col.metrics?.testErrorCount && col.metrics.testErrorCount > 0
+                        ? `+ ${col.metrics.testErrorCount} errors`
+                        : '')
+                    : `${col.metrics.testFailCount} ` +
+                      (col.metrics?.testErrorCount ? `+ ${col.metrics.testErrorCount} errors` : '')}
                 </TableCell>
                 <TableCell>
                   {col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2)}

--- a/src/app/src/pages/prompts/PromptDialog.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.tsx
@@ -54,9 +54,10 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
               .map((evalData) => {
                 const passCount = evalData.metrics?.testPassCount ?? 0;
                 const failCount = evalData.metrics?.testFailCount ?? 0;
+                const errorCount = evalData.metrics?.testErrorCount ?? 0;
                 const passRate =
-                  passCount + failCount > 0
-                    ? ((passCount / (passCount + failCount)) * 100.0).toFixed(2) + '%'
+                  passCount + failCount + errorCount > 0
+                    ? ((passCount / (passCount + failCount + errorCount)) * 100.0).toFixed(2) + '%'
                     : '-';
                 return (
                   <TableRow key={`eval-${evalData.id}`}>
@@ -71,7 +72,9 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
                     <TableCell>{evalData.metrics?.score?.toFixed(2) ?? '-'}</TableCell>
                     <TableCell>{passRate}</TableCell>
                     <TableCell>{passCount}</TableCell>
-                    <TableCell>{failCount}</TableCell>
+                    <TableCell>
+                      {failCount} {errorCount > 0 ? `+ ${errorCount} errors` : ''}
+                    </TableCell>
                   </TableRow>
                 );
               })}

--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -22,6 +22,7 @@ import {
   type ResultLightweightWithLabel,
   type EvaluateSummaryV2,
   isProviderOptions,
+  ResultFailureReason,
 } from '@promptfoo/types';
 import { convertResultsToTable } from '@promptfoo/util/convertEvalResultsToTable';
 import FrameworkCompliance from './FrameworkCompliance';
@@ -95,7 +96,11 @@ const App: React.FC = () => {
         console.warn(`Could not get failures for plugin ${pluginId}`);
         return;
       }
-      if (pluginId && !result.gradingResult?.pass) {
+      if (
+        pluginId &&
+        !result.gradingResult?.pass &&
+        result.failureReason !== ResultFailureReason.ERROR
+      ) {
         if (!failures[pluginId]) {
           failures[pluginId] = [];
         }

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -213,6 +213,7 @@ export async function doEval(
 
     let successes = 0;
     let failures = 0;
+    let errors = 0;
     const tokenUsage = {
       total: 0,
       prompt: 0,
@@ -229,13 +230,16 @@ export async function doEval(
       if (prompt.metrics?.testFailCount) {
         failures += prompt.metrics.testFailCount;
       }
+      if (prompt.metrics?.testErrorCount) {
+        errors += prompt.metrics.testErrorCount;
+      }
       tokenUsage.total += prompt.metrics?.tokenUsage?.total || 0;
       tokenUsage.prompt += prompt.metrics?.tokenUsage?.prompt || 0;
       tokenUsage.completion += prompt.metrics?.tokenUsage?.completion || 0;
       tokenUsage.cached += prompt.metrics?.tokenUsage?.cached || 0;
       tokenUsage.numRequests += prompt.metrics?.tokenUsage?.numRequests || 0;
     }
-    const totalTests = successes + failures;
+    const totalTests = successes + failures + errors;
     const passRate = (successes / totalTests) * 100;
 
     if (cmdObj.table && getLogLevel() !== 'debug' && totalTests < 500) {
@@ -297,6 +301,9 @@ export async function doEval(
 
     logger.info(chalk.green.bold(`Successes: ${successes}`));
     logger.info(chalk.red.bold(`Failures: ${failures}`));
+    if (!Number.isNaN(errors)) {
+      logger.info(chalk.red.bold(`Errors: ${errors}`));
+    }
     if (!Number.isNaN(passRate)) {
       logger.info(chalk.blue.bold(`Pass Rate: ${passRate.toFixed(2)}%`));
     }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -39,15 +39,23 @@ async function handlePrompt(id: string) {
       'Dataset ID': evl.datasetId.slice(0, 6),
       'Raw score': evl.metrics?.score?.toFixed(2) || '-',
       'Pass rate':
-        evl.metrics && evl.metrics.testPassCount + evl.metrics.testFailCount > 0
+        evl.metrics &&
+        evl.metrics.testPassCount + evl.metrics.testFailCount + evl.metrics.testErrorCount > 0
           ? `${(
               (evl.metrics.testPassCount /
-                (evl.metrics.testPassCount + evl.metrics.testFailCount)) *
+                (evl.metrics.testPassCount +
+                  evl.metrics.testFailCount +
+                  evl.metrics.testErrorCount)) *
               100
             ).toFixed(2)}%`
           : '-',
       'Pass count': evl.metrics?.testPassCount || '-',
-      'Fail count': evl.metrics?.testFailCount || '-',
+      'Fail count':
+        evl.metrics?.testFailCount ||
+        '-' +
+          (evl.metrics?.testErrorCount && evl.metrics.testErrorCount > 0
+            ? `+ ${evl.metrics.testErrorCount} errors`
+            : ''),
     });
   }
   logger.info(wrapTable(table));
@@ -119,15 +127,25 @@ async function handleDataset(id: string) {
       'Raw score': prompt.prompt.metrics?.score?.toFixed(2) || '-',
       'Pass rate':
         prompt.prompt.metrics &&
-        prompt.prompt.metrics.testPassCount + prompt.prompt.metrics.testFailCount > 0
+        prompt.prompt.metrics.testPassCount +
+          prompt.prompt.metrics.testFailCount +
+          prompt.prompt.metrics.testErrorCount >
+          0
           ? `${(
               (prompt.prompt.metrics.testPassCount /
-                (prompt.prompt.metrics.testPassCount + prompt.prompt.metrics.testFailCount)) *
+                (prompt.prompt.metrics.testPassCount +
+                  prompt.prompt.metrics.testFailCount +
+                  prompt.prompt.metrics.testErrorCount)) *
               100
             ).toFixed(2)}%`
           : '-',
       'Pass count': prompt.prompt.metrics?.testPassCount || '-',
-      'Fail count': prompt.prompt.metrics?.testFailCount || '-',
+      'Fail count':
+        prompt.prompt.metrics?.testFailCount ||
+        '-' +
+          (prompt.prompt.metrics?.testErrorCount && prompt.prompt.metrics.testErrorCount > 0
+            ? `+ ${prompt.prompt.metrics.testErrorCount} errors`
+            : ''),
     });
   }
   logger.info(wrapTable(table));

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -8,15 +8,16 @@ import {
   uniqueIndex,
   real,
 } from 'drizzle-orm/sqlite-core';
-import type {
-  Prompt,
-  ProviderResponse,
-  GradingResult,
-  UnifiedConfig,
-  ProviderOptions,
-  AtomicTestCase,
-  CompletedPrompt,
-  EvaluateSummaryV2,
+import {
+  type Prompt,
+  type ProviderResponse,
+  type GradingResult,
+  type UnifiedConfig,
+  type ProviderOptions,
+  type AtomicTestCase,
+  type CompletedPrompt,
+  type EvaluateSummaryV2,
+  ResultFailureReason,
 } from '../types';
 
 // ------------ Prompts ------------
@@ -100,6 +101,7 @@ export const evalResultsTable = sqliteTable(
     // Output-related fields
     response: text('response', { mode: 'json' }).$type<ProviderResponse>(),
     error: text('error'),
+    failureReason: integer('failure_reason').default(ResultFailureReason.NONE).notNull(),
 
     // Result-related fields
     success: integer('success', { mode: 'boolean' }).notNull(),

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -16,17 +16,18 @@ import { generateIdFromPrompt } from './models/prompt';
 import { maybeEmitAzureOpenAiWarning } from './providers/azureUtil';
 import { generatePrompts } from './suggestions';
 import telemetry from './telemetry';
-import type {
-  ApiProvider,
-  Assertion,
-  CompletedPrompt,
-  EvaluateOptions,
-  EvaluateResult,
-  EvaluateStats,
-  Prompt,
-  ProviderResponse,
-  RunEvalOptions,
-  TestSuite,
+import {
+  ResultFailureReason,
+  type ApiProvider,
+  type Assertion,
+  type CompletedPrompt,
+  type EvaluateOptions,
+  type EvaluateResult,
+  type EvaluateStats,
+  type Prompt,
+  type ProviderResponse,
+  type RunEvalOptions,
+  type TestSuite,
 } from './types';
 import { JsonlFileWriter } from './util/exportToFile/writeToFile';
 import invariant from './util/invariant';
@@ -255,6 +256,7 @@ class Evaluator {
         ...setup,
         response,
         success: false,
+        failureReason: ResultFailureReason.NONE,
         score: 0,
         namedScores: {},
         latencyMs,
@@ -298,6 +300,7 @@ class Evaluator {
         });
         if (!checkResult.pass) {
           ret.error = checkResult.reason;
+          ret.failureReason = ResultFailureReason.ASSERT;
         }
         ret.success = checkResult.pass;
         ret.score = checkResult.score;
@@ -340,6 +343,7 @@ class Evaluator {
         ...setup,
         error: String(err) + '\n\n' + (err as Error).stack,
         success: false,
+        failureReason: ResultFailureReason.ERROR,
         score: 0,
         namedScores: {},
         latencyMs,

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -404,6 +404,7 @@ export default class Eval {
     const stats: EvaluateStats = {
       successes: 0,
       failures: 0,
+      errors: 0,
       tokenUsage: {
         cached: 0,
         completion: 0,
@@ -416,6 +417,7 @@ export default class Eval {
     for (const prompt of this.prompts) {
       stats.successes += prompt.metrics?.testPassCount || 0;
       stats.failures += prompt.metrics?.testFailCount || 0;
+      stats.errors += prompt.metrics?.testErrorCount || 0;
       stats.tokenUsage.prompt += prompt.metrics?.tokenUsage.prompt || 0;
       stats.tokenUsage.cached += prompt.metrics?.tokenUsage.cached || 0;
       stats.tokenUsage.completion += prompt.metrics?.tokenUsage.completion || 0;

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -9,6 +9,7 @@ import type {
   Prompt,
   ProviderOptions,
   ProviderResponse,
+  ResultFailureReason,
 } from '../types';
 import { type EvaluateResult } from '../types';
 import { getCurrentTimestamp } from '../util/time';
@@ -32,6 +33,7 @@ export default class EvalResult {
       namedScores,
       cost,
       metadata,
+      failureReason,
     } = result;
     const args = {
       id: randomUUID(),
@@ -51,6 +53,7 @@ export default class EvalResult {
       latencyMs,
       cost,
       metadata,
+      failureReason,
     };
     if (persist) {
       const db = getDb();
@@ -148,6 +151,7 @@ export default class EvalResult {
   latencyMs: number;
   cost: number;
   metadata: Record<string, any>;
+  failureReason: ResultFailureReason;
   persisted: boolean;
 
   constructor(opts: {
@@ -168,6 +172,7 @@ export default class EvalResult {
     latencyMs?: number | null;
     cost?: number | null;
     metadata?: Record<string, any> | null;
+    failureReason: ResultFailureReason;
     persisted?: boolean;
   }) {
     this.id = opts.id;
@@ -188,6 +193,7 @@ export default class EvalResult {
     this.latencyMs = opts.latencyMs || 0;
     this.cost = opts.cost || 0;
     this.metadata = opts.metadata || {};
+    this.failureReason = opts.failureReason;
     this.persisted = opts.persisted || false;
   }
 
@@ -226,6 +232,7 @@ export default class EvalResult {
       testIdx: this.testIdx,
       vars: this.testCase.vars || {},
       metadata: this.metadata,
+      failureReason: this.failureReason,
     };
   }
 }

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import { TERMINAL_MAX_WIDTH } from './constants';
-import type { EvaluateTable } from './types';
+import { ResultFailureReason, type EvaluateTable } from './types';
 
 function ellipsize(str: string, maxLen: number) {
   if (str.length > maxLen) {
@@ -33,14 +33,14 @@ export function generateTable(
   for (const row of evaluateTable.body.slice(0, maxRows)) {
     table.push([
       ...row.vars.map((v) => ellipsize(v, tableCellMaxLength)),
-      ...row.outputs.map(({ pass, score, text }) => {
+      ...row.outputs.map(({ pass, score, text, failureReason: failureType }) => {
         text = ellipsize(text, tableCellMaxLength);
         if (pass) {
           return chalk.green('[PASS] ') + text;
         } else if (!pass) {
           // color everything red up until '---'
           return (
-            chalk.red('[FAIL] ') +
+            chalk.red(failureType === ResultFailureReason.ASSERT ? '[FAIL] ' : '[ERROR] ') +
             text
               .split('---')
               .map((c, idx) => (idx === 0 ? chalk.red.bold(c) : c))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,7 @@ const PromptMetricsSchema = z.object({
   score: z.number(),
   testPassCount: z.number(),
   testFailCount: z.number(),
+  testErrorCount: z.number(),
   assertPassCount: z.number(),
   assertFailCount: z.number(),
   totalLatencyMs: z.number(),
@@ -266,6 +267,7 @@ export interface EvaluateTable {
 export interface EvaluateStats {
   successes: number;
   failures: number;
+  errors: number;
   tokenUsage: Required<TokenUsage>;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,6 +200,15 @@ export interface PromptWithMetadata {
   count: number;
 }
 
+export enum ResultFailureReason {
+  // The test passed, or we don't know exactly why the test case failed.
+  NONE = 0,
+  // The test case failed because an assertion rejected it.
+  ASSERT = 1,
+  // Test case failed due to some other error.
+  ERROR = 2,
+}
+
 export interface EvaluateResult {
   id?: string; // on the new version 2, this is stored per-result
   description?: string; // on the new version 2, this is stored per-result // FIXME(ian): The EvalResult model doesn't pass this through, but that's ok since we can use testCase.description?
@@ -212,6 +221,7 @@ export interface EvaluateResult {
   vars: Record<string, string | object>;
   response?: ProviderResponse;
   error?: string | null;
+  failureReason: ResultFailureReason;
   success: boolean;
   score: number;
   latencyMs: number;
@@ -224,6 +234,7 @@ export interface EvaluateResult {
 export interface EvaluateTableOutput {
   id: string;
   pass: boolean;
+  failureReason: ResultFailureReason;
   score: number;
   namedScores: Record<string, number>;
   text: string;

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -11,6 +11,7 @@ export class PromptMetrics {
   score: number;
   testPassCount: number;
   testFailCount: number;
+  testErrorCount: number;
   assertPassCount: number;
   assertFailCount: number;
   totalLatencyMs: number;
@@ -23,6 +24,7 @@ export class PromptMetrics {
     this.score = 0;
     this.testPassCount = 0;
     this.testFailCount = 0;
+    this.testErrorCount = 0;
     this.assertPassCount = 0;
     this.assertFailCount = 0;
     this.totalLatencyMs = 0;

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -105,6 +105,7 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
       prompt: result.prompt.raw,
       provider: result.provider?.label || result.provider?.id || 'unknown provider',
       pass: result.success,
+      failureReason: result.failureReason,
       cost: result.cost || 0,
     };
     invariant(result.promptId, 'Prompt ID is required');

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -1,9 +1,10 @@
-import type {
-  CompletedPrompt,
-  EvaluateTable,
-  EvaluateTableRow,
-  ResultsFile,
-  TokenUsage,
+import {
+  ResultFailureReason,
+  type CompletedPrompt,
+  type EvaluateTable,
+  type EvaluateTableRow,
+  type ResultsFile,
+  type TokenUsage,
 } from '../types';
 import invariant from '../util/invariant';
 
@@ -123,6 +124,7 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     prompt.metrics.score += result.score;
     prompt.metrics.testPassCount += result.success ? 1 : 0;
     prompt.metrics.testFailCount += result.success ? 0 : 1;
+    prompt.metrics.testErrorCount += result.failureReason === ResultFailureReason.ERROR ? 1 : 0;
     prompt.metrics.assertPassCount +=
       result.gradingResult?.componentResults?.filter((r) => r.pass).length || 0;
     prompt.metrics.assertFailCount +=

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -51,6 +51,7 @@ import {
   isProviderOptions,
   OutputFileExtension,
   type EvaluateSummaryV2,
+  ResultFailureReason,
 } from '../types';
 import invariant from '../util/invariant';
 import { getConfigDirectoryPath } from './config/manage';
@@ -62,7 +63,11 @@ import { getNunjucksEngine } from './templates';
 const DEFAULT_QUERY_LIMIT = 100;
 
 const outputToSimpleString = (output: EvaluateTableOutput) => {
-  const passFailText = output.pass ? '[PASS]' : '[FAIL]';
+  const passFailText = output.pass
+    ? '[PASS]'
+    : output.failureReason === ResultFailureReason.ASSERT
+      ? '[FAIL]'
+      : '[ERROR]';
   const namedScoresText = Object.entries(output.namedScores)
     .map(([name, value]) => `${name}: ${value?.toFixed(2)}`)
     .join(', ');

--- a/test/commands/eval/filterFailingTests.test.ts
+++ b/test/commands/eval/filterFailingTests.test.ts
@@ -1,5 +1,5 @@
 import { filterFailingTests } from '../../../src/commands/eval/filterFailingTests';
-import type { EvaluateSummaryV2, TestSuite } from '../../../src/types';
+import { ResultFailureReason, type EvaluateSummaryV2, type TestSuite } from '../../../src/types';
 import { readOutput } from '../../../src/util';
 
 jest.mock('../../../src/util', () => {
@@ -37,6 +37,7 @@ describe('filterFailingTests', () => {
           {
             ...restResult,
             success: true,
+            failureReason: ResultFailureReason.NONE,
             provider: { id: 'provider1' },
             vars: varsSuccess,
             promptIdx: 0,
@@ -47,6 +48,7 @@ describe('filterFailingTests', () => {
           {
             ...restResult,
             success: false,
+            failureReason: ResultFailureReason.NONE,
             provider: { id: 'provider2' },
             vars: varsFailure,
             promptIdx: 0,
@@ -89,6 +91,7 @@ describe('filterFailingTests', () => {
         results: [
           {
             success: true,
+            failureReason: ResultFailureReason.NONE,
             provider: { id: 'provider1' },
             vars: varsSuccess,
             prompt: {

--- a/test/factories/evalFactory.ts
+++ b/test/factories/evalFactory.ts
@@ -31,6 +31,7 @@ export default class EvalFactory {
           score: 1,
           testPassCount: 1,
           testFailCount: 1,
+          testErrorCount: 0,
           assertPassCount: 1,
           assertFailCount: 1,
           totalLatencyMs: 200,

--- a/test/factories/evalFactory.ts
+++ b/test/factories/evalFactory.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ResultFailureReason } from '../../src';
 import { getDb } from '../../src/database';
 import { evalsTable } from '../../src/database/tables';
 import Eval from '../../src/models/eval';
@@ -64,6 +65,7 @@ export default class EvalFactory {
           tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
         },
         error: null,
+        failureReason: ResultFailureReason.NONE,
         success: true,
         score: 1,
         latencyMs: 100,
@@ -115,6 +117,7 @@ export default class EvalFactory {
           tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
         },
         error: null,
+        failureReason: ResultFailureReason.NONE,
         success: false,
         score: 0,
         latencyMs: 100,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -64,7 +64,6 @@ describe('index.ts exports', () => {
     'TestCaseWithVarsFileSchema',
     'TestSuiteConfigSchema',
     'TestSuiteSchema',
-    'TestSuiteConfigSchema',
     'UnifiedConfigSchema',
     'VarsSchema',
   ];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,6 +55,7 @@ describe('index.ts exports', () => {
     'NotPrefixedAssertionTypesSchema',
     'OutputConfigSchema',
     'OutputFileExtension',
+    'ResultFailureReason',
     'ScenarioSchema',
     'SpecialAssertionTypesSchema',
     'TestCaseSchema',
@@ -63,6 +64,7 @@ describe('index.ts exports', () => {
     'TestCaseWithVarsFileSchema',
     'TestSuiteConfigSchema',
     'TestSuiteSchema',
+    'TestSuiteConfigSchema',
     'UnifiedConfigSchema',
     'VarsSchema',
   ];

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -5,7 +5,12 @@ import cliState from '../../src/cliState';
 import { getDb } from '../../src/database';
 import * as googleSheets from '../../src/googleSheets';
 import Eval from '../../src/models/eval';
-import type { ApiProvider, EvaluateResult, TestCase } from '../../src/types';
+import {
+  ResultFailureReason,
+  type ApiProvider,
+  type EvaluateResult,
+  type TestCase,
+} from '../../src/types';
 import {
   maybeLoadFromExternalFile,
   parsePathOrGlob,
@@ -214,6 +219,7 @@ describe('util', () => {
       const results: EvaluateResult[] = [
         {
           success: true,
+          failureReason: ResultFailureReason.NONE,
           score: 1.0,
           namedScores: {},
           latencyMs: 1000,

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -27,7 +27,6 @@ export function createMockResponse(options: Partial<Response> = {}): Response {
     blob: () => Promise.resolve(new Blob()),
     arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     formData: () => Promise.resolve(new FormData()),
-    // @ts-expect-error
     bytes: () => Promise.resolve(new Uint8Array()),
     bodyUsed: false,
     body: null,
@@ -35,6 +34,6 @@ export function createMockResponse(options: Partial<Response> = {}): Response {
       return createMockResponse(this);
     },
     ...options,
-  };
+  } as Response;
   return mockResponse;
 }

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -27,6 +27,8 @@ export function createMockResponse(options: Partial<Response> = {}): Response {
     blob: () => Promise.resolve(new Blob()),
     arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     formData: () => Promise.resolve(new FormData()),
+    // @ts-expect-error
+    bytes: () => Promise.resolve(new Uint8Array()),
     bodyUsed: false,
     body: null,
     clone() {

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -27,7 +27,6 @@ export function createMockResponse(options: Partial<Response> = {}): Response {
     blob: () => Promise.resolve(new Blob()),
     arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     formData: () => Promise.resolve(new FormData()),
-    bytes: () => Promise.resolve(new Uint8Array()),
     bodyUsed: false,
     body: null,
     clone() {


### PR DESCRIPTION
followups
- redteam reporting and ui
- eval reporting
- cloud

I think you can already implicitly tell whether a test failed due to error from a lack of gradingResults/componentResults.  So not totally sure if this is necessary, but it is definitely way cleaner to set a flag this way.