### PR TITLE
fix(webui): add error boundary to React Markdown component

### DIFF
--- a/src/app/src/pages/eval/components/MarkdownErrorBoundary.tsx
+++ b/src/app/src/pages/eval/components/MarkdownErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class MarkdownErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(
+      `MarkdownErrorBoundary caught an error: ${error.message} ${errorInfo.componentStack}`,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default MarkdownErrorBoundary;

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -38,6 +38,8 @@ import CustomMetrics from './CustomMetrics';
 import EvalOutputCell from './EvalOutputCell';
 import EvalOutputPromptDialog from './EvalOutputPromptDialog';
 import GenerateTestCases from './GenerateTestCases';
+import MarkdownErrorBoundary from './MarkdownErrorBoundary';
+import ResultsTableErrorBoundary from './ResultsTableErrorBoundary';
 import type { TruncatedTextProps } from './TruncatedText';
 import TruncatedText from './TruncatedText';
 import { useStore as useMainStore } from './store';
@@ -425,7 +427,9 @@ function ResultsTable({
                 return (
                   <div className="cell">
                     {renderMarkdown ? (
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
+                      <MarkdownErrorBoundary fallback={<>{value}</>}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
+                      </MarkdownErrorBoundary>
                     ) : (
                       <>{value}</>
                     )}
@@ -908,4 +912,12 @@ function ResultsTable({
   );
 }
 
-export default React.memo(ResultsTable);
+function ResultsTableWithErrorBoundary(props: ResultsTableProps) {
+  return (
+    <ResultsTableErrorBoundary>
+      <ResultsTable {...props} />
+    </ResultsTableErrorBoundary>
+  );
+}
+
+export default React.memo(ResultsTableWithErrorBoundary);


### PR DESCRIPTION
This PR introduces an error boundary for the React Markdown component to handle rendering errors gracefully.
- Added a `MarkdownErrorBoundary` component to encapsulate the React Markdown rendering.
- Updated `ResultsTable` to use the new error boundary for its markdown rendering logic.