### PR TITLE
fix: revert 49bdcba - restore TruncatedText for var display

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -421,7 +421,7 @@ function ResultsTable({
                     {renderMarkdown ? (
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
                     ) : (
-                      <>{value}</>
+                      <TruncatedText text={value} maxLength={maxTextLength} />
                     )}
                   </div>
                 );


### PR DESCRIPTION
This reverts commit 49bdcba4251b4766188493fa0c002214eec2c890. The direct value output was causing a React error when displaying nested objects in transformVars output. TruncatedText component properly handles object serialization. Fixes #2633