### PR TITLE
feat(providers): add support for multiple providers in single config file

### DIFF
--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -98,8 +98,31 @@ Providers are specified using various syntax options:
 
 3. File-based configuration:
 
-   ```yaml
-   - file://path/to/provider_config.yaml
+   Load a single provider:
+
+   ```yaml title="provider.yaml"
+   id: openai:chat:gpt-4o-mini
+   config:
+     temperature: 0.7
+   ```
+
+   Or multiple providers:
+
+   ```yaml title="providers.yaml"
+   - id: openai:gpt-4o-mini
+     config:
+       temperature: 0.7
+   - id: anthropic:messages:claude-3-5-sonnet-20241022
+     config:
+       max_tokens: 1000
+   ```
+
+   Reference in your configuration:
+
+   ```yaml title="promptfooconfig.yaml"
+   providers:
+     - file://provider.yaml # single provider as an object
+     - file://providers.yaml # multiple providers as an array
    ```
 
 ## Configuring Providers

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -85,7 +85,11 @@ export async function loadApiProviders(
   } = {},
 ): Promise<ApiProvider[]> {
   const { basePath } = options;
-  const env = options.env || cliState.config?.env;
+
+  const env = {
+    ...cliState.config?.env,
+    ...options.env,
+  };
 
   if (typeof providerPaths === 'string') {
     // Check if the string path points to a file

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -376,7 +376,6 @@ describe('loadApiProvider', () => {
 describe('loadApiProviders', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    // Reset cliState.config before each test
     cliState.config = undefined;
   });
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -61,12 +61,14 @@ describe('loadApiProvider', () => {
       },
     };
     jest.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(jsonContent));
+    jest.mocked(yaml.load).mockReturnValue(jsonContent);
 
     const provider = await loadApiProvider('file://test.json', {
       basePath: '/test',
     });
 
     expect(fs.readFileSync).toHaveBeenCalledWith(path.join('/test', 'test.json'), 'utf8');
+    expect(yaml.load).toHaveBeenCalledWith(JSON.stringify(jsonContent));
     expect(provider).toBeDefined();
     expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('gpt-4', expect.any(Object));
   });


### PR DESCRIPTION
Adds ability to load multiple providers from a single YAML/JSON file

Relates to https://github.com/promptfoo/promptfoo/issues/3153 