### PR TITLE
fix(fetch): correct TLS options for proxy settings

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -76,8 +76,8 @@ export async function fetchWithProxy(
   if (caCertPath) {
     try {
       const resolvedPath = path.resolve(cliState.basePath || '', caCertPath);
-      const ca = fs.readFileSync(resolvedPath);
-      tlsOptions.ca = [ca];
+      const ca = fs.readFileSync(resolvedPath, 'utf8');
+      tlsOptions.ca = ca;
       logger.debug(`Using custom CA certificate from ${resolvedPath}`);
     } catch (e) {
       logger.warn(`Failed to read CA certificate from ${caCertPath}: ${e}`);
@@ -89,6 +89,7 @@ export async function fetchWithProxy(
     const agent = new ProxyAgent({
       uri: proxyUrl,
       proxyTls: tlsOptions,
+      requestTls: tlsOptions,
     });
     setGlobalDispatcher(agent);
   }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -250,13 +250,19 @@ describe('fetchWithProxy', () => {
     await fetchWithProxy('https://example.com');
 
     const actualPath = jest.mocked(fs.readFileSync).mock.calls[0][0] as string;
+    const actualEncoding = jest.mocked(fs.readFileSync).mock.calls[0][1];
     const normalizedActual = path.normalize(actualPath).replace(/^\w:/, '');
     const normalizedExpected = path.normalize(mockCertPath).replace(/^\w:/, '');
     expect(normalizedActual).toBe(normalizedExpected);
+    expect(actualEncoding).toBe('utf8');
     expect(ProxyAgent).toHaveBeenCalledWith({
       uri: mockProxyUrl,
       proxyTls: {
-        ca: [mockCertContent],
+        ca: mockCertContent,
+        rejectUnauthorized: true,
+      },
+      requestTls: {
+        ca: mockCertContent,
         rejectUnauthorized: true,
       },
     });
@@ -293,6 +299,9 @@ describe('fetchWithProxy', () => {
       proxyTls: {
         rejectUnauthorized: true,
       },
+      requestTls: {
+        rejectUnauthorized: true,
+      },
     });
     expect(setGlobalDispatcher).toHaveBeenCalledWith(expect.any(ProxyAgent));
   });
@@ -319,6 +328,9 @@ describe('fetchWithProxy', () => {
     expect(ProxyAgent).toHaveBeenCalledWith({
       uri: mockProxyUrl,
       proxyTls: {
+        rejectUnauthorized: false,
+      },
+      requestTls: {
         rejectUnauthorized: false,
       },
     });
@@ -357,6 +369,7 @@ describe('fetchWithProxy', () => {
 
     const expectedPath = path.normalize(path.join(mockBasePath, mockCertPath));
     const actualPath = jest.mocked(fs.readFileSync).mock.calls[0][0] as string;
+    const actualEncoding = jest.mocked(fs.readFileSync).mock.calls[0][1];
 
     const normalizedActual = path.normalize(actualPath).replace(/^\w:/, '');
     const normalizedExpected = path.normalize(expectedPath).replace(/^\w:/, '');
@@ -364,12 +377,17 @@ describe('fetchWithProxy', () => {
     const normalizedCertPath = path.normalize(mockCertPath);
 
     expect(normalizedActual).toBe(normalizedExpected);
+    expect(actualEncoding).toBe('utf8');
     expect(normalizedActual).toContain(normalizedBasePath);
     expect(normalizedActual).toContain(normalizedCertPath);
     expect(ProxyAgent).toHaveBeenCalledWith({
       uri: mockProxyUrl,
       proxyTls: {
-        ca: [mockCertContent],
+        ca: mockCertContent,
+        rejectUnauthorized: true,
+      },
+      requestTls: {
+        ca: mockCertContent,
         rejectUnauthorized: true,
       },
     });
@@ -432,6 +450,9 @@ describe('fetchWithProxy', () => {
       expect(ProxyAgent).toHaveBeenCalledWith({
         uri: testCase.expected.url,
         proxyTls: {
+          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
+        },
+        requestTls: {
           rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
         },
       });


### PR DESCRIPTION
This PR addresses an issue with TLS options when using proxy settings.

- Updated the handling of CA certificates to read them as UTF-8 strings.
- Added `requestTls` options to the proxy agent configuration.

No breaking changes introduced.