### PR TITLE
docs(providers): add Llama 4 model details

### DIFF
--- a/site/docs/providers/openrouter.md
+++ b/site/docs/providers/openrouter.md
@@ -68,7 +68,8 @@ For a complete list of 300+ models and detailed pricing, visit [OpenRouter Model
 
 ## Basic Configuration
 
-```yaml
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: openrouter:meta-llama/llama-4-scout:free
     config:

--- a/site/docs/providers/openrouter.md
+++ b/site/docs/providers/openrouter.md
@@ -23,7 +23,9 @@ Latest releases:
 | [cohere/command-r-08-2024](https://openrouter.ai/cohere/command-r-08-2024)                                 | 128,000              |
 | [deepseek/deepseek-r1](https://openrouter.ai/deepseek/deepseek-r1)                                         | 64,000               |
 | [deepseek/deepseek-r1-distill-llama-70b](https://openrouter.ai/deepseek/deepseek-r1-distill-llama-70b)     | 131,072              |
+| [deepseek/deepseek-v3-base:free](https://openrouter.ai/deepseek/deepseek-v3-base)                          | 131,072              |
 | [google/gemini-2.0-flash-exp:free](https://openrouter.ai/google/gemini-2.0-flash-exp:free)                 | 1,048,576            |
+| [google/gemini-2.5-pro-preview](https://openrouter.ai/google/gemini-2.5-pro-preview)                       | 1,000,000            |
 | [google/gemini-flash-1.5](https://openrouter.ai/google/gemini-flash-1.5)                                   | 1,000,000            |
 | [google/gemini-flash-1.5-8b](https://openrouter.ai/google/gemini-flash-1.5-8b)                             | 1,000,000            |
 | [google/gemini-pro-1.5](https://openrouter.ai/google/gemini-pro-1.5)                                       | 2,000,000            |
@@ -37,14 +39,21 @@ Latest releases:
 | [meta-llama/llama-3.2-3b-instruct](https://openrouter.ai/meta-llama/llama-3.2-3b-instruct)                 | 131,000              |
 | [meta-llama/llama-3.2-11b-vision-instruct](https://openrouter.ai/meta-llama/llama-3.2-11b-vision-instruct) | 131,072              |
 | [meta-llama/llama-3.3-70b-instruct](https://openrouter.ai/meta-llama/llama-3.3-70b-instruct)               | 131,072              |
+| [meta-llama/llama-4-scout:free](https://openrouter.ai/meta-llama/llama-4-scout)                            | 512,000              |
+| [meta-llama/llama-4-scout](https://openrouter.ai/meta-llama/llama-4-scout)                                 | 131,072              |
+| [meta-llama/llama-4-maverick:free](https://openrouter.ai/meta-llama/llama-4-maverick)                      | 256,000              |
+| [meta-llama/llama-4-maverick](https://openrouter.ai/meta-llama/llama-4-maverick)                           | 131,072              |
 | [microsoft/phi-4](https://openrouter.ai/microsoft/phi-4)                                                   | 16,384               |
 | [microsoft/wizardlm-2-8x22b](https://openrouter.ai/microsoft/wizardlm-2-8x22b)                             | 65,536               |
 | [mistralai/codestral-2501](https://openrouter.ai/mistralai/codestral-2501)                                 | 256,000              |
 | [mistralai/mistral-8b](https://openrouter.ai/mistralai/mistral-8b)                                         | 128,000              |
 | [mistralai/mistral-nemo](https://openrouter.ai/mistralai/mistral-nemo)                                     | 131,072              |
+| [mistralai/ministral-8b](https://openrouter.ai/mistralai/ministral-8b)                                     | 131,072              |
 | [neversleep/llama-3-lumimaid-8b:extended](https://openrouter.ai/neversleep/llama-3-lumimaid-8b:extended)   | 24,576               |
 | [openai/gpt-4o-mini](https://openrouter.ai/openai/gpt-4o-mini)                                             | 128,000              |
 | [openai/gpt-4o-mini-2024-07-18](https://openrouter.ai/openai/gpt-4o-mini-2024-07-18)                       | 128,000              |
+| [openhands/openhands-lm-32b-v0.1](https://openrouter.ai/openhands/openhands-lm-32b-v0.1)                   | 16,384               |
+| [openrouter/quasar-alpha](https://openrouter.ai/openrouter/quasar-alpha)                                   | 1,000,000            |
 | [eva-unit-01/eva-qwen-2.5-72b](https://openrouter.ai/eva-unit-01/eva-qwen-2.5-72b)                         | 16,384               |
 | [eva-unit-01/eva-qwen-2.5-32b](https://openrouter.ai/eva-unit-01/eva-qwen-2.5-32b)                         | 16,384               |
 | [qwen/qwen-2.5-coder-32b-instruct](https://openrouter.ai/qwen/qwen-2.5-coder-32b-instruct)                 | 33,000               |
@@ -52,6 +61,8 @@ Latest releases:
 | [qwen/qwen-2.5-72b-instruct](https://openrouter.ai/qwen/qwen-2.5-72b-instruct)                             | 32,768               |
 | [qwen/qwq-32b-preview](https://openrouter.ai/qwen/qwq-32b-preview)                                         | 32,768               |
 | [qwen/qvq-72b-preview](https://openrouter.ai/qwen/qvq-72b-preview)                                         | 128,000              |
+| [scb10x/typhoon2-8b-instruct](https://openrouter.ai/scb10x/typhoon2-8b-instruct)                           | 8,192                |
+| [scb10x/typhoon2-70b-instruct](https://openrouter.ai/scb10x/typhoon2-70b-instruct)                         | 8,192                |
 
 For a complete list of 300+ models and detailed pricing, visit [OpenRouter Models](https://openrouter.ai/models).
 
@@ -59,15 +70,20 @@ For a complete list of 300+ models and detailed pricing, visit [OpenRouter Model
 
 ```yaml
 providers:
-  - id: openrouter:google/gemini-flash-1.5-8b
+  - id: openrouter:meta-llama/llama-4-scout:free
     config:
       temperature: 0.7
       max_tokens: 1000
 
-  - id: openrouter:meta-llama/llama-3.3-70b
+  - id: openrouter:meta-llama/llama-4-maverick:free
     config:
       temperature: 0.5
       max_tokens: 2000
+
+  - id: openrouter:google/gemini-2.5-pro-preview
+    config:
+      temperature: 0.7
+      max_tokens: 4000
 ```
 
 ## Features

--- a/site/docs/providers/togetherai.md
+++ b/site/docs/providers/togetherai.md
@@ -10,7 +10,8 @@ Together AI's API is compatible with OpenAI's API, which means all parameters av
 
 Configure a Together AI model in your promptfoo configuration:
 
-```yaml
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: togetherai:meta-llama/Llama-3.3-70B-Instruct-Turbo
     config:
@@ -18,19 +19,6 @@ providers:
 ```
 
 The provider requires an API key stored in the `TOGETHER_API_KEY` environment variable.
-
-## Model Types
-
-Together AI offers several types of models:
-
-```yaml
-# Chat model (default)
-- id: togetherai:meta-llama/Llama-3.3-70B-Instruct-Turbo
-
-# Other model types
-- id: togetherai:completion:meta-llama/Llama-2-70b-hf
-- id: togetherai:embedding:togethercomputer/m2-bert-80M-8k-retrieval
-```
 
 ## Key Features
 
@@ -67,35 +55,46 @@ config:
 
 ## Popular Models
 
-Together AI offers over 200 models. Here are some popular options by category:
+Together AI offers over 200 models. Here are some of the most popular models by category:
 
-### Chat Models
+### Llama 4 Models
 
-- **Llama 3**:
-  - `meta-llama/Llama-3.3-70B-Instruct-Turbo`
-  - `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo`
-  - `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`
-- **Reasoning**:
-  - `deepseek-ai/DeepSeek-R1`
-  - `deepseek-ai/DeepSeek-V3`
-- **Mixture of Experts**:
-  - `mistralai/Mixtral-8x7B-Instruct-v0.1`
-  - `mistralai/Mixtral-8x22B-Instruct-v0.1`
-- **Qwen**:
-  - `Qwen/Qwen2.5-7B-Instruct-Turbo`
-  - `Qwen/Qwen2.5-72B-Instruct`
+- **Llama 4 Maverick**: `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` (524,288 context length, FP8)
+- **Llama 4 Scout**: `meta-llama/Llama-4-Scout-17B-16E-Instruct` (327,680 context length, FP16)
+
+### DeepSeek Models
+
+- **DeepSeek R1**: `deepseek-ai/DeepSeek-R1` (128,000 context length, FP8)
+- **DeepSeek R1 Distill Llama 70B**: `deepseek-ai/DeepSeek-R1-Distill-Llama-70B` (131,072 context length, FP16)
+- **DeepSeek R1 Distill Qwen 14B**: `deepseek-ai/DeepSeek-R1-Distill-Qwen-14B` (131,072 context length, FP16)
+- **DeepSeek V3**: `deepseek-ai/DeepSeek-V3` (16,384 context length, FP8)
+
+### Llama 3 Models
+
+- **Llama 3.3 70B Instruct Turbo**: `meta-llama/Llama-3.3-70B-Instruct-Turbo` (131,072 context length, FP8)
+- **Llama 3.1 70B Instruct Turbo**: `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` (131,072 context length, FP8)
+- **Llama 3.1 405B Instruct Turbo**: `meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo` (130,815 context length, FP8)
+- **Llama 3.1 8B Instruct Turbo**: `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo` (131,072 context length, FP8)
+- **Llama 3.2 3B Instruct Turbo**: `meta-llama/Llama-3.2-3B-Instruct-Turbo` (131,072 context length, FP16)
+
+### Mixtral Models
+
+- **Mixtral-8x7B Instruct**: `mistralai/Mixtral-8x7B-Instruct-v0.1` (32,768 context length, FP16)
+- **Mixtral-8x22B Instruct**: `mistralai/Mixtral-8x22B-Instruct-v0.1` (65,536 context length, FP16)
+- **Mistral Small 3 Instruct (24B)**: `mistralai/Mistral-Small-24B-Instruct-2501` (32,768 context length, FP16)
+
+### Qwen Models
+
+- **Qwen 2.5 72B Instruct Turbo**: `Qwen/Qwen2.5-72B-Instruct-Turbo` (32,768 context length, FP8)
+- **Qwen 2.5 7B Instruct Turbo**: `Qwen/Qwen2.5-7B-Instruct-Turbo` (32,768 context length, FP8)
+- **Qwen 2.5 Coder 32B Instruct**: `Qwen/Qwen2.5-Coder-32B-Instruct` (32,768 context length, FP16)
+- **QwQ-32B**: `Qwen/QwQ-32B` (32,768 context length, FP16)
 
 ### Vision Models
 
-- `meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo`
-- `meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo`
-- `Qwen/Qwen2-VL-72B-Instruct`
-
-### Embedding Models
-
-- `togethercomputer/m2-bert-80M-8k-retrieval`
-- `mistralai/Mixtral-8x7B-Embeddings`
-- `Xenova/all-MiniLM-L6-v2`
+- **Llama 3.2 Vision**: `meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo` (131,072 context length, FP16)
+- **Qwen 2.5 Vision Language 72B**: `Qwen/Qwen2.5-VL-72B-Instruct` (32,768 context length, FP8)
+- **Qwen 2 VL 72B**: `Qwen/Qwen2-VL-72B-Instruct` (32,768 context length, FP16)
 
 ### Free Endpoints
 
@@ -105,17 +104,18 @@ Together AI offers free tiers with reduced rate limits:
 - `meta-llama/Llama-Vision-Free`
 - `deepseek-ai/DeepSeek-R1-Distill-Llama-70B-Free`
 
+For a complete list of all 200+ available models and their specifications, refer to the [Together AI Models page](https://docs.together.ai/docs/inference-models).
+
 ## Example Configuration
 
-```yaml
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.jsons
 providers:
-  # Chat model
-  - id: togetherai:meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
+  - id: togetherai:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
     config:
       temperature: 0.7
-      top_k: 50
+      max_tokens: 4096
 
-  # Model with function calling
   - id: togetherai:deepseek-ai/DeepSeek-R1
     config:
       temperature: 0.0

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -36,13 +36,15 @@ Note: Claude models support up to 200,000 tokens context length and include buil
 
 Meta's Llama models are available through Vertex AI with the following versions:
 
+- `vertex:llama4-scout-instruct-maas` - Llama 4 Scout 17B (16 experts) with 10M context
+- `vertex:llama4-maverick-instruct-maas` - Llama 4 Maverick 17B (128 experts) with 1M context
 - `vertex:llama-3.3-70b-instruct-maas` - Latest Llama 3.3 70B model (Preview)
 - `vertex:llama-3.2-90b-vision-instruct-maas` - Vision-capable Llama 3.2 90B (Preview)
 - `vertex:llama-3.1-405b-instruct-maas` - Llama 3.1 405B (GA)
 - `vertex:llama-3.1-70b-instruct-maas` - Llama 3.1 70B (Preview)
 - `vertex:llama-3.1-8b-instruct-maas` - Llama 3.1 8B (Preview)
 
-Note: Llama models support up to 128,000 tokens context length and include built-in safety features through Llama Guard.
+Note: Llama models support built-in safety features through Llama Guard. Llama 4 models support up to 10M tokens context length (Scout) and 1M tokens (Maverick) and are natively multimodal, supporting both text and image inputs.
 
 #### Llama Configuration Example
 
@@ -57,6 +59,15 @@ providers:
         safetySettings:
           enabled: true # Llama Guard is enabled by default
           llama_guard_settings: {} # Optional custom settings
+
+  - id: vertex:llama4-scout-instruct-maas
+    config:
+      region: us-central1
+      temperature: 0.7
+      maxOutputTokens: 2048
+      llamaConfig:
+        safetySettings:
+          enabled: true
 ```
 
 By default, Llama models use Llama Guard for content safety. You can disable it by setting `enabled: false`, but this is not recommended for production use.
@@ -113,6 +124,7 @@ npm install google-auth-library
    - Searching for "Claude"
    - Clicking "Enable" on the models you want to use
 3. Set your project in gcloud CLI:
+
    ```sh
    gcloud config set project PROJECT_ID
    ```
@@ -205,11 +217,10 @@ See [Google's SafetySetting API documentation](https://ai.google.dev/api/generat
 
 ### Llama Model Features
 
-- Support for text and vision tasks (Llama 3.2)
+- Support for text and vision tasks (Llama 3.2 and all Llama 4 models)
 - Built-in safety with Llama Guard (enabled by default)
 - Available in `us-central1` region
-- Quota limits vary by model version (30-60 QPM)
-- Maximum context length of 128,000 tokens
+- Quota limits vary by model version
 - Requires specific endpoint format for API calls
 - Only supports unary (non-streaming) responses in promptfoo
 
@@ -219,7 +230,7 @@ See [Google's SafetySetting API documentation](https://ai.google.dev/api/generat
 - **Guard Integration**: All Llama models use Llama Guard for content safety by default
 - **Specific Endpoint**: Uses a different API endpoint than other Vertex models
 - **Model Status**: Most models are in Preview state, with Llama 3.1 405B being Generally Available (GA)
-- **Vision Support**: Only Llama 3.2 90B supports image input
+- **Vision Support**: Llama 3.2 90B and all Llama 4 models support image input
 
 ### Claude Model Features
 


### PR DESCRIPTION
This update adds documentation for Llama 4 models across OpenRouter and Vertex AI.
- Includes new models like Llama 4 Scout and Maverick.
- Updates context length and multimodal support details for Llama 4 series.