### PR TITLE
revert: "build: create `dist/` using TypeScript's `"module": "Node16"` setting (#2686)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,12 +16,6 @@ const config: Config = {
     '<rootDir>/examples',
     '<rootDir>/node_modules',
   ],
-  moduleNameMapper: {
-    // converts imports for .js files except for jest.mock('../test.js')
-    // See https://github.com/swc-project/jest/issues/64#issuecomment-1029753225
-    // (mirror https://lightrun.com/answers/swc-project-jest-es-import-of-typescript-with-js-extension-fails)
-    [/^(?!\.\.\/test\.js)(\.{1,2}\/.*)\.js$/.source]: '$1',
-  },
   transform: {
     '^.+\\.m?[tj]sx?$': '@swc/jest',
   },

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -22,8 +22,8 @@ export async function importModule(modulePath: string, functionName?: string) {
   );
 
   try {
-    if (modulePath.endsWith('.ts')) {
-      logger.debug('TypeScript detected, importing tsx/cjs');
+    if (modulePath.endsWith('.ts') || modulePath.endsWith('.mjs')) {
+      logger.debug('TypeScript/ESM module detected, importing tsx/cjs');
       // @ts-ignore: It actually works
       await import('tsx/cjs');
     }

--- a/src/providers/azure.ts
+++ b/src/providers/azure.ts
@@ -5,7 +5,7 @@ import type {
   FunctionDefinition,
   RunStepMessageCreationDetails,
   RunStepToolCallDetails,
-} from '@azure/openai-assistants' with { 'resolution-mode': 'import' };
+} from '@azure/openai-assistants';
 import dedent from 'dedent';
 import { fetchWithCache } from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';

--- a/src/providers/bam.ts
+++ b/src/providers/bam.ts
@@ -2,7 +2,7 @@ import type {
   Client as GenAIClient,
   TextGenerationCreateInput,
   TextGenerationCreateOutput,
-} from '@ibm-generative-ai/node-sdk' with { 'resolution-mode': 'import' };
+} from '@ibm-generative-ai/node-sdk';
 import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -213,7 +213,7 @@ class CrescendoProvider implements ApiProvider {
     });
 
     const assertToUse = test?.assert?.find((a: { type: string }) => a.type);
-    const { getGraderById } = await import('../../graders.js');
+    const { getGraderById } = await import('../../graders');
     let graderPassed: boolean | undefined;
 
     while (roundNum < this.maxRounds) {

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -84,7 +84,7 @@ export default class GoatProvider implements ApiProvider {
 
     let assertToUse: Assertion | AssertionSet | undefined;
     let graderPassed: boolean | undefined;
-    const { getGraderById } = await import('../graders.js');
+    const { getGraderById } = await import('../graders');
     let test: AtomicTestCase | undefined;
 
     if (context?.test) {

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -220,7 +220,7 @@ async function runRedteamConversation({
     }
 
     const assertToUse = test?.assert?.find((a: { type: string }) => a.type);
-    const { getGraderById } = await import('../graders.js');
+    const { getGraderById } = await import('../graders');
     let graderPassed: boolean | undefined;
     if (test && assertToUse) {
       const grader = getGraderById(assertToUse.type);

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -578,7 +578,7 @@ export async function runRedteamConversation({
           }
         }
 
-        const { getGraderById } = await import('../graders.js');
+        const { getGraderById } = await import('../graders');
         let graderPassed: boolean | undefined;
         const assertToUse = test?.assert?.find((a: { type: string }) => a.type);
 

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -31,7 +31,7 @@ async function loadRedteamProvider({
     ret = redteamProvider;
   } else if (typeof redteamProvider === 'string' || isProviderOptions(redteamProvider)) {
     logger.debug(`Loading redteam provider: ${JSON.stringify(redteamProvider)}`);
-    const loadApiProvidersModule = await import('../../providers.js');
+    const loadApiProvidersModule = await import('../../providers');
     // Async import to avoid circular dependency
     ret = (await loadApiProvidersModule.loadApiProviders([redteamProvider]))[0];
   } else {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -104,14 +104,14 @@ describe('cache configuration', () => {
 
   it('should use memory cache in test environment', async () => {
     process.env.NODE_ENV = 'test';
-    const cacheModule = await import('../src/cache.js');
+    const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
     expect(cache.store).toHaveProperty('name', 'memory');
   });
 
   it('should use disk cache in non-test environment', async () => {
     process.env.NODE_ENV = 'production';
-    const cacheModule = await import('../src/cache.js');
+    const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
     expect(cache.store).toHaveProperty('name', 'fs-hash');
   });
@@ -119,7 +119,7 @@ describe('cache configuration', () => {
   it('should respect custom cache path', async () => {
     process.env.PROMPTFOO_CACHE_PATH = '/custom/cache/path';
     process.env.NODE_ENV = 'production';
-    const cacheModule = await import('../src/cache.js');
+    const cacheModule = await import('../src/cache');
     cacheModule.getCache();
     expect(fs.mkdirSync).toHaveBeenCalledWith('/custom/cache/path', { recursive: true });
   });
@@ -130,7 +130,7 @@ describe('cache configuration', () => {
     process.env.PROMPTFOO_CACHE_MAX_SIZE = '1000000';
     process.env.NODE_ENV = 'production';
 
-    const cacheModule = await import('../src/cache.js');
+    const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
     expect(cache.store).toHaveProperty('name', 'fs-hash');
   });
@@ -139,7 +139,7 @@ describe('cache configuration', () => {
     existsSyncMock.mockReturnValue(true);
     process.env.NODE_ENV = 'production';
 
-    const cacheModule = await import('../src/cache.js');
+    const cacheModule = await import('../src/cache');
     cacheModule.getCache();
     expect(mkdirSyncMock).not.toHaveBeenCalled();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,19 @@
 {
   "compilerOptions": {
-    // Base configuration
-    "baseUrl": "./",
-    "rootDir": ".",
-    "outDir": "dist",
-
-    // Module settings
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-
-    // Compilation settings
-    "target": "es2022",
-    "composite": true,
-    "strict": true,
-    "skipLibCheck": true,
-
-    // Source maps and declarations
-    "sourceMap": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "target": "es2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "rootDir": ".",
+    "baseUrl": "./"
   },
   "include": ["src/", "typings/**/*", "test/", "./package.json", "src/**/*.json", "test/**/*.json"],
   "exclude": ["node_modules", "dist", "src/workers/**/*", "src/app/**/*"]


### PR DESCRIPTION
This reverts commit a19993c02750471110293ff2c214a85aef289044.

Sorry @aloisklink we're running into errors relating to `await import('../graders.js');` I am going to try to de-ciricularize the dependencies this week and PR your change again after that. 

Thank you so much for your help! 