### PR TITLE
fix(providers): catch Vertex finish_reason errors correctly

### DIFF
--- a/src/providers/vertex.ts
+++ b/src/providers/vertex.ts
@@ -559,6 +559,11 @@ export class VertexChatProvider extends VertexGenericProvider {
             return {
               error: 'Content was blocked due to safety settings.',
             };
+          } else if (datum.candidates && datum.candidates[0]?.finishReason !== 'STOP') {
+            // e.g. MALFORMED_FUNCTION_CALL
+            return {
+              error: `Finish reason ${datum.candidates[0]?.finishReason}: ${JSON.stringify(data)}`,
+            };
           }
         }
 

--- a/src/providers/vertexUtil.ts
+++ b/src/providers/vertexUtil.ts
@@ -34,7 +34,17 @@ interface Content {
 
 interface Candidate {
   content: Content;
-  finishReason?: 'FINISH_REASON_STOP' | 'STOP' | 'SAFETY';
+  finishReason?:
+    | 'FINISH_REASON_UNSPECIFIED'
+    | 'STOP'
+    | 'MAX_TOKENS'
+    | 'SAFETY'
+    | 'RECITATION'
+    | 'OTHER'
+    | 'BLOCKLIST'
+    | 'PROHIBITED_CONTENT'
+    | 'SPII'
+    | 'MALFORMED_FUNCTION_CALL';
   safetyRatings: SafetyRating[];
 }
 


### PR DESCRIPTION
Multi-part responses with a finish_reason error (e.g. MALFORMED_FUNCTION_CALL) on parts > 1 resulted in the errors being ignored. This fix ensures that they're caught correctly