### PR TITLE
chore: display # selected plugins in accordion text

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -282,6 +282,7 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
     }
 
     const isExpanded = expandedCategories.has(category);
+    const selectedCount = pluginsToShow.filter((plugin) => selectedPlugins.has(plugin)).length;
 
     return (
       <Accordion
@@ -302,7 +303,7 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
           <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
             <Typography variant="h6" sx={{ fontWeight: 'medium', flex: 1 }}>
-              {category}
+              {category} ({selectedCount}/{pluginsToShow.length})
             </Typography>
             {isExpanded && (
               <Box


### PR DESCRIPTION
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/27f97c09-ae32-4594-8252-62c23509462c">
