### PR TITLE
chore(providers): add support for extra_body in Anthropic API

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -59,6 +59,7 @@ Claude models are available across multiple platforms. Here's how the model name
 | tools           | -                     | An array of tool or function definitions for the model to call    |
 | tool_choice     | -                     | An object specifying the tool to call                             |
 | headers         | -                     | Additional headers to be sent with the API request                |
+| extra_body      | -                     | Additional parameters to be included in the API request body      |
 
 ### Prompt Template
 
@@ -93,6 +94,7 @@ The Anthropic provider supports several options to customize the behavior of the
 - `top_k`: Only sample from the top K options for each subsequent token.
 - `tools`: An array of tool or function definitions for the model to call.
 - `tool_choice`: An object specifying the tool to call.
+- `extra_body`: Additional parameters to pass directly to the Anthropic API request body.
 
 Example configuration with options and prompts:
 
@@ -102,6 +104,8 @@ providers:
     config:
       temperature: 0.0
       max_tokens: 512
+      extra_body:
+        custom_param: 'test_value'
 prompts:
   - file://prompt.json
 ```

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -66,20 +66,21 @@ const ANTHROPIC_MODELS = [
 ];
 
 interface AnthropicMessageOptions {
-  apiKey?: string;
   apiBaseUrl?: string;
-  temperature?: number;
-  max_tokens?: number;
-  top_p?: number;
-  top_k?: number;
-  model?: string;
+  apiKey?: string;
   cost?: number;
-  tools?: Anthropic.Tool[];
+  extra_body?: Record<string, any>;
+  headers?: Record<string, string>;
+  max_tokens?: number;
+  model?: string;
+  temperature?: number;
   tool_choice?:
     | Anthropic.MessageCreateParams.ToolChoiceAny
     | Anthropic.MessageCreateParams.ToolChoiceAuto
     | Anthropic.MessageCreateParams.ToolChoiceTool;
-  headers?: Record<string, string>;
+  tools?: Anthropic.Tool[];
+  top_k?: number;
+  top_p?: number;
 }
 
 function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
@@ -260,6 +261,9 @@ export class AnthropicMessagesProvider implements ApiProvider {
       temperature: this.config.temperature || getEnvFloat('ANTHROPIC_TEMPERATURE', 0),
       ...(this.config.tools ? { tools: maybeLoadFromExternalFile(this.config.tools) } : {}),
       ...(this.config.tool_choice ? { tool_choice: this.config.tool_choice } : {}),
+      ...(typeof this.config?.extra_body === 'object' && this.config.extra_body
+        ? this.config.extra_body
+        : {}),
     };
 
     logger.debug(`Calling Anthropic Messages API: ${JSON.stringify(params)}`);

--- a/test/providers/anthropic.test.ts
+++ b/test/providers/anthropic.test.ts
@@ -157,6 +157,79 @@ describe('Anthropic', () => {
       provider.config.tool_choice = undefined;
     });
 
+    it('should include extra_body parameters in API call', async () => {
+      const provider = new AnthropicMessagesProvider('claude-3-5-sonnet-20241022', {
+        config: {
+          extra_body: {
+            top_p: 0.9,
+            custom_param: 'test_value',
+          },
+        },
+      });
+
+      jest
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockImplementation()
+        .mockResolvedValue({
+          content: [{ type: 'text', text: 'Test response' }],
+        } as Anthropic.Messages.Message);
+
+      await provider.callApi('Test prompt');
+
+      expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
+      expect(provider.anthropic.messages.create).toHaveBeenCalledWith(
+        {
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Test prompt' }],
+            },
+          ],
+          temperature: 0,
+          stream: false,
+          top_p: 0.9,
+          custom_param: 'test_value',
+        },
+        {},
+      );
+    });
+
+    it('should not include extra_body when it is not an object', async () => {
+      const provider = new AnthropicMessagesProvider('claude-3-5-sonnet-20241022', {
+        config: {
+          extra_body: undefined,
+        },
+      });
+
+      jest
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockImplementation()
+        .mockResolvedValue({
+          content: [{ type: 'text', text: 'Test response' }],
+        } as Anthropic.Messages.Message);
+
+      await provider.callApi('Test prompt');
+
+      expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
+      expect(provider.anthropic.messages.create).toHaveBeenCalledWith(
+        {
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Test prompt' }],
+            },
+          ],
+          temperature: 0,
+          stream: false,
+        },
+        {},
+      );
+    });
+
     it('should not use cache if caching is disabled for ToolUse requests', async () => {
       jest
         .spyOn(provider.anthropic.messages, 'create')


### PR DESCRIPTION
Add support for the 'extra_body' parameter in the Anthropic API provider.
- Allows passing additional custom parameters to API calls.
- Includes test cases to validate the functionality.