### PR TITLE
chore: add getRemoteGenerationUrl mocks to redteam tests

### DIFF
--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -2,6 +2,7 @@ import { fetchWithCache } from '../../../src/cache';
 import { VERSION } from '../../../src/constants';
 import logger from '../../../src/logger';
 import { extractEntities } from '../../../src/redteam/extraction/entities';
+import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import type { ApiProvider } from '../../../src/types';
 
 jest.mock('../../../src/logger', () => ({
@@ -22,6 +23,11 @@ jest.mock('../../../src/envars', () => {
   };
 });
 
+jest.mock('../../../src/redteam/remoteGeneration', () => ({
+  ...jest.requireActual('../../../src/redteam/remoteGeneration'),
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('https://api.promptfoo.app/task'),
+}));
+
 describe('Entities Extractor', () => {
   let provider: ApiProvider;
   let originalEnv: NodeJS.ProcessEnv;
@@ -38,6 +44,7 @@ describe('Entities Extractor', () => {
       id: jest.fn().mockReturnValue('test-provider'),
     };
     jest.clearAllMocks();
+    jest.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.app/task');
   });
 
   afterEach(() => {

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -1,6 +1,7 @@
 import { fetchWithCache } from '../../../src/cache';
 import { VERSION } from '../../../src/constants';
 import { extractSystemPurpose } from '../../../src/redteam/extraction/purpose';
+import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import type { ApiProvider } from '../../../src/types';
 
 jest.mock('../../../src/logger', () => ({
@@ -11,6 +12,11 @@ jest.mock('../../../src/logger', () => ({
 
 jest.mock('../../../src/cache', () => ({
   fetchWithCache: jest.fn(),
+}));
+
+jest.mock('../../../src/redteam/remoteGeneration', () => ({
+  ...jest.requireActual('../../../src/redteam/remoteGeneration'),
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('https://api.promptfoo.app/task'),
 }));
 
 describe('System Purpose Extractor', () => {
@@ -31,6 +37,7 @@ describe('System Purpose Extractor', () => {
       id: jest.fn().mockReturnValue('test-provider'),
     };
     jest.clearAllMocks();
+    jest.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.app/task');
   });
 
   afterEach(() => {

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -8,6 +8,7 @@ import {
   formatPrompts,
   RedTeamGenerationResponse,
 } from '../../../src/redteam/extraction/util';
+import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import type { ApiProvider } from '../../../src/types';
 
 jest.mock('../../../src/logger', () => ({
@@ -20,6 +21,10 @@ jest.mock('../../../src/cache', () => ({
   fetchWithCache: jest.fn(),
 }));
 
+jest.mock('../../../src/redteam/remoteGeneration', () => ({
+  getRemoteGenerationUrl: jest.fn().mockReturnValue('https://api.promptfoo.app/task'),
+}));
+
 describe('fetchRemoteGeneration', () => {
   beforeAll(() => {
     delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;
@@ -27,6 +32,7 @@ describe('fetchRemoteGeneration', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.app/task');
   });
 
   it('should fetch remote generation for purpose task', async () => {
@@ -116,6 +122,31 @@ describe('fetchRemoteGeneration', () => {
     await expect(fetchRemoteGeneration('purpose', ['prompt'])).rejects.toThrow('Invalid input');
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("Error using remote generation for task 'purpose':"),
+    );
+  });
+
+  it('should use custom remote generation URL when provided', async () => {
+    const customUrl = 'https://custom-api.example.com/generate';
+    jest.mocked(getRemoteGenerationUrl).mockReturnValue(customUrl);
+
+    const mockResponse = {
+      data: {
+        task: 'purpose',
+        result: 'This is a purpose',
+      },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    await fetchRemoteGeneration('purpose', ['prompt1']);
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      customUrl,
+      expect.any(Object),
+      REQUEST_TIMEOUT_MS,
+      'json',
     );
   });
 });


### PR DESCRIPTION
- Add mock for getRemoteGenerationUrl in entities, purpose, and util tests
- Add test case for custom remote generation URL
- Reset mock URL in beforeEach blocks