### PR TITLE
fix(webui): ensure nested variables are rendered correctly

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -411,7 +411,13 @@ function ResultsTable({
                 <TableHeader text={varName} maxLength={maxTextLength} className="font-bold" />
               ),
               cell: (info: CellContext<EvaluateTableRow, string>) => {
-                const value = info.getValue();
+                let value: string | object = info.getValue();
+                if (typeof value === 'object') {
+                  value = JSON.stringify(value, null, 2);
+                  if (renderMarkdown) {
+                    value = `\`\`\`json\n${value}\n\`\`\``;
+                  }
+                }
                 const truncatedValue =
                   value.length > maxTextLength
                     ? `${value.substring(0, maxTextLength - 3).trim()}...`


### PR DESCRIPTION
Fixes the issue where nested variables were not rendered properly in the ResultsTable component.

- Adds tests to verify rendering of nested variables as JSON with and without markdown.
- Resolves issue #2633.