### PR TITLE
fix: add support for tool_resources in openai assistants

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -531,6 +531,7 @@ The following properties can be overwritten in provider config:
 - `thread.messages` - A list of message objects that the thread is created with.
 - `temperature` - Temperature for the model
 - `toolChoice` - Controls whether the AI should use a tool
+- `tool_resources` - Tool resources to include in the thread - see [Assistant v2 tool resources](https://platform.openai.com/docs/assistants/migration)
 - `attachments` - File attachments to include in messages - see [Assistant v2 attachments](https://platform.openai.com/docs/assistants/migration)
 
 Here's an example of a more detailed config:

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -542,6 +542,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         ? { tools: maybeLoadFromExternalFile(renderVarsInObject(config.tools, context?.vars)) }
         : {}),
       ...(config.tool_choice ? { tool_choice: config.tool_choice } : {}),
+      ...(config.tool_resources ? { tool_resources: config.tool_resources } : {}),
       ...(config.response_format
         ? {
             response_format: maybeLoadFromExternalFile(
@@ -710,9 +711,11 @@ type OpenAiAssistantOptions = OpenAiSharedOptions & {
   toolChoice?:
     | 'none'
     | 'auto'
+    | 'required'
     | { type: 'function'; function?: { name: string } }
     | { type: 'file_search' };
   attachments?: OpenAI.Beta.Threads.Message.Attachment[];
+  tool_resources?: OpenAI.Beta.Threads.ThreadCreateAndRunParams['tool_resources'];
 };
 
 export class OpenAiAssistantProvider extends OpenAiGenericProvider {
@@ -767,6 +770,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
       metadata: this.assistantConfig.metadata || undefined,
       temperature: this.assistantConfig.temperature || undefined,
       tool_choice: this.assistantConfig.toolChoice || undefined,
+      tool_resources: this.assistantConfig.tool_resources || undefined,
       thread: {
         messages,
       },


### PR DESCRIPTION
In OpenAI assistants V2 there is a new config option required when using their vector store along with tools. This PR adds support for this config option to be passed along to the assistant. 
See documentation from OpenAI here https://platform.openai.com/docs/assistants/migration 