### PR TITLE
feat(providers): update default Anthropic providers to latest version

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -501,12 +501,12 @@ export class AnthropicCompletionProvider implements ApiProvider {
   }
 }
 
-export const DefaultGradingProvider = new AnthropicMessagesProvider('claude-3-5-sonnet-20240620');
+export const DefaultGradingProvider = new AnthropicMessagesProvider('claude-3-7-sonnet-20250219');
 export const DefaultGradingJsonProvider = new AnthropicMessagesProvider(
-  'claude-3-5-sonnet-20240620',
+  'claude-3-7-sonnet-20250219',
 );
 export const DefaultSuggestionsProvider = new AnthropicMessagesProvider(
-  'claude-3-5-sonnet-20240620',
+  'claude-3-7-sonnet-20250219',
 );
 
 export class AnthropicLlmRubricProvider extends AnthropicMessagesProvider {
@@ -571,5 +571,5 @@ export class AnthropicLlmRubricProvider extends AnthropicMessagesProvider {
   }
 }
 export const DefaultLlmRubricProvider = new AnthropicLlmRubricProvider(
-  'claude-3-5-sonnet-20240620',
+  'claude-3-7-sonnet-20250219',
 );


### PR DESCRIPTION
Update default Anthropic providers to use the latest version identifiers.

- Changed provider identifiers from 'claude-3-5-sonnet-20240620' to 'claude-3-7-sonnet-20250219'.
- Ensures compatibility with the updated Anthropic API.