### PR TITLE
refactor(prompts): consolidate prompt processing logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,9 @@ import assertions from './assertions';
 import * as cache from './cache';
 import { evaluate as doEvaluate } from './evaluator';
 import guardrails from './guardrails';
-import logger from './logger';
 import { runDbMigrations } from './migrate';
 import Eval from './models/eval';
-import { readPrompts, readProviderPromptMap } from './prompts';
+import { readProviderPromptMap, processPrompts } from './prompts';
 import providers, { loadApiProvider } from './providers';
 import { loadApiProviders } from './providers';
 import { extractEntities } from './redteam/extraction/entities';
@@ -20,13 +19,11 @@ import type {
   TestSuite,
   EvaluateTestSuite,
   ProviderOptions,
-  PromptFunction,
   Scenario,
 } from './types';
 import { readFilters, writeMultipleOutputs, writeOutput } from './util';
 import invariant from './util/invariant';
 import { readTests } from './util/testCaseReader';
-import { PromptSchema } from './validators/prompts';
 
 export * from './types';
 
@@ -48,32 +45,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     nunjucksFilters: await readFilters(testSuite.nunjucksFilters || {}),
 
     // Full prompts expected (not filepaths)
-    prompts: (
-      await Promise.all(
-        testSuite.prompts.map(async (promptInput) => {
-          if (typeof promptInput === 'function') {
-            return {
-              raw: promptInput.toString(),
-              label: promptInput?.name ?? promptInput.toString(),
-              function: promptInput as PromptFunction,
-            };
-          } else if (typeof promptInput === 'string') {
-            return readPrompts(promptInput);
-          }
-          try {
-            return PromptSchema.parse(promptInput);
-          } catch (error) {
-            logger.warn(
-              `Prompt input is not a valid prompt schema: ${error}\nFalling back to serialized JSON as raw prompt.`,
-            );
-            return {
-              raw: JSON.stringify(promptInput),
-              label: JSON.stringify(promptInput),
-            };
-          }
-        }),
-      )
-    ).flat(),
+    prompts: await processPrompts(testSuite.prompts),
   };
 
   // Resolve nested providers

--- a/test/prompts/index.test.ts
+++ b/test/prompts/index.test.ts
@@ -329,6 +329,22 @@ describe('readPrompts', () => {
     ]);
   });
 
+  it('should read a markdown file', async () => {
+    const mdContent = '# Test Heading\n\nThis is a test markdown file.';
+    jest.mocked(fs.readFileSync).mockReturnValueOnce(mdContent);
+    jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
+    jest.mocked(maybeFilePath).mockReturnValueOnce(true);
+
+    await expect(readPrompts('test.md')).resolves.toEqual([
+      {
+        raw: mdContent,
+        label: 'test.md: # Test Heading\n\nThis is a test markdown file....',
+      },
+    ]);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledWith('test.md', 'utf8');
+  });
+
   it('should read a .py prompt object array', async () => {
     const prompts = [
       { id: 'prompts.py:prompt1', label: 'First prompt' },

--- a/test/prompts/index.test.ts
+++ b/test/prompts/index.test.ts
@@ -690,7 +690,6 @@ describe('processPrompts', () => {
   });
 
   it('should process string prompts by calling readPrompts', async () => {
-    // Setup mock for fs.readFileSync since readPrompts uses it
     jest.mocked(fs.readFileSync).mockReturnValueOnce('test prompt');
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
 
@@ -741,7 +740,6 @@ describe('processPrompts', () => {
       label: 'test label',
     };
 
-    // Setup mock for fs.readFileSync since readPrompts uses it
     jest.mocked(fs.readFileSync).mockReturnValueOnce('file prompt');
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
 
@@ -762,7 +760,6 @@ describe('processPrompts', () => {
   });
 
   it('should flatten array results from readPrompts', async () => {
-    // Setup mock for fs.readFileSync since readPrompts uses it
     jest.mocked(fs.readFileSync).mockReturnValueOnce('prompt1\n---\nprompt2');
     jest.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
 


### PR DESCRIPTION
This PR refactors the prompt processing logic by introducing a new function `processPrompts` in the prompts directory.
- Removed redundant code from `evaluate` function.
- Updated tests to cover the new `processPrompts` function.
No breaking changes.