### PR TITLE
fix(docs): conditionally enable gtag only in production

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -89,10 +89,13 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-        gtag: {
-          trackingID: 'G-3TS8QLZQ93',
-          anonymizeIP: true,
-        },
+        gtag:
+          process.env.NODE_ENV === 'production'
+            ? {
+                trackingID: 'G-3TS8QLZQ93',
+                anonymizeIP: true,
+              }
+            : undefined,
       }),
     ],
   ],

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -90,12 +90,12 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag:
-          process.env.NODE_ENV !== 'development'
-            ? {
+          process.env.NODE_ENV === 'development'
+            ? undefined
+            : {
                 trackingID: 'G-3TS8QLZQ93',
                 anonymizeIP: true,
-              }
-            : undefined,
+              },
       }),
     ],
   ],

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -90,7 +90,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag:
-          process.env.NODE_ENV === 'production'
+          process.env.NODE_ENV !== 'development'
             ? {
                 trackingID: 'G-3TS8QLZQ93',
                 anonymizeIP: true,

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "NODE_ENV=development docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Conditionally enable Google Analytics tracking script (gtag) only in production mode to prevent errors in development.
- Updated `docusaurus.config.js` to check `NODE_ENV` before enabling gtag.
- Adjusted the `start` script in `package.json` to explicitly set `NODE_ENV=development`. No breaking changes.