### PR TITLE
chore(webui): improve back and next buttons for purpose/targets pages

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Purpose.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useTelemetry } from '@app/hooks/useTelemetry';
-import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import { Alert } from '@mui/material';
 import Box from '@mui/material/Box';

--- a/src/app/src/pages/redteam/setup/components/Purpose.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.tsx
@@ -15,10 +15,9 @@ import Prompts from './Prompts';
 
 interface PromptsProps {
   onNext: () => void;
-  onBack: () => void;
 }
 
-export default function Purpose({ onNext, onBack }: PromptsProps) {
+export default function Purpose({ onNext }: PromptsProps) {
   const { config, updateApplicationDefinition } = useRedTeamConfig();
   const { recordEvent } = useTelemetry();
 
@@ -167,22 +166,11 @@ export default function Purpose({ onNext, onBack }: PromptsProps) {
           <Box
             sx={{
               display: 'flex',
-              justifyContent: 'space-between',
+              justifyContent: 'flex-end',
               alignItems: 'center',
               mt: 4,
             }}
           >
-            <Button
-              variant="outlined"
-              startIcon={<KeyboardArrowLeftIcon />}
-              onClick={onBack}
-              sx={{
-                px: 4,
-                py: 1,
-              }}
-            >
-              Back
-            </Button>
             <Button
               variant="contained"
               endIcon={<KeyboardArrowRightIcon />}

--- a/src/app/src/pages/redteam/setup/components/Targets/index.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import { callApi } from '@app/utils/api';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -30,6 +31,7 @@ import WebSocketEndpointConfiguration from './WebSocketEndpointConfiguration';
 
 interface TargetsProps {
   onNext: () => void;
+  onBack: () => void;
   setupModalOpen: boolean;
 }
 
@@ -74,7 +76,7 @@ const requiresPrompt = (target: ProviderOptions) => {
   return target.id !== 'http' && target.id !== 'websocket' && target.id !== 'browser';
 };
 
-export default function Targets({ onNext, setupModalOpen }: TargetsProps) {
+export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps) {
   const { config, updateConfig } = useRedTeamConfig();
   const theme = useTheme();
   const selectedTarget = config.target || DEFAULT_HTTP_TARGET;
@@ -546,6 +548,17 @@ export default function Targets({ onNext, setupModalOpen }: TargetsProps) {
           </Alert>
         )}
         <Button
+          variant="outlined"
+          startIcon={<KeyboardArrowLeftIcon />}
+          onClick={onBack}
+          sx={{
+            px: 4,
+            py: 1,
+          }}
+        >
+          Back
+        </Button>
+        <Button
           variant="contained"
           onClick={onNext}
           endIcon={<KeyboardArrowRightIcon />}
@@ -557,6 +570,7 @@ export default function Targets({ onNext, setupModalOpen }: TargetsProps) {
             px: 4,
             py: 1,
             minWidth: '150px',
+            ml: 2,
           }}
         >
           Next

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -429,10 +429,10 @@ export default function RedTeamSetupPage() {
         </OuterSidebarContainer>
         <TabContent>
           <CustomTabPanel value={value} index={0}>
-            <Purpose onNext={handleNext} onBack={handleBack} />
+            <Purpose onNext={handleNext} />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={1}>
-            <Targets onNext={handleNext} setupModalOpen={setupModalOpen} />
+            <Targets onNext={handleNext} onBack={handleBack} setupModalOpen={setupModalOpen} />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={2}>
             <Plugins onNext={handleNext} onBack={handleBack} />


### PR DESCRIPTION
As noted in #2267, the back button is broken on the "Applications" aka Purpose page.  This PR removes the button and adds the missing back button to the Targets page.