### PR TITLE
fix(docs): random grammar fix for model-graded metrics

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -10,7 +10,7 @@ Output-based:
 
 - [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric) - checks if the LLM output matches given requirements, using a language model to grade the output based on the rubric.
 - [`model-graded-closedqa`](/docs/configuration/expected-outputs/model-graded/model-graded-closedqa) - similar to the above, a "criteria-checking" eval that ensures the answer meets a specific requirement. Uses an OpenAI-authored prompt from their public evals.
-- [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - a factual consistency eval which, given a completion `A` and reference answer `B` evaluates whether A is a subset of B, A is a superset of B, A and B are equivalent, A and B disagree, or A and B differ, but difference don't matter from the perspective of factuality. Uses the prompt from OpenAI's public evals.
+- [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - a factual consistency eval which, given a completion `A` and reference answer `B` evaluates whether A is a subset of B, A is a superset of B, A and B are equivalent, A and B disagree, or A and B differ, but that the difference doesn't matter from the perspective of factuality. It uses the prompt from OpenAI's public evals.
 - [`g-eval`](/docs/configuration/expected-outputs/model-graded/g-eval) - uses chain-of-thought prompting to evaluate outputs based on custom criteria, following the G-Eval framework.
 - [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - ensure that LLM output is related to original query
 - [`classifier`](/docs/configuration/expected-outputs/classifier) - see classifier grading docs.


### PR DESCRIPTION
- Thanks @shmoosa for finding the issue
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix grammar in `index.md` for `factuality` description by adding missing word "that".
> 
>   - **Docs**:
>     - Fix grammar in `index.md` for `factuality` description by adding missing word "that".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=promptfoo%2Fpromptfoo&utm_source=github&utm_medium=referral)<sup> for d721f88c7d7a1b33517f71bca90a5a3399902833. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->