### PR TITLE
fix(testCaseReader): correctly process file:// URLs for YAML files

### DIFF
--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -325,7 +325,7 @@ export async function readTests(
         if (
           isJavascriptFile(pathWithoutFunction) ||
           pathWithoutFunction.endsWith('.py') ||
-          globOrTest.includes(':')
+          globOrTest.replace(/^file:\/\//, '').includes(':')
         ) {
           ret.push(...(await readStandaloneTestsFile(globOrTest, basePath)));
         } else {


### PR DESCRIPTION
Fixes an issue where YAML files prefixed with file:// were incorrectly processed by readStandaloneTestsFile