### PR TITLE
fix(scripts): ensure GitHub CLI is installed in preversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint": "eslint . --max-warnings=0",
     "local:web": "npm run dev --prefix src/app",
     "local": "ts-node --cwdMode --transpileOnly src/main.ts",
-    "preversion": "[ \"$(git rev-parse --abbrev-ref HEAD)\" = \"main\" ] || (echo \"Error: Must be on main branch to version\" && exit 1) && git pull origin main && git checkout -b \"chore/bump-version-$(date +%s)\"",
+    "preversion": "command -v gh >/dev/null 2>&1 || (echo \"Error: GitHub CLI required.\" && exit 1) && [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"main\" ] || (echo \"Error: Must be on main branch to version\" && exit 1) && git pull origin main && git checkout -b \"chore/bump-version-$(date +%s)\"",
     "postversion": "npm run citation:generate && git add CITATION.cff && git commit --amend --no-edit && gh pr create --repo promptfoo/promptfoo --title \"chore: bump version $npm_package_version\" --body \"\"",
     "prepublishOnly": "npm run build:clean && npm run build",
     "test:app": "npm run test --prefix src/app",


### PR DESCRIPTION
Ensure the GitHub CLI is installed before proceeding with the preversion script.
- Added a check for the 'gh' command in the preversion script.
- Prevents proceeding if the CLI is not available.