### PR TITLE
chore(providers): refactor OpenAI image provider to remove OpenAI Node SDK dependency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "cybercriminal",
     "cyberseceval",
     "dall",
+    "DALLE",
     "DASHSCOPE",
     "Dedup",
     "deduped",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
     "cybercrime",
     "cybercriminal",
     "cyberseceval",
+    "dall",
     "DASHSCOPE",
     "Dedup",
     "deduped",

--- a/examples/openai-dalle-images/README.md
+++ b/examples/openai-dalle-images/README.md
@@ -1,11 +1,38 @@
-To get started, set your OPENAI_API_KEY environment variable.
+# OpenAI DALL-E Image Generation Example
 
-Next, edit promptfooconfig.yaml.
+A simple example showing how to evaluate OpenAI's DALL-E image generation models with promptfoo.
 
-Then run:
+## Quick Start
 
-```
+```bash
+# Create this example
+npx promptfoo@latest init --example openai-dalle-images
+
+# Set your API key
+export OPENAI_API_KEY=your-key-here
+
+# Run the evaluation
 promptfoo eval
+
+# View the results
+promptfoo view
 ```
 
-Afterwards, you can view the results by running `promptfoo view`
+## What's in this Example
+
+- Tests two artistic style prompts (Van Gogh vs. Dali)
+- Compares DALL-E 3 and DALL-E 2 outputs
+- Configures different image sizes and response formats
+- Tests with different subjects
+
+## Key Notes
+
+- Each model supports different sizes:
+  - DALL-E 3: 1024x1024, 1792x1024, 1024x1792
+  - DALL-E 2: 256x256, 512x512, 1024x1024
+- `response_format: b64_json` returns raw JSON with base64-encoded image data. Image links with the default format `url` expire after ~ 2 hours.
+
+## Documentation
+
+- [OpenAI DALL-E API Documentation](https://platform.openai.com/docs/guides/images)
+- [promptfoo OpenAI Provider Documentation](https://promptfoo.dev/docs/providers/openai)

--- a/examples/openai-dalle-images/promptfooconfig.yaml
+++ b/examples/openai-dalle-images/promptfooconfig.yaml
@@ -4,10 +4,17 @@ prompts:
   - 'In the style of Dali: {{subject}}'
 
 providers:
-  - openai:image:dall-e-3
+  - id: openai:image:dall-e-3
+    config:
+      size: 1024x1024 # Valid sizes for DALL-E 3: 1024x1024, 1792x1024, 1024x1792
+
+  - id: openai:image:dall-e-2
+    config:
+      size: 512x512 # Valid sizes for DALL-E 2: 256x256, 512x512, 1024x1024
+      response_format: b64_json # Returns the raw JSON response with base64-encoded image data
 
 tests:
   - vars:
-      subject: bananas
+      subject: apples
   - vars:
       subject: new york city

--- a/examples/openai-dalle-images/promptfooconfig.yaml
+++ b/examples/openai-dalle-images/promptfooconfig.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 prompts:
-  - 'In the style of Van Gogh: {{subject}}'
-  - 'In the style of Dali: {{subject}}'
+  - 'In the style of {{artist}}: {{subject}}'
 
 providers:
   - id: openai:image:dall-e-3
@@ -11,10 +10,21 @@ providers:
   - id: openai:image:dall-e-2
     config:
       size: 512x512 # Valid sizes for DALL-E 2: 256x256, 512x512, 1024x1024
-      response_format: b64_json # Returns the raw JSON response with base64-encoded image data
+      # response_format: b64_json # Returns the raw JSON response with base64-encoded image data
 
 tests:
   - vars:
-      subject: apples
+      artist: Van Gogh
+      subject: sunset over mountains
   - vars:
-      subject: new york city
+      artist: Dali
+      subject: melting clocks
+  - vars:
+      artist: Picasso
+      subject: abstract faces
+  - vars:
+      artist: Monet
+      subject: water lilies
+  - vars:
+      artist: Warhol
+      subject: colorful soup cans

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -1,4 +1,3 @@
-import dedent from 'dedent';
 import { OpenAiGenericProvider } from '.';
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
@@ -9,43 +8,159 @@ import { REQUEST_TIMEOUT_MS } from '../shared';
 import type { OpenAiSharedOptions } from './types';
 import { formatOpenAiError } from './util';
 
-// OpenAI image models
 export type OpenAiImageModel = 'dall-e-2' | 'dall-e-3';
-
-// Operation types
 export type OpenAiImageOperation = 'generation' | 'variation' | 'edit';
-
-// Model-specific size options
 export type DallE2Size = '256x256' | '512x512' | '1024x1024';
 export type DallE3Size = '1024x1024' | '1792x1024' | '1024x1792';
 
-// Common image options for both models
+const DALLE2_VALID_SIZES: DallE2Size[] = ['256x256', '512x512', '1024x1024'];
+const DALLE3_VALID_SIZES: DallE3Size[] = ['1024x1024', '1792x1024', '1024x1792'];
+const DEFAULT_SIZE = '1024x1024';
+
 type CommonImageOptions = {
   n?: number;
   response_format?: 'url' | 'b64_json';
 };
 
-// DALL-E 3 specific options
 type DallE3Options = CommonImageOptions & {
   size?: DallE3Size;
   quality?: 'standard' | 'hd';
   style?: 'natural' | 'vivid';
 };
 
-// DALL-E 2 specific options
 type DallE2Options = CommonImageOptions & {
   size?: DallE2Size;
-  // For image edits
   image?: string; // Base64-encoded image or image URL
   mask?: string; // Base64-encoded mask image
-  // Operation type
   operation?: OpenAiImageOperation;
 };
 
-// Combined options type
 type OpenAiImageOptions = OpenAiSharedOptions & {
   model?: OpenAiImageModel;
 } & (DallE2Options | DallE3Options);
+
+function validateSizeForModel(size: string, model: string): { valid: boolean; message?: string } {
+  if (model === 'dall-e-3' && !DALLE3_VALID_SIZES.includes(size as DallE3Size)) {
+    return {
+      valid: false,
+      message: `Invalid size "${size}" for DALL-E 3. Valid sizes are: ${DALLE3_VALID_SIZES.join(', ')}`,
+    };
+  }
+
+  if (model === 'dall-e-2' && !DALLE2_VALID_SIZES.includes(size as DallE2Size)) {
+    return {
+      valid: false,
+      message: `Invalid size "${size}" for DALL-E 2. Valid sizes are: ${DALLE2_VALID_SIZES.join(', ')}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+function formatOutput(
+  data: any,
+  prompt: string,
+  responseFormat?: string,
+): string | { error: string } {
+  if (responseFormat === 'b64_json') {
+    const b64Json = data.data[0].b64_json;
+    if (!b64Json) {
+      return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
+    }
+
+    return JSON.stringify(data);
+  } else {
+    const url = data.data[0].url;
+    if (!url) {
+      return { error: `No image URL found in response: ${JSON.stringify(data)}` };
+    }
+
+    const sanitizedPrompt = prompt
+      .replace(/\r?\n|\r/g, ' ')
+      .replace(/\[/g, '(')
+      .replace(/\]/g, ')');
+    const ellipsizedPrompt = ellipsize(sanitizedPrompt, 50);
+
+    return `![${ellipsizedPrompt}](${url})`;
+  }
+}
+
+function prepareRequestBody(
+  model: string,
+  prompt: string,
+  size: string,
+  responseFormat: string,
+  config: any,
+): Record<string, any> {
+  const body: Record<string, any> = {
+    model,
+    prompt,
+    n: config.n || 1,
+    size,
+    response_format: responseFormat,
+  };
+
+  if (model === 'dall-e-3') {
+    if ('quality' in config && config.quality) {
+      body.quality = config.quality;
+    }
+
+    if ('style' in config && config.style) {
+      body.style = config.style;
+    }
+  }
+
+  return body;
+}
+
+async function callOpenAiImageApi(
+  url: string,
+  body: Record<string, any>,
+  headers: Record<string, string>,
+  timeout: number,
+): Promise<{ data: any; cached: boolean; status: number; statusText: string }> {
+  return await fetchWithCache(
+    url,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    },
+    timeout,
+  );
+}
+
+async function processApiResponse(
+  data: any,
+  prompt: string,
+  responseFormat: string,
+  cached: boolean,
+): Promise<ProviderResponse> {
+  if (data.error) {
+    await data?.deleteFromCache?.();
+    return {
+      error: formatOpenAiError(data),
+    };
+  }
+
+  try {
+    const formattedOutput = formatOutput(data, prompt, responseFormat);
+    if (typeof formattedOutput === 'object') {
+      return formattedOutput;
+    }
+
+    return {
+      output: formattedOutput,
+      cached,
+      ...(responseFormat === 'b64_json' ? { isBase64: true, format: 'json' } : {}),
+    };
+  } catch (err) {
+    await data?.deleteFromCache?.();
+    return {
+      error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
+    };
+  }
+}
 
 export class OpenAiImageProvider extends OpenAiGenericProvider {
   config: OpenAiImageOptions;
@@ -56,64 +171,6 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
   ) {
     super(modelName, options);
     this.config = options.config || {};
-  }
-
-  /**
-   * Validate the size parameter for the given model
-   */
-  private validateSizeForModel(size: string, model: string): { valid: boolean; message?: string } {
-    if (model === 'dall-e-3') {
-      const validSizes: DallE3Size[] = ['1024x1024', '1792x1024', '1024x1792'];
-      if (!validSizes.includes(size as DallE3Size)) {
-        return {
-          valid: false,
-          message: `Invalid size "${size}" for DALL-E 3. Valid sizes are: ${validSizes.join(', ')}`,
-        };
-      }
-    } else if (model === 'dall-e-2') {
-      const validSizes: DallE2Size[] = ['256x256', '512x512', '1024x1024'];
-      if (!validSizes.includes(size as DallE2Size)) {
-        return {
-          valid: false,
-          message: `Invalid size "${size}" for DALL-E 2. Valid sizes are: ${validSizes.join(', ')}`,
-        };
-      }
-    }
-    return { valid: true };
-  }
-
-  /**
-   * Format the output based on the response format and data
-   */
-  private formatOutput(
-    data: any,
-    prompt: string,
-    responseFormat?: string,
-  ): string | { error: string } {
-    if (responseFormat === 'b64_json') {
-      const b64Json = data.data[0].b64_json;
-      if (!b64Json) {
-        return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
-      }
-
-      // Return the original JSON response with base64 data
-      // This allows the UI to handle the data directly
-      return JSON.stringify(data);
-    } else {
-      // Default URL format
-      const url = data.data[0].url;
-      if (!url) {
-        return { error: `No image URL found in response: ${JSON.stringify(data)}` };
-      }
-
-      const sanitizedPrompt = prompt
-        .replace(/\r?\n|\r/g, ' ')
-        .replace(/\[/g, '(')
-        .replace(/\]/g, ')');
-      const ellipsizedPrompt = ellipsize(sanitizedPrompt, 50);
-
-      return `![${ellipsizedPrompt}](${url})`;
-    }
   }
 
   async callApi(
@@ -127,143 +184,65 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
       );
     }
 
