### PR TITLE
chore: Save test case from EvalResult

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -742,7 +742,7 @@ class Evaluator {
       }
 
       try {
-        await this.evalRecord.addResult(row, evalStep.test);
+        await this.evalRecord.addResult(row);
       } catch (error) {
         logger.error(`Error saving result: ${error} ${safeJsonStringify(row)}`);
       }

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -17,7 +17,6 @@ import { getUserEmail } from '../globalConfig/accounts';
 import logger from '../logger';
 import { hashPrompt } from '../prompts/utils';
 import type {
-  AtomicTestCase,
   CompletedPrompt,
   EvaluateResult,
   EvaluateStats,

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -347,8 +347,8 @@ export default class Eval {
     return convertResultsToTable(await this.toResultsFile());
   }
 
-  async addResult(result: EvaluateResult, test: AtomicTestCase) {
-    const newResult = await EvalResult.createFromEvaluateResult(this.id, result, test, {
+  async addResult(result: EvaluateResult) {
+    const newResult = await EvalResult.createFromEvaluateResult(this.id, result, {
       persist: this.persisted,
     });
     if (!this.persisted) {

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -21,7 +21,6 @@ export default class EvalResult {
   static async createFromEvaluateResult(
     evalId: string,
     result: EvaluateResult,
-    testCase: AtomicTestCase,
     opts?: { persist: boolean },
   ) {
     const persist = opts?.persist == null ? true : opts.persist;
@@ -37,6 +36,7 @@ export default class EvalResult {
       cost,
       metadata,
       failureReason,
+      testCase,
     } = result;
     const args = {
       id: randomUUID(),

--- a/test/factories/evalFactory.ts
+++ b/test/factories/evalFactory.ts
@@ -48,107 +48,101 @@ export default class EvalFactory {
         },
       },
     ]);
-    await eval_.addResult(
-      {
-        description: 'test-description',
-        promptIdx: 0,
-        testIdx: 0,
-        testCase: { vars: { state: 'colorado' }, assert: [{ type: 'contains', value: 'Denver' }] },
-        promptId: 'test-prompt',
-        provider: { id: 'test-provider', label: 'test-label' },
-        prompt: {
-          raw: 'What is the capital of {{state}}?',
-          label: 'What is the capital of {{state}}?',
-        },
-        vars: { state: 'colorado' },
-        response: {
-          output: 'denver',
-          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
-        },
-        error: null,
-        failureReason: ResultFailureReason.NONE,
-        success: true,
+    await eval_.addResult({
+      description: 'test-description',
+      promptIdx: 0,
+      testIdx: 0,
+      testCase: { vars: { state: 'colorado' }, assert: [{ type: 'contains', value: 'Denver' }] },
+      promptId: 'test-prompt',
+      provider: { id: 'test-provider', label: 'test-label' },
+      prompt: {
+        raw: 'What is the capital of {{state}}?',
+        label: 'What is the capital of {{state}}?',
+      },
+      vars: { state: 'colorado' },
+      response: {
+        output: 'denver',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+      },
+      error: null,
+      failureReason: ResultFailureReason.NONE,
+      success: true,
+      score: 1,
+      latencyMs: 100,
+      gradingResult: {
+        pass: true,
         score: 1,
-        latencyMs: 100,
-        gradingResult: {
-          pass: true,
-          score: 1,
-          reason: 'Expected output "denver" to equal "Denver"',
-          namedScores: {},
-          tokensUsed: { total: 10, prompt: 5, completion: 5, cached: 0 },
-
-          componentResults: [
-            {
-              pass: true,
-              score: 1,
-              reason: 'Expected output "denver" to equal "Denver"',
-              assertion: {
-                type: 'equals',
-                value: 'denver',
-              },
-            },
-          ],
-          assertion: null,
-        },
-
+        reason: 'Expected output "denver" to equal "Denver"',
         namedScores: {},
-        cost: 0.007,
-        metadata: {},
+        tokensUsed: { total: 10, prompt: 5, completion: 5, cached: 0 },
+
+        componentResults: [
+          {
+            pass: true,
+            score: 1,
+            reason: 'Expected output "denver" to equal "Denver"',
+            assertion: {
+              type: 'equals',
+              value: 'denver',
+            },
+          },
+        ],
+        assertion: null,
       },
-      { vars: { state: 'colorado' }, assert: [{ type: 'contains', value: 'Denver' }] },
-    );
-    await eval_.addResult(
-      {
-        description: 'test-description',
-        promptIdx: 0,
-        testIdx: 1,
-        testCase: {
-          vars: { state: 'california' },
-          assert: [{ type: 'contains', value: 'Sacramento' }],
-        },
-        promptId: 'test-prompt',
-        provider: { id: 'test-provider', label: 'test-label' },
-        prompt: {
-          raw: 'What is the capital of {{state}}?',
-          label: 'What is the capital of {{state}}?',
-        },
+
+      namedScores: {},
+      cost: 0.007,
+      metadata: {},
+    });
+    await eval_.addResult({
+      description: 'test-description',
+      promptIdx: 0,
+      testIdx: 1,
+      testCase: {
         vars: { state: 'california' },
-        response: {
-          output: 'san francisco',
-          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
-        },
-        error: null,
-        failureReason: ResultFailureReason.NONE,
-        success: false,
-        score: 0,
-        latencyMs: 100,
-        gradingResult: {
-          pass: false,
-          score: 0,
-          reason: 'Expected output "san francisco" to equal "Sacramento"',
-          namedScores: {},
-          tokensUsed: { total: 10, prompt: 5, completion: 5, cached: 0 },
-
-          componentResults: [
-            {
-              pass: false,
-              score: 0,
-              reason: 'Expected output "san francisco" to equal "Sacramento"',
-              assertion: {
-                type: 'equals',
-                value: 'denver',
-              },
-            },
-          ],
-          assertion: null,
-        },
-
-        namedScores: {},
-        cost: 0.007,
-        metadata: {},
+        assert: [{ type: 'contains', value: 'Sacramento' }],
       },
-      { vars: { state: 'california' }, assert: [{ type: 'contains', value: 'Sacramento' }] },
-    );
+      promptId: 'test-prompt',
+      provider: { id: 'test-provider', label: 'test-label' },
+      prompt: {
+        raw: 'What is the capital of {{state}}?',
+        label: 'What is the capital of {{state}}?',
+      },
+      vars: { state: 'california' },
+      response: {
+        output: 'san francisco',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+      },
+      error: null,
+      failureReason: ResultFailureReason.NONE,
+      success: false,
+      score: 0,
+      latencyMs: 100,
+      gradingResult: {
+        pass: false,
+        score: 0,
+        reason: 'Expected output "san francisco" to equal "Sacramento"',
+        namedScores: {},
+        tokensUsed: { total: 10, prompt: 5, completion: 5, cached: 0 },
+
+        componentResults: [
+          {
+            pass: false,
+            score: 0,
+            reason: 'Expected output "san francisco" to equal "Sacramento"',
+            assertion: {
+              type: 'equals',
+              value: 'denver',
+            },
+          },
+        ],
+        assertion: null,
+      },
+
+      namedScores: {},
+      cost: 0.007,
+      metadata: {},
+    });
 
     return eval_;
   }

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -53,11 +53,7 @@ describe('EvalResult', () => {
   describe('createFromEvaluateResult', () => {
     it('should create and persist an EvalResult', async () => {
       const evalId = 'test-eval-id';
-      const result = await EvalResult.createFromEvaluateResult(
-        evalId,
-        mockEvaluateResult,
-        mockTestCase,
-      );
+      const result = await EvalResult.createFromEvaluateResult(evalId, mockEvaluateResult);
 
       expect(result).toBeInstanceOf(EvalResult);
       expect(result.evalId).toBe(evalId);
@@ -72,12 +68,9 @@ describe('EvalResult', () => {
 
     it('should create without persisting when persist option is false', async () => {
       const evalId = 'test-eval-id';
-      const result = await EvalResult.createFromEvaluateResult(
-        evalId,
-        mockEvaluateResult,
-        mockTestCase,
-        { persist: false },
-      );
+      const result = await EvalResult.createFromEvaluateResult(evalId, mockEvaluateResult, {
+        persist: false,
+      });
 
       expect(result).toBeInstanceOf(EvalResult);
       expect(result.persisted).toBe(false);
@@ -112,11 +105,8 @@ describe('EvalResult', () => {
         evalId,
         {
           ...mockEvaluateResult,
-          provider: serializedProvider, // Use pre-serialized provider
-        },
-        {
-          ...testCaseWithCircular,
-          provider: serializedProvider, // Use pre-serialized provider
+          provider: serializedProvider, // Use pre-serialized provider,
+          testCase: testCaseWithCircular,
         },
         { persist: true },
       );
@@ -163,8 +153,9 @@ describe('EvalResult', () => {
         {
           ...mockEvaluateResult,
           provider: providerWithNestedData,
+          testCase: testCaseWithNestedData,
         },
-        testCaseWithNestedData,
+
         { persist: true },
       );
 
@@ -183,23 +174,17 @@ describe('EvalResult', () => {
       const evalId = 'test-eval-id-multiple';
 
       // Create multiple results
-      await EvalResult.createFromEvaluateResult(
-        evalId,
-        {
-          ...mockEvaluateResult,
-          testIdx: 0,
-        },
-        mockTestCase,
-      );
+      await EvalResult.createFromEvaluateResult(evalId, {
+        ...mockEvaluateResult,
+        testIdx: 0,
+        testCase: mockTestCase,
+      });
 
-      await EvalResult.createFromEvaluateResult(
-        evalId,
-        {
-          ...mockEvaluateResult,
-          testIdx: 1,
-        },
-        mockTestCase,
-      );
+      await EvalResult.createFromEvaluateResult(evalId, {
+        ...mockEvaluateResult,
+        testIdx: 1,
+        testCase: mockTestCase,
+      });
 
       const results = await EvalResult.findManyByEvalId(evalId);
       expect(results).toHaveLength(2);
@@ -210,23 +195,17 @@ describe('EvalResult', () => {
     it('should filter by testIdx when provided', async () => {
       const evalId = 'test-eval-id-filter';
 
-      await EvalResult.createFromEvaluateResult(
-        evalId,
-        {
-          ...mockEvaluateResult,
-          testIdx: 0,
-        },
-        mockTestCase,
-      );
+      await EvalResult.createFromEvaluateResult(evalId, {
+        ...mockEvaluateResult,
+        testIdx: 0,
+        testCase: mockTestCase,
+      });
 
-      await EvalResult.createFromEvaluateResult(
-        evalId,
-        {
-          ...mockEvaluateResult,
-          testIdx: 1,
-        },
-        mockTestCase,
-      );
+      await EvalResult.createFromEvaluateResult(evalId, {
+        ...mockEvaluateResult,
+        testIdx: 1,
+        testCase: mockTestCase,
+      });
 
       const results = await EvalResult.findManyByEvalId(evalId, { testIdx: 0 });
       expect(results).toHaveLength(1);
@@ -260,11 +239,7 @@ describe('EvalResult', () => {
     });
 
     it('should update existing results', async () => {
-      const result = await EvalResult.createFromEvaluateResult(
-        'test-eval-id',
-        mockEvaluateResult,
-        mockTestCase,
-      );
+      const result = await EvalResult.createFromEvaluateResult('test-eval-id', mockEvaluateResult);
 
       result.score = 0.5;
       await result.save();
@@ -276,11 +251,7 @@ describe('EvalResult', () => {
 
   describe('toEvaluateResult', () => {
     it('should convert EvalResult to EvaluateResult format', async () => {
-      const result = await EvalResult.createFromEvaluateResult(
-        'test-eval-id',
-        mockEvaluateResult,
-        mockTestCase,
-      );
+      const result = await EvalResult.createFromEvaluateResult('test-eval-id', mockEvaluateResult);
 
       const evaluateResult = result.toEvaluateResult();
 

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -244,7 +244,7 @@ describe('util', () => {
         },
       ];
       const eval_ = new Eval({});
-      eval_.addResult(results[0], {});
+      await eval_.addResult(results[0]);
 
       const shareableUrl = null;
       await writeOutput(outputPath, eval_, shareableUrl);


### PR DESCRIPTION
Not sure why we were passing in the test case separately. The test case on the evaluateResult is just a reference to the test case we passed in.

We passed in the `evalStep` here:
https://github.com/promptfoo/promptfoo/blob/2caf61f043eb6d7a4851f1121947bd74b1c90e96/src/evaluator.ts#L698

Deconstructed in `callApi` arguments:
https://github.com/promptfoo/promptfoo/blob/2caf61f043eb6d7a4851f1121947bd74b1c90e96/src/evaluator.ts#L104

Pass it to `callApi` here: 
https://github.com/promptfoo/promptfoo/blob/2caf61f043eb6d7a4851f1121947bd74b1c90e96/src/evaluator.ts#L181C1-L182C1

Set it to `testCase` on the `EvaluateResult` Here:
https://github.com/promptfoo/promptfoo/blob/2caf61f043eb6d7a4851f1121947bd74b1c90e96/src/evaluator.ts#L228

But then pass it in to `addResult` from the `evalStep`?
https://github.com/promptfoo/promptfoo/blob/2caf61f043eb6d7a4851f1121947bd74b1c90e96/src/evaluator.ts#L745
