### PR TITLE
feat(fetch): add support for custom SSL certificates

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -62,6 +62,21 @@ No, we do not collect any personally identifiable information (PII).
 
 Requests to most providers are made via [proxy-agent](https://www.npmjs.com/package/proxy-agent), which respects `HTTP_PROXY` and `HTTPS_PROXY` [environment variables](https://www.npmjs.com/package/proxy-from-env#environment-variables) of the form `[protocol://]<host>[:port]`.
 
+### How do I configure SSL certificates and security?
+
+For environments with custom certificate authorities (like corporate environments), you can configure SSL/TLS settings using these environment variables:
+
+1. `PROMPTFOO_CA_CERT_PATH`: Path to a custom CA certificate bundle. For example:
+
+   ```bash
+   export PROMPTFOO_CA_CERT_PATH=/path/to/ca-bundle.crt
+   ```
+
+2. `PROMPTFOO_INSECURE_SSL`: Set to `true` to disable SSL certificate verification (not recommended for production):
+   ```bash
+   export PROMPTFOO_INSECURE_SSL=true
+   ```
+
 ### How does Promptfoo integrate with existing development workflows?
 
 Promptfoo can be integrated into CI/CD pipelines via [GitHub Action](https://github.com/promptfoo/promptfoo-action), used with testing frameworks like Jest and Vitest, and incorporated into various stages of the development process.

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
+import path from 'path';
 import { ProxyAgent } from 'proxy-agent';
+import cliState from './cliState';
 import { VERSION } from './constants';
 import { getEnvInt, getEnvBool, getEnvString } from './envars';
 import logger from './logger';
@@ -55,9 +57,10 @@ export async function fetchWithProxy(
   const caCertPath = getEnvString('PROMPTFOO_CA_CERT_PATH');
   if (caCertPath) {
     try {
-      const ca = fs.readFileSync(caCertPath);
+      const resolvedPath = path.resolve(cliState.basePath || '', caCertPath);
+      const ca = fs.readFileSync(resolvedPath);
       agentOptions.ca = ca;
-      logger.debug(`Using custom CA certificate from ${caCertPath}`);
+      logger.debug(`Using custom CA certificate from ${resolvedPath}`);
     } catch (e) {
       logger.warn(`Failed to read CA certificate from ${caCertPath}: ${e}`);
     }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,6 +1,7 @@
+import fs from 'fs';
 import { ProxyAgent } from 'proxy-agent';
 import { VERSION } from './constants';
-import { getEnvInt, getEnvBool } from './envars';
+import { getEnvInt, getEnvBool, getEnvString } from './envars';
 import logger from './logger';
 import invariant from './util/invariant';
 import { sleep } from './util/time';
@@ -46,9 +47,23 @@ export async function fetchWithProxy(
     }
   }
 
-  const agent = new ProxyAgent({
-    rejectUnauthorized: false,
-  });
+  const agentOptions: Record<string, any> = {
+    rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
+  };
+
+  // Support custom CA certificates
+  const caCertPath = getEnvString('PROMPTFOO_CA_CERT_PATH');
+  if (caCertPath) {
+    try {
+      const ca = fs.readFileSync(caCertPath);
+      agentOptions.ca = ca;
+      logger.debug(`Using custom CA certificate from ${caCertPath}`);
+    } catch (e) {
+      logger.warn(`Failed to read CA certificate from ${caCertPath}: ${e}`);
+    }
+  }
+
+  const agent = new ProxyAgent(agentOptions);
 
   return fetch(finalUrl, { ...finalOptions, agent } as RequestInit);
 }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -53,4 +53,6 @@ export type EnvOverrides = {
   WATSONX_AI_PROJECT_ID?: string;
   WATSONX_AI_BEARER_TOKEN?: string;
   WATSONX_AI_AUTH_TYPE?: string;
+  PROMPTFOO_CA_CERT_PATH?: string;
+  PROMPTFOO_INSECURE_SSL?: string;
 };

--- a/src/validators/providers.ts
+++ b/src/validators/providers.ts
@@ -66,6 +66,9 @@ export const ProviderEnvOverridesSchema = z.object({
   WATSONX_AI_APIKEY: z.string().optional(),
   WATSONX_AI_PROJECT_ID: z.string().optional(),
   WATSONX_AI_BEARER_TOKEN: z.string().optional(),
+  WATSONX_AI_AUTH_TYPE: z.string().optional(),
+  PROMPTFOO_CA_CERT_PATH: z.string().optional(),
+  PROMPTFOO_INSECURE_SSL: z.string().optional(),
 });
 
 export const ProviderOptionsSchema = z

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,44 +1,157 @@
 import fs from 'fs';
+import { ProxyAgent } from 'proxy-agent';
+import { VERSION } from '../src/constants';
 import { getEnvString, getEnvBool } from '../src/envars';
-import { fetchWithProxy } from '../src/fetch';
+import {
+  fetchWithProxy,
+  fetchWithRetries,
+  fetchWithTimeout,
+  handleRateLimit,
+  isRateLimited,
+} from '../src/fetch';
+import logger from '../src/logger';
+import { sleep } from '../src/util/time';
+import { createMockResponse } from './util/utils';
 
-// Mock environment variables
+// Mock modules
+jest.mock('../src/util/time', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('proxy-agent', () => {
+  return {
+    ProxyAgent: jest.fn().mockImplementation((options) => ({
+      options,
+      // Add required agent methods
+      addRequest: jest.fn(),
+      destroy: jest.fn(),
+    })),
+  };
+});
+
+jest.mock('../src/logger');
 jest.mock('../src/envars', () => ({
   getEnvString: jest.fn(),
   getEnvBool: jest.fn(),
+  getEnvInt: jest.fn().mockReturnValue(100),
 }));
 
-// Mock fs
 jest.mock('fs', () => ({
   readFileSync: jest.fn(),
-}));
-
-jest.mock('../src/util/time', () => ({
-  sleep: jest.fn(),
 }));
 
 describe('fetchWithProxy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(global, 'fetch').mockImplementation();
+    jest.mocked(ProxyAgent).mockClear();
   });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
+  // Original tests
+  it('should add version header to all requests', async () => {
+    const url = 'https://example.com/api';
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-promptfoo-version': VERSION,
+        }),
+      }),
+    );
+  });
+
+  it('should handle URLs with basic auth credentials', async () => {
+    const url = 'https://username:password@example.com/api';
+    const options = { headers: { 'Content-Type': 'application/json' } };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+  });
+
+  it('should handle URLs without auth credentials', async () => {
+    const url = 'https://example.com/api';
+    const options = { headers: { 'Content-Type': 'application/json' } };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+  });
+
+  it('should handle invalid URLs gracefully', async () => {
+    const invalidUrl = 'not-a-url';
+    await fetchWithProxy(invalidUrl);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/URL parsing failed in fetchWithProxy: TypeError/),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(invalidUrl, expect.any(Object));
+  });
+
+  it('should preserve existing Authorization headers when no URL credentials', async () => {
+    const url = 'https://example.com/api';
+    const options = {
+      headers: {
+        Authorization: 'Bearer token123',
+        'Content-Type': 'application/json',
+      },
+    };
+
+    await fetchWithProxy(url, options);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer token123',
+          'Content-Type': 'application/json',
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+  });
+
+  // New CA certificate tests
   it('should use custom CA certificate when PROMPTFOO_CA_CERT_PATH is set', async () => {
     const mockCertPath = '/path/to/cert.pem';
     const mockCertContent = 'mock-cert-content';
 
-    (jest.mocked(getEnvString)).mockImplementation((key: string) => {
-      if (key === 'PROMPTFOO_CA_CERT_PATH') {return mockCertPath;}
+    jest.mocked(getEnvString).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_CA_CERT_PATH') {
+        return mockCertPath;
+      }
       return undefined;
     });
-    (jest.mocked(getEnvBool)).mockImplementation((key: string) => {
-      if (key === 'PROMPTFOO_INSECURE_SSL') {return false;}
+    jest.mocked(getEnvBool).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_INSECURE_SSL') {
+        return false;
+      }
       return undefined;
     });
