### PR TITLE
fix(redteam): combine strategy configs for chained strategies

### DIFF
--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -203,7 +203,9 @@ async function applyStrategies(
             strategyId: t?.metadata?.strategyId || strategy.id,
             ...(t?.metadata?.pluginId && { pluginId: t.metadata.pluginId }),
             ...(t?.metadata?.pluginConfig && { pluginConfig: t.metadata.pluginConfig }),
-            ...(strategy.config && { strategyConfig: strategy.config }),
+            ...(strategy.config && {
+              strategyConfig: { ...strategy.config, ...(t?.metadata?.strategyConfig || {}) },
+            }),
           },
         })),
     );
@@ -455,6 +457,7 @@ export async function synthesize({
       logger.info(`Generating tests for ${plugin.id}...`);
     }
     const { action } = Plugins.find((p) => p.key === plugin.id) || {};
+
     if (action) {
       logger.debug(`Generating tests for ${plugin.id}...`);
       let pluginTests = await action({


### PR DESCRIPTION
Merge strategy configs so things like `maxRounds` will apply when you do a multi-lingual crescendo attack.

Proof:
![image](https://github.com/user-attachments/assets/ad68eb68-72ff-44e2-9492-53d76a53cbb5)
