### PR TITLE
chore(redteam): store attack prompt instead of rendered prompt in metadata

### DIFF
--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -63,8 +63,10 @@ async function runRedteamConversation({
 
   let highestScore = 0;
   let bestResponse = '';
-
+  let finalIteration = 0;
+  let bestInjectVar: string | undefined = undefined;
   let targetPrompt: string | null = null;
+
   const totalTokenUsage = {
     total: 0,
     prompt: 0,
@@ -80,8 +82,6 @@ async function runRedteamConversation({
     isOnTopic: boolean;
     graderPassed: boolean | undefined;
   }[] = [];
-  let finalIteration = 0;
-  let finalTargetPrompt: string | undefined = undefined;
 
   for (let i = 0; i < numIterations; i++) {
     const redteamBody = JSON.stringify(redteamHistory);
@@ -262,7 +262,7 @@ async function runRedteamConversation({
       if (currentScore > highestScore) {
         highestScore = currentScore;
         bestResponse = targetResponse.output;
-        finalTargetPrompt = targetPrompt;
+        bestInjectVar = newInjectVar;
       }
 
       // Update the user message to include both scores
@@ -353,7 +353,7 @@ async function runRedteamConversation({
       finalIteration,
       highestScore,
       previousOutputs: JSON.stringify(previousOutputs, null, 2),
-      redteamFinalPrompt: finalTargetPrompt,
+      redteamFinalPrompt: bestInjectVar,
     },
     tokenUsage: totalTokenUsage,
   };

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -557,7 +557,6 @@ export async function runRedteamConversation({
           logger.debug(`[Depth ${depth}, Attempt ${attempts}] New max score: ${maxScore}`);
         } else if (score > bestScore) {
           bestScore = score;
-          bestNode.prompt = newInjectVar;
           noImprovementCount = 0;
           logger.debug(
             `[Depth ${depth}, Attempt ${attempts}] New best score: ${score}. Max score: ${maxScore}`,

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -553,9 +553,11 @@ export async function runRedteamConversation({
         if (score > maxScore) {
           maxScore = score;
           bestResponse = targetResponse.output;
+          bestNode.prompt = newInjectVar;
           logger.debug(`[Depth ${depth}, Attempt ${attempts}] New max score: ${maxScore}`);
         } else if (score > bestScore) {
           bestScore = score;
+          bestNode.prompt = newInjectVar;
           noImprovementCount = 0;
           logger.debug(
             `[Depth ${depth}, Attempt ${attempts}] New best score: ${score}. Max score: ${maxScore}`,
@@ -616,7 +618,7 @@ export async function runRedteamConversation({
             output: targetResponse.output,
             metadata: {
               highestScore: maxScore,
-              redteamFinalPrompt: targetPrompt,
+              redteamFinalPrompt: bestNode.prompt,
               stoppingReason,
               attempts,
               treeOutputs: JSON.stringify(treeOutputs, null, 2),
@@ -644,7 +646,7 @@ export async function runRedteamConversation({
             output: bestResponse,
             metadata: {
               highestScore: maxScore,
-              redteamFinalPrompt: targetPrompt,
+              redteamFinalPrompt: bestNode.prompt,
               stoppingReason,
               attempts,
               treeOutputs: JSON.stringify(treeOutputs, null, 2),
@@ -673,7 +675,7 @@ export async function runRedteamConversation({
             output: bestResponse,
             metadata: {
               highestScore: maxScore,
-              redteamFinalPrompt: targetPrompt,
+              redteamFinalPrompt: bestNode.prompt,
               stoppingReason,
               attempts,
               treeOutputs: JSON.stringify(treeOutputs, null, 2),
@@ -762,7 +764,7 @@ export async function runRedteamConversation({
     output: bestResponse,
     metadata: {
       highestScore: maxScore,
-      redteamFinalPrompt: finalTargetPrompt,
+      redteamFinalPrompt: bestNode.prompt,
       stoppingReason,
       attempts,
       treeOutputs: JSON.stringify(treeOutputs, null, 2),


### PR DESCRIPTION
The redteamFinalPrompt metadata field now stores the raw attack prompt
(newInjectVar) instead of the full rendered prompt. This makes the behavior
consistent between iterative and tree-based approaches, and better reflects
the actual attack that succeeded. This is also reflective of the other strategies. 