### PR TITLE
chore(webui): ensure thumbs remain active after selection

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useShiftKey } from '@app/hooks/useShiftKey';
 import Tooltip from '@mui/material/Tooltip';
-import { ResultFailureReason, type EvaluateTableOutput } from '@promptfoo/types';
-import { diffSentences, diffJson, diffWords } from 'diff';
+import { type EvaluateTableOutput, ResultFailureReason } from '@promptfoo/types';
+import { diffJson, diffSentences, diffWords } from 'diff';
 import remarkGfm from 'remark-gfm';
 import CustomMetrics from './CustomMetrics';
 import EvalOutputPromptDialog from './EvalOutputPromptDialog';
@@ -52,6 +52,19 @@ function EvalOutputCell({
   const { renderMarkdown, prettifyJson, showPrompts, showPassFail, maxImageWidth, maxImageHeight } =
     useResultsViewStore();
   const [openPrompt, setOpen] = React.useState(false);
+  const [activeRating, setActiveRating] = React.useState<boolean | null>(
+    output.gradingResult?.componentResults?.find((result) => result.assertion?.type === 'human')
+      ?.pass ?? null,
+  );
+
+  // Update activeRating when output changes
+  React.useEffect(() => {
+    const humanRating = output.gradingResult?.componentResults?.find(
+      (result) => result.assertion?.type === 'human',
+    )?.pass;
+    setActiveRating(humanRating ?? null);
+  }, [output]);
+
   const handlePromptOpen = () => {
     setOpen(true);
   };
@@ -226,6 +239,7 @@ function EvalOutputCell({
 
   const handleRating = React.useCallback(
     (isPass: boolean) => {
+      setActiveRating(isPass);
       onRating(isPass, undefined, output.gradingResult?.comment);
     },
     [onRating, output.gradingResult?.comment],
@@ -396,12 +410,18 @@ function EvalOutputCell({
           />
         </>
       )}
-      <span className="action" onClick={() => handleRating(true)}>
+      <span
+        className={`action ${activeRating === true ? 'active' : ''}`}
+        onClick={() => handleRating(true)}
+      >
         <Tooltip title="Mark test passed (score 1.0)">
           <span>👍</span>
         </Tooltip>
       </span>
-      <span className="action" onClick={() => handleRating(false)}>
+      <span
+        className={`action ${activeRating === false ? 'active' : ''}`}
+        onClick={() => handleRating(false)}
+      >
         <Tooltip title="Mark test failed (score 0.0)">
           <span>👎</span>
         </Tooltip>

--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -165,9 +165,15 @@ table.results-table,
   font-size: 1.25rem;
 }
 
+/* Show all actions on hover */
 .results-table .first-prompt-col:hover .cell-actions,
 .results-table .second-prompt-column:hover .cell-actions {
   visibility: visible;
+}
+
+/* Always show active thumbs */
+.results-table tr .cell-actions .action.active {
+  visibility: visible !important;
 }
 
 .results-table tr .cell-detail {
@@ -188,6 +194,10 @@ table.results-table,
 
 .results-table tr .cell-actions .action {
   cursor: pointer;
+}
+
+.results-table tr .cell-actions .action.active span {
+  filter: saturate(1.5);
 }
 
 /* Table-within-a-cell, used for markdown tables */


### PR DESCRIPTION
Fixes an issue where thumbs (like/dislike) would not visually persist after being clicked.

- Added state management for active thumbs in EvalOutputCell.
- Updated CSS to visually indicate active thumbs.

No breaking changes.