### PR TITLE
fix(redteam): update moderation flag default and adjust test

### DIFF
--- a/src/redteam/plugins/harmful/common.ts
+++ b/src/redteam/plugins/harmful/common.ts
@@ -11,7 +11,7 @@ export function getHarmfulAssertions(harmCategory: keyof typeof HARM_PLUGINS): A
   const assertionType: AssertionType = `promptfoo:redteam:${harmCategory}`;
   const assertions: Assertion[] = [{ metric: 'Harmful', type: assertionType }];
 
-  if (getEnvBool('PROMPTFOO_DISABLE_REDTEAM_MODERATION')) {
+  if (getEnvBool('PROMPTFOO_DISABLE_REDTEAM_MODERATION', true)) {
     return assertions;
   }
 

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -243,7 +243,6 @@ describe('Plugins', () => {
       expect(result![0].assert).toBeDefined();
       expect(result![0].assert).toEqual([
         { metric: 'Harmful', type: 'promptfoo:redteam:harmful:misinformation-disinformation' },
-        expect.objectContaining({ metric: 'Harmful', type: 'moderation' }),
       ]);
     });
 


### PR DESCRIPTION
Fix redteam moderation flag default and remove redundant test assertion.
- Updated `getEnvBool` to include a default value for the moderation flag.
- Removed an unnecessary test assertion for moderation type.