### PR TITLE
chore: Return detailed error messages from fetch

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -225,8 +225,8 @@ export async function fetchWithRetries(
         const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());
         await sleep(waitTime);
       }
-      lastError = error;
+      lastError = errorMessage;
     }
   }
-  throw new Error(`Request failed after ${maxRetries} retries: ${(lastError as Error).message}`);
+  throw new Error(`Request failed after ${maxRetries} retries: ${lastError}`);
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -183,7 +183,7 @@ export async function fetchWithRetries(
 ): Promise<Response> {
   const maxRetries = Math.max(0, retries);
 
-  let lastError;
+  let lastErrorMessage: string | undefined;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);
 
   for (let i = 0; i <= maxRetries; i++) {
@@ -225,8 +225,8 @@ export async function fetchWithRetries(
         const waitTime = Math.pow(2, i) * (backoff + 1000 * Math.random());
         await sleep(waitTime);
       }
-      lastError = errorMessage;
+      lastErrorMessage = errorMessage;
     }
   }
-  throw new Error(`Request failed after ${maxRetries} retries: ${lastError}`);
+  throw new Error(`Request failed after ${maxRetries} retries: ${lastErrorMessage}`);
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -651,7 +651,7 @@ describe('fetchWithRetries', () => {
     jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
     await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
-      'Request failed after 2 retries: Network error',
+      'Request failed after 2 retries: Error: Network error',
     );
 
     expect(global.fetch).toHaveBeenCalledTimes(3);
@@ -662,7 +662,7 @@ describe('fetchWithRetries', () => {
     jest.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
     await expect(fetchWithRetries('https://example.com', {}, 1000, 1)).rejects.toThrow(
-      'Request failed after 1 retries: Network error',
+      'Request failed after 1 retries: Error: Network error',
     );
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -722,7 +722,7 @@ describe('fetchWithRetries', () => {
     global.fetch = mockFetch;
 
     await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
-      'Request failed after 2 retries: Network error',
+      'Request failed after 2 retries: Error: Network error',
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -736,7 +736,7 @@ describe('fetchWithRetries', () => {
     jest.mocked(global.fetch).mockRejectedValue(error);
 
     await expect(fetchWithRetries('https://example.com', {}, 1000, 1)).rejects.toThrow(
-      'Request failed after 1 retries: Network error',
+      'Request failed after 1 retries: Error: Network error (Cause: Connection refused) (Code: ECONNREFUSED)',
     );
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -747,7 +747,7 @@ describe('fetchWithRetries', () => {
     jest.mocked(global.fetch).mockRejectedValue('String error');
 
     await expect(fetchWithRetries('https://example.com', {}, 1000, 1)).rejects.toThrow(
-      'Request failed after 1 retries: undefined',
+      'Request failed after 1 retries: String error',
     );
 
     expect(global.fetch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Previously this would always just return "fetch failed". Now this returns usable error messages like: 

```TypeError: fetch failed (Cause: RequestContentLengthMismatchError: Request body length does not match content-length header)```