### PR TITLE
fix(ui): fix stateful/stateless setting for providers

### DIFF
--- a/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
+++ b/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
@@ -64,7 +64,6 @@ const defaultConfig: Config = {
   purpose: '',
   entities: [],
   numTests: 10,
-  stateless: true,
   applicationDefinition: {
     purpose: '',
     redteamUser: '',
@@ -152,7 +151,6 @@ export const EXAMPLE_CONFIG: Config = {
   purpose: applicationDefinitionToPurpose(EXAMPLE_APPLICATION_DEFINITION),
   entities: [],
   numTests: 10,
-  stateless: true,
   applicationDefinition: EXAMPLE_APPLICATION_DEFINITION,
 };
 

--- a/src/app/src/pages/redteam/setup/types.ts
+++ b/src/app/src/pages/redteam/setup/types.ts
@@ -8,7 +8,6 @@ export interface Config {
   strategies: RedteamStrategy[];
   purpose?: string;
   numTests?: number;
-  stateless?: boolean;
   applicationDefinition: {
     purpose?: string;
     systemPrompt?: string;

--- a/src/redteam/sharedFrontend.ts
+++ b/src/redteam/sharedFrontend.ts
@@ -3,8 +3,6 @@ import type { UnifiedConfig } from '../types';
 import { type Severity, type Plugin, riskCategorySeverityMap } from './constants';
 import type { RedteamPluginObject, SavedRedteamConfig } from './types';
 
-const MULTI_TURN_STRATEGIES = ['goat', 'crescendo'];
-
 export function getRiskCategorySeverityMap(
   plugins?: RedteamPluginObject[],
 ): Record<Plugin, Severity> {
@@ -48,17 +46,11 @@ export function getUnifiedConfig(
         if (typeof strategy === 'string') {
           return { id: strategy };
         }
-        const strategyConfig = {
+        return {
           id: strategy.id,
-          config: {},
           ...(strategy.config &&
             Object.keys(strategy.config).length > 0 && { config: strategy.config }),
         };
-        // Don't bother setting the stateless config for single-turn strategies
-        if (MULTI_TURN_STRATEGIES.includes(strategy.id)) {
-          strategyConfig.config.stateless = config.stateless;
-        }
-        return strategyConfig;
       }),
     },
   };

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -127,7 +127,6 @@ export interface SavedRedteamConfig {
   strategies: RedteamStrategy[];
   purpose?: string;
   numTests?: number;
-  stateless?: boolean;
   applicationDefinition: {
     purpose?: string;
     systemPrompt?: string;


### PR DESCRIPTION
- Revert changes made in #2645 as having `stateless` as an attribute in a top-level config object is confusing
- Surface an error on the Strategies page when there is a discrepancy between strategies configured with stateful/stateless settings
- The following issues will be addressed in a follow-up PR
- [ ] **TODO**: Have the change automatically applied even if the user does not click the rad
io buttons to change system stateful/stateless setting
- [ ] **TODO**: Surface an error when the configuration is loaded if a discrepancy does exist
- [ ] **TODO**: Add a test