### PR TITLE
chore(providers): change default validateStatus to accept all http status codes

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -501,7 +501,7 @@ Supported config options:
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |
 | maxRetries        | number                  | Maximum number of retry attempts for failed requests. Defaults to 4.                                                                                                                |
-| validateStatus    | Function                | A function that takes a status code and returns a boolean indicating if the response should be treated as successful. By default, considers status codes 200-299 as successful.     |
+| validateStatus    | Function                | A function that takes a status code and returns a boolean indicating if the response should be treated as successful. By default, accepts all status codes.                         |
 
 Note: All string values in the config (including those nested in `headers`, `body`, and `queryParams`) support Nunjucks templating. This means you can use the `{{prompt}}` variable or any other variables passed in the test context.
 
@@ -519,13 +519,13 @@ import { HttpConfigGenerator } from '@site/src/components/HttpConfigGenerator';
 
 The HTTP provider throws errors for:
 
-- Invalid response status codes
 - Network errors or request failures
 - Invalid response parsing
 - Session parsing errors
 - Invalid request configurations
+- Status codes that fail the configured validation (if `validateStatus` is set)
 
-By default, responses with status codes outside 200-299 are treated as errors. You can customize this using the `validateStatus` option:
+By default, all response status codes are accepted. You can customize this using the `validateStatus` option:
 
 ```yaml
 providers:
@@ -535,7 +535,7 @@ providers:
       # Function-based validation
       validateStatus: (status) => status < 500  # Accept any status below 500
       # Or string-based expression
-      validateStatus: 'status >= 200 && status <= 299'  # Default behavior
+      validateStatus: 'status >= 200 && status <= 299'  # Accept only 2xx responses
       # Or load from file
       validateStatus: 'file://validators/status.js'  # Load default export
       validateStatus: 'file://validators/status.js:validateStatus'  # Load specific function

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -197,9 +197,9 @@ const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
                     padding={10}
                     placeholder={dedent`Customize HTTP status code validation. Examples:
 
