### PR TITLE
fix: csv bom parsing

### DIFF
--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -80,7 +80,7 @@ export async function readStandaloneTestsFile(
     telemetry.recordAndSendOnce('feature_used', {
       feature: 'csv tests file - local',
     });
-    rows = parseCsv(fs.readFileSync(resolvedVarsPath, 'utf-8'), { columns: true });
+    rows = parseCsv(fs.readFileSync(resolvedVarsPath, 'utf-8'), { columns: true, bom: true });
   } else if (fileExtension === 'json') {
     telemetry.recordAndSendOnce('feature_used', {
       feature: 'json tests file',

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -76,6 +76,31 @@ describe('readStandaloneTestsFile', () => {
     ]);
   });
 
+  it('should read CSV file with BOM (Byte Order Mark) and return test cases', async () => {
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue(
+        '\uFEFFvar1,var2,__expected\nvalue1,value2,expected1\nvalue3,value4,expected2',
+      );
+    const result = await readStandaloneTestsFile('test.csv');
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringContaining('test.csv'), 'utf-8');
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
+  });
+
   it('should read JSON file and return test cases', async () => {
     jest.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify([


### PR DESCRIPTION
#### Context

Seems like excel generally saves csv files as UTF-8 (with BOM) and this [breaks parsing](https://stackoverflow.com/questions/66402555/first-property-inaccsesible-of-objects-parsed-by-csv-parse) of the csv with the current settings. 

#### Fix

Update the options of `csv-parse` to detect bom marks. It is [recommended](https://csv.js.org/parse/options/bom/) in the docs to enable this option though the default value is false.

**BEFORE**
<img width="338" alt="Screenshot 2024-11-25 at 5 59 41 PM" src="https://github.com/user-attachments/assets/d4e3c1f6-4170-4a65-9fdc-6658cd34e9f1">

**AFTER**
<img width="338" alt="Screenshot 2024-11-25 at 5 59 09 PM" src="https://github.com/user-attachments/assets/0b67b792-6195-4515-ab75-a83198c35370">

