### PR TITLE
chore(share): add confirmation step before generating public share link

### DIFF
--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -33,11 +33,8 @@ const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, evalId, onShare 
       }
 
       try {
-        console.log('check-domain request:', `/results/share/check-domain?id=${evalId}`);
         const response = await callApi(`/results/share/check-domain?id=${evalId}`);
-        console.log('check-domain response:', response);
         const data = await response.json();
-        console.log('check-domain response:', data);
 
         if (response.ok) {
           // Only show confirmation for public domain shares

--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import Button from '@mui/material/Button';
@@ -19,7 +19,13 @@ interface ShareModalProps {
 const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [copied, setCopied] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(true);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  useEffect(() => {
+    // Check if the URL is using the public domain
+    const isPublicDomain = shareUrl.includes('app.promptfoo.dev');
+    setShowConfirmation(isPublicDomain);
+  }, [shareUrl]);
 
   const handleCopyClick = () => {
     if (inputRef.current) {
@@ -32,7 +38,6 @@ const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
   const handleClose = () => {
     onClose();
     setCopied(false);
-    setShowConfirmation(true);
   };
 
   const handleConfirm = () => {
@@ -84,7 +89,9 @@ const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
               }}
             />
             <DialogContentText sx={{ fontSize: '0.75rem' }}>
-              Shared URLs are deleted after 2 weeks.
+              {shareUrl.includes('api.promptfoo.dev')
+                ? 'Shared URLs are deleted after 2 weeks.'
+                : 'This URL is accessible to users with access to your organization.'}
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -19,6 +19,7 @@ interface ShareModalProps {
 const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [copied, setCopied] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(true);
 
   const handleCopyClick = () => {
     if (inputRef.current) {
@@ -31,6 +32,11 @@ const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
   const handleClose = () => {
     onClose();
     setCopied(false);
+    setShowConfirmation(true);
+  };
+
+  const handleConfirm = () => {
+    setShowConfirmation(false);
   };
 
   return (
@@ -39,30 +45,55 @@ const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, shareUrl }) => {
       onClose={handleClose}
       PaperProps={{ style: { minWidth: 'min(660px, 100%)' } }}
     >
-      <DialogTitle>Your eval is ready to share</DialogTitle>
-      <DialogContent>
-        <TextField
-          inputRef={inputRef}
-          value={shareUrl}
-          fullWidth
-          InputProps={{
-            readOnly: true,
-            endAdornment: (
-              <IconButton onClick={handleCopyClick}>
-                {copied ? <CheckIcon /> : <FileCopyIcon />}
-              </IconButton>
-            ),
-          }}
-        />
-        <DialogContentText sx={{ fontSize: '0.75rem' }}>
-          Shared URLs are deleted after 2 weeks.
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose} color="primary">
-          Close
-        </Button>
-      </DialogActions>
+      {showConfirmation ? (
+        <>
+          <DialogTitle>Share Evaluation</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              You are about to generate a publicly accessible link for this evaluation. Anyone with
+              this link will be able to view your evaluation results.
+              <br />
+              <br />
+              Would you like to proceed?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} color="primary" variant="contained">
+              Generate Share Link
+            </Button>
+          </DialogActions>
+        </>
+      ) : (
+        <>
+          <DialogTitle>Your eval is ready to share</DialogTitle>
+          <DialogContent>
+            <TextField
+              inputRef={inputRef}
+              value={shareUrl}
+              fullWidth
+              InputProps={{
+                readOnly: true,
+                endAdornment: (
+                  <IconButton onClick={handleCopyClick}>
+                    {copied ? <CheckIcon /> : <FileCopyIcon />}
+                  </IconButton>
+                ),
+              }}
+            />
+            <DialogContentText sx={{ fontSize: '0.75rem' }}>
+              Shared URLs are deleted after 2 weeks.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} color="primary">
+              Close
+            </Button>
+          </DialogActions>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -3,7 +3,6 @@ import type { Command } from 'commander';
 import dedent from 'dedent';
 import readline from 'readline';
 import { URL } from 'url';
-import { DEFAULT_SHARE_VIEW_BASE_URL } from '../constants';
 import { getEnvString } from '../envars';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
@@ -13,31 +12,7 @@ import telemetry from '../telemetry';
 import { setupEnv } from '../util';
 import invariant from '../util/invariant';
 
-interface ShareDomainResult {
-  domain: string;
-  isPublicShare: boolean;
-}
-
-export function determineShareDomain(eval_: Eval): ShareDomainResult {
-  const sharing = eval_.config.sharing;
-  logger.debug(
-    `Share config: isCloudEnabled=${cloudConfig.isEnabled()}, sharing=${JSON.stringify(sharing)}, evalId=${eval_.id}`,
-  );
-
-  const isPublicShare =
-    !cloudConfig.isEnabled() && (!sharing || sharing === true || !('appBaseUrl' in sharing));
-
-  const domain = isPublicShare
-    ? DEFAULT_SHARE_VIEW_BASE_URL
-    : cloudConfig.isEnabled()
-      ? cloudConfig.getAppUrl()
-      : typeof sharing === 'object' && sharing.appBaseUrl
-        ? sharing.appBaseUrl
-        : DEFAULT_SHARE_VIEW_BASE_URL;
-
-  logger.debug(`Share domain determined: domain=${domain}, isPublic=${isPublicShare}`);
-  return { domain, isPublicShare };
-}
+export { determineShareDomain } from '../share';
 
 export async function createPublicUrl(evalRecord: Eval, showAuth: boolean) {
   const url = await createShareableUrl(evalRecord, showAuth);

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -3,6 +3,7 @@ import type { Command } from 'commander';
 import dedent from 'dedent';
 import readline from 'readline';
 import { URL } from 'url';
+import { DEFAULT_SHARE_VIEW_BASE_URL } from '../constants';
 import { getEnvString } from '../envars';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
@@ -11,6 +12,32 @@ import { createShareableUrl } from '../share';
 import telemetry from '../telemetry';
 import { setupEnv } from '../util';
 import invariant from '../util/invariant';
+
+interface ShareDomainResult {
+  domain: string;
+  isPublicShare: boolean;
+}
+
+export function determineShareDomain(eval_: Eval): ShareDomainResult {
+  const sharing = eval_.config.sharing;
+  logger.debug(
+    `Share config: isCloudEnabled=${cloudConfig.isEnabled()}, sharing=${JSON.stringify(sharing)}, evalId=${eval_.id}`,
+  );
+
+  const isPublicShare =
+    !cloudConfig.isEnabled() && (!sharing || sharing === true || !('appBaseUrl' in sharing));
+
+  const domain = isPublicShare
+    ? DEFAULT_SHARE_VIEW_BASE_URL
+    : cloudConfig.isEnabled()
+      ? cloudConfig.getAppUrl()
+      : typeof sharing === 'object' && sharing.appBaseUrl
+        ? sharing.appBaseUrl
+        : DEFAULT_SHARE_VIEW_BASE_URL;
+
+  logger.debug(`Share domain determined: domain=${domain}, isPublic=${isPublicShare}`);
+  return { domain, isPublicShare };
+}
 
 export async function createPublicUrl(evalRecord: Eval, showAuth: boolean) {
   const url = await createShareableUrl(evalRecord, showAuth);

--- a/src/share.ts
+++ b/src/share.ts
@@ -2,11 +2,11 @@ import input from '@inquirer/input';
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 import { URL } from 'url';
-import { SHARE_API_BASE_URL, SHARE_VIEW_BASE_URL, DEFAULT_SHARE_VIEW_BASE_URL } from './constants';
+import { determineShareDomain } from './commands/share';
+import { DEFAULT_SHARE_VIEW_BASE_URL, SHARE_API_BASE_URL, SHARE_VIEW_BASE_URL } from './constants';
 import { getEnvBool, getEnvInt, isCI } from './envars';
 import { fetchWithProxy } from './fetch';
-import { getAuthor } from './globalConfig/accounts';
-import { getUserEmail, setUserEmail } from './globalConfig/accounts';
+import { getAuthor, getUserEmail, setUserEmail } from './globalConfig/accounts';
 import { cloudConfig } from './globalConfig/cloud';
 import logger from './logger';
 import type Eval from './models/eval';
@@ -333,16 +333,13 @@ export async function createShareableUrl(
   }
   logger.debug(`New eval ID on remote instance: ${evalId}`);
 
-  // 5. Generate final URL
-  const appBaseUrl = cloudConfig.isEnabled()
-    ? cloudConfig.getAppUrl()
-    : (evalRecord.config.sharing as any)?.appBaseUrl || SHARE_VIEW_BASE_URL;
+  const { domain } = determineShareDomain(evalRecord);
 
   const fullUrl = cloudConfig.isEnabled()
-    ? `${appBaseUrl}/eval/${evalId}`
+    ? `${domain}/eval/${evalId}`
     : SHARE_VIEW_BASE_URL === DEFAULT_SHARE_VIEW_BASE_URL
-      ? `${appBaseUrl}/eval/${evalId}`
-      : `${appBaseUrl}/eval/?evalId=${evalId}`;
+      ? `${domain}/eval/${evalId}`
+      : `${domain}/eval/?evalId=${evalId}`;
 
   return showAuth ? fullUrl : stripAuthFromUrl(fullUrl);
 }


### PR DESCRIPTION
This update introduces a confirmation dialog in the share modal to ensure users are aware of the implications of generating a public share link.

- Added a confirmation step before creating a shareable link.
- Updated UI to include the confirmation dialog.

Logged in to cloud/or not using default public domain for sharing:

https://github.com/user-attachments/assets/153f1447-bf69-43ce-9514-dcb9f4c44689

Logged out:


https://github.com/user-attachments/assets/34e0ef72-c21f-48c9-ab1a-ce4af65b1c40

