### PR TITLE
fix: add first round of goat in metadata field

### DIFF
--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -138,7 +138,11 @@ export default class GoatProvider implements ApiProvider {
       output: messages[messages.length - 1]?.content,
       metadata: {
         redteamFinalPrompt: messages[messages.length - 2]?.content,
-        messages: JSON.stringify(messages, null, 2),
+        messages: JSON.stringify(
+          [{ content: context?.prompt?.raw || '', role: 'user' }, ...messages],
+          null,
+          2,
+        ),
       },
       tokenUsage: totalTokenUsage,
     };


### PR DESCRIPTION
@mldangelo can you confirm this is correct, the endpoint expects the initial message only as `prompt` and not in `messages`?