### PR TITLE
fix(assertions): add valueFromScript support to contains assertions

### DIFF
--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -4,21 +4,23 @@ import invariant from '../util/invariant';
 export const handleContains = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"contains" assertion type must have a string or number value');
+  const value = valueFromScript ?? renderedValue;
+  invariant(value, '"contains" assertion type must have a string or number value');
   invariant(
-    typeof renderedValue === 'string' || typeof renderedValue === 'number',
+    typeof value === 'string' || typeof value === 'number',
     '"contains" assertion type must have a string or number value',
   );
-  const pass = outputString.includes(String(renderedValue)) !== inverse;
+  const pass = outputString.includes(String(value)) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain "${renderedValue}"`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain "${value}"`,
     assertion,
   };
 };
@@ -26,21 +28,23 @@ export const handleContains = ({
 export const handleIContains = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"icontains" assertion type must have a string or number value');
+  const value = valueFromScript ?? renderedValue;
+  invariant(value, '"icontains" assertion type must have a string or number value');
   invariant(
-    typeof renderedValue === 'string' || typeof renderedValue === 'number',
+    typeof value === 'string' || typeof value === 'number',
     '"icontains" assertion type must have a string or number value',
   );
-  const pass = outputString.toLowerCase().includes(String(renderedValue).toLowerCase()) !== inverse;
+  const pass = outputString.toLowerCase().includes(String(value).toLowerCase()) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain "${renderedValue}"`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain "${value}"`,
     assertion,
   };
 };
@@ -48,25 +52,25 @@ export const handleIContains = ({
 export const handleContainsAny = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"contains-any" assertion type must have a value');
-  if (typeof renderedValue === 'string') {
+  let value = valueFromScript ?? renderedValue;
+  invariant(value, '"contains-any" assertion type must have a value');
+  if (typeof value === 'string') {
     // Handle quoted values and escaped commas
-    renderedValue =
-      renderedValue
-        .match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g)
-        ?.map((v) => v.trim().replace(/^"|"$/g, '')) ?? [];
+    value =
+      value.match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g)?.map((v) => v.trim().replace(/^"|"$/g, '')) ?? [];
   }
-  invariant(Array.isArray(renderedValue), '"contains-any" assertion type must have an array value');
-  const pass = renderedValue.some((value) => outputString.includes(String(value))) !== inverse;
+  invariant(Array.isArray(value), '"contains-any" assertion type must have an array value');
+  const pass = value.some((v) => outputString.includes(String(v))) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain one of "${renderedValue.join(', ')}"`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain one of "${value.join(', ')}"`,
     assertion,
   };
 };
