### PR TITLE
chore(webui): add reusable error boundary component

### DIFF
--- a/src/app/src/components/ErrorBoundary.tsx
+++ b/src/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Alert, Box, Button, Collapse, Typography } from '@mui/material';
+
+interface Props {
+  children: React.ReactNode;
+  name?: string; // Name of the component/page being wrapped
+  fallback?: React.ReactNode; // Optional custom fallback UI
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  showDetails: boolean;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.setState({ errorInfo });
+
+    // Log to console
+    console.error(`Error in ${this.props.name || 'component'}:`, {
+      error,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  private handleReload = (): void => {
+    window.location.reload();
+  };
+
+  private toggleDetails = (): void => {
+    this.setState((prevState) => ({ showDetails: !prevState.showDetails }));
+  };
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      const isDev = process.env.NODE_ENV === 'development';
+
+      return (
+        <Box sx={{ p: 2, maxWidth: '100%' }}>
+          <Alert
+            severity="error"
+            action={
+              <Button color="inherit" size="small" onClick={this.handleReload}>
+                Reload Page
+              </Button>
+            }
+          >
+            <Typography variant="subtitle1" gutterBottom>
+              Something went wrong {this.props.name ? `in ${this.props.name}` : ''}.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Please try reloading the page.
+            </Typography>
+          </Alert>
+
+          {isDev && (
+            <Box sx={{ mt: 2 }}>
+              <Button size="small" variant="outlined" onClick={this.toggleDetails} sx={{ mb: 1 }}>
+                {this.state.showDetails ? 'Hide' : 'Show'} Error Details
+              </Button>
+              <Collapse in={this.state.showDetails}>
+                <Box
+                  sx={{
+                    mt: 1,
+                    p: 2,
+                    bgcolor: 'grey.100',
+                    borderRadius: 1,
+                    fontFamily: 'monospace',
+                    fontSize: '0.875rem',
+                    overflow: 'auto',
+                  }}
+                >
+                  <Typography variant="h6" gutterBottom>
+                    Error Details:
+                  </Typography>
+                  <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>
+                    {this.state.error?.name}: {this.state.error?.message}
+                  </pre>
+                  {this.state.error?.stack && (
+                    <>
+                      <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+                        Stack Trace:
+                      </Typography>
+                      <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>
+                        {this.state.error.stack}
+                      </pre>
+                    </>
+                  )}
+                  {this.state.errorInfo && (
+                    <>
+                      <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+                        Component Stack:
+                      </Typography>
+                      <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>
+                        {this.state.errorInfo.componentStack}
+                      </pre>
+                    </>
+                  )}
+                </Box>
+              </Collapse>
+            </Box>
+          )}
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/app/src/pages/datasets/page.tsx
+++ b/src/app/src/pages/datasets/page.tsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { callApi } from '@app/utils/api';
 import type { TestCasesWithMetadata } from '@promptfoo/types';
+import ErrorBoundary from '../../components/ErrorBoundary';
 import Datasets from './Datasets';
 
 export default function DatasetsPage() {
+  return (
+    <ErrorBoundary name="Datasets Page">
+      <DatasetsPageContent />
+    </ErrorBoundary>
+  );
+}
+
+function DatasetsPageContent() {
   const [testCases, setTestCases] = useState<
     (TestCasesWithMetadata & { recentEvalDate: string })[]
   >([]);

--- a/src/app/src/pages/datasets/page.tsx
+++ b/src/app/src/pages/datasets/page.tsx
@@ -4,14 +4,6 @@ import type { TestCasesWithMetadata } from '@promptfoo/types';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import Datasets from './Datasets';
 
-export default function DatasetsPage() {
-  return (
-    <ErrorBoundary name="Datasets Page">
-      <DatasetsPageContent />
-    </ErrorBoundary>
-  );
-}
-
 function DatasetsPageContent() {
   const [testCases, setTestCases] = useState<
     (TestCasesWithMetadata & { recentEvalDate: string })[]
@@ -41,4 +33,12 @@ function DatasetsPageContent() {
   }, []);
 
   return <Datasets data={testCases} isLoading={isLoading} error={error} />;
+}
+
+export default function DatasetsPage() {
+  return (
+    <ErrorBoundary name="Datasets Page">
+      <DatasetsPageContent />
+    </ErrorBoundary>
+  );
 }

--- a/src/app/src/pages/history/page.tsx
+++ b/src/app/src/pages/history/page.tsx
@@ -4,14 +4,6 @@ import type { StandaloneEval } from '@promptfoo/util';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import History from './History';
 
-export default function HistoryPage() {
-  return (
-    <ErrorBoundary name="History Page">
-      <HistoryPageContent />
-    </ErrorBoundary>
-  );
-}
-
 function HistoryPageContent() {
   const [cols, setCols] = useState<StandaloneEval[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -37,4 +29,12 @@ function HistoryPageContent() {
   }, []);
 
   return <History data={cols} isLoading={isLoading} error={error} />;
+}
+
+export default function HistoryPage() {
+  return (
+    <ErrorBoundary name="History Page">
+      <HistoryPageContent />
+    </ErrorBoundary>
+  );
 }

--- a/src/app/src/pages/history/page.tsx
+++ b/src/app/src/pages/history/page.tsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { callApi } from '@app/utils/api';
 import type { StandaloneEval } from '@promptfoo/util';
+import ErrorBoundary from '../../components/ErrorBoundary';
 import History from './History';
 
 export default function HistoryPage() {
+  return (
+    <ErrorBoundary name="History Page">
+      <HistoryPageContent />
+    </ErrorBoundary>
+  );
+}
+
+function HistoryPageContent() {
   const [cols, setCols] = useState<StandaloneEval[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/src/pages/prompts/page.tsx
+++ b/src/app/src/pages/prompts/page.tsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { callApi } from '@app/utils/api';
 import type { PromptWithMetadata } from '@promptfoo/types';
+import ErrorBoundary from '../../components/ErrorBoundary';
 import Prompts from './Prompts';
 
 export default function PromptsPage() {
+  return (
+    <ErrorBoundary name="Prompts Page">
+      <PromptsPageContent />
+    </ErrorBoundary>
+  );
+}
+
+function PromptsPageContent() {
   const [prompts, setPrompts] = useState<(PromptWithMetadata & { recentEvalDate: string })[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/src/pages/prompts/page.tsx
+++ b/src/app/src/pages/prompts/page.tsx
@@ -4,14 +4,6 @@ import type { PromptWithMetadata } from '@promptfoo/types';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import Prompts from './Prompts';
 
-export default function PromptsPage() {
-  return (
-    <ErrorBoundary name="Prompts Page">
-      <PromptsPageContent />
-    </ErrorBoundary>
-  );
-}
-
 function PromptsPageContent() {
   const [prompts, setPrompts] = useState<(PromptWithMetadata & { recentEvalDate: string })[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -39,4 +31,12 @@ function PromptsPageContent() {
   }, []);
 
   return <Prompts data={prompts} isLoading={isLoading} error={error} />;
+}
+
+export default function PromptsPage() {
+  return (
+    <ErrorBoundary name="Prompts Page">
+      <PromptsPageContent />
+    </ErrorBoundary>
+  );
 }


### PR DESCRIPTION
Add a reusable error boundary component to the web UI.

- Introduced `ErrorBoundary` component for handling errors in React components.
- Integrated the error boundary into the datasets, history, and prompts pages.

No breaking changes.