### PR TITLE
chore(cli): address punycode deprecation warning for Node.js 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
   },
   "overrides": {
     "uri-js": "npm:uri-js-replace",
-    "whatwg-url": "14.1.0"
+    "whatwg-url": "14.1.0",
+    "*": {
+      "whatwg-url": "14.1.0"
+    }
   },
   "peerDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.602.0",


### PR DESCRIPTION
### Summary of Changes

This pull request addresses the deprecation warning for the `punycode` module in Node.js 22 by updating the `overrides` section in the `package.json` file.

### Testing Considerations

1. `nvm use 22` 
2. `npm i && npm rebuild` 
3. `npm run build`
4. `npm link promptfoo`
5. verify with `which promptfoo`
6. run `promptfoo --version`
