### PR TITLE
chore: Allow overriding default and redteam providers globally

### DIFF
--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -13,7 +13,7 @@ import { extractEntities } from './extraction/entities';
 import { extractSystemPurpose } from './extraction/purpose';
 import { Plugins } from './plugins';
 import { CustomPlugin } from './plugins/custom';
-import { loadRedteamProvider } from './providers/shared';
+import { redteamProviderManager } from './providers/shared';
 import { loadStrategy, Strategies, validateStrategies } from './strategies';
 import { DEFAULT_LANGUAGES } from './strategies/multilingual';
 import type { RedteamPluginObject, RedteamStrategyObject, SynthesizeOptions } from './types';
@@ -244,7 +244,7 @@ export async function synthesize({
   }
   validateStrategies(strategies);
 
-  const redteamProvider = await loadRedteamProvider({ provider });
+  const redteamProvider = await redteamProviderManager.getProvider({ provider });
 
   // We need to know how many languages we're generating for
   // We generate multilingual attacks for all of our test cases so it's plugins * strategies * languages

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -16,7 +16,7 @@ import { maybeLoadFromExternalFile } from '../../util';
 import { retryWithDeduplication, sampleArray } from '../../util/generation';
 import { extractVariablesFromTemplate, getNunjucksEngine } from '../../util/templates';
 import { sleep } from '../../util/time';
-import { loadRedteamProvider } from '../providers/shared';
+import { redteamProviderManager } from '../providers/shared';
 import { removePrefix } from '../util';
 
 /**
@@ -229,7 +229,7 @@ export abstract class RedteamGraderBase {
       const err = error as Error;
       throw new Error(dedent`
         Error rendering rubric template: ${err.message}
-      
+
         Required variables: ${extractedVars.join(', ')}
         Missing variables: ${missingVars.length > 0 ? missingVars.join(', ') : 'none'}
         Available variables: ${availableVars.join(', ')}
@@ -282,7 +282,7 @@ export abstract class RedteamGraderBase {
 
     const grade = await matchesLlmRubric(finalRubric, llmOutput, {
       ...test.options,
-      provider: await loadRedteamProvider({
+      provider: await redteamProviderManager.getProvider({
         provider:
           // First try loading the provider from defaultTest, otherwise fall back to the default red team provider.
           cliState.config?.defaultTest?.provider ||

--- a/src/redteam/plugins/crossSessionLeak.ts
+++ b/src/redteam/plugins/crossSessionLeak.ts
@@ -3,7 +3,7 @@ import logger from '../../logger';
 import type { Assertion, AtomicTestCase, GradingResult, TestCase } from '../../types';
 import { extractJsonObjects } from '../../util/json';
 import { getNunjucksEngine } from '../../util/templates';
-import { loadRedteamProvider } from '../providers/shared';
+import { redteamProviderManager } from '../providers/shared';
 import { RedteamPluginBase, RedteamGraderBase } from './base';
 
 export const PLUGIN_ID = 'promptfoo:redteam:cross-session-leak';
@@ -71,7 +71,7 @@ export class CrossSessionLeakPlugin extends RedteamPluginBase {
       purpose: this.purpose,
       n,
     });
-    const provider = await loadRedteamProvider({
+    const provider = await redteamProviderManager.getProvider({
       provider: this.provider,
       jsonOnly: true,
     });

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -17,7 +17,7 @@ import { extractFirstJsonObject } from '../../../util/json';
 import { getNunjucksEngine } from '../../../util/templates';
 import { shouldGenerateRemote } from '../../remoteGeneration';
 import { isBasicRefusal } from '../../util';
-import { getTargetResponse, loadRedteamProvider, type TargetResponse } from '../shared';
+import { getTargetResponse, redteamProviderManager, type TargetResponse } from '../shared';
 import { CRESCENDO_SYSTEM_PROMPT, REFUSAL_SYSTEM_PROMPT, EVAL_SYSTEM_PROMPT } from './prompts';
 
 const DEFAULT_MAX_ROUNDS = 10;
@@ -99,7 +99,7 @@ class CrescendoProvider implements ApiProvider {
           preferSmallModel: true,
         });
       } else {
-        this.redTeamProvider = await loadRedteamProvider({
+        this.redTeamProvider = await redteamProviderManager.getProvider({
           provider: this.config.redteamProvider,
           preferSmallModel: true,
           jsonOnly: true,
@@ -118,7 +118,7 @@ class CrescendoProvider implements ApiProvider {
           preferSmallModel: true,
         });
       } else {
-        this.scoringProvider = await loadRedteamProvider({
+        this.scoringProvider = await redteamProviderManager.getProvider({
           provider: this.config.redteamProvider,
           preferSmallModel: true,
         });

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -14,7 +14,7 @@ import { extractFirstJsonObject } from '../../util/json';
 import { getNunjucksEngine } from '../../util/templates';
 import { shouldGenerateRemote } from '../remoteGeneration';
 import { ATTACKER_SYSTEM_PROMPT, JUDGE_SYSTEM_PROMPT, ON_TOPIC_SYSTEM_PROMPT } from './prompts';
-import { getTargetResponse, loadRedteamProvider } from './shared';
+import { getTargetResponse, redteamProviderManager } from './shared';
 
 // Based on: https://arxiv.org/abs/2312.02119
 
@@ -275,7 +275,7 @@ class RedteamIterativeProvider implements ApiProvider {
       prompt: context.prompt,
       filters: context.filters,
       vars: context.vars,
-      redteamProvider: await loadRedteamProvider({
+      redteamProvider: await redteamProviderManager.getProvider({
         provider: this.redteamProvider,
         jsonOnly: true,
       }),

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../types';
 import { extractFirstJsonObject } from '../../util/json';
 import { extractVariablesFromTemplates, getNunjucksEngine } from '../../util/templates';
-import { getTargetResponse, loadRedteamProvider, type TargetResponse } from './shared';
+import { getTargetResponse, redteamProviderManager, type TargetResponse } from './shared';
 
 const NUM_ITERATIONS = process.env.PROMPTFOO_NUM_JAILBREAK_ITERATIONS
   ? Number.parseInt(process.env.PROMPTFOO_NUM_JAILBREAK_ITERATIONS, 10)
@@ -306,7 +306,7 @@ class RedteamIterativeProvider implements ApiProvider {
       prompt: context.prompt,
       filters: context.filters,
       vars: context.vars,
-      redteamProvider: await loadRedteamProvider({
+      redteamProvider: await redteamProviderManager.getProvider({
         provider: this.redteamProvider,
         preferSmallModel: false,
         jsonOnly: true,

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -31,7 +31,7 @@ import { getNunjucksEngine } from '../../util/templates';
 import { shouldGenerateRemote } from '../remoteGeneration';
 import { PENALIZED_PHRASES } from './constants';
 import { ATTACKER_SYSTEM_PROMPT, JUDGE_SYSTEM_PROMPT, ON_TOPIC_SYSTEM_PROMPT } from './prompts';
-import { getTargetResponse, loadRedteamProvider } from './shared';
+import { getTargetResponse, redteamProviderManager } from './shared';
 
 // Based on: https://arxiv.org/abs/2312.02119
 
@@ -631,7 +631,7 @@ class RedteamIterativeTreeProvider implements ApiProvider {
         preferSmallModel: false,
       });
     } else {
-      redteamProvider = await loadRedteamProvider({
+      redteamProvider = await redteamProviderManager.getProvider({
         provider: this.config.redteamProvider,
         jsonOnly: true,
       });

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -67,8 +67,8 @@ class RedteamProviderManager {
     provider?: RedteamFileConfig['provider'];
     jsonOnly?: boolean;
     preferSmallModel?: boolean;
-  }) {
-    if (this.provider) {
+  }): Promise<ApiProvider> {
+    if (this.provider && this.jsonOnlyProvider) {
       logger.debug(`[RedteamProviderManager] Using cached redteam provider: ${this.provider.id()}`);
       return jsonOnly ? this.jsonOnlyProvider : this.provider;
     }

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -11,7 +11,7 @@ import {
 } from '../../types';
 import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
 
-export async function loadRedteamProvider({
+async function loadRedteamProvider({
   provider,
   jsonOnly = false,
   preferSmallModel = false,
@@ -20,8 +20,6 @@ export async function loadRedteamProvider({
   jsonOnly?: boolean;
   preferSmallModel?: boolean;
 } = {}) {
-  // FIXME(ian): This approach only works on CLI, it doesn't work when running via node module.
-  // That's ok for now because we only officially support redteams from CLI.
   let ret;
   const redteamProvider = provider || cliState.config?.redteam?.provider;
   if (isApiProvider(redteamProvider)) {
@@ -46,6 +44,51 @@ export async function loadRedteamProvider({
   }
   return ret;
 }
+
+class RedteamProviderManager {
+  private provider: ApiProvider | undefined;
+  private overrideDefaultProvider = false;
+
+  async setProvider(provider: ApiProvider) {
+    this.provider = provider;
+  }
+
+  setOverrideDefaultProvider(value: boolean) {
+    this.overrideDefaultProvider = value;
+  }
+
+  getOverrideDefaultProvider() {
+    return this.overrideDefaultProvider;
+  }
+
+  async getProvider({ provider,
+    jsonOnly = false,
+    preferSmallModel = false,
+  }: {
+    provider?: RedteamFileConfig['provider'];
+    jsonOnly?: boolean;
+    preferSmallModel?: boolean;
+  }) {
+    if (this.provider) {
+      logger.debug(`[RedteamProviderManager] Using cached redteam provider: ${this.provider.id()}`);
+    } else {
+      logger.debug(
+        `[RedteamProviderManager] Loading redteam provider: ${JSON.stringify({
+          providedConfig: typeof provider == 'string' ? provider : provider?.id ?? 'none',
+          jsonOnly,
+          preferSmallModel,
+        })}`,
+      );
+      this.provider = await loadRedteamProvider({ provider, jsonOnly, preferSmallModel });
+      logger.debug(`[RedteamProviderManager] Loaded redteam provider: ${this.provider.id()}`);
+    }
+    return this.provider;
+  }
+
+
+}
+
+export const redteamProviderManager = new RedteamProviderManager();
 
 export type TargetResponse = {
   output: string;

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -6,7 +6,7 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { loadRedteamProvider } from '../providers/shared';
+import { redteamProviderManager } from '../providers/shared';
 import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
 
 const DEFAULT_MATH_CONCEPTS = ['set theory', 'group theory', 'abstract algebra'];
@@ -91,7 +91,10 @@ export async function generateMathPrompt(
 }
 
 export async function encodeMathPrompt(text: string, concept: string): Promise<string> {
-  const redteamProvider = await loadRedteamProvider({ jsonOnly: true, preferSmallModel: true });
+  const redteamProvider = await redteamProviderManager.getProvider({
+    jsonOnly: true,
+    preferSmallModel: true,
+  });
   const examplePrompt = EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)];
 
   const result = await redteamProvider.callApi(

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -6,7 +6,7 @@ import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import type { TestCase } from '../../types';
-import { loadRedteamProvider } from '../providers/shared';
+import { redteamProviderManager } from '../providers/shared';
 import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
 
 export const DEFAULT_LANGUAGES = ['bn', 'sw', 'jv']; // Bengali, Swahili, Javanese
@@ -85,7 +85,10 @@ export async function generateMultilingual(
 }
 
 export async function translate(text: string, lang: string): Promise<string> {
-  const redteamProvider = await loadRedteamProvider({ jsonOnly: true, preferSmallModel: true });
+  const redteamProvider = await redteamProviderManager.getProvider({
+    jsonOnly: true,
+    preferSmallModel: true,
+  });
   const result = await redteamProvider.callApi(
     dedent`Translate the <Text> below to language '${lang}'. Respond with JSON object containing {translation: string}.
 

--- a/test/redteam/strategies/multilingual.test.ts
+++ b/test/redteam/strategies/multilingual.test.ts
@@ -1,6 +1,7 @@
 import { SingleBar } from 'cli-progress';
 import { fetchWithCache } from '../../../src/cache';
 import logger from '../../../src/logger';
+import { redteamProviderManager } from '../../../src/redteam/providers/shared';
 import { shouldGenerateRemote } from '../../../src/redteam/remoteGeneration';
 import { addMultilingual } from '../../../src/redteam/strategies/multilingual';
 import type { AtomicTestCase } from '../../../src/types';
@@ -22,13 +23,16 @@ jest.mock('../../../src/cache', () => ({
   }),
 }));
 
-jest.mock('../../../src/redteam/providers/shared', () => ({
-  loadRedteamProvider: jest.fn().mockResolvedValue({
-    callApi: jest.fn().mockResolvedValue({
-      output: '{"translation": "Hallo Welt"}',
-    }),
-  }),
-}));
+jest.spyOn(redteamProviderManager, 'getProvider').mockResolvedValue({
+  callApi: jest.fn().mockResolvedValue({ output: '{"translation": "Hallo Welt"}' }),
+  config: {},
+  getOpenAiBody: jest.fn(),
+  modelName: 'test-model',
+  id: 'test-provider',
+  type: 'openai',
+  isAvailable: jest.fn().mockResolvedValue(true),
+  validateConfig: jest.fn(),
+} as any);
 
 jest.mock('cli-progress', () => ({
   Presets: {


### PR DESCRIPTION
1. Setup a global manager to handle the redteam provider. Allows us to override it globally.
2. Allow setting a global completion provider override - https://github.com/promptfoo/promptfoo/pull/2333/files#diff-e9d74f25919e5aca3ef968793552d9198df382ca66225c6efe1954b9cfdcd48d