### PR TITLE
fix: escape single quotes in golang provider

### DIFF
--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -79,8 +79,10 @@ export class GolangProvider implements ApiProvider {
         delete context.logger;
       }
 
+      const safePrompt = prompt.replace(/'/g, "\\'");
+
       const args =
-        apiType === 'call_api' ? [prompt, this.options, context] : [prompt, this.options];
+        apiType === 'call_api' ? [safePrompt, this.options, context] : [safePrompt, this.options];
       logger.debug(
         `Running Golang script ${absPath} with scriptPath ${this.scriptPath} and args: ${safeJsonStringify(args)}`,
       );


### PR DESCRIPTION
[DRAFT] PR to fix an issue where prompt arguments with single quotes break the provider, since it runs as a bash command under-the-hood