### PR TITLE
chore(providers): enable templating of Google API credentials

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,3 +1,4 @@
+import { getNunjucksEngine } from '../util/templates';
 import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
@@ -54,7 +55,7 @@ class GoogleGenericProvider implements ApiProvider {
   }
 
   getApiHost(): string | undefined {
-    return (
+    const apiHost = (
       this.config.apiHost ||
       this.env?.GOOGLE_API_HOST ||
       this.env?.PALM_API_HOST ||
@@ -62,16 +63,24 @@ class GoogleGenericProvider implements ApiProvider {
       getEnvString('PALM_API_HOST') ||
       DEFAULT_API_HOST
     );
+    if (apiHost) {
+      return getNunjucksEngine().renderString(apiHost, {});
+    }
+    return undefined;
   }
 
   getApiKey(): string | undefined {
-    return (
+    const apiKey = (
       this.config.apiKey ||
       this.env?.GOOGLE_API_KEY ||
       this.env?.PALM_API_KEY ||
       getEnvString('GOOGLE_API_KEY') ||
       getEnvString('PALM_API_KEY')
     );
+    if (apiKey) {
+      return getNunjucksEngine().renderString(apiKey, {});
+    }
+    return undefined;
   }
 
   // @ts-ignore: Prompt is not used in this implementation

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,4 +1,3 @@
-import { getNunjucksEngine } from '../util/templates';
 import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
@@ -10,6 +9,7 @@ import type {
 } from '../types';
 import type { EnvOverrides } from '../types/env';
 import { maybeLoadFromExternalFile, renderVarsInObject } from '../util';
+import { getNunjucksEngine } from '../util/templates';
 import { CHAT_MODELS } from './googleShared';
 import { parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
 import { maybeCoerceToGeminiFormat } from './vertexUtil';
@@ -55,14 +55,13 @@ class GoogleGenericProvider implements ApiProvider {
   }
 
   getApiHost(): string | undefined {
-    const apiHost = (
+    const apiHost =
       this.config.apiHost ||
       this.env?.GOOGLE_API_HOST ||
       this.env?.PALM_API_HOST ||
       getEnvString('GOOGLE_API_HOST') ||
       getEnvString('PALM_API_HOST') ||
-      DEFAULT_API_HOST
-    );
+      DEFAULT_API_HOST;
     if (apiHost) {
       return getNunjucksEngine().renderString(apiHost, {});
     }
@@ -70,13 +69,12 @@ class GoogleGenericProvider implements ApiProvider {
   }
 
   getApiKey(): string | undefined {
-    const apiKey = (
+    const apiKey =
       this.config.apiKey ||
       this.env?.GOOGLE_API_KEY ||
       this.env?.PALM_API_KEY ||
       getEnvString('GOOGLE_API_KEY') ||
-      getEnvString('PALM_API_KEY')
-    );
+      getEnvString('PALM_API_KEY');
     if (apiKey) {
       return getNunjucksEngine().renderString(apiKey, {});
     }
@@ -319,3 +317,5 @@ export class GoogleChatProvider extends GoogleGenericProvider {
     }
   }
 }
+
+export { DEFAULT_API_HOST, GoogleGenericProvider };

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -317,5 +317,3 @@ export class GoogleChatProvider extends GoogleGenericProvider {
     }
   }
 }
-
-export { DEFAULT_API_HOST, GoogleGenericProvider };

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -1,6 +1,7 @@
 import * as cache from '../../src/cache';
 import { GoogleChatProvider } from '../../src/providers/google';
 import * as vertexUtil from '../../src/providers/vertexUtil';
+import * as templates from '../../src/util/templates';
 
 jest.mock('../../src/cache', () => ({
   fetchWithCache: jest.fn(),
@@ -8,6 +9,12 @@ jest.mock('../../src/cache', () => ({
 
 jest.mock('../../src/providers/vertexUtil', () => ({
   maybeCoerceToGeminiFormat: jest.fn(),
+}));
+
+jest.mock('../../src/util/templates', () => ({
+  getNunjucksEngine: jest.fn(() => ({
+    renderString: jest.fn((str) => str),
+  })),
 }));
 
 describe('GoogleChatProvider', () => {
@@ -22,39 +29,61 @@ describe('GoogleChatProvider', () => {
         topK: 40,
       },
     });
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe('constructor and configuration', () => {
-    it('should handle API key from different sources', () => {
+    it('should handle API key from different sources and render with Nunjucks', () => {
+      const mockRenderString = jest.fn((str) => `rendered-${str}`);
+      jest.mocked(templates.getNunjucksEngine).mockReturnValue({
+        renderString: mockRenderString,
+      } as any);
+
       // From config
       const providerWithConfigKey = new GoogleChatProvider('gemini-pro', {
         config: { apiKey: 'config-key' },
       });
-      expect(providerWithConfigKey.getApiKey()).toBe('config-key');
+      expect(providerWithConfigKey.getApiKey()).toBe('rendered-config-key');
+      expect(mockRenderString).toHaveBeenCalledWith('config-key', {});
 
       // From env override
       const providerWithEnvOverride = new GoogleChatProvider('gemini-pro', {
         env: { GOOGLE_API_KEY: 'env-key' },
       });
-      expect(providerWithEnvOverride.getApiKey()).toBe('env-key');
+      expect(providerWithEnvOverride.getApiKey()).toBe('rendered-env-key');
+      expect(mockRenderString).toHaveBeenCalledWith('env-key', {});
+
+      // No API key
+      const providerWithNoKey = new GoogleChatProvider('gemini-pro');
+      expect(providerWithNoKey.getApiKey()).toBeUndefined();
     });
 
-    it('should handle API host from different sources', () => {
+    it('should handle API host from different sources and render with Nunjucks', () => {
+      const mockRenderString = jest.fn((str) => `rendered-${str}`);
+      jest.mocked(templates.getNunjucksEngine).mockReturnValue({
+        renderString: mockRenderString,
+      } as any);
+
       // From config
       const providerWithConfigHost = new GoogleChatProvider('gemini-pro', {
         config: { apiHost: 'custom.host.com' },
       });
-      expect(providerWithConfigHost.getApiHost()).toBe('custom.host.com');
+      expect(providerWithConfigHost.getApiHost()).toBe('rendered-custom.host.com');
+      expect(mockRenderString).toHaveBeenCalledWith('custom.host.com', {});
 
       // From env override
       const providerWithEnvOverride = new GoogleChatProvider('gemini-pro', {
         env: { GOOGLE_API_HOST: 'env.host.com' },
       });
-      expect(providerWithEnvOverride.getApiHost()).toBe('env.host.com');
+      expect(providerWithEnvOverride.getApiHost()).toBe('rendered-env.host.com');
+      expect(mockRenderString).toHaveBeenCalledWith('env.host.com', {});
+
+      // Default host
+      const providerWithDefaultHost = new GoogleChatProvider('gemini-pro');
+      expect(providerWithDefaultHost.getApiHost()).toBe(
+        'rendered-generativelanguage.googleapis.com',
+      );
+      expect(mockRenderString).toHaveBeenCalledWith('generativelanguage.googleapis.com', {});
     });
 
     it('should handle custom provider ID', () => {
@@ -63,12 +92,6 @@ describe('GoogleChatProvider', () => {
         id: customId,
       });
       expect(providerWithCustomId.id()).toBe(customId);
-    });
-
-    it('should handle default configuration', () => {
-      const defaultProvider = new GoogleChatProvider('gemini-pro');
-      expect(defaultProvider.getApiHost()).toBe('generativelanguage.googleapis.com');
-      expect(defaultProvider.id()).toBe('google:gemini-pro');
     });
 
     it('should handle configuration with safety settings', () => {
@@ -96,14 +119,12 @@ describe('GoogleChatProvider', () => {
         },
       });
 
-      // Mock maybeCoerceToGeminiFormat
       jest.mocked(vertexUtil.maybeCoerceToGeminiFormat).mockReturnValueOnce({
         contents: [{ role: 'user', parts: [{ text: 'test prompt' }] }],
         coerced: false,
         systemInstruction: undefined,
       });
 
-      // Mock fetchWithCache to return empty candidates
       jest.mocked(cache.fetchWithCache).mockResolvedValueOnce({
         data: {
           candidates: [],
@@ -125,20 +146,18 @@ describe('GoogleChatProvider', () => {
         },
       });
 
-      // Mock maybeCoerceToGeminiFormat
       jest.mocked(vertexUtil.maybeCoerceToGeminiFormat).mockReturnValueOnce({
         contents: [{ role: 'user', parts: [{ text: 'test prompt' }] }],
         coerced: false,
         systemInstruction: undefined,
       });
 
-      // Mock fetchWithCache to return malformed response
       jest.mocked(cache.fetchWithCache).mockResolvedValueOnce({
         data: {
           candidates: [
             {
               content: {
-                parts: null, // This will cause the map function to throw
+                parts: null,
               },
             },
           ],
@@ -172,7 +191,6 @@ describe('GoogleChatProvider', () => {
         },
       });
 
-      // Mock fetchWithCache to return error response
       jest.mocked(cache.fetchWithCache).mockResolvedValueOnce({
         data: {
           error: {
@@ -381,14 +399,12 @@ describe('GoogleChatProvider', () => {
         },
       });
 
-      // Mock maybeCoerceToGeminiFormat
       jest.mocked(vertexUtil.maybeCoerceToGeminiFormat).mockReturnValueOnce({
         contents: [{ role: 'user', parts: [{ text: 'test prompt' }] }],
         coerced: false,
         systemInstruction: undefined,
       });
 
-      // Mock fetchWithCache to return error
       jest.mocked(cache.fetchWithCache).mockRejectedValueOnce(new Error('API call failed'));
 
       const response = await provider.callGemini('test prompt');


### PR DESCRIPTION
Allow Nunjucks template variables in Google API key and host values. This fixes issue #3256 where users couldn't reference environment variables in their Google provider configuration.