### PR TITLE
fix(redteam): improve logging and message handling in Crescendo and Goat providers

### DIFF
--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -417,6 +417,12 @@ class CrescendoProvider implements ApiProvider {
       }
     }
 
+    if (Object.keys(parsedOutput).length !== expectedKeys.length) {
+      logger.debug(
+        `[Crescendo] Unexpected keys in response: ${Object.keys(parsedOutput).join(', ')}`,
+      );
+    }
+
     logger.debug(dedent`
       [Crescendo] Received from red teaming chat:
 
@@ -424,12 +430,6 @@ class CrescendoProvider implements ApiProvider {
       rationaleBehindJailbreak: ${parsedOutput.rationaleBehindJailbreak}
       lastResponseSummary: ${parsedOutput.lastResponseSummary}
     `);
-
-    if (Object.keys(parsedOutput).length !== expectedKeys.length) {
-      logger.debug(
-        `[Crescendo] Unexpected keys in response: ${Object.keys(parsedOutput).join(', ')}`,
-      );
-    }
 
     this.memory.addMessage(this.redTeamingChatConversationId, {
       role: 'assistant',

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -392,7 +392,7 @@ class CrescendoProvider implements ApiProvider {
       throw new Error(`Error from redteam provider: ${response.error}`);
     }
     if (!response.output) {
-      logger.warning(`[Crescendo] No output from redteam provider: ${safeJsonStringify(response)}`);
+      logger.debug(`[Crescendo] No output from redteam provider: ${safeJsonStringify(response)}`);
       return {
         generatedQuestion: undefined,
         tokenUsage: undefined,

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -392,7 +392,7 @@ class CrescendoProvider implements ApiProvider {
       throw new Error(`Error from redteam provider: ${response.error}`);
     }
     if (!response.output) {
-      logger.debug(`[Crescendo] No output from redteam provider: ${safeJsonStringify(response)}`);
+      logger.debug(`[Crescendo] No output from redteam provider: ${JSON.stringify(response)}`);
       return {
         generatedQuestion: undefined,
         tokenUsage: undefined,
@@ -417,12 +417,6 @@ class CrescendoProvider implements ApiProvider {
       }
     }
 
-    if (Object.keys(parsedOutput).length !== expectedKeys.length) {
-      logger.debug(
-        `[Crescendo] Unexpected keys in response: ${Object.keys(parsedOutput).join(', ')}`,
-      );
-    }
-
     logger.debug(dedent`
       [Crescendo] Received from red teaming chat:
 
@@ -430,6 +424,12 @@ class CrescendoProvider implements ApiProvider {
       rationaleBehindJailbreak: ${parsedOutput.rationaleBehindJailbreak}
       lastResponseSummary: ${parsedOutput.lastResponseSummary}
     `);
+
+    if (Object.keys(parsedOutput).length !== expectedKeys.length) {
+      logger.debug(
+        `[Crescendo] Unexpected keys in response: ${Object.keys(parsedOutput).join(', ')}`,
+      );
+    }
 
     this.memory.addMessage(this.redTeamingChatConversationId, {
       role: 'assistant',

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -169,9 +169,9 @@ export default class GoatProvider implements ApiProvider {
     delete context?.vars?.sessionId;
 
     return {
-      output: messages.filter((m) => m?.role === 'user').slice(-1)[0]?.content,
+      output: messages.filter((m) => m?.role === 'assistant').slice(-1)[0]?.content,
       metadata: {
-        redteamFinalPrompt: messages.filter((m) => m?.role === 'assistant').slice(-1)[0]?.content,
+        redteamFinalPrompt: messages.filter((m) => m?.role === 'user').slice(-1)[0]?.content,
         messages: JSON.stringify(
           messages.filter((m) => m?.role),
           null,

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -15,6 +15,14 @@ import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
 
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const getLastMessageContent = (messages: Message[], role: Message['role']): string | undefined =>
+  messages.filter((m) => m?.role === role).slice(-1)[0]?.content;
+
 export default class GoatProvider implements ApiProvider {
   private maxTurns: number;
   private readonly injectVar: string;
@@ -60,7 +68,7 @@ export default class GoatProvider implements ApiProvider {
     const targetProvider: ApiProvider | undefined = context?.originalProvider;
     invariant(targetProvider, 'Expected originalProvider to be set');
 
-    const messages: { content: string; role: 'user' | 'assistant' | 'system' }[] = [];
+    const messages: Message[] = [];
     const totalTokenUsage = {
       total: 0,
       prompt: 0,
@@ -149,8 +157,8 @@ export default class GoatProvider implements ApiProvider {
         }
 
         messages.push({
-          content: stringifiedOutput,
           role: 'assistant',
+          content: stringifiedOutput,
         });
 
         if (targetResponse.tokenUsage) {
@@ -169,14 +177,10 @@ export default class GoatProvider implements ApiProvider {
     delete context?.vars?.sessionId;
 
     return {
-      output: messages.filter((m) => m?.role === 'assistant').slice(-1)[0]?.content,
+      output: getLastMessageContent(messages, 'assistant'),
       metadata: {
-        redteamFinalPrompt: messages.filter((m) => m?.role === 'user').slice(-1)[0]?.content,
-        messages: JSON.stringify(
-          messages.filter((m) => m?.role),
-          null,
-          2,
-        ),
+        redteamFinalPrompt: getLastMessageContent(messages, 'user'),
+        messages: JSON.stringify(messages, null, 2),
       },
       tokenUsage: totalTokenUsage,
     };

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -9,7 +9,6 @@ import {
   type TokenUsage,
   type CallApiContextParams,
 } from '../../types';
-import invariant from '../../util/invariant';
 import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
@@ -122,11 +121,11 @@ export async function getTargetResponse(
     await sleep(targetProvider.delay);
   }
   if (targetRespRaw?.output) {
-    const output =
+    const output = (
       typeof targetRespRaw.output === 'string'
         ? targetRespRaw.output
-        : safeJsonStringify(targetRespRaw.output);
-    invariant(output, `Expected output to be a string, got ${safeJsonStringify(targetRespRaw)}`);
+        : safeJsonStringify(targetRespRaw.output)
+    ) as string;
     return {
       output,
       sessionId: targetRespRaw.sessionId,


### PR DESCRIPTION
- Fixed condition to validate message structure in GoatProvider.
- Updated output retrieval logic in GoatProvider to ensure correct user message is returned.
- Changed warning to debug log for missing output in CrescendoProvider.