### PR TITLE
fix: invariant failed: llm-rubric produced malformed response

### DIFF
--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -185,8 +185,9 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       } else if (message.content && (message.function_call || message.tool_calls)) {
         if (Array.isArray(message.tool_calls) && message.tool_calls.length === 0) {
           output = message.content;
+        } else {
+          output = message;
         }
-        output = message;
       } else if (message.content === null) {
         output = message.function_call || message.tool_calls;
       } else {

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -203,6 +203,28 @@ describe('OpenAI Provider', () => {
       expect(result.isRefusal).toBe(true);
     });
 
+    it('should handle empty function tool callbacks array correctly', async () => {
+      const mockResponse = {
+        data: {
+          choices: [{ message: { content: 'Test output', tool_calls: [] } }],
+          usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetchWithCache.mockResolvedValue(mockResponse);
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
+      const result = await provider.callApi(
+        JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
+      );
+
+      expect(mockFetchWithCache).toHaveBeenCalledTimes(1);
+      expect(result.output).toBe('Test output');
+      expect(result.tokenUsage).toEqual({ total: 10, prompt: 5, completion: 5 });
+    });
+
     it('should handle function tool callbacks correctly', async () => {
       const mockResponse = {
         data: {


### PR DESCRIPTION
If `/v1/chat/completions` of an OpenAI compatible API is called and the response has `tool_calls: []`, the content of the response is not treated as a string but as JSON. This causes all llm-rubric assertions to fail with following error:

```
Error: Invariant failed: llm-rubric produced malformed response
    at invariant (/promptfoo/src/util/invariant.ts:26:9)
    at matchesLlmRubric (/promptfoo/src/matchers.ts:441:12)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async handleLlmRubric (/promptfoo/src/assertions/llmRubric.ts:23:9)
    at async runAssertion (/promptfoo/src/assertions/index.ts:279:20)
    at async /promptfoo/src/assertions/index.ts:358:22
```

This bug is reproducible by using any LLM that is served using [vLLM](https://blog.vllm.ai) or any other solution that sets `tool_calls: []`. The reason is that responses from vLLM always have `tool_calls: []` instead of not defining that property. As llm-rubric assertions [expect the responses to be strings](https://github.com/promptfoo/promptfoo/blob/5fb89d63f22ea05e875aa70e629db643dc0c4b22/src/matchers.ts#L441) instead of objects, all llm-rubric assertions will fail in case vLLM's API is used. OpenAI's own API does not inlcude that property in its response when it is not needed.

It seems that there was an `else` block missing from the code. In this PR I've included that missing block and a simple test case that will fail without the block.