### PR TITLE
fix: properly classify API errors with ResultFailureReason.ERROR

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -248,6 +248,7 @@ export async function runEval({
 
     if (response.error) {
       ret.error = response.error;
+      ret.failureReason = ResultFailureReason.ERROR;
     } else if (response.output === null || response.output === undefined) {
       // NOTE: empty output often indicative of guardrails, so behavior differs for red teams.
       if (isRedteam) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -249,6 +249,7 @@ export async function runEval({
     if (response.error) {
       ret.error = response.error;
       ret.failureReason = ResultFailureReason.ERROR;
+      ret.success = false;
     } else if (response.output === null || response.output === undefined) {
       // NOTE: empty output often indicative of guardrails, so behavior differs for red teams.
       if (isRedteam) {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -1874,6 +1874,45 @@ describe('evaluator', () => {
     Eval.prototype.addResult = originalAddResult;
     errorSpy.mockRestore();
   });
+
+  it('evaluate with provider error response', async () => {
+    const mockApiProviderWithError: ApiProvider = {
+      id: jest.fn().mockReturnValue('test-provider-error'),
+      callApi: jest.fn().mockResolvedValue({
+        output: 'Some output',
+        error: 'API error occurred',
+        tokenUsage: { total: 5, prompt: 5, completion: 0, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProviderWithError],
+      prompts: [toPrompt('Test prompt')],
+      tests: [],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        stats: expect.objectContaining({
+          successes: 0,
+          errors: 1,
+          failures: 0,
+        }),
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            error: 'API error occurred',
+            failureReason: ResultFailureReason.ERROR,
+            success: false,
+            score: 0,
+          }),
+        ]),
+      }),
+    );
+    expect(mockApiProviderWithError.callApi).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('generateVarCombinations', () => {


### PR DESCRIPTION

## Issue
When examining the code, I identified that API errors (like 400 Bad Request) were not being properly classified. The root cause was in the error handling logic:

1. In `src/types/index.ts`, we have the `ResultFailureReason` enum that defines different types of failures:
```typescript
export enum ResultFailureReason {
  NONE = 0,      // The test passed, or we don't know exactly why the test case failed
  ASSERT = 1,    // The test case failed because an assertion rejected it
  ERROR = 2,     // Test case failed due to some other error
}
```

2. In `src/evaluator.ts`, API errors (like 400 Bad Request) were being handled in the `if (response.error)` block, but this block was only setting the error message without setting `failureReason` to `ResultFailureReason.ERROR`:
```typescript
if (response.error) {
  ret.error = response.error;
  // Missing: ret.failureReason = ResultFailureReason.ERROR
}
```

3. The `failureReason` was only being set to `ResultFailureReason.ERROR` in the catch block at the end, which only handles exceptions thrown during evaluation, not API errors returned in the response.

## Changes
- Modified the error handling in `src/evaluator.ts` to properly set `failureReason = ResultFailureReason.ERROR` when an API error occurs in the response
- This ensures API errors are correctly classified and show up appropriately in both the "Errors" and "Failures" views
