### PR TITLE
fix(webui): support sorting on pass / fail count & raw score

### DIFF
--- a/src/app/src/pages/progress/Progress.tsx
+++ b/src/app/src/pages/progress/Progress.tsx
@@ -17,6 +17,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import TextField from '@mui/material/TextField';
+import type { PromptMetrics } from '@promptfoo/types';
 import type { StandaloneEval } from '@promptfoo/util';
 
 export default function Cols() {
@@ -110,6 +111,17 @@ export default function Cols() {
     setAnchorEl(null);
   };
 
+  const getSortedValues = (sortOrder: string, a: number, b: number): number => {
+    return sortOrder === 'asc' ? a - b : b - a;
+  };
+
+  const getValue = (metrics: PromptMetrics | undefined, sortField: string): number => {
+    if (metrics) {
+      return metrics[sortField as keyof PromptMetrics] as number;
+    }
+    return 0;
+  };
+
   const filteredCols = React.useMemo(() => {
     return cols.filter(
       (col) =>
@@ -128,8 +140,8 @@ export default function Cols() {
       if (sortField === 'passRate') {
         const aValue = Number.parseFloat(calculatePassRate(a.metrics));
         const bValue = Number.parseFloat(calculatePassRate(b.metrics));
-        return sortOrder === 'asc' ? aValue - bValue : bValue - aValue;
-      } else {
+        return getSortedValues(sortOrder, aValue, bValue);
+      } else if (sortField === 'evalId') {
         // Ensure sortField is a key of StandaloneEval
         if (sortField in a && sortField in b) {
           const aValue = a[sortField as keyof StandaloneEval] || '';
@@ -139,6 +151,10 @@ export default function Cols() {
             : bValue.toString().localeCompare(aValue.toString());
         }
         return 0;
+      } else {
+        const aValue = getValue(a.metrics, sortField);
+        const bValue = getValue(b.metrics, sortField);
+        return getSortedValues(sortOrder, aValue, bValue);
       }
     });
   }, [filteredCols, sortField, sortOrder]);


### PR DESCRIPTION
# What
- The progress / history page now supports sorting on pass count, fail count, and raw score

# Why
- On hover of the column headers, an arrow presents, indicating an expected UX of being able to sort the column (pass count, fail count, || raw score). But upon click of the sort arrow, nothing would happen.

# Now
(Note - Recording is a little laggy as I am playing around with red teaming while recording)

[Screencast from 2024-11-30 14-44-42.webm](https://github.com/user-attachments/assets/c91fd710-4d1d-4ea1-8365-e12a7e1c1461)

# Before
[Screencast from 2024-11-30 14-43-28.webm](https://github.com/user-attachments/assets/570a0e7e-69b6-43da-9453-438a3491188b)

