### PR TITLE
fix: prevent user from interacting with Back button on the first page of the redteam setup

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Purpose.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.tsx
@@ -173,6 +173,7 @@ export default function Purpose({ onNext, onBack }: PromptsProps) {
             }}
           >
             <Button
+              disabled
               variant="outlined"
               startIcon={<KeyboardArrowLeftIcon />}
               onClick={onBack}


### PR DESCRIPTION
# What
- Disable back button on first page of the redteam setup

# Why
- The web application errors out and offers a grey screen if the user clicks back on the first page.

## Now

![image](https://github.com/user-attachments/assets/27daa396-b981-4e75-bead-eb848670011b)

## Before

[Screencast from 2024-11-30 10-48-06.webm](https://github.com/user-attachments/assets/00783ad1-a3f1-4626-83e4-a7c7303cc065)
