### PR TITLE
fix(prompts): restore behavior that delays yaml parsing until after variable substitution

### DIFF
--- a/src/prompts/processors/yaml.ts
+++ b/src/prompts/processors/yaml.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import yaml from 'js-yaml';
+import logger from '../../logger';
 import type { Prompt } from '../../types';
 
 /**
@@ -14,11 +15,16 @@ import type { Prompt } from '../../types';
  */
 export function processYamlFile(filePath: string, prompt: Partial<Prompt>): Prompt[] {
   const fileContents = fs.readFileSync(filePath, 'utf8');
-  const parsed = yaml.load(fileContents);
+  let maybeParsed: string | undefined = fileContents;
+  try {
+    maybeParsed = JSON.stringify(yaml.load(fileContents));
+  } catch (e) {
+    logger.debug(`Error parsing YAML file ${filePath}: ${e}`);
+  }
   return [
     {
-      raw: JSON.stringify(parsed),
-      label: prompt.label || `${filePath}: ${JSON.stringify(parsed).slice(0, 80)}`,
+      raw: maybeParsed,
+      label: prompt.label || `${filePath}: ${maybeParsed?.slice(0, 80)}`,
       config: prompt.config,
     },
   ];

--- a/test/prompts/processors/yaml.test.ts
+++ b/test/prompts/processors/yaml.test.ts
@@ -1,13 +1,17 @@
+import dedent from 'dedent';
 import * as fs from 'fs';
+import logger from '../../../src/logger';
 import { processYamlFile } from '../../../src/prompts/processors/yaml';
 
 jest.mock('fs');
+jest.mock('../../../src/logger');
 
 describe('processYamlFile', () => {
   const mockReadFileSync = jest.mocked(fs.readFileSync);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(logger.debug).mockClear();
   });
 
   it('should process a valid YAML file without a label', () => {
@@ -99,5 +103,27 @@ template: "{{ variable }}   "
 
     const result = processYamlFile(filePath, {});
     expect(result[0].raw).toBe(expectedJson);
+  });
+
+  it('should handle invalid YAML and return raw file contents', () => {
+    const filePath = 'issue-2368.yaml';
+    const fileContent = dedent`
+    {% import "system_prompt.yaml" as system_prompt %}
+    {% import "user_prompt.yaml" as user_prompt %}
+    {{ system_prompt.system_prompt() }}
+    {{ user_prompt.user_prompt(example) }}`;
+
+    mockReadFileSync.mockReturnValue(fileContent);
+
+    expect(processYamlFile(filePath, {})).toEqual([
+      {
+        raw: fileContent,
+        label: `${filePath}: ${fileContent.slice(0, 80)}`,
+        config: undefined,
+      },
+    ]);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/Error parsing YAML file issue-2368\.yaml:/),
+    );
   });
 });


### PR DESCRIPTION
### Summary

This PR addresses issue #2368 by modifying the YAML processor to handle files containing Nunjucks templates gracefully. Previously, such files could cause YAMLException errors due to the YAML parser attempting to parse Nunjucks syntax. The changes ensure that these files are preserved as raw text.