### PR TITLE
chore(auth): synchronize email between `promptfoo config set email` and `promptfoo auth login`

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,6 +2,7 @@ import confirm from '@inquirer/confirm';
 import type { Command } from 'commander';
 import { z } from 'zod';
 import { getUserEmail, setUserEmail } from '../globalConfig/accounts';
+import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
 import telemetry from '../telemetry';
 
@@ -34,6 +35,14 @@ export function configCommand(program: Command) {
     .command('email <email>')
     .description('Set user email')
     .action(async (email: string) => {
+      if (cloudConfig.getApiKey()) {
+        logger.error(
+          "Cannot update email while logged in. Email is managed through 'promptfoo auth login'. Please use 'promptfoo auth logout' first if you want to use a different email.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const parsedEmail = EmailSchema.safeParse(email);
       if (!parsedEmail.success) {
         logger.error(`Invalid email address: ${email}`);
@@ -54,6 +63,14 @@ export function configCommand(program: Command) {
     .description('Unset user email')
     .option('-f, --force', 'Force unset without confirmation')
     .action(async (options) => {
+      if (cloudConfig.getApiKey()) {
+        logger.error(
+          "Cannot update email while logged in. Email is managed through 'promptfoo auth login'. Please use 'promptfoo auth logout' first if you want to use a different email.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const currentEmail = getUserEmail();
       if (!currentEmail) {
         logger.info('No email is currently set.');

--- a/test/commands/auth.test.ts
+++ b/test/commands/auth.test.ts
@@ -1,0 +1,243 @@
+import { Command } from 'commander';
+import { authCommand } from '../../src/commands/auth';
+import { fetchWithProxy } from '../../src/fetch';
+import { getUserEmail, setUserEmail } from '../../src/globalConfig/accounts';
+import { cloudConfig } from '../../src/globalConfig/cloud';
+import logger from '../../src/logger';
+
+jest.mock('../../src/globalConfig/accounts');
+jest.mock('../../src/globalConfig/cloud');
+jest.mock('../../src/logger');
+jest.mock('../../src/telemetry');
+jest.mock('../../src/fetch');
+jest.mock('readline', () => ({
+  createInterface: jest.fn().mockReturnValue({
+    question: jest.fn((query, cb) => cb('test@example.com')),
+    close: jest.fn(),
+  }),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('auth command', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    program = new Command();
+    authCommand(program);
+  });
+
+  describe('login', () => {
+    it('should set email in config after successful login with API key', async () => {
+      // Mock successful login response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ user: { email: 'test@example.com' } }),
+      });
+
+      // Mock cloud config validation
+      jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValueOnce({
+        user: { email: 'test@example.com' },
+      });
+
+      // Execute login command
+      const loginCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'login');
+      await loginCmd?.parseAsync(['node', 'test', '--api-key', 'test-key']);
+
+      // Verify email was set
+      expect(setUserEmail).toHaveBeenCalledWith('test@example.com');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged in'));
+    });
+
+    it('should handle interactive login flow successfully', async () => {
+      // Mock successful login response
+      jest.mocked(fetchWithProxy).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      // Mock cloud config validation
+      jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValueOnce({
+        user: { email: 'test@example.com' },
+      });
+
+      // Execute login command without API key
+      const loginCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'login');
+      await loginCmd?.parseAsync(['node', 'test']);
+
+      // Verify login flow
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('A login link has been sent'),
+      );
+      expect(setUserEmail).toHaveBeenCalledWith('test@example.com');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged in'));
+    });
+
+    it('should handle login request failure', async () => {
+      // Mock failed login response
+      jest.mocked(fetchWithProxy).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Bad Request',
+      });
+
+      // Execute login command without API key
+      const loginCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'login');
+      await loginCmd?.parseAsync(['node', 'test']);
+
+      // Verify error handling
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to send login request: Bad Request'),
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should handle token validation failure', async () => {
+      // Mock successful login response but failed token validation
+      jest.mocked(fetchWithProxy).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      jest
+        .mocked(cloudConfig.validateAndSetApiToken)
+        .mockRejectedValueOnce(new Error('Invalid token'));
+
+      // Execute login command without API key
+      const loginCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'login');
+      await loginCmd?.parseAsync(['node', 'test']);
+
+      // Verify error handling
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Authentication failed: Invalid token'),
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should overwrite existing email in config after successful login', async () => {
+      // Mock existing email
+      jest.mocked(getUserEmail).mockReturnValue('old@example.com');
+
+      // Mock successful login response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ user: { email: 'new@example.com' } }),
+      });
+
+      // Mock cloud config validation
+      jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValueOnce({
+        user: { email: 'new@example.com' },
+      });
+
+      // Execute login command
+      const loginCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'login');
+      await loginCmd?.parseAsync(['node', 'test', '--api-key', 'test-key']);
+
+      // Verify email was overwritten
+      expect(setUserEmail).toHaveBeenCalledWith('new@example.com');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged in'));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Updating local email configuration from old@example.com to new@example.com',
+        ),
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should unset email in config after logout', async () => {
+      // Mock existing email
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+
+      // Execute logout command
+      const logoutCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'logout');
+      await logoutCmd?.parseAsync(['node', 'test']);
+
+      // Verify email was unset
+      expect(setUserEmail).toHaveBeenCalledWith('');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged out'));
+    });
+  });
+
+  describe('whoami', () => {
+    it('should show user info when logged in', async () => {
+      // Mock logged in state
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key');
+      jest.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+      jest.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');
+
+      // Mock successful user info response
+      jest.mocked(fetchWithProxy).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            user: { email: 'test@example.com' },
+            organization: { name: 'Test Org' },
+          }),
+      });
+
+      // Execute whoami command
+      const whoamiCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'whoami');
+      await whoamiCmd?.parseAsync(['node', 'test']);
+
+      // Verify output
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Currently logged in as:'));
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('test@example.com'));
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Test Org'));
+    });
+
+    it('should handle not logged in state', async () => {
+      // Mock not logged in state
+      jest.mocked(getUserEmail).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+
+      // Execute whoami command
+      const whoamiCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'whoami');
+      await whoamiCmd?.parseAsync(['node', 'test']);
+
+      // Verify output
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Not logged in'));
+    });
+
+    it('should handle API error', async () => {
+      // Mock logged in state but API error
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key');
+      jest.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+
+      // Mock failed user info response
+      jest.mocked(fetchWithProxy).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Internal Server Error',
+      });
+
+      // Execute whoami command
+      const whoamiCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'whoami');
+      await whoamiCmd?.parseAsync(['node', 'test']);
+
+      // Verify error handling
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to get user info'));
+      expect(process.exitCode).toBe(1);
+    });
+  });
+});

