### PR TITLE
chore: remote generation if logged into cloud

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -16,7 +16,7 @@ import {
 } from './prompts';
 import { loadApiProvider } from './providers';
 import { getDefaultProviders } from './providers/defaults';
-import { shouldGenerateRemote } from './redteam/util';
+import { shouldGenerateRemote } from './redteam/remoteGeneration';
 import { doRemoteGrading } from './remoteGrading';
 import type {
   ApiClassificationProvider,

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -4,7 +4,7 @@ import { getEnvString } from '../envars';
 import { fetchWithRetries } from '../fetch';
 import { getUserEmail } from '../globalConfig/accounts';
 import logger from '../logger';
-import { getRemoteGenerationUrl } from '../redteam/constants';
+import { getRemoteGenerationUrl } from '../redteam/remoteGeneration';
 import type {
   ApiProvider,
   ProviderResponse,

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -25,9 +25,9 @@ import {
   DEFAULT_STRATEGIES,
   ADDITIONAL_STRATEGIES,
 } from '../constants';
+import { shouldGenerateRemote } from '../remoteGeneration';
 import type { RedteamStrategyObject, SynthesizeOptions } from '../types';
 import type { RedteamFileConfig, RedteamCliGenerateOptions } from '../types';
-import { shouldGenerateRemote } from '../util';
 
 function getConfigHash(configPath: string): string {
   const content = fs.readFileSync(configPath, 'utf8');

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import logger from '../../logger';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
-import { getRemoteGenerationUrl } from '../constants';
+import { getRemoteGenerationUrl } from '../remoteGeneration';
 
 interface PoisonOptions {
   documents: string[];

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -1,9 +1,3 @@
-import { getEnvString } from '../envars';
-
-export function getRemoteGenerationUrl(): string {
-  return getEnvString('PROMPTFOO_REMOTE_GENERATION_URL', 'https://api.promptfoo.dev/v1/generate');
-}
-
 export const DEFAULT_NUM_TESTS_PER_PLUGIN = 5;
 
 export const REDTEAM_MODEL = 'openai:chat:gpt-4o';

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import logger from '../../logger';
 import type { ApiProvider } from '../../types';
-import { shouldGenerateRemote } from '../util';
+import { shouldGenerateRemote } from '../remoteGeneration';
 import type { RedTeamTask } from './util';
 import { callExtraction, fetchRemoteGeneration, formatPrompts } from './util';
 

--- a/src/redteam/extraction/purpose.ts
+++ b/src/redteam/extraction/purpose.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import logger from '../../logger';
 import type { ApiProvider } from '../../types';
-import { shouldGenerateRemote } from '../util';
+import { shouldGenerateRemote } from '../remoteGeneration';
 import type { RedTeamTask } from './util';
 import { callExtraction, fetchRemoteGeneration, formatPrompts } from './util';
 
@@ -21,11 +21,11 @@ export async function extractSystemPurpose(
   // Fallback to local extraction
   const prompt = dedent`
     The following are prompts that are being used to test an LLM application:
-    
+
     ${formatPrompts(prompts)}
-    
+
     Given the above prompts, output the "system purpose" of the application in a single sentence, enclosed in <Purpose> tags.
-    
+
     Example outputs:
     <Purpose>Provide users a way to manage finances</Purpose>
     <Purpose>Executive assistant that helps with scheduling and reminders</Purpose>

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -7,7 +7,7 @@ import { getEnvBool } from '../../envars';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { ApiProvider } from '../../types';
-import { getRemoteGenerationUrl } from '../constants';
+import { getRemoteGenerationUrl } from '../remoteGeneration';
 
 export const RedTeamGenerationResponse = z.object({
   task: z.string(),

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -6,9 +6,13 @@ import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { ApiProvider, PluginActionParams, PluginConfig, TestCase } from '../../types';
 import type { HarmPlugin } from '../constants';
-import { PII_PLUGINS, REDTEAM_PROVIDER_HARM_PLUGINS, getRemoteGenerationUrl } from '../constants';
+import { PII_PLUGINS, REDTEAM_PROVIDER_HARM_PLUGINS } from '../constants';
 import { UNALIGNED_PROVIDER_HARM_PLUGINS } from '../constants';
-import { neverGenerateRemote, shouldGenerateRemote } from '../util';
+import {
+  neverGenerateRemote,
+  shouldGenerateRemote,
+  getRemoteGenerationUrl,
+} from '../remoteGeneration';
 import { type RedteamPluginBase } from './base';
 import { ContractPlugin } from './contracts';
 import { CrossSessionLeakPlugin } from './crossSessionLeak';

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -15,7 +15,8 @@ import type {
 } from '../../../types';
 import { extractFirstJsonObject } from '../../../util/json';
 import { getNunjucksEngine } from '../../../util/templates';
-import { isBasicRefusal, shouldGenerateRemote } from '../../util';
+import { shouldGenerateRemote } from '../../remoteGeneration';
+import { isBasicRefusal } from '../../util';
 import { getTargetResponse, loadRedteamProvider, type TargetResponse } from '../shared';
 import { CRESCENDO_SYSTEM_PROMPT, REFUSAL_SYSTEM_PROMPT, EVAL_SYSTEM_PROMPT } from './prompts';
 

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -11,8 +11,7 @@ import type {
   ProviderOptions,
   ProviderResponse,
 } from '../../types/providers';
-import { getRemoteGenerationUrl } from '../constants';
-import { neverGenerateRemote } from '../util';
+import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
 
 export default class GoatProvider implements ApiProvider {
   private maxTurns: number;

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -12,7 +12,7 @@ import {
 } from '../../types';
 import { extractFirstJsonObject } from '../../util/json';
 import { getNunjucksEngine } from '../../util/templates';
-import { shouldGenerateRemote } from '../util';
+import { shouldGenerateRemote } from '../remoteGeneration';
 import { ATTACKER_SYSTEM_PROMPT, JUDGE_SYSTEM_PROMPT, ON_TOPIC_SYSTEM_PROMPT } from './prompts';
 import { getTargetResponse, loadRedteamProvider } from './shared';
 

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -28,7 +28,7 @@ import type {
 } from '../../types';
 import { extractFirstJsonObject } from '../../util/json';
 import { getNunjucksEngine } from '../../util/templates';
-import { shouldGenerateRemote } from '../util';
+import { shouldGenerateRemote } from '../remoteGeneration';
 import { PENALIZED_PHRASES } from './constants';
 import { ATTACKER_SYSTEM_PROMPT, JUDGE_SYSTEM_PROMPT, ON_TOPIC_SYSTEM_PROMPT } from './prompts';
 import { getTargetResponse, loadRedteamProvider } from './shared';

--- a/src/redteam/remoteGeneration.ts
+++ b/src/redteam/remoteGeneration.ts
@@ -1,0 +1,27 @@
+import cliState from '../cliState';
+import { getEnvBool, getEnvString } from '../envars';
+import { CloudConfig } from '../globalConfig/cloud';
+
+export function getRemoteGenerationUrl(): string {
+  // Check env var first
+  const envUrl = getEnvString('PROMPTFOO_REMOTE_GENERATION_URL');
+  if (envUrl) {
+    return envUrl;
+  }
+  // If logged into cloud use that url + /task
+  const cloudConfig = new CloudConfig();
+  if (cloudConfig.isEnabled()) {
+    return cloudConfig.getApiHost() + '/task';
+  }
+  // otherwise use the default
+  return 'https://api.promptfoo.app/task';
+}
+
+export function neverGenerateRemote(): boolean {
+  return getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION');
+}
+
+export function shouldGenerateRemote(): boolean {
+  // Generate remotely when the user has not disabled it and does not have an OpenAI key.
+  return (!neverGenerateRemote() && !getEnvString('OPENAI_API_KEY')) || (cliState.remote ?? false);
+}

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -6,8 +6,7 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { getRemoteGenerationUrl } from '../constants';
-import { neverGenerateRemote } from '../util';
+import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
 
 async function generateCitations(
   testCases: TestCase[],

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -6,9 +6,8 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { getRemoteGenerationUrl } from '../constants';
 import { loadRedteamProvider } from '../providers/shared';
-import { shouldGenerateRemote } from '../util';
+import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
 
 const DEFAULT_MATH_CONCEPTS = ['set theory', 'group theory', 'abstract algebra'];
 

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -6,9 +6,8 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { getRemoteGenerationUrl } from '../constants';
 import { loadRedteamProvider } from '../providers/shared';
-import { shouldGenerateRemote } from '../util';
+import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
 
 const DEFAULT_LANGUAGES = ['bn', 'sw', 'jv']; // Bengali, Swahili, Javanese
 

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -5,8 +5,7 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { getRemoteGenerationUrl } from '../constants';
-import { neverGenerateRemote } from '../util';
+import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
 
 async function generateCompositePrompts(
   testCases: TestCase[],

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -1,6 +1,3 @@
-import cliState from '../cliState';
-import { getEnvBool, getEnvString } from '../envars';
-
 const REFUSAL_PREFIXES = [
   'Sorry',
   "I'm sorry",
@@ -21,15 +18,6 @@ const REFUSAL_SUBSTRINGS = [
   'If you have any other non-malicious requests',
   "I'm not able to provide",
 ];
-
-export function neverGenerateRemote(): boolean {
-  return getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION');
-}
-
-export function shouldGenerateRemote(): boolean {
-  // Generate remotely when the user has not disabled it and does not have an OpenAI key.
-  return (!neverGenerateRemote() && !getEnvString('OPENAI_API_KEY')) || (cliState.remote ?? false);
-}
 
 export function isBasicRefusal(response: string): boolean {
   const lowerResponse = response.trim().toLowerCase();

--- a/src/remoteGrading.ts
+++ b/src/remoteGrading.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from './cache';
 import logger from './logger';
 import { REQUEST_TIMEOUT_MS } from './providers/shared';
-import { getRemoteGenerationUrl } from './redteam/constants';
+import { getRemoteGenerationUrl } from './redteam/remoteGeneration';
 import type { GradingResult } from './types';
 
 type RemoteGradingPayload = {

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -1,15 +1,13 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import logger from '../../logger';
+import { getRemoteGenerationUrl } from '../../redteam/remoteGeneration';
 
 export const redteamRouter = Router();
 
-const CLOUD_FUNCTION_URL =
-  process.env.PROMPTFOO_REMOTE_GENERATION_URL || 'https://api.promptfoo.dev/v1/generate';
-
 redteamRouter.post('/:task', async (req: Request, res: Response): Promise<void> => {
   const { task } = req.params;
-
+  const cloudFunctionUrl = getRemoteGenerationUrl();
   logger.debug(`Received ${task} task request:`, {
     method: req.method,
     url: req.url,
@@ -17,8 +15,8 @@ redteamRouter.post('/:task', async (req: Request, res: Response): Promise<void> 
   });
 
   try {
-    logger.debug(`Sending request to cloud function: ${CLOUD_FUNCTION_URL}`);
-    const response = await fetch(CLOUD_FUNCTION_URL, {
+    logger.debug(`Sending request to cloud function: ${cloudFunctionUrl}`);
+    const response = await fetch(cloudFunctionUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/test/assertions/index.test.ts
+++ b/test/assertions/index.test.ts
@@ -22,6 +22,10 @@ import type {
 } from '../../src/types';
 import { TestGrader } from '../util/utils';
 
+jest.mock('../../src/redteam/remoteGeneration', () => ({
+  shouldGenerateRemote: jest.fn().mockReturnValue(false),
+}));
+
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -37,7 +37,7 @@ jest.mock('../src/cliState');
 jest.mock('../src/remoteGrading', () => ({
   doRemoteGrading: jest.fn(),
 }));
-jest.mock('../src/redteam/util', () => ({
+jest.mock('../src/redteam/remoteGeneration', () => ({
   shouldGenerateRemote: jest.fn().mockReturnValue(true),
 }));
 jest.mock('proxy-agent', () => ({

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -97,6 +97,12 @@ jest.mock('../../src/logger', () => ({
   warn: jest.fn(),
 }));
 
+jest.mock('../../src/redteam/remoteGeneration', () => ({
+  shouldGenerateRemote: jest.fn().mockReturnValue(false),
+  neverGenerateRemote: jest.fn().mockReturnValue(false),
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('http://test-url'),
+}));
+
 const mockFetch = jest.mocked(jest.fn());
 global.fetch = mockFetch;
 

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -14,6 +14,11 @@ jest.mock('../../../src/util/config/load', () => ({
   combineConfigs: jest.fn(),
   resolveConfigs: jest.fn(),
 }));
+jest.mock('../../../src/redteam/remoteGeneration', () => ({
+  shouldGenerateRemote: jest.fn().mockReturnValue(false),
+  neverGenerateRemote: jest.fn().mockReturnValue(false),
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('http://test-url'),
+}));
 jest.mock('../../../src/util/config/manage');
 
 describe('doGenerateRedteam', () => {

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -58,7 +58,7 @@ describe('Entities Extractor', () => {
 
     expect(result).toEqual(['Apple', 'Google']);
     expect(fetchWithCache).toHaveBeenCalledWith(
-      'https://api.promptfoo.dev/v1/generate',
+      'https://api.promptfoo.app/task',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -51,7 +51,7 @@ describe('System Purpose Extractor', () => {
 
     expect(result).toBe('Remote extracted purpose');
     expect(fetchWithCache).toHaveBeenCalledWith(
-      'https://api.promptfoo.dev/v1/generate',
+      'https://api.promptfoo.app/task',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -45,7 +45,7 @@ describe('fetchRemoteGeneration', () => {
 
     expect(result).toBe('This is a purpose');
     expect(fetchWithCache).toHaveBeenCalledWith(
-      'https://api.promptfoo.dev/v1/generate',
+      'https://api.promptfoo.app/task',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -76,7 +76,7 @@ describe('fetchRemoteGeneration', () => {
 
     expect(result).toEqual(['Entity1', 'Entity2']);
     expect(fetchWithCache).toHaveBeenCalledWith(
-      'https://api.promptfoo.dev/v1/generate',
+      'https://api.promptfoo.app/task',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -8,7 +8,7 @@ import {
   PII_PLUGINS,
 } from '../../../src/redteam/constants';
 import { Plugins } from '../../../src/redteam/plugins';
-import { shouldGenerateRemote, neverGenerateRemote } from '../../../src/redteam/util';
+import { shouldGenerateRemote, neverGenerateRemote } from '../../../src/redteam/remoteGeneration';
 import type { ApiProvider } from '../../../src/types';
 
 jest.mock('../../../src/cache');

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -13,9 +13,10 @@ import type { ApiProvider } from '../../../src/types';
 
 jest.mock('../../../src/cache');
 jest.mock('../../../src/logger');
-jest.mock('../../../src/redteam/util', () => ({
+jest.mock('../../../src/redteam/remoteGeneration', () => ({
   shouldGenerateRemote: jest.fn().mockReturnValue(false),
   neverGenerateRemote: jest.fn().mockReturnValue(false),
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('http://test-url'),
 }));
 jest.mock('../../../src/cliState', () => ({
   __esModule: true,

--- a/test/redteam/providers/goat.test.ts
+++ b/test/redteam/providers/goat.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { getRemoteGenerationUrl } from '../../../src/redteam/constants';
 import RedteamGoatProvider from '../../../src/redteam/providers/goat';
+import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import type {
   ApiProvider,
   CallApiContextParams,

--- a/test/redteam/remoteGeneration.test.ts
+++ b/test/redteam/remoteGeneration.test.ts
@@ -1,0 +1,103 @@
+import cliState from '../../src/cliState';
+import { getEnvBool, getEnvString } from '../../src/envars';
+import { readGlobalConfig } from '../../src/globalConfig/globalConfig';
+import {
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+  shouldGenerateRemote,
+} from '../../src/redteam/remoteGeneration';
+
+describe('shouldGenerateRemote', () => {
+  jest.mock('../../src/envars');
+  jest.mock('../../src/cliState', () => ({
+    remote: undefined,
+  }));
+  beforeEach(() => {
+    jest.resetAllMocks();
+    cliState.remote = undefined;
+  });
+
+  it('should return true when remote generation is not disabled and no OpenAI key exists', () => {
+    jest.mocked(getEnvBool).mockReturnValue(false);
+    jest.mocked(getEnvString).mockReturnValue('');
+    expect(shouldGenerateRemote()).toBe(true);
+  });
+
+  it('should return false when remote generation is disabled via env var', () => {
+    jest.mocked(getEnvBool).mockReturnValue(true);
+    jest.mocked(getEnvString).mockReturnValue('');
+    expect(shouldGenerateRemote()).toBe(false);
+  });
+
+  it('should return false when OpenAI key exists', () => {
+    jest.mocked(getEnvBool).mockReturnValue(false);
+    jest.mocked(getEnvString).mockReturnValue('sk-123');
+    expect(shouldGenerateRemote()).toBe(false);
+  });
+
+  it('should return false when remote generation is disabled via env var and OpenAI key exists', () => {
+    jest.mocked(getEnvBool).mockReturnValue(true);
+    jest.mocked(getEnvString).mockReturnValue('sk-123');
+    expect(shouldGenerateRemote()).toBe(false);
+  });
+
+  it('should return true when cliState.remote is true regardless of other conditions', () => {
+    jest.mocked(getEnvBool).mockReturnValue(true);
+    jest.mocked(getEnvString).mockReturnValue('sk-123');
+    cliState.remote = true;
+    expect(shouldGenerateRemote()).toBe(true);
+  });
+});
+
+describe('neverGenerateRemote', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return true when PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION is set to true', () => {
+    jest.mocked(getEnvBool).mockReturnValue(true);
+    expect(neverGenerateRemote()).toBe(true);
+  });
+
+  it('should return false when PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION is set to false', () => {
+    jest.mocked(getEnvBool).mockReturnValue(false);
+    expect(neverGenerateRemote()).toBe(false);
+  });
+});
+
+describe('getRemoteGenerationUrl', () => {
+  jest.mock('../../src/envars');
+  jest.mock('../../src/globalConfig/globalConfig');
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return env URL + /task when PROMPTFOO_REMOTE_GENERATION_URL is set', () => {
+    jest.mocked(getEnvString).mockReturnValue('https://custom.api.com');
+    expect(getRemoteGenerationUrl()).toBe('https://custom.api.com/task');
+  });
+
+  it('should return cloud API host + /task when cloud is enabled and no env URL is set', () => {
+    jest.mocked(getEnvString).mockReturnValue('');
+    jest.mocked(readGlobalConfig).mockReturnValue({
+      cloud: {
+        apiKey: 'some-api-key',
+        apiHost: 'https://cloud.api.com',
+      },
+    });
+
+    expect(getRemoteGenerationUrl()).toBe('https://cloud.api.com/task');
+  });
+
+  it('should return default URL when cloud is disabled and no env URL is set', () => {
+    jest.mocked(getEnvString).mockReturnValue('');
+    jest.mocked(readGlobalConfig).mockReturnValue({
+      cloud: {
+        apiKey: undefined,
+        apiHost: 'https://cloud.api.com',
+      },
+    });
+
+    expect(getRemoteGenerationUrl()).toBe('https://api.promptfoo.app/task');
+  });
+});

--- a/test/redteam/remoteGeneration.test.ts
+++ b/test/redteam/remoteGeneration.test.ts
@@ -7,11 +7,13 @@ import {
   shouldGenerateRemote,
 } from '../../src/redteam/remoteGeneration';
 
+jest.mock('../../src/envars');
+jest.mock('../../src/globalConfig/globalConfig');
+jest.mock('../../src/envars');
+jest.mock('../../src/cliState', () => ({
+  remote: undefined,
+}));
 describe('shouldGenerateRemote', () => {
-  jest.mock('../../src/envars');
-  jest.mock('../../src/cliState', () => ({
-    remote: undefined,
-  }));
   beforeEach(() => {
     jest.resetAllMocks();
     cliState.remote = undefined;
@@ -66,14 +68,12 @@ describe('neverGenerateRemote', () => {
 });
 
 describe('getRemoteGenerationUrl', () => {
-  jest.mock('../../src/envars');
-  jest.mock('../../src/globalConfig/globalConfig');
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('should return env URL + /task when PROMPTFOO_REMOTE_GENERATION_URL is set', () => {
-    jest.mocked(getEnvString).mockReturnValue('https://custom.api.com');
+    jest.mocked(getEnvString).mockReturnValue('https://custom.api.com/task');
     expect(getRemoteGenerationUrl()).toBe('https://custom.api.com/task');
   });
 

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -1,7 +1,4 @@
-import cliState from '../../src/cliState';
-import { getEnvBool, getEnvString } from '../../src/envars';
-import { neverGenerateRemote, removePrefix } from '../../src/redteam/util';
-import { shouldGenerateRemote } from '../../src/redteam/util';
+import { removePrefix } from '../../src/redteam/util';
 
 describe('removePrefix', () => {
   it('should remove a simple prefix', () => {
@@ -30,64 +27,5 @@ describe('removePrefix', () => {
 
   it('should handle prefix that is the entire string', () => {
     expect(removePrefix('Prompt:', 'Prompt')).toBe('');
-  });
-});
-
-jest.mock('../../src/envars');
-jest.mock('../../src/cliState', () => ({
-  remote: undefined,
-}));
-
-describe('shouldGenerateRemote', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    cliState.remote = undefined;
-  });
-
-  it('should return true when remote generation is not disabled and no OpenAI key exists', () => {
-    jest.mocked(getEnvBool).mockReturnValue(false);
-    jest.mocked(getEnvString).mockReturnValue('');
-    expect(shouldGenerateRemote()).toBe(true);
-  });
-
-  it('should return false when remote generation is disabled via env var', () => {
-    jest.mocked(getEnvBool).mockReturnValue(true);
-    jest.mocked(getEnvString).mockReturnValue('');
-    expect(shouldGenerateRemote()).toBe(false);
-  });
-
-  it('should return false when OpenAI key exists', () => {
-    jest.mocked(getEnvBool).mockReturnValue(false);
-    jest.mocked(getEnvString).mockReturnValue('sk-123');
-    expect(shouldGenerateRemote()).toBe(false);
-  });
-
-  it('should return false when remote generation is disabled via env var and OpenAI key exists', () => {
-    jest.mocked(getEnvBool).mockReturnValue(true);
-    jest.mocked(getEnvString).mockReturnValue('sk-123');
-    expect(shouldGenerateRemote()).toBe(false);
-  });
-
-  it('should return true when cliState.remote is true regardless of other conditions', () => {
-    jest.mocked(getEnvBool).mockReturnValue(true);
-    jest.mocked(getEnvString).mockReturnValue('sk-123');
-    cliState.remote = true;
-    expect(shouldGenerateRemote()).toBe(true);
-  });
-});
-
-describe('neverGenerateRemote', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('should return true when PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION is set to true', () => {
-    jest.mocked(getEnvBool).mockReturnValue(true);
-    expect(neverGenerateRemote()).toBe(true);
-  });
-
-  it('should return false when PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION is set to false', () => {
-    jest.mocked(getEnvBool).mockReturnValue(false);
-    expect(neverGenerateRemote()).toBe(false);
   });
 });


### PR DESCRIPTION
Use the cloud api if you're logged into a cloud instance

I had to move a bunch of stuff to another file so node/server-side libraries wouldn't be pulled into the web app.