### PR TITLE
fix(env): add override option to dotenv.config for --env-file support

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -328,7 +328,7 @@ export function printBorder() {
 export function setupEnv(envPath: string | undefined) {
   if (envPath) {
     logger.info(`Loading environment variables from ${envPath}`);
-    dotenv.config({ path: envPath });
+    dotenv.config({ path: envPath, override: true });
   } else {
     dotenv.config();
   }


### PR DESCRIPTION
Fixes regression in --env-file option that caused environment variables to be reset to default .env values when both .env and custom env file were present. Modified setupEnv function to use override=true when loading from a specified env file path and added comprehensive test coverage to prevent future regressions. Fixes #3501