### PR TITLE
docs: update configuration.md

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -777,7 +777,14 @@ In some cases, you may already have a set of tests that you want to use in addit
 There are two approaches:
 
 1. Run these tests as a separate evaluation. See the [getting started](https://www.promptfoo.dev/docs/getting-started/) guide for evaluations. For grading, you will likely want to use the [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric/) or [`moderation`](/docs/configuration/expected-outputs/moderation/) assertion types.
-1. You can also add your custom tests to the `tests` section of the generated `redteam.yaml` configuration file.
+2. You can also add your custom tests to the `tests` section of the generated `redteam.yaml` configuration file.
+  > [!NOTE]
+  > When adding custom test cases to already geenrated `redteam.yaml` file, please ensure that you do not remove the metadata section at the very end which has the configHash value.
+  >```
+  > metadata:
+  >     configHash: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  > ```
+  > If this metadata section (shown above) is deleted, the test cases will be geenrated again when you execute `promptfoo redteam run`. The `redteam.yaml` file will be overwritten removing custom cases you may have added.
 
 Either way, this will allow you to evaluate your custom tests.
 


### PR DESCRIPTION
 Updated the "Adding custom tests" section of the redteam docs to indicate that removing metadata containing hash values will result in the custom cases added to redteam.yaml being lost and overwritten.