### PR TITLE
chore(webui): make datasets optional in history and prompts components

### DIFF
--- a/src/app/src/pages/history/History.tsx
+++ b/src/app/src/pages/history/History.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import DownloadIcon from '@mui/icons-material/Download';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -23,23 +23,47 @@ interface HistoryProps {
   data: StandaloneEval[];
   isLoading: boolean;
   error: string | null;
+  showDatasetColumn?: boolean;
 }
 
-export default function History({ data, isLoading, error }: HistoryProps) {
-  const [sortField, setSortField] = useState<string | null>(null);
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+interface FilterState {
+  evalId: string;
+  datasetId: string;
+  provider: string;
+  promptId: string;
+}
+
+interface SortState {
+  field: string | null;
+  order: 'asc' | 'desc';
+}
+
+const calculatePassRate = (
+  metrics: { testPassCount: number; testFailCount: number } | undefined,
+): string => {
+  if (metrics?.testPassCount != null && metrics?.testFailCount != null) {
+    return (
+      (metrics.testPassCount / (metrics.testPassCount + metrics.testFailCount)) *
+      100
+    ).toFixed(2);
+  }
+  return '-';
+};
+
+const getSortedValues = (sortOrder: string, a: number, b: number): number => {
+  return sortOrder === 'asc' ? a - b : b - a;
+};
+
+const getValue = (metrics: PromptMetrics | undefined, sortField: string): number => {
+  if (metrics) {
+    return metrics[sortField as keyof PromptMetrics] as number;
+  }
+  return 0;
+};
+
+const ExportButton = ({ onExport }: { onExport: (format: string) => void }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [page, setPage] = React.useState(1);
-  const [filter, setFilter] = useState({ evalId: '', datasetId: '', provider: '', promptId: '' });
-
-  const rowsPerPage = 25;
   const open = Boolean(anchorEl);
-
-  const handleSort = (field: string) => {
-    const isAsc = sortField === field && sortOrder === 'asc';
-    setSortField(field);
-    setSortOrder(isAsc ? 'desc' : 'asc');
-  };
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -49,69 +73,328 @@ export default function History({ data, isLoading, error }: HistoryProps) {
     setAnchorEl(null);
   };
 
-  const calculatePassRate = (
-    metrics: { testPassCount: number; testFailCount: number } | undefined,
-  ) => {
-    if (metrics?.testPassCount != null && metrics?.testFailCount != null) {
-      return (
-        (metrics.testPassCount / (metrics.testPassCount + metrics.testFailCount)) *
-        100
-      ).toFixed(2);
+  const handleExportFormat = (format: string) => {
+    onExport(format);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        id="export-button"
+        aria-controls={open ? 'export-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        startIcon={<DownloadIcon />}
+      >
+        Export
+      </Button>
+      <Menu
+        id="export-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'export-button',
+        }}
+      >
+        <MenuItem onClick={() => handleExportFormat('csv')}>CSV</MenuItem>
+        <MenuItem onClick={() => handleExportFormat('json')}>JSON</MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+const FilterBar = ({
+  filter,
+  onFilterChange,
+  evalIdOptions,
+  datasetIdOptions,
+  providerOptions,
+  promptIdOptions,
+  showDatasetColumn,
+}: {
+  filter: FilterState;
+  onFilterChange: (newFilter: FilterState) => void;
+  evalIdOptions: string[];
+  datasetIdOptions: string[];
+  providerOptions: string[];
+  promptIdOptions: string[];
+  showDatasetColumn: boolean;
+}) => {
+  const handleFilterChange = (key: keyof FilterState, value: string) => {
+    onFilterChange({ ...filter, [key]: value });
+  };
+
+  return (
+    <Box display="flex" flexDirection="row" gap={2} my={2}>
+      <Autocomplete
+        options={evalIdOptions}
+        value={filter.evalId}
+        onChange={(event, newValue) => handleFilterChange('evalId', newValue || '')}
+        renderInput={(params) => (
+          <TextField {...params} label="Eval ID" variant="outlined" size="small" fullWidth />
+        )}
+        sx={{ width: 220 }}
+      />
+      {showDatasetColumn && (
+        <Autocomplete
+          options={datasetIdOptions}
+          value={filter.datasetId}
+          onChange={(event, newValue) => handleFilterChange('datasetId', newValue || '')}
+          renderInput={(params) => (
+            <TextField {...params} label="Dataset ID" variant="outlined" size="small" fullWidth />
+          )}
+          sx={{ width: 220 }}
+        />
+      )}
+      <Autocomplete
+        options={providerOptions}
+        value={filter.provider}
+        onChange={(event, newValue) => handleFilterChange('provider', newValue || '')}
+        renderInput={(params) => (
+          <TextField {...params} label="Provider" variant="outlined" size="small" fullWidth />
+        )}
+        sx={{ width: 220 }}
+      />
+      <Autocomplete
+        options={promptIdOptions}
+        value={filter.promptId}
+        onChange={(event, newValue) => handleFilterChange('promptId', newValue || '')}
+        renderInput={(params) => (
+          <TextField {...params} label="Prompt ID" variant="outlined" size="small" fullWidth />
+        )}
+        sx={{ width: 220 }}
+      />
+    </Box>
+  );
+};
+
+const HistoryTable = ({
+  cols,
+  sortState,
+  onSort,
+  page,
+  rowsPerPage,
+  showDatasetColumn,
+  onRowClick,
+}: {
+  cols: StandaloneEval[];
+  sortState: SortState;
+  onSort: (field: string) => void;
+  page: number;
+  rowsPerPage: number;
+  showDatasetColumn: boolean;
+  onRowClick: (col: StandaloneEval) => void;
+}) => {
+  const { field: sortField, order: sortOrder } = sortState;
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>
+            <TableSortLabel
+              active={sortField === 'evalId'}
+              direction={sortField === 'evalId' ? sortOrder : 'asc'}
+              onClick={() => onSort('evalId')}
+            >
+              Eval
+            </TableSortLabel>
+          </TableCell>
+          {showDatasetColumn && <TableCell>Dataset</TableCell>}
+          <TableCell>Provider</TableCell>
+          <TableCell>Prompt</TableCell>
+          <TableCell>
+            <TableSortLabel
+              active={sortField === 'passRate'}
+              direction={sortField === 'passRate' ? sortOrder : 'asc'}
+              onClick={() => onSort('passRate')}
+            >
+              Pass Rate %
+            </TableSortLabel>
+          </TableCell>
+          <TableCell>
+            <TableSortLabel
+              active={sortField === 'testPassCount'}
+              direction={sortField === 'testPassCount' ? sortOrder : 'asc'}
+              onClick={() => onSort('testPassCount')}
+            >
+              Pass Count
+            </TableSortLabel>
+          </TableCell>
+          <TableCell>
+            <TableSortLabel
+              active={sortField === 'testFailCount'}
+              direction={sortField === 'testFailCount' ? sortOrder : 'asc'}
+              onClick={() => onSort('testFailCount')}
+            >
+              Fail Count
+            </TableSortLabel>
+          </TableCell>
+          <TableCell>
+            <TableSortLabel
+              active={sortField === 'score'}
+              direction={sortField === 'score' ? sortOrder : 'asc'}
+              onClick={() => onSort('score')}
+            >
+              Raw score
+            </TableSortLabel>
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {cols.slice((page - 1) * rowsPerPage, page * rowsPerPage).map((col, index) => (
+          <TableRow key={index} hover onClick={() => onRowClick(col)}>
+            <TableCell>
+              <Link to={`/eval?evalId=${col.evalId || ''}`} onClick={(e) => e.stopPropagation()}>
+                {col.evalId}
+              </Link>
+            </TableCell>
+            {showDatasetColumn && (
+              <TableCell>
+                <Link
+                  to={`/datasets?id=${col.datasetId || ''}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {col.datasetId?.slice(0, 6)}
+                </Link>
+              </TableCell>
+            )}
+            <TableCell>{col.provider}</TableCell>
+            <TableCell>
+              <Link to={`/prompts?id=${col.promptId || ''}`} onClick={(e) => e.stopPropagation()}>
+                [{col.promptId?.slice(0, 6)}]
+              </Link>{' '}
+              {col.raw}
+            </TableCell>
+            <TableCell>{calculatePassRate(col.metrics)}</TableCell>
+            <TableCell>
+              {col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`}
+            </TableCell>
+            <TableCell>
+              {col.metrics?.testFailCount == null
+                ? '- ' +
+                  (col.metrics?.testErrorCount && col.metrics.testErrorCount > 0
+                    ? `+ ${col.metrics.testErrorCount} errors`
+                    : '')
+                : `${col.metrics.testFailCount} ` +
+                  (col.metrics?.testErrorCount ? `+ ${col.metrics.testErrorCount} errors` : '')}
+            </TableCell>
+            <TableCell>
+              {col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default function History({
+  data,
+  isLoading,
+  error,
+  showDatasetColumn = true,
+}: HistoryProps) {
+  const [sortState, setSortState] = useState<SortState>({ field: null, order: 'asc' });
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState<FilterState>({
+    evalId: '',
+    datasetId: '',
+    provider: '',
+    promptId: '',
+  });
+
+  const rowsPerPage = 25;
+
+  useEffect(() => {
+    if (!showDatasetColumn) {
+      setFilter((prev) => ({ ...prev, datasetId: '' }));
     }
-    return '-';
-  };
+  }, [showDatasetColumn]);
 
-  const convertToCSV = (arr: StandaloneEval[]) => {
-    const headers = [
-      'Eval',
-      'Dataset',
-      'Provider',
-      'Prompt',
-      'Pass Rate %',
-      'Pass Count',
-      'Fail Count',
-      'Raw score',
-    ];
-    const rows = arr.map((col) => [
-      col.evalId ?? '',
-      col.datasetId?.slice(0, 6) ?? '',
-      col.provider ?? '',
-      (col.promptId?.slice(0, 6) ?? '') + ' ' + (col.raw ?? ''),
-      calculatePassRate(col.metrics),
-      col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`,
-      col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`,
-      col.metrics?.testErrorCount == null ? '-' : `${col.metrics.testErrorCount}`,
-      col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2),
-    ]);
-    return [headers]
-      .concat(rows)
-      .map((it) => it.map((value) => value ?? '').join(','))
-      .join('\n');
-  };
+  const handleSort = useCallback((field: string) => {
+    setSortState((prev) => ({
+      field,
+      order: prev.field === field && prev.order === 'asc' ? 'desc' : 'asc',
+    }));
+  }, []);
 
-  const handleExport = (format: string) => {
-    const dataStr = format === 'json' ? JSON.stringify(data) : convertToCSV(data);
-    const blob = new Blob([dataStr], { type: `text/${format};charset=utf-8;` });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `cols_export.${format}`;
-    link.click();
-    URL.revokeObjectURL(link.href);
-    setAnchorEl(null);
-  };
+  const handleRowClick = useCallback(
+    (col: StandaloneEval) => {
+      const newFilter = {
+        evalId: col.evalId,
+        promptId: col.promptId || '',
+        provider: col.provider,
+        datasetId: '',
+      };
 
-  const getSortedValues = (sortOrder: string, a: number, b: number): number => {
-    return sortOrder === 'asc' ? a - b : b - a;
-  };
+      if (showDatasetColumn) {
+        newFilter.datasetId = col.datasetId || '';
+      }
 
-  const getValue = (metrics: PromptMetrics | undefined, sortField: string): number => {
-    if (metrics) {
-      return metrics[sortField as keyof PromptMetrics] as number;
-    }
-    return 0;
-  };
+      setFilter(newFilter);
+    },
+    [showDatasetColumn],
+  );
 
-  const filteredCols = React.useMemo(() => {
+  const convertToCSV = useCallback(
+    (arr: StandaloneEval[]) => {
+      const headers = [
+        'Eval',
+        ...(showDatasetColumn ? ['Dataset'] : []),
+        'Provider',
+        'Prompt',
+        'Pass Rate %',
+        'Pass Count',
+        'Fail Count',
+        'Raw score',
+      ];
+
+      const rows = arr.map((col) => {
+        const baseRow = [col.evalId ?? ''];
+
+        if (showDatasetColumn) {
+          baseRow.push(col.datasetId?.slice(0, 6) ?? '');
+        }
+
+        baseRow.push(
+          col.provider ?? '',
+          (col.promptId?.slice(0, 6) ?? '') + ' ' + (col.raw ?? ''),
+          calculatePassRate(col.metrics),
+          col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`,
+          col.metrics?.testFailCount == null ? '-' : `${col.metrics.testFailCount}`,
+          col.metrics?.testErrorCount == null ? '-' : `${col.metrics.testErrorCount}`,
+          col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2),
+        );
+
+        return baseRow;
+      });
+
+      return [headers]
+        .concat(rows)
+        .map((it) => it.map((value) => value ?? '').join(','))
+        .join('\n');
+    },
+    [showDatasetColumn],
+  );
+
+  const handleExport = useCallback(
+    (format: string) => {
+      const dataStr = format === 'json' ? JSON.stringify(data) : convertToCSV(data);
+      const blob = new Blob([dataStr], { type: `text/${format};charset=utf-8;` });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `cols_export.${format}`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    },
+    [data, convertToCSV],
+  );
+
+  const filteredCols = useMemo(() => {
     return data.filter(
       (col) =>
         (filter.evalId ? col.evalId?.includes(filter.evalId) : true) &&
@@ -121,17 +404,19 @@ export default function History({ data, isLoading, error }: HistoryProps) {
     );
   }, [data, filter]);
 
-  const sortedCols = React.useMemo(() => {
-    return filteredCols.sort((a, b) => {
-      if (!sortField) {
-        return 0;
-      }
+  const sortedCols = useMemo(() => {
+    const { field: sortField, order: sortOrder } = sortState;
+
+    if (!sortField) {
+      return filteredCols;
+    }
+
+    return [...filteredCols].sort((a, b) => {
       if (sortField === 'passRate') {
         const aValue = Number.parseFloat(calculatePassRate(a.metrics));
         const bValue = Number.parseFloat(calculatePassRate(b.metrics));
         return getSortedValues(sortOrder, aValue, bValue);
       } else if (sortField === 'evalId') {
-        // Ensure sortField is a key of StandaloneEval
         if (sortField in a && sortField in b) {
           const aValue = a[sortField as keyof StandaloneEval] || '';
           const bValue = b[sortField as keyof StandaloneEval] || '';
@@ -146,207 +431,67 @@ export default function History({ data, isLoading, error }: HistoryProps) {
         return getSortedValues(sortOrder, aValue, bValue);
       }
     });
-  }, [filteredCols, sortField, sortOrder]);
+  }, [filteredCols, sortState]);
 
-  const evalIdOptions = React.useMemo(
-    () => Array.from(new Set(data.map((col) => col.evalId))),
-    [data],
-  );
-  const datasetIdOptions = React.useMemo(
-    () => Array.from(new Set(data.map((col) => col.datasetId))),
-    [data],
-  );
-  const providerOptions = React.useMemo(
-    () => Array.from(new Set(data.map((col) => col.provider))),
-    [data],
-  );
-  const promptIdOptions = React.useMemo(
-    () => Array.from(new Set(data.map((col) => col.promptId))),
-    [data],
-  );
+  const evalIdOptions = useMemo(() => {
+    const options = data
+      .map((col) => col.evalId)
+      .filter((id): id is string => id !== null && id !== undefined);
+    return Array.from(new Set(options));
+  }, [data]);
 
+  const datasetIdOptions = useMemo(() => {
+    const options = data
+      .map((col) => col.datasetId)
+      .filter((id): id is string => id !== null && id !== undefined);
+    return Array.from(new Set(options));
+  }, [data]);
+
+  const providerOptions = useMemo(() => {
+    const options = data
+      .map((col) => col.provider)
+      .filter((provider): provider is string => provider !== null && provider !== undefined);
+    return Array.from(new Set(options));
+  }, [data]);
+
+  const promptIdOptions = useMemo(() => {
+    const options = data
+      .map((col) => col.promptId)
+      .filter((id): id is string => id !== null && id !== undefined);
+    return Array.from(new Set(options));
+  }, [data]);
+
+  // Render
   return (
     <Box paddingX={2}>
       <Box display="flex" justifyContent="space-between" alignItems="center">
         <h2>Eval History</h2>
-        <div>
-          <Button
-            id="export-button"
-            aria-controls={open ? 'export-menu' : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
-            onClick={handleClick}
-            startIcon={<DownloadIcon />}
-          >
-            Export
-          </Button>
-          <Menu
-            id="export-menu"
-            anchorEl={anchorEl}
-            open={open}
-            onClose={handleClose}
-            MenuListProps={{
-              'aria-labelledby': 'export-button',
-            }}
-          >
-            <MenuItem onClick={() => handleExport('csv')}>CSV</MenuItem>
-            <MenuItem onClick={() => handleExport('json')}>JSON</MenuItem>
-          </Menu>
-        </div>
+        <ExportButton onExport={handleExport} />
       </Box>
+
       <Box>This page shows performance metrics for recent evals.</Box>
-      <Box display="flex" flexDirection="row" gap={2} my={2}>
-        <Autocomplete
-          options={evalIdOptions}
-          value={filter.evalId}
-          onChange={(event, newValue) => {
-            setFilter({ ...filter, evalId: newValue || '' });
-          }}
-          renderInput={(params) => (
-            <TextField {...params} label="Eval ID" variant="outlined" size="small" fullWidth />
-          )}
-          sx={{ width: 220 }}
-        />
-        <Autocomplete
-          options={datasetIdOptions}
-          value={filter.datasetId}
-          onChange={(event, newValue) => {
-            setFilter({ ...filter, datasetId: newValue || '' });
-          }}
-          renderInput={(params) => (
-            <TextField {...params} label="Dataset ID" variant="outlined" size="small" fullWidth />
-          )}
-          sx={{ width: 220 }}
-        />
-        <Autocomplete
-          options={providerOptions}
-          value={filter.provider}
-          onChange={(event, newValue) => {
-            setFilter({ ...filter, provider: newValue || '' });
-          }}
-          renderInput={(params) => (
-            <TextField {...params} label="Provider" variant="outlined" size="small" fullWidth />
-          )}
-          sx={{ width: 220 }}
-        />
-        <Autocomplete
-          options={promptIdOptions}
-          value={filter.promptId}
-          onChange={(event, newValue) => {
-            setFilter({ ...filter, promptId: newValue || '' });
-          }}
-          renderInput={(params) => (
-            <TextField {...params} label="Prompt ID" variant="outlined" size="small" fullWidth />
-          )}
-          sx={{ width: 220 }}
-        />
-      </Box>
+
+      <FilterBar
+        filter={filter}
+        onFilterChange={setFilter}
+        evalIdOptions={evalIdOptions}
+        datasetIdOptions={datasetIdOptions}
+        providerOptions={providerOptions}
+        promptIdOptions={promptIdOptions}
+        showDatasetColumn={showDatasetColumn}
+      />
+
       <TableContainer>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                <TableSortLabel
-                  active={sortField === 'evalId'}
-                  direction={sortField === 'evalId' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('evalId')}
-                >
-                  Eval
-                </TableSortLabel>
-              </TableCell>
-              <TableCell>Dataset</TableCell>
-              <TableCell>Provider</TableCell>
-              <TableCell>Prompt</TableCell>
-              <TableCell>
-                <TableSortLabel
-                  active={sortField === 'passRate'}
-                  direction={sortField === 'passRate' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('passRate')}
-                >
-                  Pass Rate %
-                </TableSortLabel>
-              </TableCell>
-              <TableCell>
-                <TableSortLabel
-                  active={sortField === 'testPassCount'}
-                  direction={sortField === 'testPassCount' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('testPassCount')}
-                >
-                  Pass Count
-                </TableSortLabel>
-              </TableCell>
-              <TableCell>
-                <TableSortLabel
-                  active={sortField === 'testFailCount'}
-                  direction={sortField === 'testFailCount' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('testFailCount')}
-                >
-                  Fail Count
-                </TableSortLabel>
-              </TableCell>
-              <TableCell>
-                <TableSortLabel
-                  active={sortField === 'score'}
-                  direction={sortField === 'score' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('score')}
-                >
-                  Raw score
-                </TableSortLabel>
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {sortedCols.slice((page - 1) * rowsPerPage, page * rowsPerPage).map((col, index) => (
-              <TableRow
-                key={index}
-                hover
-                onClick={() =>
-                  setFilter({
-                    ...filter,
-                    evalId: col.evalId,
-                    datasetId: col.datasetId || '',
-                    promptId: col.promptId || '',
-                    provider: col.provider,
-                  })
-                }
-              >
-                <TableCell>
-                  <Link to={`/eval?evalId=${col.evalId}`} onClick={(e) => e.stopPropagation()}>
-                    {col.evalId}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Link to={`/datasets?id=${col.datasetId}`} onClick={(e) => e.stopPropagation()}>
-                    {col.datasetId?.slice(0, 6)}
-                  </Link>
-                </TableCell>
-                <TableCell>{col.provider}</TableCell>
-                <TableCell>
-                  <Link to={`/prompts?id=${col.promptId}`} onClick={(e) => e.stopPropagation()}>
-                    [{col.promptId?.slice(0, 6)}]
-                  </Link>{' '}
-                  {col.raw}
-                </TableCell>
-                <TableCell>{calculatePassRate(col.metrics)}</TableCell>
-                <TableCell>
-                  {col.metrics?.testPassCount == null ? '-' : `${col.metrics.testPassCount}`}
-                </TableCell>
-                <TableCell>
-                  {col.metrics?.testFailCount == null
-                    ? '- ' +
-                      (col.metrics?.testErrorCount && col.metrics.testErrorCount > 0
-                        ? `+ ${col.metrics.testErrorCount} errors`
-                        : '')
-                    : `${col.metrics.testFailCount} ` +
-                      (col.metrics?.testErrorCount ? `+ ${col.metrics.testErrorCount} errors` : '')}
-                </TableCell>
-                <TableCell>
-                  {col.metrics?.score == null ? '-' : col.metrics.score?.toFixed(2)}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <HistoryTable
+          cols={sortedCols}
+          sortState={sortState}
+          onSort={handleSort}
+          page={page}
+          rowsPerPage={rowsPerPage}
+          showDatasetColumn={showDatasetColumn}
+          onRowClick={handleRowClick}
+        />
+
         {Math.ceil(filteredCols.length / rowsPerPage) > 1 && (
           <Pagination
             count={Math.ceil(sortedCols.length / rowsPerPage)}
@@ -356,6 +501,7 @@ export default function History({ data, isLoading, error }: HistoryProps) {
           />
         )}
       </TableContainer>
+
       {isLoading && (
         <Box display="flex" justifyContent="center" my={4}>
           <CircularProgress />

--- a/src/app/src/pages/history/page.tsx
+++ b/src/app/src/pages/history/page.tsx
@@ -4,7 +4,11 @@ import type { StandaloneEval } from '@promptfoo/util';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import History from './History';
 
-function HistoryPageContent() {
+interface HistoryPageProps {
+  showDatasetColumn?: boolean;
+}
+
+function HistoryPageContent({ showDatasetColumn = true }: HistoryPageProps) {
   const [cols, setCols] = useState<StandaloneEval[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -28,13 +32,20 @@ function HistoryPageContent() {
     })();
   }, []);
 
-  return <History data={cols} isLoading={isLoading} error={error} />;
+  return (
+    <History
+      data={cols}
+      isLoading={isLoading}
+      error={error}
+      showDatasetColumn={showDatasetColumn}
+    />
+  );
 }
 
-export default function HistoryPage() {
+export default function HistoryPage({ showDatasetColumn = true }: HistoryPageProps) {
   return (
     <ErrorBoundary name="History Page">
-      <HistoryPageContent />
+      <HistoryPageContent showDatasetColumn={showDatasetColumn} />
     </ErrorBoundary>
   );
 }

--- a/src/app/src/pages/prompts/PromptDialog.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.tsx
@@ -26,9 +26,15 @@ interface PromptDialogProps {
   openDialog: boolean;
   handleClose: () => void;
   selectedPrompt: PromptWithMetadata & { recentEvalDate: string };
+  showDatasetColumn?: boolean;
 }
 
-const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, selectedPrompt }) => {
+const PromptDialog: React.FC<PromptDialogProps> = ({
+  openDialog,
+  handleClose,
+  selectedPrompt,
+  showDatasetColumn = true,
+}) => {
   const [copySnackbar, setCopySnackbar] = React.useState(false);
 
   const sortedEvals = useMemo(
@@ -75,6 +81,9 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
     variant: 'body2' as const,
     sx: { display: 'block', textAlign: 'right' },
   };
+
+  // Adjust the widths based on whether dataset column is shown
+  const evalIdWidth = showDatasetColumn ? '25%' : '35%';
 
   return (
     <>
@@ -247,8 +256,8 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
               <Table stickyHeader size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
                 <TableHead>
                   <TableRow>
-                    <TableCell sx={{ width: '25%' }}>Eval ID</TableCell>
-                    <TableCell sx={{ width: '15%' }}>Dataset ID</TableCell>
+                    <TableCell sx={{ width: evalIdWidth }}>Eval ID</TableCell>
+                    {showDatasetColumn && <TableCell sx={{ width: '15%' }}>Dataset ID</TableCell>}
                     <TableCell align="right" sx={commonCellStyles}>
                       Raw Score
                     </TableCell>
@@ -271,7 +280,7 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
                     <TableRow key={`eval-${evalData.id}`} hover>
                       <TableCell
                         sx={{
-                          width: '25%',
+                          width: evalIdWidth,
                           fontFamily: 'monospace',
                           overflow: 'hidden',
                           textOverflow: 'ellipsis',
@@ -302,31 +311,33 @@ const PromptDialog: React.FC<PromptDialogProps> = ({ openDialog, handleClose, se
                           </Typography>
                         </Link>
                       </TableCell>
-                      <TableCell
-                        sx={{
-                          width: '15%',
-                          fontFamily: 'monospace',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        <Link
-                          to={`/datasets/?id=${evalData.datasetId}`}
-                          style={{
-                            textDecoration: 'none',
-                            color: 'inherit',
+                      {showDatasetColumn && (
+                        <TableCell
+                          sx={{
+                            width: '15%',
+                            fontFamily: 'monospace',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
                           }}
                         >
-                          <Typography
-                            variant="body2"
-                            color="primary"
-                            sx={{ '&:hover': { textDecoration: 'underline' } }}
+                          <Link
+                            to={`/datasets/?id=${evalData.datasetId}`}
+                            style={{
+                              textDecoration: 'none',
+                              color: 'inherit',
+                            }}
                           >
-                            {evalData.datasetId.slice(0, 6)}
-                          </Typography>
-                        </Link>
-                      </TableCell>
+                            <Typography
+                              variant="body2"
+                              color="primary"
+                              sx={{ '&:hover': { textDecoration: 'underline' } }}
+                            >
+                              {evalData.datasetId.slice(0, 6)}
+                            </Typography>
+                          </Link>
+                        </TableCell>
+                      )}
                       <TableCell align="right" sx={commonCellStyles}>
                         <Typography {...commonTypographyStyles}>
                           {evalData.metrics.score?.toFixed(2) ?? '-'}

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -31,6 +31,7 @@ interface PromptsProps {
   data: (PromptWithMetadata & { recentEvalDate: string })[];
   isLoading: boolean;
   error: string | null;
+  showDatasetColumn?: boolean;
 }
 
 const LoadingSkeleton = () => (
@@ -54,7 +55,12 @@ const LoadingSkeleton = () => (
   </TableBody>
 );
 
-export default function Prompts({ data, isLoading, error }: PromptsProps) {
+export default function Prompts({
+  data,
+  isLoading,
+  error,
+  showDatasetColumn = true,
+}: PromptsProps) {
   const [searchParams] = useSearchParams();
   const [sort, setSort] = useState<SortState>({ field: 'date', order: 'desc' });
   const [page, setPage] = useState(1);
@@ -385,6 +391,7 @@ export default function Prompts({ data, isLoading, error }: PromptsProps) {
           openDialog={dialogState.open}
           handleClose={handleClose}
           selectedPrompt={paginatedPrompts[dialogState.selectedIndex]}
+          showDatasetColumn={showDatasetColumn}
         />
       )}
     </Box>

--- a/src/app/src/pages/prompts/page.tsx
+++ b/src/app/src/pages/prompts/page.tsx
@@ -4,7 +4,11 @@ import type { PromptWithMetadata } from '@promptfoo/types';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import Prompts from './Prompts';
 
-function PromptsPageContent() {
+interface PromptsPageProps {
+  showDatasetColumn?: boolean;
+}
+
+function PromptsPageContent({ showDatasetColumn = true }: PromptsPageProps) {
   const [prompts, setPrompts] = useState<(PromptWithMetadata & { recentEvalDate: string })[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -30,13 +34,20 @@ function PromptsPageContent() {
     fetchPrompts();
   }, []);
 
-  return <Prompts data={prompts} isLoading={isLoading} error={error} />;
+  return (
+    <Prompts
+      data={prompts}
+      isLoading={isLoading}
+      error={error}
+      showDatasetColumn={showDatasetColumn}
+    />
+  );
 }
 
-export default function PromptsPage() {
+export default function PromptsPage({ showDatasetColumn = true }: PromptsPageProps) {
   return (
     <ErrorBoundary name="Prompts Page">
-      <PromptsPageContent />
+      <PromptsPageContent showDatasetColumn={showDatasetColumn} />
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
- Added a feature to allow toggling the visibility of dataset columns in history and prompts components.
- Updated related components and pages to support the new optional dataset functionality.
No breaking changes.