### PR TITLE
fix(Dockerfile): Create .promptfoo directory in Dockerfile and remove initContainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ ENV PROMPTFOO_SELF_HOSTED=1
 RUN chown -R promptfoo:promptfoo /app
 USER promptfoo
 
+RUN mkdir -p /home/promptfoo/.promptfoo
+
 EXPOSE 3000
 
 # Set up healthcheck

--- a/helm/chart/promptfoo/templates/deployment.yaml
+++ b/helm/chart/promptfoo/templates/deployment.yaml
@@ -30,14 +30,6 @@ spec:
       serviceAccountName: {{ include "promptfoo.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-      - name: take-data-dir-ownership
-        image: alpine:latest
-        command: [ "sh", "-c", "mkdir -p /home/promptfoo/.promptfoo && chmod -R 777 /home/promptfoo/.promptfoo" ]
-
-        volumeMounts:
-        - name: config
-          mountPath: /home/promptfoo/.promptfoo
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
The Dockerfile now creates the .promptfoo directory, which avoids permission issues. The initContainer in the Helm chart was removed as it is no longer needed.

It should fix issues that people are reporting with permissions problems and any need to create separate container just to fix permissions.

Fixes need for workaround stated here: https://github.com/promptfoo/promptfoo/issues/3251#issuecomment-2700423562

( Also named volume approach #1 doesnt work as expected )