### PR TITLE
fix(providers): handle function expressions in transform response

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -202,11 +202,15 @@ export async function createTransformResponse(
     return (data, text, context) => {
       try {
         const trimmedParser = parser.trim();
+        // Check if it's a function expression (either arrow or regular)
+        const isFunctionExpression = /^(\(.*?\)\s*=>|function\s*\(.*?\))/.test(trimmedParser);
         const transformFn = new Function(
           'json',
           'text',
           'context',
-          `try { return (${trimmedParser}); } catch(e) { throw new Error('Transform failed: ' + e.message); }`,
+          isFunctionExpression
+            ? `try { return (${trimmedParser})(json, text, context); } catch(e) { throw new Error('Transform failed: ' + e.message); }`
+            : `try { return (${trimmedParser}); } catch(e) { throw new Error('Transform failed: ' + e.message); }`,
         );
         let resp: ProviderResponse | string;
         if (context) {


### PR DESCRIPTION
fix(http): handle function expressions in transform response

- Added support for parsing and executing function expressions in the transformResponse logic.
- Extended test coverage to validate various function expression scenarios.

This fixes the issuse reported in: https://github.com/promptfoo/promptfoo/issues/2901