### PR TITLE
fix: support @smithy/node-http-handler ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "@ibm-cloud/watsonx-ai": "^1.1.0",
         "@ibm-generative-ai/node-sdk": "^2.0.6",
         "@playwright/browser-chromium": "^1.47.2",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/node-http-handler": "^3.1.1 || ^4.0.0",
         "google-auth-library": "^9.7.0",
         "ibm-cloud-sdk-core": "^5.0.2",
         "langfuse": "^3.7.0",
@@ -825,37 +825,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/protocol-http": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
@@ -949,37 +918,6 @@
         "@smithy/util-middleware": "^4.0.1",
         "@smithy/util-retry": "^4.0.1",
         "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1154,37 +1092,6 @@
         "@smithy/smithy-client": "^4.1.6",
         "@smithy/types": "^4.1.0",
         "@smithy/util-stream": "^4.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1462,37 +1369,6 @@
         "@smithy/util-middleware": "^4.0.1",
         "@smithy/util-retry": "^4.0.1",
         "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10026,30 +9902,16 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
-      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
-        "@smithy/types": "^3.7.2",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
-      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
@@ -10440,61 +10302,32 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
-      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.9",
-        "@smithy/protocol-http": "^4.1.8",
-        "@smithy/querystring-builder": "^3.0.11",
-        "@smithy/types": "^3.7.2",
+        "@smithy/abort-controller": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/querystring-builder": "^4.0.1",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
-      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
-        "@smithy/types": "^3.7.2",
-        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
-      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
@@ -10542,7 +10375,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
       "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
@@ -10963,51 +10795,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
@@ -11026,7 +10813,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@ibm-cloud/watsonx-ai": "^1.1.0",
     "@ibm-generative-ai/node-sdk": "^2.0.6",
     "@playwright/browser-chromium": "^1.47.2",
-    "@smithy/node-http-handler": "^3.1.1",
+    "@smithy/node-http-handler": "^3.1.1 || ^4.0.0",
     "google-auth-library": "^9.7.0",
     "ibm-cloud-sdk-core": "^5.0.2",
     "langfuse": "^3.7.0",


### PR DESCRIPTION
Change the `peerDependencies` on `@smithy/node-http-handler` to support `^3.1.1 || ^4.0.0`, as that's the version used by the new AWS SDKs since v3.723.0.

The only breaking change in v4.0.0 seems to be dropping Node.JS v16 support, see [`@smithy/node-http-handler` CHANGELOG.md][1].

[1]: https://github.com/smithy-lang/smithy-typescript/blob/9ffe82d60dd45787a4279eb9723290edb39d0e10/packages/node-http-handler/CHANGELOG.md

---

`npm test` seems to work fine, but if anybody uses AWS Bedrock, it might be worth retesting the AWS Bedrock provider just to sanity check that the [`@smithy/node-http-handler` CHANGELOG.md][1] is correct and there are no other changes!