### PR TITLE
chore(redteam): add fallback to harmful grader for specific ID patterns

### DIFF
--- a/src/redteam/graders.ts
+++ b/src/redteam/graders.ts
@@ -115,7 +115,7 @@ export const GRADERS: Record<RedteamAssertionTypes, RedteamGraderBase> = {
 
 export function getGraderById(id: string): RedteamGraderBase | undefined {
   // First try to get the exact grader
-  const grader = GRADERS[id as keyof typeof GRADERS];
+  const grader = id in GRADERS ? GRADERS[id] : undefined;
 
   // If not found but the ID starts with 'promptfoo:redteam:harmful', use the general harmful grader
   if (!grader && id.startsWith('promptfoo:redteam:harmful')) {

--- a/src/redteam/graders.ts
+++ b/src/redteam/graders.ts
@@ -114,5 +114,13 @@ export const GRADERS: Record<RedteamAssertionTypes, RedteamGraderBase> = {
 };
 
 export function getGraderById(id: string): RedteamGraderBase | undefined {
-  return GRADERS[id as keyof typeof GRADERS];
+  // First try to get the exact grader
+  const grader = GRADERS[id as keyof typeof GRADERS];
+
+  // If not found but the ID starts with 'promptfoo:redteam:harmful', use the general harmful grader
+  if (!grader && id.startsWith('promptfoo:redteam:harmful')) {
+    return GRADERS['promptfoo:redteam:harmful'];
+  }
+
+  return grader;
 }

--- a/src/redteam/graders.ts
+++ b/src/redteam/graders.ts
@@ -115,7 +115,7 @@ export const GRADERS: Record<RedteamAssertionTypes, RedteamGraderBase> = {
 
 export function getGraderById(id: string): RedteamGraderBase | undefined {
   // First try to get the exact grader
-  const grader = id in GRADERS ? GRADERS[id] : undefined;
+  const grader = id in GRADERS ? GRADERS[id as keyof typeof GRADERS] : undefined;
 
   // If not found but the ID starts with 'promptfoo:redteam:harmful', use the general harmful grader
   if (!grader && id.startsWith('promptfoo:redteam:harmful')) {

--- a/test/redteam/graders.test.ts
+++ b/test/redteam/graders.test.ts
@@ -15,6 +15,14 @@ describe('getGraderById', () => {
     expect(harmfulGrader).toBeInstanceOf(HarmfulGrader);
   });
 
+  it('should return harmful grader for IDs starting with promptfoo:redteam:harmful', () => {
+    const specificHarmfulGrader = getGraderById('promptfoo:redteam:harmful:specific-type');
+    expect(specificHarmfulGrader).toBeInstanceOf(HarmfulGrader);
+
+    const anotherHarmfulGrader = getGraderById('promptfoo:redteam:harmful-with-suffix');
+    expect(anotherHarmfulGrader).toBeInstanceOf(HarmfulGrader);
+  });
+
   it('should return undefined for invalid ID', () => {
     const invalidGrader = getGraderById('invalid-id');
     expect(invalidGrader).toBeUndefined();


### PR DESCRIPTION
This PR introduces a fallback mechanism in the `getGraderById` function to return the harmful grader for IDs starting with 'promptfoo:redteam:harmful'.
- Updated `getGraderById` to include the fallback logic.
- Added corresponding test cases to ensure correct functionality.