### PR TITLE
chore!: remove direct provider exports in favor of loadApiProvider (undocumented node package feature)

### DIFF
--- a/site/docs/usage/node-package.md
+++ b/site/docs/usage/node-package.md
@@ -15,7 +15,7 @@ npm install promptfoo
 
 ## Usage
 
-Use `promptfoo` as a library in your project by importing the `evaluate` function:
+Use `promptfoo` as a library in your project by importing the `evaluate` function and other utilities:
 
 ```ts
 import promptfoo from 'promptfoo';
@@ -34,6 +34,21 @@ The results of the evaluation are returned as an [`EvaluateSummary` object](/doc
 ### Provider functions
 
 A `ProviderFunction` is a Javascript function that implements an LLM API call. It takes a prompt string and a context. It returns the LLM response or an error. See [`ProviderFunction` type](/docs/configuration/reference#providerfunction).
+
+You can load providers using the `loadApiProvider` function:
+
+```ts
+// Load a provider with default options
+const provider = await loadApiProvider('openai:o3-mini');
+
+// Load a provider with custom options
+const providerWithOptions = await loadApiProvider('azure:chat:test', {
+  options: {
+    apiHost: 'test-host',
+    apiKey: 'test-key',
+  },
+});
+```
 
 ### Assertion functions
 

--- a/site/docs/usage/node-package.md
+++ b/site/docs/usage/node-package.md
@@ -38,6 +38,8 @@ A `ProviderFunction` is a Javascript function that implements an LLM API call. I
 You can load providers using the `loadApiProvider` function:
 
 ```ts
+import { loadApiProvider } from 'promptfoo';
+
 // Load a provider with default options
 const provider = await loadApiProvider('openai:o3-mini');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { runDbMigrations } from './migrate';
 import Eval from './models/eval';
 import { readProviderPromptMap, processPrompts } from './prompts';
 import { loadApiProvider, loadApiProviders } from './providers';
-import providers from './providers/registry';
 import { extractEntities } from './redteam/extraction/entities';
 import { extractSystemPurpose } from './redteam/extraction/purpose';
 import { GRADERS } from './redteam/graders';
@@ -142,18 +141,13 @@ const redteam = {
   },
 };
 
-const providersWithLoader = {
-  ...providers,
-  loadApiProvider,
-} as const;
-
-export { assertions, cache, evaluate, providersWithLoader as providers, redteam, guardrails };
+export { assertions, cache, evaluate, loadApiProvider, redteam, guardrails };
 
 export default {
   assertions,
   cache,
   evaluate,
-  providers: providersWithLoader,
+  loadApiProvider,
   redteam,
   guardrails,
 };

--- a/src/providers/bam.ts
+++ b/src/providers/bam.ts
@@ -92,7 +92,7 @@ export function convertResponse(response: TextGenerationCreateOutput): ProviderR
   return providerResponse;
 }
 
-export class BAMChatProvider implements ApiProvider {
+export class BAMProvider implements ApiProvider {
   modelName: string;
   config?: BAMGenerationParameters;
   moderations?: BAMModerations;
@@ -191,5 +191,3 @@ export class BAMChatProvider implements ApiProvider {
     }
   }
 }
-
-export class BAMEmbeddingProvider extends BAMChatProvider {}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -20,7 +20,7 @@ import {
   AzureCompletionProvider,
   AzureEmbeddingProvider,
 } from './azure';
-import { BAMChatProvider, BAMEmbeddingProvider } from './bam';
+import { BAMChatProvider } from './bam';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './bedrock';
 import { BrowserProvider } from './browser';
 import { ClouderaAiChatCompletionProvider } from './cloudera';
@@ -1024,66 +1024,3 @@ export const providerMap: ProviderFactory[] = [
     },
   },
 ];
