### PR TITLE
fix: re-enable validation warning for invalid dereferenced configs

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -156,7 +156,7 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
     // Validator requires `prompts`, but prompts is not actually required for redteam.
     const UnifiedConfigSchemaWithoutPrompts = UnifiedConfigSchema.innerType()
       .innerType()
-      .omit({ prompts: true });
+      .extend({ prompts: UnifiedConfigSchema.innerType().innerType().shape.prompts.optional() });
     const validationResult = UnifiedConfigSchemaWithoutPrompts.safeParse(dereferencedConfig);
     if (!validationResult.success) {
       logger.warn(

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -154,14 +154,15 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
     const rawConfig = yaml.load(fs.readFileSync(configPath, 'utf-8'));
     const dereferencedConfig = await dereferenceConfig(rawConfig as UnifiedConfig);
     // Validator requires `prompts`, but prompts is not actually required for redteam.
-    /*
-    const validationResult = UnifiedConfigSchema.safeParse(dereferencedConfig);
+    const UnifiedConfigSchemaWithoutPrompts = UnifiedConfigSchema.innerType()
+      .innerType()
+      .omit({ prompts: true });
+    const validationResult = UnifiedConfigSchemaWithoutPrompts.safeParse(dereferencedConfig);
     if (!validationResult.success) {
       logger.warn(
         `Invalid configuration file ${configPath}:\n${fromError(validationResult.error).message}`,
       );
     }
-    */
     ret = dereferencedConfig;
   } else if (isJavascriptFile(configPath)) {
     const imported = await importModule(configPath);

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -976,13 +976,11 @@ describe('readConfig', () => {
   it('should throw validation error for invalid dereferenced config', async () => {
     const mockConfig = {
       description: 'invalid_config',
-      prompts: ['test prompt'],
       providers: [{ $ref: 'defaultParams.yaml#/invalidKey' }],
     };
 
     const dereferencedConfig = {
       description: 'invalid_config',
-      prompts: ['test prompt'],
       providers: [{ invalid: true }], // This will fail validation
     };
 


### PR DESCRIPTION
Re-enables validation warning that catches malformed configuration objects
after JSON schema dereferencing. This helps catch configuration errors
like unrecognized provider properties.