### PR TITLE
fix(share): correct URL display when self-hosting

### DIFF
--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -101,7 +101,9 @@ export function shareCommand(program: Command) {
           return;
         }
 
-        const baseUrl = getEnvString('PROMPTFOO_SHARING_APP_BASE_URL');
+        const baseUrl =
+          getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
+          getEnvString('PROMPTFOO_REMOTE_APP_BASE_URL');
         const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
 
         const confirmed = await askForConfirmation(hostname);

--- a/test/commands/share.test.ts
+++ b/test/commands/share.test.ts
@@ -82,7 +82,7 @@ describe('Share Command', () => {
     // Test just the hostname determination logic directly
     it('should use app.promptfoo.dev by default if no environment variables are set', () => {
       // Mock environment variables to return undefined
-      jest.mocked(envars.getEnvString).mockImplementation(() => undefined);
+      jest.mocked(envars.getEnvString).mockImplementation(() => '');
 
       const baseUrl =
         envars.getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
@@ -98,7 +98,7 @@ describe('Share Command', () => {
         if (key === 'PROMPTFOO_SHARING_APP_BASE_URL') {
           return 'https://custom-domain.com';
         }
-        return undefined;
+        return '';
       });
 
       const baseUrl =
@@ -115,7 +115,7 @@ describe('Share Command', () => {
         if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
           return 'https://self-hosted-domain.com';
         }
-        return undefined;
+        return '';
       });
 
       const baseUrl =
@@ -135,7 +135,7 @@ describe('Share Command', () => {
         if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
           return 'https://remote-domain.com';
         }
-        return undefined;
+        return '';
       });
 
       const baseUrl =

--- a/test/commands/share.test.ts
+++ b/test/commands/share.test.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { createAndDisplayShareableUrl, shareCommand } from '../../src/commands/share';
+import * as envars from '../../src/envars';
 import logger from '../../src/logger';
-import type Eval from '../../src/models/eval';
 import { createShareableUrl } from '../../src/share';
 
 jest.mock('../../src/share');
@@ -10,6 +10,9 @@ jest.mock('../../src/telemetry', () => ({
   record: jest.fn(),
   send: jest.fn(),
 }));
+jest.mock('../../src/envars');
+jest.mock('readline');
+jest.mock('../../src/models/eval');
 
 describe('Share Command', () => {
   describe('createAndDisplayShareableUrl', () => {
@@ -18,7 +21,7 @@ describe('Share Command', () => {
     });
 
     it('should return a URL and log it when successful', async () => {
-      const mockEval = { id: 'test-eval-id' } as Eval;
+      const mockEval = { id: 'test-eval-id' } as any;
       const mockUrl = 'https://app.promptfoo.dev/eval/test-eval-id';
 
       jest.mocked(createShareableUrl).mockResolvedValue(mockUrl);
@@ -31,7 +34,7 @@ describe('Share Command', () => {
     });
 
     it('should pass showAuth parameter correctly', async () => {
-      const mockEval = { id: 'test-eval-id' } as Eval;
+      const mockEval = { id: 'test-eval-id' } as any;
       const mockUrl = 'https://app.promptfoo.dev/eval/test-eval-id';
 
       jest.mocked(createShareableUrl).mockResolvedValue(mockUrl);
@@ -42,7 +45,7 @@ describe('Share Command', () => {
     });
 
     it('should return null when createShareableUrl returns null', async () => {
-      const mockEval = { id: 'test-eval-id' } as Eval;
+      const mockEval = { id: 'test-eval-id' } as any;
 
       jest.mocked(createShareableUrl).mockResolvedValue(null);
 
@@ -74,6 +77,73 @@ describe('Share Command', () => {
       expect(options?.find((o) => o.short === '-y')).toBeDefined();
       expect(options?.find((o) => o.long === '--show-auth')).toBeDefined();
       expect(options?.find((o) => o.long === '--env-path')).toBeDefined();
+    });
+
+    // Test just the hostname determination logic directly
+    it('should use app.promptfoo.dev by default if no environment variables are set', () => {
+      // Mock environment variables to return undefined
+      jest.mocked(envars.getEnvString).mockImplementation(() => undefined);
+
+      const baseUrl =
+        envars.getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
+        envars.getEnvString('PROMPTFOO_REMOTE_APP_BASE_URL');
+      const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+
+      expect(hostname).toBe('app.promptfoo.dev');
+    });
+
+    it('should use PROMPTFOO_SHARING_APP_BASE_URL for hostname when set', () => {
+      // Mock PROMPTFOO_SHARING_APP_BASE_URL
+      jest.mocked(envars.getEnvString).mockImplementation((key) => {
+        if (key === 'PROMPTFOO_SHARING_APP_BASE_URL') {
+          return 'https://custom-domain.com';
+        }
+        return undefined;
+      });
+
+      const baseUrl =
+        envars.getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
+        envars.getEnvString('PROMPTFOO_REMOTE_APP_BASE_URL');
+      const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+
+      expect(hostname).toBe('custom-domain.com');
+    });
+
+    it('should use PROMPTFOO_REMOTE_APP_BASE_URL for hostname when PROMPTFOO_SHARING_APP_BASE_URL is not set', () => {
+      // Mock PROMPTFOO_REMOTE_APP_BASE_URL
+      jest.mocked(envars.getEnvString).mockImplementation((key) => {
+        if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
+          return 'https://self-hosted-domain.com';
+        }
+        return undefined;
+      });
+
+      const baseUrl =
+        envars.getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
+        envars.getEnvString('PROMPTFOO_REMOTE_APP_BASE_URL');
+      const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+
+      expect(hostname).toBe('self-hosted-domain.com');
+    });
+
+    it('should prioritize PROMPTFOO_SHARING_APP_BASE_URL over PROMPTFOO_REMOTE_APP_BASE_URL', () => {
+      // Mock both environment variables
+      jest.mocked(envars.getEnvString).mockImplementation((key) => {
+        if (key === 'PROMPTFOO_SHARING_APP_BASE_URL') {
+          return 'https://sharing-domain.com';
+        }
+        if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
+          return 'https://remote-domain.com';
+        }
+        return undefined;
+      });
+
+      const baseUrl =
+        envars.getEnvString('PROMPTFOO_SHARING_APP_BASE_URL') ||
+        envars.getEnvString('PROMPTFOO_REMOTE_APP_BASE_URL');
+      const hostname = baseUrl ? new URL(baseUrl).hostname : 'app.promptfoo.dev';
+
+      expect(hostname).toBe('sharing-domain.com');
     });
   });
 });

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -2,7 +2,7 @@ import type EvalResult from 'src/models/evalResult';
 import { getUserEmail } from '../src/globalConfig/accounts';
 import { cloudConfig } from '../src/globalConfig/cloud';
 import type Eval from '../src/models/eval';
-import { stripAuthFromUrl, createShareableUrl } from '../src/share';
+import { stripAuthFromUrl, createShareableUrl, determineShareDomain } from '../src/share';
 import { cloudCanAcceptChunkedResults } from '../src/util/cloud';
 
 const mockFetch = jest.fn();
@@ -20,6 +20,19 @@ jest.mock('../src/globalConfig/accounts', () => ({
 
 jest.mock('../src/util/cloud', () => ({
   cloudCanAcceptChunkedResults: jest.fn(),
+}));
+
+jest.mock('../src/envars', () => ({
+  getEnvBool: jest.fn(),
+  getEnvInt: jest.fn(),
+  getEnvString: jest.fn().mockReturnValue(undefined),
+  isCI: jest.fn(),
+}));
+
+jest.mock('../src/constants', () => ({
+  DEFAULT_SHARE_VIEW_BASE_URL: 'https://app.promptfoo.dev',
+  SHARE_API_BASE_URL: 'https://api.promptfoo.dev',
+  SHARE_VIEW_BASE_URL: 'https://app.promptfoo.dev',
 }));
 
 describe('stripAuthFromUrl', () => {
@@ -58,9 +71,99 @@ describe('stripAuthFromUrl', () => {
   });
 });
 
+describe('determineShareDomain', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the mock to return undefined for all environment variables
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => undefined);
+  });
+
+  it('should use DEFAULT_SHARE_VIEW_BASE_URL when no custom domain is specified', () => {
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    const mockEval: Partial<Eval> = {
+      config: {},
+      id: 'test-eval-id',
+    };
+
+    const result = determineShareDomain(mockEval as Eval);
+    expect(result.domain).toBe('https://app.promptfoo.dev');
+    expect(result.isPublicShare).toBe(true);
+  });
+
+  it('should use PROMPTFOO_REMOTE_APP_BASE_URL when specified', () => {
+    const customDomain = 'https://my-custom-instance.com';
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
+        return customDomain;
+      }
+      return undefined;
+    });
+
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    const mockEval: Partial<Eval> = {
+      config: {},
+      id: 'test-eval-id',
+    };
+
+    const result = determineShareDomain(mockEval as Eval);
+    expect(result.domain).toBe(customDomain);
+    expect(result.isPublicShare).toBe(true);
+  });
+
+  it('should use config sharing.appBaseUrl when provided', () => {
+    const configAppBaseUrl = 'https://config-specified-domain.com';
+
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    const mockEval: Partial<Eval> = {
+      config: {
+        sharing: {
+          appBaseUrl: configAppBaseUrl,
+        },
+      },
+      id: 'test-eval-id',
+    };
+
+    const result = determineShareDomain(mockEval as Eval);
+    expect(result.domain).toBe(configAppBaseUrl);
+    expect(result.isPublicShare).toBe(false);
+  });
+
+  it('should prioritize config sharing.appBaseUrl over environment variables', () => {
+    const configAppBaseUrl = 'https://config-specified-domain.com';
+    const envAppBaseUrl = 'https://env-specified-domain.com';
+
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
+        return envAppBaseUrl;
+      }
+      return undefined;
+    });
+
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    const mockEval: Partial<Eval> = {
+      config: {
+        sharing: {
+          appBaseUrl: configAppBaseUrl,
+        },
+      },
+      id: 'test-eval-id',
+    };
+
+    const result = determineShareDomain(mockEval as Eval);
+    expect(result.domain).toBe(configAppBaseUrl);
+    expect(result.isPublicShare).toBe(false);
+  });
+});
+
 describe('createShareableUrl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset the mock to return undefined for all environment variables
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => undefined);
     // Setup default successful response
     mockFetch.mockResolvedValue({
       ok: true,
@@ -107,6 +210,10 @@ describe('createShareableUrl', () => {
 
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
       jest.mocked(cloudConfig.getApiKey).mockReturnValue('mock-api-key');
+      // Reset the environment variable mock
+      jest
+        .requireMock('../src/envars')
+        .getEnvString.mockImplementation((_key: string) => undefined);
 
       // Reset fetch mock between tests
       mockFetch.mockReset();
@@ -199,7 +306,6 @@ describe('createShareableUrl', () => {
       const result = await createShareableUrl(mockEval as Eval);
 
       // Verify sendEvalResults was used (not chunked)
-      // expect(mockEval.loadResults).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/api/eval'),
         expect.objectContaining({
@@ -235,7 +341,6 @@ describe('createShareableUrl', () => {
       const result = await createShareableUrl(mockEval as Eval);
 
       // Verify chunks were sent
-      // expect(mockEval.loadResults).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/api/eval'),
         expect.objectContaining({
@@ -252,5 +357,49 @@ describe('createShareableUrl', () => {
       );
       expect(result).toBe('https://app.promptfoo.dev/eval/mock-eval-id');
     });
+  });
+
+  // Add test for custom domain
+  it('creates URL with custom domain from environment variables', async () => {
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    const customDomain = 'https://my-custom-instance.com';
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((key: string) => {
+      if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
+        return customDomain;
+      }
+      return undefined;
+    });
+
+    const mockEval: Partial<Eval> = {
+      config: {},
+      author: 'test@example.com',
+      useOldResults: jest.fn().mockReturnValue(false),
+      loadResults: jest.fn().mockResolvedValue(undefined),
+      results: [{ id: '1' }, { id: '2' }] as EvalResult[],
+      save: jest.fn().mockResolvedValue(undefined),
+      toEvaluateSummary: jest.fn().mockResolvedValue({}),
+      getTable: jest.fn().mockResolvedValue([]),
+    };
+
+    // Mock the health check and response
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ version: '0.103.7' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ version: '0.103.7' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'mock-eval-id' }),
+      });
+
+    const result = await createShareableUrl(mockEval as Eval);
+
+    // Verify the URL uses the custom domain
+    expect(result).toBe(`${customDomain}/eval/?evalId=mock-eval-id`);
   });
 });

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -25,7 +25,7 @@ jest.mock('../src/util/cloud', () => ({
 jest.mock('../src/envars', () => ({
   getEnvBool: jest.fn(),
   getEnvInt: jest.fn(),
-  getEnvString: jest.fn().mockReturnValue(undefined),
+  getEnvString: jest.fn().mockReturnValue(''),
   isCI: jest.fn(),
 }));
 
@@ -74,8 +74,8 @@ describe('stripAuthFromUrl', () => {
 describe('determineShareDomain', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the mock to return undefined for all environment variables
-    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => undefined);
+    // Reset the mock to return empty string for all environment variables
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => '');
   });
 
   it('should use DEFAULT_SHARE_VIEW_BASE_URL when no custom domain is specified', () => {
@@ -97,7 +97,7 @@ describe('determineShareDomain', () => {
       if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
         return customDomain;
       }
-      return undefined;
+      return '';
     });
 
     jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
@@ -139,7 +139,7 @@ describe('determineShareDomain', () => {
       if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
         return envAppBaseUrl;
       }
-      return undefined;
+      return '';
     });
 
     jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
@@ -162,8 +162,8 @@ describe('determineShareDomain', () => {
 describe('createShareableUrl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the mock to return undefined for all environment variables
-    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => undefined);
+    // Reset the mock to return empty string for all environment variables
+    jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => '');
     // Setup default successful response
     mockFetch.mockResolvedValue({
       ok: true,
@@ -211,9 +211,7 @@ describe('createShareableUrl', () => {
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
       jest.mocked(cloudConfig.getApiKey).mockReturnValue('mock-api-key');
       // Reset the environment variable mock
-      jest
-        .requireMock('../src/envars')
-        .getEnvString.mockImplementation((_key: string) => undefined);
+      jest.requireMock('../src/envars').getEnvString.mockImplementation((_key: string) => '');
 
       // Reset fetch mock between tests
       mockFetch.mockReset();
@@ -368,7 +366,7 @@ describe('createShareableUrl', () => {
       if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
         return customDomain;
       }
-      return undefined;
+      return '';
     });
 
     const mockEval: Partial<Eval> = {


### PR DESCRIPTION
When self-hosting promptfoo, the share command was showing URLs pointing to app.promptfoo.dev instead of the self-hosted domain, even though the data was correctly sent to the self-hosted API. This fix:

- Updates hostname determination to check both PROMPTFOO_SHARING_APP_BASE_URL and PROMPTFOO_REMOTE_APP_BASE_URL
- Modifies determineShareDomain to properly handle custom domains from environment variables
- Ensures the final displayed URL matches the actual API endpoint being used Fixes #3291