### PR TITLE
fix(ci): update Node.js 22.x matrix configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporarily disabled 22.x due to github runner compatibility issues
-        # TODO(Michael): Re-enable once issues are resolved, 2024-08-23
-        node: ['18.x', '20.x']
+        node: ['18.x', '20.x', '22.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
           # Remove when https://github.com/nodejs/node/issues/51766 is resolved


### PR DESCRIPTION
- Add Node.js 22.x back to test matrix
