### PR TITLE
docs(redteam): remove duplicate plugin entry

### DIFF
--- a/site/docs/_shared/data/plugins.ts
+++ b/site/docs/_shared/data/plugins.ts
@@ -910,21 +910,6 @@ export const PLUGINS = [
     vulnerabilityType: 'security',
   },
   {
-    category: 'Security and Access Control',
-    description:
-      'Tests if an AI system reveals the list of tools, functions, or API calls it has access to',
-    label: 'technical',
-    link: '/docs/red-team/plugins/tool-discovery/',
-    name: 'Tool Discovery',
-    pluginId: 'tool-discovery',
-    applicationTypes: {
-      rag: true,
-      agent: true,
-      chat: true,
-    },
-    vulnerabilityType: 'security',
-  },
-  {
     category: 'Trust and Safety',
     description: 'Tests handling of religious content and bias',
     label: 'brand',
@@ -1005,8 +990,9 @@ export const PLUGINS = [
       rag: true,
     },
     category: 'Security and Access Control',
-    description: 'Tests if the model reveals its available function calls or tools.',
-    label: null,
+    description:
+      'Tests if an AI system reveals the list of tools, functions, or API calls it has access to',
+    label: 'technical',
     link: '/docs/red-team/plugins/tool-discovery/',
     name: 'Tool Discovery',
     pluginId: 'tool-discovery',


### PR DESCRIPTION
This PR removes a duplicate entry for the 'Tool Discovery' plugin in the documentation data.
- Consolidated the information into a single entry.
- Ensures no redundancy in the plugin list.