### PR TITLE
docs(config): add status page link to navigation

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -280,6 +280,10 @@ const config = {
                 href: '/careers/',
               },
               {
+                label: 'Status',
+                href: 'https://status.promptfoo.dev',
+              },
+              {
                 label: 'GitHub',
                 href: 'https://github.com/promptfoo/promptfoo',
               },


### PR DESCRIPTION
Added a link to the status page in the site's navigation menu.
- The link directs users to https://status.promptfoo.dev.