### PR TITLE
fix(generation): handle cases where vars is not an array

### DIFF
--- a/src/testCases.ts
+++ b/src/testCases.ts
@@ -480,9 +480,9 @@ export async function synthesize({
       `Expected at least one JSON object in the response for persona ${persona}, got ${personaResponseObjects.length}`,
     );
     const parsed = personaResponseObjects[0] as { vars: VarMapping[] };
-    logger.debug(`Received ${parsed.vars.length} test cases`);
+    logger.debug(`Received ${parsed.vars?.length} test cases`);
     if (progressBar) {
-      progressBar.increment(parsed.vars.length);
+      progressBar.increment(parsed.vars?.length);
     }
     return parsed.vars || [];
   };


### PR DESCRIPTION
Ensure the code gracefully handles scenarios where 'vars' is undefined or not an array.
- Added optional chaining to access 'vars.length'.
- Prevents errors when 'vars' is null or undefined.