### PR TITLE
fix(logging): enforce single-argument type for logger methods

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -43,7 +43,7 @@ export function listCommand(program: Command) {
         };
       });
 
-      logger.info(wrapTable(tableData));
+      logger.info(wrapTable(tableData) as string);
       printBorder();
 
       logger.info(
@@ -83,7 +83,7 @@ export function listCommand(program: Command) {
         'Most recent eval': prompt.recentEvalId.slice(0, 6),
       }));
 
-      logger.info(wrapTable(tableData));
+      logger.info(wrapTable(tableData) as string);
       printBorder();
       logger.info(
         `Run ${chalk.green('promptfoo show prompt <id>')} to see details of a specific prompt.`,
@@ -125,7 +125,7 @@ export function listCommand(program: Command) {
         'Most recent eval': dataset.recentEvalId.slice(0, 6),
       }));
 
-      logger.info(wrapTable(tableData));
+      logger.info(wrapTable(tableData) as string);
       printBorder();
       logger.info(
         `Run ${chalk.green('promptfoo show dataset <id>')} to see details of a specific dataset.`,

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -17,12 +17,9 @@ export function getDirectory(): string {
 }
 
 export async function importModule(modulePath: string, functionName?: string) {
-  logger.debug('Attempting to import module:', {
-    modulePath,
-    resolvedPath: path.resolve(modulePath),
-    fileUrl: pathToFileURL(path.resolve(modulePath)).toString(),
-    functionName,
-  });
+  logger.debug(
+    `Attempting to import module: ${JSON.stringify({ resolvedPath: path.resolve(modulePath), moduleId: modulePath })}`,
+  );
 
   try {
     if (modulePath.endsWith('.ts') || modulePath.endsWith('.mjs')) {
@@ -31,14 +28,12 @@ export async function importModule(modulePath: string, functionName?: string) {
       await import('tsx/cjs');
     }
     const resolvedPath = pathToFileURL(path.resolve(modulePath));
-    logger.debug('Attempting ESM import from:', resolvedPath.toString());
+    logger.debug(`Attempting ESM import from: ${resolvedPath.toString()}`);
     const importedModule = await import(resolvedPath.toString());
     const mod = importedModule?.default?.default || importedModule?.default || importedModule;
-    logger.debug('Successfully imported module:', {
-      hasDefaultDefault: !!importedModule?.default?.default,
-      hasDefault: !!importedModule?.default,
-      moduleType: typeof mod,
-    });
+    logger.debug(
+      `Successfully imported module: ${JSON.stringify({ resolvedPath, moduleId: modulePath })}`,
+    );
     if (functionName) {
       logger.debug(`Returning named export: ${functionName}`);
       return mod[functionName];
@@ -46,25 +41,22 @@ export async function importModule(modulePath: string, functionName?: string) {
     return mod;
   } catch (err) {
     // If ESM import fails, try CommonJS require as fallback
-    logger.debug('ESM import failed:', err);
+    logger.debug(`ESM import failed: ${err}`);
     logger.debug('Attempting CommonJS require fallback...');
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const importedModule = require(path.resolve(modulePath));
       const mod = importedModule?.default?.default || importedModule?.default || importedModule;
-      logger.debug('Successfully required module:', {
-        hasDefaultDefault: !!importedModule?.default?.default,
-        hasDefault: !!importedModule?.default,
-        moduleType: typeof mod,
-        exports: Object.keys(mod),
-      });
+      logger.debug(
+        `Successfully required module: ${JSON.stringify({ resolvedPath: path.resolve(modulePath), moduleId: modulePath })}`,
+      );
       if (functionName) {
         logger.debug(`Returning named export: ${functionName}`);
         return mod[functionName];
       }
       return mod;
     } catch (requireErr) {
-      logger.debug('CommonJS require also failed:', requireErr);
+      logger.debug(`CommonJS require also failed: ${requireErr}`);
       throw requireErr;
     }
   }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { globSync } from 'glob';
 import * as path from 'path';
 import readline from 'readline';
+import type winston from 'winston';
 import { runAssertions, runCompareAssertion } from './assertions';
 import { fetchWithCache, getCache } from './cache';
 import cliState from './cliState';
@@ -224,7 +225,7 @@ class Evaluator {
             test,
 
             // All of these are removed in python and script providers, but every Javascript provider gets them
-            logger,
+            logger: logger as winston.Logger,
             fetchWithCache,
             getCache,
           },

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -10,7 +10,7 @@ export async function checkGoogleSheetAccess(url: string) {
       return { public: false, status: response.status };
     }
   } catch (error) {
-    logger.error('Error checking sheet access:', error);
+    logger.error(`Error checking sheet access: ${error}`);
     return { public: false };
   }
 }

--- a/src/integrations/huggingfaceDatasets.ts
+++ b/src/integrations/huggingfaceDatasets.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { fetchWithProxy } from '../fetch';
 import logger from '../logger';
 import type { TestCase } from '../types';
@@ -89,8 +90,8 @@ export async function fetchHuggingFaceDataset(
       // Log schema information on first request
       logger.debug(`[Huggingface Dataset] Dataset features: ${JSON.stringify(data.features)}`);
       logger.debug(
-        '[Huggingface Dataset] Using query parameters:',
-        Object.fromEntries(queryParams),
+        dedent`[Huggingface Dataset] Using query parameters:
+        ${Object.fromEntries(queryParams)}`,
       );
     }
 

--- a/src/integrations/huggingfaceDatasets.ts
+++ b/src/integrations/huggingfaceDatasets.ts
@@ -87,7 +87,7 @@ export async function fetchHuggingFaceDataset(
 
     if (offset === 0) {
       // Log schema information on first request
-      logger.debug('[Huggingface Dataset] Dataset features:', data.features);
+      logger.debug(`[Huggingface Dataset] Dataset features: ${JSON.stringify(data.features)}`);
       logger.debug(
         '[Huggingface Dataset] Using query parameters:',
         Object.fromEntries(queryParams),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,7 +19,6 @@ export const LOG_LEVELS = {
 
 type LogLevel = keyof typeof LOG_LEVELS;
 
-// Create a type that enforces strict single-string argument logging
 type StrictLogMethod = (message: string) => winston.Logger;
 type StrictLogger = Omit<winston.Logger, keyof typeof LOG_LEVELS> & {
   [K in keyof typeof LOG_LEVELS]: StrictLogMethod;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -94,7 +94,7 @@ export function setLogLevel(level: LogLevel) {
   }
 }
 
-// Create a wrapper that enforces strict single-string argument logging
+// Wrapper enforces strict single-string argument logging
 const logger: StrictLogger = Object.assign({}, winstonLogger, {
   error: (message: string) => winstonLogger.error(message),
   warn: (message: string) => winstonLogger.warn(message),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,6 +15,14 @@ export const LOG_LEVELS = {
   warn: 1,
   info: 2,
   debug: 3,
+} as const;
+
+type LogLevel = keyof typeof LOG_LEVELS;
+
+// Create a type that enforces strict single-string argument logging
+type StrictLogMethod = (message: string) => winston.Logger;
+type StrictLogger = Omit<winston.Logger, keyof typeof LOG_LEVELS> & {
+  [K in keyof typeof LOG_LEVELS]: StrictLogMethod;
 };
 
 const consoleFormatter = winston.format.printf(
@@ -45,7 +53,7 @@ const fileFormatter = winston.format.printf((info: winston.Logform.Transformable
   return `${timestamp} [${info.level.toUpperCase()}]${location}: ${info.message}`;
 });
 
-const logger = winston.createLogger({
+const winstonLogger = winston.createLogger({
   levels: LOG_LEVELS,
   transports: [
     new winston.transports.Console({
@@ -56,10 +64,10 @@ const logger = winston.createLogger({
 });
 
 if (!getEnvString('PROMPTFOO_DISABLE_ERROR_LOG', '')) {
-  logger.on('data', (chunk) => {
+  winstonLogger.on('data', (chunk) => {
     if (
       chunk.level === 'error' &&
-      !logger.transports.some((t) => t instanceof winston.transports.File)
+      !winstonLogger.transports.some((t) => t instanceof winston.transports.File)
     ) {
       // Only create the errors file if there are any errors
       const fileTransport = new winston.transports.File({
@@ -67,7 +75,7 @@ if (!getEnvString('PROMPTFOO_DISABLE_ERROR_LOG', '')) {
         level: 'error',
         format: winston.format.combine(winston.format.simple(), fileFormatter),
       });
-      logger.add(fileTransport);
+      winstonLogger.add(fileTransport);
 
       // Re-log the error that triggered this so it's written to the file
       fileTransport.write(chunk);
@@ -75,16 +83,24 @@ if (!getEnvString('PROMPTFOO_DISABLE_ERROR_LOG', '')) {
   });
 }
 
-export function getLogLevel() {
-  return logger.transports[0].level;
+export function getLogLevel(): LogLevel {
+  return winstonLogger.transports[0].level as LogLevel;
 }
 
-export function setLogLevel(level: keyof typeof LOG_LEVELS) {
+export function setLogLevel(level: LogLevel) {
   if (level in LOG_LEVELS) {
-    logger.transports[0].level = level;
+    winstonLogger.transports[0].level = level;
   } else {
     throw new Error(`Invalid log level: ${level}`);
   }
 }
+
+// Create a wrapper that enforces strict single-string argument logging
+const logger: StrictLogger = Object.assign({}, winstonLogger, {
+  error: (message: string) => winstonLogger.error(message),
+  warn: (message: string) => winstonLogger.warn(message),
+  info: (message: string) => winstonLogger.info(message),
+  debug: (message: string) => winstonLogger.debug(message),
+}) as StrictLogger;
 
 export default logger;

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -14,7 +14,7 @@ export async function runDbMigrations() {
     await migrate(db, { migrationsFolder });
     logger.debug('[DB Migrate] Migrations completed');
   } catch (error) {
-    logger.error('Error running database migrations:', error);
+    logger.error(`Error running database migrations: ${error}`);
   }
 }
 

--- a/src/providers/adaline.gateway.ts
+++ b/src/providers/adaline.gateway.ts
@@ -264,7 +264,7 @@ export class AdalineGatewayEmbeddingProvider extends AdalineGatewayGenericProvid
         },
       };
     } catch (error) {
-      logger.error('Error calling embedding API on Adaline Gateway:', error);
+      logger.error(`Error calling embedding API on Adaline Gateway: ${error}`);
       throw error;
     }
   }

--- a/src/providers/azure.ts
+++ b/src/providers/azure.ts
@@ -347,7 +347,7 @@ export class AzureGenericProvider implements ApiProvider {
         const token = await this.getAccessToken();
         return { Authorization: 'Bearer ' + token };
       } catch (err) {
-        logger.info('Azure Authentication failed. Please check your credentials.', err);
+        logger.info(`Azure Authentication failed. Please check your credentials: ${err}`);
         throw new Error(`Azure Authentication failed. 
 Please choose one of the following options:
   1. Set an API key via the AZURE_API_KEY environment variable.

--- a/src/providers/cloudflare-ai.ts
+++ b/src/providers/cloudflare-ai.ts
@@ -273,7 +273,9 @@ export class CloudflareAiEmbeddingProvider extends CloudflareAiGenericProvider {
     try {
       const embedding = data.result.data[0];
       if (!embedding) {
-        logger.error('No data could be found in the Cloudflare API response', JSON.stringify(data));
+        logger.error(
+          `No data could be found in the Cloudflare API response: ${JSON.stringify(data)}`,
+        );
         throw new Error('No embedding returned');
       }
       const ret = {

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -419,7 +419,7 @@ export function redteamGenerateCommand(
             logger.error(`  ${err.path.join('.')}: ${err.message}`);
           });
         } else {
-          logger.error('An unexpected error occurred:', error);
+          logger.error(`An unexpected error occurred: ${error}`);
         }
         process.exit(1);
       }

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -164,7 +164,7 @@ export async function doGenerateRedteam(
     logger.debug(`strategies: ${strategyObjs.map((s) => s.id ?? s).join(', ')}`);
   } catch (error) {
     logger.error('Error logging plugins and strategies. One did not have a valid id.');
-    logger.error(error);
+    logger.error(`Error details: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   const config = {
@@ -419,7 +419,9 @@ export function redteamGenerateCommand(
             logger.error(`  ${err.path.join('.')}: ${err.message}`);
           });
         } else {
-          logger.error(`An unexpected error occurred: ${error}`);
+          logger.error(
+            `An unexpected error occurred: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
         process.exit(1);
       }

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -132,7 +132,7 @@ async function doPoisonDocuments(options: PoisonOptions) {
 
       logger.info(chalk.green(`✓ Successfully poisoned ${isFile ? docPath : 'document'}`));
     } catch (error) {
-      logger.error(`Failed to poison ${docPath}:`, error);
+      logger.error(`Failed to poison ${docPath}: ${error}`);
     }
   }
 

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -167,7 +167,7 @@ export function poisonCommand(program: Command) {
           ...opts,
         });
       } catch (error) {
-        logger.error('An unexpected error occurred:', error);
+        logger.error(`An unexpected error occurred: ${error}`);
         process.exit(1);
       }
     });

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -70,7 +70,7 @@ export function redteamRunCommand(program: Command) {
             logger.error(`  ${err.path.join('.')}: ${err.message}`);
           });
         } else {
-          logger.error('An unexpected error occurred:', error);
+          logger.error(`An unexpected error occurred: ${error}`);
         }
         process.exitCode = 1;
       }

--- a/src/redteam/plugins/cyberseceval.ts
+++ b/src/redteam/plugins/cyberseceval.ts
@@ -66,7 +66,7 @@ async function fetchDataset(
 
     return testCases;
   } catch (error) {
-    logger.error('[CyberSecEval] Error fetching dataset:', error);
+    logger.error(`[CyberSecEval] Error fetching dataset: ${error}`);
     return [];
   }
 }

--- a/src/server/routes/configs.ts
+++ b/src/server/routes/configs.ts
@@ -32,7 +32,7 @@ configsRouter.get('/', async (req: Request, res: Response): Promise<void> => {
 
     res.json({ configs });
   } catch (error) {
-    logger.error('Error fetching configs:', error);
+    logger.error(`Error fetching configs: ${error}`);
     res.status(500).json({ error: 'Failed to fetch configs' });
   }
 });
@@ -60,7 +60,7 @@ configsRouter.post('/', async (req: Request, res: Response): Promise<void> => {
 
     res.json(result);
   } catch (error) {
-    logger.error('Error saving config:', error);
+    logger.error(`Error saving config: ${error}`);
     res.status(500).json({ error: 'Failed to save config' });
   }
 });
@@ -83,7 +83,7 @@ configsRouter.get('/:type', async (req: Request, res: Response): Promise<void> =
 
     res.json({ configs });
   } catch (error) {
-    logger.error('Error fetching configs:', error);
+    logger.error(`Error fetching configs: ${error}`);
     res.status(500).json({ error: 'Failed to fetch configs' });
   }
 });
@@ -106,7 +106,7 @@ configsRouter.get('/:type/:id', async (req: Request, res: Response): Promise<voi
 
     res.json(config[0]);
   } catch (error) {
-    logger.error('Error fetching config:', error);
+    logger.error(`Error fetching config: ${error}`);
     res.status(500).json({ error: 'Failed to fetch config' });
   }
 });

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -124,11 +124,13 @@ redteamRouter.post('/cancel', async (req: Request, res: Response): Promise<void>
 redteamRouter.post('/:task', async (req: Request, res: Response): Promise<void> => {
   const { task } = req.params;
   const cloudFunctionUrl = getRemoteGenerationUrl();
-  logger.debug(`Received ${task} task request:`, {
-    method: req.method,
-    url: req.url,
-    body: req.body,
-  });
+  logger.debug(
+    `Received ${task} task request: ${JSON.stringify({
+      method: req.method,
+      url: req.url,
+      body: req.body,
+    })}`,
+  );
 
   try {
     logger.debug(`Sending request to cloud function: ${cloudFunctionUrl}`);

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -149,10 +149,10 @@ redteamRouter.post('/:task', async (req: Request, res: Response): Promise<void> 
     }
 
     const data = await response.json();
-    logger.debug(`Received response from cloud function:`, data);
+    logger.debug(`Received response from cloud function: ${JSON.stringify(data)}`);
     res.json(data);
   } catch (error) {
-    logger.error(`Error in ${task} task:`, error);
+    logger.error(`Error in ${task} task: ${error}`);
     res.status(500).json({ error: `Failed to process ${task} task` });
   }
 });

--- a/src/table.ts
+++ b/src/table.ts
@@ -8,7 +8,7 @@ export function generateTable(
   evaluateTable: EvaluateTable,
   tableCellMaxLength = 250,
   maxRows = 25,
-) {
+): string {
   const head = evaluateTable.head;
   const headLength = head.prompts.length + head.vars.length;
   const table = new Table({
@@ -45,7 +45,7 @@ export function generateTable(
       }),
     ]);
   }
-  return table;
+  return table.toString();
 }
 
 export function wrapTable(rows: Record<string, string | number>[]) {

--- a/test/googleSheets.test.ts
+++ b/test/googleSheets.test.ts
@@ -93,7 +93,9 @@ describe('Google Sheets Integration', () => {
 
       const result = await checkGoogleSheetAccess(TEST_SHEET_URL);
       expect(result).toEqual({ public: false });
-      expect(logger.error).toHaveBeenCalledWith('Error checking sheet access:', expect.any(Error));
+      expect(logger.error).toHaveBeenCalledWith(
+        `Error checking sheet access: ${new Error('Network error')}`,
+      );
     });
   });
 


### PR DESCRIPTION
This PR updates the logger implementation to enforce a single-argument type for its methods, preventing potential misuse.
- Updated logger methods to strictly accept a single string argument.
- Adjusted all logger calls across the codebase to comply with the new type constraints.