### PR TITLE
chore(providers): support entire ProviderResponse output

### DIFF
--- a/site/docs/providers/echo.md
+++ b/site/docs/providers/echo.md
@@ -13,7 +13,21 @@ To use the Echo Provider, set the provider ID to `echo` in your configuration fi
 ```yaml
 providers:
   - echo
+  # or
+  - id: echo
+    label: pass through provider
 ```
+
+## Response Format
+
+The Echo Provider returns a complete `ProviderResponse` object with the following fields:
+
+- `output`: The original input string
+- `cost`: Always 0
+- `cached`: Always false
+- `tokenUsage`: Set to `{ total: 0, prompt: 0, completion: 0 }`
+- `isRefusal`: Always false
+- `metadata`: Any additional metadata provided in the context
 
 ## Usage
 
@@ -49,3 +63,7 @@ The Echo Provider is useful for:
 - **Debugging and Testing Prompts**: Ensure prompts and variable substitutions work correctly before using complex providers.
 
 - **Assertion and Pre-generated Output Evaluation**: Test assertion logic on known inputs and validate pre-generated outputs without new API calls.
+
+- **Testing Transformations**: Test how transformations affect the output without the variability of an LLM response.
+
+- **Mocking in Test Environments**: Use as a drop-in replacement for other providers in test environments when you don't want to make actual API calls.

