### PR TITLE
fix: Clearer error message in testCaseReader, test cleanup

### DIFF
--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -17,10 +17,10 @@ import { runPython } from '../python/pythonUtils';
 import telemetry from '../telemetry';
 import type {
   CsvRow,
+  ProviderOptions,
   TestCase,
   TestCaseWithVarsFile,
   TestSuiteConfig,
-  ProviderOptions,
 } from '../types';
 import { isJavascriptFile } from './file';
 
@@ -81,7 +81,7 @@ export async function readStandaloneTestsFile(
   const effectiveColonCount = isWindowsPath ? colonCount - 1 : colonCount;
 
   if (effectiveColonCount > 1) {
-    throw new Error(`Invalid Python test file path: ${varsPath}`);
+    throw new Error(`Too many colons. Invalid test file script path: ${varsPath}`);
   }
 
   const pathWithoutFunction =

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -3,17 +3,17 @@ import * as fs from 'fs';
 import { globSync } from 'glob';
 import yaml from 'js-yaml';
 import { testCaseFromCsvRow } from '../../src/csv';
-import { getEnvString, getEnvBool } from '../../src/envars';
+import { getEnvBool, getEnvString } from '../../src/envars';
 import { fetchCsvFromGoogleSheet } from '../../src/googleSheets';
 import logger from '../../src/logger';
 import { loadApiProvider } from '../../src/providers';
 import type { AssertionType, TestCase, TestCaseWithVarsFile } from '../../src/types';
 import {
+  loadTestsFromGlob,
   readStandaloneTestsFile,
   readTest,
   readTests,
   readVarsFiles,
-  loadTestsFromGlob,
 } from '../../src/util/testCaseReader';
 
 jest.mock('proxy-agent', () => ({
@@ -301,14 +301,9 @@ describe('readStandaloneTestsFile', () => {
     );
   });
 
-  it('should throw error for invalid Python file path', async () => {
-    const mockRunPython = jest.requireMock('../../src/python/pythonUtils').runPython;
-    mockRunPython.mockRejectedValueOnce(
-      new Error('Invalid Python test file path: test.py:invalid:extra'),
-    );
-
+  it('should handle Python files with invalid function name in readStandaloneTestsFile', async () => {
     await expect(readStandaloneTestsFile('test.py:invalid:extra')).rejects.toThrow(
-      'Invalid Python test file path: test.py:invalid:extra',
+      'Too many colons. Invalid test file script path: test.py:invalid:extra',
     );
   });
 });
@@ -792,15 +787,8 @@ describe('readTests', () => {
   });
 
   it('should handle Python files with invalid function name in readTests', async () => {
-    const mockRunPython = jest.requireMock('../../src/python/pythonUtils').runPython;
-    mockRunPython.mockReset();
-    mockRunPython.mockRejectedValueOnce(
-      new Error('Invalid Python test file path: test.py:invalid:extra'),
-    );
-    jest.mocked(globSync).mockReturnValueOnce(['test.py']);
-
     await expect(readTests(['test.py:invalid:extra'])).rejects.toThrow(
-      'Invalid Python test file path: test.py:invalid:extra',
+      'Too many colons. Invalid test file script path: test.py:invalid:extra',
     );
   });
 


### PR DESCRIPTION
- fixing error message to both indicate this code path can be reached with .js and .ts files, as well as resolution hint
- removing unused mocks

Open to feedback on the error message text. But the current test is pretty explicitly checking for extra colons and would be nice to provide a clearer error.

I'd like to next add full support for .ts and .js to take function names with the same default function name, to be consistent with dynamic prompts. Should be simple fix, same implementation as provider, and adding tests.