### PR TITLE
Log all reasons in geval in case of multiply assert values

### DIFF
--- a/src/assertions/geval.ts
+++ b/src/assertions/geval.ts
@@ -18,15 +18,12 @@ export const handleGEval = async ({
 
   if (Array.isArray(renderedValue)) {
     const scores: number[] = [];
-    const failedReasons: string[] = [];
+    const reasons: string[] = [];
     for (const value of renderedValue) {
       const resp = await matchesGEval(value, prompt || '', outputString, threshold, test.options);
 
       scores.push(resp.score);
-
-      if (resp.score < threshold) {
-        failedReasons.push(resp.reason);
-      }
+      reasons.push(resp.reason);
     }
 
     const scoresSum = scores.reduce((a, b) => a + b, 0);
@@ -35,7 +32,7 @@ export const handleGEval = async ({
       assertion,
       pass: scoresSum / scores.length >= threshold,
       score: scoresSum / scores.length,
-      reason: failedReasons.join('\n'),
+      reason: reasons.join('\n\n'),
     };
   } else {
     const resp = await matchesGEval(


### PR DESCRIPTION
It fixes the issue, that if you have a test case with array of values in `g-eval` assertion, and the test is passed, then in web-server test history you don't see reasons and can't understand, why llm decided, that test is passed. It fixes this problem

<img width="1157" alt="Screenshot 2025-03-28 at 11 58 31" src="https://github.com/user-attachments/assets/0f2fdaf2-ee79-45a5-9d46-8a8ca8e87b7a" />
