### PR TITLE
chore(webui): add configurable validateStatus to redteam HTTP target setup

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -112,8 +112,8 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 padding={10}
                 placeholder={dedent`Optional: Transform the API response before using it. Format as either:
 
-                  1. A JSON path expression: \`json.choices[0].message.content\`
-                  2. A function that receives response data: \`(json, text) => json.choices[0].message.content\`
+                  1. A JavaScript object path: \`json.choices[0].message.content\`
+                  2. A function that receives response data: \`(json, text) => json.choices[0].message.content || text\`
                 `}
                 style={{
                   fontFamily: '"Fira code", "Fira Mono", monospace',

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -51,15 +51,15 @@ function validateTransform(code: string, type: 'request' | 'response'): string |
     // Check if it's a function definition
     if (code.includes('=>') || code.startsWith('function')) {
       const funcStr = code.includes('=>') ? code : `(${code})`;
-      
+
       // Extract arguments
       const argsMatch = funcStr.match(/^\s*\(([^)]*)\)\s*=>|\bfunction\s*\w*\s*\(([^)]*)\)/);
       if (!argsMatch) {
         return null;
       }
-      
-      const args = (argsMatch[1] || argsMatch[2] || '').split(',').map(arg => arg.trim());
-      
+
+      const args = (argsMatch[1] || argsMatch[2] || '').split(',').map((arg) => arg.trim());
+
       if (type === 'request' && args.length !== 1) {
         return 'Request transform should take exactly one argument (prompt)';
       } else if (type === 'response' && args.length !== 2) {
@@ -83,31 +83,34 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
   const theme = useTheme();
   const darkMode = theme.palette.mode === 'dark';
 
-  const handleTransformChange = useCallback((type: 'request' | 'response', code: string) => {
-    const warning = validateTransform(code, type);
-    const field = type === 'request' ? 'transformRequest' : 'transformResponse';
-    updateCustomTarget(field, code);
-    
-    // Clear any existing warning
-    const warningEl = document.getElementById(`${type}-transform-warning`);
-    if (warningEl) {
-      warningEl.remove();
-    }
-    
-    // Show new warning if needed
-    if (warning) {
-      const editorEl = document.querySelector(`[data-transform="${type}"]`);
-      if (editorEl) {
-        const alertEl = document.createElement('div');
-        alertEl.id = `${type}-transform-warning`;
-        alertEl.style.color = theme.palette.warning.main;
-        alertEl.style.fontSize = '0.75rem';
-        alertEl.style.marginTop = '0.5rem';
-        alertEl.textContent = warning;
-        editorEl.parentElement?.appendChild(alertEl);
+  const handleTransformChange = useCallback(
+    (type: 'request' | 'response', code: string) => {
+      const warning = validateTransform(code, type);
+      const field = type === 'request' ? 'transformRequest' : 'transformResponse';
+      updateCustomTarget(field, code);
+
+      // Clear any existing warning
+      const warningEl = document.getElementById(`${type}-transform-warning`);
+      if (warningEl) {
+        warningEl.remove();
       }
-    }
-  }, [theme.palette.warning.main, updateCustomTarget]);
+
+      // Show new warning if needed
+      if (warning) {
+        const editorEl = document.querySelector(`[data-transform="${type}"]`);
+        if (editorEl) {
+          const alertEl = document.createElement('div');
+          alertEl.id = `${type}-transform-warning`;
+          alertEl.style.color = theme.palette.warning.main;
+          alertEl.style.fontSize = '0.75rem';
+          alertEl.style.marginTop = '0.5rem';
+          alertEl.textContent = warning;
+          editorEl.parentElement?.appendChild(alertEl);
+        }
+      }
+    },
+    [theme.palette.warning.main, updateCustomTarget],
+  );
 
   return (
     <Box mt={4}>
@@ -169,9 +172,11 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 onValueChange={(code) => handleTransformChange('response', code)}
                 highlight={(code) => highlight(code, languages.javascript)}
                 padding={10}
-                placeholder={dedent`Optional: A JavaScript expression to parse the response.
+                placeholder={dedent`Transform the API response before using it. Format as either:
 
-                  e.g. \`json.choices[0].message.content\``}
+                  1. A JSON path expression: \`json.choices[0].message.content\`
+                  2. A function that receives response data: \`(json, text) => json.choices[0].message.content\`
+                `}
                 style={{
                   fontFamily: '"Fira code", "Fira Mono", monospace',
                   fontSize: 14,
@@ -180,15 +185,16 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
               />
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Optionally, configure a response transform to extract a specific part of the HTTP
-              response. See{' '}
+              Need to extract specific data from the response? Use a JSON path expression or a
+              function that receives both parsed JSON and raw text. Perfect for accessing nested
+              fields, handling custom formats, or parsing non-JSON responses. See{' '}
               <a
                 href="https://www.promptfoo.dev/docs/providers/http/#response-parser"
                 target="_blank"
               >
                 docs
               </a>{' '}
-              for more information.
+              for more examples.
             </Typography>
           </Box>
           <Box mt={4} mb={2}>

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -164,7 +164,7 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
           <Box mt={4} mb={2}>
             <Stack direction="row" alignItems="center" spacing={1}>
               <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                Configure Success Conditions
+                Configure HTTP Status Code Validation
               </Typography>
               <FormControlLabel
                 control={
@@ -175,7 +175,7 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                     }}
                   />
                 }
-                label="Custom rules"
+                label="Custom"
               />
             </Stack>
             {selectedTarget.config.validateStatus !== undefined && (
@@ -197,9 +197,9 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                     padding={10}
                     placeholder={dedent`Customize HTTP status code validation. Examples:
 
-                      \`status >= 200 && status < 300\`  // Default: accept 2xx codes - javascript expression
-                      \`(status) => status < 500\`       // Accept anything but server errors - javascript function
-                      \`() => true\`                     // Accept all responses - javascript function`}
+                      status >= 200 && status < 300  // Default: accept 2xx codes - javascript expression
+                      (status) => status < 500       // Accept anything but server errors - javascript function
+                      () => true                     // Accept all responses - javascript function`}
                     style={{
                       fontFamily: '"Fira code", "Fira Mono", monospace',
                       fontSize: 14,

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -123,16 +123,15 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
               />
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Need to extract specific data from the response? Use a JSON path expression or a
-              function that receives both parsed JSON and raw text. Perfect for accessing nested
-              fields, handling custom formats, or parsing non-JSON responses. See{' '}
+              Optionally, configure a response transform to extract a specific part of the HTTP
+              response. See{' '}
               <a
                 href="https://www.promptfoo.dev/docs/providers/http/#response-parser"
                 target="_blank"
               >
                 docs
               </a>{' '}
-              for more examples.
+              for more information.
             </Typography>
           </Box>
           <Box mt={4} mb={2}>

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -30,6 +30,7 @@ import { highlight, languages } from 'prismjs/components/prism-core';
 import 'prismjs/components/prism-javascript';
 import type { ProviderOptions } from '../../types';
 import 'prismjs/themes/prism.css';
+import { FormControlLabel, Switch } from '@mui/material';
 
 interface TestTargetConfigurationProps {
   testingTarget: boolean;
@@ -162,6 +163,69 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 for more information.
               </Typography>
             </Box>
+          </Box>
+          <Box mt={4} mb={2}>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                Configure Success Conditions
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={selectedTarget.config.validateStatus !== undefined}
+                    onChange={(e) => {
+                      updateCustomTarget(
+                        'validateStatus',
+                        e.target.checked ? '' : undefined
+                      );
+                    }}
+                  />
+                }
+                label="Custom rules"
+              />
+            </Stack>
+            {selectedTarget.config.validateStatus !== undefined && (
+              <Box mt={2} p={2} border={1} borderColor="grey.300" borderRadius={1}>
+                <Box
+                  sx={{
+                    border: 1,
+                    borderColor: 'grey.300',
+                    borderRadius: 1,
+                    mt: 1,
+                    position: 'relative',
+                    backgroundColor: darkMode ? '#1e1e1e' : '#fff',
+                  }}
+                >
+                  <Editor
+                    value={selectedTarget.config.validateStatus}
+                    onValueChange={(code) => updateCustomTarget('validateStatus', code)}
+                    highlight={(code) => highlight(code, languages.javascript)}
+                    padding={10}
+                    placeholder={dedent`Customize HTTP status code validation. Examples:
+
+                      \`status >= 200 && status < 300\`  // Default: accept 2xx codes - javascript expression
+                      \`(status) => status < 500\`       // Accept anything but server errors - javascript function
+                      \`() => true\`                     // Accept all responses - javascript function`}
+                    style={{
+                      fontFamily: '"Fira code", "Fira Mono", monospace',
+                      fontSize: 14,
+                      minHeight: '106px',
+                    }}
+                  />
+                </Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  Customize which HTTP status codes are treated as successful responses. By default accepts 200-299.
+                  See{' '}
+                  <a
+                    href="https://www.promptfoo.dev/docs/providers/http/#error-handling"
+                    target="_blank"
+                  >
+                    docs
+                  </a>{' '}
+                  for more details.
+                </Typography>
+              </Box>
+            )}
           </Box>
         </Box>
       )}

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -110,7 +110,7 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 onValueChange={(code) => updateCustomTarget('transformResponse', code)}
                 highlight={(code) => highlight(code, languages.javascript)}
                 padding={10}
-                placeholder={dedent`Transform the API response before using it. Format as either:
+                placeholder={dedent`Optional: Transform the API response before using it. Format as either:
 
                   1. A JSON path expression: \`json.choices[0].message.content\`
                   2. A function that receives response data: \`(json, text) => json.choices[0].message.content\`

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Editor from 'react-simple-code-editor';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoIcon from '@mui/icons-material/Info';
@@ -41,6 +41,37 @@ interface TestTargetConfigurationProps {
   hasTestedTarget: boolean;
 }
 
+function validateTransform(code: string, type: 'request' | 'response'): string | null {
+  try {
+    // Skip validation for empty code
+    if (!code.trim()) {
+      return null;
+    }
+
+    // Check if it's a function definition
+    if (code.includes('=>') || code.startsWith('function')) {
+      const funcStr = code.includes('=>') ? code : `(${code})`;
+      
+      // Extract arguments
+      const argsMatch = funcStr.match(/^\s*\(([^)]*)\)\s*=>|\bfunction\s*\w*\s*\(([^)]*)\)/);
+      if (!argsMatch) {
+        return null;
+      }
+      
+      const args = (argsMatch[1] || argsMatch[2] || '').split(',').map(arg => arg.trim());
+      
+      if (type === 'request' && args.length !== 1) {
+        return 'Request transform should take exactly one argument (prompt)';
+      } else if (type === 'response' && args.length !== 2) {
+        return 'Response transform should take two arguments (json, text)';
+      }
+    }
+    return null;
+  } catch {
+    return null; // Ignore parsing errors - let runtime catch them
+  }
+}
+
 const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
   testingTarget,
   handleTestTarget,
@@ -51,6 +82,32 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
 }) => {
   const theme = useTheme();
   const darkMode = theme.palette.mode === 'dark';
+
+  const handleTransformChange = useCallback((type: 'request' | 'response', code: string) => {
+    const warning = validateTransform(code, type);
+    const field = type === 'request' ? 'transformRequest' : 'transformResponse';
+    updateCustomTarget(field, code);
+    
+    // Clear any existing warning
+    const warningEl = document.getElementById(`${type}-transform-warning`);
+    if (warningEl) {
+      warningEl.remove();
+    }
+    
+    // Show new warning if needed
+    if (warning) {
+      const editorEl = document.querySelector(`[data-transform="${type}"]`);
+      if (editorEl) {
+        const alertEl = document.createElement('div');
+        alertEl.id = `${type}-transform-warning`;
+        alertEl.style.color = theme.palette.warning.main;
+        alertEl.style.fontSize = '0.75rem';
+        alertEl.style.marginTop = '0.5rem';
+        alertEl.textContent = warning;
+        editorEl.parentElement?.appendChild(alertEl);
+      }
+    }
+  }, [theme.palette.warning.main, updateCustomTarget]);
 
   return (
     <Box mt={4}>
@@ -69,15 +126,17 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 position: 'relative',
                 backgroundColor: darkMode ? '#1e1e1e' : '#fff',
               }}
+              data-transform="request"
             >
               <Editor
                 value={selectedTarget.config.transformRequest || ''}
-                onValueChange={(code) => updateCustomTarget('transformRequest', code)}
+                onValueChange={(code) => handleTransformChange('request', code)}
                 highlight={(code) => highlight(code, languages.javascript)}
                 padding={10}
-                placeholder={dedent`Optional: A JavaScript expression to transform the prompt before sending.
+                placeholder={dedent`Optional: A JavaScript expression to transform the prompt before sending. Format as either:
 
-                  e.g. \`{ messages: [{ role: 'user', content: prompt }] }\``}
+                  1. A JSON object with prompt variable: \`{ messages: [{ role: 'user', content: prompt }] }\`
+                  2. A function that receives the prompt: \`(prompt) => ({ messages: [{ role: 'user', content: prompt }], temperature: 0.7 })\``}
                 style={{
                   fontFamily: '"Fira code", "Fira Mono", monospace',
                   fontSize: 14,
@@ -103,10 +162,11 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                 position: 'relative',
                 backgroundColor: darkMode ? '#1e1e1e' : '#fff',
               }}
+              data-transform="response"
             >
               <Editor
                 value={selectedTarget.config.transformResponse || ''}
-                onValueChange={(code) => updateCustomTarget('transformResponse', code)}
+                onValueChange={(code) => handleTransformChange('response', code)}
                 highlight={(code) => highlight(code, languages.javascript)}
                 padding={10}
                 placeholder={dedent`Optional: A JavaScript expression to parse the response.

--- a/src/app/src/pages/redteam/setup/components/Targets/index.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/index.tsx
@@ -252,7 +252,6 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
     setTestResult(null);
     recordEvent('feature_used', { feature: 'redteam_config_target_test' });
     try {
-      console.log('selectedTarget', selectedTarget);
       const response = await callApi('/providers/test', {
         method: 'POST',
         headers: {
@@ -260,8 +259,6 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
         },
         body: JSON.stringify(selectedTarget),
       });
-
-      console.log('response', response);
 
       if (!response.ok) {
         throw new Error('Network response was not ok');
@@ -293,9 +290,7 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
       console.error('Error testing target:', error);
       setTestResult({
         success: false,
-        message: `An error occurred while testing the target: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        message: 'An error occurred while testing the target.',
       });
     } finally {
       setTestingTarget(false);

--- a/src/app/src/pages/redteam/setup/components/Targets/index.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/index.tsx
@@ -252,6 +252,7 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
     setTestResult(null);
     recordEvent('feature_used', { feature: 'redteam_config_target_test' });
     try {
+      console.log('selectedTarget', selectedTarget);
       const response = await callApi('/providers/test', {
         method: 'POST',
         headers: {
@@ -259,6 +260,8 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
         },
         body: JSON.stringify(selectedTarget),
       });
+
+      console.log('response', response);
 
       if (!response.ok) {
         throw new Error('Network response was not ok');
@@ -290,7 +293,9 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
       console.error('Error testing target:', error);
       setTestResult({
         success: false,
-        message: 'An error occurred while testing the target.',
+        message: `An error occurred while testing the target: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       });
     } finally {
       setTestingTarget(false);

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -502,6 +502,7 @@ export class HttpProvider implements ApiProvider {
       this.config.maxRetries,
     );
 
+    logger.warn(`[HTTP Provider]: Response: ${JSON.stringify(response)}`);
     logger.debug(`[HTTP Provider]: Response: ${response.data}`);
     if (!(await this.validateStatus)(response.status)) {
       throw new Error(

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -534,7 +534,6 @@ export class HttpProvider implements ApiProvider {
       this.config.maxRetries,
     );
 
-    logger.warn(`[HTTP Provider]: Response: ${JSON.stringify(response)}`);
     logger.debug(`[HTTP Provider]: Response: ${response.data}`);
     if (!(await this.validateStatus)(response.status)) {
       throw new Error(

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -369,7 +369,14 @@ export async function createValidateStatus(
     }
     // Handle string template - wrap in a function body
     try {
-      return new Function('status', `return ${validator}`) as (status: number) => boolean;
+      const trimmedValidator = validator.trim();
+      // Check if it's an arrow function or regular function
+      if (trimmedValidator.includes('=>') || trimmedValidator.startsWith('function')) {
+        // For arrow functions and regular functions, evaluate the whole function
+        return new Function(`return ${trimmedValidator}`)() as (status: number) => boolean;
+      }
+      // For expressions, wrap in a function body
+      return new Function('status', `return ${trimmedValidator}`) as (status: number) => boolean;
     } catch (err: any) {
       throw new Error(`Invalid status validator expression: ${err?.message || String(err)}`);
     }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -243,7 +243,16 @@ export async function createTransformRequest(
   }
 
   if (typeof transform === 'function') {
-    return (prompt) => transform(prompt);
+    return async (prompt) => {
+      try {
+        return await transform(prompt);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        const wrappedError = new Error(`Error in request transform function: ${errorMessage}`);
+        logger.error(wrappedError.message);
+        throw wrappedError;
+      }
+    };
   }
 
   if (typeof transform === 'string') {
@@ -261,16 +270,36 @@ export async function createTransformRequest(
         functionName,
       );
       if (typeof requiredModule === 'function') {
-        return requiredModule;
+        return async (prompt) => {
+          try {
+            return await requiredModule(prompt);
+          } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            const wrappedError = new Error(
+              `Error in request transform function from ${filename}: ${errorMessage}`,
+            );
+            logger.error(wrappedError.message);
+            throw wrappedError;
+          }
+        };
       }
       throw new Error(
         `Request transform malformed: ${filename} must export a function or have a default export as a function`,
       );
     }
     // Handle string template
-    return (prompt) => {
-      const rendered = nunjucks.renderString(transform, { prompt });
-      return new Function('prompt', `${rendered}`)(prompt);
+    return async (prompt) => {
+      try {
+        const rendered = nunjucks.renderString(transform, { prompt });
+        return await new Function('prompt', `${rendered}`)(prompt);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        const wrappedError = new Error(
+          `Error in request transform string template: ${errorMessage}`,
+        );
+        logger.error(wrappedError.message);
+        throw wrappedError;
+      }
     };
   }
 

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1815,6 +1815,69 @@ describe('validateStatus', () => {
       'Status validator malformed: invalid-validator.js - Module not found',
     );
   });
+
+  it('should handle string-based arrow function validateStatus', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: '(s) => s < 500',
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+  });
+
+  it('should handle string-based regular function validateStatus', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'function(status) { return status < 500; }',
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+  });
+
+  it('should handle parameterless arrow function validateStatus', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: '() => true',
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+  });
 });
 
 describe('session parser', () => {


### PR DESCRIPTION
This PR introduces a configurable `validateStatus` option for HTTP requests.
- Adds UI elements to toggle and customize HTTP status validation.
- Updates the HTTP provider to support various validation formats, including expressions and functions.

<img width="1134" alt="Screenshot 2025-01-15 at 10 27 58 PM" src="https://github.com/user-attachments/assets/294ecc95-e825-4b6c-9bec-31beb74bbdfc" />

