### PR TITLE
fix(go-provider): resolve CallApi redeclaration issue

### DIFF
--- a/examples/golang-provider/evaluation/main.go
+++ b/examples/golang-provider/evaluation/main.go
@@ -38,6 +38,8 @@ func handlePrompt(prompt string, options map[string]interface{}, ctx map[string]
 	}, nil
 }
 
+var CallApi func(string, map[string]interface{}, map[string]interface{}) (map[string]interface{}, error)
+
 func init() {
 	// Assign our implementation to the wrapper's CallApi function.
 	// This makes it available to promptfoo for evaluation.

--- a/src/golang/adapter.go.template
+++ b/src/golang/adapter.go.template
@@ -1,9 +1,0 @@
-package main
-
-// This file is auto-generated to adapt the wrapper to different Go code structures.
-// It provides a declaration for CallApi if one doesn't already exist in the user's code.
-
-// CallApi is the provider's implementation 
-// IMPORTANT: This declaration is conditional and will be removed if the user's code already
-// declares CallApi to avoid redeclaration errors.
-var CallApi func(string, map[string]interface{}, map[string]interface{}) (map[string]interface{}, error) 

--- a/src/golang/adapter.go.template
+++ b/src/golang/adapter.go.template
@@ -1,0 +1,9 @@
+package main
+
+// This file is auto-generated to adapt the wrapper to different Go code structures.
+// It provides a declaration for CallApi if one doesn't already exist in the user's code.
+
+// CallApi is the provider's implementation 
+// IMPORTANT: This declaration is conditional and will be removed if the user's code already
+// declares CallApi to avoid redeclaration errors.
+var CallApi func(string, map[string]interface{}, map[string]interface{}) (map[string]interface{}, error) 

--- a/src/golang/wrapper.go
+++ b/src/golang/wrapper.go
@@ -10,14 +10,6 @@ import (
 // Function type definitions for the API functions
 type ApiFunc func(string, map[string]interface{}, map[string]interface{}) (map[string]interface{}, error)
 
-// Variable to hold the function implementation, allowing it to be replaced in tests
-var CallApi = defaultCallApi
-
-// Default implementation that will be replaced by the actual provider
-func defaultCallApi(prompt string, options map[string]interface{}, ctx map[string]interface{}) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("CallApi not implemented")
-}
-
 func main() {
 	if len(os.Args) != 4 {
 		fmt.Println("Usage: golang_wrapper <script_path> <function_name> <json_args>")
@@ -39,6 +31,7 @@ func main() {
 	f := reflect.ValueOf(nil)
 	switch functionName {
 	case "call_api", "CallApi":
+		// Use the CallApi function defined in the user's code
 		f = reflect.ValueOf(CallApi)
 	default:
 		fmt.Printf("Unknown function: %s\n", functionName)

--- a/src/golang/wrapper_test.go
+++ b/src/golang/wrapper_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 )
 
+// Declare CallApi variable for tests
+// This is needed because we've removed it from wrapper.go
+var CallApi func(string, map[string]interface{}, map[string]interface{}) (map[string]interface{}, error)
+
 var (
 	errEmptyOutput = errors.New("empty output")
 	errInvalidJSON = errors.New("invalid JSON")

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -180,5 +180,3 @@ export class GolangProvider implements ApiProvider {
     return this.executeGolangScript(prompt, undefined, 'call_classification_api');
   }
 }
-
-export { execAsync };

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -113,15 +113,7 @@ export class GolangProvider implements ApiProvider {
             if (entry.isDirectory()) {
               copyDir(srcPath, destPath);
             } else {
-              // Special handling for main.go to remove var CallApi declaration
-              if (entry.name === 'main.go') {
-                let content = fs.readFileSync(srcPath, 'utf-8');
-                // Remove the var CallApi declaration while preserving the file
-                content = content.replace(/\/\/\s*CallApi[\s\S]*?var\s+CallApi[\s\S]*?\n/s, '');
-                fs.writeFileSync(destPath, content);
-              } else {
-                fs.copyFileSync(srcPath, destPath);
-              }
+              fs.copyFileSync(srcPath, destPath);
             }
           }
         };
@@ -137,11 +129,31 @@ export class GolangProvider implements ApiProvider {
         fs.mkdirSync(scriptDir, { recursive: true });
         fs.copyFileSync(path.join(__dirname, '../golang/wrapper.go'), tempWrapperPath);
 
+        // Check if the user's script declares CallApi
+        const userScript = fs.readFileSync(path.join(tempDir, relativeScriptPath), 'utf-8');
+        const hasCallApiDeclaration =
+          userScript.includes('var CallApi') || userScript.includes('var CallApi func');
+
+        // Create an adapter.go file based on whether the user script has a CallApi declaration
+        const adapterTemplatePath = path.join(__dirname, '../golang/adapter.go.template');
+        const adapterContent = fs.readFileSync(adapterTemplatePath, 'utf-8');
+
+        // Only include the adapter if the user's code doesn't declare CallApi
+        const tempAdapterPath = path.join(scriptDir, 'adapter.go');
+        if (hasCallApiDeclaration) {
+          // Create an empty adapter to avoid compilation issues
+          fs.writeFileSync(tempAdapterPath, '// Auto-generated empty adapter\npackage main\n');
+          logger.debug(`User script declares CallApi, using empty adapter`);
+        } else {
+          fs.writeFileSync(tempAdapterPath, adapterContent);
+          logger.debug(`User script doesn't declare CallApi, using adapter to provide it`);
+        }
+
         const executablePath = path.join(tempDir, 'golang_wrapper');
         const tempScriptPath = path.join(tempDir, relativeScriptPath);
 
-        // Build from the script directory
-        const compileCommand = `cd ${scriptDir} && ${this.config.goExecutable || 'go'} build -o ${executablePath} wrapper.go ${path.basename(relativeScriptPath)}`;
+        // Build from the script directory, including the adapter
+        const compileCommand = `cd ${scriptDir} && ${this.config.goExecutable || 'go'} build -o ${executablePath} wrapper.go adapter.go ${path.basename(relativeScriptPath)}`;
         await execAsync(compileCommand);
 
         const jsonArgs = safeJsonStringify(args) || '[]';


### PR DESCRIPTION
This PR addresses the issue of CallApi redeclaration in the Go provider.

- Introduced an adapter.go template to conditionally declare CallApi.
- Updated wrapper.go and tests to align with the new approach.
- Adjusted the build process to include the adapter.