### PR TITLE
chore(schema): make extensions field nullable

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -951,10 +951,17 @@
           }
         },
         "extensions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "metadata": {
           "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/metadata/allOf/0"

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -257,13 +257,13 @@ export async function renderPrompt(
 
 /**
  * Runs extension hooks for the given hook name and context.
- * @param extensions - An array of extension paths.
+ * @param extensions - An array of extension paths, or null.
  * @param hookName - The name of the hook to run.
  * @param context - The context object to pass to the hook.
  * @returns A Promise that resolves when all hooks have been run.
  */
 export async function runExtensionHook(
-  extensions: string[] | undefined,
+  extensions: string[] | null | undefined,
   hookName: string,
   context: any,
 ) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -776,6 +776,7 @@ export const TestSuiteSchema = z.object({
           },
         ),
     )
+    .nullable()
     .optional(),
 
   // Redteam configuration - used only when generating redteam tests
@@ -857,7 +858,7 @@ export const TestSuiteConfigSchema = z.object({
   derivedMetrics: z.array(DerivedMetricSchema).optional(),
 
   // Extension that is called at various plugin points
-  extensions: z.array(z.string()).optional(),
+  extensions: z.array(z.string()).nullable().optional(),
 
   // Any other information about this configuration.
   metadata: MetadataSchema.optional(),
@@ -870,6 +871,7 @@ export const TestSuiteConfigSchema = z.object({
 });
 
 export type TestSuiteConfig = z.infer<typeof TestSuiteConfigSchema>;
+
 export const UnifiedConfigSchema = TestSuiteConfigSchema.extend({
   evaluateOptions: EvaluateOptionsSchema.optional(),
   commandLineOptions: CommandLineOptionsSchema.partial().optional(),
@@ -891,6 +893,16 @@ export const UnifiedConfigSchema = TestSuiteConfigSchema.extend({
       data.providers = data.targets;
       delete data.targets;
     }
+
+    // Handle null extensions, undefined extensions, or empty arrays by deleting the field
+    if (
+      data.extensions === null ||
+      data.extensions === undefined ||
+      (Array.isArray(data.extensions) && data.extensions.length === 0)
+    ) {
+      delete data.extensions;
+    }
+
     return data;
   });
 

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -395,6 +395,11 @@ describe('runExtensionHook', () => {
     expect(transform).not.toHaveBeenCalled();
   });
 
+  it('should not call transform if extensions is null', async () => {
+    await runExtensionHook(null, 'testHook', { data: 'test' });
+    expect(transform).not.toHaveBeenCalled();
+  });
+
   it('should call transform for each extension', async () => {
     const extensions = ['ext1', 'ext2', 'ext3'];
     const hookName = 'testHook';

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -3,6 +3,8 @@ import {
   TestCaseSchema,
   CommandLineOptionsSchema,
   TestSuiteConfigSchema,
+  UnifiedConfigSchema,
+  TestSuiteSchema,
 } from '../../src/types';
 
 describe('isGradingResult', () => {
@@ -292,5 +294,66 @@ describe('TestSuiteConfigSchema env property', () => {
       prompts: ['prompt1'],
     };
     expect(() => TestSuiteConfigSchema.parse(config)).not.toThrow();
+  });
+});
+
+describe('UnifiedConfigSchema extensions handling', () => {
+  it('should remove null extensions', () => {
+    const config = {
+      providers: ['provider1'],
+      prompts: ['prompt1'],
+      extensions: null,
+    };
+    const parsed = UnifiedConfigSchema.parse(config);
+    expect(parsed.extensions).toBeUndefined();
+  });
+
+  it('should remove undefined extensions', () => {
+    const config = {
+      providers: ['provider1'],
+      prompts: ['prompt1'],
+      extensions: undefined,
+    };
+    const parsed = UnifiedConfigSchema.parse(config);
+    expect(parsed.extensions).toBeUndefined();
+  });
+
+  it('should remove empty array extensions', () => {
+    const config = {
+      providers: ['provider1'],
+      prompts: ['prompt1'],
+      extensions: [],
+    };
+    const parsed = UnifiedConfigSchema.parse(config);
+    expect(parsed.extensions).toBeUndefined();
+  });
+
+  it('should preserve valid extensions array', () => {
+    const config = {
+      providers: ['provider1'],
+      prompts: ['prompt1'],
+      extensions: ['ext1', 'ext2'],
+    };
+    const parsed = UnifiedConfigSchema.parse(config);
+    expect(parsed.extensions).toEqual(['ext1', 'ext2']);
+  });
+});
+
+describe('TestSuiteSchema extensions field', () => {
+  it('should allow null extensions', () => {
+    const suite = {
+      providers: [{ id: () => 'provider1' }],
+      prompts: [{ raw: 'prompt1', label: 'test' }],
+      extensions: null,
+    };
+    expect(() => TestSuiteSchema.parse(suite)).not.toThrow();
+  });
+
+  it('should allow undefined extensions', () => {
+    const suite = {
+      providers: [{ id: () => 'provider1' }],
+      prompts: [{ raw: 'prompt1', label: 'test' }],
+    };
+    expect(() => TestSuiteSchema.parse(suite)).not.toThrow();
   });
 });


### PR DESCRIPTION
This PR updates the schema and related logic to allow the 'extensions' field to be nullable.
- Adjusted schema definitions and validation rules.
- Updated tests to cover new nullable behavior.