### PR TITLE
chore(config): add fallback for eval without configuration

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -457,7 +457,7 @@ export async function handleNoConfiguration(): Promise<never> {
     ${runCommand} init`);
 
   const shouldInit = await confirm({
-    message: 'Would you like to initialize a new promptfooconfig?',
+    message: 'Would you like to initialize a new project?',
     default: true,
   });
 

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -448,11 +448,11 @@ export async function handleNoConfiguration(): Promise<never> {
   const runCommand = isRunningUnderNpx() ? 'npx promptfoo eval' : 'promptfoo eval';
 
   logger.warn(dedent`
-    No configuration found. Try running with:
+    No promptfooconfig found. Try running with:
 
     ${runCommand} -c path/to/promptfooconfig.yaml
 
-    Or create a configuration with:
+    Or create a config with:
 
     ${runCommand} init`);
 

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -1,4 +1,6 @@
 import $RefParser from '@apidevtools/json-schema-ref-parser';
+import confirm from '@inquirer/confirm';
+import dedent from 'dedent';
 import * as fs from 'fs';
 import { globSync } from 'glob';
 import yaml from 'js-yaml';
@@ -8,9 +10,10 @@ import { readAssertions } from '../../assertions';
 import { validateAssertions } from '../../assertions/validateAssertions';
 import cliState from '../../cliState';
 import { filterTests } from '../../commands/eval/filterTests';
-import { getEnvBool } from '../../envars';
+import { getEnvBool, isCI } from '../../envars';
 import { importModule } from '../../esm';
 import logger from '../../logger';
+import { initializeProject } from '../../onboarding';
 import { readPrompts, readProviderPromptMap } from '../../prompts';
 import { loadApiProviders } from '../../providers';
 import telemetry from '../../telemetry';
@@ -26,7 +29,7 @@ import {
   type TestSuite,
   type UnifiedConfig,
 } from '../../types';
-import { maybeLoadFromExternalFile, readFilters } from '../../util';
+import { isRunningUnderNpx, maybeLoadFromExternalFile, readFilters } from '../../util';
 import { isJavascriptFile } from '../../util/file';
 import invariant from '../../util/invariant';
 import { PromptSchema } from '../../validators/prompts';
@@ -436,6 +439,35 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
   return combinedConfig;
 }
 
+/**
+ * Handles the case when no configuration is found.
+ * Offers to initialize a new project if not in CI mode.
+ * @returns {Promise<never>} This function always exits the process.
+ */
+export async function handleNoConfiguration(): Promise<never> {
+  const runCommand = isRunningUnderNpx() ? 'npx promptfoo eval' : 'promptfoo eval';
+
+  logger.warn(dedent`
+    No configuration found. Try running with:
+
+    ${runCommand} -c path/to/promptfooconfig.yaml
+
+    Or create a configuration with:
+
+    ${runCommand} init`);
+
+  const shouldInit = await confirm({
+    message: 'Would you like to initialize a new promptfooconfig?',
+    default: true,
+  });
+
+  if (shouldInit) {
+    await initializeProject(null, true);
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
 export async function resolveConfigs(
   cmdObj: Partial<CommandLineOptions>,
   _defaultConfig: Partial<UnifiedConfig>,
@@ -507,16 +539,33 @@ export async function resolveConfigs(
     redteam: fileConfig.redteam || defaultConfig.redteam,
   };
 
-  // Validation
-  if (!config.prompts || config.prompts.length === 0) {
+  // Check if we're missing both configuration and CLI arguments
+  const hasPrompts = Boolean(
+    config.prompts && typeof config.prompts === 'string'
+      ? config.prompts.length > 0
+      : Array.isArray(config.prompts)
+        ? config.prompts.length > 0
+        : false,
+  );
+  const hasProviders = Boolean(config.providers && config.providers.length > 0);
+  const hasConfigFile = Boolean(configPaths);
+
+  // If there's no config and no CLI args, and we're not in CI, offer to initialize
+  if (!hasConfigFile && !hasPrompts && !hasProviders && !isCI()) {
+    await handleNoConfiguration();
+  }
+
+  // Continue with normal validation
+  if (!hasPrompts) {
     logger.error('You must provide at least 1 prompt');
     process.exit(1);
   }
 
-  if (!config.providers || config.providers.length === 0) {
+  if (!hasProviders) {
     logger.error('You must specify at least 1 provider (for example, openai:gpt-4o)');
     process.exit(1);
   }
+
   invariant(Array.isArray(config.providers), 'providers must be an array');
   // Parse prompts, providers, and tests
   const parsedPrompts = await readPrompts(config.prompts, cmdObj.prompts ? undefined : basePath);

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1228,7 +1228,7 @@ describe('No configuration handling', () => {
       // Execute and verify
       await expect(realHandleNoConfiguration()).rejects.toThrow('Test exited with code 1');
 
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No configuration found'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No promptfooconfig found'));
       expect(confirm).toHaveBeenCalledWith({
         message: 'Would you like to initialize a new promptfooconfig?',
         default: true,
@@ -1245,7 +1245,7 @@ describe('No configuration handling', () => {
       // Execute and verify
       await expect(realHandleNoConfiguration()).rejects.toThrow('Test exited with code 0');
 
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No configuration found'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No promptfooconfig found'));
       expect(confirm).toHaveBeenCalledWith({
         message: 'Would you like to initialize a new promptfooconfig?',
         default: true,


### PR DESCRIPTION
This update introduces a fallback mechanism for the 'eval' command when no configuration is detected.
- Prompts the user to initialize a new project if not in CI mode.
- Provides clear guidance on how to proceed in the absence of a configuration file.