### PR TITLE
chore(assertions): improve python assertion configuration passing

### DIFF
--- a/examples/python-assert-external/assert_with_config.py
+++ b/examples/python-assert-external/assert_with_config.py
@@ -2,6 +2,7 @@ def get_assert(output, context):
     print("Prompt:", context["prompt"])
     print("Vars", context["vars"]["topic"])
     print("Context", context)
+    print("Config", context.get("config", {}))
 
     test_configuration = context.get("config", {})
     canonical_fruit_list = test_configuration.get("fruitList", [])

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -139,18 +139,8 @@ export async function runAssertion({
     logProbs,
     provider,
     providerResponse,
-    ...(assertion.config ? { config: assertion.config } : {}),
+    ...(assertion.config ? { config: structuredClone(assertion.config) } : {}),
   };
-
-  const assertList = test['assert'] ? test['assert'] : [];
-  if (assertIndex !== undefined && assertIndex >= 0 && assertIndex < assertList.length) {
-    // HACK but treat the deserialized config as a brand new object
-    // thus eliminating the possibility of a circular reference
-    const assertionConfig = assertList[assertIndex] ? assertList[assertIndex]['config'] : {};
-    if (assertionConfig !== undefined) {
-      context.config = JSON.parse(JSON.stringify(assertionConfig));
-    }
-  }
 
   // Render assertion values
   let renderedValue = assertion.value;

--- a/test/assertions/index.test.ts
+++ b/test/assertions/index.test.ts
@@ -574,11 +574,6 @@ describe('runAssertion', () => {
     },
   };
 
-  const javascriptBooleanAssertionWithoutConfig: Assertion = {
-    type: 'javascript',
-    value: 'output.length <= context.config.maximumOutputSize',
-  };
-
   const javascriptStringAssertionWithNumberAndThreshold: Assertion = {
     type: 'javascript',
     value: 'output.length * 10',

--- a/test/assertions/index.test.ts
+++ b/test/assertions/index.test.ts
@@ -1557,34 +1557,6 @@ describe('runAssertion', () => {
     });
   });
 
-  it('should correctly set configuration from the test case when assert index is valid', async () => {
-    const output = 'Expected output';
-
-    const result: GradingResult = await runAssertion({
-      prompt: 'Some prompt',
-      provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
-      assertion: javascriptBooleanAssertionWithoutConfig,
-      test: {
-        assert: [
-          {
-            type: 'javascript',
-            value: 'output.length <= context.config.maximumOutputSize',
-            config: {
-              maximumOutputSize: 50,
-            },
-          } as Assertion,
-        ],
-      } as AtomicTestCase,
-      providerResponse: { output },
-      assertIndex: 0,
-    });
-    expect(result).toMatchObject({
-      pass: true,
-      score: 1.0,
-      reason: 'Assertion passed',
-    });
-  });
-
   it('should fail when javascript returns an output string that is larger than the maximum size threshold', async () => {
     const output = 'Expected output with some extra characters';
 


### PR DESCRIPTION
As was pointed out by @kmeshcheryakov in #1771, there was an issue with the `jsonSafeStringify` function that prevented the configuration from being passed into python assertions cleanly. The previous PR "fixed" the problem but did it in a hacky way. The cleaner way is to just do a deep clone of the configuration object before it is passed into any of the run functions (for Python or for JS) thus ensuring that any serialization that removes circular references will not strip the configuration inadvertently.

Final fix for #1729 