### PR TITLE
chore: expose `deleteFromCache` to evict cache keys after fetch by providers

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -123,8 +123,7 @@ export async function fetchWithCache<T = any>(
       // Don't cache if the parsed data contains an error
       if (format === 'json' && parsedData?.error) {
         logger.debug(`Not caching ${url} because it contains an 'error' key: ${parsedData.error}`);
-        errorResponse = data;
-        return;
+        return data;
       }
       logger.debug(`Storing ${url} response in cache: ${data}`);
       return data;
@@ -149,10 +148,8 @@ export async function fetchWithCache<T = any>(
     statusText: parsedResponse.statusText,
     headers: parsedResponse.headers,
     deleteFromCache: async () => {
-      if (cached) {
-        await cache.del(cacheKey);
-        logger.debug(`Evicted from cache: ${cacheKey}`);
-      }
+      await cache.del(cacheKey);
+      logger.debug(`Evicted from cache: ${cacheKey}`);
     },
   };
 }

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -159,6 +159,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       }
     } catch (err) {
       logger.error(`API call error: ${String(err)}`);
+      await data.deleteFromCache?.();
       return {
         error: `API call error: ${String(err)}`,
       };
@@ -166,10 +167,12 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     logger.debug(`\tOpenAI chat completions API response: ${JSON.stringify(data)}`);
     if (data.error) {
+      await data.deleteFromCache?.();
       return {
         error: formatOpenAiError(data),
       };
     }
+
     try {
       const message = data.choices[0].message;
       if (message.refusal) {
@@ -251,6 +254,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         ),
       };
     } catch (err) {
+      await data.deleteFromCache?.();
       return {
         error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
       };

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -159,7 +159,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       }
     } catch (err) {
       logger.error(`API call error: ${String(err)}`);
-      await data.deleteFromCache?.();
+      await data?.deleteFromCache?.();
       return {
         error: `API call error: ${String(err)}`,
       };
@@ -254,7 +254,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         ),
       };
     } catch (err) {
-      await data.deleteFromCache?.();
+      await data?.deleteFromCache?.();
       return {
         error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
       };

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -167,21 +167,26 @@ describe('fetchWithCache', () => {
       const result = await fetchWithCache(url, {}, 1000);
 
       expect(mockedFetch).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         cached: false,
         data: response,
         status: 200,
         statusText: 'OK',
         headers: { 'x-session-id': '45', 'content-type': 'application/json' },
       });
+      expect(result.deleteFromCache).toBeInstanceOf(Function);
 
       // Second call should use cache
       const cachedResult = await fetchWithCache(url, {}, 1000);
       expect(mockedFetch).toHaveBeenCalledTimes(1); // No additional fetch calls
-      expect(cachedResult).toEqual({
-        ...result,
+      expect(cachedResult).toMatchObject({
+        data: response,
+        status: 200,
+        statusText: 'OK',
+        headers: { 'x-session-id': '45', 'content-type': 'application/json' },
         cached: true,
       });
+      expect(cachedResult.deleteFromCache).toBeInstanceOf(Function);
     });
 
     it('should not cache failed requests', async () => {
@@ -304,19 +309,27 @@ describe('fetchWithCache', () => {
 
       const firstResult = await fetchWithCache(url, {}, 1000);
       expect(mockedFetch).toHaveBeenCalledTimes(1);
-      expect(firstResult).toEqual({
+      expect(firstResult).toMatchObject({
         cached: false,
         data: response,
         status: 200,
         statusText: 'OK',
         headers: { 'content-type': 'application/json', 'x-session-id': '45' },
       });
+      expect(firstResult.deleteFromCache).toBeInstanceOf(Function);
 
       // Second call should fetch again
       mockedFetch.mockResolvedValueOnce(mockResponse);
       const secondResult = await fetchWithCache(url, {}, 1000);
       expect(mockedFetch).toHaveBeenCalledTimes(2);
-      expect(secondResult).toEqual(firstResult);
+      expect(secondResult).toMatchObject({
+        cached: false,
+        data: response,
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json', 'x-session-id': '45' },
+      });
+      expect(secondResult.deleteFromCache).toBeInstanceOf(Function);
     });
   });
 


### PR DESCRIPTION
I am adding this because some openai-compatible apis do not return HTTP status codes that reflect the actual outcome (openrouter). This means we cache things like rate limit errors.

In theory this should be handled at the evaluator level, because we never want to cache an error for any provider.  But that would be a heavy refactor