### PR TITLE
feat(redteam): Advanced redteam configurations from cloud provider

### DIFF
--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -53,21 +53,8 @@ export function redteamRunCommand(program: Command) {
 
       if (opts.config && UUID_REGEX.test(opts.config)) {
         const configObj = await getConfigFromCloud(opts.config);
-        const provider = await getProviderModelFromCloud(configObj.provider);
 
-        opts.liveRedteamConfig = getUnifiedConfig(configObj.config);
-
-        // If the session source is client, we need to generate a session id for the test
-        if (provider.sessionSource === 'client') {
-          opts.liveRedteamConfig.defaultTest = {
-            options: {
-              transformVars: '{ ...vars, sessionId: context.uuid }',
-            },
-          };
-        }
-        if (provider.extensions) {
-          opts.liveRedteamConfig.extensions = provider.extensions;
-        }
+        opts.liveRedteamConfig = configObj;
 
         opts.config = undefined;
 

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -4,11 +4,10 @@ import cliState from '../../cliState';
 import logger, { setLogLevel } from '../../logger';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
-import { getConfigFromCloud, getProviderModelFromCloud } from '../../util/cloud';
-import { MULTI_TURN_STRATEGIES } from '../constants';
+import { getConfigFromCloud } from '../../util/cloud';
 import { doRedteamRun } from '../shared';
 import { getUnifiedConfig } from '../sharedFrontend';
-import type { RedteamRunOptions, StrategyConfig } from '../types';
+import type { RedteamRunOptions } from '../types';
 import { poisonCommand } from './poison';
 
 const UUID_REGEX = /^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/;
@@ -55,13 +54,6 @@ export function redteamRunCommand(program: Command) {
       if (opts.config && UUID_REGEX.test(opts.config)) {
         const configObj = await getConfigFromCloud(opts.config);
         const provider = await getProviderModelFromCloud(configObj.provider);
-
-        // if the provider is stateful, mark all the multi-turn strategies as stateful
-        configObj.config.strategies.forEach((strategy: StrategyConfig) => {
-          if (MULTI_TURN_STRATEGIES.includes(strategy.id as any)) {
-            strategy.config = { ...(strategy.config || {}), stateful: provider.stateful };
-          }
-        });
 
         opts.liveRedteamConfig = getUnifiedConfig(configObj.config);
 

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -6,7 +6,6 @@ import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
 import { getConfigFromCloud } from '../../util/cloud';
 import { doRedteamRun } from '../shared';
-import { getUnifiedConfig } from '../sharedFrontend';
 import type { RedteamRunOptions } from '../types';
 import { poisonCommand } from './poison';
 

--- a/src/util/cloud.ts
+++ b/src/util/cloud.ts
@@ -1,12 +1,14 @@
+import { getUnifiedConfig } from 'src/redteam/sharedFrontend';
+import type { UnifiedConfig } from 'src/types';
 import { fetchWithProxy } from '../fetch';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
-import type { SavedRedteamConfig } from '../redteam/types';
 import type { ProviderOptions } from '../types/providers';
 import { ProviderOptionsSchema } from '../validators/providers';
 import invariant from './invariant';
 
 const CHUNKED_RESULTS_BUILD_DATE = new Date('2025-01-10');
+const FORMATTED_CONFIG_ENDPOINT_BUILD_DATE = new Date('2025-03-07');
 
 export function makeRequest(path: string, method: string, body?: any): Promise<Response> {
   const apiHost = cloudConfig.getApiHost();
@@ -17,78 +19,6 @@ export function makeRequest(path: string, method: string, body?: any): Promise<R
     body: JSON.stringify(body),
     headers: { Authorization: `Bearer ${apiKey}` },
   });
-}
-
-export async function getProviderModelFromCloud(id: string) {
-  if (!cloudConfig.isEnabled()) {
-    throw new Error(
-      `Could not fetch Provider ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
-    );
-  }
-  try {
-    const response = await makeRequest(`api/providers/${id}`, 'GET');
-    const body = await response.json();
-    if (response.ok) {
-      logger.info(`Provider fetched from cloud: ${id}`);
-      logger.debug(`Provider from cloud: ${JSON.stringify(body, null, 2)}`);
-    } else {
-      throw new Error(`Failed to fetch provider from cloud: ${response.statusText}`);
-    }
-    return body;
-  } catch (e) {
-    logger.error(`Failed to fetch provider from cloud: ${id}.`);
-    logger.error(String(e));
-    throw new Error(`Failed to fetch provider from cloud: ${id}.`);
-  }
-}
-
-export async function getProviderFromCloud(id: string): Promise<ProviderOptions & { id: string }> {
-  if (!cloudConfig.isEnabled()) {
-    throw new Error(
-      `Could not fetch Provider ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
-    );
-  }
-  try {
-    const model = await getProviderModelFromCloud(id);
-    const provider = ProviderOptionsSchema.parse(model.config);
-    // The provider options schema has ID field as optional but we know it's required for cloud providers
-    invariant(provider.id, `Provider ${id} has no id in ${model.config}`);
-    return { ...provider, id: provider.id };
-  } catch (e) {
-    logger.error(`Failed to fetch provider from cloud: ${id}.`);
-    logger.error(String(e));
-    throw new Error(`Failed to fetch provider from cloud: ${id}.`);
-  }
-}
-
-interface CloudConfig {
-  id: string;
-  config: SavedRedteamConfig;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export async function getConfigFromCloud(id: string): Promise<CloudConfig> {
-  if (!cloudConfig.isEnabled()) {
-    throw new Error(
-      `Could not fetch Config ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
-    );
-  }
-  try {
-    const response = await makeRequest(`api/redteam/configs/${id}`, 'GET');
-    const body = await response.json();
-    if (response.ok) {
-      logger.info(`Config fetched from cloud: ${id}`);
-      logger.debug(`Config from cloud: ${JSON.stringify(body, null, 2)}`);
-    } else {
-      throw new Error(`Failed to fetch config from cloud: ${response.statusText}`);
-    }
-    return body;
-  } catch (e) {
-    logger.error(`Failed to fetch config from cloud: ${id}.`);
-    logger.error(String(e));
-    throw new Error(`Failed to fetch config from cloud: ${id}.`);
-  }
 }
 
 export async function targetApiBuildDate(): Promise<Date | null> {
@@ -105,6 +35,61 @@ export async function targetApiBuildDate(): Promise<Date | null> {
     return null;
   } catch {
     return null;
+  }
+}
+
+async function cloudCanBuildFormattedConfig() {
+  const buildDate = await targetApiBuildDate();
+  return buildDate != null && buildDate > FORMATTED_CONFIG_ENDPOINT_BUILD_DATE;
+}
+
+export async function getProviderFromCloud(id: string): Promise<ProviderOptions & { id: string }> {
+  if (!cloudConfig.isEnabled()) {
+    throw new Error(
+      `Could not fetch Provider ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
+    );
+  }
+  try {
+    const response = await makeRequest(`api/providers/${id}`, 'GET');
+    const body = await response.json();
+    const provider = ProviderOptionsSchema.parse(body.config);
+    // The provider options schema has ID field as optional but we know it's required for cloud providers
+    invariant(provider.id, `Provider ${id} has no id in ${body.config}`);
+    return { ...provider, id: provider.id };
+  } catch (e) {
+    logger.error(`Failed to fetch provider from cloud: ${id}.`);
+    logger.error(String(e));
+    throw new Error(`Failed to fetch provider from cloud: ${id}.`);
+  }
+}
+
+export async function getConfigFromCloud(id: string): Promise<UnifiedConfig> {
+  if (!cloudConfig.isEnabled()) {
+    throw new Error(
+      `Could not fetch Config ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
+    );
+  }
+  try {
+    const canBuildFormattedConfig = await cloudCanBuildFormattedConfig();
+    if (canBuildFormattedConfig) {
+      const response = await makeRequest(`api/redteam/configs/${id}/unified`, 'GET');
+      const body = await response.json();
+      return body;
+    } else {
+      const response = await makeRequest(`api/redteam/configs/${id}`, 'GET');
+      const body = await response.json();
+      if (response.ok) {
+        logger.info(`Config fetched from cloud: ${id}`);
+        logger.debug(`Config from cloud: ${JSON.stringify(body, null, 2)}`);
+      } else {
+        throw new Error(`Failed to fetch config from cloud: ${response.statusText}`);
+      }
+      return getUnifiedConfig(body.config);
+    }
+  } catch (e) {
+    logger.error(`Failed to fetch config from cloud: ${id}.`);
+    logger.error(String(e));
+    throw new Error(`Failed to fetch config from cloud: ${id}.`);
   }
 }
 

--- a/src/util/cloud.ts
+++ b/src/util/cloud.ts
@@ -1,8 +1,8 @@
-import { getUnifiedConfig } from 'src/redteam/sharedFrontend';
-import type { UnifiedConfig } from 'src/types';
 import { fetchWithProxy } from '../fetch';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
+import { getUnifiedConfig } from '../redteam/sharedFrontend';
+import type { UnifiedConfig } from '../types';
 import type { ProviderOptions } from '../types/providers';
 import { ProviderOptionsSchema } from '../validators/providers';
 import invariant from './invariant';
@@ -38,7 +38,7 @@ export async function targetApiBuildDate(): Promise<Date | null> {
   }
 }
 
-async function cloudCanBuildFormattedConfig() {
+export async function cloudCanBuildFormattedConfig() {
   const buildDate = await targetApiBuildDate();
   return buildDate != null && buildDate > FORMATTED_CONFIG_ENDPOINT_BUILD_DATE;
 }
@@ -71,12 +71,15 @@ export async function getConfigFromCloud(id: string): Promise<UnifiedConfig> {
   }
   try {
     const canBuildFormattedConfig = await cloudCanBuildFormattedConfig();
+
     if (canBuildFormattedConfig) {
       const response = await makeRequest(`api/redteam/configs/${id}/unified`, 'GET');
+
       const body = await response.json();
       return body;
     } else {
       const response = await makeRequest(`api/redteam/configs/${id}`, 'GET');
+
       const body = await response.json();
       if (response.ok) {
         logger.info(`Config fetched from cloud: ${id}`);

--- a/src/util/cloud.ts
+++ b/src/util/cloud.ts
@@ -19,7 +19,7 @@ export function makeRequest(path: string, method: string, body?: any): Promise<R
   });
 }
 
-export async function getProviderFromCloud(id: string): Promise<ProviderOptions & { id: string }> {
+export async function getProviderModelFromCloud(id: string) {
   if (!cloudConfig.isEnabled()) {
     throw new Error(
       `Could not fetch Provider ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
@@ -27,7 +27,6 @@ export async function getProviderFromCloud(id: string): Promise<ProviderOptions 
   }
   try {
     const response = await makeRequest(`api/providers/${id}`, 'GET');
-
     const body = await response.json();
     if (response.ok) {
       logger.info(`Provider fetched from cloud: ${id}`);
@@ -35,9 +34,25 @@ export async function getProviderFromCloud(id: string): Promise<ProviderOptions 
     } else {
       throw new Error(`Failed to fetch provider from cloud: ${response.statusText}`);
     }
-    const provider = ProviderOptionsSchema.parse(body.config);
+    return body;
+  } catch (e) {
+    logger.error(`Failed to fetch provider from cloud: ${id}.`);
+    logger.error(String(e));
+    throw new Error(`Failed to fetch provider from cloud: ${id}.`);
+  }
+}
+
+export async function getProviderFromCloud(id: string): Promise<ProviderOptions & { id: string }> {
+  if (!cloudConfig.isEnabled()) {
+    throw new Error(
+      `Could not fetch Provider ${id} from cloud. Cloud config is not enabled. Please run \`promptfoo auth login\` to login.`,
+    );
+  }
+  try {
+    const model = await getProviderModelFromCloud(id);
+    const provider = ProviderOptionsSchema.parse(model.config);
     // The provider options schema has ID field as optional but we know it's required for cloud providers
-    invariant(provider.id, `Provider ${id} has no id in ${body.config}`);
+    invariant(provider.id, `Provider ${id} has no id in ${model.config}`);
     return { ...provider, id: provider.id };
   } catch (e) {
     logger.error(`Failed to fetch provider from cloud: ${id}.`);

--- a/test/util/cloud.test.ts
+++ b/test/util/cloud.test.ts
@@ -189,6 +189,7 @@ describe('cloud utils', () => {
 
       mockFetchWithProxy.mockResolvedValueOnce({
         json: () => Promise.resolve(mockProvider),
+        ok: true,
       } as Response);
 
       const result = await getProviderFromCloud('test-provider');
@@ -257,9 +258,11 @@ describe('cloud utils', () => {
 
       mockFetchWithProxy.mockResolvedValueOnce({
         json: () => Promise.resolve({ buildDate: '2025-03-011' }),
+        ok: true,
       } as Response);
       mockFetchWithProxy.mockResolvedValueOnce({
         json: () => Promise.resolve(mockUnifiedConfig),
+        ok: true,
       } as Response);
 
       const result = await getConfigFromCloud('test-config');

--- a/test/util/cloud.test.ts
+++ b/test/util/cloud.test.ts
@@ -1,9 +1,14 @@
 import { fetchWithProxy } from '../../src/fetch';
 import { cloudConfig } from '../../src/globalConfig/cloud';
-import { makeRequest } from '../../src/util/cloud';
+import { makeRequest, getProviderFromCloud, getConfigFromCloud } from '../../src/util/cloud';
+import * as cloudUtils from '../../src/util/cloud';
 
 jest.mock('../../src/fetch');
 jest.mock('../../src/globalConfig/cloud');
+jest.mock('../../src/util/cloud', () => ({
+  ...jest.requireActual('../../src/util/cloud'),
+  cloudCanBuildFormattedConfig: jest.fn().mockResolvedValue(true),
+}));
 
 describe('cloud utils', () => {
   const mockFetchWithProxy = jest.mocked(fetchWithProxy);
@@ -166,6 +171,181 @@ describe('cloud utils', () => {
         body: undefined,
         headers: { Authorization: 'Bearer test-api-key' },
       });
+    });
+  });
+
+  describe('getProviderFromCloud', () => {
+    beforeEach(() => {
+      mockCloudConfig.isEnabled.mockReturnValue(true);
+    });
+
+    it('should fetch and parse provider successfully', async () => {
+      const mockProvider = {
+        config: {
+          id: 'test-provider',
+          label: 'Test Provider',
+        },
+      };
+
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockProvider),
+      } as Response);
+
+      const result = await getProviderFromCloud('test-provider');
+
+      expect(result).toEqual({ ...mockProvider.config });
+      expect(mockFetchWithProxy).toHaveBeenCalledWith(
+        'https://api.example.com/api/providers/test-provider',
+        {
+          method: 'GET',
+          headers: { Authorization: 'Bearer test-api-key' },
+        },
+      );
+    });
+
+    it('should throw error when cloud config is not enabled', async () => {
+      mockCloudConfig.isEnabled.mockReturnValue(false);
+
+      await expect(getProviderFromCloud('test-provider')).rejects.toThrow(
+        'Could not fetch Provider test-provider from cloud. Cloud config is not enabled.',
+      );
+    });
+
+    it('should throw error when provider fetch fails', async () => {
+      mockFetchWithProxy.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(getProviderFromCloud('test-provider')).rejects.toThrow(
+        'Failed to fetch provider from cloud: test-provider.',
+      );
+    });
+
+    it('should throw error when provider has no id', async () => {
+      const mockProvider = {
+        config: {
+          label: 'Test Provider',
+          // Missing id field
+        },
+      };
+
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve({ buildDate: '2025-03-011' }),
+      } as Response);
+
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockProvider),
+      } as Response);
+
+      await expect(getProviderFromCloud('test-provider')).rejects.toThrow(
+        'Failed to fetch provider from cloud: test-provider.',
+      );
+    });
+  });
+
+  describe('getConfigFromCloud', () => {
+    beforeEach(() => {
+      mockCloudConfig.isEnabled.mockReturnValue(true);
+      jest.mocked(cloudUtils.cloudCanBuildFormattedConfig).mockResolvedValueOnce(true);
+    });
+
+    it('should fetch unified config when formatted config is supported', async () => {
+      const mockUnifiedConfig = {
+        description: 'Test Config',
+        providers: ['test-provider'],
+        prompts: ['test prompt'],
+        tests: [{ vars: { input: 'test' } }],
+      };
+
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve({ buildDate: '2025-03-011' }),
+      } as Response);
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockUnifiedConfig),
+      } as Response);
+
+      const result = await getConfigFromCloud('test-config');
+
+      expect(result).toEqual(mockUnifiedConfig);
+      expect(mockFetchWithProxy).toHaveBeenCalledWith(
+        'https://api.example.com/api/redteam/configs/test-config/unified',
+        {
+          method: 'GET',
+          headers: { Authorization: 'Bearer test-api-key' },
+        },
+      );
+    });
+
+    it('should fetch and transform regular config when formatted config is not supported', async () => {
+      const mockConfig = {
+        config: {
+          description: 'Test Config',
+          target: {
+            id: 'test-provider',
+            config: {
+              type: 'openai',
+              model: 'gpt-4',
+            },
+          },
+          prompts: ['test prompt'],
+          plugins: ['test-plugin'],
+          strategies: ['test-strategy'],
+        },
+      };
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: () => Promise.resolve({ buildDate: '2024-03-011' }),
+      } as Response);
+      mockFetchWithProxy.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      const result = await getConfigFromCloud('test-config');
+
+      expect(result).toMatchObject({
+        description: 'Test Config',
+        targets: [{ id: 'test-provider' }],
+        prompts: ['test prompt'],
+        redteam: {
+          plugins: [{ id: 'test-plugin' }],
+          strategies: [{ id: 'test-strategy' }],
+        },
+      });
+      expect(mockFetchWithProxy).toHaveBeenCalledWith(
+        'https://api.example.com/api/redteam/configs/test-config',
+        {
+          method: 'GET',
+          headers: { Authorization: 'Bearer test-api-key' },
+        },
+      );
+    });
+
+    it('should throw error when cloud config is not enabled', async () => {
+      mockCloudConfig.isEnabled.mockReturnValue(false);
+
+      await expect(getConfigFromCloud('test-config')).rejects.toThrow(
+        'Could not fetch Config test-config from cloud. Cloud config is not enabled.',
+      );
+    });
+
+    it('should throw error when config fetch fails', async () => {
+      jest.mocked(cloudUtils.cloudCanBuildFormattedConfig).mockResolvedValueOnce(true);
+      mockFetchWithProxy.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(getConfigFromCloud('test-config')).rejects.toThrow(
+        'Failed to fetch config from cloud: test-config.',
+      );
+    });
+
+    it('should throw error when response is not ok', async () => {
+      jest.mocked(cloudUtils.cloudCanBuildFormattedConfig).mockResolvedValueOnce(false);
+      mockFetchWithProxy.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({}),
+      } as Response);
+
+      await expect(getConfigFromCloud('test-config')).rejects.toThrow(
+        'Failed to fetch config from cloud: test-config.',
+      );
     });
   });
 });


### PR DESCRIPTION
We have a new cloud endpoint that will generate the unified config for us!

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances redteam configurations from cloud provider with support for statefulness, session creation, and extensions, and adds tests for cloud configuration fetching.
> 
>   - **Behavior**:
>     - Fetches advanced redteam configurations from cloud provider in `run.ts`.
>     - Supports statefulness, session creation, and extensions.
>     - Uses `getConfigFromCloud()` to fetch configurations, supporting unified configs if available.
>   - **Functions**:
>     - `getConfigFromCloud()` in `cloud.ts` now returns `UnifiedConfig` and checks for formatted config support.
>     - Adds `cloudCanBuildFormattedConfig()` to determine if formatted configs are supported.
>   - **Tests**:
>     - Extensive tests for `getConfigFromCloud()` and `getProviderFromCloud()` in `cloud.test.ts`.
>     - Mocks `cloudCanBuildFormattedConfig()` to simulate different scenarios.
>   - **Misc**:
>     - Removes unused `getUnifiedConfig` import in `run.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=promptfoo%2Fpromptfoo&utm_source=github&utm_medium=referral)<sup> for 9da69de608f848bdf73a3ffd21da1773c06c7c3f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->