### PR TITLE
docs(redteam): update configuration.md

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -781,6 +781,10 @@ There are two approaches:
 
 Either way, this will allow you to evaluate your custom tests.
 
+:::warning
+When adding custom test cases to already geenrated `redteam.yaml` file, please ensure that you do not remove the metadata section at the very end which contains the configHash value.
+:::
+
 ### Loading custom tests from CSV
 
 Promptfoo supports loading tests from CSV as well as Google Sheets. See [CSV loading](/docs/configuration/guide/#loading-tests-from-csv) and [Google Sheets](/docs/integrations/google-sheets/) for more info.


### PR DESCRIPTION
Updated the "Adding custom tests" section of the redteam docs to indicate that removing metadata containing hash values will result in the custom cases added to redteam.yaml being lost and overwritten.