### PR TITLE
fix(deps): update lock file to resolve yanked dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28395,9 +28395,9 @@
       "peer": true
     },
     "node_modules/motion-dom": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.16.0.tgz",
-      "integrity": "sha512-4bmEwajSdrljzDAYpu6ceEdtI4J5PH25fmN8YSx7Qxk6OMrC10CXM0D5y+VO/pFZjhmCvm2bGf7Rus482kwhzA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.16.1.tgz",
+      "integrity": "sha512-XVNf3iCfZn9OHPZYJQy5YXXLn0NuPNvtT3YCat89oAnr4D88Cr52KqFgKa8dWElBK8uIoQhpJMJEG+dyniYycQ==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^11.16.0"


### PR DESCRIPTION
fix(deps): update lock file to resolve yanked dependency

- Updated the package-lock.json to use motion-dom version 11.16.1 instead of the yanked 11.16.0.
- Ensures compatibility and resolves potential installation issues.