### PR TITLE
chore(providers): make number of retry attempts configurable for HTTP provider

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -468,6 +468,10 @@ providers:
         user_message: '{{prompt}}'
 ```
 
+## Request Retries
+
+The HTTP provider automatically retries failed requests and rate-limited responses. By default, it will attempt up to 4 retries with exponential backoff. You can configure the maximum number of retries using the `maxRetries` option:
+
 ## Reference
 
 Supported config options:
@@ -482,6 +486,7 @@ Supported config options:
 | queryParams       | Record\<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                                                           |
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |
+| maxRetries        | number                  | Maximum number of retry attempts for failed requests. Defaults to 4.                                                                                                                |
 
 Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
 

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -322,14 +322,6 @@ module.exports = (json, text) => {
 };
 ```
 
-You can also use a default export:
-
-```javascript
-export default (json, text) => {
-  return json.choices[0].message.content;
-};
-```
-
 You can also specify a function name to be imported from a file:
 
 ```yaml
@@ -470,19 +462,34 @@ providers:
 
 ## Request Retries
 
-The HTTP provider automatically retries failed requests and rate-limited responses. By default, it will attempt up to 4 retries with exponential backoff. You can configure the maximum number of retries using the `maxRetries` option:
+The HTTP provider automatically retries failed requests in the following scenarios:
+
+- Rate limiting (HTTP 429)
+- Server errors
+- Network failures
+
+By default, it will attempt up to 4 retries with exponential backoff. You can configure the maximum number of retries using the `maxRetries` option:
+
+```yaml
+providers:
+  - id: my-api
+    type: http
+    config:
+      url: https://api.example.com/v1/chat
+      maxRetries: 2 # Override default of 4 retries
+```
 
 ## Reference
 
 Supported config options:
 
-| Option            | Type                    | Description                                                                                                                                                                         |
+| Field             | Type                    | Description                                                                                                                                                                         |
 | ----------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url               | string                  | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                                                             |
-| request           | string                  | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                                                                   |
-| method            | string                  | The HTTP method to use for the request. Defaults to 'GET' if not specified.                                                                                                         |
-| headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |
-| body              | Record\<string, any>    | The request body. For POST requests, this will be sent as JSON.                                                                                                                     |
+| url               | string                  | The API endpoint URL.                                                                                                                                                               |
+| method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
+| headers           | Record\<string, string> | HTTP headers to include with the request.                                                                                                                                           |
+| body              | object \| string        | Request body. Objects are automatically stringified as JSON.                                                                                                                        |
+| request           | string                  | Raw HTTP request template. Alternative to url/method/headers/body.                                                                                                                  |
 | queryParams       | Record\<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                                                           |
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -322,6 +322,14 @@ module.exports = (json, text) => {
 };
 ```
 
+You can also use a default export:
+
+```javascript
+export default (json, text) => {
+  return json.choices[0].message.content;
+};
+```
+
 You can also specify a function name to be imported from a file:
 
 ```yaml
@@ -485,10 +493,10 @@ Supported config options:
 
 | Field             | Type                    | Description                                                                                                                                                                         |
 | ----------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url               | string                  | The API endpoint URL.                                                                                                                                                               |
+| url               | string                  | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                                                             |
 | method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
-| headers           | Record\<string, string> | HTTP headers to include with the request.                                                                                                                                           |
-| body              | object \| string        | Request body. Objects are automatically stringified as JSON.                                                                                                                        |
+| headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |
+| body              | object \| string        | The request body. For POST requests, objects are automatically stringified as JSON.                                                                                                 |
 | request           | string                  | Raw HTTP request template. Alternative to url/method/headers/body.                                                                                                                  |
 | queryParams       | Record\<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                                                           |
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -480,8 +480,7 @@ By default, it will attempt up to 4 retries with exponential backoff. You can co
 
 ```yaml
 providers:
-  - id: my-api
-    type: http
+  - id: http
     config:
       url: https://api.example.com/v1/chat
       maxRetries: 2 # Override default of 4 retries
@@ -491,13 +490,13 @@ providers:
 
 Supported config options:
 
-| Field             | Type                    | Description                                                                                                                                                                         |
+| Option            | Type                    | Description                                                                                                                                                                         |
 | ----------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | url               | string                  | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                                                             |
