### PR TITLE
chore(providers): add EU Nova models to Bedrock

### DIFF
--- a/src/providers/bedrock.ts
+++ b/src/providers/bedrock.ts
@@ -812,6 +812,9 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'us.meta.llama3-3-70b-instruct-v1:0': BEDROCK_MODEL.LLAMA3_3,
 
   // EU Models
+  'eu.amazon.nova-lite-v1:0': BEDROCK_MODEL.AMAZON_NOVA,
+  'eu.amazon.nova-micro-v1:0': BEDROCK_MODEL.AMAZON_NOVA,
+  'eu.amazon.nova-pro-v1:0': BEDROCK_MODEL.AMAZON_NOVA,
   'eu.anthropic.claude-3-5-sonnet-20240620-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'eu.anthropic.claude-3-haiku-20240307-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'eu.anthropic.claude-3-sonnet-20240229-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,


### PR DESCRIPTION
Add EU Nova models to the Bedrock provider configuration.
- Introduced 'eu.amazon.nova-lite-v1:0', 'eu.amazon.nova-micro-v1:0', and 'eu.amazon.nova-pro-v1:0' mappings.
No breaking changes.