### PR TITLE
fix: Use cloud api for remote harmful generation

### DIFF
--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -1,10 +1,12 @@
 import { fetchWithCache } from '../cache';
 import { VERSION } from '../constants';
-import { getEnvString } from '../envars';
 import { fetchWithRetries } from '../fetch';
 import { getUserEmail } from '../globalConfig/accounts';
 import logger from '../logger';
-import { getRemoteGenerationUrl } from '../redteam/remoteGeneration';
+import {
+  getRemoteGenerationUrl,
+  getRemoteGenerationUrlForUnaligned,
+} from '../redteam/remoteGeneration';
 import type {
   ApiProvider,
   ProviderResponse,
@@ -54,11 +56,12 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
     };
 
     try {
-      logger.debug(`Calling promptfoo generate harmful API with body: ${JSON.stringify(body)}`);
+      logger.debug(
+        `[HarmfulCompletionProvider] Calling generate harmful API (${getRemoteGenerationUrlForUnaligned()}) with body: ${JSON.stringify(body)}`,
+      );
       // We're using the promptfoo API to avoid having users provide their own unaligned model.
       const response = await fetchWithRetries(
-        getEnvString('PROMPTFOO_UNALIGNED_INFERENCE_ENDPOINT') ||
-          'https://api.promptfoo.dev/redteam/generateHarmful',
+        getRemoteGenerationUrlForUnaligned(),
         {
           method: 'POST',
           headers: {
@@ -66,22 +69,25 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
           },
           body: JSON.stringify(body),
         },
-        10000,
+        30000,
         2,
       );
 
       if (!response.ok) {
-        throw new Error(`API call failed with status ${response.status}: ${await response.text()}`);
+        throw new Error(
+          `[HarmfulCompletionProvider] API call failed with status ${response.status}: ${await response.text()}`,
+        );
       }
 
       const data = await response.json();
-      logger.debug(`promptfoo API call response: ${JSON.stringify(data)}`);
+      logger.debug(`[HarmfulCompletionProvider] API call response: ${JSON.stringify(data)}`);
       return {
         output: [data.output].flat(),
       };
     } catch (err) {
+      logger.info(`[HarmfulCompletionProvider] API call error: ${String(err)}`);
       return {
-        error: `API call error: ${String(err)}`,
+        error: `[HarmfulCompletionProvider]API call error: ${String(err)}`,
       };
     }
   }

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -11,8 +11,7 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
       const result = await fetchRemoteGeneration('entities' as RedTeamTask, prompts);
       return result as string[];
     } catch (error) {
-      logger.warn(`Error using remote generation, returning empty list: ${error}`);
-      return [];
+      logger.warn(`Error using remote generation, falling back to local extraction: ${error}`);
     }
   }
 
@@ -24,17 +23,21 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
 
     Each line in your response must begin with the string "Entity:".
   `;
+  try {
+    return callExtraction(provider, prompt, (output: string) => {
+      const entities = output
+        .split('\n')
+        .filter((line) => line.trim().startsWith('Entity:'))
+        .map((line) => line.substring(line.indexOf('Entity:') + 'Entity:'.length).trim());
 
-  return callExtraction(provider, prompt, (output: string) => {
-    const entities = output
-      .split('\n')
-      .filter((line) => line.trim().startsWith('Entity:'))
-      .map((line) => line.substring(line.indexOf('Entity:') + 'Entity:'.length).trim());
+      if (entities.length === 0) {
+        logger.debug('No entities were extracted from the prompts.');
+      }
 
-    if (entities.length === 0) {
-      logger.debug('No entities were extracted from the prompts.');
-    }
-
-    return entities;
-  });
+      return entities;
+    });
+  } catch (error) {
+    logger.warn(`Error using local extraction, returning empty list: ${error}`);
+    return [];
+  }
 }

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -11,7 +11,8 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
       const result = await fetchRemoteGeneration('entities' as RedTeamTask, prompts);
       return result as string[];
     } catch (error) {
-      logger.warn(`Error using remote generation, falling back to local extraction: ${error}`);
+      logger.warn(`Error using remote generation, returning empty list: ${error}`);
+      return [];
     }
   }
 

--- a/src/redteam/remoteGeneration.ts
+++ b/src/redteam/remoteGeneration.ts
@@ -25,3 +25,18 @@ export function shouldGenerateRemote(): boolean {
   // Generate remotely when the user has not disabled it and does not have an OpenAI key.
   return (!neverGenerateRemote() && !getEnvString('OPENAI_API_KEY')) || (cliState.remote ?? false);
 }
+
+export function getRemoteGenerationUrlForUnaligned(): string {
+  // Check env var first
+  const envUrl = getEnvString('PROMPTFOO_UNALIGNED_INFERENCE_ENDPOINT');
+  if (envUrl) {
+    return envUrl;
+  }
+  // If logged into cloud use that url + /task
+  const cloudConfig = new CloudConfig();
+  if (cloudConfig.isEnabled()) {
+    return cloudConfig.getApiHost() + '/task/harmful';
+  }
+  // otherwise use the default
+  return 'https://api.promptfoo.app/task/harmful';
+}


### PR DESCRIPTION
We were always hitting our public cloud api even if people were logged into their on-prem hosted version.