### PR TITLE
chore(scripts): specify repository for postversion PR creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "local:web": "npm run dev --prefix src/app",
     "local": "ts-node --cwdMode --transpileOnly src/main.ts",
     "preversion": "[ \"$(git rev-parse --abbrev-ref HEAD)\" = \"main\" ] || (echo \"Error: Must be on main branch to version\" && exit 1) && git pull origin main && git checkout -b \"chore/bump-version-$(date +%s)\"",
-    "postversion": "npm run citation:generate && git add CITATION.cff && git commit --amend --no-edit && gh pr create --title \"chore: bump version $npm_package_version\" --body \"\"",
+    "postversion": "npm run citation:generate && git add CITATION.cff && git commit --amend --no-edit && gh pr create --repo promptfoo/promptfoo --title \"chore: bump version $npm_package_version\" --body \"\"",
     "prepublishOnly": "npm run build:clean && npm run build",
     "test:app": "npm run test --prefix src/app",
     "test:integration": "jest --config jest.integration.config.ts integration",


### PR DESCRIPTION
Updated the postversion script to explicitly specify the repository for PR creation.
- Ensures the PR is created in the correct repository.