-                      status >= 200 && status < 300  // Default: accept 2xx codes - javascript expression
-                      (status) => status < 500       // Accept anything but server errors - javascript function
-                      () => true                     // Accept all responses - javascript function`}
+                      () => true                     // Default: accept all responses - javascript function
+                      status >= 200 && status < 300  // Accept 2xx codes - javascript expression
+                      (status) => status < 500       // Accept anything but server errors - javascript function`}
                     style={{
                       fontFamily: '"Fira code", "Fira Mono", monospace',
                       fontSize: 14,

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -337,7 +337,7 @@ export async function createValidateStatus(
   validator: string | ((status: number) => boolean) | undefined,
 ): Promise<(status: number) => boolean> {
   if (!validator) {
-    return (status: number) => status >= 200 && status < 300;
+    return (status: number) => true;
   }
 
   if (typeof validator === 'function') {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1812,6 +1812,163 @@ describe('validateStatus', () => {
       'Status validator malformed: invalid-validator.js - Module not found',
     );
   });
+
+  describe('string-based validators', () => {
+    it('should handle expression format', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: 'status >= 200 && status < 300',
+        },
+      });
+
+      // Test successful case
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status: 201,
+        statusText: 'Created',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+
+      // Test failure case
+      const errorResponse = {
+        data: 'Error message',
+        status: 400,
+        statusText: 'Bad Request',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+      await expect(provider.callApi('test')).rejects.toThrow(
+        'HTTP call failed with status 400 Bad Request: Error message',
+      );
+    });
+
+    it('should handle arrow function format with parameter', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: '(s) => s < 500',
+        },
+      });
+
+      // Test accepting 4xx status
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status: 404,
+        statusText: 'Not Found',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+
+      // Test rejecting 5xx status
+      const errorResponse = {
+        data: 'Error message',
+        status: 500,
+        statusText: 'Server Error',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+      await expect(provider.callApi('test')).rejects.toThrow(
+        'HTTP call failed with status 500 Server Error: Error message',
+      );
+    });
+
+    it('should handle arrow function format without parameter', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: '() => true',
+        },
+      });
+
+      // Test accepting all status codes
+      const responses = [
+        { status: 200, statusText: 'OK' },
+        { status: 404, statusText: 'Not Found' },
+        { status: 500, statusText: 'Server Error' },
+      ];
+
+      for (const { status, statusText } of responses) {
+        const mockResponse = {
+          data: JSON.stringify({ result: 'success' }),
+          status,
+          statusText,
+          cached: false,
+        };
+        jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+        const result = await provider.callApi('test');
+        expect(result.output).toEqual({ result: 'success' });
+      }
+    });
+
+    it('should handle regular function format', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: 'function(status) { return status < 500; }',
+        },
+      });
+
+      // Test accepting 4xx status
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status: 404,
+        statusText: 'Not Found',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+
+      // Test rejecting 5xx status
+      const errorResponse = {
+        data: 'Error message',
+        status: 500,
+        statusText: 'Server Error',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+      await expect(provider.callApi('test')).rejects.toThrow(
+        'HTTP call failed with status 500 Server Error: Error message',
+      );
+    });
+
+    it('should handle malformed string expressions', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: 'invalid[syntax',
+        },
+      });
+
+      const mockResponse = {
+        data: 'response',
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      await expect(provider.callApi('test')).rejects.toThrow('Invalid status validator expression');
+    });
+  });
 });
 
 describe('session parser', () => {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1552,7 +1552,7 @@ describe('session handling', () => {
 });
 
 describe('error handling', () => {
-  it('should throw error for non-200 responses', async () => {
+  it('should accept non-200 responses by default', async () => {
     const provider = new HttpProvider('http://test.com', {
       config: {
         method: 'POST',
@@ -1569,9 +1569,8 @@ describe('error handling', () => {
     };
     jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 400 Bad Request: Error message',
-    );
+    const result = await provider.callApi('test');
+    expect(result.output).toBe('Error message');
   });
 
   it('should throw session parsing errors', async () => {
@@ -1625,260 +1624,193 @@ describe('error handling', () => {
 });
 
 describe('validateStatus', () => {
-  describe('default behavior', () => {
-    it('should use default validation (200-299) when validateStatus is not provided', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-        },
-      });
-
-      const mockResponse = {
-        data: 'Error message',
-        status: 400,
-        statusText: 'Bad Request',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      await expect(provider.callApi('test')).rejects.toThrow(
-        'HTTP call failed with status 400 Bad Request: Error message',
-      );
+  it('should accept all status codes by default when validateStatus is not provided', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+      },
     });
+
+    const mockResponse = {
+      data: 'Response with non-2xx status',
+      status: 400,
+      statusText: 'Bad Request',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toBe('Response with non-2xx status');
   });
 
-  describe('string-based validators', () => {
-    it('should handle expression format', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: 'status >= 200 && status < 300',
-        },
-      });
-
-      // Test successful case
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status: 201,
-        statusText: 'Created',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-
-      // Test failure case
-      const errorResponse = {
-        data: 'Error message',
-        status: 400,
-        statusText: 'Bad Request',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-      await expect(provider.callApi('test')).rejects.toThrow(
-        'HTTP call failed with status 400 Bad Request: Error message',
-      );
+  it('should accept server errors by default when validateStatus is not provided', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+      },
     });
 
-    it('should handle arrow function format with parameter', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: '(s) => s < 500',
-        },
-      });
+    const mockResponse = {
+      data: 'Server error response',
+      status: 500,
+      statusText: 'Internal Server Error',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-      // Test accepting 4xx status
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status: 404,
-        statusText: 'Not Found',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-
-      // Test rejecting 5xx status
-      const errorResponse = {
-        data: 'Error message',
-        status: 500,
-        statusText: 'Server Error',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-      await expect(provider.callApi('test')).rejects.toThrow(
-        'HTTP call failed with status 500 Server Error: Error message',
-      );
-    });
-
-    it('should handle arrow function format without parameter', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: '() => true',
-        },
-      });
-
-      // Test accepting all status codes
-      const responses = [
-        { status: 200, statusText: 'OK' },
-        { status: 404, statusText: 'Not Found' },
-        { status: 500, statusText: 'Server Error' },
-      ];
-
-      for (const { status, statusText } of responses) {
-        const mockResponse = {
-          data: JSON.stringify({ result: 'success' }),
-          status,
-          statusText,
-          cached: false,
-        };
-        jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-        const result = await provider.callApi('test');
-        expect(result.output).toEqual({ result: 'success' });
-      }
-    });
-
-    it('should handle regular function format', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: 'function(status) { return status < 500; }',
-        },
-      });
-
-      // Test accepting 4xx status
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status: 404,
-        statusText: 'Not Found',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-
-      // Test rejecting 5xx status
-      const errorResponse = {
-        data: 'Error message',
-        status: 500,
-        statusText: 'Server Error',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-      await expect(provider.callApi('test')).rejects.toThrow(
-        'HTTP call failed with status 500 Server Error: Error message',
-      );
-    });
+    const result = await provider.callApi('test');
+    expect(result.output).toBe('Server error response');
   });
 
