### PR TITLE
Parse strings in llm rubric outputs 

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -452,8 +452,8 @@ export async function matchesLlmRubric(
     let score = parsed.score;
 
     // Handle invalid or missing scores
-    if (typeof score !== 'number' || Number.isNaN(score)) {
-      score = pass ? 1.0 : 0.0;
+    if (typeof score !== 'number') {
+      score = Number.isNaN(Number(score)) ? Number(pass) : Number(score);
     }
 
     // Apply threshold check if threshold is defined

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -449,6 +449,10 @@ export async function matchesLlmRubric(
     const parsed = jsonObjects[0] as Partial<GradingResult>;
     const threshold = assertion?.threshold;
     let pass = parsed.pass ?? true;
+    if (typeof pass as any === 'string') {
+      pass = /^(true|yes|pass|y)$/i.test(String(pass));
+    }
+
     let score = parsed.score;
 
     // Handle invalid or missing scores

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -632,6 +632,58 @@ describe('matchesLlmRubric', () => {
     );
   });
 
+  it('should handle string pass values', async () => {
+    const rubricPrompt = 'Rubric prompt';
+    const output = 'Sample output';
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: rubricPrompt,
+      threshold: 0.8,
+    };
+
+    const stringPassResult = { reason: 'String pass', pass: 'true' };
+    const stringPassOptions: GradingConfig = {
+      rubricPrompt,
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: JSON.stringify(stringPassResult),
+        }),
+      },
+    };
+
+    await expect(
+      matchesLlmRubric(rubricPrompt, output, stringPassOptions, {}, assertion),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        assertion,
+        pass: true,
+        reason: 'String pass',
+      }),
+    );
+
+    const stringFailResult = { reason: 'String fail', pass: 'false' };
+    const stringFailOptions: GradingConfig = {
+      rubricPrompt,
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: JSON.stringify(stringFailResult),
+        }),
+      },
+    };
+
+    await expect(
+      matchesLlmRubric(rubricPrompt, output, stringFailOptions, {}, assertion),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        assertion,
+        pass: false,
+        reason: 'String fail',
+      }),
+    );
+  });
+
   it('should load rubric prompt from external file when specified', async () => {
     const rubric = 'Test rubric';
     const llmOutput = 'Test output';

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -600,6 +600,38 @@ describe('matchesLlmRubric', () => {
     );
   });
 
+  it('should handle string scores', async () => {
+    const rubricPrompt = 'Rubric prompt';
+    const output = 'Sample output';
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: rubricPrompt,
+      threshold: 0.8,
+    };
+
+    const stringScoreResult = { score: '0.9', reason: 'String score' };
+    const stringScoreOptions: GradingConfig = {
+      rubricPrompt,
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: JSON.stringify(stringScoreResult),
+        }),
+      },
+    };
+
+    await expect(
+      matchesLlmRubric(rubricPrompt, output, stringScoreOptions, {}, assertion),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        assertion,
+        score: 0.9,
+        pass: true,
+        reason: 'String score',
+      }),
+    );
+  });
+
   it('should load rubric prompt from external file when specified', async () => {
     const rubric = 'Test rubric';
     const llmOutput = 'Test output';


### PR DESCRIPTION
Occasionally, the grading LLM may output grading json with string values used for `score` or `pass` properties. This PR implements string parsing which would handle such cases and try to parse string `score` as number and string `pass` as boolean. 

closes  #3036