### PR TITLE
chore(eval): add redteamFinalPrompt to download menu

### DIFF
--- a/src/app/src/pages/eval/components/DownloadMenu.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.tsx
@@ -123,6 +123,7 @@ function DownloadMenu() {
           output: row.outputs[0].text.includes('---')
             ? row.outputs[0].text.split('---\n')[1]
             : row.outputs[0].text,
+          redteamFinalPrompt: row.outputs[0].metadata?.redteamFinalPrompt,
         },
         assert: [
           {


### PR DESCRIPTION
Add the redteamFinalPrompt field to the download menu component.
- Ensures metadata is included in the download functionality.