### PR TITLE
chore: dont actually truncate vars because they are scrollable

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -421,7 +421,8 @@ function ResultsTable({
                     {renderMarkdown ? (
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
                     ) : (
-                      <TruncatedText text={value} maxLength={maxTextLength} />
+                      // Don't actually truncate vars because they are scrollable
+                      <TruncatedText text={value} maxLength={Number.MAX_VALUE} />
                     )}
                   </div>
                 );


### PR DESCRIPTION
Just noting, TruncatedText could use a refactor to remove the non-truncation logic someplace else so we can use it here.  But for now we do this.