-    (jest.mocked(fs.readFileSync)).mockReturnValue(mockCertContent);
+    jest.mocked(fs.readFileSync).mockReturnValue(mockCertContent);
 
     const mockFetch = jest.fn().mockResolvedValue(new Response());
     global.fetch = mockFetch;
@@ -46,15 +159,10 @@ describe('fetchWithProxy', () => {
     await fetchWithProxy('https://example.com');
 
     expect(fs.readFileSync).toHaveBeenCalledWith(mockCertPath);
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://example.com',
+    expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            ca: mockCertContent,
-            rejectUnauthorized: true,
-          }),
-        }),
+        ca: mockCertContent,
+        rejectUnauthorized: true,
       }),
     );
   });
@@ -62,11 +170,13 @@ describe('fetchWithProxy', () => {
   it('should handle missing CA certificate file gracefully', async () => {
     const mockCertPath = '/path/to/nonexistent.pem';
 
-    (jest.mocked(getEnvString)).mockImplementation((key: string) => {
-      if (key === 'PROMPTFOO_CA_CERT_PATH') {return mockCertPath;}
+    jest.mocked(getEnvString).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_CA_CERT_PATH') {
+        return mockCertPath;
+      }
       return undefined;
     });
-    (jest.mocked(fs.readFileSync)).mockImplementation(() => {
+    jest.mocked(fs.readFileSync).mockImplementation(() => {
       throw new Error('File not found');
     });
 
@@ -76,22 +186,19 @@ describe('fetchWithProxy', () => {
     await fetchWithProxy('https://example.com');
 
     expect(fs.readFileSync).toHaveBeenCalledWith(mockCertPath);
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://example.com',
+    expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: true,
-          }),
-        }),
+        rejectUnauthorized: true,
       }),
     );
   });
 
   it('should disable SSL verification when PROMPTFOO_INSECURE_SSL is true', async () => {
-    (jest.mocked(getEnvString)).mockReturnValue(undefined);
-    (jest.mocked(getEnvBool)).mockImplementation((key: string) => {
-      if (key === 'PROMPTFOO_INSECURE_SSL') {return true;}
+    jest.mocked(getEnvString).mockReturnValue(undefined);
+    jest.mocked(getEnvBool).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_INSECURE_SSL') {
+        return true;
+      }
       return undefined;
     });
 
@@ -100,15 +207,155 @@ describe('fetchWithProxy', () => {
 
     await fetchWithProxy('https://example.com');
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://example.com',
+    expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false,
-          }),
-        }),
+        rejectUnauthorized: false,
       }),
     );
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'fetch').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should resolve when fetch completes before timeout', async () => {
+    const mockResponse = createMockResponse({ ok: true });
+    jest.mocked(global.fetch).mockImplementationOnce(() => Promise.resolve(mockResponse));
+
+    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
+    await expect(fetchPromise).resolves.toBe(mockResponse);
+  });
+
+  it('should reject when request times out', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 6000)));
+
+    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
+    jest.advanceTimersByTime(5000);
+
+    await expect(fetchPromise).rejects.toThrow('Request timed out after 5000 ms');
+  });
+});
+
+describe('isRateLimited', () => {
+  it('should detect standard rate limit headers', () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'X-RateLimit-Remaining': '0',
+      }),
+      status: 200,
+    });
+    expect(isRateLimited(response)).toBe(true);
+  });
+
+  it('should detect 429 status code', () => {
+    const response = createMockResponse({
+      status: 429,
+    });
+    expect(isRateLimited(response)).toBe(true);
+  });
+
+  it('should detect OpenAI specific rate limits', () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'x-ratelimit-remaining-requests': '0',
+      }),
+    });
+    expect(isRateLimited(response)).toBe(true);
+
+    const tokenResponse = createMockResponse({
+      headers: new Headers({
+        'x-ratelimit-remaining-tokens': '0',
+      }),
+    });
+    expect(isRateLimited(tokenResponse)).toBe(true);
+  });
+});
+
+describe('handleRateLimit', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.mocked(sleep).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should handle OpenAI reset headers', async () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'x-ratelimit-reset-requests': '5',
+      }),
+    });
+
+    const promise = handleRateLimit(response);
+    jest.advanceTimersByTime(5000);
+    await promise;
+
+    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
+  });
+
+  it('should handle standard rate limit reset headers', async () => {
+    const futureTime = Math.floor((Date.now() + 5000) / 1000);
+    const response = createMockResponse({
+      headers: new Headers({
+        'X-RateLimit-Reset': futureTime.toString(),
+      }),
+    });
+
+    const promise = handleRateLimit(response);
+    await promise;
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/Rate limited, waiting \d+ms before retry/),
+    );
+  });
+});
+
+describe('fetchWithRetries', () => {
+  beforeEach(() => {
+    jest.mocked(sleep).mockClear();
+    jest.spyOn(global, 'fetch').mockImplementation();
+    jest.clearAllMocks();
+  });
+
+  it('should make exactly one attempt when retries is 0', async () => {
+    const successResponse = createMockResponse();
+    jest.mocked(global.fetch).mockResolvedValueOnce(successResponse);
+
+    await fetchWithRetries('https://example.com', {}, 1000, 0);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled(); // Should not sleep when retries=0
+  });
+
+  it('should handle negative retry values by treating them as 0', async () => {
+    const successResponse = createMockResponse();
+    jest.mocked(global.fetch).mockResolvedValueOnce(successResponse);
+
+    await fetchWithRetries('https://example.com', {}, 1000, -1);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should make retries+1 total attempts', async () => {
+    jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
+      'Request failed after 2 retries: Network error',
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(3); // Initial attempt + 2 retries
+    expect(sleep).toHaveBeenCalledTimes(2); // Should sleep between attempts, but not after last attempt
   });
 });

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,444 +1,114 @@
-import { ProxyAgent } from 'proxy-agent';
-import { VERSION } from '../src/constants';
-import { getEnvBool } from '../src/envars';
-import {
-  fetchWithProxy,
-  fetchWithRetries,
-  fetchWithTimeout,
-  handleRateLimit,
-  isRateLimited,
-} from '../src/fetch';
-import logger from '../src/logger';
-import { sleep } from '../src/util/time';
-import { createMockResponse } from './util/utils';
+import fs from 'fs';
+import { getEnvString, getEnvBool } from '../src/envars';
+import { fetchWithProxy } from '../src/fetch';
+
+// Mock environment variables
+jest.mock('../src/envars', () => ({
+  getEnvString: jest.fn(),
+  getEnvBool: jest.fn(),
+}));
+
+// Mock fs
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}));
 
 jest.mock('../src/util/time', () => ({
-  sleep: jest.fn().mockResolvedValue(undefined),
-}));
-
-jest.mock('proxy-agent');
-jest.mock('../src/logger');
-jest.mock('../src/envars', () => ({
-  ...jest.requireActual('../src/envars'),
-  getEnvInt: jest.fn().mockReturnValue(100),
-  getEnvBool: jest.fn().mockReturnValue(false),
-}));
-
-jest.mock('../src/fetch', () => ({
-  ...jest.requireActual('../src/fetch'),
   sleep: jest.fn(),
 }));
 
 describe('fetchWithProxy', () => {
   beforeEach(() => {
-    jest.spyOn(global, 'fetch').mockImplementation();
-    jest.mocked(ProxyAgent).mockClear();
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should add version header to all requests', async () => {
-    const url = 'https://example.com/api';
-    await fetchWithProxy(url);
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      url,
+  it('should use custom CA certificate when PROMPTFOO_CA_CERT_PATH is set', async () => {
+    const mockCertPath = '/path/to/cert.pem';
+    const mockCertContent = 'mock-cert-content';
+
+    (jest.mocked(getEnvString)).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_CA_CERT_PATH') {return mockCertPath;}
+      return undefined;
+    });
+    (jest.mocked(getEnvBool)).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_INSECURE_SSL') {return false;}
+      return undefined;
+    });
+    (jest.mocked(fs.readFileSync)).mockReturnValue(mockCertContent);
+
+    const mockFetch = jest.fn().mockResolvedValue(new Response());
+    global.fetch = mockFetch;
+
+    await fetchWithProxy('https://example.com');
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(mockCertPath);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com',
       expect.objectContaining({
-        headers: expect.objectContaining({
-          'x-promptfoo-version': VERSION,
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            ca: mockCertContent,
+            rejectUnauthorized: true,
+          }),
         }),
       }),
     );
   });
 
