### PR TITLE
feat: add aws bedrock knowledge base support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,8 @@
         "promptfoo": "dist/src/main.js"
       },
       "devDependencies": {
+        "@aws-sdk/client-bedrock-agent": "^3.712.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.712.0",
         "@aws-sdk/client-bedrock-runtime": "^3.706.0",
         "@aws-sdk/credential-provider-sso": "^3.699.0",
         "@azure/identity": "^4.5.0",
@@ -140,6 +142,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
+        "@aws-sdk/client-bedrock-agent": "^3.712.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.712.0",
         "@aws-sdk/client-bedrock-runtime": "^3.602.0",
         "@aws-sdk/credential-provider-sso": "^3.686.0",
         "@azure/identity": "^4.0.0",
@@ -875,6 +879,650 @@
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent/-/client-bedrock-agent-3.712.0.tgz",
+      "integrity": "sha512-W4gXUuRC7PF/mhzwSmETrsOI5p4sU79yRcjPVCqOFnH3LZIDTk+7GovLVQ/a5eX43tWfAjtPcG64169oxpjHow==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.712.0.tgz",
+      "integrity": "sha512-b1gNBxG2Je4Zoewoh/XHbTZrXlvMwCT4PmdpAvLX0nhdiOkJgrxFngRjQQkZ64+SFdzhLxlfIuRwQUcFZuXHlQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/eventstream-serde-browser": "^3.0.14",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.11",
+        "@smithy/eventstream-serde-node": "^3.0.13",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/client-sso": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.712.0.tgz",
+      "integrity": "sha512-tBo/eW3YpZ9f3Q1qA7aA8uliNFJJX0OP7R2IUJ8t6rqVTk15wWCEPNmXzUZKgruDnKUfCaF4+r9q/Yy4fBc9PA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.712.0.tgz",
+      "integrity": "sha512-xNFrG9syrG6pxUP7Ld/nu3afQ9+rbJM9qrE+wDNz4VnNZ3vLiJty4fH85zBFhOQ5OF2DIJTWsFzXGi2FYjsCMA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/client-sts": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.712.0.tgz",
+      "integrity": "sha512-gIO6BD+hkEe3GKQhbiFP0zcNQv0EkP1Cl9SOstxS+X9CeudEgVX/xEPUjyoFVkfkntPBJ1g0I1u5xOzzRExl4g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.712.0.tgz",
+      "integrity": "sha512-sTsdQ/Fm/suqMdpjhMuss/5uKL18vcuWnNTQVrG9iGNRqZLbq65MXquwbUpgzfoUmIcH+4CrY6H2ebpTIECIag==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.712.0.tgz",
+      "integrity": "sha512-gXrHymW3rMRYORkPVQwL8Gi5Lu92F16SoZR543x03qCi7rm00oL9tRD85ACxkhprS1Wh8lUIUMNoeiwnYWTNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.712.0.tgz",
+      "integrity": "sha512-8lCMxY7Lb9VK9qdlNXRJXE3W1UDVURnJZ3a4XWYNY6yr1TfQaN40mMyXX1oNlXXJtMV0szRvjM8dZj37E/ESAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.712.0.tgz",
+      "integrity": "sha512-26X21bZ4FWsVpqs33uOXiB60TOWQdVlr7T7XONDFL/XN7GEpUJkWuuIB4PTok6VOmh1viYcdxZQqekXPuzXexQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/client-sso": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.712.0.tgz",
+      "integrity": "sha512-tBo/eW3YpZ9f3Q1qA7aA8uliNFJJX0OP7R2IUJ8t6rqVTk15wWCEPNmXzUZKgruDnKUfCaF4+r9q/Yy4fBc9PA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.712.0.tgz",
+      "integrity": "sha512-xNFrG9syrG6pxUP7Ld/nu3afQ9+rbJM9qrE+wDNz4VnNZ3vLiJty4fH85zBFhOQ5OF2DIJTWsFzXGi2FYjsCMA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/client-sts": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.712.0.tgz",
+      "integrity": "sha512-gIO6BD+hkEe3GKQhbiFP0zcNQv0EkP1Cl9SOstxS+X9CeudEgVX/xEPUjyoFVkfkntPBJ1g0I1u5xOzzRExl4g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.712.0.tgz",
+      "integrity": "sha512-sTsdQ/Fm/suqMdpjhMuss/5uKL18vcuWnNTQVrG9iGNRqZLbq65MXquwbUpgzfoUmIcH+4CrY6H2ebpTIECIag==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.712.0.tgz",
+      "integrity": "sha512-gXrHymW3rMRYORkPVQwL8Gi5Lu92F16SoZR543x03qCi7rm00oL9tRD85ACxkhprS1Wh8lUIUMNoeiwnYWTNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.712.0.tgz",
+      "integrity": "sha512-8lCMxY7Lb9VK9qdlNXRJXE3W1UDVURnJZ3a4XWYNY6yr1TfQaN40mMyXX1oNlXXJtMV0szRvjM8dZj37E/ESAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.712.0.tgz",
+      "integrity": "sha512-26X21bZ4FWsVpqs33uOXiB60TOWQdVlr7T7XONDFL/XN7GEpUJkWuuIB4PTok6VOmh1viYcdxZQqekXPuzXexQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-bedrock-agent/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "whatwg-url": "14.1.0"
   },
   "peerDependencies": {
+    "@aws-sdk/client-bedrock-agent": "^3.712.0",
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.712.0",
     "@aws-sdk/client-bedrock-runtime": "^3.602.0",
     "@aws-sdk/credential-provider-sso": "^3.686.0",
     "@azure/identity": "^4.0.0",
@@ -86,7 +88,9 @@
     "puppeteer-extra-plugin-stealth": "^2.11.2"
   },
   "devDependencies": {
+    "@aws-sdk/client-bedrock-agent": "^3.712.0",
     "@aws-sdk/client-bedrock-runtime": "^3.706.0",
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.712.0",
     "@aws-sdk/credential-provider-sso": "^3.699.0",
     "@azure/identity": "^4.5.0",
     "@eslint/js": "^9.16.0",

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1,6 +1,6 @@
 # Bedrock
 
-The `bedrock` lets you use Amazon Bedrock in your evals. This is a common way to access Anthropic's Claude, Meta's Llama 3.1, Amazon's Nova, AI21's Jamba, and other models. The complete list of available models can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns).
+The `bedrock` provider lets you use Amazon Bedrock in your evals. This includes access to foundation models like Anthropic's Claude, Meta's Llama 3.1, Amazon's Nova, AI21's Jamba, as well as Bedrock Knowledge Bases. The complete list of available models can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns).
 
 ## Setup
 
