### PR TITLE
fix: Crescendo would bail after a single refusal with stateful bots

### DIFF
--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -310,7 +310,7 @@ export class CrescendoProvider implements ApiProvider {
           `[Crescendo] Refusal check result: isRefusal=${isRefusal}, rationale=${refusalRationale}`,
         );
 
-        if (isRefusal) {
+        if (isRefusal && !this.stateful) {
           logger.debug('\n[Crescendo] Response Rejected, performing back tracking...\n');
           backtrackCount++;
           this.targetConversationId = await this.backtrackMemory(this.targetConversationId);


### PR DESCRIPTION
This at least gives the strategy a chance to find a jailbreak if it's stateful. We can't backtrack with stateful conversations because the server will continue with the current conversation.