-  describe('error handling', () => {
-    it('should handle malformed string expressions', async () => {
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: 'invalid[syntax',
-        },
-      });
-
-      const mockResponse = {
-        data: 'response',
-        status: 200,
-        statusText: 'OK',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      await expect(provider.callApi('test')).rejects.toThrow('Invalid status validator expression');
+  it('should use custom validateStatus function to restrict to 2xx codes when specified', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: (status: number) => status >= 200 && status < 300,
+      },
     });
 
-    it('should throw error for malformed file-based validator', async () => {
-      jest.mocked(importModule).mockRejectedValueOnce(new Error('Module not found'));
+    const mockResponse = {
+      data: 'Error message',
+      status: 400,
+      statusText: 'Bad Request',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-      await expect(createValidateStatus('file://invalid-validator.js')).rejects.toThrow(
-        /Status validator malformed/,
-      );
-    });
-
-    it('should throw error for unsupported validator type', async () => {
-      await expect(createValidateStatus(123 as any)).rejects.toThrow(
-        'Unsupported status validator type: number',
-      );
-    });
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 400 Bad Request: Error message',
+    );
   });
 
-  describe('file-based validators', () => {
-    it('should handle file-based validateStatus', async () => {
-      const mockValidator = jest.fn((status) => status < 500);
-      jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
-
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: 'file://validator.js',
-        },
-      });
-
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status: 404,
-        statusText: 'Not Found',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-      expect(importModule).toHaveBeenCalledWith(
-        path.resolve('/mock/base/path', 'validator.js'),
-        undefined,
-      );
-      expect(mockValidator).toHaveBeenCalledWith(404);
+  it('should use validateStatus in raw request mode', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        request: dedent`
+          GET /api/data HTTP/1.1
+          Host: example.com
+        `,
+        validateStatus: (status: number) => status < 500,
+      },
     });
 
-    it('should handle file-based validateStatus with specific function', async () => {
-      const mockValidator = jest.fn((status) => status < 500);
-      jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-      const provider = new HttpProvider('http://test.com', {
-        config: {
-          method: 'POST',
-          body: { key: 'value' },
-          validateStatus: 'file://validator.js:validateStatus',
-        },
-      });
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+  });
 
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status: 404,
-        statusText: 'Not Found',
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-      expect(importModule).toHaveBeenCalledWith(
-        path.resolve('/mock/base/path', 'validator.js'),
-        'validateStatus',
-      );
-      expect(mockValidator).toHaveBeenCalledWith(404);
+  it('should handle string-based validateStatus', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'status >= 200 && status <= 299',
+      },
     });
