### PR TITLE
chore(providers): add validateStatus option to HTTP provider

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -501,6 +501,7 @@ Supported config options:
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |
 | maxRetries        | number                  | Maximum number of retry attempts for failed requests. Defaults to 4.                                                                                                                |
+| validateStatus    | Function                | A function that takes a status code and returns a boolean indicating if the response should be treated as successful. By default, considers status codes 200-299 as successful.     |
 
 Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
 
@@ -518,25 +519,20 @@ import { HttpConfigGenerator } from '@site/src/components/HttpConfigGenerator';
 
 The HTTP provider throws errors in the following scenarios:
 
-- Non-200 HTTP status codes (any response with status < 200 or >= 300)
+- Invalid response status codes (configurable via `validateStatus`)
 - Network errors or request failures
 - Invalid response parsing
 - Session parsing errors
 - Invalid request configurations
 
-These errors will propagate up to your application, allowing you to handle them appropriately. For example:
+By default, any response with status code outside the 200-299 range is considered an error. You can customize this behavior using the `validateStatus` option:
 
 ```yaml
 providers:
   - id: https
     config:
       url: 'https://example.com/api'
-      method: 'POST'
-      headers:
-        'Content-Type': 'application/json'
-      body:
-        prompt: '{{prompt}}'
-      maxRetries: 3 # Will retry on network errors or rate limits
+      validateStatus: (status) => status < 500 # Accept any status code below 500
 ```
 
-Note that while the provider will automatically retry on certain errors (like rate limits) based on the `maxRetries` configuration, other errors will be thrown immediately.
+The provider will automatically retry certain errors (like rate limits) based on the `maxRetries` configuration, while other errors will be thrown immediately.

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -525,7 +525,9 @@ The HTTP provider throws errors in the following scenarios:
 - Session parsing errors
 - Invalid request configurations
 
-By default, any response with status code outside the 200-299 range is considered an error. You can customize this behavior using the `validateStatus` option:
+By default, any response with status code outside the 200-299 range is considered an error. You can customize this behavior using the `validateStatus` option in three ways:
+
+### Function-based validation
 
 ```yaml
 providers:
@@ -533,6 +535,54 @@ providers:
     config:
       url: 'https://example.com/api'
       validateStatus: (status) => status < 500 # Accept any status code below 500
+```
+
+### String-based validation
+
+You can provide a JavaScript expression as a string:
+
+```yaml
+providers:
+  - id: https
+    config:
+      url: 'https://example.com/api'
+      validateStatus: 'status >= 200 && status <= 299' # Default behavior
+```
+
+### File-based validation
+
+You can load the validator from an external JavaScript file:
+
+```yaml
+providers:
+  - id: https
+    config:
+      url: 'https://example.com/api'
+      validateStatus: 'file://validators/status.js' # Load default export
+```
+
+Or specify a particular function from the file:
+
+```yaml
+providers:
+  - id: https
+    config:
+      url: 'https://example.com/api'
+      validateStatus: 'file://validators/status.js:validateStatus' # Load specific function
+```
+
+Example validator file (`validators/status.js`):
+
+```javascript
+// Using default export
+export default function (status) {
+  return status < 500;
+}
+
+// Or named export
+export function validateStatus(status) {
+  return status < 500;
+}
 ```
 
 The provider will automatically retry certain errors (like rate limits) based on the `maxRetries` configuration, while other errors will be thrown immediately.

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -517,72 +517,38 @@ import { HttpConfigGenerator } from '@site/src/components/HttpConfigGenerator';
 
 ## Error Handling
 
-The HTTP provider throws errors in the following scenarios:
+The HTTP provider throws errors for:
 
-- Invalid response status codes (configurable via `validateStatus`)
+- Invalid response status codes
 - Network errors or request failures
 - Invalid response parsing
 - Session parsing errors
 - Invalid request configurations
 
-By default, any response with status code outside the 200-299 range is considered an error. You can customize this behavior using the `validateStatus` option in three ways:
-
-### Function-based validation
+By default, responses with status codes outside 200-299 are treated as errors. You can customize this using the `validateStatus` option:
 
 ```yaml
 providers:
   - id: https
     config:
       url: 'https://example.com/api'
-      validateStatus: (status) => status < 500 # Accept any status code below 500
-```
-
-### String-based validation
-
-You can provide a JavaScript expression as a string:
-
-```yaml
-providers:
-  - id: https
-    config:
-      url: 'https://example.com/api'
-      validateStatus: 'status >= 200 && status <= 299' # Default behavior
-```
-
-### File-based validation
-
-You can load the validator from an external JavaScript file:
-
-```yaml
-providers:
-  - id: https
-    config:
-      url: 'https://example.com/api'
-      validateStatus: 'file://validators/status.js' # Load default export
-```
-
-Or specify a particular function from the file:
-
-```yaml
-providers:
-  - id: https
-    config:
-      url: 'https://example.com/api'
-      validateStatus: 'file://validators/status.js:validateStatus' # Load specific function
+      # Function-based validation
+      validateStatus: (status) => status < 500  # Accept any status below 500
+      # Or string-based expression
+      validateStatus: 'status >= 200 && status <= 299'  # Default behavior
+      # Or load from file
+      validateStatus: 'file://validators/status.js'  # Load default export
+      validateStatus: 'file://validators/status.js:validateStatus'  # Load specific function
 ```
 
 Example validator file (`validators/status.js`):
 
 ```javascript
-// Using default export
-export default function (status) {
-  return status < 500;
-}
-
+export default (status) => status < 500;
 // Or named export
 export function validateStatus(status) {
   return status < 500;
 }
 ```
 
