### PR TITLE
fix(env): ensure environment variables are properly merged and rendered in nunjucks

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -847,7 +847,17 @@
           }
         },
         "env": {
-          "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties/properties/env"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties/properties/env"
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "derivedMetrics": {
           "type": "array",

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -165,10 +165,8 @@ export async function renderPrompt(
       vars[key] = (vars[key] as string).replace(/\n$/, '');
     }
   }
-
   // Resolve variable mappings
   resolveVariables(vars);
-
   // Third party integrations
   if (prompt.raw.startsWith('portkey://')) {
     const portKeyResult = await getPortkeyPrompt(prompt.raw.slice('portkey://'.length), vars);
@@ -201,7 +199,6 @@ export async function renderPrompt(
     );
     return heliconeResult;
   }
-
   // Render prompt
   try {
     if (getEnvBool('PROMPTFOO_DISABLE_JSON_AUTOESCAPE')) {
@@ -209,12 +206,11 @@ export async function renderPrompt(
     }
 
     const parsed = JSON.parse(basePrompt);
-
     // The _raw_ prompt is valid JSON. That means that the user likely wants to substitute vars _within_ the JSON itself.
     // Recursively walk the JSON structure. If we find a string, render it with nunjucks.
     return JSON.stringify(renderVarsInObject(parsed, vars), null, 2);
   } catch {
-    return nunjucks.renderString(basePrompt, vars);
+    return renderVarsInObject(nunjucks.renderString(basePrompt, vars), vars);
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -797,7 +797,7 @@ export const TestSuiteConfigSchema = z.object({
   nunjucksFilters: z.record(z.string(), z.string()).optional(),
 
   // Envvar overrides
-  env: ProviderEnvOverridesSchema.optional(),
+  env: z.union([ProviderEnvOverridesSchema, z.record(z.string(), z.string())]).optional(),
 
   // Metrics to calculate after the eval has been completed
   derivedMetrics: z.array(DerivedMetricSchema).optional(),

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -1,4 +1,5 @@
 import nunjucks from 'nunjucks';
+import cliState from '../cliState';
 import { getEnvBool } from '../envars';
 import type { NunjucksFilterMap } from '../types';
 
@@ -30,7 +31,10 @@ export function getNunjucksEngine(
   if (
     !getEnvBool('PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS', getEnvBool('PROMPTFOO_SELF_HOSTED', false))
   ) {
-    env.addGlobal('env', process.env);
+    env.addGlobal('env', {
+      ...process.env,
+      ...cliState.config?.env,
+    });
   }
 
   env.addFilter('load', function (str) {

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -52,12 +52,58 @@ describe('renderPrompt', () => {
     expect(renderedPrompt).toBe('Test prompt value1');
   });
 
+  it('should render nested variables in non-JSON prompts', async () => {
+    const prompt = toPrompt('Test {{ outer[inner] }}');
+    const renderedPrompt = await renderPrompt(
+      prompt,
+      { outer: { key1: 'value1' }, inner: 'key1' },
+      {},
+    );
+    expect(renderedPrompt).toBe('Test value1');
+  });
+
+  it('should handle complex variable substitutions in non-JSON prompts', async () => {
+    const prompt = toPrompt('{{ var1[var2] }}');
+    const renderedPrompt = await renderPrompt(
+      prompt,
+      {
+        var1: { hello: 'world' },
+        var2: 'hello',
+      },
+      {},
+    );
+    expect(renderedPrompt).toBe('world');
+  });
+
   it('should render a JSON prompt', async () => {
     const prompt = toPrompt('[{"text": "Test prompt "}, {"text": "{{ var1 }}"}]');
     const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' }, {});
     expect(renderedPrompt).toBe(
       JSON.stringify(JSON.parse('[{"text":"Test prompt "},{"text":"value1"}]'), null, 2),
     );
+  });
+
+  it('should render nested variables in JSON prompts', async () => {
+    const prompt = toPrompt('{"text": "{{ outer[inner] }}"}');
+    const renderedPrompt = await renderPrompt(
+      prompt,
+      { outer: { key1: 'value1' }, inner: 'key1' },
+      {},
+    );
+    expect(renderedPrompt).toBe(JSON.stringify({ text: 'value1' }, null, 2));
+  });
+
+  it('should handle complex variable substitutions in JSON prompts', async () => {
+    const prompt = toPrompt('{"message": "{{ var1[var2] }}"}');
+    const renderedPrompt = await renderPrompt(
+      prompt,
+      {
+        var1: { hello: 'world' },
+        var2: 'hello',
+      },
+      {},
+    );
+    expect(renderedPrompt).toBe(JSON.stringify({ message: 'world' }, null, 2));
   });
 
   it('should render a JSON prompt and escape the var string', async () => {

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -216,7 +216,6 @@ describe('getNunjucksEngine', () => {
       };
       const engine = getNunjucksEngine();
       const rendered = engine.renderString('{{ env.PROCESS_VAR }}', {});
-      console.log('Rendered value:', rendered);
       expect(rendered).toBe('overridden_value');
       expect(engine.renderString('{{ env.CONFIG_VAR }}', {})).toBe('config_value');
       cliState.config = initialConfig;


### PR DESCRIPTION
This PR addresses issues with environment variables handling in nunjucks rendering.
- Added support for merging CLI state environment variables with process.env.
- Improved tests to cover various edge cases for environment variable handling.

Resolves https://github.com/promptfoo/promptfoo/issues/3122