### PR TITLE
fix(redteam): add support for entity merging in config

### DIFF
--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -170,6 +170,7 @@ export async function doGenerateRedteam(
     language: redteamConfig?.language || options.language,
     maxConcurrency: options.maxConcurrency,
     numTests: redteamConfig?.numTests ?? options.numTests,
+    entities: redteamConfig?.entities,
     plugins,
     provider: redteamConfig?.provider || options.provider,
     purpose: redteamConfig?.purpose || options.purpose,
@@ -196,6 +197,8 @@ export async function doGenerateRedteam(
     delay: config.delay,
     abortSignal: options.abortSignal,
   } as SynthesizeOptions);
+
+  logger.warn(`synthesize entities: ${JSON.stringify(entities)}`);
 
   if (redteamTests.length === 0) {
     logger.warn('No test cases generated. Please check for errors and try again.');

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -198,8 +198,6 @@ export async function doGenerateRedteam(
     abortSignal: options.abortSignal,
   } as SynthesizeOptions);
 
-  logger.warn(`synthesize entities: ${JSON.stringify(entities)}`);
-
   if (redteamTests.length === 0) {
     logger.warn('No test cases generated. Please check for errors and try again.');
     return null;

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -301,11 +301,11 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
       for (const redteamKey of Object.keys(config.redteam) as Array<keyof typeof redteam>) {
         if (['entities', 'plugins', 'strategies'].includes(redteamKey)) {
           if (Array.isArray(config.redteam[redteamKey])) {
-            const currentValue = redteam[redteamKey];
+            const currentValue = redteam[redteamKey] || [];
             const newValue = config.redteam[redteamKey];
-            if (Array.isArray(currentValue) && Array.isArray(newValue)) {
+            if (Array.isArray(newValue)) {
               (redteam[redteamKey] as unknown[]) = [
-                ...new Set([...currentValue, ...newValue]),
+                ...new Set([...(currentValue as unknown[]), ...(newValue as unknown[])]),
               ].sort();
             }
           }
@@ -441,7 +441,6 @@ export async function resolveConfigs(
     // The user has provided a config file, so we do not want to use the default config.
     defaultConfig = {};
   }
-
   // Standalone assertion mode
   if (cmdObj.assertions) {
     telemetry.recordAndSendOnce('feature_used', {

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -315,11 +315,12 @@ export const RedteamConfigSchema = z
       numTests: data.numTests,
       plugins: uniquePlugins,
       strategies,
+      ...(data.delay ? { delay: data.delay } : {}),
+      ...(data.entities ? { entities: data.entities } : {}),
       ...(data.injectVar ? { injectVar: data.injectVar } : {}),
       ...(data.language ? { language: data.language } : {}),
       ...(data.provider ? { provider: data.provider } : {}),
       ...(data.purpose ? { purpose: data.purpose } : {}),
-      ...(data.delay ? { delay: data.delay } : {}),
     };
   });
 

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -300,4 +300,183 @@ describe('doGenerateRedteam', () => {
       }),
     );
   });
+
+  it('should pass entities from redteam config to synthesize', async () => {
+    jest.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        providers: [],
+      },
+      config: {
+        redteam: {
+          entities: ['Company X', 'John Doe', 'Product Y'],
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+    });
+
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        prompts: [{ raw: 'Test prompt' }],
+        providers: [],
+        tests: [],
+      }),
+    );
+
+    jest.mocked(synthesize).mockResolvedValue({
+      testCases: [
+        {
+          vars: { input: 'Test input' },
+          assert: [{ type: 'equals', value: 'Test output' }],
+          metadata: { pluginId: 'redteam' },
+        },
+      ],
+      purpose: 'Test purpose',
+      entities: ['Company X', 'John Doe', 'Product Y'],
+    });
+
+    const options: RedteamCliGenerateOptions = {
+      output: 'output.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: true,
+      force: true,
+      config: 'config.yaml',
+    };
+
+    await doGenerateRedteam(options);
+
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entities: ['Company X', 'John Doe', 'Product Y'],
+        plugins: expect.any(Array),
+        prompts: ['Test prompt'],
+        strategies: expect.any(Array),
+      }),
+    );
+  });
+
+  it('should handle undefined entities in redteam config', async () => {
+    jest.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        providers: [],
+      },
+      config: {
+        redteam: {
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+    });
+
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        prompts: [{ raw: 'Test prompt' }],
+        providers: [],
+        tests: [],
+      }),
+    );
+
+    jest.mocked(synthesize).mockResolvedValue({
+      testCases: [
+        {
+          vars: { input: 'Test input' },
+          assert: [{ type: 'equals', value: 'Test output' }],
+          metadata: { pluginId: 'redteam' },
+        },
+      ],
+      purpose: 'Test purpose',
+      entities: [],
+    });
+
+    const options: RedteamCliGenerateOptions = {
+      output: 'output.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: true,
+      force: true,
+      config: 'config.yaml',
+    };
+
+    await doGenerateRedteam(options);
+
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: [expect.objectContaining({ id: 'harmful:hate', numTests: 5 })],
+        prompts: ['Test prompt'],
+        strategies: [],
+        abortSignal: undefined,
+        delay: undefined,
+        language: undefined,
+        maxConcurrency: undefined,
+        numTests: undefined,
+      }),
+    );
+  });
+
+  it('should write entities to output config', async () => {
+    jest.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        providers: [],
+      },
+      config: {
+        redteam: {
+          entities: ['Company X', 'John Doe', 'Product Y'],
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+    });
+
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        prompts: [{ raw: 'Test prompt' }],
+        providers: [],
+        tests: [],
+      }),
+    );
+
+    jest.mocked(synthesize).mockResolvedValue({
+      testCases: [
+        {
+          vars: { input: 'Test input' },
+          assert: [{ type: 'equals', value: 'Test output' }],
+          metadata: { pluginId: 'redteam' },
+        },
+      ],
+      purpose: 'Test purpose',
+      entities: ['Company X', 'John Doe', 'Product Y'],
+    });
+
+    const options: RedteamCliGenerateOptions = {
+      output: 'output.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: true,
+      force: true,
+      config: 'config.yaml',
+    };
+
+    await doGenerateRedteam(options);
+
+    expect(writePromptfooConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redteam: expect.objectContaining({
+          entities: ['Company X', 'John Doe', 'Product Y'],
+        }),
+        defaultTest: expect.objectContaining({
+          metadata: expect.objectContaining({
+            entities: ['Company X', 'John Doe', 'Product Y'],
+          }),
+        }),
+      }),
+      'output.yaml',
+    );
+  });
 });

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -542,6 +542,151 @@ describe('combineConfigs', () => {
 
     expect(result.redteam).toBeUndefined();
   });
