### PR TITLE
chore: exclude test files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
   "types": "dist/src/index.d.ts",
   "typings": "dist/src/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!test",
+    "!test/**/*",
+    "!**/*.test.*",
+    "!**/__tests__"
   ],
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
shrinks package from 12.7 MB to about 9.8 MB