### PR TITLE
test(providers): add mocks to reduce CI flakes and logs

### DIFF
--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -11,11 +11,16 @@ import type { ProviderOptions } from '../src/types';
 
 jest.mock('fs');
 jest.mock('js-yaml');
-jest.mock('../src/providers/openai');
+jest.mock('../src/fetch');
+jest.mock('../src/globalConfig/accounts');
+jest.mock('../src/globalConfig/cloud');
+jest.mock('../src/globalConfig/globalConfig');
 jest.mock('../src/providers/http');
-jest.mock('../src/providers/websocket');
-jest.mock('../src/providers/scriptCompletion');
+jest.mock('../src/providers/openai');
 jest.mock('../src/providers/pythonCompletion');
+jest.mock('../src/providers/scriptCompletion');
+jest.mock('../src/providers/websocket');
+jest.mock('../src/logger');
 
 describe('loadApiProvider', () => {
   beforeEach(() => {

--- a/test/providers/openai.test.ts
+++ b/test/providers/openai.test.ts
@@ -9,6 +9,8 @@ import {
 } from '../../src/providers/openai';
 
 jest.mock('../../src/cache');
+jest.mock('../../src/globalConfig/globalConfig');
+jest.mock('../../src/logger');
 
 describe('OpenAI Provider', () => {
   beforeEach(() => {

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -8,10 +8,10 @@ import {
   PromptfooSimulatedUserProvider,
 } from '../../src/providers/promptfoo';
 
-jest.mock('../../src/fetch');
 jest.mock('../../src/cache');
-jest.mock('../../src/globalConfig/accounts');
 jest.mock('../../src/envars');
+jest.mock('../../src/fetch');
+jest.mock('../../src/globalConfig/accounts');
 jest.mock('../../src/globalConfig/cloud', () => ({
   CloudConfig: class {
     isEnabled() {
@@ -22,6 +22,8 @@ jest.mock('../../src/globalConfig/cloud', () => ({
     }
   },
 }));
+jest.mock('../../src/globalConfig/globalConfig');
+jest.mock('../../src/logger');
 
 describe('PromptfooHarmfulCompletionProvider', () => {
   beforeEach(() => {


### PR DESCRIPTION
This PR adds additional mocks to the test suite to address excessive logging and CI flakiness.
- Introduced mocks for logger and global configuration modules.
- Improved test stability by isolating dependencies.