### PR TITLE
fix(webui): correct keyboard shortcut order in DownloadMenu

### DIFF
--- a/src/app/src/pages/eval/components/DownloadMenu.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.tsx
@@ -269,19 +269,22 @@ function DownloadMenu() {
             downloadConfig();
             break;
           case '2':
-            downloadCsv();
+            downloadFailedTestsConfig();
             break;
           case '3':
-            downloadTable();
+            downloadCsv();
             break;
           case '4':
-            downloadDpoJson();
+            downloadTable();
             break;
           case '5':
-            downloadHumanEvalTestCases();
+            downloadBurpPayloads();
             break;
           case '6':
-            downloadBurpPayloads();
+            downloadDpoJson();
+            break;
+          case '7':
+            downloadHumanEvalTestCases();
             break;
         }
       }


### PR DESCRIPTION
Corrected the keyboard shortcut order for the DownloadMenu component in the web UI.
- Adjusted the mapping of shortcut keys to their respective download functions.
No breaking changes introduced.