### PR TITLE
fix: use replicate moderation provider when OpenAI key not present

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,5 +1,6 @@
 import invariant from 'tiny-invariant';
 import cliState from './cliState';
+import { getEnvString } from './envars';
 import logger from './logger';
 import {
   ANSWER_RELEVANCY_GENERATE,
@@ -16,6 +17,7 @@ import {
 } from './prompts';
 import { loadApiProvider } from './providers';
 import { getDefaultProviders } from './providers/defaults';
+import { LLAMA_GUARD_REPLICATE_PROVIDER } from './redteam/constants';
 import { shouldGenerateRemote } from './redteam/remoteGeneration';
 import { doRemoteGrading } from './remoteGrading';
 import type {
@@ -924,10 +926,19 @@ export async function matchesModeration(
   { userPrompt, assistantResponse, categories = [] }: ModerationMatchOptions,
   grading?: GradingConfig,
 ) {
+  // Get default providers
+  const defaultProviders = await getDefaultProviders();
+
+  // Check for Replicate API key and override provider if specified in grading config
+  const hasReplicateKey = getEnvString('REPLICATE_API_KEY') || getEnvString('REPLICATE_API_TOKEN');
+  const defaultModerationProvider = hasReplicateKey
+    ? await loadApiProvider(LLAMA_GUARD_REPLICATE_PROVIDER)
+    : defaultProviders.moderationProvider;
+
   const moderationProvider = (await getAndCheckProvider(
     'moderation',
     grading?.provider,
-    (await getDefaultProviders()).moderationProvider,
+    defaultModerationProvider,
     'moderation check',
   )) as ApiModerationProvider;
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -929,8 +929,10 @@ export async function matchesModeration(
   // Get default providers
   const defaultProviders = await getDefaultProviders();
 
-  // Check for Replicate API key and override provider if specified in grading config
-  const hasReplicateKey = getEnvString('REPLICATE_API_KEY') || getEnvString('REPLICATE_API_TOKEN');
+  // Only try to use Replicate if OpenAI is not available
+  const hasOpenAiKey = getEnvString('OPENAI_API_KEY');
+  const hasReplicateKey =
+    !hasOpenAiKey && (getEnvString('REPLICATE_API_KEY') || getEnvString('REPLICATE_API_TOKEN'));
   const defaultModerationProvider = hasReplicateKey
     ? await loadApiProvider(LLAMA_GUARD_REPLICATE_PROVIDER)
     : defaultProviders.moderationProvider;

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import cliState from '../src/cliState';
-import { getAndCheckProvider, getGradingProvider, matchesClassification } from '../src/matchers';
+import {
+  getAndCheckProvider,
+  getGradingProvider,
+  matchesClassification,
+  matchesModeration,
+} from '../src/matchers';
 import {
   matchesSimilarity,
   matchesLlmRubric,
@@ -14,8 +19,14 @@ import {
 } from '../src/matchers';
 import { ANSWER_RELEVANCY_GENERATE, CONTEXT_RECALL, CONTEXT_RELEVANCE } from '../src/prompts';
 import { HuggingfaceTextClassificationProvider } from '../src/providers/huggingface';
-import { OpenAiChatCompletionProvider, OpenAiEmbeddingProvider } from '../src/providers/openai';
+import {
+  OpenAiChatCompletionProvider,
+  OpenAiEmbeddingProvider,
+  OpenAiModerationProvider,
+} from '../src/providers/openai';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai';
+import { ReplicateModerationProvider } from '../src/providers/replicate';
+import { LLAMA_GUARD_REPLICATE_PROVIDER } from '../src/redteam/constants';
 import * as remoteGrading from '../src/remoteGrading';
 import type {
   GradingConfig,
@@ -1237,5 +1248,70 @@ describe('matchesContextRecall', () => {
     expect(mockCallApi).toHaveBeenCalledWith(expect.stringContaining(CONTEXT_RECALL.slice(0, 100)));
 
     mockCallApi.mockRestore();
+  });
+});
+
+describe('matchesModeration', () => {
+  const mockModerationResponse = {
+    flags: [],
+    tokenUsage: { total: 5, prompt: 2, completion: 3 },
+  };
+
+  beforeEach(() => {
+    // Clear all environment variables
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.REPLICATE_API_KEY;
+    delete process.env.REPLICATE_API_TOKEN;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should use OpenAI when OPENAI_API_KEY is present', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const openAiSpy = jest
+      .spyOn(OpenAiModerationProvider.prototype, 'callModerationApi')
+      .mockResolvedValue(mockModerationResponse);
+
+    await matchesModeration({
+      userPrompt: 'test prompt',
+      assistantResponse: 'test response',
+    });
+
+    expect(openAiSpy).toHaveBeenCalledWith('test prompt', 'test response');
+  });
+
+  it('should fallback to Replicate when only REPLICATE_API_KEY is present', async () => {
+    process.env.REPLICATE_API_KEY = 'test-key';
+    const replicateSpy = jest
+      .spyOn(ReplicateModerationProvider.prototype, 'callModerationApi')
+      .mockResolvedValue(mockModerationResponse);
+
+    await matchesModeration({
+      userPrompt: 'test prompt',
+      assistantResponse: 'test response',
+    });
+
+    expect(replicateSpy).toHaveBeenCalledWith('test prompt', 'test response');
+  });
+
+  it('should respect provider override in grading config', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const replicateSpy = jest
+      .spyOn(ReplicateModerationProvider.prototype, 'callModerationApi')
+      .mockResolvedValue(mockModerationResponse);
+
+    await matchesModeration(
+      {
+        userPrompt: 'test prompt',
+        assistantResponse: 'test response',
+      },
+      {
+        provider: LLAMA_GUARD_REPLICATE_PROVIDER,
+      },
+    );
+
+    expect(replicateSpy).toHaveBeenCalledWith('test prompt', 'test response');
   });
 });


### PR DESCRIPTION
Ensures Replicate moderation provider is properly loaded and used when OpenAI API key is not available but Replicate key is present.