### PR TITLE
chore(providers): Add support and docs for gemini 2.5 pro to Google Chat Provider

### DIFF
--- a/examples/google-aistudio-gemini/README.md
+++ b/examples/google-aistudio-gemini/README.md
@@ -11,6 +11,7 @@ This example demonstrates using Google's Gemini models with promptfoo to evaluat
 
 The example tests across multiple Gemini models:
 
+- Gemini 2.5 Pro Experimental
 - Gemini 2.0 Flash
 - Gemini 2.0 Flash Thinking
 - Gemini 1.5 Flash

--- a/examples/google-aistudio-gemini/promptfooconfig.yaml
+++ b/examples/google-aistudio-gemini/promptfooconfig.yaml
@@ -9,7 +9,7 @@ providers:
   - google:gemini-2.0-flash-exp
   - google:gemini-2.0-flash-thinking-exp
 
-  - id: google:gemini-1.5-flash
+  - id: google:gemini-2.5-pro-exp-03-25
     config:
       temperature: 0.7
       maxOutputTokens: 512

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -7,7 +7,7 @@ You can use it by specifying one of the [available models](https://ai.google.dev
 ## Available Models
 
 - `google:gemini-2.5-pro-exp-03-25` - Latest thinking model, designed to tackle increasingly complex problems with enhanced reasoning capabilities.
-- `google:gemini-2.0-flash-exp` - Latest multimodal model with next generation features
+- `google:gemini-2.0-flash-exp` - Multimodal model with next generation features
 - `google:gemini-2.0-flash-thinking-exp` - Optimized for complex reasoning and problem-solving
 - `google:gemini-1.5-flash-8b` - Fast and cost-efficient multimodal model
 - `google:gemini-1.5-pro` - Best performing multimodal model for complex reasoning

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -6,6 +6,7 @@ You can use it by specifying one of the [available models](https://ai.google.dev
 
 ## Available Models
 
+- `google:gemini-2.5-pro-exp-03-25` - Latest thinking model, designed to tackle increasingly complex problems with enhanced reasoning capabilities.
 - `google:gemini-2.0-flash-exp` - Latest multimodal model with next generation features
 - `google:gemini-2.0-flash-thinking-exp` - Optimized for complex reasoning and problem-solving
 - `google:gemini-1.5-flash-8b` - Fast and cost-efficient multimodal model

--- a/src/providers/googleShared.ts
+++ b/src/providers/googleShared.ts
@@ -36,6 +36,7 @@ export const CHAT_MODELS = [
   'gemini-1.5-pro-preview-0409',
   'gemini-1.5-pro-preview-0514',
   'gemini-1.5-pro-exp-0827',
+  'gemini-2.5-pro-exp-03-25',
   'gemini-pro',
   'gemini-pro-vision',
   'gemini-ultra',


### PR DESCRIPTION
Added support for gemini 2.5 Pro. Seems to work out of the box, so we just added a google.md entry and added gemini-2.5 to our `google-aistudio-gemini` example. It's not yet supported on Vertex yet, so that was omitted. 

```
$ promptfoo eval -c examples/google-aistudio-gemini
Running 1 concurrent evaluations with up to 4 threads...
[████████████████████████████████████████] 100% | ETA: 0s | 1/1 | google:gemini-2.5-pro-exp-03-25 "Given this" puzzle=If 

┌────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────┐
│ puzzle                                                         │ [google:gemini-2.5-pro-exp-03-25] Given this math puzzle:      │
│                                                                │ {{puzzle}}                                                     │
│                                                                │ Provide a short, clear answer with minimal explanation.        │
├────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
│ If a train travels at 60 mph for 2.5 hours, then at 40 mph for │ [PASS] The average speed for the entire journey is 52.5 mph.   │
│ 1.5 hours, what is the average speed for the entire journey?   │                                                                │
└────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────┘
================================================================================================================================

```