+
+  it('should combine redteam entities from multiple configs', async () => {
+    const config1 = {
+      prompts: ['prompt1'],
+      providers: ['provider1'],
+      redteam: {
+        entities: ['entity1', 'entity2'],
+        plugins: ['plugin1'],
+        strategies: ['strategy1'],
+      },
+    };
+    const config2 = {
+      prompts: ['prompt2'],
+      providers: ['provider2'],
+      redteam: {
+        entities: ['entity2', 'entity3'],
+        plugins: ['plugin2'],
+        strategies: ['strategy2'],
+      },
+    };
+
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(JSON.stringify(config1))
+      .mockReturnValueOnce(JSON.stringify(config2));
+
+    const result = await combineConfigs(['config1.json', 'config2.json']);
+
+    expect(result.redteam).toEqual({
+      entities: ['entity1', 'entity2', 'entity3'],
+      plugins: ['plugin1', 'plugin2'],
+      strategies: ['strategy1', 'strategy2'],
+    });
+  });
+
+  it('should handle redteam config with undefined arrays', async () => {
+    const config1 = {
+      prompts: ['prompt1'],
+      providers: ['provider1'],
+      redteam: {
+        entities: undefined,
+        plugins: ['plugin1'],
+        strategies: undefined,
+      },
+    };
+    const config2 = {
+      prompts: ['prompt2'],
+      providers: ['provider2'],
+      redteam: {
+        entities: ['entity1'],
+        plugins: undefined,
+        strategies: ['strategy1'],
+      },
+    };
+
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(JSON.stringify(config1))
+      .mockReturnValueOnce(JSON.stringify(config2));
+
+    const result = await combineConfigs(['config1.json', 'config2.json']);
+
+    expect(result.redteam).toEqual({
+      entities: ['entity1'],
+      plugins: ['plugin1'],
+      strategies: ['strategy1'],
+    });
+  });
+
+  it('should preserve non-array redteam properties', async () => {
+    const config1 = {
+      prompts: ['prompt1'],
+      providers: ['provider1'],
+      redteam: {
+        entities: ['entity1'],
+        plugins: ['plugin1'],
+        strategies: ['strategy1'],
+        delay: 1000,
+        language: 'en',
+        provider: 'openai:gpt-4',
+      },
+    };
+    const config2 = {
+      prompts: ['prompt2'],
+      providers: ['provider2'],
+      redteam: {
+        entities: ['entity2'],
+        plugins: ['plugin2'],
+        strategies: ['strategy2'],
+        delay: 2000,
+        purpose: 'testing',
+      },
+    };
+
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(JSON.stringify(config1))
+      .mockReturnValueOnce(JSON.stringify(config2));
+
+    const result = await combineConfigs(['config1.json', 'config2.json']);
+
+    expect(result.redteam).toEqual({
+      entities: ['entity1', 'entity2'],
+      plugins: ['plugin1', 'plugin2'],
+      strategies: ['strategy1', 'strategy2'],
+      delay: 2000,
+      language: 'en',
+      provider: 'openai:gpt-4',
+      purpose: 'testing',
+    });
+  });
+
+  it('should handle empty redteam arrays', async () => {
+    const config1 = {
+      prompts: ['prompt1'],
+      providers: ['provider1'],
+      redteam: {
+        entities: [],
+        plugins: ['plugin1'],
+        strategies: [],
+      },
+    };
+    const config2 = {
+      prompts: ['prompt2'],
+      providers: ['provider2'],
+      redteam: {
+        entities: ['entity1'],
+        plugins: [],
+        strategies: ['strategy1'],
+      },
+    };
+
+    jest
+      .mocked(fs.readFileSync)
+      .mockReturnValueOnce(JSON.stringify(config1))
+      .mockReturnValueOnce(JSON.stringify(config2));
+
+    const result = await combineConfigs(['config1.json', 'config2.json']);
+
+    expect(result.redteam).toEqual({
+      entities: ['entity1'],
+      plugins: ['plugin1'],
+      strategies: ['strategy1'],
+    });
+  });
 });
 
 describe('dereferenceConfig', () => {


### PR DESCRIPTION
- Add entities field to redteam config schema
- Pass entities from config to synthesize function
- Combine entities arrays when merging multiple configs
- Add tests for entities handling in config loading and validation