### PR TITLE
chore(webui): only show action buttons for the currently hovered cell, rather than both cells for that row

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -165,7 +165,8 @@ table.results-table,
   font-size: 1.25rem;
 }
 
-.results-table tr:hover .cell-actions {
+.results-table .first-prompt-col:hover .cell-actions,
+.results-table .second-prompt-column:hover .cell-actions {
   visibility: visible;
 }
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -589,6 +589,7 @@ function ResultsTable({
             cell: (info: CellContext<EvaluateTableRow, EvaluateTableOutput>) => {
               const output = getOutput(info.row.index, idx);
               return output ? (
+                // hmm
                 <EvalOutputCell
                   output={output}
                   maxTextLength={maxTextLength}
@@ -781,7 +782,7 @@ function ResultsTable({
                       }}
                       className={`${isMetadataCol ? 'variable' : ''} ${
                         shouldDrawRowBorder ? 'first-prompt-row' : ''
-                      } ${shouldDrawColBorder ? 'first-prompt-col' : ''}`}
+                      } ${shouldDrawColBorder ? 'first-prompt-col' : 'second-prompt-column'}`}
                     >
                       {cellContent}
                     </td>

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -589,7 +589,6 @@ function ResultsTable({
             cell: (info: CellContext<EvaluateTableRow, EvaluateTableOutput>) => {
               const output = getOutput(info.row.index, idx);
               return output ? (
-                // hmm
                 <EvalOutputCell
                   output={output}
                   maxTextLength={maxTextLength}


### PR DESCRIPTION
# What
- Prevent action buttons from being shown for both columns when hovering over a single column in the eval comparison view

# Why
- Action buttons are per cell so the UX is more clear when the buttons are shown on a per cell:hover basis.

## Now
[Screencast from 2024-11-30 11-28-22.webm](https://github.com/user-attachments/assets/b068b51a-c781-4c9b-a21d-030ab6d54029)

## Before
[Screencast from 2024-11-30 11-30-59.webm](https://github.com/user-attachments/assets/111c0c2e-92d6-4796-ab20-98cb8b50b564)
