### PR TITLE
feat: add configurable CSV delimiter support

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -14,6 +14,7 @@ export type EnvVars = {
   PROMPTFOO_CACHE_TTL?: number;
   PROMPTFOO_CACHE_TYPE?: 'memory' | 'disk';
   PROMPTFOO_CONFIG_DIR?: string;
+  PROMPTFOO_CSV_DELIMITER?: string;
   PROMPTFOO_DELAY_MS?: number;
   PROMPTFOO_DISABLE_AJV_STRICT_MODE?: boolean;
   PROMPTFOO_DISABLE_CONVERSATION_VAR?: boolean;

--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { parse as parsePath } from 'path';
 import invariant from 'tiny-invariant';
 import { testCaseFromCsvRow } from './csv';
-import { getEnvBool } from './envars';
+import { getEnvBool, getEnvString } from './envars';
 import { fetchCsvFromGoogleSheet } from './googleSheets';
 import logger from './logger';
 import { loadApiProvider } from './providers';
@@ -57,7 +57,6 @@ export async function readVarsFiles(
       Object.assign(ret, yamlData);
     }
   }
-
   return ret;
 }
 
@@ -80,7 +79,12 @@ export async function readStandaloneTestsFile(
     telemetry.recordAndSendOnce('feature_used', {
       feature: 'csv tests file - local',
     });
-    rows = parseCsv(fs.readFileSync(resolvedVarsPath, 'utf-8'), { columns: true, bom: true });
+    const delimiter = getEnvString('PROMPTFOO_CSV_DELIMITER', ',');
+    rows = parseCsv(fs.readFileSync(resolvedVarsPath, 'utf-8'), {
+      columns: true,
+      bom: true,
+      delimiter,
+    });
   } else if (fileExtension === 'json') {
     telemetry.recordAndSendOnce('feature_used', {
       feature: 'json tests file',

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -50,7 +50,6 @@ jest.mock('../src/googleSheets', () => ({
 }));
 jest.mock('../src/logger');
 
-// Mock the envars module
 jest.mock('../src/envars', () => ({
   ...jest.requireActual('../src/envars'),
   getEnvBool: jest.fn(),

--- a/test/testCases.test.ts
+++ b/test/testCases.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { globSync } from 'glob';
 import yaml from 'js-yaml';
 import { testCaseFromCsvRow } from '../src/csv';
+import { getEnvString } from '../src/envars';
 import { fetchCsvFromGoogleSheet } from '../src/googleSheets';
 import logger from '../src/logger';
 import { loadApiProvider } from '../src/providers';
@@ -26,6 +27,7 @@ jest.mock('glob', () => ({
 jest.mock('../src/providers', () => ({
   loadApiProvider: jest.fn(),
 }));
+jest.mock('../src/fetch');
 
 jest.mock('fs', () => ({
   readFileSync: jest.fn(),
@@ -47,6 +49,13 @@ jest.mock('../src/googleSheets', () => ({
   fetchCsvFromGoogleSheet: jest.fn(),
 }));
 jest.mock('../src/logger');
+
+// Mock the envars module
+jest.mock('../src/envars', () => ({
+  ...jest.requireActual('../src/envars'),
+  getEnvBool: jest.fn(),
+  getEnvString: jest.fn().mockImplementation((key, defaultValue) => defaultValue),
+}));
 
 describe('readStandaloneTestsFile', () => {
   beforeEach(() => {
@@ -169,6 +178,58 @@ describe('readStandaloneTestsFile', () => {
 
   it('should return an empty array for unsupported file types', async () => {
     await expect(readStandaloneTestsFile('test.txt')).resolves.toEqual([]);
+  });
+
+  it('should read CSV file with default delimiter', async () => {
+    jest.mocked(getEnvString).mockReturnValue(',');
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue('var1,var2,__expected\nvalue1,value2,expected1\nvalue3,value4,expected2');
+
+    const result = await readStandaloneTestsFile('test.csv');
+
+    expect(getEnvString).toHaveBeenCalledWith('PROMPTFOO_CSV_DELIMITER', ',');
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringContaining('test.csv'), 'utf-8');
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
+  });
+
+  it('should read CSV file with custom delimiter', async () => {
+    jest.mocked(getEnvString).mockReturnValue(';');
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValue('var1;var2;__expected\nvalue1;value2;expected1\nvalue3;value4;expected2');
+
+    const result = await readStandaloneTestsFile('test.csv');
+
+    expect(getEnvString).toHaveBeenCalledWith('PROMPTFOO_CSV_DELIMITER', ',');
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringContaining('test.csv'), 'utf-8');
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
- Add PROMPTFOO_CSV_DELIMITER environment variable
- Update CSV parsing to use configurable delimiter
- Add unit tests for custom delimiter functionality