### PR TITLE
feat(eval): add metadata filtering for tests

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -34,10 +34,10 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 | `--env-file, --env-path <path>`     | Path to .env file                                                       |
 | `--filter-failing <path>`           | Path to JSON output file with failing tests                             |
 | `-n, --filter-first-n <number>`     | Only run the first N tests                                              |
-| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern              |
-| `--filter-providers <providers>`    | Only run tests with these providers                                     |
 | `--filter-sample <number>`          | Only run a random sample of N tests                                     |
 | `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                |
+| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern              |
+| `--filter-providers <providers>`    | Only run tests with these providers                                     |
 | `--filter-targets <targets>`        | Only run tests with these targets                                       |
 | `--grader <provider>`               | Model that will grade outputs                                           |
 | `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                  |

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -37,6 +37,7 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 | `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern              |
 | `--filter-providers <providers>`    | Only run tests with these providers                                     |
 | `--filter-sample <number>`          | Only run a random sample of N tests                                     |
+| `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                |
 | `--filter-targets <targets>`        | Only run tests with these targets                                       |
 | `--grader <provider>`               | Model that will grade outputs                                           |
 | `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                  |

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -332,3 +332,9 @@ For the `eval` command, you may also want to disable the progress bar and table 
 ```sh
 FORCE_COLOR=0 promptfoo eval --no-progress-bar --no-table
 ```
+
+Filters can be combined. For example:
+
+```bash
+promptfoo eval --filter-metadata strat
+```

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -332,9 +332,3 @@ For the `eval` command, you may also want to disable the progress bar and table 
 ```sh
 FORCE_COLOR=0 promptfoo eval --no-progress-bar --no-table
 ```
-
-Filters can be combined. For example:
-
-```bash
-promptfoo eval --filter-metadata strat
-```

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -1327,15 +1327,18 @@
               "type": "integer",
               "exclusiveMinimum": 0
             },
-            "filterSample": {
-              "type": "integer",
-              "exclusiveMinimum": 0
+            "filterMetadata": {
+              "type": "string"
             },
             "filterPattern": {
               "type": "string"
             },
             "filterProviders": {
               "type": "string"
+            },
+            "filterSample": {
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "filterTargets": {
               "type": "string"

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -134,11 +134,11 @@ export async function doEval(
     }
 
     testSuite.tests = await filterTests(testSuite, {
-      firstN: cmdObj.filterFirstN,
-      pattern: cmdObj.filterPattern,
       failing: cmdObj.filterFailing,
-      sample: cmdObj.filterSample,
+      firstN: cmdObj.filterFirstN,
       metadata: cmdObj.filterMetadata,
+      pattern: cmdObj.filterPattern,
+      sample: cmdObj.filterSample,
     });
 
     if (

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -39,7 +39,6 @@ const EvalCommandSchema = CommandLineOptionsSchema.extend({
   help: z.boolean().optional(),
   interactiveProviders: z.boolean().optional(),
   remote: z.boolean().optional(),
-  filterMetadata: z.string().optional(),
 }).partial();
 
 type EvalCommandOptions = z.infer<typeof EvalCommandSchema>;
@@ -141,15 +140,6 @@ export async function doEval(
       sample: cmdObj.filterSample,
       metadata: cmdObj.filterMetadata,
     });
-    logger.debug(
-      `Filter options: ${JSON.stringify({
-        firstN: cmdObj.filterFirstN,
-        pattern: cmdObj.filterPattern,
-        failing: cmdObj.filterFailing,
-        sample: cmdObj.filterSample,
-        metadata: cmdObj.filterMetadata,
-      })}`,
-    );
 
     if (
       config.redteam &&

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -39,6 +39,7 @@ const EvalCommandSchema = CommandLineOptionsSchema.extend({
   help: z.boolean().optional(),
   interactiveProviders: z.boolean().optional(),
   remote: z.boolean().optional(),
+  filterMetadata: z.string().optional(),
 }).partial();
 
 type EvalCommandOptions = z.infer<typeof EvalCommandSchema>;
@@ -138,7 +139,17 @@ export async function doEval(
       pattern: cmdObj.filterPattern,
       failing: cmdObj.filterFailing,
       sample: cmdObj.filterSample,
+      metadata: cmdObj.filterMetadata,
     });
+    logger.debug(
+      `Filter options: ${JSON.stringify({
+        firstN: cmdObj.filterFirstN,
+        pattern: cmdObj.filterPattern,
+        failing: cmdObj.filterFailing,
+        sample: cmdObj.filterSample,
+        metadata: cmdObj.filterMetadata,
+      })}`,
+    );
 
     if (
       config.redteam &&
@@ -516,6 +527,10 @@ export function evalCommand(
     )
     .option('--filter-sample <number>', 'Only run a random sample of N tests')
     .option('--filter-failing <path>', 'Path to json output file')
+    .option(
+      '--filter-metadata <key=value>',
+      'Only run tests whose metadata matches the key=value pair (e.g. --filter-metadata pluginId=debug-access)',
+    )
 
     // Output configuration
     .option(

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -1,64 +1,93 @@
+import logger from '../../logger';
 import type { TestSuite } from '../../types';
 import { filterFailingTests } from './filterFailingTests';
 
-interface Args {
-  firstN?: string | number;
-  sample?: string | number;
+interface FilterOptions {
+  firstN?: number | string;
   pattern?: string;
   failing?: string;
+  sample?: number | string;
+  metadata?: string;
 }
 
 type Tests = TestSuite['tests'];
 
-export async function filterTests(testSuite: TestSuite, args: Args): Promise<Tests> {
-  const tests = testSuite.tests;
+export async function filterTests(testSuite: TestSuite, options: FilterOptions): Promise<Tests> {
+  let tests = testSuite.tests || [];
 
-  if (!tests) {
+  logger.debug(`Starting filterTests with options: ${JSON.stringify(options)}`);
+  logger.debug(`Initial test count: ${tests.length}`);
+
+  if (Object.keys(options).length === 0) {
+    logger.debug('No filter options provided, returning all tests');
     return tests;
   }
 
-  if (Object.keys(args).length === 0) {
-    return tests;
+  if (options.metadata) {
+    const [key, value] = options.metadata.split('=');
+    if (!key || value === undefined) {
+      throw new Error('--filter-metadata must be specified in key=value format');
+    }
+    logger.debug(`Filtering for metadata ${key}=${value}`);
+    logger.debug(`Before metadata filter: ${tests.length} tests`);
+    logger.debug('First few tests metadata:');
+    tests.slice(0, 3).forEach((test, i) => {
+      logger.debug(`Test ${i} metadata: ${JSON.stringify(test.metadata)}`);
+    });
+
+    tests = tests.filter((test) => {
+      if (!test.metadata) {
+        logger.debug(`Test has no metadata: ${JSON.stringify(test)}`);
+        return false;
+      }
+      const matches = test.metadata[key] === value;
+      if (!matches) {
+        logger.debug(
+          `Test metadata doesn't match. Expected ${key}=${value}, got ${JSON.stringify(test.metadata)}`,
+        );
+      }
+      return matches;
+    });
+
+    logger.debug(`After metadata filter: ${tests.length} tests`);
   }
 
