### PR TITLE
chore: Fix an error in Google SpreadSheet(Authenticated) with a header without a value

### DIFF
--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -68,7 +68,7 @@ export async function fetchCsvFromGoogleSheetAuthenticated(url: string): Promise
   return dataRows.map((row) => {
     const csvRow: CsvRow = {};
     headers.forEach((header, index) => {
-      csvRow[header] = row[index];
+      csvRow[header] = row[index] ?? '';
     });
     return csvRow;
   });

--- a/test/googleSheets.test.ts
+++ b/test/googleSheets.test.ts
@@ -158,7 +158,7 @@ describe('Google Sheets Integration', () => {
       const mockResponse = {
         data: {
           values: [
-            ['header1', 'header2'],
+            ['header1', 'header2', 'header3'],
             ['value1', 'value2'],
           ],
         },
@@ -166,7 +166,7 @@ describe('Google Sheets Integration', () => {
       spreadsheets.values.get.mockResolvedValue(mockResponse);
 
       const result = await fetchCsvFromGoogleSheetAuthenticated(TEST_SHEET_URL);
-      expect(result).toEqual([{ header1: 'value1', header2: 'value2' }]);
+      expect(result).toEqual([{ header1: 'value1', header2: 'value2', header3: '' }]);
       expect(spreadsheets.values.get).toHaveBeenCalledWith({
         spreadsheetId: '1234567890',
         range: 'A1:ZZZ',


### PR DESCRIPTION
We got error:
```
TypeError: Cannot read properties of undefined (reading 'trim')
    at testCaseFromCsvRow (/path/to/node_modules/promptfoo/dist/src/csv.js:140:23)
    at /path/to/node_modules/promptfoo/dist/src/util/testCaseReader.js:203:51
    at Array.map (<anonymous>)
    at readStandaloneTestsFile (/path/to/node_modules/promptfoo/dist/src/util/testCaseReader.js:202:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async combineConfigs (/path/to/node_modules/promptfoo/dist/src/util/config/load.js:264:30)
    at async resolveConfigs (/path/to/node_modules/promptfoo/dist/src/util/config/load.js:423:22)
    at async runEvaluation (/path/to/node_modules/promptfoo/dist/src/commands/eval.js:136:55)
    at async doEval (/path/to/node_modules/promptfoo/dist/src/commands/eval.js:388:12)
```
<img width="922" alt="2025-03-01 23 05 34" src="https://github.com/user-attachments/assets/c2822058-cc1a-4bbd-ad6f-a837726d56bf" />

This problem seems to occur in the following case.

- There is a header
- No value generated by function( `=IF('sheet'!A1, brabra, "")` )

`interface CsvRow { [key: string]: string; }` is not null.  But it has null because of `sheets_v4.Schema$ValueRange.values?: any[][] | null | undefined`.