### PR TITLE
Revert "chore: Map RBAC-tagIds when pulling redteam configs from the cloud"

### DIFF
--- a/src/redteam/sharedFrontend.ts
+++ b/src/redteam/sharedFrontend.ts
@@ -33,10 +33,9 @@ export function getUnifiedConfig(
 ): UnifiedConfig & { redteam: NonNullable<UnifiedConfig['redteam']> } {
   // Remove UI specific configs from target
   const target = { ...config.target, config: { ...config.target.config } };
-  const metadata = { rbacTagIds: config.target.rbacTagIds };
   delete target.config.sessionSource;
   delete target.config.stateful;
-  delete target.rbacTagIds;
+
   const defaultTest = {
     ...(config.defaultTest ?? {}),
     options: {
@@ -97,6 +96,5 @@ export function getUnifiedConfig(
         };
       }),
     },
-    metadata,
   };
 }

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -144,7 +144,7 @@ export interface RedteamRunOptions {
 export interface SavedRedteamConfig {
   description: string;
   prompts: string[];
-  target: ProviderOptions & { rbacTagIds?: string[] };
+  target: ProviderOptions;
   plugins: (RedteamPlugin | { id: string; config?: any })[];
   strategies: RedteamStrategy[];
   purpose?: string;


### PR DESCRIPTION
Reverts promptfoo/promptfoo#3229