### PR TITLE
feat(providers): add common provider types for redteam providers

### DIFF
--- a/src/redteam/plugins/beavertails.ts
+++ b/src/redteam/plugins/beavertails.ts
@@ -1,4 +1,5 @@
 import { fetchHuggingFaceDataset } from '../../integrations/huggingfaceDatasets';
+import logger from '../../logger';
 import type { ApiProvider, Assertion, AtomicTestCase, GradingResult, TestCase } from '../../types';
 import { isBasicRefusal } from '../util';
 import { RedteamGraderBase, RedteamPluginBase } from './base';
@@ -54,7 +55,7 @@ export async function fetchAllDatasets(limit: number): Promise<BeaverTailsTestCa
       }),
     );
   } catch (error) {
-    console.error('Error fetching BeaverTails datasets:', error);
+    logger.error(`Error fetching BeaverTails datasets: ${error}`);
     return [];
   }
 }

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -9,7 +9,6 @@ import type {
   AtomicTestCase,
   CallApiContextParams,
   CallApiOptionsParams,
-  GuardrailResponse,
   NunjucksFilterMap,
   Prompt,
   RedteamFileConfig,
@@ -22,6 +21,7 @@ import { sleep } from '../../../util/time';
 import { shouldGenerateRemote } from '../../remoteGeneration';
 import { isBasicRefusal } from '../../util';
 import type { Message } from '../shared';
+import type { BaseRedteamMetadata, BaseRedteamResponse } from '../shared';
 import {
   getLastMessageContent,
   getTargetResponse,
@@ -36,9 +36,7 @@ export const DEFAULT_MAX_BACKTRACKS = 10;
 /**
  * Represents metadata for the Crescendo conversation process.
  */
-export interface CrescendoMetadata {
-  redteamFinalPrompt?: string;
-  messages: string;
+export interface CrescendoMetadata extends BaseRedteamMetadata {
   crescendoRoundsCompleted: number;
   crescendoBacktrackCount: number;
   crescendoResult: boolean;
@@ -49,11 +47,8 @@ export interface CrescendoMetadata {
 /**
  * Represents the complete response from a Crescendo conversation.
  */
-export interface CrescendoResponse {
-  output: string;
+export interface CrescendoResponse extends BaseRedteamResponse {
   metadata: CrescendoMetadata;
-  tokenUsage: TokenUsage;
-  guardrails?: GuardrailResponse;
 }
 
 interface CrescendoConfig {

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -20,11 +20,12 @@ import { sleep } from '../../util/time';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
 import type { Message } from './shared';
 import { getLastMessageContent } from './shared';
+import type { BaseRedteamMetadata, BaseRedteamResponse } from './shared';
 
 /**
  * Represents metadata for the GOAT conversation process.
  */
-export interface GoatMetadata {
+export interface GoatMetadata extends BaseRedteamMetadata {
   redteamFinalPrompt?: string;
   messages: string;
   stopReason: 'Grader failed' | 'Max turns reached';
@@ -33,7 +34,7 @@ export interface GoatMetadata {
 /**
  * Represents the complete response from a GOAT conversation.
  */
-export interface GoatResponse {
+export interface GoatResponse extends BaseRedteamResponse {
   output: string;
   metadata: GoatMetadata;
   tokenUsage: TokenUsage;

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -23,6 +23,28 @@ import { checkPenalizedPhrases, getTargetResponse, redteamProviderManager } from
 
 // Based on: https://arxiv.org/abs/2312.02119
 
+interface IterativeMetadata {
+  finalIteration: number;
+  highestScore: number;
+  redteamFinalPrompt?: string;
+  redteamHistory: {
+    prompt: string;
+    output: string;
+    score: number;
+    isOnTopic: boolean;
+    graderPassed: boolean | undefined;
+    guardrails: GuardrailResponse | undefined;
+  }[];
+}
+
+interface TokenUsage {
+  total: number;
+  prompt: number;
+  completion: number;
+  numRequests: number;
+  cached: number;
+}
+
 async function runRedteamConversation({
   context,
   filters,
@@ -45,7 +67,11 @@ async function runRedteamConversation({
   targetProvider: ApiProvider;
   test?: AtomicTestCase;
   vars: Record<string, string | object>;
-}) {
+}): Promise<{
+  output: string;
+  metadata: IterativeMetadata;
+  tokenUsage: TokenUsage;
+}> {
   const nunjucks = getNunjucksEngine();
   const goal = vars[injectVar];
 
@@ -438,14 +464,15 @@ class RedteamIterativeProvider implements ApiProvider {
     return 'promptfoo:redteam:iterative';
   }
 
-  /**
-   *
-   * @param prompt - Rendered prompt. This is unused because we need the raw prompt in order to generate attacks
-   * @param context
-   * @param options
-   * @returns
-   */
-  async callApi(prompt: string, context?: CallApiContextParams, options?: CallApiOptionsParams) {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<{
+    output: string;
+    metadata: IterativeMetadata;
+    tokenUsage: TokenUsage;
+  }> {
     logger.debug(`[Iterative] callApi context: ${safeJsonStringify(context)}`);
     invariant(context?.originalProvider, 'Expected originalProvider to be set');
     invariant(context.vars, 'Expected vars to be set');

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -37,6 +37,7 @@ import { shouldGenerateRemote } from '../remoteGeneration';
 import { PENALIZED_PHRASES } from './constants';
 import { ATTACKER_SYSTEM_PROMPT, JUDGE_SYSTEM_PROMPT, ON_TOPIC_SYSTEM_PROMPT } from './prompts';
 import { getTargetResponse, redteamProviderManager } from './shared';
+import type { BaseRedteamMetadata, BaseRedteamResponse } from './shared';
 
 // Based on: https://arxiv.org/abs/2312.02119
 
@@ -376,15 +377,10 @@ export interface TreeSearchOutput {
 /**
  * Represents metadata for the iterative tree search process.
  */
-export interface TreeIterativeMetadata {
+export interface TreeIterativeMetadata extends BaseRedteamMetadata {
   highestScore: number;
   redteamFinalPrompt?: string;
-  stoppingReason:
-    | 'TARGET_SCORE'
-    | 'MAX_ATTEMPTS'
-    | 'MAX_DEPTH'
-    | 'NO_IMPROVEMENT'
-    | 'GRADER_FAILED';
+  stopReason: 'TARGET_SCORE' | 'MAX_ATTEMPTS' | 'MAX_DEPTH' | 'NO_IMPROVEMENT' | 'GRADER_FAILED';
   attempts: number;
   redteamTreeHistory: TreeSearchOutput[];
 }
@@ -392,11 +388,8 @@ export interface TreeIterativeMetadata {
 /**
  * Represents the complete response from a red team conversation.
  */
-export interface RedteamTreeResponse {
-  output: string;
+export interface RedteamTreeResponse extends BaseRedteamResponse {
   metadata: TreeIterativeMetadata;
-  tokenUsage: TokenUsage;
-  guardrails?: GuardrailResponse;
 }
 
 /**
@@ -637,9 +630,10 @@ export async function runRedteamConversation({
             metadata: {
               highestScore: maxScore,
               redteamFinalPrompt: bestNode.prompt,
-              stoppingReason,
+              messages: JSON.stringify(treeOutputs, null, 2),
               attempts,
               redteamTreeHistory: treeOutputs,
+              stopReason: stoppingReason,
             },
             tokenUsage: totalTokenUsage,
             guardrails: targetResponse.guardrails,
@@ -667,9 +661,10 @@ export async function runRedteamConversation({
             metadata: {
               highestScore: maxScore,
               redteamFinalPrompt: bestNode.prompt,
-              stoppingReason,
+              messages: JSON.stringify(treeOutputs, null, 2),
               attempts,
               redteamTreeHistory: treeOutputs,
+              stopReason: stoppingReason,
             },
             tokenUsage: totalTokenUsage,
             guardrails: targetResponse.guardrails,
@@ -698,9 +693,10 @@ export async function runRedteamConversation({
             metadata: {
               highestScore: maxScore,
               redteamFinalPrompt: bestNode.prompt,
-              stoppingReason,
+              messages: JSON.stringify(treeOutputs, null, 2),
               attempts,
               redteamTreeHistory: treeOutputs,
+              stopReason: stoppingReason,
             },
             tokenUsage: totalTokenUsage,
             guardrails: targetResponse.guardrails,
@@ -790,9 +786,10 @@ export async function runRedteamConversation({
     metadata: {
       highestScore: maxScore,
       redteamFinalPrompt: bestNode.prompt,
-      stoppingReason,
+      messages: JSON.stringify(treeOutputs, null, 2),
       attempts,
       redteamTreeHistory: treeOutputs,
+      stopReason: stoppingReason,
     },
     tokenUsage: totalTokenUsage,
     guardrails: finalTargetResponse.guardrails,

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -169,3 +169,22 @@ export function checkPenalizedPhrases(output: string): boolean {
 
   return hasPartialMatch || hasExactMatch;
 }
+
+/**
+ * Base metadata interface shared by all redteam providers
+ */
+export interface BaseRedteamMetadata {
+  redteamFinalPrompt?: string;
+  messages: string;
+  stopReason: string;
+}
+
+/**
+ * Base response interface shared by all redteam providers
+ */
+export interface BaseRedteamResponse {
+  output: string;
+  metadata: BaseRedteamMetadata;
+  tokenUsage: TokenUsage;
+  guardrails?: GuardrailResponse;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,7 +220,7 @@ export interface EvaluateResult {
   promptId: string; // on the new version 2, this is stored per-result
   provider: Pick<ProviderOptions, 'id' | 'label'>;
   prompt: Prompt;
-  vars: Record<string, string | object>;
+  vars: Vars;
   response?: ProviderResponse;
   error?: string | null;
   failureReason: ResultFailureReason;

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -17,6 +17,7 @@ jest.mock('glob', () => ({
 
 jest.mock('../src/esm');
 jest.mock('../src/logger');
+jest.mock('../src/globalConfig/globalConfig');
 jest.mock('../src/evaluatorHelpers', () => ({
   ...jest.requireActual('../src/evaluatorHelpers'),
   runExtensionHook: jest.fn(),

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../../src/cache', () => ({
 jest.mock('../../../src/redteam/remoteGeneration', () => ({
   getRemoteGenerationUrl: jest.fn().mockReturnValue('https://api.promptfoo.app/task'),
 }));
+jest.mock('../../../src/globalConfig/globalConfig');
 
 describe('fetchRemoteGeneration', () => {
   beforeAll(() => {

--- a/test/redteam/plugins/beavertails.test.ts
+++ b/test/redteam/plugins/beavertails.test.ts
@@ -3,8 +3,9 @@ import { fetchAllDatasets } from '../../../src/redteam/plugins/beavertails';
 import type { TestCase } from '../../../src/types';
 
 jest.mock('../../../src/integrations/huggingfaceDatasets');
-jest.mock('../../../src/globalConfig/globalConfig');
 jest.mock('../../../src/logger');
+jest.mock('../../../src/fetch');
+jest.mock('../../../src/globalConfig/globalConfig');
 
 describe('fetchAllDatasets', () => {
   beforeEach(() => {

--- a/test/redteam/plugins/beavertails.test.ts
+++ b/test/redteam/plugins/beavertails.test.ts
@@ -3,6 +3,8 @@ import { fetchAllDatasets } from '../../../src/redteam/plugins/beavertails';
 import type { TestCase } from '../../../src/types';
 
 jest.mock('../../../src/integrations/huggingfaceDatasets');
+jest.mock('../../../src/globalConfig/globalConfig');
+jest.mock('../../../src/logger');
 
 describe('fetchAllDatasets', () => {
   beforeEach(() => {

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -6,6 +6,9 @@ import { createApp } from '../../src/server/server';
 import invariant from '../../src/util/invariant';
 import EvalFactory from '../factories/evalFactory';
 
+jest.mock('../../src/globalConfig/globalConfig');
+jest.mock('../../src/logger');
+
 describe('eval routes', () => {
   const app = createApp();
 


### PR DESCRIPTION
This PR introduces common provider types for redteam providers to enhance code consistency and maintainability.

- Added shared metadata and response types for redteam providers.
- Updated existing providers to utilize the new shared types.