@@ -216,6 +216,40 @@ config:
   top_p: 0.9
   top_k: 50
 ```
+
+### Knowledge Base
+
+To use a Bedrock Knowledge Base, specify the knowledge base ID after `bedrock:knowledge-base:`:
+
+```yaml
+providers:
+  - id: bedrock:knowledge-base:my-knowledge-base-id
+    config:
+      region: 'us-east-1'
+      modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2' # Optional
+      maxTokens: 1024 # Optional
+      temperature: 0.7 # Optional
+      topP: 0.9 # Optional
+      stopSequences: ["\n", '---'] # Optional
+      retrievalConfiguration: # Optional
+        vectorSearchConfiguration:
+          numberOfResults: 3
+          approximateMaxTokens: 1000
+      promptTemplate: # Optional
+        textPromptTemplate: "Answer the question using the following context: {{context}}\nQuestion: {{question}}"
+      orchestrationConfiguration: # Optional
+        promptTemplate:
+          textPromptTemplate: "Answer the question using the following context: {{context}}\nQuestion: {{question}}"
+        queryTransformationConfiguration:
+          type: 'QUERY_DECOMPOSITION'
+```
+
+The Knowledge Base provider requires:
+
+- A valid knowledge base ID
+- The `@aws-sdk/client-bedrock-agent-runtime` package installed
+
+The Knowledge Base provider will use the specified model to generate responses based on the content in your knowledge base. You can customize the retrieval and generation process using the configuration options shown above.
 
 ## Model-graded tests
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -20,6 +20,7 @@ import {
 } from './providers/azure';
 import { BAMChatProvider, BAMEmbeddingProvider } from './providers/bam';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './providers/bedrock';
+import { AwsBedrockKnowledgeBaseProvider } from './providers/bedrock';
 import { BrowserProvider } from './providers/browser';
 import * as CloudflareAiProviders from './providers/cloudflare-ai';
 import { CohereChatCompletionProvider, CohereEmbeddingProvider } from './providers/cohere';
@@ -256,6 +257,8 @@ export async function loadApiProvider(
       ret = new AwsBedrockCompletionProvider(modelName, providerOptions);
     } else if (modelType === 'embeddings' || modelType === 'embedding') {
       ret = new AwsBedrockEmbeddingProvider(modelName, providerOptions);
+    } else if (modelType === 'knowledge-base') {
+      ret = new AwsBedrockKnowledgeBaseProvider(modelName, providerOptions);
     } else {
       ret = new AwsBedrockCompletionProvider(
         `${modelType}${modelName ? `:${modelName}` : ''}`,
@@ -598,6 +601,7 @@ export default {
 
   AwsBedrockCompletionProvider,
   AwsBedrockEmbeddingProvider,
+  AwsBedrockKnowledgeBaseProvider,
   BrowserProvider,
   CohereChatCompletionProvider,
   CohereEmbeddingProvider,


### PR DESCRIPTION
Adds support for AWS Bedrock Knowledge Bases.  Example configuration.

```yaml
providers:
  - id: bedrock:knowledge-base:my-knowledge-base-id
    config:
      region: 'us-east-1'
      modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2' # Optional
      maxTokens: 1024 # Optional
      temperature: 0.7 # Optional
      topP: 0.9 # Optional
      stopSequences: ["\n", '---'] # Optional
      retrievalConfiguration: # Optional
        vectorSearchConfiguration:
          numberOfResults: 3
          approximateMaxTokens: 1000
      promptTemplate: # Optional
        textPromptTemplate: "Answer the question using the following context: {{context}}\nQuestion: {{question}}"
      orchestrationConfiguration: # Optional
        promptTemplate:
          textPromptTemplate: "Answer the question using the following context: {{context}}\nQuestion: {{question}}"
        queryTransformationConfiguration:
          type: 'QUERY_DECOMPOSITION'
```