### PR TITLE
chore: add support for `apiKeyRequired` in openai provider

### DIFF
--- a/site/docs/providers/litellm.md
+++ b/site/docs/providers/litellm.md
@@ -11,6 +11,7 @@ providers:
   - id: openai:chat:<model name>
     config:
       apiBaseUrl: http://0.0.0.0:4000/
+      apiKeyRequired: false
 ```
 
 For example, to use gpt-4o:
@@ -21,6 +22,7 @@ For example, to use gpt-4o:
   // highlight-end
     config:
       apiBaseUrl: http://0.0.0.0:4000/
+      apiKeyRequired: false
 ```
 
 Or to use Anthropic's Claude (remember, we're not actually using the OpenAI API, we're using LiteLLM which supports the OpenAI format):
@@ -31,6 +33,7 @@ Or to use Anthropic's Claude (remember, we're not actually using the OpenAI API,
   // highlight-end
     config:
       apiBaseUrl: http://0.0.0.0:4000/
+      apiKeyRequired: false
 ```
 
 Alternatively, you can use the `OPENAI_BASE_URL` environment variable instead of the `apiBaseUrl` config property:

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -131,7 +131,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     context?: CallApiContextParams,
     callApiOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    if (!this.getApiKey()) {
+    if (this.requiresApiKey() && !this.getApiKey()) {
       throw new Error(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -35,7 +35,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
     context?: CallApiContextParams,
     callApiOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    if (!this.getApiKey()) {
+    if (this.requiresApiKey() && !this.getApiKey()) {
       throw new Error(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );
@@ -75,7 +75,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.getApiKey()}`,
+            ...(this.getApiKey() ? { Authorization: `Bearer ${this.getApiKey()}` } : {}),
             ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
             ...this.config.headers,
           },

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -223,7 +223,7 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
     context?: CallApiContextParams,
     callApiOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    if (!this.getApiKey()) {
+    if (this.requiresApiKey() && !this.getApiKey()) {
       throw new Error(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );
@@ -258,7 +258,7 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
 
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${this.getApiKey()}`,
+      ...(this.getApiKey() ? { Authorization: `Bearer ${this.getApiKey()}` } : {}),
       ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
       ...config.headers,
     };

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -75,6 +75,10 @@ export class OpenAiGenericProvider implements ApiProvider {
     );
   }
 
+  requiresApiKey(): boolean {
+    return this.config.apiKeyRequired ?? true;
+  }
+
   // @ts-ignore: Params are not used in this implementation
   async callApi(
     prompt: string,

--- a/src/providers/openai/moderation.ts
+++ b/src/providers/openai/moderation.ts
@@ -182,7 +182,7 @@ export class OpenAiModerationProvider
     assistantResponse: string | (TextInput | ImageInput)[],
   ): Promise<ProviderModerationResponse> {
     const apiKey = this.getApiKey();
-    if (!apiKey) {
+    if (this.requiresApiKey() && !apiKey) {
       return handleApiError(
         'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
       );
@@ -213,7 +213,7 @@ export class OpenAiModerationProvider
 
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
       ...(this.getOrganization() ? { 'OpenAI-Organization': this.getOrganization() } : {}),
       ...this.config.headers,
     };

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -4,6 +4,7 @@ import { type OpenAiFunction, type OpenAiTool } from './util';
 export interface OpenAiSharedOptions {
   apiKey?: string;
   apiKeyEnvar?: string;
+  apiKeyRequired?: boolean;
   apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;

--- a/test/providers/openai/index.test.ts
+++ b/test/providers/openai/index.test.ts
@@ -9,6 +9,10 @@ describe('OpenAI Provider', () => {
       },
     });
 
+    beforeEach(() => {
+      process.env = {};
+    });
+
     it('should generate correct API URL', () => {
       expect(provider.getApiUrl()).toBe('https://api.openai.com/v1');
     });
@@ -20,12 +24,69 @@ describe('OpenAI Provider', () => {
       expect(customProvider.getApiUrl()).toBe('https://custom.openai.com/v1');
     });
 
+    it('should use custom API base URL', () => {
+      const customProvider = new OpenAiGenericProvider('test-model', {
+        config: { apiBaseUrl: 'https://custom.api.com/openai' },
+      });
+      expect(customProvider.getApiUrl()).toBe('https://custom.api.com/openai');
+    });
+
     it('should get organization', () => {
       expect(provider.getOrganization()).toBe('test-org');
     });
 
+    it('should get organization from env', () => {
+      process.env.OPENAI_ORGANIZATION = 'env-org';
+      const envProvider = new OpenAiGenericProvider('test-model');
+      expect(envProvider.getOrganization()).toBe('env-org');
+    });
+
     it('should get API key', () => {
       expect(provider.getApiKey()).toBe('test-key');
+    });
+
+    it('should get API key from env', () => {
+      process.env.OPENAI_API_KEY = 'env-key';
+      const envProvider = new OpenAiGenericProvider('test-model');
+      expect(envProvider.getApiKey()).toBe('env-key');
+    });
+
+    it('should get API key from custom env var', () => {
+      process.env.CUSTOM_API_KEY = 'custom-key';
+      const customProvider = new OpenAiGenericProvider('test-model', {
+        config: { apiKeyEnvar: 'CUSTOM_API_KEY' },
+      });
+      expect(customProvider.getApiKey()).toBe('custom-key');
+    });
+
+    it('should generate correct ID', () => {
+      expect(provider.id()).toBe('openai:test-model');
+    });
+
+    it('should generate custom ID with API host', () => {
+      const customProvider = new OpenAiGenericProvider('test-model', {
+        config: { apiHost: 'custom.openai.com' },
+      });
+      expect(customProvider.id()).toBe('test-model');
+    });
+
+    it('should have correct string representation', () => {
+      expect(provider.toString()).toBe('[OpenAI Provider test-model]');
+    });
+
+    it('should require API key by default', () => {
+      expect(provider.requiresApiKey()).toBe(true);
+    });
+
+    it('should allow disabling API key requirement', () => {
+      const customProvider = new OpenAiGenericProvider('test-model', {
+        config: { apiKeyRequired: false },
+      });
+      expect(customProvider.requiresApiKey()).toBe(false);
+    });
+
+    it('should throw not implemented for callApi', async () => {
+      await expect(provider.callApi('test prompt')).rejects.toThrow('Not implemented');
     });
   });
 });


### PR DESCRIPTION
purposely doesn't add it to all openai apis - realtime, responses seem like they won't be shared