### PR TITLE
fix(config): Broken load configuration flow from YAML

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -1409,6 +1409,9 @@
         },
         "targets": {
           "$ref": "#/definitions/PromptfooConfigSchema/properties/providers"
+        },
+        "stateless": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -459,6 +459,7 @@ export default function RedTeamSetupPage() {
         strategies: yamlConfig.redteam?.strategies || [],
         purpose: yamlConfig.redteam?.purpose || '',
         entities: yamlConfig.redteam?.entities || [],
+        stateless: yamlConfig.stateless === undefined ? true : yamlConfig.stateless,
         applicationDefinition: {
           purpose: yamlConfig.redteam?.purpose || '',
           // We could potentially parse these from redteam.purpose if it follows a specific format.

--- a/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
+++ b/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
@@ -18,7 +18,7 @@ const orderRedTeam = (redteam: any): any => {
 
 const orderKeys = (obj: any): any => {
   const orderedObj: any = {};
-  const keyOrder = ['description', 'targets', 'prompts', 'redteam'];
+  const keyOrder = ['description', 'targets', 'prompts', 'redteam', 'stateless'];
 
   keyOrder.forEach((key) => {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {

--- a/src/redteam/sharedFrontend.ts
+++ b/src/redteam/sharedFrontend.ts
@@ -32,6 +32,7 @@ export function getUnifiedConfig(
     description: config.description,
     targets: [config.target],
     prompts: config.prompts,
+    stateless: config.stateless,
     redteam: {
       purpose: config.purpose,
       numTests: config.numTests,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -798,6 +798,7 @@ export const UnifiedConfigSchema = TestSuiteConfigSchema.extend({
   commandLineOptions: CommandLineOptionsSchema.partial().optional(),
   providers: ProvidersSchema.optional(),
   targets: ProvidersSchema.optional(),
+  stateless: z.boolean().optional(),
 })
   .refine(
     (data) => {


### PR DESCRIPTION
- Define `stateless` as an attribute in the `UnifiedConfigSchema` and ensure that it is correctly serialized in the YAML configuration
- Also ensure that `stateless` is correctly parsed when loading a YAML configuration from file
- [ ] **TODO**: This does make the `stateless` attribute passed into the provider somewhat vestigial/redundant as PromptFoo will automatically override it based on the `stateless` setting defined in the root config. Need to figure out what is the most elegant way to handle this situation.