--- a/src/providers/echo.ts
+++ b/src/providers/echo.ts
@@ -7,7 +7,6 @@ export class EchoProvider implements ApiProvider {
   public label?: string;
   public config?: any;
   public delay?: number;
-  public transform?: string;
 
   constructor(options: ProviderOptions = {}) {
     this.options = options;

--- a/src/providers/echo.ts
+++ b/src/providers/echo.ts
@@ -1,11 +1,20 @@
 import type { ApiProvider, ProviderOptions, ProviderResponse } from '../types/providers';
+import { sleep } from '../util/time';
 
 export class EchoProvider implements ApiProvider {
   private options: ProviderOptions;
 
+  public label?: string;
+  public config?: any;
+  public delay?: number;
+  public transform?: string;
+
   constructor(options: ProviderOptions = {}) {
     this.options = options;
     this.id = options.id ? () => options.id! : this.id;
+    this.label = options.label;
+    this.config = options.config;
+    this.delay = options.delay;
   }
 
   id(): string {
@@ -21,6 +30,11 @@ export class EchoProvider implements ApiProvider {
     options?: Record<string, any>,
     context?: any,
   ): Promise<ProviderResponse> {
+    if (this.delay && this.delay > 0) {
+      await sleep(this.delay);
+    }
+
+    // Create a complete ProviderResponse object
     const response: ProviderResponse = {
       output: input,
       raw: input,

--- a/src/providers/echo.ts
+++ b/src/providers/echo.ts
@@ -1,0 +1,40 @@
+import type { ApiProvider, ProviderOptions, ProviderResponse } from '../types/providers';
+
+export class EchoProvider implements ApiProvider {
+  private options: ProviderOptions;
+
+  constructor(options: ProviderOptions = {}) {
+    this.options = options;
+    this.id = options.id ? () => options.id! : this.id;
+  }
+
+  id(): string {
+    return 'echo';
+  }
+
+  toString(): string {
+    return '[Echo Provider]';
+  }
+
+  async callApi(
+    input: string,
+    options?: Record<string, any>,
+    context?: any,
+  ): Promise<ProviderResponse> {
+    const response: ProviderResponse = {
+      output: input,
+      raw: input,
+      cost: 0,
+      cached: false,
+      tokenUsage: {
+        total: 0,
+        prompt: 0,
+        completion: 0,
+      },
+      isRefusal: false,
+      metadata: context?.metadata || {},
+    };
+
+    return response;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -28,6 +28,7 @@ import { ClouderaAiChatCompletionProvider } from './cloudera';
 import * as CloudflareAiProviders from './cloudflare-ai';
 import { CohereChatCompletionProvider, CohereEmbeddingProvider } from './cohere';
 import { DatabricksMosaicAiChatCompletionProvider } from './databricks';
+import { EchoProvider } from './echo';
 import { FalImageGenerationProvider } from './fal';
 import { GolangProvider } from './golangCompletion';
 import { GoogleChatProvider } from './google';
@@ -368,13 +369,7 @@ export const providerMap: ProviderFactory[] = [
       providerOptions: ProviderOptions,
       context: LoadApiProviderContext,
     ) => {
-      const provider: ApiProvider = {
-        id: () => 'echo',
-        async callApi(input: string, options?: Record<string, any>, context?: any) {
-          return { output: input };
-        },
-      };
-      return provider;
+      return new EchoProvider(providerOptions);
     },
   },
   {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -33,7 +33,19 @@ describe('loadApiProvider', () => {
   it('should load echo provider', async () => {
     const provider = await loadApiProvider('echo');
     expect(provider.id()).toBe('echo');
-    await expect(provider.callApi('test')).resolves.toEqual({ output: 'test' });
+    await expect(provider.callApi('test')).resolves.toEqual({
+      output: 'test',
+      raw: 'test',
+      cost: 0,
+      cached: false,
+      isRefusal: false,
+      tokenUsage: {
+        total: 0,
+        prompt: 0,
+        completion: 0,
+      },
+      metadata: {},
+    });
   });
 
   it('should load file provider from yaml', async () => {

--- a/test/providers/echo.test.ts
+++ b/test/providers/echo.test.ts
@@ -1,0 +1,103 @@
+import { EchoProvider } from '../../src/providers/echo';
+
+describe('EchoProvider', () => {
+  describe('constructor', () => {
+    it('should initialize with default options', () => {
+      const provider = new EchoProvider();
+      expect(provider['options']).toEqual({});
+    });
+
+    it('should initialize with provided options', () => {
+      const options = { config: { test: 'value' } };
+      const provider = new EchoProvider(options);
+      expect(provider['options']).toEqual(options);
+    });
+
+    it('should initialize with id function if id is provided', () => {
+      const options = { id: 'custom-echo' };
+      const provider = new EchoProvider(options);
+      expect(provider.id()).toBe('custom-echo');
+    });
+  });
+
+  describe('id', () => {
+    it('should return the default id string', () => {
+      const provider = new EchoProvider();
+      expect(provider.id()).toBe('echo');
+    });
+  });
+
+  describe('toString', () => {
+    it('should return the correct string representation', () => {
+      const provider = new EchoProvider();
+      expect(provider.toString()).toBe('[Echo Provider]');
+    });
+  });
+
+  describe('callApi', () => {
+    it('should return input as output', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.output).toBe(input);
+      expect(result.raw).toBe(input);
+    });
+
+    it('should include tokenUsage data in response', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.tokenUsage).toEqual({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+      });
+    });
+
+    it('should set cost to 0', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.cost).toBe(0);
+    });
+
+    it('should set cached to false', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.cached).toBe(false);
+    });
+
+    it('should set isRefusal to false', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.isRefusal).toBe(false);
+    });
+
+    it('should merge provided metadata with default metadata', async () => {
+      const input = 'Test input';
+      const context = { metadata: { test: 'value' } };
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input, {}, context);
+
+      expect(result.metadata).toEqual({
+        test: 'value',
+      });
+    });
+
+    it('should handle empty input', async () => {
+      const input = '';
+      const provider = new EchoProvider();
+      const result = await provider.callApi(input);
+
+      expect(result.output).toBe('');
+      expect(result.raw).toBe('');
+    });
+  });
+});

--- a/test/providers/echo.test.ts
+++ b/test/providers/echo.test.ts
@@ -5,12 +5,28 @@ describe('EchoProvider', () => {
     it('should initialize with default options', () => {
       const provider = new EchoProvider();
       expect(provider['options']).toEqual({});
+      expect(provider.label).toBeUndefined();
+      expect(provider.config).toBeUndefined();
+      expect(provider.delay).toBeUndefined();
+      expect(provider.transform).toBeUndefined();
     });
 
     it('should initialize with provided options', () => {
-      const options = { config: { test: 'value' } };
+      const options = {
+        config: { test: 'value' },
+        label: 'Test Echo',
+        delay: 100,
+        transform: 'return { output: input.toUpperCase() };',
+      };
       const provider = new EchoProvider(options);
-      expect(provider['options']).toEqual(options);
+      expect(provider).toEqual(
+        expect.objectContaining({
+          options,
+          label: 'Test Echo',
+          config: { test: 'value' },
+          delay: 100,
+        }),
+      );
     });
 
     it('should initialize with id function if id is provided', () => {
@@ -80,7 +96,7 @@ describe('EchoProvider', () => {
       expect(result.isRefusal).toBe(false);
     });
 
-    it('should merge provided metadata with default metadata', async () => {
+    it('should preserve context metadata', async () => {
       const input = 'Test input';
       const context = { metadata: { test: 'value' } };
       const provider = new EchoProvider();
@@ -89,6 +105,17 @@ describe('EchoProvider', () => {
       expect(result.metadata).toEqual({
         test: 'value',
       });
+    });
+
+    it('should respect the configured delay', async () => {
+      const input = 'Test input';
+      const provider = new EchoProvider({ delay: 100 });
+
+      const startTime = Date.now();
+      await provider.callApi(input);
+      const endTime = Date.now();
+
+      expect(endTime - startTime).toBeGreaterThanOrEqual(90); // Allow for small timing variations
     });
 
     it('should handle empty input', async () => {

--- a/test/providers/echo.test.ts
+++ b/test/providers/echo.test.ts
@@ -8,7 +8,6 @@ describe('EchoProvider', () => {
       expect(provider.label).toBeUndefined();
       expect(provider.config).toBeUndefined();
       expect(provider.delay).toBeUndefined();
-      expect(provider.transform).toBeUndefined();
     });
 
     it('should initialize with provided options', () => {

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -78,10 +78,14 @@ describe('Provider Registry', () => {
       expect(factory).toBeDefined();
 
       const provider = await factory!.create('echo', mockProviderOptions, mockContext);
-      expect(provider.id()).toBe('echo');
+      const expectedId = mockProviderOptions.id || 'echo';
+      expect(provider.id()).toBe(expectedId);
 
       const result = await provider.callApi('test input');
       expect(result.output).toBe('test input');
+      expect(result.raw).toBe('test input');
+      expect(result.cost).toBe(0);
+      expect(result.isRefusal).toBe(false);
     });
 
     it('should handle python provider correctly', async () => {


### PR DESCRIPTION
chore(echo-provider): enhance documentation and implementation

- Updated Echo Provider documentation with detailed response format and use cases.
- Refactored Echo Provider implementation for clarity and added comprehensive tests.