-    // Merge configs from the provider and the prompt
     const config = {
       ...this.config,
       ...context?.prompt?.config,
     };
 
-    // Check model and set default if not provided
     const model = config.model || this.modelName;
     const operation = ('operation' in config && config.operation) || 'generation';
-
-    // Set default response format
     const responseFormat = config.response_format || 'url';
 
-    // Set the API endpoint based on the operation
-    let endpoint = '/images/generations';
-    if (model === 'dall-e-2') {
-      if (operation === 'variation') {
-        endpoint = '/images/variations';
-      } else if (operation === 'edit') {
-        endpoint = '/images/edits';
-      }
-    } else if (operation !== 'generation') {
+    if (operation !== 'generation') {
       return {
-        error: `Operation ${operation} is only supported for dall-e-2 model.`,
+        error: `Only 'generation' operations are currently supported. '${operation}' operations are not implemented.`,
       };
     }
 
-    // For generation operation, use JSON body
-    if (operation === 'generation') {
-      // Set default size based on model
-      let size = config.size;
-      if (!size) {
-        size = model === 'dall-e-3' ? '1024x1024' : '1024x1024';
-      }
+    const endpoint = '/images/generations';
+    const size = config.size || DEFAULT_SIZE;
 
-      // Validate size for the selected model
-      const sizeValidation = this.validateSizeForModel(size as string, model);
-      if (!sizeValidation.valid) {
-        return { error: sizeValidation.message };
-      }
+    const sizeValidation = validateSizeForModel(size as string, model);
+    if (!sizeValidation.valid) {
+      return { error: sizeValidation.message };
+    }
 
-      // Prepare the request body
-      const body: Record<string, any> = {
-        model,
-        prompt,
-        n: config.n || 1,
-        size,
-        response_format: responseFormat,
-      };
+    const body = prepareRequestBody(model, prompt, size as string, responseFormat, config);
 
-      // DALL-E 3 specific options
-      if (model === 'dall-e-3') {
-        if ('quality' in config && config.quality) {
-          body.quality = config.quality;
-        }
+    logger.debug(`Calling OpenAI Image API: ${JSON.stringify(body)}`);
 
-        if ('style' in config && config.style) {
-          body.style = config.style;
-        }
-      }
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.getApiKey()}`,
+      ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
+      ...config.headers,
+    };
 
-      logger.debug(`Calling OpenAI Image API: ${JSON.stringify(body)}`);
+    let data, status, statusText;
+    let cached = false;
+    try {
+      ({ data, cached, status, statusText } = await callOpenAiImageApi(
+        `${this.getApiUrl()}${endpoint}`,
+        body,
+        headers,
+        REQUEST_TIMEOUT_MS,
+      ));
 
-      let data, status, statusText;
-      let cached = false;
-      try {
-        ({ data, cached, status, statusText } = await fetchWithCache(
-          `${this.getApiUrl()}${endpoint}`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.getApiKey()}`,
-              ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
-              ...config.headers,
-            },
-            body: JSON.stringify(body),
-          },
-          REQUEST_TIMEOUT_MS,
-        ));
-
-        if (status < 200 || status >= 300) {
-          return {
-            error: `API error: ${status} ${statusText}\n${typeof data === 'string' ? data : JSON.stringify(data)}`,
-          };
-        }
-      } catch (err) {
-        logger.error(`API call error: ${String(err)}`);
-        await data?.deleteFromCache?.();
+      if (status < 200 || status >= 300) {
         return {
-          error: `API call error: ${String(err)}`,
+          error: `API error: ${status} ${statusText}\n${typeof data === 'string' ? data : JSON.stringify(data)}`,
         };
       }
-
-      logger.debug(`\tOpenAI image API response: ${JSON.stringify(data)}`);
-      if (data.error) {
-        await data?.deleteFromCache?.();
-        return {
-          error: formatOpenAiError(data),
-        };
-      }
-
-      try {
-        // Format output based on response format
-        const formattedOutput = this.formatOutput(data, prompt, responseFormat);
-        if (typeof formattedOutput === 'object') {
-          return formattedOutput;
-        }
-
-        return {
-          output: formattedOutput,
-          cached,
-          ...(responseFormat === 'b64_json' ? { isBase64: true, format: 'json' } : {}),
-        };
-      } catch (err) {
-        await data?.deleteFromCache?.();
-        return {
-          error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
-        };
-      }
-    } else {
-      // For variation and edit operations, we need to use FormData and include image data
-      if (!('image' in config) || !config.image) {
-        return {
-          error: 'Image data is required for variation and edit operations',
-        };
-      }
-
-      // Inform about unimplemented feature with more details
+    } catch (err) {
+      logger.error(`API call error: ${String(err)}`);
+      await data?.deleteFromCache?.();
       return {
-        error: dedent`
-          Image ${operation} operations require FormData with binary image data. 
-          This is not fully implemented yet. For these operations, you need to:
-          1. Provide a base64-encoded image in the 'image' parameter
-          2. For edits, also provide a 'mask' and 'prompt'
-          3. Implement FormData handling on the client side`,
+        error: `API call error: ${String(err)}`,
       };
     }
