### PR TITLE
test: make share test more robust

### DIFF
--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
@@ -139,7 +140,7 @@ evalRouter.patch('/:id/author', async (req: Request, res: Response): Promise<voi
       const validationError = fromZodError(error);
       res.status(400).json({ error: validationError.message });
     } else {
-      console.error('Failed to update eval author:', error);
+      logger.error(`Failed to update eval author: ${error}`);
       res.status(500).json({ error: 'Failed to update eval author' });
     }
   }
@@ -242,7 +243,9 @@ evalRouter.post('/', async (req: Request, res: Response): Promise<void> => {
       res.json({ id: eval_.id });
     }
   } catch (error) {
-    console.error('Failed to write eval to database', error, body);
+    logger.error(dedent`Failed to write eval to database:
+      Error: ${error}
+      Body: ${JSON.stringify(body, null, 2)}`);
     res.status(500).json({ error: 'Failed to write eval to database' });
   }
 });

--- a/test/server/share.test.ts
+++ b/test/server/share.test.ts
@@ -16,7 +16,6 @@ describe('share', () => {
   });
 
   beforeEach(async () => {
-    // Create fresh app instance and clean database for each test
     app = createApp();
     await deleteAllEvals();
   });

--- a/test/server/share.test.ts
+++ b/test/server/share.test.ts
@@ -2,32 +2,94 @@ import request from 'supertest';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import { createApp } from '../../src/server/server';
+import { deleteAllEvals } from '../../src/util';
 import results_v3 from './v3evalToShare.json';
 import results_v4 from './v4evalToShare.json';
 
+jest.mock('../../src/logger');
+
 describe('share', () => {
-  const app = createApp();
+  let app: ReturnType<typeof createApp>;
+
   beforeAll(async () => {
     await runDbMigrations();
   });
 
+  beforeEach(async () => {
+    // Create fresh app instance and clean database for each test
+    app = createApp();
+    await deleteAllEvals();
+  });
+
   it('should accept a version 3 results file', async () => {
-    const res = await request(app).post('/api/eval').send(results_v3);
+    const res = await request(app).post('/api/eval').send(results_v3).timeout(5000);
+
     expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id');
+
     const eval_ = await Eval.findById(res.body.id as string);
     expect(eval_).not.toBeNull();
     expect(eval_?.version()).toBe(3);
+
     const results = await eval_?.getResults();
+    expect(results).toBeDefined();
+    expect(Array.isArray(results)).toBe(true);
     expect(results).toHaveLength(8);
   });
 
   it('should accept a new eval', async () => {
-    const res = await request(app).post('/api/eval').send(results_v4);
+    const res = await request(app).post('/api/eval').send(results_v4).timeout(5000);
+
     expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id');
+
     const eval_ = await Eval.findById(res.body.id as string);
     expect(eval_).not.toBeNull();
     expect(eval_?.version()).toBe(4);
+
     const results = await eval_?.getResults();
+    expect(results).toBeDefined();
+    expect(Array.isArray(results)).toBe(true);
     expect(results).toHaveLength(8);
+  });
+
+  describe('error handling', () => {
+    it('should handle empty request body', async () => {
+      const res = await request(app).post('/api/eval').send({}).timeout(5000);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toBe('Failed to write eval to database');
+    });
+
+    it('should handle invalid v3 eval data', async () => {
+      const res = await request(app)
+        .post('/api/eval')
+        .send({
+          data: {
+            results: null,
+            config: null,
+          },
+        })
+        .timeout(5000);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toBe('Failed to write eval to database');
+    });
+
+    it('should handle database errors', async () => {
+      const res = await request(app)
+        .post('/api/eval')
+        .send({
+          config: {},
+          results: [],
+        })
+        .timeout(5000);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toBe('Failed to write eval to database');
+    });
   });
 });


### PR DESCRIPTION
Fix flaky tests by adding timeout to requests and isolating app instances for each test.
- Added timeout to test requests to avoid hanging.
- Ensured a fresh app instance and database cleanup before each test.