### PR TITLE
docs: guide on LangChain PromptTemplates

### DIFF
--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -58,9 +58,9 @@ export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> 
 
 ## Testing with Promptfoo
 
-To make the evaluation of prompts more seamless, the prompts can be loaded directly to Promptfoo tests. This way whenever in the application the prompts are updated, the tests can evaluate the most up to date prompt.
+To make the evaluation of prompts more seamless, the prompts can be loaded directly into Promptfoo tests. This way, whenever the prompts are updated in the application, the tests can evaluate the most up-to-date prompt.
 
-Change the prompt to a function that can be loaded in Promptfoo configuration file, as described in loading [prompt functions documentation](https://www.promptfoo.dev/docs/configuration/parameters/). Change how the substitution of variables is done to regular JS substitution.
+Change the prompt to a function that can be loaded in the Promptfoo configuration file, as described in the [prompt functions documentation](https://www.promptfoo.dev/docs/configuration/parameters/). Change how the substitution of variables is done to regular JS substitution.
 
 ```tsx
 export function toneEvaluationInstructions(vars): string {
@@ -89,7 +89,7 @@ ${vars.vars.prompt}
 }
 ```
 
-In Promptfoo test, load the prompt. Promptfoo tests will pass variables in a vars object. In this vars object the variables are accessible as vars.vars. Example above shows accessing prompt as vars.vars.prompt.
+In Promptfoo tests, load the prompt. Promptfoo tests will pass variables in a vars object. In this vars object, the variables are accessible as vars.vars. The example above shows accessing prompt as vars.vars.prompt.
 
 ```yaml
 prompts:
@@ -137,4 +137,4 @@ export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> 
 }
 ```
 
-In conclusion, this setup allows to load most up to date prompts from the application code and test them continuously. In addition, the changes in formatting now allow for integration with LangChain PromptTemplate.
+In conclusion, this setup allows you to load the most up-to-date prompts from your application code, test them continuously, and integrate with LangChain PromptTemplate by properly handling the formatting differences between the two systems. For more information, see the [LangChain PromptTemplate documentation](https://python.langchain.com/api_reference/core/prompts/langchain_core.prompts.prompt.PromptTemplate.html) and [Promptfoo's prompt functions guide](https://www.promptfoo.dev/docs/configuration/parameters/).

--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -1,4 +1,4 @@
-# Use LangChain PromptTemplate with PromptFoo
+# Using LangChain PromptTemplate with PromptFoo
 
 LangChain PromptTemplate is commonly used to format prompts with injecting variables. PromptFoo allows you to evaluate and test your prompts systematically. Combining the two can streamline your workflow, enabling you to test the prompts that use LangChain PromptTemplate in application code directly within PromptFoo.
 
@@ -55,6 +55,7 @@ export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> 
 
 ```
 
+
 ## Testing with PromptFoo
 
 To make the evaluation of prompts more seamless, the prompts can be loaded directly to PromptFoo tests. This way whenever in the application the prompts are updated, the tests can evaluate the most up to date prompt.
@@ -88,6 +89,7 @@ ${vars.vars.prompt}
 }
 ```
 
+
 In PromptFoo test, load the prompt. PromptFoo tests will pass variables in a vars object. In this vars object the variables are accessible as vars.vars. Example above shows accessing prompt as vars.vars.prompt.
 
 ```yaml
@@ -113,10 +115,13 @@ Do this by setting the environment variable:
 export PROMPTFOO_DISABLE_TEMPLATING=true
 ```
 
+
 An example of formatting issues between Nunjucks and LangChain PromptTemplate:
 
 - {{…}} with LangChain PromptTemplate marks escaping the curly brace and {…} is used for substitution
 - {{…}} with PromptFoo is used for substitution
+
+
 
 Finally, change how variables are passed to the prompt in application code. 
 
@@ -136,5 +141,6 @@ export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> 
 }
 
 ```
+
 
 In conclusion, this setup allows to load most up to date prompts from the application code and test them continuously. In addition, the changes in formatting now allow for integration with LangChain PromptTemplate.

--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -1,6 +1,6 @@
-# Using LangChain PromptTemplate with PromptFoo
+# Using LangChain PromptTemplate with Promptfoo
 
-LangChain PromptTemplate is commonly used to format prompts with injecting variables. PromptFoo allows you to evaluate and test your prompts systematically. Combining the two can streamline your workflow, enabling you to test the prompts that use LangChain PromptTemplate in application code directly within PromptFoo.
+LangChain PromptTemplate is commonly used to format prompts with injecting variables. Promptfoo allows you to evaluate and test your prompts systematically. Combining the two can streamline your workflow, enabling you to test the prompts that use LangChain PromptTemplate in application code directly within Promptfoo.
 
 ## Example of LangChain PromptTemplate
 
@@ -35,36 +35,36 @@ Do not respond in markdown and respond in JSON format:
 This prompt can be loaded and used with LangChain PromptTemplate. Here is a simplified example:
 
 ```tsx
-import { PromptTemplate } from "@langchain/core/prompts";
-import { evaluationInstructions } from "./prompt-template";
+import { PromptTemplate } from '@langchain/core/prompts';
+import { evaluationInstructions } from './prompt-template';
 
 export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> {
-    const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
+  const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
 
-    // Substitute prompt into the prompt template and evaluate
-    // Assume attemptCompletion handles the completion from a model
-    const validationResult = await attemptCompletion(prompt, instructionTemplate);
+  // Substitute prompt into the prompt template and evaluate
+  // Assume attemptCompletion handles the completion from a model
+  const validationResult = await attemptCompletion(prompt, instructionTemplate);
 
-    if (validationResult.rudeOrOffensiveLanguage === "true" || 
-        validationResult.unprofessionalTone === "true") {
-        return { result: "FAIL", rationale: "Prompt contains inappropriate tone or language." };
-    }
+  if (
+    validationResult.rudeOrOffensiveLanguage === 'true' ||
+    validationResult.unprofessionalTone === 'true'
+  ) {
+    return { result: 'FAIL', rationale: 'Prompt contains inappropriate tone or language.' };
+  }
 
-    return { result: "PASS", rationale: "Prompt is appropriate." };
+  return { result: 'PASS', rationale: 'Prompt is appropriate.' };
 }
-
 ```
 
+## Testing with Promptfoo
 
-## Testing with PromptFoo
+To make the evaluation of prompts more seamless, the prompts can be loaded directly to Promptfoo tests. This way whenever in the application the prompts are updated, the tests can evaluate the most up to date prompt.
 
-To make the evaluation of prompts more seamless, the prompts can be loaded directly to PromptFoo tests. This way whenever in the application the prompts are updated, the tests can evaluate the most up to date prompt.
-
-Change the prompt to a function that can be loaded in PromptFoo configuration file, as described in loading [prompt functions documentation](https://www.promptfoo.dev/docs/configuration/parameters/). Change how the substitution of variables is done to regular JS substitution.
+Change the prompt to a function that can be loaded in Promptfoo configuration file, as described in loading [prompt functions documentation](https://www.promptfoo.dev/docs/configuration/parameters/). Change how the substitution of variables is done to regular JS substitution.
 
 ```tsx
-export funtion toneEvaluationInstructions(vars): string {
-`## Objective
+export function toneEvaluationInstructions(vars): string {
+  `## Objective
 Evaluate if the user prompt falls under any of the following tone or language categories.
 
 ## Criteria for Prompts
@@ -89,8 +89,7 @@ ${vars.vars.prompt}
 }
 ```
 
-
-In PromptFoo test, load the prompt. PromptFoo tests will pass variables in a vars object. In this vars object the variables are accessible as vars.vars. Example above shows accessing prompt as vars.vars.prompt.
+In Promptfoo test, load the prompt. Promptfoo tests will pass variables in a vars object. In this vars object the variables are accessible as vars.vars. Example above shows accessing prompt as vars.vars.prompt.
 
 ```yaml
 prompts:
@@ -102,12 +101,12 @@ providers:
 tests:
   - description: 'Simple tone detection test'
     vars:
-      prompt: "Hello, how are you?"
+      prompt: 'Hello, how are you?'
     assert:
       - type: is-json
 ```
 
-To avoid formatting conflicts between LangChain and PromptFoo, ensure PromptFoo's internal templating engine is disabled. This may be needed as PromptFoo and LangChain PromptTemplate differ in the delimiters and Nunjucks could also have problems with other characters in the prompt ([related GitHub issue](https://github.com/promptfoo/promptfoo/pull/405/files)). 
+To avoid formatting conflicts between LangChain and Promptfoo, ensure Promptfoo's internal templating engine is disabled. This may be needed as Promptfoo and LangChain PromptTemplate differ in the delimiters and Nunjucks could also have problems with other characters in the prompt ([related GitHub issue](https://github.com/promptfoo/promptfoo/pull/405/files)).
 
 Do this by setting the environment variable:
 
@@ -115,32 +114,27 @@ Do this by setting the environment variable:
 export PROMPTFOO_DISABLE_TEMPLATING=true
 ```
 
-
 An example of formatting issues between Nunjucks and LangChain PromptTemplate:
 
-- {{…}} with LangChain PromptTemplate marks escaping the curly brace and {…} is used for substitution
-- {{…}} with PromptFoo is used for substitution
+- `{{...}}` with LangChain PromptTemplate marks escaping the curly brace and `{...}` is used for substitution
+- `{{...}}` with Promptfoo is used for substitution
 
-
-
-Finally, change how variables are passed to the prompt in application code. 
+Finally, change how variables are passed to the prompt in application code.
 
 ```tsx
-// Format prompt to be similar with PromptFoo passed variables from test
+// Format prompt to be similar with Promptfoo passed variables from test
 function formatPrompt(prompt: string): promptfooWrapper {
   return { vars: { prompt: prompt } };
 }
 
 export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> {
-		const promptfooWrapper = formatPrompt(prompt);
-    const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
+  const promptfooWrapper = formatPrompt(prompt);
+  const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
 
-    const validationResult = await attemptCompletion(promptfooWrapper, instructionTemplate);
+  const validationResult = await attemptCompletion(promptfooWrapper, instructionTemplate);
 
-    // ... Rest of the code
+  // ... Rest of the code
 }
-
 ```
-
 
 In conclusion, this setup allows to load most up to date prompts from the application code and test them continuously. In addition, the changes in formatting now allow for integration with LangChain PromptTemplate.

--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -1,0 +1,140 @@
+# Use LangChain PromptTemplate with PromptFoo
+
+LangChain PromptTemplate is commonly used to format prompts with injecting variables. PromptFoo allows you to evaluate and test your prompts systematically. Combining the two can streamline your workflow, enabling you to test the prompts that use LangChain PromptTemplate in application code directly within PromptFoo.
+
+## Example of LangChain PromptTemplate
+
+For example, this is one way a prompt could be saved in a TypeScript/JavaScript application.
+
+```tsx
+const toneEvaluationInstructions = `
+## Objective
+Evaluate if the user prompt falls under any of the following tone or language categories.
+
+## Criteria for Prompts
+1. Rude or Offensive Language:
+  - Use of profanity or vulgar language
+  - Insults or derogatory terms directed at individuals or groups
+
+2. Unprofessional Tone:
+  - Overly casual or slang-heavy language
+  - Disorganized or incoherent statements
+
+## Response Format
+Do not respond in markdown and respond in JSON format:
+{{
+  "rudeOrOffensiveLanguage": "true" | "false",
+  "unprofessionalTone": "true" | "false",
+}}
+
+## Prompt: 
+{prompt}
+`;
+```
+
+This prompt can be loaded and used with LangChain PromptTemplate. Here is a simplified example:
+
+```tsx
+import { PromptTemplate } from "@langchain/core/prompts";
+import { evaluationInstructions } from "./prompt-template";
+
+export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> {
+    const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
+
+    // Substitute prompt into the prompt template and evaluate
+    // Assume attemptCompletion handles the completion from a model
+    const validationResult = await attemptCompletion(prompt, instructionTemplate);
+
+    if (validationResult.rudeOrOffensiveLanguage === "true" || 
+        validationResult.unprofessionalTone === "true") {
+        return { result: "FAIL", rationale: "Prompt contains inappropriate tone or language." };
+    }
+
+    return { result: "PASS", rationale: "Prompt is appropriate." };
+}
+
+```
+
+## Testing with PromptFoo
+
+To make the evaluation of prompts more seamless, the prompts can be loaded directly to PromptFoo tests. This way whenever in the application the prompts are updated, the tests can evaluate the most up to date prompt.
+
+Change the prompt to a function that can be loaded in PromptFoo configuration file, as described in loading [prompt functions documentation](https://www.promptfoo.dev/docs/configuration/parameters/). Change how the substitution of variables is done to regular JS substitution.
+
+```tsx
+export funtion toneEvaluationInstructions(vars): string {
+`## Objective
+Evaluate if the user prompt falls under any of the following tone or language categories.
+
+## Criteria for Prompts
+1. Rude or Offensive Language:
+  - Use of profanity or vulgar language
+  - Insults or derogatory terms directed at individuals or groups
+
+2. Unprofessional Tone:
+  - Overly casual or slang-heavy language
+  - Disorganized or incoherent statements
+
+## Response Format
+Do not respond in markdown and respond in JSON format:
+{{
+  "rudeOrOffensiveLanguage": "true" | "false",
+  "unprofessionalTone": "true" | "false",
+}}
+
+## Prompt: 
+${vars.vars.prompt}
+`;
+}
+```
+
+In PromptFoo test, load the prompt. PromptFoo tests will pass variables in a vars object. In this vars object the variables are accessible as vars.vars. Example above shows accessing prompt as vars.vars.prompt.
+
+```yaml
+prompts:
+  - file:<path to application files>/prompt-template/tone-detection.js:toneEvaluationInstructions
+
+providers:
+  - openai:gpt-4o-mini
+
+tests:
+  - description: 'Simple tone detection test'
+    vars:
+      prompt: "Hello, how are you?"
+    assert:
+      - type: is-json
+```
+
+To avoid formatting conflicts between LangChain and PromptFoo, ensure PromptFoo's internal templating engine is disabled. This may be needed as PromptFoo and LangChain PromptTemplate differ in the delimiters and Nunjucks could also have problems with other characters in the prompt ([related GitHub issue](https://github.com/promptfoo/promptfoo/pull/405/files)). 
+
+Do this by setting the environment variable:
+
+```bash
+export PROMPTFOO_DISABLE_TEMPLATING=true
+```
+
+An example of formatting issues between Nunjucks and LangChain PromptTemplate:
+
+- {{…}} with LangChain PromptTemplate marks escaping the curly brace and {…} is used for substitution
+- {{…}} with PromptFoo is used for substitution
+
+Finally, change how variables are passed to the prompt in application code. 
+
+```tsx
+// Format prompt to be similar with PromptFoo passed variables from test
+function formatPrompt(prompt: string): promptfooWrapper {
+  return { vars: { prompt: prompt } };
+}
+
+export async function evaluatePrompt(prompt: string): Promise<EvaluationResult> {
+		const promptfooWrapper = formatPrompt(prompt);
+    const instructionTemplate = PromptTemplate.fromTemplate(evaluationInstructions);
+
+    const validationResult = await attemptCompletion(promptfooWrapper, instructionTemplate);
+
+    // ... Rest of the code
+}
+
+```
+
+In conclusion, this setup allows to load most up to date prompts from the application code and test them continuously. In addition, the changes in formatting now allow for integration with LangChain PromptTemplate.

--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -89,11 +89,15 @@ ${vars.vars.prompt}
 }
 ```
 
+:::note
+In this example, we're using Typescript (.ts) - but you can use regular Javascript (.js) too
+:::
+
 In Promptfoo tests, load the prompt. Promptfoo tests will pass variables in a vars object. In this vars object, the variables are accessible as vars.vars. The example above shows accessing prompt as vars.vars.prompt.
 
 ```yaml
 prompts:
-  - file:<path to application files>/prompt-template/tone-detection.js:toneEvaluationInstructions
+  - file:<path to application files>/prompt-template/tone-detection.ts:toneEvaluationInstructions
 
 providers:
   - openai:gpt-4o-mini


### PR DESCRIPTION
This guide covers:
- Using LangChain PromtTemplate for prompts defined in the application code
- Using PromptFoo to test the prompts defined in the application and the necessary formatting configurations