### PR TITLE
chore(providers): add support for the WATSONX_AI_AUTH_TYPE env

### DIFF
--- a/examples/watsonx/README.md
+++ b/examples/watsonx/README.md
@@ -1,4 +1,23 @@
-To get started, set your `WATSONX_AI_APIKEY` or `WATSONX_AI_BEARER_TOKEN`, and `WATSONX_AI_PROJECT_ID` environment variables.
+To get started, you need to set up authentication and project ID. You can choose between two authentication methods:
+
+**Option 1: IAM Authentication**
+```sh
+export WATSONX_AI_AUTH_TYPE=iam
+export WATSONX_AI_APIKEY=your-ibm-cloud-api-key
+```
+
+**Option 2: Bearer Token Authentication**
+```sh
+export WATSONX_AI_AUTH_TYPE=bearertoken
+export WATSONX_AI_BEARER_TOKEN=your-ibm-cloud-bearer-token
+```
+
+Then set your project ID:
+```sh
+export WATSONX_AI_PROJECT_ID=your-ibm-project-id
+```
+
+Note: If `WATSONX_AI_AUTH_TYPE` is not set, the provider will automatically choose the authentication method based on which credentials are available, preferring IAM authentication if both are present.
 
 Follow the instructions in [watsonx.md](../../site/docs/providers/watsonx.md) to retrieve your API keys, bearer token, and project ID.
 
@@ -6,13 +25,13 @@ Next, edit promptfooconfig.yaml.
 
 Then run:
 
-```
+```sh
 npm run local -- eval --config examples/watsonx/promptfooconfig.yaml
 ```
 
 or
 
-```
+```sh
 promptfoo eval
 ```
 

--- a/examples/watsonx/README.md
+++ b/examples/watsonx/README.md
@@ -1,18 +1,21 @@
 To get started, you need to set up authentication and project ID. You can choose between two authentication methods:
 
 **Option 1: IAM Authentication**
+
 ```sh
 export WATSONX_AI_AUTH_TYPE=iam
 export WATSONX_AI_APIKEY=your-ibm-cloud-api-key
 ```
 
 **Option 2: Bearer Token Authentication**
+
 ```sh
 export WATSONX_AI_AUTH_TYPE=bearertoken
 export WATSONX_AI_BEARER_TOKEN=your-ibm-cloud-bearer-token
 ```
 
 Then set your project ID:
+
 ```sh
 export WATSONX_AI_PROJECT_ID=your-ibm-project-id
 ```

--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -69,18 +69,21 @@ To install the WatsonX provider, use the following steps:
    You can choose between two authentication methods:
 
    **Option 1: IAM Authentication**
+
    ```sh
    export WATSONX_AI_AUTH_TYPE=iam
    export WATSONX_AI_APIKEY=your-ibm-cloud-api-key
    ```
 
    **Option 2: Bearer Token Authentication**
+
    ```sh
    export WATSONX_AI_AUTH_TYPE=bearertoken
    export WATSONX_AI_BEARER_TOKEN=your-ibm-cloud-bearer-token
    ```
 
    Then set your project ID:
+
    ```sh
    export WATSONX_AI_PROJECT_ID=your-ibm-project-id
    ```
@@ -95,10 +98,10 @@ To install the WatsonX provider, use the following steps:
        config:
          # Option 1: IAM Authentication
          apiKey: your-ibm-cloud-api-key
-         
+
          # Option 2: Bearer Token Authentication
          # apiBearerToken: your-ibm-cloud-bearer-token
-         
+
          projectId: your-ibm-project-id
          serviceUrl: https://us-south.ml.cloud.ibm.com
    ```

--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -66,31 +66,41 @@ To install the WatsonX provider, use the following steps:
 
 2. Set up the necessary environment variables:
 
+   You can choose between two authentication methods:
+
+   **Option 1: IAM Authentication**
    ```sh
+   export WATSONX_AI_AUTH_TYPE=iam
    export WATSONX_AI_APIKEY=your-ibm-cloud-api-key
    ```
 
-   or
-
-   ```
+   **Option 2: Bearer Token Authentication**
+   ```sh
+   export WATSONX_AI_AUTH_TYPE=bearertoken
    export WATSONX_AI_BEARER_TOKEN=your-ibm-cloud-bearer-token
    ```
 
-   then
-
-   ```
+   Then set your project ID:
+   ```sh
    export WATSONX_AI_PROJECT_ID=your-ibm-project-id
    ```
 
-3. Alternatively, you can configure the API key and project ID directly in the configuration file.
+   Note: If `WATSONX_AI_AUTH_TYPE` is not set, the provider will automatically choose the authentication method based on which credentials are available, preferring IAM authentication if both are present.
+
+3. Alternatively, you can configure the authentication and project ID directly in the configuration file:
 
    ```yaml
    providers:
      - id: watsonx:ibm/granite-13b-chat-v2
