### PR TITLE
docs(links): update Discord links to new invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm](https://img.shields.io/npm/dm/promptfoo)](https://npmjs.com/package/promptfoo)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/typpo/promptfoo/main.yml)](https://github.com/promptfoo/promptfoo/actions/workflows/main.yml)
 ![MIT license](https://img.shields.io/github/license/promptfoo/promptfoo)
-[![Discord](https://github.com/user-attachments/assets/2092591a-ccc5-42a7-aeb6-24a2808950fd)](https://discord.gg/gHPS9jjfbs)
+[![Discord](https://github.com/user-attachments/assets/2092591a-ccc5-42a7-aeb6-24a2808950fd)](https://discord.gg/promptfoo)
 
 `promptfoo` is a developer-friendly local tool for testing LLM applications. Stop the trial-and-error approach - start shipping secure, reliable AI apps.
 
@@ -62,4 +62,4 @@ It also can generate [security vulnerability reports](https://www.promptfoo.dev/
 
 We welcome contributions! Check out our [contributing guide](https://www.promptfoo.dev/docs/contributing/) to get started.
 
-Join our [Discord community](https://discord.gg/gHPS9jjfbs) for help and discussion.
+Join our [Discord community](https://discord.gg/promptfoo) for help and discussion.

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -3,7 +3,7 @@ title: Contributing to promptfoo
 sidebar_label: Contributing
 ---
 
-We welcome contributions from the community to help make promptfoo better. This guide will help you get started. If you have any questions, please reach out to us on [Discord](https://discord.gg/gHPS9jjfbs) or through a [GitHub issue](https://github.com/promptfoo/promptfoo/issues/new).
+We welcome contributions from the community to help make promptfoo better. This guide will help you get started. If you have any questions, please reach out to us on [Discord](https://discord.gg/promptfoo) or through a [GitHub issue](https://github.com/promptfoo/promptfoo/issues/new).
 
 ## Project Overview
 
@@ -15,7 +15,7 @@ There are several ways to contribute to promptfoo:
 
 1. **Submit Pull Requests**: Anyone can contribute by forking the repository and submitting pull requests. You don't need to be a collaborator to contribute code or documentation changes.
 
-2. **Report Issues**: Help us by reporting bugs or suggesting improvements through GitHub issues or [Discord](https://discord.gg/gHPS9jjfbs).
+2. **Report Issues**: Help us by reporting bugs or suggesting improvements through GitHub issues or [Discord](https://discord.gg/promptfoo).
 
 3. **Improve Documentation**: Documentation improvements are always welcome, including fixing typos, adding examples, or writing guides.
 
@@ -79,7 +79,7 @@ We particularly welcome contributions in the following areas:
 
    Note: The development experience is a little bit different than how it runs in production. In development, the web UI is served using a Vite server. In all other environments, the front end is built and served as a static site via the Express server.
 
-If you're not sure where to start, check out our [good first issues](https://github.com/promptfoo/promptfoo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or join our [Discord community](https://discord.gg/gHPS9jjfbs) for guidance.
+If you're not sure where to start, check out our [good first issues](https://github.com/promptfoo/promptfoo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or join our [Discord community](https://discord.gg/promptfoo) for guidance.
 
 ## Development Workflow
 
@@ -290,7 +290,7 @@ You can view the contents of each of these tables by running `npx drizzle-kit st
 
 ## Release Steps
 
-Note: releases are only issued by maintainers. If you need to to release a new version quickly please send a message on [Discord](https://discord.gg/gHPS9jjfbs).
+Note: releases are only issued by maintainers. If you need to to release a new version quickly please send a message on [Discord](https://discord.gg/promptfoo).
 
 As a maintainer, when you are ready to release a new version:
 
@@ -322,7 +322,7 @@ As a maintainer, when you are ready to release a new version:
 If you need help or have questions, you can:
 
 - Open an issue on GitHub.
-- Join our [Discord community](https://discord.gg/gHPS9jjfbs).
+- Join our [Discord community](https://discord.gg/promptfoo).
 
 ## Code of Conduct
 

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -175,7 +175,7 @@ const config = {
                 label: 'GitHub',
               },
               {
-                href: 'https://discord.gg/gHPS9jjfbs',
+                href: 'https://discord.gg/promptfoo',
                 label: 'Discord',
               },
             ],
@@ -188,7 +188,7 @@ const config = {
             'aria-label': 'GitHub repository',
           },
           {
-            href: 'https://discord.gg/gHPS9jjfbs',
+            href: 'https://discord.gg/promptfoo',
             position: 'right',
             className: 'header-discord-link',
             'aria-label': 'Discord community',
@@ -285,7 +285,7 @@ const config = {
               },
               {
                 label: 'Discord',
-                href: 'https://discord.gg/gHPS9jjfbs',
+                href: 'https://discord.gg/promptfoo',
               },
               {
                 label: 'LinkedIn',

--- a/site/src/pages/contact.tsx
+++ b/site/src/pages/contact.tsx
@@ -103,7 +103,7 @@ function Contact(): JSX.Element {
           </Typography>
           <Typography variant="body1" gutterBottom>
             💬 Join our{' '}
-            <Link href="https://discord.gg/gHPS9jjfbs" target="_blank">
+            <Link href="https://discord.gg/promptfoo" target="_blank">
               Discord
             </Link>
           </Typography>

--- a/src/app/src/components/InfoModal.test.tsx
+++ b/src/app/src/components/InfoModal.test.tsx
@@ -67,7 +67,7 @@ describe('InfoModal', () => {
       { text: 'Documentation', href: 'https://www.promptfoo.dev/docs/intro' },
       { text: 'GitHub Repository', href: 'https://github.com/promptfoo/promptfoo' },
       { text: 'File an Issue', href: 'https://github.com/promptfoo/promptfoo/issues' },
-      { text: 'Join Our Discord Community', href: 'https://discord.gg/gHPS9jjfbs' },
+      { text: 'Join Our Discord Community', href: 'https://discord.gg/promptfoo' },
       { text: 'Book a Meeting', href: 'https://cal.com/team/promptfoo/intro2' },
     ];
 

--- a/src/app/src/components/InfoModal.tsx
+++ b/src/app/src/components/InfoModal.tsx
@@ -33,7 +33,7 @@ const links: { icon: React.ReactNode; text: string; href: string }[] = [
   {
     icon: <ForumIcon fontSize="small" />,
     text: 'Join Our Discord Community',
-    href: 'https://discord.gg/gHPS9jjfbs',
+    href: 'https://discord.gg/promptfoo',
   },
   {
     icon: <CalendarTodayIcon fontSize="small" />,


### PR DESCRIPTION
Updated all references to the Discord invite link to reflect the new URL.

- Replaced old Discord invite links with the updated one across documentation and code.
- Ensured consistency in all user-facing mentions of the Discord community.