### PR TITLE
Included a note to the "Adding custom tests" section of the redteam docs

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -778,6 +778,13 @@ There are two approaches:
 
 1. Run these tests as a separate evaluation. See the [getting started](https://www.promptfoo.dev/docs/getting-started/) guide for evaluations. For grading, you will likely want to use the [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric/) or [`moderation`](/docs/configuration/expected-outputs/moderation/) assertion types.
 2. You can also add your custom tests to the `tests` section of the generated `redteam.yaml` configuration file.
+  > [!NOTE]
+  > When adding custom test cases to already geenrated `redteam.yaml` file, please ensure that you do not remove the metadata section at the very end which has the configHash value.
+  >```
+  > metadata:
+  >     configHash: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  > ```
+  > If this metadata section (shown above) is deleted, the test cases will be geenrated again when you execute `promptfoo redteam run`. The `redteam.yaml` file will be overwritten removing custom cases you may have added.
 
 Either way, this will allow you to evaluate your custom tests.
 

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -777,7 +777,7 @@ In some cases, you may already have a set of tests that you want to use in addit
 There are two approaches:
 
 1. Run these tests as a separate evaluation. See the [getting started](https://www.promptfoo.dev/docs/getting-started/) guide for evaluations. For grading, you will likely want to use the [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric/) or [`moderation`](/docs/configuration/expected-outputs/moderation/) assertion types.
-1. You can also add your custom tests to the `tests` section of the generated `redteam.yaml` configuration file.
+2. You can also add your custom tests to the `tests` section of the generated `redteam.yaml` configuration file.
 
 Either way, this will allow you to evaluate your custom tests.
 


### PR DESCRIPTION
Previously the section stated:

```
In some cases, you may already have a set of tests that you want to use in addition to the ones that Promptfoo generates.

There are two approaches:

   1. Run these tests as a separate evaluation. See the [getting started](https://www.promptfoo.dev/docs/getting-started/) guide for evaluations. For grading, you will likely want to use the [llm-rubric](https://www.promptfoo.dev/docs/configuration/expected-outputs/model-graded/llm-rubric/) or [moderation](https://www.promptfoo.dev/docs/configuration/expected-outputs/moderation/) assertion types.
   2. You can also add your custom tests to the tests section of the generated redteam.yaml configuration file.

Either way, this will allow you to evaluate your custom tests.
``` 

However, when trying the second approach, I found out that the last metadata section in redteam.yaml file which contains the configHash value has to be preserved, when adding the custom cases. On the face of it, it may seem like adding content to the file would require removing hash (so as to not fail the file integrity checks), but doing so just generates the dynamic test cases again and overwrites any custom cases an user may have added. Hopefully, this note would provide some more guidance on how to go about implementing the custom cases via editing the redteam.yaml file.