### PR TITLE
feat: add --filter-errors-only parameter to `eval`

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -33,6 +33,7 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 | `--description <description>`       | Description of the eval run                                             |
 | `--env-file, --env-path <path>`     | Path to .env file                                                       |
 | `--filter-failing <path>`           | Path to JSON output file with failing tests                             |
+| `--filter-errors-only <path>`       | Path to JSON output file with error tests                               |
 | `-n, --filter-first-n <number>`     | Only run the first N tests                                              |
 | `--filter-sample <number>`          | Only run a random sample of N tests                                     |
 | `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                |

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -517,6 +517,7 @@ export function evalCommand(
     )
     .option('--filter-sample <number>', 'Only run a random sample of N tests')
     .option('--filter-failing <path>', 'Path to json output file')
+    .option('--filter-errors-only <path>', 'Path to json output file with error tests')
     .option(
       '--filter-metadata <key=value>',
       'Only run tests whose metadata matches the key=value pair (e.g. --filter-metadata pluginId=debug-access)',

--- a/src/commands/eval/filterErrorTests.ts
+++ b/src/commands/eval/filterErrorTests.ts
@@ -1,0 +1,24 @@
+import type { TestSuite } from '../../types';
+import { ResultFailureReason } from '../../types';
+import { readOutput, resultIsForTestCase } from '../../util';
+
+type Tests = NonNullable<TestSuite['tests']>;
+
+export async function filterErrorTests(testSuite: TestSuite, outputPath: string): Promise<Tests> {
+  if (!testSuite.tests) {
+    return [];
+  }
+
+  const { results } = await readOutput(outputPath);
+  const errorResults = results.results.filter(
+    (result) => result.failureReason === ResultFailureReason.ERROR,
+  );
+
+  if (errorResults.length === 0) {
+    return [];
+  }
+
+  return [...testSuite.tests].filter((test) => {
+    return errorResults.some((result) => resultIsForTestCase(result, test));
+  }) as Tests;
+}

--- a/src/commands/eval/filterTests.ts
+++ b/src/commands/eval/filterTests.ts
@@ -1,5 +1,6 @@
 import logger from '../../logger';
 import type { TestSuite } from '../../types';
+import { filterErrorTests } from './filterErrorTests';
 import { filterFailingTests } from './filterFailingTests';
 
 interface FilterOptions {
@@ -8,6 +9,7 @@ interface FilterOptions {
   metadata?: string;
   pattern?: string;
   sample?: number | string;
+  errorsOnly?: string;
 }
 
 type Tests = TestSuite['tests'];
@@ -50,6 +52,10 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
 
   if (options.failing) {
     tests = await filterFailingTests(testSuite, options.failing);
+  }
+
+  if (options.errorsOnly) {
+    tests = await filterErrorTests(testSuite, options.errorsOnly);
   }
 
   if (options.pattern) {

--- a/test/commands/eval/filterErrorTests.test.ts
+++ b/test/commands/eval/filterErrorTests.test.ts
@@ -1,0 +1,119 @@
+import { filterErrorTests } from '../../../src/commands/eval/filterErrorTests';
+import { ResultFailureReason, type EvaluateSummaryV2, type TestSuite } from '../../../src/types';
+import { readOutput } from '../../../src/util';
+
+jest.mock('../../../src/util', () => {
+  return {
+    ...jest.requireActual('../../../src/util'),
+    readOutput: jest.fn(),
+  };
+});
+
+describe('filterErrorTests', () => {
+  const varsSuccess = { successKey: 'value' };
+  const varsError = { errorKey: 'value' };
+  const successTest = { vars: varsSuccess };
+  const errorTest = { vars: varsError };
+  const testSuite = {
+    tests: [successTest, errorTest],
+  } as unknown as TestSuite;
+  const outputPath = 'outputPath.json';
+  const restResult = {
+    prompt: {
+      raw: 'prompt',
+      label: 'prompt',
+    },
+    score: 0.5,
+    latencyMs: 1_000,
+    namedScores: {},
+  };
+
+  beforeEach(() => {
+    jest.mocked(readOutput).mockResolvedValue({
+      results: {
+        version: 2,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        results: [
+          {
+            ...restResult,
+            success: true,
+            failureReason: ResultFailureReason.NONE,
+            provider: { id: 'provider1' },
+            vars: varsSuccess,
+            promptIdx: 0,
+            testIdx: 0,
+            testCase: {},
+            promptId: 'foo',
+          },
+          {
+            ...restResult,
+            success: false,
+            failureReason: ResultFailureReason.ERROR,
+            provider: { id: 'provider2' },
+            vars: varsError,
+            promptIdx: 0,
+            testIdx: 0,
+            testCase: {},
+            promptId: 'foo',
+          },
+        ],
+        table: {} as any,
+        stats: {} as any,
+      } as EvaluateSummaryV2,
+    } as any);
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  it('can filter using vars', async () => {
+    const result = await filterErrorTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([errorTest]);
+  });
+
+  it('can filter using test provider', async () => {
+    const errorTest1 = { provider: 'provider1', vars: varsError };
+    const errorTest2 = { provider: 'provider2', vars: varsError };
+    const testSuite = {
+      tests: [errorTest1, errorTest2],
+    } as unknown as TestSuite;
+
+    const result = await filterErrorTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([errorTest2]);
+  });
+
+  it('returns empty array when no error tests', async () => {
+    jest.mocked(readOutput).mockResolvedValue({
+      results: {
+        version: 2,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        results: [
+          {
+            success: true,
+            failureReason: ResultFailureReason.NONE,
+            provider: { id: 'provider1' },
+            vars: varsSuccess,
+            prompt: {
+              raw: 'prompt',
+              label: 'prompt',
+            },
+            score: 0.5,
+            latencyMs: 1000,
+            namedScores: {},
+            promptIdx: 0,
+            testIdx: 0,
+            testCase: {},
+            promptId: 'foo',
+          },
+        ],
+        table: {} as any,
+        stats: {} as any,
+      } as EvaluateSummaryV2,
+    } as any);
+
+    const result = await filterErrorTests(testSuite, outputPath);
+
+    expect(result).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
This allows you to re-run only the test cases that failed due to network errors or other types of errors