-  it('should handle URLs with basic auth credentials', async () => {
-    const url = 'https://username:password@example.com/api';
-    const options = { headers: { 'Content-Type': 'application/json' } };
+  it('should handle missing CA certificate file gracefully', async () => {
+    const mockCertPath = '/path/to/nonexistent.pem';
 
-    await fetchWithProxy(url, options);
+    (jest.mocked(getEnvString)).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_CA_CERT_PATH') {return mockCertPath;}
+      return undefined;
+    });
+    (jest.mocked(fs.readFileSync)).mockImplementation(() => {
+      throw new Error('File not found');
+    });
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
+    const mockFetch = jest.fn().mockResolvedValue(new Response());
+    global.fetch = mockFetch;
+
+    await fetchWithProxy('https://example.com');
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(mockCertPath);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com',
       expect.objectContaining({
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-          'x-promptfoo-version': VERSION,
-        },
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: true,
+          }),
+        }),
       }),
     );
   });
 
-  it('should handle URLs without auth credentials', async () => {
-    const url = 'https://example.com/api';
-    const options = { headers: { 'Content-Type': 'application/json' } };
+  it('should disable SSL verification when PROMPTFOO_INSECURE_SSL is true', async () => {
+    (jest.mocked(getEnvString)).mockReturnValue(undefined);
+    (jest.mocked(getEnvBool)).mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_INSECURE_SSL') {return true;}
+      return undefined;
+    });
 
-    await fetchWithProxy(url, options);
+    const mockFetch = jest.fn().mockResolvedValue(new Response());
+    global.fetch = mockFetch;
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      url,
+    await fetchWithProxy('https://example.com');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com',
       expect.objectContaining({
-        headers: {
-          'Content-Type': 'application/json',
-          'x-promptfoo-version': VERSION,
-        },
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false,
+          }),
+        }),
       }),
     );
