### PR TITLE
chore(cli): update show command to default to most recent eval

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -160,16 +160,26 @@ async function handleDataset(id: string) {
 
 export async function showCommand(program: Command) {
   const showCommand = program
-    .command('show <id>')
-    .description('Show details of a specific resource')
+    .command('show [id]')
+    .description('Show details of a specific resource (defaults to most recent)')
     .option('--env-file, --env-path <path>', 'Path to .env file')
-    .action(async (id: string, cmdObj: { envPath?: string }) => {
+    .action(async (id: string | undefined, cmdObj: { envPath?: string }) => {
       setupEnv(cmdObj.envPath);
       telemetry.record('command_used', {
         name: 'show',
       });
 
       await telemetry.send();
+
+      if (!id) {
+        const latestEval = await Eval.latest();
+        if (latestEval) {
+          return handleEval(latestEval.id);
+        }
+        logger.error('No evaluations found');
+        return;
+      }
+
       const evl = await getEvalFromId(id);
       if (evl) {
         return handleEval(id);
@@ -189,9 +199,19 @@ export async function showCommand(program: Command) {
     });
 
   showCommand
-    .command('eval <id>')
-    .description('Show details of a specific evaluation')
-    .action(handleEval);
+    .command('eval [id]')
+    .description('Show details of a specific evaluation (defaults to most recent)')
+    .action(async (id?: string) => {
+      if (!id) {
+        const latestEval = await Eval.latest();
+        if (latestEval) {
+          return handleEval(latestEval.id);
+        }
+        logger.error('No evaluations found');
+        return;
+      }
+      return handleEval(id);
+    });
 
   showCommand
     .command('prompt <id>')


### PR DESCRIPTION
The `show` CLI command now defaults to showing the most recent evaluation if no ID is specified.
- Updated the `show` and `eval` commands to handle optional IDs.
- Added logic to fetch and display the latest evaluation when no ID is provided.