+| request           | string                  | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                                                                   |
 | method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
 | headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |
 | body              | object \| string        | The request body. For POST requests, objects are automatically stringified as JSON.                                                                                                 |
-| request           | string                  | Raw HTTP request template. Alternative to url/method/headers/body.                                                                                                                  |
 | queryParams       | Record\<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                                                           |
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -55,9 +55,10 @@ export async function fetchWithCache<T = any>(
   timeout: number = REQUEST_TIMEOUT_MS,
   format: 'json' | 'text' = 'json',
   bust: boolean = false,
+  maxRetries?: number,
 ): Promise<FetchWithCacheResult<T>> {
   if (!enabled || bust) {
-    const resp = await fetchWithRetries(url, options, timeout);
+    const resp = await fetchWithRetries(url, options, timeout, maxRetries);
 
     const respText = await resp.text();
     try {
@@ -86,7 +87,7 @@ export async function fetchWithCache<T = any>(
   const cachedResponse = await cache.wrap(cacheKey, async () => {
     // Fetch the actual data and store it in the cache
     cached = false;
-    const response = await fetchWithRetries(url, options, timeout);
+    const response = await fetchWithRetries(url, options, timeout, maxRetries);
     const responseText = await response.text();
     const headers = Object.fromEntries(response.headers.entries());
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -124,12 +124,12 @@ export async function fetchWithRetries(
   url: RequestInfo,
   options: RequestInit = {},
   timeout: number,
-  maxRetries: number = 4,
+  retries: number = 4,
 ): Promise<Response> {
   let lastError;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);
 
-  for (let i = 0; i < maxRetries; i++) {
+  for (let i = 0; i < retries; i++) {
     let response;
     try {
       response = await fetchWithTimeout(url, options, timeout);
@@ -140,7 +140,7 @@ export async function fetchWithRetries(
 
       if (response && isRateLimited(response)) {
         logger.debug(
-          `Rate limited on URL ${url}: ${response.status} ${response.statusText}, waiting before retry ${i + 1}/${maxRetries}`,
+          `Rate limited on URL ${url}: ${response.status} ${response.statusText}, waiting before retry ${i + 1}/${retries}`,
         );
         await handleRateLimit(response);
         continue;
@@ -169,5 +169,5 @@ export async function fetchWithRetries(
       await sleep(waitTime);
     }
   }
-  throw new Error(`Request failed after ${maxRetries} retries: ${(lastError as Error).message}`);
+  throw new Error(`Request failed after ${retries} retries: ${(lastError as Error).message}`);
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -124,12 +124,12 @@ export async function fetchWithRetries(
   url: RequestInfo,
   options: RequestInit = {},
   timeout: number,
-  retries: number = 4,
+  maxRetries: number = 4,
 ): Promise<Response> {
   let lastError;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);
 
-  for (let i = 0; i < retries; i++) {
+  for (let i = 0; i < maxRetries; i++) {
     let response;
     try {
       response = await fetchWithTimeout(url, options, timeout);
@@ -140,7 +140,7 @@ export async function fetchWithRetries(
 
       if (response && isRateLimited(response)) {
         logger.debug(
-          `Rate limited on URL ${url}: ${response.status} ${response.statusText}, waiting before retry ${i + 1}/${retries}`,
+          `Rate limited on URL ${url}: ${response.status} ${response.statusText}, waiting before retry ${i + 1}/${maxRetries}`,
         );
         await handleRateLimit(response);
         continue;
@@ -169,5 +169,5 @@ export async function fetchWithRetries(
       await sleep(waitTime);
     }
   }
-  throw new Error(`Request failed after ${retries} retries: ${(lastError as Error).message}`);
+  throw new Error(`Request failed after ${maxRetries} retries: ${(lastError as Error).message}`);
 }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -505,6 +505,8 @@ export class HttpProvider implements ApiProvider {
         },
         REQUEST_TIMEOUT_MS,
         'text',
+        undefined,
+        this.config.maxRetries,
       );
     } catch (err) {
       return {

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -34,6 +34,7 @@ export const HttpProviderConfigSchema = z.object({
    * @deprecated
    */
   responseParser: z.union([z.string(), z.function()]).optional(),
+  maxRetries: z.number().optional(),
 });
 
 export type HttpProviderConfig = z.infer<typeof HttpProviderConfigSchema>;
@@ -433,6 +434,7 @@ export class HttpProvider implements ApiProvider {
         REQUEST_TIMEOUT_MS,
         'text',
         context?.debug,
+        this.config.maxRetries,
       );
     } catch (err) {
       return {

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -23,6 +23,7 @@ const nunjucks = getNunjucksEngine();
 export const HttpProviderConfigSchema = z.object({
   body: z.union([z.record(z.any()), z.string(), z.array(z.any())]).optional(),
   headers: z.record(z.string()).optional(),
+  maxRetries: z.number().min(0).optional(),
   method: z.string().optional(),
   queryParams: z.record(z.string()).optional(),
   request: z.string().optional(),
@@ -31,10 +32,9 @@ export const HttpProviderConfigSchema = z.object({
   transformResponse: z.union([z.string(), z.function()]).optional(),
   url: z.string().optional(),
   /**
-   * @deprecated
+   * @deprecated use transformResponse instead
    */
   responseParser: z.union([z.string(), z.function()]).optional(),
-  maxRetries: z.number().optional(),
 });
 
 export type HttpProviderConfig = z.infer<typeof HttpProviderConfigSchema>;

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -74,9 +74,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       );
 
       if (!response.ok) {
-        throw new Error(
-          `[HarmfulCompletionProvider] API call failed with status ${response.status}: ${await response.text()}`,
-        );
+        throw new Error(`API call failed with status ${response.status}: ${await response.text()}`);
       }
 
       const data = await response.json();
@@ -85,9 +83,9 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
         output: [data.output].flat(),
       };
     } catch (err) {
-      logger.info(`[HarmfulCompletionProvider] API call error: ${String(err)}`);
+      logger.info(`[HarmfulCompletionProvider] ${err}`);
       return {
-        error: `[HarmfulCompletionProvider]API call error: ${String(err)}`,
+        error: `[HarmfulCompletionProvider] ${err}`,
       };
     }
   }

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -9,6 +9,7 @@ import {
   HttpProvider,
   processJsonBody,
 } from '../../src/providers/http';
+import { REQUEST_TIMEOUT_MS } from '../../src/providers/shared';
 import { maybeLoadFromExternalFile } from '../../src/util';
 
 jest.mock('../../src/cache', () => ({
@@ -1132,7 +1133,7 @@ describe('createTransformRequest', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ key: 'value', transformed: 'TEST' }),
       },
-      expect.any(Number),
+      REQUEST_TIMEOUT_MS,
       'text',
       undefined,
       undefined,
@@ -1389,7 +1390,7 @@ describe('request transformation', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ key: 'value', transformed: 'TEST' }),
       },
-      expect.any(Number),
+      REQUEST_TIMEOUT_MS,
       'text',
       undefined,
       undefined,
@@ -1425,7 +1426,7 @@ describe('response handling', () => {
         method: 'POST',
         headers: { 'Content-Type': 'text/plain' },
         body: 'test',
-        transformResponse: (_data: any, text: string) => text,
+        transformResponse: (data: Record<string, unknown>, text: string) => text,
       },
     });
 
@@ -1439,7 +1440,7 @@ describe('response handling', () => {
     jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
     const result = await provider.callApi('test');
-    expect(result.output).toBe('Raw response');
+    expect(result.output).toBe(mockResponse.data);
   });
 
   it('should include debug information when requested', async () => {
@@ -1495,8 +1496,6 @@ describe('session handling', () => {
 
     const result = await provider.callApi('test');
     expect(result.sessionId).toBe('test-session');
-    expect(sessionParser).toHaveBeenCalledWith({
-      headers: { 'x-session-id': 'test-session' },
-    });
+    expect(sessionParser).toHaveBeenCalledWith({ headers: mockResponse.headers });
   });
 });

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1,8 +1,7 @@
 import dedent from 'dedent';
 import path from 'path';
-import { disableCache, fetchWithCache } from '../../src/cache';
+import { fetchWithCache } from '../../src/cache';
 import { importModule } from '../../src/esm';
-import { fetchWithRetries } from '../../src/fetch';
 import {
   createTransformRequest,
   createTransformResponse,


### PR DESCRIPTION
This PR introduces the ability to configure the number of retry attempts for the HTTP provider.
- Added `maxRetries` option in the HTTP provider configuration.
- Updated documentation and tests to reflect the new feature.