-
-export default {
-  AI21ChatCompletionProvider,
-  AnthropicCompletionProvider,
-  AnthropicMessagesProvider,
-  AwsBedrockCompletionProvider,
-  AwsBedrockEmbeddingProvider,
-  AzureAssistantProvider,
-  AzureChatCompletionProvider,
-  AzureCompletionProvider,
-  AzureEmbeddingProvider,
-  /** @deprecated Use AzureAssistantProvider instead (renamed in 0.96.0) */
-  AzureOpenAiAssistantProvider: AzureAssistantProvider,
-  /** @deprecated Use AzureChatCompletionProvider instead (renamed in 0.96.0) */
-  AzureOpenAiChatCompletionProvider: AzureChatCompletionProvider,
-  /** @deprecated Use AzureCompletionProvider instead (renamed in 0.96.0) */
-  AzureOpenAiCompletionProvider: AzureCompletionProvider,
-  /** @deprecated Use AzureEmbeddingProvider instead (renamed in 0.96.0) */
-  AzureOpenAiEmbeddingProvider: AzureEmbeddingProvider,
-  BAMChatProvider,
-  BAMEmbeddingProvider,
-  BrowserProvider,
-  ClouderaAiChatCompletionProvider,
-  CohereChatCompletionProvider,
-  CohereEmbeddingProvider,
-  FalImageGenerationProvider,
-  GolangProvider,
-  GoogleChatProvider,
-  GroqProvider,
-  HttpProvider,
-  HuggingfaceFeatureExtractionProvider,
-  HuggingfaceSentenceSimilarityProvider,
-  HuggingfaceTextClassificationProvider,
-  HuggingfaceTextGenerationProvider,
-  HuggingfaceTokenExtractionProvider,
-  LlamaProvider,
-  LocalAiChatProvider,
-  LocalAiCompletionProvider,
-  LocalAiEmbeddingProvider,
-  ManualInputProvider,
-  MistralChatCompletionProvider,
-  MistralEmbeddingProvider,
-  OllamaChatProvider,
-  OllamaCompletionProvider,
-  OllamaEmbeddingProvider,
-  OpenAiAssistantProvider,
-  OpenAiChatCompletionProvider,
-  OpenAiCompletionProvider,
-  OpenAiEmbeddingProvider,
-  OpenAiImageProvider,
-  OpenAiModerationProvider,
-  PortkeyChatCompletionProvider,
-  PythonProvider,
-  ReplicateImageProvider,
-  ReplicateModerationProvider,
-  ReplicateProvider,
-  ScriptCompletionProvider,
-  VertexChatProvider,
-  VertexEmbeddingProvider,
-  VoyageEmbeddingProvider,
-  WatsonXProvider,
-  WebhookProvider,
-};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -20,7 +20,7 @@ import {
   AzureCompletionProvider,
   AzureEmbeddingProvider,
 } from './azure';
-import { BAMChatProvider } from './bam';
+import { BAMProvider } from './bam';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './bedrock';
 import { BrowserProvider } from './browser';
 import { ClouderaAiChatCompletionProvider } from './cloudera';
@@ -209,7 +209,7 @@ export const providerMap: ProviderFactory[] = [
       const modelType = splits[1];
       const modelName = splits.slice(2).join(':');
       if (modelType === 'chat') {
-        return new BAMChatProvider(modelName || 'ibm/granite-13b-chat-v2', providerOptions);
+        return new BAMProvider(modelName || 'ibm/granite-13b-chat-v2', providerOptions);
       }
       throw new Error(
         `Invalid BAM provider: ${providerPath}. Use one of the following providers: bam:chat:<model name>`,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -40,7 +40,7 @@ describe('index.ts exports', () => {
     'isApiProvider',
     'isGradingResult',
     'isProviderOptions',
-    'providers',
+    'loadApiProvider',
     'redteam',
   ];
 
@@ -111,7 +111,7 @@ describe('index.ts exports', () => {
       cache: index.cache,
       evaluate: index.evaluate,
       guardrails: index.guardrails,
-      providers: index.providers,
+      loadApiProvider: index.loadApiProvider,
       redteam: index.redteam,
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: Direct access to providers through `promptfoo.providers` is being removed in favor of `loadApiProvider` to dynamically load providers. This allows us to import some providers at runtime and make promptfoo faster for the majority of users. 