### PR TITLE
docs: add redirect for troubleshooting link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39494,6 +39494,7 @@
       "dependencies": {
         "@calcom/embed-react": "^1.5.1",
         "@docusaurus/core": "^3.6.3",
+        "@docusaurus/plugin-client-redirects": "^3.6.3",
         "@docusaurus/plugin-content-docs": "^3.6.3",
         "@docusaurus/plugin-google-gtag": "^3.6.3",
         "@docusaurus/preset-classic": "^3.6.3",
@@ -39520,6 +39521,30 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "site/node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.6.3.tgz",
+      "integrity": "sha512-fQDCxoJCO1jXNQGQmhgYoX3Yx+Z2xSbrLf3PBET6pHnsRk6gGW/VuCHcfQuZlJzbTxN0giQ5u3XcQQ/LzXftJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "site/node_modules/@mui/icons-material": {

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -323,7 +323,20 @@ const config = {
         indexName: 'promptfoo',
       },
     }),
-  plugins: [require.resolve('docusaurus-plugin-image-zoom')],
+  plugins: [
+    require.resolve('docusaurus-plugin-image-zoom'),
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            from: '/docs/category/troubleshooting',
+            to: '/docs/usage/troubleshooting',
+          },
+        ],
+      },
+    ],
+  ],
 
   // Mermaid diagram support
   markdown: {

--- a/site/package.json
+++ b/site/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@calcom/embed-react": "^1.5.1",
     "@docusaurus/core": "^3.6.3",
+    "@docusaurus/plugin-client-redirects": "^3.6.3",
     "@docusaurus/plugin-content-docs": "^3.6.3",
     "@docusaurus/plugin-google-gtag": "^3.6.3",
     "@docusaurus/preset-classic": "^3.6.3",


### PR DESCRIPTION
This PR introduces a client-side redirect for the troubleshooting documentation link to address the issue of broken links indexed by Google https://letmegooglethat.com/?q=promptfoo+troubleshooting and configures a redirect from `/docs/category/troubleshooting` to `/docs/usage/troubleshooting`. Note that this method of redirect is not ideal (server-side would be better) but this gets a fix out now. We can handle a server side later.