### PR TITLE
fix: Support for jsonl test cases

### DIFF
--- a/examples/jsonl-test-cases/README.md
+++ b/examples/jsonl-test-cases/README.md
@@ -1,0 +1,17 @@
+# JSON Lines (JSONL) Test Cases Example
+
+This example demonstrates how to define test cases using the JSON Lines text file format.
+
+## Usage
+
+1. Initialize this example by running:
+
+```sh
+npx promptfoo@latest init --example jsonl-test-cases
+```
+
+2. Run the evaluation with:
+
+```sh
+npx promptfoo@latest eval -c jsonl-test-cases/promptfooconfig.yaml
+```

--- a/examples/jsonl-test-cases/cases.jsonl
+++ b/examples/jsonl-test-cases/cases.jsonl
@@ -1,0 +1,2 @@
+{"vars": {"target_language": "French", "text": "Hello, world!" }, "assert": [{"type": "equals", "value": "Translate the following text to French: Hello, world!"}]}
+{"vars": {"target_language": "Spanish", "text": "Hello, world!" }, "assert": [{"type": "equals", "value": "Translate the following text to Spanish: Hello, world!"}]}

--- a/examples/jsonl-test-cases/promptfooconfig.yaml
+++ b/examples/jsonl-test-cases/promptfooconfig.yaml
@@ -1,0 +1,8 @@
+prompts:
+  - 'Translate the following text to {{target_language}}: {{text}}'
+
+providers:
+  # Just repeats the markdown back to us
+  - echo
+
+tests: file://cases.jsonl

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -172,12 +172,33 @@ export async function readStandaloneTestsFile(
       feature: 'json tests file',
     });
     rows = yaml.load(fs.readFileSync(resolvedVarsPath, 'utf-8')) as unknown as any;
+  }
+  // Handle .jsonl files
+  else if (fileExtension === 'jsonl') {
+    telemetry.recordAndSendOnce('feature_used', {
+      feature: 'jsonl tests file',
+    });
+
+    const fileContent = fs.readFileSync(resolvedVarsPath, 'utf-8');
+
+    return fileContent
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line, idx) => {
+        const row = JSON.parse(line);
+        return {
+          ...row,
+          options: row.options ?? {},
+          description: `Row #${idx + 1}`,
+        };
+      });
   } else if (fileExtension === 'yaml' || fileExtension === 'yml') {
     telemetry.recordAndSendOnce('feature_used', {
       feature: 'yaml tests file',
     });
     rows = yaml.load(fs.readFileSync(resolvedVarsPath, 'utf-8')) as unknown as any;
   }
+
   return rows.map((row, idx) => {
     const test = testCaseFromCsvRow(row);
     test.description ||= `Row #${idx + 1}`;

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -130,6 +130,30 @@ describe('readStandaloneTestsFile', () => {
     ]);
   });
 
+  it('should read JSONL file and return test cases', async () => {
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      `{"vars":{"var1":"value1","var2":"value2"},"assert":[{"type":"equals","value":"Hello World"}]}
+        {"vars":{"var1":"value3","var2":"value4"},"assert":[{"type":"equals","value":"Hello World"}]}`,
+    );
+    const result = await readStandaloneTestsFile('test.jsonl');
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringContaining('test.jsonl'), 'utf-8');
+    expect(result).toEqual([
+      {
+        assert: [{ type: 'equals', value: 'Hello World' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ type: 'equals', value: 'Hello World' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
+  });
+
   it('should read YAML file and return test cases', async () => {
     jest.mocked(fs.readFileSync).mockReturnValue(dedent`
       - var1: value1


### PR DESCRIPTION
`tests: file://tests.jsonl` is currently unsupported although the [docs](https://www.promptfoo.dev/docs/configuration/parameters/#import-from-jsonjsonl) indicate it should. 