### PR TITLE
fix(redteam): Type of ALL_STRATEGIES to be as const

### DIFF
--- a/src/app/src/pages/redteam/setup/components/strategies/utils.ts
+++ b/src/app/src/pages/redteam/setup/components/strategies/utils.ts
@@ -26,6 +26,9 @@ export const STRATEGY_PROBE_MULTIPLIER: Record<Strategy, number> = {
   'best-of-n': 1,
   pandamonium: 5,
   hex: 1,
+  audio: 1,
+  image: 1,
+  retry: 1,
 };
 
 export function getEstimatedProbes(config: Config) {

--- a/src/app/src/pages/redteam/setup/components/strategies/utils.ts
+++ b/src/app/src/pages/redteam/setup/components/strategies/utils.ts
@@ -7,28 +7,28 @@ export function getStrategyId(strategy: RedteamStrategy): string {
 }
 
 export const STRATEGY_PROBE_MULTIPLIER: Record<Strategy, number> = {
-  default: 1,
-  basic: 1,
-  jailbreak: 10,
-  'jailbreak:composite': 5,
-  'prompt-injection': 1,
+  audio: 1,
   base64: 1,
+  basic: 1,
+  'best-of-n': 1,
   citation: 1,
   crescendo: 10,
+  default: 1,
   gcg: 1,
   goat: 5,
-  'jailbreak:tree': 150,
+  hex: 1,
+  image: 1,
+  jailbreak: 10,
+  'jailbreak:composite': 5,
   'jailbreak:likert': 1,
+  'jailbreak:tree': 150,
   leetspeak: 1,
   'math-prompt': 1,
   multilingual: 3, // This won't matter, we multiply all probes by number of languages
-  rot13: 1,
-  'best-of-n': 1,
   pandamonium: 5,
-  hex: 1,
-  audio: 1,
-  image: 1,
+  'prompt-injection': 1,
   retry: 1,
+  rot13: 1,
 };
 
 export function getEstimatedProbes(config: Config) {

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -582,9 +582,8 @@ export const ADDITIONAL_STRATEGIES = [
 ] as const;
 export type AdditionalStrategy = (typeof ADDITIONAL_STRATEGIES)[number];
 
-export const ALL_STRATEGIES = [
-  ...['default', ...DEFAULT_STRATEGIES, ...ADDITIONAL_STRATEGIES].sort(),
-] as const;
+const _ALL_STRATEGIES = ['default', ...DEFAULT_STRATEGIES, ...ADDITIONAL_STRATEGIES] as const;
+export const ALL_STRATEGIES = [..._ALL_STRATEGIES].sort();
 export type Strategy = (typeof ALL_STRATEGIES)[number];
 
 export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
@@ -677,6 +676,8 @@ export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
   'system-prompt-override': 'Tests for system prompt override vulnerabilities',
   'reasoning-dos':
     'Tests for vulnerabilities to computational resource exhaustion through excessive reasoning patterns',
+  audio: 'Tests handling of audio content',
+  image: 'Tests handling of image content',
 };
 
 // These names are displayed in risk cards and in the table
@@ -766,6 +767,8 @@ export const displayNameOverrides: Record<Plugin | Strategy, string> = {
   ssrf: 'SSRF Vulnerability',
   'system-prompt-override': 'System Prompt Override',
   'reasoning-dos': 'Reasoning DoS',
+  audio: 'Audio Content',
+  image: 'Image Content',
 };
 
 export enum Severity {


### PR DESCRIPTION
Previously calling `.sort()` removed the type safety of having all the keys being static. This should address that, and also adds some missing strategies in places.