### PR TITLE
chore(providers): update Groq documentation with latest models

### DIFF
--- a/examples/groq/promptfooconfig.yaml
+++ b/examples/groq/promptfooconfig.yaml
@@ -7,7 +7,7 @@ prompts:
 
 providers:
   - id: groq:gemma2-9b-it
-  - id: groq:llama3-groq-8b-8192-tool-use-preview
+  - id: groq:llama-3.3-70b-versatile
     config:
       max_completion_tokens: 300
       tools:

--- a/examples/tool-use/promptfooconfig.yaml
+++ b/examples/tool-use/promptfooconfig.yaml
@@ -41,7 +41,7 @@ providers:
   - id: openai:chat:gpt-4o-mini
     config:
       tools: file://external_tools.yaml
-  - id: groq:llama3-groq-70b-8192-tool-use-preview
+  - id: groq:llama-3.3-70b-versatile
     config:
       tools:
         - type: function

--- a/site/docs/providers/groq.md
+++ b/site/docs/providers/groq.md
@@ -21,7 +21,7 @@ Configure the Groq provider in your promptfoo configuration file:
 
 ```yaml
 providers:
-  - id: groq:llama3-groq-70b-8192-tool-use-preview
+  - id: groq:llama-3.3-70b-versatile
     config:
       temperature: 0.7
       max_completion_tokens: 100
@@ -57,17 +57,23 @@ Key configuration options:
 
 Groq supports a variety of models, including:
 
-- `gemma-7b-it`
-- `gemma2-9b-it`
-- `llama-3.1-405b-reasoning`
-- `llama-3.1-70b-versatile`
-- `llama-3.1-8b-instant`
-- `llama2-70b-4096`
-- `llama3-70b-8192`
-- `llama3-8b-8192`
-- `llama3-groq-70b-8192-tool-use-preview` (recommended for tool use)
-- `llama3-groq-8b-8192-tool-use-preview` (recommended for tool use)
-- `mixtral-8x7b-32768`
+### Production Models
+
+- `gemma2-9b-it` - Google's 9B parameter instruction-tuned model (8K context)
+- `llama-3.3-70b-versatile` - Meta's 70B parameter model with 128K context window
+- `llama-3.1-8b-instant` - Meta's 8B parameter model with 128K context window
+- `llama-guard-3-8b` - Meta's 8B parameter safety model (8K context)
+- `llama3-70b-8192` - Meta's 70B parameter model with 8K context window
+- `llama3-8b-8192` - Meta's 8B parameter model with 8K context window
+- `mixtral-8x7b-32768` - Mistral's model with 32K context window
+
+### Preview Models
+
+- `llama-3.3-70b-specdec` - Meta's 70B parameter model for specialized tasks (8K context)
+- `llama-3.2-1b-preview` - Meta's 1B parameter model with 128K context window
+- `llama-3.2-3b-preview` - Meta's 3B parameter model with 128K context window
+- `llama-3.2-11b-vision-preview` - Meta's 11B parameter multimodal model
+- `llama-3.2-90b-vision-preview` - Meta's 90B parameter multimodal model
 
 For the most up-to-date list and detailed information about each model, refer to the [Groq Console documentation](https://console.groq.com/docs/models).
 
@@ -77,7 +83,7 @@ Specify the Groq provider in your test configuration:
 
 ```yaml
 providers:
-  - id: groq:llama3-groq-70b-8192-tool-use-preview
+  - id: groq:llama-3.3-70b-versatile
     config:
       temperature: 0.5
       max_tokens: 150
@@ -98,7 +104,7 @@ Groq supports tool use, allowing models to call predefined functions. Configure 
 
 ```yaml
 providers:
-  - id: groq:llama3-groq-70b-8192-tool-use-preview
+  - id: groq:llama-3.3-70b-versatile
     config:
       tools:
         - type: function
@@ -121,7 +127,7 @@ providers:
       tool_choice: auto
 ```
 
-For complex tools or ambiguous queries, use the `llama3-groq-70b-8192-tool-use-preview` model.
+For complex tools or ambiguous queries, use the `llama-3.3-70b-versatile` model.
 
 ## Additional Capabilities
 

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -33,7 +33,7 @@ providers:
 | [GitHub](./github.md)                               | GitHub AI Gateway                          | `github:gpt-4o-mini`                            |
 | [Google AI Studio (PaLM)](./palm.md)                | Gemini and PaLM models                     | `google:gemini-pro`                             |
 | [Google Vertex AI](./vertex.md)                     | Google Cloud's AI platform                 | `vertex:gemini-pro`                             |
-| [Groq](./groq.md)                                   | High-performance inference API             | `groq:llama3-70b-8192-tool-use-preview`         |
+| [Groq](./groq.md)                                   | High-performance inference API             | `groq:llama-3.3-70b-versatile`                  |
 | [Hugging Face](./huggingface.md)                    | Access thousands of models                 | `huggingface:text-generation:gpt2`              |
 | [IBM BAM](./ibm-bam.md)                             | IBM's foundation models                    | `bam:chat:ibm/granite-13b-chat-v2`              |
 | [LiteLLM](./litellm.md)                             | Unified interface for multiple providers   | Compatible with OpenAI syntax                   |


### PR DESCRIPTION
Updated Groq provider documentation to reflect the latest models.
- Replaced references to outdated models with the current 'llama-3.3-70b-versatile'.
- Enhanced model descriptions and categorized them into production and preview sections.