@@ -74,27 +78,24 @@ export const handleContainsAny = ({
 export const handleIContainsAny = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"icontains-any" assertion type must have a value');
-  if (typeof renderedValue === 'string') {
-    renderedValue = renderedValue.split(',').map((v) => v.trim());
+  let value = valueFromScript ?? renderedValue;
+  invariant(value, '"icontains-any" assertion type must have a value');
+  if (typeof value === 'string') {
+    value = value.split(',').map((v) => v.trim());
   }
-  invariant(
-    Array.isArray(renderedValue),
-    '"icontains-any" assertion type must have an array value',
-  );
+  invariant(Array.isArray(value), '"icontains-any" assertion type must have an array value');
   const pass =
-    renderedValue.some((value) =>
-      outputString.toLowerCase().includes(String(value).toLowerCase()),
-    ) !== inverse;
+    value.some((v) => outputString.toLowerCase().includes(String(v).toLowerCase())) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain one of "${renderedValue.join(', ')}"`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain one of "${value.join(', ')}"`,
     assertion,
   };
 };
@@ -102,22 +103,24 @@ export const handleIContainsAny = ({
 export const handleContainsAll = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"contains-all" assertion type must have a value');
-  if (typeof renderedValue === 'string') {
-    renderedValue = renderedValue.split(',').map((v) => v.trim());
+  let value = valueFromScript ?? renderedValue;
+  invariant(value, '"contains-all" assertion type must have a value');
+  if (typeof value === 'string') {
+    value = value.split(',').map((v) => v.trim());
   }
-  invariant(Array.isArray(renderedValue), '"contains-all" assertion type must have an array value');
-  const missingStrings = renderedValue.filter((value) => !outputString.includes(String(value)));
+  invariant(Array.isArray(value), '"contains-all" assertion type must have an array value');
+  const missingStrings = value.filter((v) => !outputString.includes(String(v)));
   const pass = (missingStrings.length === 0) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain all of [${renderedValue.join(', ')}]. Missing: [${missingStrings.join(', ')}]`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain all of [${value.join(', ')}]. Missing: [${missingStrings.join(', ')}]`,
     assertion,
   };
 };
@@ -125,19 +128,18 @@ export const handleContainsAll = ({
 export const handleIContainsAll = ({
   assertion,
   renderedValue,
+  valueFromScript,
   outputString,
   inverse,
 }: AssertionParams): GradingResult => {
-  invariant(renderedValue, '"icontains-all" assertion type must have a value');
-  if (typeof renderedValue === 'string') {
-    renderedValue = renderedValue.split(',').map((v) => v.trim());
+  let value = valueFromScript ?? renderedValue;
+  invariant(value, '"icontains-all" assertion type must have a value');
+  if (typeof value === 'string') {
+    value = value.split(',').map((v) => v.trim());
   }
-  invariant(
-    Array.isArray(renderedValue),
-    '"icontains-all" assertion type must have an array value',
-  );
-  const missingStrings = renderedValue.filter(
-    (value) => !outputString.toLowerCase().includes(String(value).toLowerCase()),
+  invariant(Array.isArray(value), '"icontains-all" assertion type must have an array value');
+  const missingStrings = value.filter(
+    (v) => !outputString.toLowerCase().includes(String(v).toLowerCase()),
   );
   const pass = (missingStrings.length === 0) !== inverse;
   return {
@@ -145,7 +147,7 @@ export const handleIContainsAll = ({
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected output to ${inverse ? 'not ' : ''}contain all of [${renderedValue.join(', ')}]. Missing: [${missingStrings.join(', ')}]`,
+      : `Expected output to ${inverse ? 'not ' : ''}contain all of [${value.join(', ')}]. Missing: [${missingStrings.join(', ')}]`,
     assertion,
   };
 };

--- a/test/assertions/contains.test.ts
+++ b/test/assertions/contains.test.ts
@@ -1,0 +1,653 @@
+import {
+  handleContains,
+  handleIContains,
+  handleContainsAny,
+  handleIContainsAny,
+  handleContainsAll,
+  handleIContainsAll,
+} from '../../src/assertions/contains';
+import type { AssertionParams, AssertionValue, AtomicTestCase, ApiProvider } from '../../src/types';
+
+const mockProvider: ApiProvider = {
+  id: () => 'mock',
+  callApi: async () => ({ output: 'mock' }),
+};
+
+const defaultParams = {
+  baseType: 'contains' as const,
+  context: {
+    vars: {},
+    test: {} as AtomicTestCase,
+    prompt: 'test prompt',
+    logProbs: undefined,
+    provider: mockProvider,
+    providerResponse: { output: 'hello world' },
+  },
+  output: 'hello world',
+  providerResponse: { output: 'hello world' },
+  test: {} as AtomicTestCase,
+};
+
+describe('handleContains', () => {
+  it('should pass when output contains the expected string', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: 'world' },
+      renderedValue: 'world' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should fail when output does not contain the expected string', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: 'universe' },
+      renderedValue: 'universe' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Expected output to contain "universe"',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle number values', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: '42' },
+      renderedValue: '42' as AssertionValue,
+      outputString: 'The answer is 42',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle inverse assertion correctly', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'not-contains', value: 'universe' },
+      renderedValue: 'universe' as AssertionValue,
+      outputString: 'hello world',
+      inverse: true,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should use valueFromScript over renderedValue when available', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: 'unused' },
+      renderedValue: 'unused' as AssertionValue,
+      valueFromScript: 'world' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should throw error when value is missing', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains' },
+      renderedValue: undefined,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    expect(() => handleContains(params)).toThrow(
+      '"contains" assertion type must have a string or number value',
+    );
+  });
+});
+
+describe('handleIContains', () => {
+  it('should pass when output contains the expected string case-insensitively', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains', value: 'WORLD' },
+      renderedValue: 'WORLD' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleIContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle mixed case in output and value', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains', value: 'WoRlD' },
+      renderedValue: 'WoRlD' as AssertionValue,
+      outputString: 'Hello WORLD',
+      inverse: false,
+    };
+
+    const result = handleIContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+});
+
+describe('handleContainsAny', () => {
+  it('should pass when output contains any of the expected strings', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: ['world', 'universe'] },
+      renderedValue: ['world', 'universe'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle comma-separated string input', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: 'world,universe' },
+      renderedValue: 'world,universe' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle quoted values with commas', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"hello, world",universe' },
+      renderedValue: '"hello, world",universe' as AssertionValue,
+      outputString: 'hello, world',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle complex quoted values with commas and spaces', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'contains-any',
+        value: '"hello, dear world", "goodbye, universe", simple',
+      },
+      renderedValue: '"hello, dear world", "goodbye, universe", simple' as AssertionValue,
+      outputString: 'hello, dear world is here',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle empty quoted strings', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"",' },
+      renderedValue: '"",' as AssertionValue,
+      outputString: '',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle escaped quotes and commas in quoted strings', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"hello\\"world,test", "another,test"' },
+      renderedValue: '"hello\\"world,test", "another,test"' as AssertionValue,
+      outputString: 'hello"world,test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle null value after regex match', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '""' },
+      renderedValue: '""' as AssertionValue,
+      outputString: 'test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle regex match with no groups', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"test"' },
+      renderedValue: '"test"' as AssertionValue,
+      outputString: 'test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle regex match with escaped characters', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"test\\test"' },
+      renderedValue: '"test\\test"' as AssertionValue,
+      outputString: 'test\\test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle regex match with complex escaping', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"test\\\\test"' },
+      renderedValue: '"test\\\\test"' as AssertionValue,
+      outputString: 'test\\\\test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle regex match with unmatched quotes', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-any', value: '"test' },
+      renderedValue: '"test' as AssertionValue,
+      outputString: 'test',
+      inverse: false,
+    };
+
+    const result = handleContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+});
+
+describe('handleIContainsAny', () => {
+  it('should pass when output contains any of the expected strings case-insensitively', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: ['WORLD', 'UNIVERSE'] },
+      renderedValue: ['WORLD', 'UNIVERSE'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle comma-separated string input case-insensitively', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: 'WORLD,UNIVERSE' },
+      renderedValue: 'WORLD,UNIVERSE' as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string input with multiple commas and spaces', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: 'HELLO,  WORLD  ,  UNIVERSE' },
+      renderedValue: 'HELLO,  WORLD  ,  UNIVERSE' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle empty string in comma-separated list', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: ',WORLD,,' },
+      renderedValue: ',WORLD,,' as AssertionValue,
+      outputString: '',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with spaces', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: '  HELLO  ' },
+      renderedValue: '  HELLO  ' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with multiple spaces between commas', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: 'HELLO  ,  WORLD' },
+      renderedValue: 'HELLO  ,  WORLD' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with multiple spaces and special characters', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: '  HELLO  ,  WORLD  ' },
+      renderedValue: '  HELLO  ,  WORLD  ' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with multiple spaces and commas', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: '  HELLO  ,  ,  WORLD  ' },
+      renderedValue: '  HELLO  ,  ,  WORLD  ' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with multiple consecutive commas', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: 'HELLO,,,,WORLD' },
+      renderedValue: 'HELLO,,,,WORLD' as AssertionValue,
+      outputString: 'hello',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle string value with only spaces and commas', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: '  ,  ,  ' },
+      renderedValue: '  ,  ,  ' as AssertionValue,
+      outputString: '',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+});
+
+describe('handleContainsAll', () => {
+  it('should pass when output contains all expected strings', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-all', value: ['hello', 'world'] },
+      renderedValue: ['hello', 'world'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContainsAll(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should fail when output is missing some expected strings', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains-all', value: ['hello', 'world', 'universe'] },
+      renderedValue: ['hello', 'world', 'universe'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleContainsAll(params);
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Expected output to contain all of [hello, world, universe]. Missing: [universe]',
+      assertion: params.assertion,
+    });
+  });
+});
+
+describe('handleIContainsAll', () => {
+  it('should pass when output contains all expected strings case-insensitively', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-all', value: ['HELLO', 'WORLD'] },
+      renderedValue: ['HELLO', 'WORLD'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleIContainsAll(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should fail when output is missing some expected strings case-insensitively', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-all', value: ['HELLO', 'WORLD', 'UNIVERSE'] },
+      renderedValue: ['HELLO', 'WORLD', 'UNIVERSE'] as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = handleIContainsAll(params);
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Expected output to contain all of [HELLO, WORLD, UNIVERSE]. Missing: [UNIVERSE]',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should handle mixed case in both output and expected values', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-all', value: ['HeLLo', 'WoRLD'] },
+      renderedValue: ['HeLLo', 'WoRLD'] as AssertionValue,
+      outputString: 'HELLO world',
+      inverse: false,
+    };
+
+    const result = handleIContainsAll(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where the `contains` assertions (`contains`, `icontains`, `contains-any`, `icontains-any`, `contains-all`, `icontains-all`) were not properly handling values loaded from external JavaScript files. The values were being stored in `valueFromScript` but the assertions were only checking `renderedValue`.

Relates to #2889 Thank you @mshavliuk!