### PR TITLE
docs(providers): update overview table with new entries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,7 @@
     "transpiling",
     "unindented",
     "uuidv",
+    "watsonx",
     "webui"
   ],
   "jest.jestCommandLine": "npm run test --",

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -28,7 +28,9 @@ providers:
 | [Azure OpenAI](./azure.md)                          | Azure-hosted OpenAI models                 | `azureopenai:gpt-4o-custom-deployment-name`     |
 | [Cloudflare AI](./cloudflare-ai.md)                 | Cloudflare's AI platform                   | `cloudflare-ai:@cf/meta/llama-3-8b-instruct`    |
 | [Cohere](./cohere.md)                               | Cohere's language models                   | `cohere:command`                                |
+| [F5](./f5.md)                                       | OpenAI-compatible AI Gateway interface     | `f5:path-name`                                  |
 | [fal.ai](./fal.md)                                  | Image Generation Provider                  | `fal:image:fal-ai/fast-sdxl`                    |
+| [GitHub](./github.md)                               | GitHub AI Gateway                          | `github:gpt-4o-mini`                            |
 | [Google AI Studio (PaLM)](./palm.md)                | Gemini and PaLM models                     | `google:gemini-pro`                             |
 | [Google Vertex AI](./vertex.md)                     | Google Cloud's AI platform                 | `vertex:gemini-pro`                             |
 | [Groq](./groq.md)                                   | High-performance inference API             | `groq:llama3-70b-8192-tool-use-preview`         |


### PR DESCRIPTION
Updated the providers overview table to include new entries for F5 and GitHub.
- Added F5 and GitHub to the providers list.
- Included their respective descriptions and example identifiers.