### PR TITLE
fix(docs): correct broken link in blog post

### DIFF
--- a/site/blog/unbounded-consumption.md
+++ b/site/blog/unbounded-consumption.md
@@ -244,7 +244,7 @@ To mitigate LLM DoS attacks, implement scalable strategies such as dynamic rate 
 
 ## Testing for Unbounded Consumption with Promptfoo
 
-Promptfoo provides several ways of testing unbounded consumption through both its [red teaming](/docs/red-team/) and [evaluations](/docs/) frameworks:
+Promptfoo provides several ways of testing unbounded consumption through both its [red teaming](/docs/red-team/) and [evaluations](/docs/intro/) frameworks:
 
 Test for potential DoS vulnerabilities:
 


### PR DESCRIPTION
fix(docs): correct broken link in blog post

- Updated the link in the 'unbounded-consumption.md' file to point to the correct documentation section.