### PR TITLE
refactor(fetch): remove unnecessary debug log

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -32,8 +32,6 @@ export function getProxyUrl(): string | undefined {
       return proxyUrl;
     }
   }
-
-  logger.debug('No proxy configuration found in environment variables');
   return undefined;
 }
 


### PR DESCRIPTION
Removed an unnecessary debug log statement from the fetch module.
- Simplifies the code by removing redundant logging.