### PR TITLE
fix: Attempt to fix metrics after share to self-hosted

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -170,6 +170,7 @@ export default class Eval {
           description: config.description,
           config,
           results: {},
+          prompts: renderedPrompts,
         })
         .run();
 

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -170,7 +170,6 @@ export default class Eval {
           description: config.description,
           config,
           results: {},
-          prompts: renderedPrompts,
         })
         .run();
 

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -214,6 +214,9 @@ evalRouter.post('/', async (req: Request, res: Response): Promise<void> => {
         createdAt: new Date(incEval.createdAt),
         results: incEval.results,
       });
+      if (incEval.prompts) {
+        eval_.addPrompts(incEval.prompts);
+      }
       logger.debug(`[POST /api/eval] Eval created with ID: ${eval_.id}`);
 
       logger.debug(`[POST /api/eval] Saved ${incEval.results.length} results to eval ${eval_.id}`);


### PR DESCRIPTION
Untested, but I suspect this change will fix the issue.

## Examples of existing state:
(note that self-hosted has no metrics information, compared to the local screenshot)

Local `view` (v0.100.4):
![Screenshot 2024-12-08 at 5 20 27 PM](https://github.com/user-attachments/assets/ce57f008-7c8f-440d-85b0-9ab0232b5c62)

Public `share` (app.promptfoo.dev):
![Screenshot 2024-12-08 at 5 21 56 PM](https://github.com/user-attachments/assets/0950da24-d714-4a41-80b5-0d83277f61e6)

Self-hosted `share` (v0.100.3):
![Screenshot 2024-12-08 at 5 22 54 PM](https://github.com/user-attachments/assets/8e4d5d85-0ba8-4199-959f-bea48fce6bc1)
