### PR TITLE
docs: updating typo for g-eval pages

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -144,7 +144,7 @@ See [Model-graded evals](/docs/configuration/expected-outputs/model-graded), [cl
 | [similar](/docs/configuration/expected-outputs/similar)                               | Embeddings and cosine similarity are above a threshold                          |
 | [classifier](/docs/configuration/expected-outputs/classifier)                         | Run LLM output through a classifier                                             |
 | [llm-rubric](/docs/configuration/expected-outputs/model-graded)                       | LLM output matches a given rubric, using a Language Model to grade output       |
-| [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                      | Chain-of-thought evaluation based on custom criteria using the G-Eval framework |
+| [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                    | Chain-of-thought evaluation based on custom criteria using the G-Eval framework |
 | [answer-relevance](/docs/configuration/expected-outputs/model-graded)                 | Ensure that LLM output is related to original query                             |
 | [context-faithfulness](/docs/configuration/expected-outputs/model-graded)             | Ensure that LLM output uses the context                                         |
 | [context-recall](/docs/configuration/expected-outputs/model-graded)                   | Ensure that ground truth appears in context                                     |

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -144,7 +144,7 @@ See [Model-graded evals](/docs/configuration/expected-outputs/model-graded), [cl
 | [similar](/docs/configuration/expected-outputs/similar)                               | Embeddings and cosine similarity are above a threshold                          |
 | [classifier](/docs/configuration/expected-outputs/classifier)                         | Run LLM output through a classifier                                             |
 | [llm-rubric](/docs/configuration/expected-outputs/model-graded)                       | LLM output matches a given rubric, using a Language Model to grade output       |
-| [geval](/docs/configuration/expected-outputs/model-graded/geval)                      | Chain-of-thought evaluation based on custom criteria using the G-Eval framework |
+| [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                      | Chain-of-thought evaluation based on custom criteria using the G-Eval framework |
 | [answer-relevance](/docs/configuration/expected-outputs/model-graded)                 | Ensure that LLM output is related to original query                             |
 | [context-faithfulness](/docs/configuration/expected-outputs/model-graded)             | Ensure that LLM output uses the context                                         |
 | [context-recall](/docs/configuration/expected-outputs/model-graded)                   | Ensure that ground truth appears in context                                     |

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -12,7 +12,7 @@ To use G-Eval in your test configuration:
 
 ```yaml
 assert:
-  - type: geval
+  - type: g-eval
     value: 'Ensure the response is factually accurate and well-structured'
     threshold: 0.7 # Optional, defaults to 0.7
 ```
@@ -21,7 +21,7 @@ You can also provide multiple evaluation criteria as an array:
 
 ```yaml
 assert:
-  - type: geval
+  - type: g-eval
     value:
       - 'Check if the response maintains a professional tone'
       - 'Verify that all technical terms are used correctly'
@@ -44,7 +44,7 @@ Like other model-graded assertions, you can override the default GPT-4o evaluato
 
 ```yaml
 assert:
-  - type: geval
+  - type: g-eval
     value: 'Ensure response is factually accurate'
     provider: openai:gpt-4o-mini
 ```
@@ -72,7 +72,7 @@ tests:
   - vars:
       topic: 'quantum computing'
     assert:
-      - type: geval
+      - type: g-eval
         value:
           - 'Explains technical concepts in simple terms'
           - 'Maintains accuracy without oversimplification'

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -11,7 +11,7 @@ Output-based:
 - [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric) - checks if the LLM output matches given requirements, using a language model to grade the output based on the rubric.
 - [`model-graded-closedqa`](/docs/configuration/expected-outputs/model-graded/model-graded-closedqa) - similar to the above, a "criteria-checking" eval that ensures the answer meets a specific requirement. Uses an OpenAI-authored prompt from their public evals.
 - [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - a factual consistency eval which, given a completion `A` and reference answer `B` evaluates whether A is a subset of B, A is a superset of B, A and B are equivalent, A and B disagree, or A and B differ, but difference don't matter from the perspective of factuality. Uses the prompt from OpenAI's public evals.
-- [`geval`](/docs/configuration/expected-outputs/model-graded/geval) - uses chain-of-thought prompting to evaluate outputs based on custom criteria, following the G-Eval framework.
+- [`g-eval`](/docs/configuration/expected-outputs/model-graded/g-eval) - uses chain-of-thought prompting to evaluate outputs based on custom criteria, following the G-Eval framework.
 - [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - ensure that LLM output is related to original query
 - [`classifier`](/docs/configuration/expected-outputs/classifier) - see classifier grading docs.
 - [`moderation`](/docs/configuration/expected-outputs/moderation) - see moderation grading docs.


### PR DESCRIPTION
- updating code example to use correct assertion type as defined in code (`g-eval` vs. `geval`). This is based off [examples](https://github.com/promptfoo/promptfoo/blob/7ba62815e3822c61c933e4dd0b68e2c506111843/examples/g-eval/promptfooconfig.yaml#L9) and [this](https://github.com/promptfoo/promptfoo/blob/7ba62815e3822c61c933e4dd0b68e2c506111843/src/types/index.ts#L367).
- Renaming the docs page for consistency 