### PR TITLE
fix: issue where script.py:myFunc fails fs stat check when PROMPTFOO_STRICT_FILES=true

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1018,15 +1018,6 @@ export function parsePathOrGlob(
   }
   const filePath = path.resolve(basePath, promptPath);
 
-  let stats;
-  try {
-    stats = fs.statSync(filePath);
-  } catch (err) {
-    if (getEnvBool('PROMPTFOO_STRICT_FILES')) {
-      throw err;
-    }
-  }
-
   let filename = path.relative(basePath, filePath);
   let functionName: string | undefined;
 
@@ -1037,6 +1028,16 @@ export function parsePathOrGlob(
       (isJavascriptFile(splits[0]) || splits[0].endsWith('.py') || splits[0].endsWith('.go'))
     ) {
       [filename, functionName] = splits;
+    }
+  }
+
+  // verify that filename without function exists
+  let stats;
+  try {
+    stats = fs.statSync(path.join(basePath, filename));
+  } catch (err) {
+    if (getEnvBool('PROMPTFOO_STRICT_FILES')) {
+      throw err;
     }
   }
 

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -475,7 +475,7 @@ describe('util', () => {
       delete process.env.PROMPTFOO_STRICT_FILES;
     });
 
-    it('should properly test file existence with colons in the path', () => {
+    it('should properly test file existence with function name in the path', () => {
       jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
       parsePathOrGlob('/base', 'script.py:myFunction');
       expect(fs.statSync).toHaveBeenCalledWith(path.join('/base', 'script.py'));

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -475,7 +475,7 @@ describe('util', () => {
       delete process.env.PROMPTFOO_STRICT_FILES;
     });
 
-    it('should properly test file existence with function name in the path', () => {
+    it('should properly test file existence when function name in the path', () => {
       jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
       parsePathOrGlob('/base', 'script.py:myFunction');
       expect(fs.statSync).toHaveBeenCalledWith(path.join('/base', 'script.py'));

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -475,6 +475,14 @@ describe('util', () => {
       delete process.env.PROMPTFOO_STRICT_FILES;
     });
 
+    it('should handle files with colons in the path including when PROMPTFOO_STRICT_FILES is true', () => {
+      process.env.PROMPTFOO_STRICT_FILES = 'false';
+      jest.spyOn(fs, 'statSync');
+      parsePathOrGlob('/base', 'script.py:myFunction');
+      expect(fs.statSync).toHaveBeenCalledWith(path.join('/base', 'script.py'));
+      delete process.env.PROMPTFOO_STRICT_FILES;
+    });
+
     it('should return empty extension for files without extension', () => {
       jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
       expect(parsePathOrGlob('/base', 'file')).toEqual({

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -475,12 +475,10 @@ describe('util', () => {
       delete process.env.PROMPTFOO_STRICT_FILES;
     });
 
-    it('should handle files with colons in the path including when PROMPTFOO_STRICT_FILES is true', () => {
-      process.env.PROMPTFOO_STRICT_FILES = 'false';
-      jest.spyOn(fs, 'statSync');
+    it('should properly test file existence with colons in the path', () => {
+      jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
       parsePathOrGlob('/base', 'script.py:myFunction');
       expect(fs.statSync).toHaveBeenCalledWith(path.join('/base', 'script.py'));
-      delete process.env.PROMPTFOO_STRICT_FILES;
     });
 
     it('should return empty extension for files without extension', () => {


### PR DESCRIPTION
- current behavior: `PROMPTFOO_STRICT_FILES=true` not compatible with python.py:MyFunc format.
- changing the parsing order so that `fs.statSync` hits the file without the function name
- this was largely masked before because `PROMPTFOO_STRICT_FILES` defaults to `false`

General comment: I ran an eval with PROMPTFOO_STRICT_FILES=false (default) and while I passed the `fs.statSync` check, the script still tried to load my python file and errored out, so I'm unclear on what the default behavior is intended to be.