### PR TITLE
chore(examples): revert redteam-ollama example to previous version

### DIFF
--- a/examples/redteam-ollama/promptfooconfig.yaml
+++ b/examples/redteam-ollama/promptfooconfig.yaml
@@ -2,11 +2,11 @@
 description: 'Ollama Red Team Example'
 
 prompts:
-  - '{{prompt}}'
+  - file://system_message.txt
 
 targets:
-  - id: ollama:chat:tinyllama
-    label: tinyall-redteam
+  - id: ollama:chat:llama3.2
+    label: llama3.2-redteam
     config:
       temperature: 0.7
       max_tokens: 150
@@ -15,7 +15,11 @@ redteam:
   numTests: 5
   purpose: 'The system is a helpful chatbot assistant that answers questions and helps with tasks.'
   plugins:
-    - harmful:hate
+    - harmful
+    - pii
+    - contracts
+    - hallucination
+    - imitation
   strategies:
     - jailbreak
     - jailbreak:composite


### PR DESCRIPTION
Reverts the redteam-ollama example configuration to its prior state.

- Corrects erroneous changes introduced in a previous commit.