### PR TITLE
fix(redteam): filter out template variables in entity extraction

### DIFF
--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -20,20 +20,34 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
 
   // Fallback to local extraction
   const prompt = dedent`
-    Extract names, brands, organizations, or IDs from the following prompts and return them as a list:
+    TASK: Extract only real-world entities from the following prompts.
+
+    ENTITIES TO EXTRACT:
+    - Person names (e.g., "John Smith", "Barack Obama")
+    - Brand names (e.g., "Google", "Apple")
+    - Organization names (e.g., "United Nations", "Stanford University")
+    - Location names (e.g., "New York", "Mount Everest")
+    - Specific identifiers (e.g., "ID-12345", "License-ABC")
+
+    DO NOT EXTRACT:
+    - Template variables in double curly braces like {{image}}, {{prompt}}, {{question}}
+    - Prompt template roles like "system", "user", "assistant", "developer"
+    - Generic terms that aren't specific named entities
+
+    PROMPTS TO ANALYZE:
 
     ${formatPrompts(prompts)}
-
-    DO NOT include prompt template roles such as "system", "developer", "user", "assistant", or other conversation roles as entities.
     
-    Each line in your response must begin with the string "Entity:".
+    FORMAT: Begin each entity with "Entity:" on a new line.
   `;
   try {
     const entities = await callExtraction(provider, prompt, (output: string) => {
       const entities = output
         .split('\n')
         .filter((line) => line.trim().startsWith('Entity:'))
-        .map((line) => line.substring(line.indexOf('Entity:') + 'Entity:'.length).trim());
+        .map((line) => line.substring(line.indexOf('Entity:') + 'Entity:'.length).trim())
+        // Filter out Nunjucks template variables (any text wrapped in double curly braces)
+        .filter((entity) => !/^\{\{\s*[^{}]+\s*\}\}$/.test(entity));
 
       if (entities.length === 0) {
         logger.debug('No entities were extracted from the prompts.');

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -106,4 +106,73 @@ describe('Entities Extractor', () => {
 
     expect(result).toEqual([]);
   });
+
+  it('should ignore Nunjucks template variables in double curly braces', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    jest.mocked(provider.callApi).mockResolvedValue({
+      output: 'Entity: John Smith\nEntity: {{image}}\nEntity: Google\nEntity: {{prompt}}',
+    });
+
+    const result = await extractEntities(provider, [
+      'Analyze this image {{image}} for John Smith from Google using {{prompt}}',
+    ]);
+
+    // After our implementation fix, template variables should be filtered out
+    expect(result).toEqual(['John Smith', 'Google']);
+  });
+
+  it('should properly extract real entities while ignoring template variables', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+
+    // Currently our extraction simply returns whatever the AI returns as entities
+    // We need to fix this to properly filter template variables
+
+    jest.mocked(provider.callApi).mockResolvedValue({
+      output: 'Entity: Microsoft\nEntity: Bill Gates\nEntity: Seattle',
+    });
+
+    const result = await extractEntities(provider, [
+      'Provide information about Microsoft, founded by Bill Gates in Seattle',
+      'Use {{image}} to analyze the logo of {{company}}',
+    ]);
+
+    expect(result).toEqual(['Microsoft', 'Bill Gates', 'Seattle']);
+    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('Microsoft'));
+  });
+
+  it('should handle complex Nunjucks variables with spaces and special characters', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    jest.mocked(provider.callApi).mockResolvedValue({
+      output:
+        'Entity: Microsoft\nEntity: {{ complex_variable with spaces }}\nEntity: {{nested.variable}}',
+    });
+
+    const result = await extractEntities(provider, [
+      'Company {{company_name}} founded in {{year}} by {{founder}}',
+      'Microsoft was established in {{ complex_variable with spaces }} using {{nested.variable}}',
+    ]);
+
+    expect(result).toEqual(['Microsoft']);
+  });
+
+  it('should handle empty prompts array', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+
+    const result = await extractEntities(provider, []);
+
+    expect(result).toEqual(['Apple', 'Google']); // Default mock response
+    expect(provider.callApi).toHaveBeenCalledWith(expect.stringContaining('PROMPTS TO ANALYZE'));
+  });
+
+  it('should handle errors in local extraction', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    jest.mocked(provider.callApi).mockRejectedValue(new Error('API call failed'));
+
+    const result = await extractEntities(provider, ['prompt']);
+
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Error using local extraction'),
+    );
+  });
 });


### PR DESCRIPTION
Fixes the entity extraction logic to exclude template variables wrapped in double curly braces.\n\n- Updated the extraction logic to filter out Nunjucks template variables.\n- Added comprehensive test cases to validate the new behavior.