### PR TITLE
chore: add better error logging for multilingual

### DIFF
--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -96,7 +96,14 @@ export async function translate(text: string, lang: string): Promise<string> {
     ${text}
     </Text>`,
   );
-  return (JSON.parse(result.output) as { translation: string }).translation;
+  try {
+    return (JSON.parse(result.output) as { translation: string }).translation;
+  } catch (error) {
+    logger.error(
+      `[translate] Error parsing translation result: ${error} Provider Output: ${result.output}`,
+    );
+    throw error;
+  }
 }
 
 export async function addMultilingual(


### PR DESCRIPTION
We're getting a lot of errors parsing the multi-lingual output, let's see why.