--- a/test/commands/auth.test.ts
+++ b/test/commands/auth.test.ts
@@ -4,6 +4,7 @@ import { fetchWithProxy } from '../../src/fetch';
 import { getUserEmail, setUserEmail } from '../../src/globalConfig/accounts';
 import { cloudConfig } from '../../src/globalConfig/cloud';
 import logger from '../../src/logger';
+import { createMockResponse } from '../util/utils';
 
 const mockCloudUser = {
   id: '1',
@@ -28,30 +29,9 @@ const mockApp = {
   url: 'https://app.example.com',
 };
 
-const createMockResponse = (options: { ok: boolean; body?: any; statusText?: string }) => {
-  return {
-    ok: options.ok,
-    headers: new Headers(),
-    redirected: false,
-    status: options.ok ? 200 : 400,
-    statusText: options.statusText || (options.ok ? 'OK' : 'Bad Request'),
-    type: 'basic' as ResponseType,
-    url: 'https://api.example.com',
-    json: () => Promise.resolve(options.body || {}),
-    text: () => Promise.resolve(''),
-    blob: () => Promise.resolve(new Blob()),
-    formData: () => Promise.resolve(new FormData()),
-    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-    bodyUsed: false,
-    body: null,
-    clone() {
-      return this;
-    },
-  } as Response;
-};
-
 jest.mock('../../src/globalConfig/accounts');
 jest.mock('../../src/globalConfig/cloud');
+jest.mock('../../src/logger');
 jest.mock('../../src/telemetry');
 jest.mock('../../src/fetch');
 jest.mock('readline', () => ({

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -1,0 +1,155 @@
+import { Command } from 'commander';
+import { configCommand } from '../../src/commands/config';
+import { getUserEmail, setUserEmail } from '../../src/globalConfig/accounts';
+import { cloudConfig } from '../../src/globalConfig/cloud';
+import logger from '../../src/logger';
+
+jest.mock('../../src/globalConfig/accounts');
+jest.mock('../../src/globalConfig/cloud');
+jest.mock('../../src/logger');
+jest.mock('../../src/telemetry');
+
+describe('config command', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    program = new Command();
+    configCommand(program);
+  });
+
+  describe('set email', () => {
+    it('should not allow setting email when user is logged in', async () => {
+      // Mock logged in state
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key');
+
+      // Execute set email command
+      const setEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'set')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await setEmailCmd?.parseAsync(['node', 'test', 'new@example.com']);
+
+      // Verify email was not set and error was shown
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot update email while logged in. Email is managed through 'promptfoo auth login'",
+        ),
+      );
+    });
+
+    it('should allow setting email when user is not logged in', async () => {
+      // Mock logged out state
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+
+      // Execute set email command
+      const setEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'set')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await setEmailCmd?.parseAsync(['node', 'test', 'test@example.com']);
+
+      // Verify email was set
+      expect(setUserEmail).toHaveBeenCalledWith('test@example.com');
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Email set to test@example.com'),
+      );
+    });
+
+    it('should validate email format even when not logged in', async () => {
+      // Mock logged out state
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+
+      // Execute set email command with invalid email
+      const setEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'set')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await setEmailCmd?.parseAsync(['node', 'test', 'invalid-email']);
+
+      // Verify email was not set and error was shown
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid email address'));
+    });
+  });
+
+  describe('unset email', () => {
+    it('should not allow unsetting email when user is logged in', async () => {
+      // Mock logged in state
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key');
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+
+      // Execute unset email command
+      const unsetEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'unset')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await unsetEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify email was not unset and error was shown
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot update email while logged in. Email is managed through 'promptfoo auth login'",
+        ),
+      );
+    });
+
+    it('should allow unsetting email when user is not logged in', async () => {
+      // Mock logged out state
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+
+      // Execute unset email command with force flag
+      const unsetEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'unset')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await unsetEmailCmd?.parseAsync(['node', 'test', '--force']);
+
+      // Verify email was unset
+      expect(setUserEmail).toHaveBeenCalledWith('');
+      expect(logger.info).toHaveBeenCalledWith('Email has been unset.');
+    });
+  });
+
+  describe('get email', () => {
+    it('should show email when it exists', async () => {
+      // Mock existing email
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+
+      // Execute get email command
+      const getEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'get')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await getEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify email was shown
+      expect(logger.info).toHaveBeenCalledWith('test@example.com');
+    });
+
+    it('should show message when no email is set', async () => {
+      // Mock no existing email
+      jest.mocked(getUserEmail).mockReturnValue(null);
+
+      // Execute get email command
+      const getEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'get')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await getEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify message was shown
+      expect(logger.info).toHaveBeenCalledWith('No email set.');
+    });
+  });
+});

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -1,13 +1,19 @@
+import confirm from '@inquirer/confirm';
 import { Command } from 'commander';
 import { configCommand } from '../../src/commands/config';
 import { getUserEmail, setUserEmail } from '../../src/globalConfig/accounts';
 import { cloudConfig } from '../../src/globalConfig/cloud';
 import logger from '../../src/logger';
