### PR TITLE
chore(webui): remove horizontal scroll from redteam setup tabs

### DIFF
--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -49,11 +49,13 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
     left: 0,
     right: 'auto',
   },
-  width: '280px',
-  minWidth: '280px',
+  width: '100%',
   backgroundColor: theme.palette.background.paper,
   '& .MuiTab-root': {
     minHeight: '48px',
+  },
+  '& .MuiTabs-scrollButtons': {
+    display: 'none',
   },
 }));
 
@@ -559,7 +561,6 @@ export default function RedTeamSetupPage() {
                 variant="scrollable"
                 value={value}
                 onChange={handleChange}
-                sx={{ width: 200 }}
               >
                 <StyledTab
                   icon={<AppIcon />}


### PR DESCRIPTION
- Remove fixed width constraint from StyledTabs
- Disable unnecessary scroll buttons
- Ensure tabs fill available space in sidebar