### PR TITLE
fix(redteam): dont fall back if entity and purpose extraction fails

### DIFF
--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -11,7 +11,10 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
       const result = await fetchRemoteGeneration('entities' as RedTeamTask, prompts);
       return result as string[];
     } catch (error) {
-      logger.warn(`Error using remote generation, falling back to local extraction: ${error}`);
+      logger.warn(
+        `[Entity Extraction] Failed, returning 0 entities. Error using remote generation: ${error}`,
+      );
+      return [];
     }
   }
 

--- a/src/redteam/extraction/purpose.ts
+++ b/src/redteam/extraction/purpose.ts
@@ -14,9 +14,8 @@ export async function extractSystemPurpose(
       const result = await fetchRemoteGeneration('purpose' as RedTeamTask, prompts);
       return result as string;
     } catch (error) {
-      logger.warn(
-        `[purpose] Error using remote generation, falling back to local extraction: ${error}`,
-      );
+      logger.warn(`[purpose] Error using remote generation, returning empty string: ${error}`);
+      return '';
     }
   }
 
@@ -40,7 +39,7 @@ export async function extractSystemPurpose(
       return match ? match[1].trim() : output.trim();
     });
   } catch (error) {
-    logger.warn(`[purpose] Error using remote generation, returning empty string: ${error}`);
+    logger.warn(`[purpose] Error using extracting purpose, returning empty string: ${error}`);
     return '';
   }
 }

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -79,16 +79,15 @@ describe('Entities Extractor', () => {
     );
   });
 
-  it('should fall back to local extraction when remote generation fails', async () => {
+  it('should not fall back to local extraction when remote generation fails', async () => {
     process.env.OPENAI_API_KEY = undefined;
     process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
     jest.mocked(fetchWithCache).mockRejectedValue(new Error('Remote generation failed'));
 
     const result = await extractEntities(provider, ['prompt1', 'prompt2']);
 
-    expect(result).toEqual(['Apple', 'Google']);
-    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('prompt1'));
-    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('prompt2'));
+    expect(result).toEqual([]);
+    expect(provider.callApi).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Error using remote generation'),
     );

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -72,15 +72,16 @@ describe('System Purpose Extractor', () => {
     );
   });
 
-  it('should fall back to local extraction when remote generation fails', async () => {
+  it('should not fall back to local extraction when remote generation fails', async () => {
     process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
+    const originalOpenaiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = undefined;
     jest.mocked(fetchWithCache).mockRejectedValue(new Error('Remote generation failed'));
-
     const result = await extractSystemPurpose(provider, ['prompt1', 'prompt2']);
 
-    expect(result).toBe('Extracted system purpose');
-    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('prompt1'));
-    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('prompt2'));
+    expect(result).toBe('');
+    expect(provider.callApi).not.toHaveBeenCalled();
+    process.env.OPENAI_API_KEY = originalOpenaiKey;
   });
 
   it('should use local extraction when remote generation is disabled', async () => {


### PR DESCRIPTION
For users relying on remote extraction this won't help anything so we'll just fail open.