-  });
-
-  it('should handle invalid URLs gracefully', async () => {
-    const invalidUrl = 'not-a-url';
-    await fetchWithProxy(invalidUrl);
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringMatching(/URL parsing failed in fetchWithProxy: TypeError/),
-    );
-    expect(global.fetch).toHaveBeenCalledWith(invalidUrl, expect.any(Object));
-  });
-
-  it('should preserve existing Authorization headers when no URL credentials', async () => {
-    const url = 'https://example.com/api';
-    const options = {
-      headers: {
-        Authorization: 'Bearer token123',
-        'Content-Type': 'application/json',
-      },
-    };
-
-    await fetchWithProxy(url, options);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      url,
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Bearer token123',
-          'Content-Type': 'application/json',
-          'x-promptfoo-version': VERSION,
-        },
-      }),
-    );
-  });
-
-  it('should warn and prefer existing Authorization header over URL credentials', async () => {
-    const url = 'https://username:password@example.com/api';
-    const options = {
-      headers: {
-        Authorization: 'Bearer token123',
-      },
-    };
-
-    await fetchWithProxy(url, options);
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Both URL credentials and Authorization header present'),
-    );
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Bearer token123',
-          'x-promptfoo-version': VERSION,
-        },
-      }),
-    );
-  });
-
-  it('should handle empty username or password in URL', async () => {
-    const url = 'https://:password@example.com/api';
-    await fetchWithProxy(url);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Basic OnBhc3N3b3Jk',
-          'x-promptfoo-version': VERSION,
-        },
-      }),
-    );
-  });
-
-  it('should handle URLs with only username', async () => {
-    const url = 'https://username@example.com/api';
-    await fetchWithProxy(url);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Basic dXNlcm5hbWU6', // Base64 encoded 'username:'
-          'x-promptfoo-version': VERSION,
-        },
-      }),
-    );
-  });
-
-  it('should preserve existing headers when adding Authorization from URL credentials', async () => {
-    const url = 'https://username:password@example.com/api';
-    const options = {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Custom-Header': 'value',
-      },
-    };
-
-    await fetchWithProxy(url, options);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://example.com/api',
-      expect.objectContaining({
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Custom-Header': 'value',
-          Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-          'x-promptfoo-version': VERSION,
-        },
-      }),
-    );
-  });
-});
-
-describe('fetchWithTimeout', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.spyOn(global, 'fetch').mockImplementation();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('should resolve when fetch completes before timeout', async () => {
-    const mockResponse = createMockResponse({ ok: true });
-    jest.mocked(global.fetch).mockImplementationOnce(() => Promise.resolve(mockResponse));
-
-    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
-    await expect(fetchPromise).resolves.toBe(mockResponse);
-  });
-
-  it('should reject when request times out', async () => {
-    jest
-      .mocked(global.fetch)
-      .mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 6000)));
-
-    const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
-    jest.advanceTimersByTime(5000);
-
-    await expect(fetchPromise).rejects.toThrow('Request timed out after 5000 ms');
-  });
-});
-
-describe('isRateLimited', () => {
-  it('should detect standard rate limit headers', () => {
-    const response = createMockResponse({
-      headers: new Headers({
-        'X-RateLimit-Remaining': '0',
-      }),
-      status: 200,
-    });
-    expect(isRateLimited(response)).toBe(true);
-  });
-
-  it('should detect 429 status code', () => {
-    const response = createMockResponse({
-      status: 429,
-    });
-    expect(isRateLimited(response)).toBe(true);
-  });
-
-  it('should detect OpenAI specific rate limits', () => {
-    const response = createMockResponse({
-      headers: new Headers({
-        'x-ratelimit-remaining-requests': '0',
-      }),
-    });
-    expect(isRateLimited(response)).toBe(true);
-
-    const tokenResponse = createMockResponse({
-      headers: new Headers({
-        'x-ratelimit-remaining-tokens': '0',
-      }),
-    });
-    expect(isRateLimited(tokenResponse)).toBe(true);
-  });
-
-  it('should return false when not rate limited', () => {
-    const response = createMockResponse({
-      headers: new Headers({
-        'X-RateLimit-Remaining': '10',
-      }),
-      status: 200,
-    });
-    expect(isRateLimited(response)).toBe(false);
-  });
-});
-
-describe('handleRateLimit', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.mocked(sleep).mockClear();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('should handle OpenAI reset headers', async () => {
-    const response = createMockResponse({
-      headers: new Headers({
-        'x-ratelimit-reset-requests': '5',
-      }),
-    });
-
-    const promise = handleRateLimit(response);
-    jest.advanceTimersByTime(5000);
-    await promise;
-
-    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
-  });
-
-  it('should handle standard rate limit reset headers', async () => {
-    const futureTime = Math.floor((Date.now() + 5000) / 1000);
-    const response = createMockResponse({
-      headers: new Headers({
-        'X-RateLimit-Reset': futureTime.toString(),
-      }),
-    });
-
-    const promise = handleRateLimit(response);
-    // No need to advance timers, sleep will resolve immediately
-    await promise;
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringMatching(/Rate limited, waiting \d+ms before retry/),
-    );
-  });
-
-  it('should handle Retry-After headers', async () => {
-    const response = createMockResponse({
-      headers: new Headers({
-        'Retry-After': '5',
-      }),
-    });
-
-    const promise = handleRateLimit(response);
-    jest.advanceTimersByTime(5000);
-    await promise;
-
-    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
-  });
-
-  it('should use default wait time when no headers present', async () => {
-    const response = createMockResponse();
-
-    const promise = handleRateLimit(response);
-    jest.advanceTimersByTime(60000);
-    await promise;
-
-    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 60000ms before retry');
-  });
-});
-
-describe('fetchWithRetries', () => {
-  beforeEach(() => {
-    jest.mocked(sleep).mockClear();
-    jest.spyOn(global, 'fetch').mockImplementation();
-    jest.clearAllMocks();
-  });
-
-  it('should make exactly one attempt when retries is 0', async () => {
-    const successResponse = createMockResponse();
-    jest.mocked(global.fetch).mockResolvedValueOnce(successResponse);
-
-    await fetchWithRetries('https://example.com', {}, 1000, 0);
-
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(sleep).not.toHaveBeenCalled(); // Should not sleep when retries=0
-  });
-
-  it('should handle negative retry values by treating them as 0', async () => {
-    const successResponse = createMockResponse();
-    jest.mocked(global.fetch).mockResolvedValueOnce(successResponse);
-
-    await fetchWithRetries('https://example.com', {}, 1000, -1);
-
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(sleep).not.toHaveBeenCalled();
-  });
-
-  it('should make retries+1 total attempts', async () => {
-    jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
-
-    await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
-      'Request failed after 2 retries: Network error',
-    );
-
-    expect(global.fetch).toHaveBeenCalledTimes(3); // Initial attempt + 2 retries
-    expect(sleep).toHaveBeenCalledTimes(2); // Should sleep between attempts, but not after last attempt
-  });
-
-  it('should not sleep after the final attempt', async () => {
-    jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
-
-    await expect(fetchWithRetries('https://example.com', {}, 1000, 1)).rejects.toThrow(
-      'Request failed after 1 retries: Network error',
-    );
-
-    expect(global.fetch).toHaveBeenCalledTimes(2); // Initial attempt + 1 retry
-    expect(sleep).toHaveBeenCalledTimes(1); // Should only sleep once between attempts
-  });
-
-  it('should handle 5XX errors when PROMPTFOO_RETRY_5XX is true', async () => {
-    jest.mocked(getEnvBool).mockReturnValueOnce(true);
-
-    const errorResponse = createMockResponse({
-      status: 502,
-      statusText: 'Bad Gateway',
-    });
-    const successResponse = createMockResponse();
-
-    jest
-      .mocked(global.fetch)
-      .mockResolvedValueOnce(errorResponse)
-      .mockResolvedValueOnce(successResponse);
-
-    await fetchWithRetries('https://example.com', {}, 1000, 2);
-
-    expect(global.fetch).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledTimes(1);
-  });
-
-  it('should handle rate limits with proper backoff', async () => {
-    const rateLimitedResponse = createMockResponse({
-      status: 429,
-      headers: new Headers({
-        'Retry-After': '1',
-      }),
-    });
-    const successResponse = createMockResponse();
-
-    jest
-      .mocked(global.fetch)
-      .mockResolvedValueOnce(rateLimitedResponse)
-      .mockResolvedValueOnce(successResponse);
-
-    await fetchWithRetries('https://example.com', {}, 1000, 2);
-
-    expect(global.fetch).toHaveBeenCalledTimes(2);
-    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Rate limited on URL'));
-    expect(sleep).toHaveBeenCalledTimes(1);
-  });
-
-  it('should respect maximum retry count', async () => {
-    jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
-
-    await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
-      'Request failed after 2 retries: Network error',
-    );
-
-    expect(global.fetch).toHaveBeenCalledTimes(3); // Initial attempt + 2 retries
-    expect(sleep).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
This PR introduces support for custom SSL certificates in the fetch module.
- Adds environment variables for custom CA certificate paths and SSL verification control.
- Updates documentation to guide users on configuration.