### PR TITLE
fix(evaluator): handle circular references during error logging

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -31,6 +31,7 @@ import {
 } from './types';
 import { JsonlFileWriter } from './util/exportToFile/writeToFile';
 import invariant from './util/invariant';
+import { safeJsonStringify } from './util/json';
 import { sleep } from './util/time';
 import { transform, type TransformContext, TransformInputType } from './util/transform';
 
@@ -666,7 +667,7 @@ class Evaluator {
       try {
         await this.evalRecord.addResult(row, evalStep.test);
       } catch (error) {
-        logger.error(`Error saving result: ${error} ${JSON.stringify(row)}`);
+        logger.error(`Error saving result: ${error} ${safeJsonStringify(row)}`);
       }
 
       for (const writer of this.fileWriters) {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import glob from 'glob';
 import { evaluate, generateVarCombinations, isAllowedPrompt } from '../src/evaluator';
 import { runExtensionHook } from '../src/evaluatorHelpers';
+import logger from '../src/logger';
 import { runDbMigrations } from '../src/migrate';
 import Eval from '../src/models/eval';
 import type { ApiProvider, TestSuite, Prompt } from '../src/types';
@@ -1730,6 +1731,46 @@ describe('evaluator', () => {
 
     expect(sleep).not.toHaveBeenCalled();
     expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles circular references when logging errors during result saving', async () => {
+    // Create a circular reference object that would cause JSON.stringify to fail
+    type CircularType = { prop: string; self?: CircularType };
+    const circularObj: CircularType = { prop: 'value' };
+    circularObj.self = circularObj;
+
+    const mockApiProvider: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider'),
+      callApi: jest.fn().mockResolvedValue({
+        output: 'Test output',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    // Mock Eval.prototype.addResult to throw an error
+    const mockAddResult = jest.fn().mockRejectedValue(new Error('Mock save error'));
+    const originalAddResult = Eval.prototype.addResult;
+    Eval.prototype.addResult = mockAddResult;
+
+    // Create a test suite that will generate a result with a circular reference
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          vars: { circular: circularObj },
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    const errorSpy = jest.spyOn(logger, 'error');
+    await evaluate(testSuite, evalRecord, {});
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error saving result: Error: Mock save error'),
+    );
+    Eval.prototype.addResult = originalAddResult;
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
### Summary of Changes
This pull request addresses issue #2439 by introducing a fix to handle circular references during error logging in the `Evaluator` class.

### Key Modifications
- Replaced `JSON.stringify` with `safeJsonStringify` in the error logging statement within `Evaluator`.
- Added a new test case to verify the handling of circular references when logging errors during result saving.

### Implementation Details
- The `safeJsonStringify` utility is used to safely serialize objects with circular references, preventing runtime errors.
- The new test case creates a circular reference object and verifies that the error logging mechanism functions correctly without throwing exceptions.

### Testing Considerations
- The new test case ensures that the fix works as intended.
- Existing tests were run to confirm no regressions were introduced.

### Breaking Changes
- None.

This fix ensures that error logging in the `Evaluator` class is robust and can handle complex object structures without causing additional errors.