-The provider will automatically retry certain errors (like rate limits) based on the `maxRetries` configuration, while other errors will be thrown immediately.
+The provider automatically retries certain errors (like rate limits) based on `maxRetries`, while other errors are thrown immediately.

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -31,7 +31,9 @@ export const HttpProviderConfigSchema = z.object({
   transformRequest: z.union([z.string(), z.function()]).optional(),
   transformResponse: z.union([z.string(), z.function()]).optional(),
   url: z.string().optional(),
-  validateStatus: z.function().returns(z.boolean()).args(z.number()).optional(),
+  validateStatus: z
+    .union([z.string(), z.function().returns(z.boolean()).args(z.number())])
+    .optional(),
   /**
    * @deprecated use transformResponse instead
    */
@@ -289,13 +291,60 @@ export function determineRequestBody(
   });
 }
 
+export async function createValidateStatus(
+  validator: string | ((status: number) => boolean) | undefined,
+): Promise<(status: number) => boolean> {
+  if (!validator) {
+    return (status: number) => status >= 200 && status < 300;
+  }
+
+  if (typeof validator === 'function') {
+    return validator;
+  }
+
+  if (typeof validator === 'string') {
+    if (validator.startsWith('file://')) {
+      let filename = validator.slice('file://'.length);
+      let functionName: string | undefined;
+      if (filename.includes(':')) {
+        const splits = filename.split(':');
+        if (splits[0] && isJavascriptFile(splits[0])) {
+          [filename, functionName] = splits;
+        }
+      }
+      try {
+        const requiredModule = await importModule(
+          path.resolve(cliState.basePath || '', filename),
+          functionName,
+        );
+        if (typeof requiredModule === 'function') {
+          return requiredModule;
+        }
+        throw new Error('Exported value must be a function');
+      } catch (err: any) {
+        throw new Error(`Status validator malformed: ${filename} - ${err?.message || String(err)}`);
+      }
+    }
+    // Handle string template - wrap in a function body
+    try {
+      return new Function('status', `return ${validator}`) as (status: number) => boolean;
+    } catch (err: any) {
+      throw new Error(`Invalid status validator expression: ${err?.message || String(err)}`);
+    }
+  }
+
+  throw new Error(
+    `Unsupported status validator type: ${typeof validator}. Expected a function, a string starting with 'file://' pointing to a JavaScript file, or a string containing a JavaScript expression.`,
+  );
+}
+
 export class HttpProvider implements ApiProvider {
   url: string;
   config: HttpProviderConfig;
   private transformResponse: Promise<(data: any, text: string) => ProviderResponse>;
   private sessionParser: Promise<({ headers }: { headers: Record<string, string> }) => string>;
   private transformRequest: Promise<(prompt: string) => any>;
-  private validateStatus: (status: number) => boolean;
+  private validateStatus: Promise<(status: number) => boolean>;
   constructor(url: string, options: ProviderOptions) {
     this.config = HttpProviderConfigSchema.parse(options.config);
     this.url = this.config.url || url;
@@ -304,8 +353,7 @@ export class HttpProvider implements ApiProvider {
     );
     this.sessionParser = createSessionParser(this.config.sessionParser);
     this.transformRequest = createTransformRequest(this.config.transformRequest);
-    this.validateStatus =
-      this.config.validateStatus ?? ((status: number) => status >= 200 && status < 300);
+    this.validateStatus = createValidateStatus(this.config.validateStatus);
     if (this.config.request) {
       this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
     } else {
@@ -442,7 +490,7 @@ export class HttpProvider implements ApiProvider {
     );
 
     logger.debug(`[HTTP Provider]: Response: ${response.data}`);
-    if (!this.validateStatus(response.status)) {
+    if (!(await this.validateStatus)(response.status)) {
       throw new Error(
         `HTTP call failed with status ${response.status} ${response.statusText}: ${response.data}`,
       );
@@ -510,7 +558,7 @@ export class HttpProvider implements ApiProvider {
 
     logger.debug(`[HTTP Provider]: Response: ${response.data}`);
 
-    if (!this.validateStatus(response.status)) {
+    if (!(await this.validateStatus)(response.status)) {
       throw new Error(
         `HTTP call failed with status ${response.status} ${response.statusText}: ${response.data}`,
       );


### PR DESCRIPTION
- Introduced a configurable `validateStatus` function to customize HTTP response status validation similar to axios override: https://axios-http.com/docs/handling_errors