+import telemetry from '../../src/telemetry';
 
 jest.mock('../../src/globalConfig/accounts');
 jest.mock('../../src/globalConfig/cloud');
 jest.mock('../../src/logger');
-jest.mock('../../src/telemetry');
+jest.mock('../../src/telemetry', () => ({
+  record: jest.fn(),
+  send: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@inquirer/confirm');
 
 describe('config command', () => {
   let program: Command;
@@ -38,6 +44,7 @@ describe('config command', () => {
           "Cannot update email while logged in. Email is managed through 'promptfoo auth login'",
         ),
       );
+      expect(process.exitCode).toBe(1);
     });
 
     it('should allow setting email when user is not logged in', async () => {
@@ -57,6 +64,11 @@ describe('config command', () => {
       expect(logger.info).toHaveBeenCalledWith(
         expect.stringContaining('Email set to test@example.com'),
       );
+      expect(telemetry.record).toHaveBeenCalledWith('command_used', {
+        name: 'config set',
+        configKey: 'email',
+      });
+      expect(telemetry.send).toHaveBeenCalledWith();
     });
 
     it('should validate email format even when not logged in', async () => {
@@ -74,6 +86,9 @@ describe('config command', () => {
       // Verify email was not set and error was shown
       expect(setUserEmail).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid email address'));
+      expect(process.exitCode).toBe(1);
+      expect(telemetry.record).not.toHaveBeenCalled();
+      expect(telemetry.send).not.toHaveBeenCalled();
     });
   });
 
@@ -98,9 +113,10 @@ describe('config command', () => {
           "Cannot update email while logged in. Email is managed through 'promptfoo auth login'",
         ),
       );
+      expect(process.exitCode).toBe(1);
     });
 
-    it('should allow unsetting email when user is not logged in', async () => {
+    it('should allow unsetting email when user is not logged in with force flag', async () => {
       // Mock logged out state
       jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
@@ -116,6 +132,75 @@ describe('config command', () => {
       // Verify email was unset
       expect(setUserEmail).toHaveBeenCalledWith('');
       expect(logger.info).toHaveBeenCalledWith('Email has been unset.');
+      expect(telemetry.record).toHaveBeenCalledWith('command_used', {
+        name: 'config unset',
+        configKey: 'email',
+      });
+      expect(telemetry.send).toHaveBeenCalledWith();
+    });
+
+    it('should handle user confirmation for unsetting email', async () => {
+      // Mock logged out state and user confirmation
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+      jest.mocked(confirm).mockResolvedValueOnce(true);
+
+      // Execute unset email command without force flag
+      const unsetEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'unset')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await unsetEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify email was unset after confirmation
+      expect(confirm).toHaveBeenCalledWith({
+        message: 'Are you sure you want to unset the email "test@example.com"?',
+        default: false,
+      });
+      expect(setUserEmail).toHaveBeenCalledWith('');
+      expect(logger.info).toHaveBeenCalledWith('Email has been unset.');
+    });
+
+    it('should handle user cancellation for unsetting email', async () => {
+      // Mock logged out state and user cancellation
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+      jest.mocked(confirm).mockResolvedValueOnce(false);
+
+      // Execute unset email command without force flag
+      const unsetEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'unset')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await unsetEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify operation was cancelled
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith('Operation cancelled.');
+      expect(telemetry.record).not.toHaveBeenCalled();
+      expect(telemetry.send).not.toHaveBeenCalled();
+    });
+
+    it('should handle case when no email is set', async () => {
+      // Mock logged out state and no existing email
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(getUserEmail).mockReturnValue(null);
+
+      // Execute unset email command
+      const unsetEmailCmd = program.commands
+        .find((cmd) => cmd.name() === 'config')
+        ?.commands.find((cmd) => cmd.name() === 'unset')
+        ?.commands.find((cmd) => cmd.name() === 'email');
+
+      await unsetEmailCmd?.parseAsync(['node', 'test']);
+
+      // Verify appropriate message was shown
+      expect(logger.info).toHaveBeenCalledWith('No email is currently set.');
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(telemetry.record).not.toHaveBeenCalled();
+      expect(telemetry.send).not.toHaveBeenCalled();
     });
   });
 
@@ -132,8 +217,13 @@ describe('config command', () => {
 
       await getEmailCmd?.parseAsync(['node', 'test']);
 
-      // Verify email was shown
+      // Verify email was shown and telemetry was recorded
       expect(logger.info).toHaveBeenCalledWith('test@example.com');
+      expect(telemetry.record).toHaveBeenCalledWith('command_used', {
+        name: 'config get',
+        configKey: 'email',
+      });
+      expect(telemetry.send).toHaveBeenCalledWith();
     });
 
     it('should show message when no email is set', async () => {
@@ -148,8 +238,13 @@ describe('config command', () => {
 
       await getEmailCmd?.parseAsync(['node', 'test']);
 
-      // Verify message was shown
+      // Verify message was shown and telemetry was recorded
       expect(logger.info).toHaveBeenCalledWith('No email set.');
+      expect(telemetry.record).toHaveBeenCalledWith('command_used', {
+        name: 'config get',
+        configKey: 'email',
+      });
+      expect(telemetry.send).toHaveBeenCalledWith();
     });
   });
 });

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -8,7 +8,6 @@ import telemetry from '../../src/telemetry';
 
 jest.mock('../../src/globalConfig/accounts');
 jest.mock('../../src/globalConfig/cloud');
-jest.mock('../../src/logger');
 jest.mock('../../src/telemetry', () => ({
   record: jest.fn(),
   send: jest.fn().mockResolvedValue(undefined),

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -49,7 +49,7 @@ describe('config command', () => {
 
     it('should allow setting email when user is not logged in', async () => {
       // Mock logged out state
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
 
       // Execute set email command
       const setEmailCmd = program.commands
@@ -73,7 +73,7 @@ describe('config command', () => {
 
     it('should validate email format even when not logged in', async () => {
       // Mock logged out state
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
 
       // Execute set email command with invalid email
       const setEmailCmd = program.commands
@@ -118,7 +118,7 @@ describe('config command', () => {
 
     it('should allow unsetting email when user is not logged in with force flag', async () => {
       // Mock logged out state
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
 
       // Execute unset email command with force flag
@@ -141,7 +141,7 @@ describe('config command', () => {
 
     it('should handle user confirmation for unsetting email', async () => {
       // Mock logged out state and user confirmation
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
       jest.mocked(confirm).mockResolvedValueOnce(true);
 
@@ -164,7 +164,7 @@ describe('config command', () => {
 
     it('should handle user cancellation for unsetting email', async () => {
       // Mock logged out state and user cancellation
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
       jest.mocked(confirm).mockResolvedValueOnce(false);
 
@@ -185,7 +185,7 @@ describe('config command', () => {
 
     it('should handle case when no email is set', async () => {
       // Mock logged out state and no existing email
-      jest.mocked(cloudConfig.getApiKey).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
       jest.mocked(getUserEmail).mockReturnValue(null);
 
       // Execute unset email command

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -13,27 +13,36 @@ export class TestGrader implements ApiProvider {
   }
 }
 
-export function createMockResponse(options: Partial<Response> = {}): Response {
+export function createMockResponse(
+  options: {
+    ok?: boolean;
+    body?: any;
+    statusText?: string;
+    status?: number;
+    headers?: Headers;
+    text?: () => Promise<string>;
+    json?: () => Promise<any>;
+  } = { ok: true },
+): Response {
+  const isOk = options.ok ?? (options.status ? options.status < 400 : true);
   const mockResponse: Response = {
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    headers: new Headers(),
+    ok: isOk,
+    status: options.status || (isOk ? 200 : 400),
+    statusText: options.statusText || (isOk ? 'OK' : 'Bad Request'),
+    headers: options.headers || new Headers(),
     redirected: false,
     type: 'basic',
     url: 'https://example.com',
-    json: () => Promise.resolve({}),
-    text: () => Promise.resolve(''),
+    json: options.json || (() => Promise.resolve(options.body || {})),
+    text: options.text || (() => Promise.resolve('')),
     blob: () => Promise.resolve(new Blob()),
     arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     formData: () => Promise.resolve(new FormData()),
-    bytes: () => Promise.resolve(new Uint8Array()),
     bodyUsed: false,
     body: null,
     clone() {
-      return createMockResponse(this);
+      return createMockResponse(options);
     },
-    ...options,
   } as Response;
   return mockResponse;
 }


### PR DESCRIPTION
- Add email sync during login to handle existing email updates
- Add email unset on logout for consistent state management
- Add validation to prevent email updates while logged in
