### PR TITLE
fix(go-mod): resolve invalid Go toolchain version warning

### DIFF
--- a/examples/golang-provider/go.mod
+++ b/examples/golang-provider/go.mod
@@ -1,5 +1,5 @@
 module github.com/yourusername/promptfoo-golang-provider
 
-go 1.23
+go 1.23.0
 
 require github.com/sashabaranov/go-openai v1.36.1


### PR DESCRIPTION
Resolve the invalid Go toolchain version warning by specifying the full version in go.mod.
- Updated the Go version from '1.23' to '1.23.0'.