### PR TITLE
fix(redteam): remove ascii-smuggling strategy

### DIFF
--- a/site/docs/_shared/data/strategies.ts
+++ b/site/docs/_shared/data/strategies.ts
@@ -14,17 +14,6 @@ export interface Strategy {
 export const strategies: Strategy[] = [
   {
     category: 'Static (Single-Turn)',
-    strategy: 'ascii-smuggling',
-    displayName: 'ASCII Smuggling',
-    description: 'Unicode tag-based instruction smuggling',
-    longDescription:
-      'Tests system resilience against Unicode tag-based instruction smuggling attacks that can bypass content filters and security controls',
-    cost: 'Low',
-    asrIncrease: '20-30%',
-    link: '/docs/red-team/strategies/ascii-smuggling/',
-  },
-  {
-    category: 'Static (Single-Turn)',
     strategy: 'base64',
     displayName: 'Base64',
     description: 'Base64 encoding bypass',

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -1181,7 +1181,6 @@
                           "jailbreak",
                           "jailbreak:composite",
                           "prompt-injection",
-                          "ascii-smuggling",
                           "base64",
                           "citation",
                           "crescendo",
@@ -1219,7 +1218,7 @@
                   }
                 ]
               },
-              "description": "Strategies to use for redteam generation.\n\nDefaults to jailbreak, jailbreak:composite\nSupports basic, default, jailbreak, jailbreak:composite, prompt-injection, ascii-smuggling, base64, citation, crescendo, goat, jailbreak:tree, leetspeak, math-prompt, multilingual, rot13, best-of-n",
+              "description": "Strategies to use for redteam generation.\n\nDefaults to jailbreak, jailbreak:composite\nSupports basic, default, jailbreak, jailbreak:composite, prompt-injection, base64, citation, crescendo, goat, jailbreak:tree, leetspeak, math-prompt, multilingual, rot13, best-of-n",
               "default": [
                 "default"
               ]

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -509,7 +509,6 @@ export type AgenticStrategy = (typeof AGENTIC_STRATEGIES)[number];
 
 export const ADDITIONAL_STRATEGIES = [
   'prompt-injection',
-  'ascii-smuggling',
   'base64',
   'citation',
   'crescendo',
@@ -1007,7 +1006,6 @@ export const pluginDescriptions: Record<Plugin, string> = {
 };
 
 export const strategyDescriptions: Record<Strategy, string> = {
-  'ascii-smuggling': 'Evaluates system resilience against Unicode tag-based instruction smuggling',
   base64: 'Tests detection and handling of Base64-encoded malicious payloads',
   basic: 'Establishes baseline security posture through fundamental test cases',
   'best-of-n': 'Jailbreak technique published by Anthropic and Stanford',
@@ -1026,7 +1024,6 @@ export const strategyDescriptions: Record<Strategy, string> = {
 };
 
 export const strategyDisplayNames: Record<Strategy, string> = {
-  'ascii-smuggling': 'ASCII Smuggling',
   base64: 'Base64 Encoding',
   basic: 'Basic',
   'best-of-n': 'Best-of-N',


### PR DESCRIPTION
This PR removes the 'ascii-smuggling' strategy from the red team strategies.

- Eliminated references and descriptions of the 'ascii-smuggling' strategy.
- Updated constants and data files accordingly.

It fixes the issue when using redteaming UI to generate config.yaml, it would list ascii-smuggling under strategies and it results in error:
```
Invalid redteam configuration:
Validation error: Custom strategies must start with file:// and end with .js or .ts, or use one of the built-in strategies: basic, default, jailbreak, jailbreak:composite, prompt-injection, base64, citation, crescendo, goat, jailbreak:tree, leetspeak, math-prompt, multilingual, rot13, best-of-n at "strategies[4].id"
```