+
+    const mockResponse = {
+      data: 'Error message',
+      status: 400,
+      statusText: 'Bad Request',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 400 Bad Request: Error message',
+    );
+  });
+
+  it('should handle file-based validateStatus', async () => {
+    const mockValidator = jest.fn((status) => status < 500);
+    jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
+
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'file://validator.js',
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+    expect(importModule).toHaveBeenCalledWith(
+      path.resolve('/mock/base/path', 'validator.js'),
+      undefined,
+    );
+    expect(mockValidator).toHaveBeenCalledWith(404);
+  });
+
+  it('should handle file-based validateStatus with specific function', async () => {
+    const mockValidator = jest.fn((status) => status < 500);
+    jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
+
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'file://validator.js:validateStatus',
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+    expect(importModule).toHaveBeenCalledWith(
+      path.resolve('/mock/base/path', 'validator.js'),
+      'validateStatus',
+    );
+    expect(mockValidator).toHaveBeenCalledWith(404);
+  });
+
+  it('should throw error for malformed file-based validateStatus', async () => {
+    jest.mocked(importModule).mockRejectedValueOnce(new Error('Module not found'));
+
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'file://invalid-validator.js',
+      },
+    });
+
+    const mockResponse = {
+      data: 'Error message',
+      status: 400,
+      statusText: 'Bad Request',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'Status validator malformed: invalid-validator.js - Module not found',
+    );
   });
 });
 
