### PR TITLE
feat: add support for for tools in Vertex provider

### DIFF
--- a/examples/google-vertex-tools/README.md
+++ b/examples/google-vertex-tools/README.md
@@ -1,0 +1,27 @@
+To call Vertex AI models in Node, you'll need to install Google's official auth client as a peer dependency:
+
+```sh
+npm i google-auth-library
+```
+
+Make sure the Vertex AI API is enabled for the relevant project in Google Cloud. Then, ensure that you've selected that project in the gcloud cli:
+
+```sh
+gcloud config set project PROJECT_ID
+```
+
+Next, make sure that you've authenticated to Google Cloud using one of these methods:
+
+- You are logged into an account using gcloud auth application-default login
+- You are running on a machine that uses a service account with the appropriate role
+- You have downloaded the credentials for a service account with the appropriate role and set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of the credentials file.
+
+Then, edit promptfooconfig.yaml
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/google-vertex-tools/promptfooconfig.yaml
+++ b/examples/google-vertex-tools/promptfooconfig.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+
+# Learn more about building a configuration: https://promptfoo.dev/docs/configuration/guide
+
+description: 'Function calling demonstration'
+
+prompts:
+  - What is the weather in {{location}}?
+
+providers:
+  - id: 'vertex:gemini-2.0-flash-001'
+    config:
+      tools: file://tools.json
+
+defaultTest:
+  assert:
+    - type: equals
+      value: get_current_weather
+      # Transform is a cleaner way to pick out specific properties.
+      # This transform returns only the 'name' property
+      transform: JSON.parse(output).functionCall.name
+    - type: similar
+      value: '{{location}}'
+      threshold: 0.9
+      # This transform returns only the parsed location argument.
+      transform: JSON.parse(output).functionCall.args.location
+
+tests:
+  - vars:
+      location: San Francisco
+
+  - vars:
+      location: New York

--- a/examples/google-vertex-tools/tools.json
+++ b/examples/google-vertex-tools/tools.json
@@ -1,0 +1,20 @@
+[
+  {
+    "functionDeclarations": [
+      {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "The city and state, e.g. San Francisco, CA or a zip code e.g. 95616"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ]
+  }
+]

--- a/src/providers/vertex.ts
+++ b/src/providers/vertex.ts
@@ -246,7 +246,7 @@ export class VertexChatProvider extends VertexGenericProvider {
     logger.debug(`Preparing to call Google Vertex API (Gemini) with body: ${JSON.stringify(body)}`);
 
     const cache = await getCache();
-    const cacheKey = `vertex:gemini:${JSON.stringify(body)}`;
+    const cacheKey = `vertex:${this.modelName}:${JSON.stringify(body)}`;
 
     let cachedResponse;
     if (isCacheEnabled()) {


### PR DESCRIPTION
feat: add support for for tools in Vertex provider

Add Tool[] block to the completion options + provide an example.
Also minor fix to avoid cache key collisions when calling the same prompt against two different Vertex models. 