### PR TITLE
chore(package): simplify files field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
   "typings": "dist/src/index.d.ts",
   "files": [
     "dist",
-    "!test",
-    "!test/**/*",
-    "!**/*.test.*",
-    "!**/__tests__"
+    "!dist/test",
+    "!dist/src/__mocks__"
   ],
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Simplified the 'files' field in package.json by removing redundant exclusion patterns.
- Focused exclusions to 'dist/test' and 'dist/src/__mocks__' only.
- Ensures clarity and maintains the whitelist approach.