### PR TITLE
docs: add link to api reference

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -175,7 +175,11 @@ const config = {
                 label: 'Docs',
               },
               {
-                href: 'https://www.promptfoo.dev/models/',
+                to: 'https://www.promptfoo.dev/docs/api-reference/',
+                label: 'API Reference',
+              },
+              {
+                to: 'https://www.promptfoo.dev/models/',
                 label: 'Foundation Model Reports',
               },
               {


### PR DESCRIPTION
`to` instead of `href` disables the external link svg icon apparently