### PR TITLE
fix: broken handling of absolute paths in hook/code import

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url';
-import * as path from 'path';
 import logger from './logger';
+import { safeResolve } from './util/file';
 
 // esm-specific crap that needs to get mocked out in tests
 
@@ -18,7 +18,7 @@ export function getDirectory(): string {
 
 export async function importModule(modulePath: string, functionName?: string) {
   logger.debug(
-    `Attempting to import module: ${JSON.stringify({ resolvedPath: path.resolve(modulePath), moduleId: modulePath })}`,
+    `Attempting to import module: ${JSON.stringify({ resolvedPath: safeResolve(modulePath), moduleId: modulePath })}`,
   );
 
   try {
@@ -27,7 +27,8 @@ export async function importModule(modulePath: string, functionName?: string) {
       // @ts-ignore: It actually works
       await import('tsx/cjs');
     }
-    const resolvedPath = pathToFileURL(path.resolve(modulePath));
+
+    const resolvedPath = pathToFileURL(safeResolve(modulePath));
     logger.debug(`Attempting ESM import from: ${resolvedPath.toString()}`);
     const importedModule = await import(resolvedPath.toString());
     const mod = importedModule?.default?.default || importedModule?.default || importedModule;
@@ -45,10 +46,10 @@ export async function importModule(modulePath: string, functionName?: string) {
     logger.debug('Attempting CommonJS require fallback...');
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const importedModule = require(path.resolve(modulePath));
+      const importedModule = require(safeResolve(modulePath));
       const mod = importedModule?.default?.default || importedModule?.default || importedModule;
       logger.debug(
-        `Successfully required module: ${JSON.stringify({ resolvedPath: path.resolve(modulePath), moduleId: modulePath })}`,
+        `Successfully required module: ${JSON.stringify({ resolvedPath: safeResolve(modulePath), moduleId: modulePath })}`,
       );
       if (functionName) {
         logger.debug(`Returning named export: ${functionName}`);

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url';
 import logger from './logger';
-import { safeResolve } from './util/file';
+import { safeResolve } from './util/file.node';
 
 // esm-specific crap that needs to get mocked out in tests
 

--- a/src/util/file.node.ts
+++ b/src/util/file.node.ts
@@ -1,0 +1,53 @@
+/**
+ * Node-only file utilities.
+ * Application tests were failing when trying to import this module possibly
+ * because of an older version of polyfilled of node:url.
+ *
+ * TODO:vedant Fix this ugly hack one day
+ */
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+function isAbsolute(filePath: string): boolean {
+  try {
+    // Handle both Windows and POSIX file URL formats
+    // Windows: file://C:/path or file:///C:/path
+    // POSIX: file:///path
+    if (filePath.startsWith('file://')) {
+      return path.isAbsolute(fileURLToPath(filePath));
+    }
+    return path.isAbsolute(filePath);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely resolves a path - only calls resolve() if the last path is relative
+ * Leaves absolute paths and absolute URLs unchanged
+ *
+ * @param paths - The path segments to resolve
+ * @returns The resolved path if last path is relative, or the last path if it's absolute
+ */
+export function safeResolve(...paths: string[]): string {
+  const lastPath = paths[paths.length - 1] || '';
+  if (isAbsolute(lastPath)) {
+    return lastPath;
+  }
+  return path.resolve(...paths);
+}
+
+/**
+ * Safely joins paths - only joins if the last path is relative
+ * If the last path is absolute or an absolute URL, returns it directly
+ *
+ * @param paths - The path segments to join
+ * @returns The joined path if last path is relative, or the last path if it's absolute
+ */
+export function safeJoin(...paths: string[]): string {
+  const lastPath = paths[paths.length - 1] || '';
+  if (isAbsolute(lastPath)) {
+    return lastPath;
+  }
+  return path.join(...paths);
+}

--- a/src/util/file.node.ts
+++ b/src/util/file.node.ts
@@ -3,7 +3,7 @@
  * Application tests were failing when trying to import this module possibly
  * because of an older version of polyfilled of node:url.
  *
- * TODO:vedant Fix this ugly hack one day
+ * TODO:vedant Fix this hack one day
  */
 import { fileURLToPath } from 'node:url';
 import path from 'path';

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,7 +1,19 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 function isAbsolute(filePath: string): boolean {
-  return filePath.startsWith('file:///') || path.isAbsolute(filePath);
+  try {
+    // Handle both Windows and POSIX file URL formats
+    // Windows: file://C:/path or file:///C:/path
+    // POSIX: file:///path
+    if (filePath.startsWith('file://')) {
+      fileURLToPath(filePath); // Validate it's a proper file URL
+      return true;
+    }
+    return path.isAbsolute(filePath);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,5 +1,9 @@
 import path from 'path';
 
+function isAbsolute(filePath: string): boolean {
+  return filePath.startsWith('file:///') || path.isAbsolute(filePath);
+}
+
 /**
  * Checks if a file is a JavaScript or TypeScript file based on its extension.
  *
@@ -19,7 +23,7 @@ export function isJavascriptFile(filePath: string): boolean {
  */
 export function safeResolve(...paths: string[]): string {
   const lastPath = paths[paths.length - 1] || '';
-  if (lastPath.startsWith('file:///') || path.isAbsolute(lastPath)) {
+  if (isAbsolute(lastPath)) {
     return lastPath;
   }
   return path.resolve(...paths);
@@ -34,7 +38,7 @@ export function safeResolve(...paths: string[]): string {
  */
 export function safeJoin(...paths: string[]): string {
   const lastPath = paths[paths.length - 1] || '';
-  if (lastPath.startsWith('file:///') || path.isAbsolute(lastPath)) {
+  if (isAbsolute(lastPath)) {
     return lastPath;
   }
   return path.join(...paths);

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,20 +1,3 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-function isAbsolute(filePath: string): boolean {
-  try {
-    // Handle both Windows and POSIX file URL formats
-    // Windows: file://C:/path or file:///C:/path
-    // POSIX: file:///path
-    if (filePath.startsWith('file://')) {
-      return path.isAbsolute(fileURLToPath(filePath));
-    }
-    return path.isAbsolute(filePath);
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Checks if a file is a JavaScript or TypeScript file based on its extension.
  *
@@ -23,34 +6,4 @@ function isAbsolute(filePath: string): boolean {
  */
 export function isJavascriptFile(filePath: string): boolean {
   return /\.(js|cjs|mjs|ts|cts|mts)$/.test(filePath);
-}
-
-/**
- * Safely resolves a path - only calls resolve() if the last path is relative
- * Leaves absolute paths and absolute URLs unchanged
- *
- * @param paths - The path segments to resolve
- * @returns The resolved path if last path is relative, or the last path if it's absolute
- */
-export function safeResolve(...paths: string[]): string {
-  const lastPath = paths[paths.length - 1] || '';
-  if (isAbsolute(lastPath)) {
-    return lastPath;
-  }
-  return path.resolve(...paths);
-}
-
-/**
- * Safely joins paths - only joins if the last path is relative
- * If the last path is absolute or an absolute URL, returns it directly
- *
- * @param paths - The path segments to join
- * @returns The joined path if last path is relative, or the last path if it's absolute
- */
-export function safeJoin(...paths: string[]): string {
-  const lastPath = paths[paths.length - 1] || '';
-  if (isAbsolute(lastPath)) {
-    return lastPath;
-  }
-  return path.join(...paths);
 }

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 /**
  * Checks if a file is a JavaScript or TypeScript file based on its extension.
  *
@@ -6,4 +8,34 @@
  */
 export function isJavascriptFile(filePath: string): boolean {
   return /\.(js|cjs|mjs|ts|cts|mts)$/.test(filePath);
+}
+
+/**
+ * Safely resolves a path - only calls resolve() if the last path is relative
+ * Leaves absolute paths and absolute URLs unchanged
+ *
+ * @param paths - The path segments to resolve
+ * @returns The resolved path if last path is relative, or the last path if it's absolute
+ */
+export function safeResolve(...paths: string[]): string {
+  const lastPath = paths[paths.length - 1] || '';
+  if (lastPath.startsWith('file:///') || path.isAbsolute(lastPath)) {
+    return lastPath;
+  }
+  return path.resolve(...paths);
+}
+
+/**
+ * Safely joins paths - only joins if the last path is relative
+ * If the last path is absolute or an absolute URL, returns it directly
+ *
+ * @param paths - The path segments to join
+ * @returns The joined path if last path is relative, or the last path if it's absolute
+ */
+export function safeJoin(...paths: string[]): string {
+  const lastPath = paths[paths.length - 1] || '';
+  if (lastPath.startsWith('file:///') || path.isAbsolute(lastPath)) {
+    return lastPath;
+  }
+  return path.join(...paths);
 }

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -7,8 +7,7 @@ function isAbsolute(filePath: string): boolean {
     // Windows: file://C:/path or file:///C:/path
     // POSIX: file:///path
     if (filePath.startsWith('file://')) {
-      fileURLToPath(filePath); // Validate it's a proper file URL
-      return true;
+      return path.isAbsolute(fileURLToPath(filePath));
     }
     return path.isAbsolute(filePath);
   } catch {

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -1,10 +1,9 @@
-import path from 'path';
 import cliState from '../cliState';
 import { importModule } from '../esm';
 import logger from '../logger';
 import { runPython } from '../python/pythonUtils';
 import type { Prompt, Vars } from '../types';
-import { isJavascriptFile } from './file';
+import { isJavascriptFile, safeJoin } from './file';
 
 export type TransformContext = {
   vars?: Vars;
@@ -77,7 +76,9 @@ async function getFileTransformFunction(filePath: string): Promise<Function> {
   const [actualFilePath, functionName] = parseFilePathAndFunctionName(
     filePath.slice('file://'.length),
   );
-  const fullPath = path.join(cliState.basePath || '', actualFilePath);
+
+  const fullPath = safeJoin(cliState.basePath || '', actualFilePath);
+
   if (isJavascriptFile(fullPath)) {
     return getJavascriptTransformFunction(fullPath, functionName);
   } else if (fullPath.endsWith('.py')) {

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -3,7 +3,8 @@ import { importModule } from '../esm';
 import logger from '../logger';
 import { runPython } from '../python/pythonUtils';
 import type { Prompt, Vars } from '../types';
-import { isJavascriptFile, safeJoin } from './file';
+import { isJavascriptFile } from './file';
+import { safeJoin } from './file.node';
 
 export type TransformContext = {
   vars?: Vars;

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -1,0 +1,79 @@
+import path from 'path';
+import { importModule } from '../src/esm';
+import logger from '../src/logger';
+
+jest.mock('../src/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+describe('ESM utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('importModule', () => {
+    it('imports JavaScript modules', async () => {
+      const modulePath = path.resolve(__dirname, 'fixtures/testModule.js');
+
+      // Mock the file system module
+      jest.mock('fs', () => ({
+        existsSync: jest.fn().mockReturnValue(true),
+        readFileSync: jest
+          .fn()
+          .mockReturnValue('module.exports = { testFunction: () => "test result" }'),
+      }));
+
+      // Mock the module
+      jest.doMock(
+        modulePath,
+        () => ({
+          default: { testFunction: () => 'test result' },
+        }),
+        { virtual: true },
+      );
+
+      const result = await importModule(modulePath);
+      expect(result).toEqual({ testFunction: expect.any(Function) });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Successfully required module'),
+      );
+    });
+
+    it('imports TypeScript modules', async () => {
+      const modulePath = path.resolve(__dirname, 'fixtures/testModule.ts');
+      jest.doMock(
+        modulePath,
+        () => ({
+          default: { testFunction: () => 'test result' },
+        }),
+        { virtual: true },
+      );
+
+      const result = await importModule(modulePath);
+      expect(result).toEqual({ testFunction: expect.any(Function) });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('TypeScript/ESM module detected'),
+      );
+    });
+
+    it('handles absolute paths', async () => {
+      const absolutePath = path.resolve('/absolute/path/module.js');
+      jest.doMock(
+        absolutePath,
+        () => ({
+          default: { testFunction: () => 'absolute path result' },
+        }),
+        { virtual: true },
+      );
+
+      const result = await importModule(absolutePath);
+      expect(result).toEqual({ testFunction: expect.any(Function) });
+    });
+  });
+});

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -1,34 +1,77 @@
-import { isJavascriptFile } from '../../src/util/file';
+import path from 'path';
+import { isJavascriptFile, safeResolve, safeJoin } from '../../src/util/file';
 
-describe('util', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+describe('file utilities', () => {
+  describe('isJavascriptFile', () => {
+    it('identifies JavaScript and TypeScript files', () => {
+      expect(isJavascriptFile('test.js')).toBe(true);
+      expect(isJavascriptFile('test.cjs')).toBe(true);
+      expect(isJavascriptFile('test.mjs')).toBe(true);
+      expect(isJavascriptFile('test.ts')).toBe(true);
+      expect(isJavascriptFile('test.cts')).toBe(true);
+      expect(isJavascriptFile('test.mts')).toBe(true);
+      expect(isJavascriptFile('test.txt')).toBe(false);
+      expect(isJavascriptFile('test.py')).toBe(false);
+    });
   });
 
-  describe('isJavascriptFile', () => {
-    it('should return true for JavaScript files', () => {
-      expect(isJavascriptFile('file.js')).toBe(true);
-      expect(isJavascriptFile('file.cjs')).toBe(true);
-      expect(isJavascriptFile('file.mjs')).toBe(true);
+  describe('safeResolve', () => {
+    it('returns absolute path unchanged', () => {
+      const absolutePath = path.resolve('/absolute/path/file.txt');
+      expect(safeResolve('some/base/path', absolutePath)).toBe(absolutePath);
     });
 
-    it('should return true for TypeScript files', () => {
-      expect(isJavascriptFile('file.ts')).toBe(true);
-      expect(isJavascriptFile('file.cts')).toBe(true);
-      expect(isJavascriptFile('file.mts')).toBe(true);
+    it('returns file URL unchanged', () => {
+      const fileUrl = 'file:///absolute/path/file.txt';
+      expect(safeResolve('some/base/path', fileUrl)).toBe(fileUrl);
     });
 
-    it('should return false for non-JavaScript/TypeScript files', () => {
-      expect(isJavascriptFile('file.txt')).toBe(false);
-      expect(isJavascriptFile('file.py')).toBe(false);
-      expect(isJavascriptFile('file.jsx')).toBe(false);
-      expect(isJavascriptFile('file.tsx')).toBe(false);
+    it('resolves relative paths', () => {
+      const expected = path.resolve('base/path', 'relative/file.txt');
+      expect(safeResolve('base/path', 'relative/file.txt')).toBe(expected);
     });
 
-    it('should handle paths with directories', () => {
-      expect(isJavascriptFile('/path/to/file.js')).toBe(true);
-      expect(isJavascriptFile('C:\\path\\to\\file.ts')).toBe(true);
-      expect(isJavascriptFile('/path/to/file.txt')).toBe(false);
+    it('handles multiple path segments', () => {
+      const absolutePath = path.resolve('/absolute/path/file.txt');
+      expect(safeResolve('base', 'path', absolutePath)).toBe(absolutePath);
+
+      const expected = path.resolve('base', 'path', 'relative/file.txt');
+      expect(safeResolve('base', 'path', 'relative/file.txt')).toBe(expected);
+    });
+
+    it('handles empty input', () => {
+      expect(safeResolve()).toBe(path.resolve());
+      expect(safeResolve('')).toBe(path.resolve(''));
+    });
+  });
+
+  describe('safeJoin', () => {
+    it('returns absolute path unchanged', () => {
+      const absolutePath = path.resolve('/absolute/path/file.txt');
+      expect(safeJoin('some/base/path', absolutePath)).toBe(absolutePath);
+    });
+
+    it('returns file URL unchanged', () => {
+      const fileUrl = 'file:///absolute/path/file.txt';
+      expect(safeJoin('some/base/path', fileUrl)).toBe(fileUrl);
+    });
+
+    it('joins relative paths', () => {
+      const expected = path.join('base/path', 'relative/file.txt');
+      expect(safeJoin('base/path', 'relative/file.txt')).toBe(expected);
+    });
+
+    it('handles multiple path segments', () => {
+      const absolutePath = path.resolve('/absolute/path/file.txt');
+      expect(safeJoin('base', 'path', absolutePath)).toBe(absolutePath);
+
+      const expected = path.join('base', 'path', 'relative/file.txt');
+      expect(safeJoin('base', 'path', 'relative/file.txt')).toBe(expected);
+    });
+
+    it('handles empty input', () => {
+      expect(safeJoin()).toBe(path.join());
+      expect(safeJoin('')).toBe(path.join(''));
     });
   });
 });

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { isJavascriptFile, safeResolve, safeJoin } from '../../src/util/file';
+import { isJavascriptFile } from '../../src/util/file';
+import { safeResolve, safeJoin } from '../../src/util/file.node';
 
 describe('file utilities', () => {
   // Helper to create platform-appropriate file URLs

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -2,6 +2,13 @@ import path from 'path';
 import { isJavascriptFile, safeResolve, safeJoin } from '../../src/util/file';
 
 describe('file utilities', () => {
+  // Helper to create platform-appropriate file URLs
+  const getFileUrl = (path: string) => {
+    return process.platform === 'win32'
+      ? `file:///C:/${path.replace(/\\/g, '/')}`
+      : `file:///${path}`;
+  };
+
   describe('isJavascriptFile', () => {
     it('identifies JavaScript and TypeScript files', () => {
       expect(isJavascriptFile('test.js')).toBe(true);
@@ -22,7 +29,7 @@ describe('file utilities', () => {
     });
 
     it('returns file URL unchanged', () => {
-      const fileUrl = 'file:///absolute/path/file.txt';
+      const fileUrl = getFileUrl('absolute/path/file.txt');
       expect(safeResolve('some/base/path', fileUrl)).toBe(fileUrl);
     });
 
@@ -52,7 +59,7 @@ describe('file utilities', () => {
     });
 
     it('returns file URL unchanged', () => {
-      const fileUrl = 'file:///absolute/path/file.txt';
+      const fileUrl = getFileUrl('absolute/path/file.txt');
       expect(safeJoin('some/base/path', fileUrl)).toBe(fileUrl);
     });
 

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -265,10 +265,15 @@ describe('util', () => {
     });
 
     describe('file path handling', () => {
+      // Helper to create mock absolute paths that work cross-platform
+      const getMockAbsolutePath = (...parts: string[]) => {
+        return process.platform === 'win32' ? path.join('C:', ...parts) : path.join('/', ...parts);
+      };
+
       it('handles absolute paths in transform files', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = ['', 'absolute', 'path', 'transform.js'].join(path.sep);
+        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.js');
 
         jest.doMock(absolutePath, () => (output: string) => output.toUpperCase(), {
           virtual: true,
@@ -282,8 +287,8 @@ describe('util', () => {
       it('handles file URLs in transform files', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const fileUrl = 'file:///absolute/path/transform.js';
-        const absolutePath = fileUrl.slice('file://'.length);
+        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.js');
+        const fileUrl = `file://${absolutePath}`;
 
         jest.doMock(absolutePath, () => (output: string) => output.toUpperCase(), {
           virtual: true,
@@ -296,7 +301,8 @@ describe('util', () => {
       it('resolves relative paths against cliState.basePath', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const basePath = ['', 'base', 'path'].join(path.sep);
+        // Use a relative path that will work cross-platform
+        const basePath = path.join('test', 'base', 'path');
         const relativePath = 'transform.js';
         const expectedPath = path.join(basePath, relativePath);
 
@@ -327,7 +333,7 @@ describe('util', () => {
       it('handles Python files with absolute paths', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = ['', 'absolute', 'path', 'transform.py'].join(path.sep);
+        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.py');
         const pythonFilePath = `file://${absolutePath}`;
 
         const transformedOutput = await transform(pythonFilePath, output, context);

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -72,6 +72,7 @@ describe('util', () => {
       jest.doMock(path.resolve('transform.js'), () => (output: string) => output.toUpperCase(), {
         virtual: true,
       });
+
       const transformFunctionPath = 'file://transform.js';
       const transformedOutput = await transform(transformFunctionPath, output, context);
       expect(transformedOutput).toBe('HELLO');
@@ -265,21 +266,16 @@ describe('util', () => {
     });
 
     describe('file path handling', () => {
-      // Helper to create mock absolute paths that work cross-platform
-      const getMockAbsolutePath = (...parts: string[]) => {
-        return process.platform === 'win32' ? path.join('C:', ...parts) : path.join('/', ...parts);
-      };
-
       it('handles absolute paths in transform files', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.js');
+        const mockPath = path.resolve('transform.js');
 
-        jest.doMock(absolutePath, () => (output: string) => output.toUpperCase(), {
+        jest.doMock(mockPath, () => (output: string) => output.toUpperCase(), {
           virtual: true,
         });
 
-        const transformFunctionPath = `file://${absolutePath}`;
+        const transformFunctionPath = 'file://transform.js';
         const transformedOutput = await transform(transformFunctionPath, output, context);
         expect(transformedOutput).toBe('HELLO');
       });
@@ -287,44 +283,13 @@ describe('util', () => {
       it('handles file URLs in transform files', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.js');
-        const fileUrl = `file://${absolutePath}`;
+        const mockPath = path.resolve('transform.js');
 
-        jest.doMock(absolutePath, () => (output: string) => output.toUpperCase(), {
+        jest.doMock(mockPath, () => (output: string) => output.toUpperCase(), {
           virtual: true,
         });
 
-        const transformedOutput = await transform(fileUrl, output, context);
-        expect(transformedOutput).toBe('HELLO');
-      });
-
-      it('resolves relative paths against cliState.basePath', async () => {
-        const output = 'hello';
-        const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const basePath = getMockAbsolutePath('test', 'fixtures'); // Use our mock path helper
-        const relativePath = 'transform.js';
-        const expectedPath = path.join(basePath, relativePath);
-
-        // Mock cliState before other operations
-        jest.mock('../../src/cliState', () => ({
-          __esModule: true,
-          default: {
-            basePath,
-          },
-        }));
-
-        // Clear module cache to ensure our mock is used
-        jest.resetModules();
-
-        // Re-import transform after mocking cliState
-        const transform = (await import('../../src/util/transform')).transform;
-
-        // Mock the resolved path, not the relative path
-        jest.doMock(expectedPath, () => (output: string) => output.toUpperCase(), {
-          virtual: true,
-        });
-
-        const transformFunctionPath = `file://${relativePath}`;
+        const transformFunctionPath = 'file://transform.js';
         const transformedOutput = await transform(transformFunctionPath, output, context);
         expect(transformedOutput).toBe('HELLO');
       });
@@ -332,15 +297,43 @@ describe('util', () => {
       it('handles Python files with absolute paths', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = getMockAbsolutePath('absolute', 'path', 'transform.py');
-        const pythonFilePath = `file://${absolutePath}`;
+        const pythonFilePath = 'file://transform.py';
 
         const transformedOutput = await transform(pythonFilePath, output, context);
         expect(transformedOutput).toBe('HELLO FROM PYTHON');
-        expect(runPython).toHaveBeenCalledWith(absolutePath, 'get_transform', [
-          output,
-          expect.any(Object),
-        ]);
+        expect(runPython).toHaveBeenCalledWith(
+          expect.stringContaining('transform.py'),
+          'get_transform',
+          [output, expect.any(Object)],
+        );
+      });
+
+      it('handles complex nested paths', async () => {
+        const output = 'hello';
+        const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+        const mockPath = path.resolve('deeply/nested/path/with spaces/transform.js');
+
+        jest.doMock(mockPath, () => (output: string) => output.toUpperCase(), {
+          virtual: true,
+        });
+
+        const transformFunctionPath = 'file://deeply/nested/path/with spaces/transform.js';
+        const transformedOutput = await transform(transformFunctionPath, output, context);
+        expect(transformedOutput).toBe('HELLO');
+      });
+
+      it('handles paths with special characters', async () => {
+        const output = 'hello';
+        const context = { vars: { key: 'value' }, prompt: { id: '123' } };
+        const mockPath = path.resolve('path/with-hyphens/and_underscores/transform.js');
+
+        jest.doMock(mockPath, () => (output: string) => output.toUpperCase(), {
+          virtual: true,
+        });
+
+        const transformFunctionPath = 'file://path/with-hyphens/and_underscores/transform.js';
+        const transformedOutput = await transform(transformFunctionPath, output, context);
+        expect(transformedOutput).toBe('HELLO');
       });
     });
   });

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -301,8 +301,7 @@ describe('util', () => {
       it('resolves relative paths against cliState.basePath', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        // Use a relative path that will work cross-platform
-        const basePath = path.join('test', 'base', 'path');
+        const basePath = getMockAbsolutePath('test', 'fixtures'); // Use our mock path helper
         const relativePath = 'transform.js';
         const expectedPath = path.join(basePath, relativePath);
 

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -268,7 +268,7 @@ describe('util', () => {
       it('handles absolute paths in transform files', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = path.resolve('/absolute/path/transform.js');
+        const absolutePath = ['', 'absolute', 'path', 'transform.js'].join(path.sep);
 
         jest.doMock(absolutePath, () => (output: string) => output.toUpperCase(), {
           virtual: true,
@@ -296,7 +296,7 @@ describe('util', () => {
       it('resolves relative paths against cliState.basePath', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const basePath = '/base/path';
+        const basePath = ['', 'base', 'path'].join(path.sep);
         const relativePath = 'transform.js';
         const expectedPath = path.join(basePath, relativePath);
 
@@ -327,7 +327,7 @@ describe('util', () => {
       it('handles Python files with absolute paths', async () => {
         const output = 'hello';
         const context = { vars: { key: 'value' }, prompt: { id: '123' } };
-        const absolutePath = path.resolve('/absolute/path/transform.py');
+        const absolutePath = ['', 'absolute', 'path', 'transform.py'].join(path.sep);
         const pythonFilePath = `file://${absolutePath}`;
 
         const transformedOutput = await transform(pythonFilePath, output, context);


### PR DESCRIPTION
- Module imports were breaking on absolute paths due to an issue in how we were calling `path.resolve`. We didn't check whether or not the right-most path was already an absolute path
- Implement a new `safeJoin` and `safeResolve` method that does just this.