+
+    logger.debug(`\tOpenAI image API response: ${JSON.stringify(data)}`);
+
+    return processApiResponse(data, prompt, responseFormat, cached);
   }
 }

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -1,25 +1,51 @@
-import type { Cache } from 'cache-manager';
-import OpenAI from 'openai';
+import dedent from 'dedent';
 import { OpenAiGenericProvider } from '.';
-import { getCache, isCacheEnabled } from '../../cache';
+import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
-import type {
-  ApiModerationProvider,
-  CallApiContextParams,
-  CallApiOptionsParams,
-  ModerationFlag,
-  ProviderModerationResponse,
-  ProviderResponse,
-} from '../../types';
+import type { CallApiContextParams, CallApiOptionsParams, ProviderResponse } from '../../types';
 import type { EnvOverrides } from '../../types/env';
-import { safeJsonStringify } from '../../util/json';
 import { ellipsize } from '../../util/text';
 import { REQUEST_TIMEOUT_MS } from '../shared';
 import type { OpenAiSharedOptions } from './types';
+import { formatOpenAiError } from './util';
 
-type OpenAiImageOptions = OpenAiSharedOptions & {
-  size?: string;
+// OpenAI image models
+export type OpenAiImageModel = 'dall-e-2' | 'dall-e-3';
+
+// Operation types
+export type OpenAiImageOperation = 'generation' | 'variation' | 'edit';
+
+// Model-specific size options
+export type DallE2Size = '256x256' | '512x512' | '1024x1024';
+export type DallE3Size = '1024x1024' | '1792x1024' | '1024x1792';
+
+// Common image options for both models
+type CommonImageOptions = {
+  n?: number;
+  response_format?: 'url' | 'b64_json';
 };
+
+// DALL-E 3 specific options
+type DallE3Options = CommonImageOptions & {
+  size?: DallE3Size;
+  quality?: 'standard' | 'hd';
+  style?: 'natural' | 'vivid';
+};
+
+// DALL-E 2 specific options
+type DallE2Options = CommonImageOptions & {
+  size?: DallE2Size;
+  // For image edits
+  image?: string; // Base64-encoded image or image URL
+  mask?: string; // Base64-encoded mask image
+  // Operation type
+  operation?: OpenAiImageOperation;
+};
+
+// Combined options type
+type OpenAiImageOptions = OpenAiSharedOptions & {
+  model?: OpenAiImageModel;
+} & (DallE2Options | DallE3Options);
 
 export class OpenAiImageProvider extends OpenAiGenericProvider {
   config: OpenAiImageOptions;
@@ -32,173 +58,211 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
     this.config = options.config || {};
   }
 
+  /**
+   * Validate the size parameter for the given model
+   */
+  private validateSizeForModel(size: string, model: string): { valid: boolean; message?: string } {
+    if (model === 'dall-e-3') {
+      const validSizes: DallE3Size[] = ['1024x1024', '1792x1024', '1024x1792'];
+      if (!validSizes.includes(size as DallE3Size)) {
+        return {
+          valid: false,
+          message: `Invalid size "${size}" for DALL-E 3. Valid sizes are: ${validSizes.join(', ')}`,
+        };
+      }
+    } else if (model === 'dall-e-2') {
+      const validSizes: DallE2Size[] = ['256x256', '512x512', '1024x1024'];
+      if (!validSizes.includes(size as DallE2Size)) {
+        return {
+          valid: false,
+          message: `Invalid size "${size}" for DALL-E 2. Valid sizes are: ${validSizes.join(', ')}`,
+        };
+      }
+    }
+    return { valid: true };
+  }
+
+  /**
+   * Format the output based on the response format and data
+   */
+  private formatOutput(
+    data: any,
+    prompt: string,
+    responseFormat?: string,
+  ): string | { error: string } {
+    if (responseFormat === 'b64_json') {
+      const b64Json = data.data[0].b64_json;
+      if (!b64Json) {
+        return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
+      }
+
+      // Return the original JSON response with base64 data
+      // This allows the UI to handle the data directly
+      return JSON.stringify(data);
+    } else {
+      // Default URL format
+      const url = data.data[0].url;
+      if (!url) {
+        return { error: `No image URL found in response: ${JSON.stringify(data)}` };
+      }
+
+      const sanitizedPrompt = prompt
+        .replace(/\r?\n|\r/g, ' ')
+        .replace(/\[/g, '(')
+        .replace(/\]/g, ')');
+      const ellipsizedPrompt = ellipsize(sanitizedPrompt, 50);
+
+      return `![${ellipsizedPrompt}](${url})`;
+    }
+  }
+
   async callApi(
     prompt: string,
     context?: CallApiContextParams,
     callApiOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    const cache = getCache();
-    const cacheKey = `openai:image:${safeJsonStringify({ context, prompt })}`;
-
     if (!this.getApiKey()) {
       throw new Error(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );
     }
 
-    const openai = new OpenAI({
-      apiKey: this.getApiKey(),
-      organization: this.getOrganization(),
-      baseURL: this.getApiUrl(),
-      maxRetries: 3,
-      timeout: REQUEST_TIMEOUT_MS,
-      defaultHeaders: this.config.headers,
-    });
-
-    let response: OpenAI.Images.ImagesResponse | undefined;
-    let cached = false;
-    if (isCacheEnabled()) {
-      // Try to get the cached response
-      const cachedResponse = await cache.get(cacheKey);
-      if (cachedResponse) {
-        logger.debug(`Retrieved cached response for ${prompt}: ${cachedResponse}`);
-        response = JSON.parse(cachedResponse as string) as OpenAI.Images.ImagesResponse;
-        cached = true;
-      }
-    }
-
-    if (!response) {
-      response = await openai.images.generate({
-        model: this.modelName,
-        prompt,
-        n: 1,
-        size:
-          ((this.config.size || process.env.OPENAI_IMAGE_SIZE) as
-            | '1024x1024'
-            | '256x256'
-            | '512x512'
-            | '1792x1024'
-            | '1024x1792'
-            | undefined) || '1024x1024',
-      });
-    }
-    const url = response.data[0].url;
-    if (!url) {
-      return {
-        error: `No image URL found in response: ${JSON.stringify(response)}`,
-      };
-    }
-
-    if (!cached && isCacheEnabled()) {
-      try {
-        await cache.set(cacheKey, JSON.stringify(response));
-      } catch (err) {
-        logger.error(`Failed to cache response: ${String(err)}`);
-      }
-    }
-
-    const sanitizedPrompt = prompt
-      .replace(/\r?\n|\r/g, ' ')
-      .replace(/\[/g, '(')
-      .replace(/\]/g, ')');
-    const ellipsizedPrompt = ellipsize(sanitizedPrompt, 50);
-    return {
-      output: `![${ellipsizedPrompt}](${url})`,
-      cached,
+    // Merge configs from the provider and the prompt
+    const config = {
+      ...this.config,
+      ...context?.prompt?.config,
     };
-  }
-}
 
-export class OpenAiModerationProvider
-  extends OpenAiGenericProvider
-  implements ApiModerationProvider
-{
-  async callModerationApi(
-    userPrompt: string, // userPrompt is not supported by OpenAI moderation API
-    assistantResponse: string,
-  ): Promise<ProviderModerationResponse> {
-    if (!this.getApiKey()) {
-      throw new Error(
-        'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
-      );
-    }
+    // Check model and set default if not provided
+    const model = config.model || this.modelName;
+    const operation = ('operation' in config && config.operation) || 'generation';
 
-    const openai = new OpenAI({
-      apiKey: this.getApiKey(),
-      organization: this.getOrganization(),
-      baseURL: this.getApiUrl(),
-      maxRetries: 3,
-      timeout: REQUEST_TIMEOUT_MS,
-    });
+    // Set default response format
+    const responseFormat = config.response_format || 'url';
 
-    let cache: Cache | undefined;
-    let cacheKey: string | undefined;
-    if (isCacheEnabled()) {
-      cache = await getCache();
-      cacheKey = `openai:${this.modelName}:${JSON.stringify(
-        this.config,
-      )}:${userPrompt}:${assistantResponse}`;
-
-      // Try to get the cached response
-      const cachedResponse = await cache.get(cacheKey);
-
-      if (cachedResponse) {
-        logger.debug(`Returning cached response for ${userPrompt}: ${cachedResponse}`);
-        return JSON.parse(cachedResponse as string);
+    // Set the API endpoint based on the operation
+    let endpoint = '/images/generations';
+    if (model === 'dall-e-2') {
+      if (operation === 'variation') {
+        endpoint = '/images/variations';
+      } else if (operation === 'edit') {
+        endpoint = '/images/edits';
       }
-    }
-
-    logger.debug(
-      `Calling OpenAI moderation API: prompt [${userPrompt}] assistant [${assistantResponse}]`,
-    );
-    let moderation: OpenAI.Moderations.ModerationCreateResponse | undefined;
-    try {
-      moderation = await openai.moderations.create({
-        model: this.modelName,
-        input: assistantResponse,
-      });
-    } catch (err) {
-      logger.error(`API call error: ${String(err)}`);
+    } else if (operation !== 'generation') {
       return {
-        error: `API call error: ${String(err)}`,
+        error: `Operation ${operation} is only supported for dall-e-2 model.`,
       };
     }
 
-    logger.debug(`\tOpenAI moderation API response: ${JSON.stringify(moderation)}`);
-    try {
-      const { results } = moderation;
-
-      const flags: ModerationFlag[] = [];
-      if (!results) {
-        throw new Error('API response error: no results');
+    // For generation operation, use JSON body
+    if (operation === 'generation') {
+      // Set default size based on model
+      let size = config.size;
+      if (!size) {
+        size = model === 'dall-e-3' ? '1024x1024' : '1024x1024';
       }
 
-      if (cache && cacheKey) {
-        await cache.set(cacheKey, JSON.stringify(moderation));
+      // Validate size for the selected model
+      const sizeValidation = this.validateSizeForModel(size as string, model);
+      if (!sizeValidation.valid) {
+        return { error: sizeValidation.message };
       }
 
-      if (results.length === 0) {
-        return { flags };
-      }
+      // Prepare the request body
+      const body: Record<string, any> = {
+        model,
+        prompt,
+        n: config.n || 1,
+        size,
+        response_format: responseFormat,
+      };
 
-      for (const result of results) {
-        if (result.flagged) {
-          for (const [category, flagged] of Object.entries(result.categories)) {
-            if (flagged) {
-              flags.push({
-                code: category,
-                description: category,
-                confidence:
-                  result.category_scores[category as keyof OpenAI.Moderation.CategoryScores],
-              });
-            }
-          }
+      // DALL-E 3 specific options
+      if (model === 'dall-e-3') {
+        if ('quality' in config && config.quality) {
+          body.quality = config.quality;
+        }
+
+        if ('style' in config && config.style) {
+          body.style = config.style;
         }
       }
-      return { flags };
-    } catch (err) {
+
+      logger.debug(`Calling OpenAI Image API: ${JSON.stringify(body)}`);
+
+      let data, status, statusText;
+      let cached = false;
+      try {
+        ({ data, cached, status, statusText } = await fetchWithCache(
+          `${this.getApiUrl()}${endpoint}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${this.getApiKey()}`,
+              ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
+              ...config.headers,
+            },
+            body: JSON.stringify(body),
+          },
+          REQUEST_TIMEOUT_MS,
+        ));
+
+        if (status < 200 || status >= 300) {
+          return {
+            error: `API error: ${status} ${statusText}\n${typeof data === 'string' ? data : JSON.stringify(data)}`,
+          };
+        }
+      } catch (err) {
+        logger.error(`API call error: ${String(err)}`);
+        await data?.deleteFromCache?.();
+        return {
+          error: `API call error: ${String(err)}`,
+        };
+      }
+
+      logger.debug(`\tOpenAI image API response: ${JSON.stringify(data)}`);
+      if (data.error) {
+        await data?.deleteFromCache?.();
+        return {
+          error: formatOpenAiError(data),
+        };
+      }
+
+      try {
+        // Format output based on response format
+        const formattedOutput = this.formatOutput(data, prompt, responseFormat);
+        if (typeof formattedOutput === 'object') {
+          return formattedOutput;
+        }
+
+        return {
+          output: formattedOutput,
+          cached,
+          ...(responseFormat === 'b64_json' ? { isBase64: true, format: 'json' } : {}),
+        };
+      } catch (err) {
+        await data?.deleteFromCache?.();
+        return {
+          error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
+        };
+      }
+    } else {
+      // For variation and edit operations, we need to use FormData and include image data
+      if (!('image' in config) || !config.image) {
+        return {
+          error: 'Image data is required for variation and edit operations',
+        };
+      }
+
+      // Inform about unimplemented feature with more details
       return {
-        error: `API response error: ${String(err)}: ${JSON.stringify(moderation)}`,
+        error: dedent`
+          Image ${operation} operations require FormData with binary image data. 
+          This is not fully implemented yet. For these operations, you need to:
+          1. Provide a base64-encoded image in the 'image' parameter
+          2. For edits, also provide a 'mask' and 'prompt'
+          3. Implement FormData handling on the client side`,
       };
     }
   }

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -24,12 +24,12 @@ export const DALLE2_COSTS: Record<DallE2Size, number> = {
 };
 
 export const DALLE3_COSTS: Record<string, number> = {
-  'standard_1024x1024': 0.04,
-  'standard_1024x1792': 0.08,
-  'standard_1792x1024': 0.08,
-  'hd_1024x1024': 0.08,
-  'hd_1024x1792': 0.12,
-  'hd_1792x1024': 0.12,
+  standard_1024x1024: 0.04,
+  standard_1024x1792: 0.08,
+  standard_1792x1024: 0.08,
+  hd_1024x1024: 0.08,
+  hd_1024x1792: 0.12,
+  hd_1792x1024: 0.12,
 };
 
 type CommonImageOptions = {
@@ -54,7 +54,10 @@ type OpenAiImageOptions = OpenAiSharedOptions & {
   model?: OpenAiImageModel;
 } & (DallE2Options | DallE3Options);
 
-export function validateSizeForModel(size: string, model: string): { valid: boolean; message?: string } {
+export function validateSizeForModel(
+  size: string,
+  model: string,
+): { valid: boolean; message?: string } {
   if (model === 'dall-e-3' && !DALLE3_VALID_SIZES.includes(size as DallE3Size)) {
     return {
       valid: false,
@@ -132,7 +135,7 @@ export function calculateImageCost(
   model: string,
   size: string,
   quality?: string,
-  n: number = 1
+  n: number = 1,
 ): number {
   const imageQuality = quality || 'standard';
 
@@ -173,7 +176,7 @@ export async function processApiResponse(
   model: string,
   size: string,
   quality?: string,
-  n: number = 1
+  n: number = 1,
 ): Promise<ProviderResponse> {
   if (data.error) {
     await data?.deleteFromCache?.();

--- a/test/providers/openai/image.functions.test.ts
+++ b/test/providers/openai/image.functions.test.ts
@@ -1,0 +1,345 @@
+import { fetchWithCache } from '../../../src/cache';
+import {
+  validateSizeForModel,
+  formatOutput,
+  prepareRequestBody,
+  calculateImageCost,
+  callOpenAiImageApi,
+  processApiResponse,
+  DALLE2_COSTS,
+  DALLE3_COSTS,
+} from '../../../src/providers/openai/image';
+
+jest.mock('../../../src/cache', () => ({
+  fetchWithCache: jest.fn(),
+}));
+
+describe('OpenAI Image Provider Functions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('validateSizeForModel', () => {
+    it('should validate valid DALL-E 3 sizes', () => {
+      expect(validateSizeForModel('1024x1024', 'dall-e-3')).toEqual({ valid: true });
+      expect(validateSizeForModel('1792x1024', 'dall-e-3')).toEqual({ valid: true });
+      expect(validateSizeForModel('1024x1792', 'dall-e-3')).toEqual({ valid: true });
+    });
+
+    it('should invalidate incorrect DALL-E 3 sizes', () => {
+      const result = validateSizeForModel('512x512', 'dall-e-3');
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain('Invalid size "512x512" for DALL-E 3');
+    });
+
+    it('should validate valid DALL-E 2 sizes', () => {
+      expect(validateSizeForModel('256x256', 'dall-e-2')).toEqual({ valid: true });
+      expect(validateSizeForModel('512x512', 'dall-e-2')).toEqual({ valid: true });
+      expect(validateSizeForModel('1024x1024', 'dall-e-2')).toEqual({ valid: true });
+    });
+
+    it('should invalidate incorrect DALL-E 2 sizes', () => {
+      const result = validateSizeForModel('1792x1024', 'dall-e-2');
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain('Invalid size "1792x1024" for DALL-E 2');
+    });
+
+    it('should validate any size for unknown models', () => {
+      expect(validateSizeForModel('any-size', 'unknown-model')).toEqual({ valid: true });
+    });
+  });
+
+  describe('formatOutput', () => {
+    it('should format URL output correctly', () => {
+      const data = {
+        data: [{ url: 'https://example.com/image.png' }],
+      };
+      const prompt = 'A test prompt';
+      const result = formatOutput(data, prompt, 'url');
+      expect(typeof result).toBe('string');
+      expect(result).toContain('![');
+      expect(result).toContain('](https://example.com/image.png)');
+    });
+
+    it('should sanitize prompt text with special characters', () => {
+      const data = {
+        data: [{ url: 'https://example.com/image.png' }],
+      };
+      const prompt = 'A test [with] brackets\nand newlines';
+      const result = formatOutput(data, prompt, 'url');
+      expect(typeof result).toBe('string');
+      expect(result).toContain('A test (with) brackets and newlines');
+    });
+
+    it('should format base64 output correctly', () => {
+      const mockData = {
+        data: [{ b64_json: 'base64encodeddata' }],
+      };
+      const result = formatOutput(mockData, 'prompt', 'b64_json');
+      expect(typeof result).toBe('string');
+      expect(result).toBe(JSON.stringify(mockData));
+    });
+
+    it('should return error when URL is missing', () => {
+      const data = { data: [{}] };
+      const result = formatOutput(data, 'prompt');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should return error when base64 data is missing', () => {
+      const data = { data: [{}] };
+      const result = formatOutput(data, 'prompt', 'b64_json');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('error');
+    });
+  });
+
+  describe('prepareRequestBody', () => {
+    it('should prepare basic request body correctly', () => {
+      const model = 'dall-e-2';
+      const prompt = 'A test prompt';
+      const size = '512x512';
+      const responseFormat = 'url';
+      const config = {};
+
+      const body = prepareRequestBody(model, prompt, size, responseFormat, config);
+
+      expect(body).toEqual({
+        model,
+        prompt,
+        size,
+        n: 1,
+        response_format: responseFormat,
+      });
+    });
+
+    it('should include n parameter from config', () => {
+      const config = { n: 2 };
+      const body = prepareRequestBody('dall-e-2', 'prompt', '512x512', 'url', config);
+      expect(body.n).toBe(2);
+    });
+
+    it('should include DALL-E 3 specific parameters', () => {
+      const config = {
+        quality: 'hd',
+        style: 'vivid',
+      };
+      const body = prepareRequestBody('dall-e-3', 'prompt', '1024x1024', 'url', config);
+
+      expect(body).toEqual({
+        model: 'dall-e-3',
+        prompt: 'prompt',
+        size: '1024x1024',
+        n: 1,
+        response_format: 'url',
+        quality: 'hd',
+        style: 'vivid',
+      });
+    });
+
+    it('should not include DALL-E 3 parameters for DALL-E 2', () => {
+      const config = {
+        quality: 'hd',
+        style: 'vivid',
+      };
+      const body = prepareRequestBody('dall-e-2', 'prompt', '512x512', 'url', config);
+
+      expect(body).not.toHaveProperty('quality');
+      expect(body).not.toHaveProperty('style');
+    });
+  });
+
+  describe('calculateImageCost', () => {
+    it('should calculate correct cost for DALL-E 2', () => {
+      expect(calculateImageCost('dall-e-2', '256x256')).toBe(DALLE2_COSTS['256x256']);
+      expect(calculateImageCost('dall-e-2', '512x512')).toBe(DALLE2_COSTS['512x512']);
+      expect(calculateImageCost('dall-e-2', '1024x1024')).toBe(DALLE2_COSTS['1024x1024']);
+    });
+
+    it('should use default size cost if size is invalid for DALL-E 2', () => {
+      expect(calculateImageCost('dall-e-2', 'invalid-size')).toBe(DALLE2_COSTS['1024x1024']);
+    });
+
+    it('should calculate correct cost for standard DALL-E 3', () => {
+      expect(calculateImageCost('dall-e-3', '1024x1024', 'standard')).toBe(
+        DALLE3_COSTS['standard_1024x1024'],
+      );
+      expect(calculateImageCost('dall-e-3', '1024x1792', 'standard')).toBe(
+        DALLE3_COSTS['standard_1024x1792'],
+      );
+    });
+
+    it('should calculate correct cost for HD DALL-E 3', () => {
+      expect(calculateImageCost('dall-e-3', '1024x1024', 'hd')).toBe(DALLE3_COSTS['hd_1024x1024']);
+      expect(calculateImageCost('dall-e-3', '1024x1792', 'hd')).toBe(DALLE3_COSTS['hd_1024x1792']);
+    });
+
+    it('should use standard quality if quality is not specified for DALL-E 3', () => {
+      expect(calculateImageCost('dall-e-3', '1024x1024')).toBe(DALLE3_COSTS['standard_1024x1024']);
+    });
+
+    it('should use default cost if model is unknown', () => {
+      expect(calculateImageCost('unknown-model', '1024x1024')).toBe(0.04);
+    });
+
+    it('should multiply cost by number of images', () => {
+      expect(calculateImageCost('dall-e-2', '256x256', undefined, 3)).toBe(
+        DALLE2_COSTS['256x256'] * 3,
+      );
+      expect(calculateImageCost('dall-e-3', '1024x1024', 'standard', 2)).toBe(
+        DALLE3_COSTS['standard_1024x1024'] * 2,
+      );
+    });
+
+    it('should use default cost for models other than DALL-E 2 or 3', () => {
+      expect(calculateImageCost('gpt-4', '1024x1024')).toBe(0.04);
+      expect(calculateImageCost('', '1024x1024')).toBe(0.04);
+    });
+  });
+
+  describe('callOpenAiImageApi', () => {
+    it('should call fetchWithCache with correct parameters', async () => {
+      const mockResponse = {
+        data: { some: 'data' },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+
+      jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+      const url = 'https://api.openai.com/v1/images/generations';
+      const body = { model: 'dall-e-3', prompt: 'test' };
+      const headers = { 'Content-Type': 'application/json' };
+      const timeout = 30000;
+
+      const result = await callOpenAiImageApi(url, body, headers, timeout);
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        url,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        },
+        timeout,
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('processApiResponse', () => {
+    it('should handle error in data', async () => {
+      const mockDeleteFromCache = jest.fn();
+      const data = {
+        error: { message: 'Some API error' },
+        deleteFromCache: mockDeleteFromCache,
+      };
+
+      const result = await processApiResponse(data, 'prompt', 'url', false, 'dall-e-2', '512x512');
+
+      expect(mockDeleteFromCache).toHaveBeenCalledWith();
+      expect(result).toHaveProperty('error');
+      expect(result.error).toContain('Some API error');
+    });
+
+    it('should return formatted output for successful response', async () => {
+      const data = {
+        data: [{ url: 'https://example.com/image.png' }],
+      };
+
+      const result = await processApiResponse(
+        data,
+        'test prompt',
+        'url',
+        false,
+        'dall-e-2',
+        '512x512',
+      );
+
+      expect(result).toHaveProperty('output');
+      expect(result).toHaveProperty('cost');
+      expect(result.cost).toBe(DALLE2_COSTS['512x512']);
+    });
+
+    it('should include base64 flags for b64_json response format', async () => {
+      const data = {
+        data: [{ b64_json: 'base64data' }],
+      };
+
+      const result = await processApiResponse(
+        data,
+        'test prompt',
+        'b64_json',
+        false,
+        'dall-e-3',
+        '1024x1024',
+        'standard',
+      );
+
+      expect(result).toHaveProperty('isBase64', true);
+      expect(result).toHaveProperty('format', 'json');
+    });
+
+    it('should set cost to 0 for cached responses', async () => {
+      const data = {
+        data: [{ url: 'https://example.com/image.png' }],
+      };
+
+      const result = await processApiResponse(
+        data,
+        'test prompt',
+        'url',
+        true,
+        'dall-e-2',
+        '512x512',
+      );
+
+      expect(result.cost).toBe(0);
+    });
+
+    it('should handle errors during output formatting', async () => {
+      const mockDeleteFromCache = jest.fn();
+      const data = {
+        data: undefined,
+        deleteFromCache: mockDeleteFromCache,
+      };
+
+      const result = await processApiResponse(
+        data,
+        'test prompt',
+        'url',
+        false,
+        'dall-e-2',
+        '512x512',
+      );
+
+      expect(result).toHaveProperty('error');
+      expect(result.error).toContain('API error: TypeError');
+      expect(result.error).toContain('Cannot read properties of undefined');
+      expect(mockDeleteFromCache).toHaveBeenCalledWith();
+    });
+
+    it('should handle a specific error case with malformed response', async () => {
+      const mockDeleteFromCache = jest.fn();
+      const data = {
+        data: { data: 'not-an-array' },
+        deleteFromCache: mockDeleteFromCache,
+      };
+
+      const result = await processApiResponse(
+        data,
+        'test prompt',
+        'url',
+        false,
+        'dall-e-2',
+        '512x512',
+      );
+
+      expect(result).toHaveProperty('error');
+      expect(result.error).toContain('API error:');
+      expect(mockDeleteFromCache).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -306,22 +306,7 @@ describe('OpenAiImageProvider', () => {
   });
 
   describe('Operation handling', () => {
-    it('should handle non-generation operations for DALL-E 2', async () => {
-      const provider = new OpenAiImageProvider('dall-e-2', {
-        config: {
-          apiKey: 'test-key',
-          operation: 'variation',
-          image: 'base64image',
-        },
-      });
-
-      const result = await provider.callApi('test prompt');
-
-      expect(result).toHaveProperty('error');
-      expect(result.error).toContain('Image variation operations');
-    });
-
-    it('should reject non-generation operations for DALL-E 3', async () => {
+    it('should reject non-generation operations', async () => {
       const provider = new OpenAiImageProvider('dall-e-3', {
         config: {
           apiKey: 'test-key',
@@ -332,21 +317,9 @@ describe('OpenAiImageProvider', () => {
       const result = await provider.callApi('test prompt');
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('Operation variation is only supported for dall-e-2 model');
-    });
-
-    it('should require image data for edit operations', async () => {
-      const provider = new OpenAiImageProvider('dall-e-2', {
-        config: {
-          apiKey: 'test-key',
-          operation: 'edit',
-        },
-      });
-
-      const result = await provider.callApi('test prompt');
-
-      expect(result).toHaveProperty('error');
-      expect(result.error).toContain('Image data is required for variation and edit operations');
+      expect(result.error).toContain(
+        "Only 'generation' operations are currently supported. 'variation' operations are not implemented.",
+      );
     });
   });
 

--- a/test/providers/openai/moderation.test.ts
+++ b/test/providers/openai/moderation.test.ts
@@ -1,0 +1,144 @@
+import OpenAI from 'openai';
+import { isCacheEnabled, getCache } from '../../../src/cache';
+import { OpenAiModerationProvider } from '../../../src/providers/openai/moderation';
+
+jest.mock('openai');
+jest.mock('../../../src/cache');
+jest.mock('../../../src/logger');
+
+describe('OpenAiModerationProvider', () => {
+  const mockOpenAI = {
+    moderations: {
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(OpenAI).mockImplementation(() => mockOpenAI as any);
+    jest.mocked(isCacheEnabled).mockReturnValue(false);
+  });
+
+  it('should moderate content successfully', async () => {
+    const provider = new OpenAiModerationProvider('text-moderation-latest', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const mockResponse = {
+      results: [
+        {
+          flagged: true,
+          categories: {
+            hate: true,
+            'hate/threatening': false,
+          },
+          category_scores: {
+            hate: 0.99,
+            'hate/threatening': 0.01,
+          },
+        },
+      ],
+    };
+
+    mockOpenAI.moderations.create.mockResolvedValue(mockResponse);
+
+    const result = await provider.callModerationApi('user input', 'assistant response');
+
+    expect(result).toEqual({
+      flags: [
+        {
+          code: 'hate',
+          description: 'hate',
+          confidence: 0.99,
+        },
+      ],
+    });
+  });
+
+  it('should handle moderation API errors', async () => {
+    const provider = new OpenAiModerationProvider('text-moderation-latest', {
+      config: { apiKey: 'test-key' },
+    });
+
+    mockOpenAI.moderations.create.mockRejectedValue(new Error('API Error'));
+
+    const result = await provider.callModerationApi('user input', 'assistant response');
+
+    expect(result).toEqual({
+      error: expect.stringContaining('API call error'),
+    });
+  });
+
+  it('should return empty flags for non-flagged content', async () => {
+    const provider = new OpenAiModerationProvider('text-moderation-latest', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const mockResponse = {
+      results: [
+        {
+          flagged: false,
+          categories: {
+            hate: false,
+            'hate/threatening': false,
+          },
+          category_scores: {
+            hate: 0.01,
+            'hate/threatening': 0.01,
+          },
+        },
+      ],
+    };
+
+    mockOpenAI.moderations.create.mockResolvedValue(mockResponse);
+
+    const result = await provider.callModerationApi('user input', 'assistant response');
+
+    expect(result).toEqual({
+      flags: [],
+    });
+  });
+
+  it('should handle missing API key', async () => {
+    const provider = new OpenAiModerationProvider('text-moderation-latest');
+
+    mockOpenAI.moderations.create.mockRejectedValue(new Error('OpenAI API key is not set'));
+
+    const result = await provider.callModerationApi('user input', 'assistant response');
+    expect(result).toEqual({
+      error: expect.stringContaining('API call error'),
+    });
+  });
+
+  it('should use cache when enabled', async () => {
+    jest.mocked(isCacheEnabled).mockReturnValue(true);
+
+    const provider = new OpenAiModerationProvider('text-moderation-latest', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const mockResponse = {
+      flags: [
+        {
+          code: 'hate',
+          description: 'hate',
+          confidence: 0.9,
+        },
+      ],
+    };
+
+    const mockCache = {
+      get: jest.fn().mockResolvedValue(JSON.stringify(mockResponse)),
+      set: jest.fn(),
+    };
+
+    jest.mocked(getCache).mockReturnValue(mockCache as any);
+
+    const result = await provider.callModerationApi('user input', 'assistant response');
+
+    expect(result).toEqual(mockResponse);
+    expect(mockCache.get).toHaveBeenCalledWith(
+      expect.stringContaining('openai:text-moderation-latest:'),
+    );
+  });
+});


### PR DESCRIPTION
Refactored the OpenAI image provider to eliminate the dependency on the OpenAI Node SDK.
- Introduced direct API calls using fetchWithCache.
- Enhanced configuration handling for image generation.
- Updated tests to reflect the new implementation.