### PR TITLE
fix(evaluator): merge test case metadata with provider response metadata

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -237,7 +237,10 @@ export async function runEval({
       namedScores: {},
       latencyMs,
       cost: response.cost,
-      metadata: response.metadata,
+      metadata: {
+        ...test.metadata,
+        ...response.metadata,
+      },
       promptIdx,
       testIdx,
       testCase: test,


### PR DESCRIPTION
This PR ensures that metadata from test cases and provider responses are merged correctly.
- Added logic to combine metadata in the evaluator.
- Introduced a test case to validate the merging behavior.