### PR TITLE
chore: fix type of Prompt to use omit

### DIFF
--- a/src/app/src/pages/prompts/PromptDialog.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.tsx
@@ -20,12 +20,12 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
-import type { PromptWithMetadata } from '@promptfoo/types';
+import type { ServerPromptWithMetadata } from '@promptfoo/types';
 
 interface PromptDialogProps {
   openDialog: boolean;
   handleClose: () => void;
-  selectedPrompt: PromptWithMetadata & { recentEvalDate: string };
+  selectedPrompt: ServerPromptWithMetadata;
   showDatasetColumn?: boolean;
 }
 

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -15,7 +15,7 @@ import TableSortLabel from '@mui/material/TableSortLabel';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
-import type { PromptWithMetadata } from '@promptfoo/types';
+import type { ServerPromptWithMetadata } from '@promptfoo/types';
 import PromptDialog from './PromptDialog';
 
 const ROWS_PER_PAGE = 10;
@@ -28,7 +28,7 @@ interface SortState {
 }
 
 interface PromptsProps {
-  data: (PromptWithMetadata & { recentEvalDate: string })[];
+  data: ServerPromptWithMetadata[];
   isLoading: boolean;
   error: string | null;
   showDatasetColumn?: boolean;

--- a/src/app/src/pages/prompts/page.tsx
+++ b/src/app/src/pages/prompts/page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { callApi } from '@app/utils/api';
-import type { PromptWithMetadata } from '@promptfoo/types';
+import type { ServerPromptWithMetadata } from '@promptfoo/types';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import Prompts from './Prompts';
 
@@ -9,7 +9,7 @@ interface PromptsPageProps {
 }
 
 function PromptsPageContent({ showDatasetColumn = true }: PromptsPageProps) {
-  const [prompts, setPrompts] = useState<(PromptWithMetadata & { recentEvalDate: string })[]>([]);
+  const [prompts, setPrompts] = useState<ServerPromptWithMetadata[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -223,6 +223,11 @@ export interface PromptWithMetadata {
   count: number;
 }
 
+// The server returns ISO formatted strings for dates, so we need to adjust the type here
+export type ServerPromptWithMetadata = Omit<PromptWithMetadata, 'recentEvalDate'> & {
+  recentEvalDate: string;
+};
+
 export enum ResultFailureReason {
   // The test passed, or we don't know exactly why the test case failed.
   NONE = 0,


### PR DESCRIPTION
I think the intent of this type was to override the `recentEvalDate` to be a string, but this doesn't work unless the key is omitted from `PromptWithMetadata`. 