-  const { firstN, pattern, failing, sample } = args;
-  let newTests: NonNullable<Tests>;
-
-  if (failing) {
-    newTests = await filterFailingTests(testSuite, failing);
-  } else {
-    newTests = [...tests];
+  if (options.failing) {
+    tests = await filterFailingTests(testSuite, options.failing);
   }
 
-  if (pattern) {
-    newTests = newTests.filter((test) => test.description && test.description.match(pattern));
+  if (options.pattern) {
+    const pattern = new RegExp(options.pattern);
+    tests = tests.filter((test) => test.description && pattern.test(test.description));
   }
 
-  if (firstN) {
-    const count = typeof firstN === 'number' ? firstN : Number.parseInt(firstN);
+  if (options.firstN !== undefined) {
+    const count =
+      typeof options.firstN === 'number' ? options.firstN : Number.parseInt(options.firstN);
 
     if (Number.isNaN(count)) {
-      throw new Error(`firstN must be a number, got: ${firstN}`);
+      throw new Error(`firstN must be a number, got: ${options.firstN}`);
     }
 
-    newTests = newTests.slice(0, count);
+    tests = tests.slice(0, count);
   }
 
-  if (sample) {
-    const count = typeof sample === 'number' ? sample : Number.parseInt(sample, 10);
+  if (options.sample !== undefined) {
+    const count =
+      typeof options.sample === 'number' ? options.sample : Number.parseInt(options.sample);
 
     if (Number.isNaN(count)) {
-      throw new Error(`sample must be a number, got: ${sample}`);
+      throw new Error(`sample must be a number, got: ${options.sample}`);
     }
 
     // Fisher-Yates shuffle and take first n elements
-    const shuffled = [...newTests];
+    const shuffled = [...tests];
     for (let i = shuffled.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
     }
-    newTests = shuffled.slice(0, count);
+    tests = shuffled.slice(0, count);
   }
 
-  return newTests;
+  return tests;
 }

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -7,7 +7,7 @@ interface FilterOptions {
   pattern?: string;
   failing?: string;
   sample?: number | string;
-  metadata?: string;
+  metadata?: string | string[];
 }
 
 type Tests = TestSuite['tests'];
@@ -28,13 +28,24 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     if (!key || value === undefined) {
       throw new Error('--filter-metadata must be specified in key=value format');
     }
+    logger.debug(`Filtering for metadata ${key}=${value}`);
+    logger.debug(`Before metadata filter: ${tests.length} tests`);
+
     tests = tests.filter((test) => {
       if (!test.metadata) {
+        logger.debug(`Test has no metadata: ${test.description || 'unnamed test'}`);
         return false;
       }
       const matches = test.metadata[key] === value;
+      if (!matches) {
+        logger.debug(
+          `Test "${test.description || 'unnamed test'}" metadata doesn't match. Expected ${key}=${value}, got ${JSON.stringify(test.metadata)}`,
+        );
+      }
       return matches;
     });
+
+    logger.debug(`After metadata filter: ${tests.length} tests remain`);
   }
 
   if (options.failing) {

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -3,11 +3,11 @@ import type { TestSuite } from '../../types';
 import { filterFailingTests } from './filterFailingTests';
 
 interface FilterOptions {
-  firstN?: number | string;
-  pattern?: string;
   failing?: string;
+  firstN?: number | string;
+  metadata?: string;
+  pattern?: string;
   sample?: number | string;
-  metadata?: string | string[];
 }
 
 type Tests = TestSuite['tests'];

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -28,28 +28,13 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     if (!key || value === undefined) {
       throw new Error('--filter-metadata must be specified in key=value format');
     }
-    logger.debug(`Filtering for metadata ${key}=${value}`);
-    logger.debug(`Before metadata filter: ${tests.length} tests`);
-    logger.debug('First few tests metadata:');
-    tests.slice(0, 3).forEach((test, i) => {
-      logger.debug(`Test ${i} metadata: ${JSON.stringify(test.metadata)}`);
-    });
-
     tests = tests.filter((test) => {
       if (!test.metadata) {
-        logger.debug(`Test has no metadata: ${JSON.stringify(test)}`);
         return false;
       }
       const matches = test.metadata[key] === value;
-      if (!matches) {
-        logger.debug(
-          `Test metadata doesn't match. Expected ${key}=${value}, got ${JSON.stringify(test.metadata)}`,
-        );
-      }
       return matches;
     });
-
-    logger.debug(`After metadata filter: ${tests.length} tests`);
   }
 
   if (options.failing) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export const CommandLineOptionsSchema = z.object({
   promptSuffix: z.string().optional(),
 
   envPath: z.string().optional(),
+  filterMetadata: z.string().optional(),
 });
 
 export type CommandLineOptions = z.infer<typeof CommandLineOptionsSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,9 +58,10 @@ export const CommandLineOptionsSchema = z.object({
   watch: z.boolean().optional(),
   filterFailing: z.string().optional(),
   filterFirstN: z.coerce.number().int().positive().optional(),
-  filterSample: z.coerce.number().int().positive().optional(),
+  filterMetadata: z.string().optional(),
   filterPattern: z.string().optional(),
   filterProviders: z.string().optional(),
+  filterSample: z.coerce.number().int().positive().optional(),
   filterTargets: z.string().optional(),
   var: z.record(z.string()).optional(),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,7 +70,6 @@ export const CommandLineOptionsSchema = z.object({
   promptSuffix: z.string().optional(),
 
   envPath: z.string().optional(),
-  filterMetadata: z.string().optional(),
 });
 
 export type CommandLineOptions = z.infer<typeof CommandLineOptionsSchema>;

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -164,22 +164,5 @@ describe('filterTests', () => {
         filterTests(testSuiteWithMetadata, { metadata: 'invalid-format' }),
       ).rejects.toThrow('--filter-metadata must be specified in key=value format');
     });
-
-    it('should handle nested metadata', async () => {
-      const testWithNestedMetadata = {
-        description: 'Test with nested metadata',
-        metadata: {
-          plugin: {
-            id: 'test-plugin',
-          },
-        },
-      };
-      const testSuite = {
-        tests: [testWithNestedMetadata],
-      } as TestSuite;
-
-      const result = await filterTests(testSuite, { metadata: 'plugin.id=test-plugin' });
-      expect(result).toHaveLength(0); // Currently returns 0 since we don't support nested paths
-    });
   });
 });

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -164,5 +164,22 @@ describe('filterTests', () => {
         filterTests(testSuiteWithMetadata, { metadata: 'invalid-format' }),
       ).rejects.toThrow('--filter-metadata must be specified in key=value format');
     });
