### PR TITLE
fix: broken docs build

### DIFF
--- a/examples/harmbench/README.md
+++ b/examples/harmbench/README.md
@@ -130,4 +130,3 @@ defaultTest:
 - [HarmBench Paper](https://arxiv.org/abs/2402.04249)
 - [HarmBench Dataset](https://github.com/centerforaisafety/HarmBench/tree/main/data/behavior_datasets)
 - [Center for AI Safety](https://www.safe.ai/)
-

--- a/examples/harmbench/README.md
+++ b/examples/harmbench/README.md
@@ -130,4 +130,4 @@ defaultTest:
 - [HarmBench Paper](https://arxiv.org/abs/2402.04249)
 - [HarmBench Dataset](https://github.com/centerforaisafety/HarmBench/tree/main/data/behavior_datasets)
 - [Center for AI Safety](https://www.safe.ai/)
-- [PromptFoo HarmBench Plugin](https://www.promptfoo.dev/docs/red-team/plugins/harmbench/)
+

--- a/site/docs/red-team/plugins/harmbench.md
+++ b/site/docs/red-team/plugins/harmbench.md
@@ -42,7 +42,6 @@ redteam:
 
 ## Related Concepts
 
-- [Evaluating LLM safety with HarmBench](/docs/guides/evaling-with-harmbench)
 - [Types of LLM Vulnerabilities](../llm-vulnerability-types.md)
 - [Harmful Content Plugin](harmful.md)
 - [BeaverTails Plugin](beavertails.md)


### PR DESCRIPTION
- Will need to remove the harmbench plugin documentation until the build passes, then re-add it to the examples README.md