### PR TITLE
fix(go-mod): update go toolchain version to valid syntax

### DIFF
--- a/examples/golang-provider/go.mod
+++ b/examples/golang-provider/go.mod
@@ -1,5 +1,5 @@
 module github.com/promptfoo/promptfoo/examples/golang-provider
 
-go 1.21
+go 1.23.6
 
 require github.com/sashabaranov/go-openai v1.37.0


### PR DESCRIPTION
Updated the Go toolchain version in the go.mod file to adhere to the 1.N.P syntax required as of Go 1.21.
- Changed the version from '1.21' to '1.23.6' to ensure compatibility.