### PR TITLE
feat: "try example" in target configuration

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
@@ -123,7 +123,12 @@ const HttpEndpointConfiguration: React.FC<HttpEndpointConfigurationProps> = ({
           }}
         >
           <Editor
-            value={requestBody}
+            value={
+              /*
+              Should always be a string, but there might be some bad state in localStorage as of 2024-12-07
+              */
+              typeof requestBody === 'string' ? requestBody : JSON.stringify(requestBody, null, 2)
+            }
             onValueChange={(code) => {
               setRequestBody(code);
               updateCustomTarget('body', code);

--- a/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
+++ b/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
@@ -21,10 +21,9 @@ export const DEFAULT_HTTP_TARGET: ProviderOptions = {
     url: '',
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    // @ts-ignore
-    body: {
+    body: JSON.stringify({
       message: '{{prompt}}',
-    },
+    }),
   },
 };
 
@@ -139,7 +138,11 @@ export const useRedTeamConfig = create<RedTeamConfigState>()(
           };
         }),
       setFullConfig: (config) => set({ config }),
-      resetConfig: () => set({ config: defaultConfig }),
+      resetConfig: () => {
+        set({ config: defaultConfig });
+        // There's a bunch of state that's not persisted that we want to reset
+        window.location.reload();
+      },
       updateApplicationDefinition: (
         section: keyof Config['applicationDefinition'],
         value: string,


### PR DESCRIPTION
- Fixes some type weirdness for request body
- Fixes a bug in resetting config
<img width="1535" alt="image" src="https://github.com/user-attachments/assets/25ee6666-da29-4a93-b2a0-467bbaf564b6">
