### PR TITLE
fix: empty response is not a failure for red team

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -274,9 +274,13 @@ class Evaluator {
       if (response.error) {
         ret.error = response.error;
       } else if (response.output === null || response.output === undefined) {
-        ret.success = false;
-        ret.score = 0;
-        ret.error = 'No output';
+        if (this.testSuite.redteam) {
+          ret.success = true;
+        } else {
+          ret.success = false;
+          ret.score = 0;
+          ret.error = 'No output';
+        }
       } else {
         // Create a copy of response so we can potentially mutate it.
         const processedResponse = { ...response };

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -274,6 +274,7 @@ class Evaluator {
       if (response.error) {
         ret.error = response.error;
       } else if (response.output === null || response.output === undefined) {
+        // NOTE: empty output often indicative of guardrails. Pass in redteam context. 
         if (this.testSuite.redteam) {
           ret.success = true;
         } else {


### PR DESCRIPTION
This is usually indicative of guardrails or something else.