@@ -2007,162 +1939,5 @@ describe('status validator error handling', () => {
     await expect(createValidateStatus(123 as any)).rejects.toThrow(
       'Unsupported status validator type: number',
     );
-  });
-});
-
-describe('string-based validators', () => {
-  it('should handle expression format', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'status >= 200 && status < 300',
-      },
-    });
-
-    // Test successful case
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 201,
-      statusText: 'Created',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-
-    // Test failure case
-    const errorResponse = {
-      data: 'Error message',
-      status: 400,
-      statusText: 'Bad Request',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 400 Bad Request: Error message',
-    );
-  });
-
-  it('should handle arrow function format with parameter', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: '(s) => s < 500',
-      },
-    });
-
-    // Test accepting 4xx status
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 404,
-      statusText: 'Not Found',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-
-    // Test rejecting 5xx status
-    const errorResponse = {
-      data: 'Error message',
-      status: 500,
-      statusText: 'Server Error',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 500 Server Error: Error message',
-    );
-  });
-
-  it('should handle arrow function format without parameter', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: '() => true',
-      },
-    });
-
-    // Test accepting all status codes
-    const responses = [
-      { status: 200, statusText: 'OK' },
-      { status: 404, statusText: 'Not Found' },
-      { status: 500, statusText: 'Server Error' },
-    ];
-
-    for (const { status, statusText } of responses) {
-      const mockResponse = {
-        data: JSON.stringify({ result: 'success' }),
-        status,
-        statusText,
-        cached: false,
-      };
-      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-      const result = await provider.callApi('test');
-      expect(result.output).toEqual({ result: 'success' });
-    }
-  });
-
-  it('should handle regular function format', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'function(status) { return status < 500; }',
-      },
-    });
-
-    // Test accepting 4xx status
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 404,
-      statusText: 'Not Found',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-
-    // Test rejecting 5xx status
-    const errorResponse = {
-      data: 'Error message',
-      status: 500,
-      statusText: 'Server Error',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 500 Server Error: Error message',
-    );
-  });
-
-  it('should handle malformed string expressions', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'invalid[syntax',
-      },
-    });
-
-    const mockResponse = {
-      data: 'response',
-      status: 200,
-      statusText: 'OK',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow('Invalid status validator expression');
   });
 });

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1552,7 +1552,7 @@ describe('session handling', () => {
 });
 
 describe('error handling', () => {
-  it('should accept non-200 responses by default', async () => {
+  it('should throw error for non-200 responses', async () => {
     const provider = new HttpProvider('http://test.com', {
       config: {
         method: 'POST',
@@ -1569,8 +1569,9 @@ describe('error handling', () => {
     };
     jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-    const result = await provider.callApi('test');
-    expect(result.output).toBe('Error message');
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 400 Bad Request: Error message',
+    );
   });
 
   it('should throw session parsing errors', async () => {
@@ -1624,193 +1625,27 @@ describe('error handling', () => {
 });
 
 describe('validateStatus', () => {
-  it('should accept all status codes by default when validateStatus is not provided', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-      },
+  describe('default behavior', () => {
+    it('should use default validation (200-299) when validateStatus is not provided', async () => {
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+        },
+      });
+
+      const mockResponse = {
+        data: 'Error message',
+        status: 400,
+        statusText: 'Bad Request',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      await expect(provider.callApi('test')).rejects.toThrow(
+        'HTTP call failed with status 400 Bad Request: Error message',
+      );
     });
-
-    const mockResponse = {
-      data: 'Response with non-2xx status',
-      status: 400,
-      statusText: 'Bad Request',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toBe('Response with non-2xx status');
-  });
-
-  it('should accept server errors by default when validateStatus is not provided', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-      },
-    });
-
-    const mockResponse = {
-      data: 'Server error response',
-      status: 500,
-      statusText: 'Internal Server Error',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toBe('Server error response');
-  });
-
-  it('should use custom validateStatus function to restrict to 2xx codes when specified', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: (status: number) => status >= 200 && status < 300,
-      },
-    });
-
-    const mockResponse = {
-      data: 'Error message',
-      status: 400,
-      statusText: 'Bad Request',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 400 Bad Request: Error message',
-    );
-  });
-
-  it('should use validateStatus in raw request mode', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        request: dedent`
-          GET /api/data HTTP/1.1
-          Host: example.com
-        `,
-        validateStatus: (status: number) => status < 500,
-      },
-    });
-
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 404,
-      statusText: 'Not Found',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-  });
-
-  it('should handle string-based validateStatus', async () => {
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'status >= 200 && status <= 299',
-      },
-    });
-
-    const mockResponse = {
-      data: 'Error message',
-      status: 400,
-      statusText: 'Bad Request',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'HTTP call failed with status 400 Bad Request: Error message',
-    );
-  });
-
-  it('should handle file-based validateStatus', async () => {
-    const mockValidator = jest.fn((status) => status < 500);
-    jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
-
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'file://validator.js',
-      },
-    });
-
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 404,
-      statusText: 'Not Found',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-    expect(importModule).toHaveBeenCalledWith(
-      path.resolve('/mock/base/path', 'validator.js'),
-      undefined,
-    );
-    expect(mockValidator).toHaveBeenCalledWith(404);
-  });
-
-  it('should handle file-based validateStatus with specific function', async () => {
-    const mockValidator = jest.fn((status) => status < 500);
-    jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
-
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'file://validator.js:validateStatus',
-      },
-    });
-
-    const mockResponse = {
-      data: JSON.stringify({ result: 'success' }),
-      status: 404,
-      statusText: 'Not Found',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    const result = await provider.callApi('test');
-    expect(result.output).toEqual({ result: 'success' });
-    expect(importModule).toHaveBeenCalledWith(
-      path.resolve('/mock/base/path', 'validator.js'),
-      'validateStatus',
-    );
-    expect(mockValidator).toHaveBeenCalledWith(404);
-  });
-
-  it('should throw error for malformed file-based validateStatus', async () => {
-    jest.mocked(importModule).mockRejectedValueOnce(new Error('Module not found'));
-
-    const provider = new HttpProvider('http://test.com', {
-      config: {
-        method: 'POST',
-        body: { key: 'value' },
-        validateStatus: 'file://invalid-validator.js',
-      },
-    });
-
-    const mockResponse = {
-      data: 'Error message',
-      status: 400,
-      statusText: 'Bad Request',
-      cached: false,
-    };
-    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
-
-    await expect(provider.callApi('test')).rejects.toThrow(
-      'Status validator malformed: invalid-validator.js - Module not found',
-    );
   });
 
   describe('string-based validators', () => {
@@ -1948,7 +1783,9 @@ describe('validateStatus', () => {
         'HTTP call failed with status 500 Server Error: Error message',
       );
     });
+  });
 
