### PR TITLE
docs(configuration): add documentation for shared variables in tests

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -303,6 +303,24 @@ defaultTest:
     provider: openai:gpt-4o-mini-0613
 ```
 
+### Default variables
+
+Use `defaultTest` to define variables that are shared across all tests:
+
+```yaml
+defaultTest:
+  vars:
+    template: 'A reusable prompt template with {{shared_var}}'
+    shared_var: 'some shared content'
+
+tests:
+  - vars:
+      unique_var: value1
+  - vars:
+      unique_var: value2
+      shared_var: 'override shared content' # Optionally override defaults
+```
+
 ### YAML references
 
 promptfoo configurations support JSON schema [references](https://opis.io/json-schema/2.x/references.html), which define reusable blocks.


### PR DESCRIPTION
### Summary of Changes
This PR updates the documentation to include guidance on using shared variables across all tests in the configuration file.

### Key Modifications
- Added a new section titled **Default variables** to the configuration guide.
- Provided an example YAML configuration demonstrating how to define and use shared variables in `defaultTest`.

### Implementation Details
The documentation now explains the usage of `defaultTest` for defining variables that are shared across multiple tests. Examples illustrate how shared variables can be overridden on a per-test basis.

### Testing Considerations
No code changes were made; this update is documentation-only. Ensure clarity and correctness by reviewing the added examples.

### Breaking Changes
None.

This update addresses GitHub issue #2378 by providing the requested guidance on shared/global variable usage in tests.