### PR TITLE
chore(cli): improve error message when attempting to share incomplete eval

### DIFF
--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
+import dedent from 'dedent';
 import readline from 'readline';
 import invariant from 'tiny-invariant';
 import { URL } from 'url';
@@ -56,9 +57,11 @@ export function shareCommand(program: Command) {
         if (eval_.prompts.length === 0) {
           // FIXME(ian): Handle this on the server side.
           logger.error(
-            `Eval ${eval_.id} is still running or did not complete successfully, so it cannot be shared.
-            
-            If your eval is still running, wait for it to complete and try again.`,
+            dedent`
+              Eval ${chalk.bold(eval_.id)} cannot be shared.
+              This may be because the eval is still running or because it did not complete successfully.
+              If your eval is still running, wait for it to complete and try again.
+            `,
           );
           process.exitCode = 1;
           return;

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -65,34 +65,34 @@ export function shareCommand(program: Command) {
         }
         if (cmdObj.yes || getEnvString('PROMPTFOO_DISABLE_SHARE_WARNING')) {
           await createPublicUrl(eval_, cmdObj.showAuth);
-        } else {
-          const reader = readline.createInterface({
-            input: process.stdin,
-            output: process.stdout,
-          });
-
-          if (cloudConfig.isEnabled()) {
-            logger.info(`Sharing eval to ${cloudConfig.getAppUrl()}`);
-            await createPublicUrl(eval_, cmdObj.showAuth);
-            process.exitCode = 0;
-            return;
-          }
-          const baseUrl = getEnvString('PROMPTFOO_SHARING_APP_BASE_URL');
-          const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
-          reader.question(
-            `Create a private shareable URL of your eval on ${hostname}?\n\nTo proceed, please confirm [Y/n] `,
-            async function (answer: string) {
-              if (answer.toLowerCase() !== 'yes' && answer.toLowerCase() !== 'y' && answer !== '') {
-                reader.close();
-                process.exitCode = 1;
-                return;
-              }
-              reader.close();
-
-              await createPublicUrl(eval_, cmdObj.showAuth);
-            },
-          );
+          return;
         }
+        const reader = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        if (cloudConfig.isEnabled()) {
+          logger.info(`Sharing eval to ${cloudConfig.getAppUrl()}`);
+          await createPublicUrl(eval_, cmdObj.showAuth);
+          process.exitCode = 0;
+          return;
+        }
+        const baseUrl = getEnvString('PROMPTFOO_SHARING_APP_BASE_URL');
+        const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+        reader.question(
+          `Create a private shareable URL of your eval on ${hostname}?\n\nTo proceed, please confirm [Y/n] `,
+          async function (answer: string) {
+            if (answer.toLowerCase() !== 'yes' && answer.toLowerCase() !== 'y' && answer !== '') {
+              reader.close();
+              process.exitCode = 1;
+              return;
+            }
+            reader.close();
+
+            await createPublicUrl(eval_, cmdObj.showAuth);
+          },
+        );
       },
     );
 }

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -48,14 +48,20 @@ export function shareCommand(program: Command) {
 
           if (!eval_) {
             logger.error('Could not load results. Do you need to run `promptfoo eval` first?');
-            process.exit(1);
+            process.exitCode = 1;
+            return;
           }
         }
         invariant(eval_, 'No eval found');
         if (eval_.prompts.length === 0) {
           // FIXME(ian): Handle this on the server side.
-          logger.error(`Eval ${eval_.id} did not complete successfully, so it cannot be shared.`);
-          process.exit(1);
+          logger.error(
+            `Eval ${eval_.id} is still running or did not complete successfully, so it cannot be shared.
+            
+            If your eval is still running, wait for it to complete and try again.`,
+          );
+          process.exitCode = 1;
+          return;
         }
         if (cmdObj.yes || getEnvString('PROMPTFOO_DISABLE_SHARE_WARNING')) {
           await createPublicUrl(eval_, cmdObj.showAuth);
@@ -68,27 +74,24 @@ export function shareCommand(program: Command) {
           if (cloudConfig.isEnabled()) {
             logger.info(`Sharing eval to ${cloudConfig.getAppUrl()}`);
             await createPublicUrl(eval_, cmdObj.showAuth);
-            process.exit(0);
-          } else {
-            const baseUrl = getEnvString('PROMPTFOO_SHARING_APP_BASE_URL');
-            const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
-            reader.question(
-              `Create a private shareable URL of your eval on ${hostname}?\n\nTo proceed, please confirm [Y/n] `,
-              async function (answer: string) {
-                if (
-                  answer.toLowerCase() !== 'yes' &&
-                  answer.toLowerCase() !== 'y' &&
-                  answer !== ''
-                ) {
-                  reader.close();
-                  process.exit(1);
-                }
-                reader.close();
-
-                await createPublicUrl(eval_, cmdObj.showAuth);
-              },
-            );
+            process.exitCode = 0;
+            return;
           }
+          const baseUrl = getEnvString('PROMPTFOO_SHARING_APP_BASE_URL');
+          const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+          reader.question(
+            `Create a private shareable URL of your eval on ${hostname}?\n\nTo proceed, please confirm [Y/n] `,
+            async function (answer: string) {
+              if (answer.toLowerCase() !== 'yes' && answer.toLowerCase() !== 'y' && answer !== '') {
+                reader.close();
+                process.exitCode = 1;
+                return;
+              }
+              reader.close();
+
+              await createPublicUrl(eval_, cmdObj.showAuth);
+            },
+          );
         }
       },
     );


### PR DESCRIPTION
Enhances the error message when attempting to share an incomplete eval, clarifying that the eval might still be running and providing guidance to wait for completion before retrying.