### PR TITLE
feat(openai): update default grading provider to gpt-4o-2024-11-20

### DIFF
--- a/src/providers/openai/defaults.ts
+++ b/src/providers/openai/defaults.ts
@@ -3,8 +3,8 @@ import { OpenAiEmbeddingProvider } from './embedding';
 import { OpenAiModerationProvider } from './moderation';
 
 export const DefaultEmbeddingProvider = new OpenAiEmbeddingProvider('text-embedding-3-large');
-export const DefaultGradingProvider = new OpenAiChatCompletionProvider('gpt-4o-2024-05-13');
-export const DefaultGradingJsonProvider = new OpenAiChatCompletionProvider('gpt-4o-2024-05-13', {
+export const DefaultGradingProvider = new OpenAiChatCompletionProvider('gpt-4o-2024-11-20');
+export const DefaultGradingJsonProvider = new OpenAiChatCompletionProvider('gpt-4o-2024-11-20', {
   config: {
     response_format: { type: 'json_object' },
   },

--- a/test/providers/openai/defaults.test.ts
+++ b/test/providers/openai/defaults.test.ts
@@ -3,15 +3,48 @@ import {
   DefaultEmbeddingProvider,
   DefaultGradingProvider,
   DefaultGradingJsonProvider,
+  DefaultSuggestionsProvider,
+  DefaultModerationProvider,
 } from '../../../src/providers/openai/defaults';
 
 describe('OpenAI default providers', () => {
-  it('should use correct model versions', () => {
-    expect(DefaultEmbeddingProvider.modelName).toBe('text-embedding-3-large');
-    expect(DefaultGradingProvider.modelName).toBe('gpt-4o-2024-11-20');
-    expect(DefaultGradingJsonProvider.modelName).toBe('gpt-4o-2024-11-20');
-    expect(DefaultGradingJsonProvider.config).toEqual({
-      response_format: { type: 'json_object' },
+  describe('DefaultEmbeddingProvider', () => {
+    it('should use correct model version', () => {
+      expect(DefaultEmbeddingProvider.modelName).toBe('text-embedding-3-large');
+      expect(DefaultEmbeddingProvider.id()).toBe('openai:text-embedding-3-large');
+    });
+  });
+
+  describe('DefaultGradingProvider', () => {
+    it('should use correct model version and configuration', () => {
+      expect(DefaultGradingProvider.modelName).toBe('gpt-4o-2024-11-20');
+      expect(DefaultGradingProvider.id()).toBe('openai:gpt-4o-2024-11-20');
+      expect(DefaultGradingProvider.config).toEqual({});
+    });
+  });
+
+  describe('DefaultGradingJsonProvider', () => {
+    it('should use correct model version and JSON configuration', () => {
+      expect(DefaultGradingJsonProvider.modelName).toBe('gpt-4o-2024-11-20');
+      expect(DefaultGradingJsonProvider.id()).toBe('openai:gpt-4o-2024-11-20');
+      expect(DefaultGradingJsonProvider.config).toEqual({
+        response_format: { type: 'json_object' },
+      });
+    });
+  });
+
+  describe('DefaultSuggestionsProvider', () => {
+    it('should use correct model version', () => {
+      expect(DefaultSuggestionsProvider.modelName).toBe('gpt-4o-2024-05-13');
+      expect(DefaultSuggestionsProvider.id()).toBe('openai:gpt-4o-2024-05-13');
+      expect(DefaultSuggestionsProvider.config).toEqual({});
+    });
+  });
+
+  describe('DefaultModerationProvider', () => {
+    it('should use correct model version', () => {
+      expect(DefaultModerationProvider.modelName).toBe('omni-moderation-latest');
+      expect(DefaultModerationProvider.id()).toBe('openai:omni-moderation-latest');
     });
   });
 });

--- a/test/providers/openai/defaults.test.ts
+++ b/test/providers/openai/defaults.test.ts
@@ -7,13 +7,8 @@ import {
 
 describe('OpenAI default providers', () => {
   it('should use correct model versions', () => {
-    // Check embedding model version
     expect(DefaultEmbeddingProvider.modelName).toBe('text-embedding-3-large');
-
-    // Check grading provider model version
     expect(DefaultGradingProvider.modelName).toBe('gpt-4o-2024-11-20');
-
-    // Check grading JSON provider model version and config
     expect(DefaultGradingJsonProvider.modelName).toBe('gpt-4o-2024-11-20');
     expect(DefaultGradingJsonProvider.config).toEqual({
       response_format: { type: 'json_object' },

--- a/test/providers/openai/defaults.test.ts
+++ b/test/providers/openai/defaults.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  DefaultEmbeddingProvider,
+  DefaultGradingProvider,
+  DefaultGradingJsonProvider,
+} from '../../../src/providers/openai/defaults';
+
+describe('OpenAI default providers', () => {
+  it('should use correct model versions', () => {
+    // Check embedding model version
+    expect(DefaultEmbeddingProvider.modelName).toBe('text-embedding-3-large');
+
+    // Check grading provider model version
+    expect(DefaultGradingProvider.modelName).toBe('gpt-4o-2024-11-20');
+
+    // Check grading JSON provider model version and config
+    expect(DefaultGradingJsonProvider.modelName).toBe('gpt-4o-2024-11-20');
+    expect(DefaultGradingJsonProvider.config).toEqual({
+      response_format: { type: 'json_object' },
+    });
+  });
+});


### PR DESCRIPTION
Updated the default grading provider to use the latest model version `gpt-4o-2024-11-20`. This comes after running some large evals internally. The model performs better and is half the cost. 