### PR TITLE
fix(webui): update Next button styling to support dark mode

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Purpose.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import { Alert } from '@mui/material';
@@ -12,7 +12,7 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { alpha } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import { EXAMPLE_CONFIG, useRedTeamConfig } from '../hooks/useRedTeamConfig';
 
 interface PromptsProps {
@@ -20,6 +20,7 @@ interface PromptsProps {
 }
 
 export default function Purpose({ onNext }: PromptsProps) {
+  const theme = useTheme();
   const { config, updateApplicationDefinition, setFullConfig } = useRedTeamConfig();
   const { recordEvent } = useTelemetry();
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
@@ -193,9 +194,9 @@ export default function Purpose({ onNext }: PromptsProps) {
               onClick={onNext}
               disabled={!isPurposePresent}
               sx={{
-                backgroundColor: '#3498db',
-                '&:hover': { backgroundColor: '#2980b9' },
-                '&:disabled': { backgroundColor: '#bdc3c7' },
+                backgroundColor: theme.palette.primary.main,
+                '&:hover': { backgroundColor: theme.palette.primary.dark },
+                '&:disabled': { backgroundColor: theme.palette.action.disabledBackground },
                 px: 4,
                 py: 1,
               }}


### PR DESCRIPTION
Changes
- Update Next button styling to use theme colors instead of hardcoded values
- Fix button background and hover states in dark mode
- Use MUI's theme system for consistent styling

![image](https://github.com/user-attachments/assets/20c06983-6c35-4671-a0c9-c12896acc529)


Before: 
The Next button in the config setup page had hardcoded colors that didn't adapt to dark mode.
![image](https://github.com/user-attachments/assets/05ad3a5a-4deb-4931-9e05-85f916218d07)