+  describe('error handling', () => {
     it('should handle malformed string expressions', async () => {
       const provider = new HttpProvider('http://test.com', {
         config: {
@@ -1967,6 +1804,80 @@ describe('validateStatus', () => {
       jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
       await expect(provider.callApi('test')).rejects.toThrow('Invalid status validator expression');
+    });
+
+    it('should throw error for malformed file-based validator', async () => {
+      jest.mocked(importModule).mockRejectedValueOnce(new Error('Module not found'));
+
+      await expect(createValidateStatus('file://invalid-validator.js')).rejects.toThrow(
+        /Status validator malformed/,
+      );
+    });
+
+    it('should throw error for unsupported validator type', async () => {
+      await expect(createValidateStatus(123 as any)).rejects.toThrow(
+        'Unsupported status validator type: number',
+      );
+    });
+  });
+
+  describe('file-based validators', () => {
+    it('should handle file-based validateStatus', async () => {
+      const mockValidator = jest.fn((status) => status < 500);
+      jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
+
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: 'file://validator.js',
+        },
+      });
+
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status: 404,
+        statusText: 'Not Found',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+      expect(importModule).toHaveBeenCalledWith(
+        path.resolve('/mock/base/path', 'validator.js'),
+        undefined,
+      );
+      expect(mockValidator).toHaveBeenCalledWith(404);
+    });
+
+    it('should handle file-based validateStatus with specific function', async () => {
+      const mockValidator = jest.fn((status) => status < 500);
+      jest.mocked(importModule).mockResolvedValueOnce(mockValidator);
+
+      const provider = new HttpProvider('http://test.com', {
+        config: {
+          method: 'POST',
+          body: { key: 'value' },
+          validateStatus: 'file://validator.js:validateStatus',
+        },
+      });
+
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status: 404,
+        statusText: 'Not Found',
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+      expect(importModule).toHaveBeenCalledWith(
+        path.resolve('/mock/base/path', 'validator.js'),
+        'validateStatus',
+      );
+      expect(mockValidator).toHaveBeenCalledWith(404);
     });
   });
 });
@@ -2096,5 +2007,162 @@ describe('status validator error handling', () => {
     await expect(createValidateStatus(123 as any)).rejects.toThrow(
       'Unsupported status validator type: number',
     );
+  });
+});
+
+describe('string-based validators', () => {
+  it('should handle expression format', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'status >= 200 && status < 300',
+      },
+    });
+
+    // Test successful case
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 201,
+      statusText: 'Created',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+
+    // Test failure case
+    const errorResponse = {
+      data: 'Error message',
+      status: 400,
+      statusText: 'Bad Request',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 400 Bad Request: Error message',
+    );
+  });
+
+  it('should handle arrow function format with parameter', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: '(s) => s < 500',
+      },
+    });
+
+    // Test accepting 4xx status
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+
+    // Test rejecting 5xx status
+    const errorResponse = {
+      data: 'Error message',
+      status: 500,
+      statusText: 'Server Error',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 500 Server Error: Error message',
+    );
+  });
+
+  it('should handle arrow function format without parameter', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: '() => true',
+      },
+    });
+
+    // Test accepting all status codes
+    const responses = [
+      { status: 200, statusText: 'OK' },
+      { status: 404, statusText: 'Not Found' },
+      { status: 500, statusText: 'Server Error' },
+    ];
+
+    for (const { status, statusText } of responses) {
+      const mockResponse = {
+        data: JSON.stringify({ result: 'success' }),
+        status,
+        statusText,
+        cached: false,
+      };
+      jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+      const result = await provider.callApi('test');
+      expect(result.output).toEqual({ result: 'success' });
+    }
+  });
+
+  it('should handle regular function format', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'function(status) { return status < 500; }',
+      },
+    });
+
+    // Test accepting 4xx status
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 404,
+      statusText: 'Not Found',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    const result = await provider.callApi('test');
+    expect(result.output).toEqual({ result: 'success' });
+
+    // Test rejecting 5xx status
+    const errorResponse = {
+      data: 'Error message',
+      status: 500,
+      statusText: 'Server Error',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(errorResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 500 Server Error: Error message',
+    );
+  });
+
+  it('should handle malformed string expressions', async () => {
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { key: 'value' },
+        validateStatus: 'invalid[syntax',
+      },
+    });
+
+    const mockResponse = {
+      data: 'response',
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await expect(provider.callApi('test')).rejects.toThrow('Invalid status validator expression');
   });
 });


### PR DESCRIPTION
Change default validateStatus function to accept all HTTP status codes.
- Updated default behavior in the HTTP provider to allow all status codes.
- Adjusted related documentation and test cases.