### PR TITLE
chore: clean up invariant references

### DIFF
--- a/test/prompts/processors/javascript.test.ts
+++ b/test/prompts/processors/javascript.test.ts
@@ -1,6 +1,6 @@
-import invariant from 'tiny-invariant';
 import { importModule } from '../../../src/esm';
 import { processJsFile, transformContext } from '../../../src/prompts/processors/javascript';
+import invariant from '../../../src/util/invariant';
 
 jest.mock('../../../src/esm', () => ({
   importModule: jest.fn(),

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -1,9 +1,9 @@
 import request from 'supertest';
-import invariant from 'tiny-invariant';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import EvalResult from '../../src/models/evalResult';
 import { createApp } from '../../src/server/server';
+import invariant from '../../src/util/invariant';
 import EvalFactory from '../factories/evalFactory';
 
 describe('eval routes', () => {


### PR DESCRIPTION
I missed these when converting the rest over. Luckily tiny-invariant is still in the package-lock.json