### PR TITLE
feat: add `.js` file support for `rubricPrompt` in `llm-rubric` assertion

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -76,7 +76,7 @@ import { handleRougeScore } from './rouge';
 import { handleSimilar } from './similar';
 import { handleContainsSql, handleIsSql } from './sql';
 import { handleStartsWith } from './startsWith';
-import { coerceString, getFinalTest, processFileReference } from './utils';
+import { coerceString, getFinalTest, loadFromJavaScriptFile, processFileReference } from './utils';
 import { handleWebhook } from './webhook';
 import { handleIsXml } from './xml';
 
@@ -162,18 +162,7 @@ export async function runAssertion({
       filePath = path.resolve(basePath, filePath);
 
       if (isJavascriptFile(filePath)) {
-        const requiredModule = await importModule(filePath, functionName);
-        if (functionName && typeof requiredModule[functionName] === 'function') {
-          valueFromScript = await Promise.resolve(requiredModule[functionName](output, context));
-        } else if (typeof requiredModule === 'function') {
-          valueFromScript = await Promise.resolve(requiredModule(output, context));
-        } else if (requiredModule.default && typeof requiredModule.default === 'function') {
-          valueFromScript = await Promise.resolve(requiredModule.default(output, context));
-        } else {
-          throw new Error(
-            `Assertion malformed: ${filePath} must export a function or have a default export as a function`,
-          );
-        }
+        valueFromScript = await loadFromJavaScriptFile(filePath, functionName, [output, context]);
         logger.debug(`Javascript script ${filePath} output: ${valueFromScript}`);
       } else if (filePath.endsWith('.py')) {
         try {

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -4,7 +4,6 @@ import yaml from 'js-yaml';
 import path from 'path';
 import cliState from '../cliState';
 import { getEnvInt } from '../envars';
-import { importModule } from '../esm';
 import logger from '../logger';
 import {
   matchesAnswerRelevance,

--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -38,7 +38,7 @@ export function getFinalTest(test: TestCase, assertion: Assertion) {
 export async function loadFromJavaScriptFile(
   filePath: string,
   functionName: string | undefined,
-  args: any[]
+  args: any[],
 ): Promise<any> {
   const requiredModule = await importModule(filePath, functionName);
   if (functionName && typeof requiredModule[functionName] === 'function') {

--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import path from 'path';
 import Clone from 'rfdc';
 import cliState from '../cliState';
+import { importModule } from '../esm';
 import { type Assertion, type TestCase } from '../types';
 
 const clone = Clone();
@@ -32,6 +33,25 @@ export function getFinalTest(test: TestCase, assertion: Assertion) {
   ret.options.provider = assertion.provider || test?.options?.provider;
   ret.options.rubricPrompt = assertion.rubricPrompt || ret.options.rubricPrompt;
   return Object.freeze(ret);
+}
+
+export async function loadFromJavaScriptFile(
+  filePath: string,
+  functionName: string | undefined,
+  args: any[]
+): Promise<any> {
+  const requiredModule = await importModule(filePath, functionName);
+  if (functionName && typeof requiredModule[functionName] === 'function') {
+    return requiredModule[functionName](...args);
+  } else if (typeof requiredModule === 'function') {
+    return requiredModule(...args);
+  } else if (requiredModule.default && typeof requiredModule.default === 'function') {
+    return requiredModule.default(...args);
+  } else {
+    throw new Error(
+      `Assertion malformed: ${filePath} must export a function or have a default export as a function`,
+    );
+  }
 }
 
 export function processFileReference(fileRef: string): object | string {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,8 +1,9 @@
 import dedent from 'dedent';
+import path from 'path';
+import { loadFromJavaScriptFile } from './assertions/utils';
 import cliState from './cliState';
 import { getEnvString } from './envars';
 import logger from './logger';
-import path from 'path';
 import {
   ANSWER_RELEVANCY_GENERATE,
   SELECT_BEST_PROMPT,
@@ -35,11 +36,10 @@ import type {
   ApiModerationProvider,
 } from './types';
 import { maybeLoadFromExternalFile } from './util';
+import { isJavascriptFile } from './util/file';
 import invariant from './util/invariant';
 import { extractJsonObjects } from './util/json';
 import { getNunjucksEngine } from './util/templates';
-import { isJavascriptFile } from './util/file';
-import { loadFromJavaScriptFile } from './assertions/utils';
 
 const nunjucks = getNunjucksEngine(undefined, false, true);
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -2,6 +2,7 @@ import dedent from 'dedent';
 import cliState from './cliState';
 import { getEnvString } from './envars';
 import logger from './logger';
+import path from 'path';
 import {
   ANSWER_RELEVANCY_GENERATE,
   SELECT_BEST_PROMPT,
@@ -37,6 +38,8 @@ import { maybeLoadFromExternalFile } from './util';
 import invariant from './util/invariant';
 import { extractJsonObjects } from './util/json';
 import { getNunjucksEngine } from './util/templates';
+import { isJavascriptFile } from './util/file';
+import { loadFromJavaScriptFile } from './assertions/utils';
 
 const nunjucks = getNunjucksEngine(undefined, false, true);
 
@@ -350,16 +353,29 @@ export async function matchesClassification(
   };
 }
 
-function loadRubricPrompt(
+async function loadRubricPrompt(
   rubricPrompt: string | object | undefined,
   defaultPrompt: string,
-): string {
+): Promise<string> {
   if (!rubricPrompt) {
     return defaultPrompt;
   }
 
-  // Load from external file if needed
-  rubricPrompt = maybeLoadFromExternalFile(rubricPrompt);
+  if (
+    typeof rubricPrompt === 'string' &&
+    rubricPrompt.startsWith('file://') &&
+    isJavascriptFile(rubricPrompt)
+  ) {
+    const basePath = cliState.basePath || '';
+    let filePath = rubricPrompt.slice('file://'.length);
+
+    const [pathPart, functionName] = filePath.split(':');
+    filePath = path.resolve(basePath, pathPart);
+    rubricPrompt = await loadFromJavaScriptFile(filePath, functionName, []);
+  } else {
+    // Load from external file if needed
+    rubricPrompt = maybeLoadFromExternalFile(rubricPrompt);
+  }
 
   // Stringify if it's an object
   if (typeof rubricPrompt === 'object') {
@@ -370,13 +386,13 @@ function loadRubricPrompt(
   return rubricPrompt;
 }
 
-export function renderLlmRubricPrompt(
+export async function renderLlmRubricPrompt(
   rubric: string,
   llmOutput: string,
   grading?: GradingConfig,
   vars?: Record<string, string | object>,
 ) {
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, DEFAULT_GRADING_PROMPT);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, DEFAULT_GRADING_PROMPT);
 
   return nunjucks.renderString(rubricPrompt, {
     output: JSON.stringify(llmOutput).slice(1, -1),
@@ -406,7 +422,7 @@ export async function matchesLlmRubric(
     });
   }
 
-  const prompt = renderLlmRubricPrompt(rubric, llmOutput, grading, vars);
+  const prompt = await renderLlmRubricPrompt(rubric, llmOutput, grading, vars);
 
   const defaultProviders = await getDefaultProviders();
   const defaultProvider =
@@ -467,7 +483,7 @@ export async function matchesFactuality(
     );
   }
 
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, OPENAI_FACTUALITY_PROMPT);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, OPENAI_FACTUALITY_PROMPT);
   const prompt = nunjucks.renderString(rubricPrompt, {
     input: JSON.stringify(input).slice(1, -1),
     ideal: JSON.stringify(expected).slice(1, -1),
@@ -567,7 +583,7 @@ export async function matchesClosedQa(
     );
   }
 
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, OPENAI_CLOSED_QA_PROMPT);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, OPENAI_CLOSED_QA_PROMPT);
   const prompt = nunjucks.renderString(rubricPrompt, {
     input: JSON.stringify(input).slice(1, -1),
     criteria: JSON.stringify(expected).slice(1, -1),
@@ -743,7 +759,7 @@ export async function matchesAnswerRelevance(
   const candidateQuestions: string[] = [];
   for (let i = 0; i < 3; i++) {
     // TODO(ian): Parallelize
-    const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, ANSWER_RELEVANCY_GENERATE);
+    const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, ANSWER_RELEVANCY_GENERATE);
     const promptText = nunjucks.renderString(rubricPrompt, {
       answer: JSON.stringify(output).slice(1, -1),
     });
@@ -860,7 +876,7 @@ export async function matchesContextRecall(
     'context recall check',
   );
 
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, CONTEXT_RECALL);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, CONTEXT_RECALL);
   const promptText = nunjucks.renderString(rubricPrompt, {
     context: JSON.stringify(context).slice(1, -1),
     groundTruth: JSON.stringify(groundTruth).slice(1, -1),
@@ -913,7 +929,7 @@ export async function matchesContextRelevance(
     'context relevance check',
   );
 
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, CONTEXT_RELEVANCE);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, CONTEXT_RELEVANCE);
   const promptText = nunjucks.renderString(rubricPrompt, {
     context: JSON.stringify(context).slice(1, -1),
     query: JSON.stringify(question).slice(1, -1),
@@ -1057,7 +1073,7 @@ export async function matchesSelectBest(
     'select-best check',
   );
 
-  const rubricPrompt = loadRubricPrompt(grading?.rubricPrompt, SELECT_BEST_PROMPT);
+  const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, SELECT_BEST_PROMPT);
   const promptText = nunjucks.renderString(rubricPrompt, {
     criteria: JSON.stringify(criteria).slice(1, -1),
     outputs: outputs.map((output) => JSON.stringify(output).slice(1, -1)),

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -1,23 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import { loadFromJavaScriptFile } from '../src/assertions/utils';
 import cliState from '../src/cliState';
-import {
-  getAndCheckProvider,
-  getGradingProvider,
-  matchesClassification,
-  matchesModeration,
-} from '../src/matchers';
-import {
-  matchesSimilarity,
-  matchesLlmRubric,
-  matchesFactuality,
-  matchesClosedQa,
-  matchesAnswerRelevance,
-  matchesContextRelevance,
-  matchesContextRecall,
-  matchesContextFaithfulness,
-} from '../src/matchers';
+import { importModule } from '../src/esm';
+import { getAndCheckProvider, getGradingProvider, matchesClassification, matchesModeration } from '../src/matchers';
+import { matchesSimilarity, matchesLlmRubric, matchesFactuality, matchesClosedQa, matchesAnswerRelevance, matchesContextRelevance, matchesContextRecall, matchesContextFaithfulness } from '../src/matchers';
 import { ANSWER_RELEVANCY_GENERATE, CONTEXT_RECALL, CONTEXT_RELEVANCE } from '../src/prompts';
+import { processJsFile } from '../src/prompts/processors/javascript';
 import { HuggingfaceTextClassificationProvider } from '../src/providers/huggingface';
 import { OpenAiChatCompletionProvider } from '../src/providers/openai/chat';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai/defaults';
@@ -26,14 +15,9 @@ import { OpenAiModerationProvider } from '../src/providers/openai/moderation';
 import { ReplicateModerationProvider } from '../src/providers/replicate';
 import { LLAMA_GUARD_REPLICATE_PROVIDER } from '../src/redteam/constants';
 import * as remoteGrading from '../src/remoteGrading';
-import type {
-  GradingConfig,
-  ProviderResponse,
-  ProviderClassificationResponse,
-  ApiProvider,
-  ProviderTypeMap,
-} from '../src/types';
+import type { GradingConfig, ProviderResponse, ProviderClassificationResponse, ApiProvider, ProviderTypeMap } from '../src/types';
 import { TestGrader } from './util/utils';
+
 
 jest.mock('../src/database', () => ({
   getDb: jest.fn().mockImplementation(() => {
@@ -59,6 +43,9 @@ jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   readFileSync: jest.fn(),
   existsSync: jest.fn(),
+}));
+jest.mock('../src/esm', () => ({
+  importModule: jest.fn(),
 }));
 
 const Grader = new TestGrader();
@@ -388,6 +375,40 @@ describe('matchesLlmRubric', () => {
         completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
       },
     });
+  })
+
+  it('should load rubric prompt from js file when specified', async () => {
+    const filePath = path.join('path', 'to', 'external', 'file.js');
+    const mockImportModule = jest.mocked(importModule);
+    const mockFunction = jest.fn(() => 'Do this: {{ rubric }}');
+    mockImportModule.mockResolvedValue(mockFunction);
+
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const grading = {
+      rubricPrompt: `file://${filePath}`,
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'Test passed' }),
+        }),
+      },
+    };
+
+    const result = await matchesLlmRubric(rubric, llmOutput, grading);
+
+    await expect(loadFromJavaScriptFile(filePath, undefined, [])).resolves.toBe(
+      'Do this: {{ rubric }}',
+    );
+
+    expect(grading.provider.callApi).toHaveBeenCalledWith(
+      expect.stringContaining('Do this: Test rubric'),
+    );
+    expect(mockImportModule).toHaveBeenCalledWith(filePath, undefined);
+
+    expect(result).toEqual(
+      expect.objectContaining({ pass: true, score: 1, reason: 'Test passed' }),
+    );
   });
 
   it('should throw an error when the external file is not found', async () => {

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -3,10 +3,23 @@ import path from 'path';
 import { loadFromJavaScriptFile } from '../src/assertions/utils';
 import cliState from '../src/cliState';
 import { importModule } from '../src/esm';
-import { getAndCheckProvider, getGradingProvider, matchesClassification, matchesModeration } from '../src/matchers';
-import { matchesSimilarity, matchesLlmRubric, matchesFactuality, matchesClosedQa, matchesAnswerRelevance, matchesContextRelevance, matchesContextRecall, matchesContextFaithfulness } from '../src/matchers';
+import {
+  getAndCheckProvider,
+  getGradingProvider,
+  matchesClassification,
+  matchesModeration,
+} from '../src/matchers';
+import {
+  matchesSimilarity,
+  matchesLlmRubric,
+  matchesFactuality,
+  matchesClosedQa,
+  matchesAnswerRelevance,
+  matchesContextRelevance,
+  matchesContextRecall,
+  matchesContextFaithfulness,
+} from '../src/matchers';
 import { ANSWER_RELEVANCY_GENERATE, CONTEXT_RECALL, CONTEXT_RELEVANCE } from '../src/prompts';
-import { processJsFile } from '../src/prompts/processors/javascript';
 import { HuggingfaceTextClassificationProvider } from '../src/providers/huggingface';
 import { OpenAiChatCompletionProvider } from '../src/providers/openai/chat';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai/defaults';
@@ -15,9 +28,14 @@ import { OpenAiModerationProvider } from '../src/providers/openai/moderation';
 import { ReplicateModerationProvider } from '../src/providers/replicate';
 import { LLAMA_GUARD_REPLICATE_PROVIDER } from '../src/redteam/constants';
 import * as remoteGrading from '../src/remoteGrading';
-import type { GradingConfig, ProviderResponse, ProviderClassificationResponse, ApiProvider, ProviderTypeMap } from '../src/types';
+import type {
+  GradingConfig,
+  ProviderResponse,
+  ProviderClassificationResponse,
+  ApiProvider,
+  ProviderTypeMap,
+} from '../src/types';
 import { TestGrader } from './util/utils';
-
 
 jest.mock('../src/database', () => ({
   getDb: jest.fn().mockImplementation(() => {
@@ -375,7 +393,7 @@ describe('matchesLlmRubric', () => {
         completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
       },
     });
-  })
+  });
 
   it('should load rubric prompt from js file when specified', async () => {
     const filePath = path.join('path', 'to', 'external', 'file.js');


### PR DESCRIPTION
This PR add a `.js` files support for the `rubricPrompt` attribute of `type: llm-rubric` assertion

ref #2971