-     config:
-       apiKey: your-ibm-cloud-api-key # replace with apiBearerToken if you are using bearer token instead of apikey
-       projectId: your-ibm-project-id
-       serviceUrl: https://us-south.ml.cloud.ibm.com
+       config:
+         # Option 1: IAM Authentication
+         apiKey: your-ibm-cloud-api-key
+         
+         # Option 2: Bearer Token Authentication
+         # apiBearerToken: your-ibm-cloud-bearer-token
+         
+         projectId: your-ibm-project-id
+         serviceUrl: https://us-south.ml.cloud.ibm.com
    ```
 
 ### Usage Examples

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -122,6 +122,7 @@ export type EnvVars = {
   WATSONX_AI_APIKEY?: string;
   WATSONX_AI_PROJECT_ID?: string;
   WATSONX_AI_BEARER_TOKEN?: string;
+  WATSONX_AI_AUTH_TYPE?: string;
 
   // node/npm
   NODE_ENV?: string;

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -380,6 +380,16 @@ export class WatsonXProvider implements ApiProvider {
       this.env?.WATSONX_AI_BEARER_TOKEN ||
       getEnvString('WATSONX_AI_BEARER_TOKEN');
 
+    const authType = this.env?.WATSONX_AI_AUTH_TYPE || getEnvString('WATSONX_AI_AUTH_TYPE');
+
+    if (authType === 'iam' && apiKey) {
+      logger.info('Using IAM Authentication based on WATSONX_AI_AUTH_TYPE.');
+      return new IamAuthenticator({ apikey: apiKey });
+    } else if (authType === 'bearertoken' && bearerToken) {
+      logger.info('Using Bearer Token Authentication based on WATSONX_AI_AUTH_TYPE.');
+      return new BearerTokenAuthenticator({ bearerToken });
+    }
+
     if (apiKey) {
       logger.info('Using IAM Authentication.');
       return new IamAuthenticator({ apikey: apiKey });

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -52,4 +52,5 @@ export type EnvOverrides = {
   WATSONX_AI_APIKEY?: string;
   WATSONX_AI_PROJECT_ID?: string;
   WATSONX_AI_BEARER_TOKEN?: string;
+  WATSONX_AI_AUTH_TYPE?: string;
 };

--- a/test/providers/watsonx.test.ts
+++ b/test/providers/watsonx.test.ts
@@ -170,6 +170,73 @@ describe('WatsonXProvider', () => {
         authenticator: expect.any(IamAuthenticator),
       });
     });
+
+    it('should use IAM Authentication when WATSONX_AI_AUTH_TYPE is set to iam', async () => {
+      const dualAuthConfig = { ...config, apiBearerToken: 'test-bearer-token' };
+      const mockedWatsonXAIClient: Partial<any> = {
+        generateText: jest.fn(),
+      };
+      jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
+
+      const provider = new WatsonXProvider(modelName, { 
+        config: dualAuthConfig,
+        env: { WATSONX_AI_AUTH_TYPE: 'iam' }
+      });
+      await provider.getClient();
+
+      expect(logger.info).toHaveBeenCalledWith('Using IAM Authentication based on WATSONX_AI_AUTH_TYPE.');
+      expect(WatsonXAI.newInstance).toHaveBeenCalledWith({
+        version: '2023-05-29',
+        serviceUrl: 'https://us-south.ml.cloud.ibm.com',
+        authenticator: expect.any(IamAuthenticator),
+      });
+    });
+
+    it('should use Bearer Token Authentication when WATSONX_AI_AUTH_TYPE is set to bearertoken', async () => {
+      const dualAuthConfig = { 
+        ...config, 
+        apiKey: 'test-api-key',
+        apiBearerToken: 'test-bearer-token'
+      };
+      const mockedWatsonXAIClient: Partial<any> = {
+        generateText: jest.fn(),
+      };
+      jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
+
+      const provider = new WatsonXProvider(modelName, { 
+        config: dualAuthConfig,
+        env: { WATSONX_AI_AUTH_TYPE: 'bearertoken' }
+      });
+      await provider.getClient();
+
+      expect(logger.info).toHaveBeenCalledWith('Using Bearer Token Authentication based on WATSONX_AI_AUTH_TYPE.');
+      expect(WatsonXAI.newInstance).toHaveBeenCalledWith({
+        version: '2023-05-29',
+        serviceUrl: 'https://us-south.ml.cloud.ibm.com',
+        authenticator: expect.any(BearerTokenAuthenticator),
+      });
+    });
+
+    it('should fallback to default behavior when WATSONX_AI_AUTH_TYPE is invalid', async () => {
+      const dualAuthConfig = { ...config, apiBearerToken: 'test-bearer-token' };
+      const mockedWatsonXAIClient: Partial<any> = {
+        generateText: jest.fn(),
+      };
+      jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
+
+      const provider = new WatsonXProvider(modelName, { 
+        config: dualAuthConfig,
+        env: { WATSONX_AI_AUTH_TYPE: 'invalid' }
+      });
+      await provider.getClient();
+
+      expect(logger.info).toHaveBeenCalledWith('Using IAM Authentication.');
+      expect(WatsonXAI.newInstance).toHaveBeenCalledWith({
+        version: '2023-05-29',
+        serviceUrl: 'https://us-south.ml.cloud.ibm.com',
+        authenticator: expect.any(IamAuthenticator),
+      });
+    });
   });
 
   describe('callApi', () => {

--- a/test/providers/watsonx.test.ts
+++ b/test/providers/watsonx.test.ts
@@ -178,13 +178,15 @@ describe('WatsonXProvider', () => {
       };
       jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
 
-      const provider = new WatsonXProvider(modelName, { 
+      const provider = new WatsonXProvider(modelName, {
         config: dualAuthConfig,
-        env: { WATSONX_AI_AUTH_TYPE: 'iam' }
+        env: { WATSONX_AI_AUTH_TYPE: 'iam' },
       });
       await provider.getClient();
 
-      expect(logger.info).toHaveBeenCalledWith('Using IAM Authentication based on WATSONX_AI_AUTH_TYPE.');
+      expect(logger.info).toHaveBeenCalledWith(
+        'Using IAM Authentication based on WATSONX_AI_AUTH_TYPE.',
+      );
       expect(WatsonXAI.newInstance).toHaveBeenCalledWith({
         version: '2023-05-29',
         serviceUrl: 'https://us-south.ml.cloud.ibm.com',
@@ -193,23 +195,25 @@ describe('WatsonXProvider', () => {
     });
 
     it('should use Bearer Token Authentication when WATSONX_AI_AUTH_TYPE is set to bearertoken', async () => {
-      const dualAuthConfig = { 
-        ...config, 
+      const dualAuthConfig = {
+        ...config,
         apiKey: 'test-api-key',
-        apiBearerToken: 'test-bearer-token'
+        apiBearerToken: 'test-bearer-token',
       };
       const mockedWatsonXAIClient: Partial<any> = {
         generateText: jest.fn(),
       };
       jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
 
-      const provider = new WatsonXProvider(modelName, { 
+      const provider = new WatsonXProvider(modelName, {
         config: dualAuthConfig,
-        env: { WATSONX_AI_AUTH_TYPE: 'bearertoken' }
+        env: { WATSONX_AI_AUTH_TYPE: 'bearertoken' },
       });
       await provider.getClient();
 
-      expect(logger.info).toHaveBeenCalledWith('Using Bearer Token Authentication based on WATSONX_AI_AUTH_TYPE.');
+      expect(logger.info).toHaveBeenCalledWith(
+        'Using Bearer Token Authentication based on WATSONX_AI_AUTH_TYPE.',
+      );
       expect(WatsonXAI.newInstance).toHaveBeenCalledWith({
         version: '2023-05-29',
         serviceUrl: 'https://us-south.ml.cloud.ibm.com',
@@ -224,9 +228,9 @@ describe('WatsonXProvider', () => {
       };
       jest.mocked(WatsonXAI.newInstance).mockReturnValue(mockedWatsonXAIClient as any);
 
-      const provider = new WatsonXProvider(modelName, { 
+      const provider = new WatsonXProvider(modelName, {
         config: dualAuthConfig,
-        env: { WATSONX_AI_AUTH_TYPE: 'invalid' }
+        env: { WATSONX_AI_AUTH_TYPE: 'invalid' },
       });
       await provider.getClient();
 


### PR DESCRIPTION
This PR adds a new environment variable, **WATSONX_AI_AUTH_TYPE**, to let users choose the authentication method for watsonx.ai (iam or bearertoken). It simplifies authentication setup by allowing control over which method to use.

1. Added support for **WATSONX_AI_AUTH_TYPE**:
- Set iam to use IAM authentication with **WATSONX_AI_APIKEY**.
- Set bearertoken to use Bearer Token authentication with **WATSONX_AI_BEARER_TOKEN**.
- If WATSONX_AI_AUTH_TYPE is not set, the system will try to detect the method based on the available keys.

2. Updated logic to give WATSONX_AI_AUTH_TYPE the highest priority.