### PR TITLE
chore(webui): prevent dialog from popping up repeatedly when component rerenders

### DIFF
--- a/src/app/src/pages/datasets/Datasets.tsx
+++ b/src/app/src/pages/datasets/Datasets.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { callApi } from '@app/utils/api';
 import Box from '@mui/material/Box';
@@ -29,6 +29,7 @@ export default function Datasets() {
   const [openDialog, setOpenDialog] = useState(false);
   const [dialogTestCaseIndex, setDialogTestCaseIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const hasShownPopup = useRef(false);
 
   const handleSort = (field: string) => {
     const order = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
@@ -64,11 +65,15 @@ export default function Datasets() {
   };
 
   useEffect(() => {
+    if (hasShownPopup.current) {
+      return;
+    }
     const testCaseId = searchParams.get('id');
     if (testCaseId) {
       const testCaseIndex = testCases.findIndex((testCase) => testCase.id.startsWith(testCaseId));
       if (testCaseIndex !== -1) {
         handleClickOpen(testCaseIndex);
+        hasShownPopup.current = true;
       }
     }
   }, [testCases, searchParams]);

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useSearchParams } from 'react-router-dom';
 import { callApi } from '@app/utils/api';
@@ -29,6 +29,7 @@ export default function Prompts() {
   const [openDialog, setOpenDialog] = useState(false);
   const [selectedPromptIndex, setSelectedPromptIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const hasShownPopup = useRef(false);
 
   const handleSort = (field: string) => {
     const order = sortField === field && sortOrder === 'asc' ? 'desc' : 'asc';
@@ -66,11 +67,15 @@ export default function Prompts() {
   };
 
   useEffect(() => {
+    if (hasShownPopup.current) {
+      return;
+    }
     const promptId = searchParams.get('id');
     if (promptId) {
       const promptIndex = prompts.findIndex((prompt) => prompt.id.startsWith(promptId));
       if (promptIndex !== -1) {
         handleClickOpen(promptIndex);
+        hasShownPopup.current = true;
       }
     }
   }, [prompts, searchParams]);


### PR DESCRIPTION
# What
- In the Datasets and Prompts view, when the user had an `?id=___` in their URL, all rerenders of the view resulted in the dialog opening again. This happened whenever the user would try to sort a column.

## Note
- Sorting by prompt or Most recent eval is broken on `/prompts` 
- Sorting by Info, Most recent eval date and Most recent eval ID is broken on `/datasets`

## Now
[Screencast from 2024-11-30 15-38-42.webm](https://github.com/user-attachments/assets/5c46fc76-106e-457f-a2c2-3cec3ecf3f21)

## Before
[Screencast from 2024-11-30 15-40-14.webm](https://github.com/user-attachments/assets/9ee7c9cb-90f0-4c62-94b8-fe546219c7c6)