+
+    it('should handle nested metadata', async () => {
+      const testWithNestedMetadata = {
+        description: 'Test with nested metadata',
+        metadata: {
+          plugin: {
+            id: 'test-plugin',
+          },
+        },
+      };
+      const testSuite = {
+        tests: [testWithNestedMetadata],
+      } as TestSuite;
+
+      const result = await filterTests(testSuite, { metadata: 'plugin.id=test-plugin' });
+      expect(result).toHaveLength(0); // Currently returns 0 since we don't support nested paths
+    });
   });
 });


### PR DESCRIPTION
### Summary
This pull request introduces the ability to filter tests based on metadata key-value pairs in the `eval` command.

### Key Changes
- Added a new `--filter-metadata` option to the `eval` command.
- Updated the `filterTests` function to support filtering tests by metadata.
- Enhanced logging for the filtering process to aid debugging.
- Updated the documentation to include the new `--filter-metadata` option.
- Added comprehensive tests for the metadata filtering functionality.

### Implementation Details
The metadata filter uses a key-value pair format (e.g., `key=value`) to match tests with the corresponding metadata. If the metadata is not present or does not match, the test is excluded.

### Testing Considerations
- Unit tests have been added to validate the behavior of the metadata filter.
- Tests cover scenarios such as valid matches, no matches, invalid formats, and combinations with other filters.

### Breaking Changes
None.