### PR TITLE
docs: fix broken transformVars example

### DIFF
--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -672,7 +672,7 @@ The `transformVars` function should return an object with the transformed variab
 
 ```yaml
 prompts:
-  - 'Summarize the following text in {{topic_length}} words: {{file_content}}'
+  - 'Summarize the following text in {{topic_length}} words: {{processed_content}}'
 
 defaultTest:
   options:
@@ -680,13 +680,13 @@ defaultTest:
       return {
         uppercase_topic: vars.topic.toUpperCase(),
         topic_length: vars.topic.length,
-        file_content: fs.readFileSync(vars.file_path, 'utf-8')
+        processed_content: vars.content.trim()
       };
 
 tests:
   - vars:
       topic: 'climate change'
-      file_path: './data/climate_article.txt'
+      content: '  This is some text about climate change that needs processing.  '
     assert:
       - type: contains
         value: '{{uppercase_topic}}'


### PR DESCRIPTION
Update documentation example to replace 'file_content' given fs is not available in line. 

Thanks for pointing this out @mshavliuk 

Fixes #2886