### PR TITLE
chore(webui): minor impovements to redteam setup strategy and plugin selection

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Prompts.tsx
+++ b/src/app/src/pages/redteam/setup/components/Prompts.tsx
@@ -55,8 +55,23 @@ export default function Prompts() {
       <Typography variant="h5" gutterBottom sx={{ fontWeight: 'medium' }}>
         Prompts
       </Typography>
-      <Typography variant="body1" paragraph>
-        {`Enter your prompts below. Use {{ prompt }} as a placeholder for user input.`}
+      <Typography
+        variant="body1"
+        paragraph
+        color="text.secondary"
+        sx={{
+          mb: 2,
+          '& code': {
+            px: 0.5,
+            py: 0.25,
+            backgroundColor: 'action.hover',
+            borderRadius: 0.5,
+            fontFamily: 'monospace',
+          },
+        }}
+      >
+        Enter your prompts below. Use <code>{'{{ prompt }}'}</code> as a placeholder where you want
+        the user's input to appear in your prompt template.
       </Typography>
       {config.prompts.map((prompt, index) => (
         <Box key={index} display="flex" alignItems="center" mb={2}>

--- a/src/app/src/pages/redteam/setup/components/Purpose.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.tsx
@@ -9,6 +9,7 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
 import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import Prompts from './Prompts';
 
@@ -32,9 +33,29 @@ export default function Purpose({ onNext, onBack }: PromptsProps) {
       <Typography variant="h4" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
         Application Details
       </Typography>
-      <Alert severity="info">
-        The more information you provide, the better the redteam attacks will be and the more
-        accurate the results.
+      <Alert
+        severity="info"
+        sx={{
+          '& .MuiAlert-icon': {
+            color: 'info.main',
+          },
+          backgroundColor: (theme) =>
+            theme.palette.mode === 'dark'
+              ? alpha(theme.palette.info.main, 0.1)
+              : alpha(theme.palette.info.main, 0.05),
+          border: (theme) =>
+            `1px solid ${
+              theme.palette.mode === 'dark'
+                ? alpha(theme.palette.info.main, 0.3)
+                : alpha(theme.palette.info.main, 0.2)
+            }`,
+          '& .MuiAlert-message': {
+            color: 'text.primary',
+          },
+        }}
+      >
+        The more information you provide, the better the redteam attacks will be. You can leave
+        fields blank if they're not relevant, and you'll be able to revise information later.
       </Alert>
 
       <Box>

--- a/src/app/src/pages/redteam/setup/components/Strategies.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.tsx
@@ -2,18 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
-import { Alert } from '@mui/material';
-import Box from '@mui/material/Box';
+import { Alert, Paper, Box, Typography, Chip } from '@mui/material';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
-import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
-import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { alpha } from '@mui/material/styles';
 import {
@@ -97,6 +93,63 @@ export default function Strategies({ onNext, onBack }: StrategiesProps) {
       <Typography variant="h4" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
         Strategy Configuration
       </Typography>
+
+      <Paper elevation={1} sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          About Testing Strategies
+        </Typography>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          LLM applications typically interact with users in one of two ways: single-turn (one-shot)
+          or multi-turn (conversational) interactions. Your choice of testing strategy should match
+          your application's interaction model.
+        </Typography>
+        <Box sx={{ ml: 2, mb: 2 }}>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            • <strong>Single-turn strategies</strong> test individual prompts in isolation. These
+            are ideal for:
+            <Box component="ul" sx={{ mt: 1, mb: 2 }}>
+              <li>Systems where each prompt is independent</li>
+              <li>API endpoints (e.g., text classification, content generation)</li>
+              <li>Completion tasks (e.g., code generation, text summarization)</li>
+            </Box>
+          </Typography>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            • <strong>Multi-turn strategies</strong>{' '}
+            <Chip
+              size="small"
+              label="Multi-turn"
+              color="secondary"
+              sx={{
+                ml: 1,
+                backgroundColor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? alpha(theme.palette.secondary.main, 0.1)
+                    : alpha(theme.palette.secondary.main, 0.1),
+                color: 'secondary.main',
+                borderColor: 'secondary.main',
+                border: 1,
+              }}
+            />{' '}
+            simulate realistic conversations through multiple exchanges. These are essential for:
+            <Box component="ul" sx={{ mt: 1, mb: 2 }}>
+              <li>Chatbots and conversational agents</li>
+              <li>Systems that maintain conversation history</li>
+              <li>Applications where context builds over time</li>
+            </Box>
+          </Typography>
+        </Box>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          <Typography variant="body2">
+            <strong>Cost vs. Coverage Trade-off:</strong> Multi-turn strategies provide deeper
+            security testing by simulating realistic user interactions, but use more API calls
+            (typically 3-10x more). Choose based on your application type:
+          </Typography>
+          <Box component="ul" sx={{ mt: 1, mb: 0 }}>
+            <li>For chatbots: Use multi-turn strategies for comprehensive testing</li>
+            <li>For simple completion APIs: Single-turn strategies are more cost-effective</li>
+          </Box>
+        </Alert>
+      </Paper>
 
       <Grid container spacing={2} sx={{ mb: 3 }}>
         {availableStrategies.map((strategy) => (

--- a/src/app/src/pages/redteam/setup/components/Strategies.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.tsx
@@ -114,23 +114,8 @@ export default function Strategies({ onNext, onBack }: StrategiesProps) {
             </Box>
           </Typography>
           <Typography variant="body2" color="text.secondary" paragraph>
-            • <strong>Multi-turn strategies</strong>{' '}
-            <Chip
-              size="small"
-              label="Multi-turn"
-              color="secondary"
-              sx={{
-                ml: 1,
-                backgroundColor: (theme) =>
-                  theme.palette.mode === 'dark'
-                    ? alpha(theme.palette.secondary.main, 0.1)
-                    : alpha(theme.palette.secondary.main, 0.1),
-                color: 'secondary.main',
-                borderColor: 'secondary.main',
-                border: 1,
-              }}
-            />{' '}
-            simulate realistic conversations through multiple exchanges. These are essential for:
+            • <strong>Multi-turn strategies</strong> simulate realistic conversations through
+            multiple exchanges. These are ideal for:
             <Box component="ul" sx={{ mt: 1, mb: 2 }}>
               <li>Chatbots and conversational agents</li>
               <li>Systems that maintain conversation history</li>
@@ -138,17 +123,6 @@ export default function Strategies({ onNext, onBack }: StrategiesProps) {
             </Box>
           </Typography>
         </Box>
-        <Alert severity="info" sx={{ mb: 2 }}>
-          <Typography variant="body2">
-            <strong>Cost vs. Coverage Trade-off:</strong> Multi-turn strategies provide deeper
-            security testing by simulating realistic user interactions, but use more API calls
-            (typically 3-10x more). Choose based on your application type:
-          </Typography>
-          <Box component="ul" sx={{ mt: 1, mb: 0 }}>
-            <li>For chatbots: Use multi-turn strategies for comprehensive testing</li>
-            <li>For simple completion APIs: Single-turn strategies are more cost-effective</li>
-          </Box>
-        </Alert>
       </Paper>
 
       <Grid container spacing={2} sx={{ mb: 3 }}>

--- a/src/app/src/pages/redteam/setup/components/Strategies.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.tsx
@@ -15,11 +15,13 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import {
   DEFAULT_STRATEGIES,
   ALL_STRATEGIES,
   strategyDescriptions,
   strategyDisplayNames,
+  MULTI_TURN_STRATEGIES,
 } from '@promptfoo/redteam/constants';
 import type { RedteamStrategy } from '@promptfoo/redteam/types';
 import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
@@ -116,6 +118,24 @@ export default function Strategies({ onNext, onBack }: StrategiesProps) {
                       {DEFAULT_STRATEGIES.includes(
                         strategy.id as (typeof DEFAULT_STRATEGIES)[number],
                       ) && <Chip label="Recommended" size="small" color="default" />}
+                      {MULTI_TURN_STRATEGIES.includes(
+                        strategy.id as (typeof MULTI_TURN_STRATEGIES)[number],
+                      ) && (
+                        <Chip
+                          label="Multi-turn"
+                          size="small"
+                          color="secondary"
+                          sx={{
+                            backgroundColor: (theme) =>
+                              theme.palette.mode === 'dark'
+                                ? alpha(theme.palette.secondary.main, 0.1)
+                                : alpha(theme.palette.secondary.main, 0.1),
+                            color: 'secondary.main',
+                            borderColor: 'secondary.main',
+                            border: 1,
+                          }}
+                        />
+                      )}
                     </Box>
                     <Typography variant="body2" color="text.secondary">
                       {strategy.description}

--- a/src/app/src/pages/redteam/setup/components/Strategies.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.tsx
@@ -31,7 +31,7 @@ interface StrategiesProps {
   onBack: () => void;
 }
 
-const availableStrategies = ALL_STRATEGIES.map((id) => ({
+const availableStrategies = ALL_STRATEGIES.filter((id) => id !== 'default').map((id) => ({
   id,
   name: strategyDisplayNames[id] || id,
   description: strategyDescriptions[id],

--- a/src/redteam/commands/setup.ts
+++ b/src/redteam/commands/setup.ts
@@ -4,7 +4,7 @@ import { startServer } from '../../server/server';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
 import { setConfigDirectoryPath } from '../../util/config/manage';
-import { BrowserBehavior } from '../../util/server';
+import { BrowserBehavior, checkServerRunning, openBrowser } from '../../util/server';
 
 export function redteamSetupCommand(program: Command) {
   program
@@ -33,8 +33,14 @@ export function redteamSetupCommand(program: Command) {
           setConfigDirectoryPath(directory);
         }
 
+        const isRunning = await checkServerRunning();
         const browserBehavior = BrowserBehavior.OPEN_TO_REDTEAM_CREATE;
-        await startServer(cmdObj.port, browserBehavior, cmdObj.filterDescription);
+
+        if (isRunning) {
+          await openBrowser(browserBehavior);
+        } else {
+          await startServer(cmdObj.port, browserBehavior, cmdObj.filterDescription);
+        }
       },
     );
 }

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -372,6 +372,9 @@ export const ALIASED_PLUGIN_MAPPINGS: Record<
 export const DEFAULT_STRATEGIES = ['jailbreak', 'prompt-injection'] as const;
 export type DefaultStrategy = (typeof DEFAULT_STRATEGIES)[number];
 
+export const MULTI_TURN_STRATEGIES = ['crescendo', 'goat'] as const;
+export type MultiTurnStrategy = (typeof MULTI_TURN_STRATEGIES)[number];
+
 export const ADDITIONAL_STRATEGIES = [
   'ascii-smuggling',
   'base64',


### PR DESCRIPTION
- Add visual indicators for multi-turn and optimizer strategies
- Improve plugin preset handling with default plugins
- Add descriptive text for different strategy types
- Make basic strategy always selected and non-removable
- Enhance prompt template instructions with code formatting
- Improve application details form with better info alert styling
- Add server check before starting redteam setup