### PR TITLE
fix(share): add backward compatibility for '-y' flag

### DIFF
--- a/site/docs/enterprise/authentication.md
+++ b/site/docs/enterprise/authentication.md
@@ -38,4 +38,4 @@ You may wish to authenticate into the CLI when using Promptfoo. Follow these ste
 All of your evals are stored locally until you share them. If you were previously an open-source user, you can share your local evals to your Promptfoo Enterprise organization by running `promptfoo share`.
 :::
 
-Authenticating with your organization's account enables [team-based sharing](/docs/usage/sharing#team-cloud-sharing-private), ensuring your evaluation results are only visible to members of your organization rather than being publicly accessible.
+Authenticating with your organization's account enables [team-based sharing](/docs/usage/sharing#enterprise-sharing), ensuring your evaluation results are only visible to members of your organization rather than being publicly accessible.

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -99,7 +99,9 @@ then promptfoo will use `/path/to/local_promptfoo` for its configuration and the
 When self-hosting, you need to set the environment variables so that the `promptfoo share` command knows how to reach your hosted application. Here's an example:
 
 ```sh
-PROMPTFOO_REMOTE_API_BASE_URL=http://localhost:3000 PROMPTFOO_REMOTE_APP_BASE_URL=http://localhost:3000 promptfoo share -y
+export PROMPTFOO_REMOTE_API_BASE_URL=http://localhost:3000
+export PROMPTFOO_REMOTE_APP_BASE_URL=http://localhost:3000
+promptfoo share
 ```
 
 This will create a shareable URL using your self-hosted service.
@@ -110,7 +112,7 @@ Similarly, the `PROMPTFOO_REMOTE_APP_BASE_URL` environment variable sets the bas
 
 These configuration options can also be set under the `sharing` property of your promptfoo config:
 
-```yaml
+```yaml title="promptfooconfig.yaml"
 sharing:
   apiBaseUrl: http://localhost:3000
   appBaseUrl: http://localhost:3000
@@ -125,7 +127,9 @@ When using a self-hosted instance, promptfoo resolves sharing URLs in this order
 3. Cloud configuration (if you've logged in with `promptfoo auth login`)
 4. Default values (api.promptfoo.app and promptfoo.app)
 
+:::tip
 If your shared URLs don't point to your self-hosted instance, ensure you're not logged into the cloud service or try setting the configuration directly in your config file.
+:::
 
 ### URL Format
 

--- a/site/docs/usage/sharing.md
+++ b/site/docs/usage/sharing.md
@@ -1,144 +1,104 @@
 ---
 sidebar_position: 40
-description: Create a remote copy of your promptfoo evals and share them with your team.
-keywords:
-  [
-    eval sharing,
-    LLM testing,
-    promptfoo sharing,
-    collaboration,
-    team collaboration,
-    shareable URL,
-    prompt engineering,
-    AI evaluation,
-  ]
+description: Share your promptfoo evals with your team through cloud, enterprise, or self-hosted instances.
+keywords: [eval sharing, LLM testing, promptfoo sharing, collaboration, team sharing]
 ---
 
 # Sharing
 
-The CLI provides a `share` command to share your evaluation results from `promptfoo eval`.
+Share your eval results with others using the `share` command.
+
+## Quick Start (Cloud)
+
+Most users will share to promptfoo.app cloud:
 
 ```sh
+# Login (one-time setup)
+promptfoo auth login
+
+# Run an eval and share it
+promptfoo eval
 promptfoo share
 ```
 
-## Basic Usage
+:::note
+Cloud sharing creates private links only visible to you and your organization. If you don't have an account, visit https://promptfoo.app/welcome to create one.
+:::
 
-When you run `promptfoo share`, it will ask for a confirmation to create a URL.
-
-If you want to skip this confirmation, you can use the `-y` or `--yes` option like this:
-
-```sh
-promptfoo share -y
-```
-
-### Sharing Specific Evals
-
-By default, `promptfoo share` shares your most recent eval. To share a specific eval, provide its ID:
+## Sharing Specific Evals
 
 ```sh
+# List available evals
+promptfoo list
+
+# Share by ID
 promptfoo share my-eval-id
 ```
 
-You can find eval IDs by running `promptfoo list` to see your eval history.
+## Enterprise Sharing
 
-### Authentication in URLs
-
-If your URLs contain authentication information, use the `--show-auth` flag to preserve it:
+If you have a Promptfoo Enterprise account:
 
 ```sh
-promptfoo share --show-auth
+# Login to your enterprise instance
+promptfoo auth login --host https://your-company.promptfoo.app
+
+# Share your eval
+promptfoo share
 ```
 
-Without this flag, authentication information (username/password) is automatically stripped from URLs for security.
+Enterprise sharing includes additional features:
 
-## Sharing Destinations
+- Team-based access controls
+- Custom sharing policies
+- SSO integration
 
-promptfoo supports multiple sharing destinations depending on your setup:
+## CI/CD Integration
 
-### Default Cloud Sharing (Public)
-
-By default, evals are shared to the public promptfoo cloud service:
+### Using API Tokens (Cloud/Enterprise)
 
 ```sh
-$ promptfoo share
-View results: https://promptfoo.app/eval/abc123
+# Authenticate with API token
+export PROMPTFOO_API_KEY=your_api_token
+
+# Run and share
+promptfoo eval --share
 ```
 
-The URL is valid for 2 weeks and is publicly accessible to anyone with the link.
+Get your API token from the "CLI Login Information" section in your account settings.
 
-### Team Cloud Sharing (Private)
+## Advanced: Self-Hosted Sharing
 
-If you're logged in with `promptfoo auth login`, evals are shared privately with your organization:
+For users with self-hosted instances:
 
 ```sh
-$ promptfoo auth login  # One-time setup
-$ promptfoo share
-View results: https://promptfoo.app/eval/abc123
+# Configure sharing to your server
+export PROMPTFOO_REMOTE_API_BASE_URL=http://your-server:3000
+export PROMPTFOO_REMOTE_APP_BASE_URL=http://your-server:3000
+
+# Share your eval (no login required)
+promptfoo share
 ```
 
-These shared results are only visible to members of your organization.
+You can also add these settings to your `promptfooconfig.yaml`:
 
-### Self-Hosted Sharing
-
-For complete control over your data, you can share to your own self-hosted instance:
-
-#### Configuration Options
-
-##### Using Config File
-
-For persistent configuration, add to your `promptfooconfig.yaml`:
-
-```yaml
+```yaml title="promptfooconfig.yaml"
 sharing:
-  apiBaseUrl: http://your-server:3000 # Where to send data
-  appBaseUrl: http://your-server:3000 # Base for shared URLs
+  apiBaseUrl: http://your-server:3000
+  appBaseUrl: http://your-server:3000
 ```
 
-##### Using Environment Variables
-
-For temporary configuration:
-
-```sh
-PROMPTFOO_REMOTE_API_BASE_URL=http://your-server:3000 PROMPTFOO_REMOTE_APP_BASE_URL=http://your-server:3000 promptfoo share
-```
-
-Additional environment variables for self-hosted setup:
-
-| Variable                                | Description                                                               |
-| --------------------------------------- | ------------------------------------------------------------------------- |
-| `PROMPTFOO_SHARING_APP_BASE_URL`        | Alternative to `PROMPTFOO_REMOTE_APP_BASE_URL` with higher priority       |
-| `PROMPTFOO_DISABLE_SHARE_EMAIL_REQUEST` | Set to `true` to skip email collection during sharing                     |
-| `PROMPTFOO_SHARE_CHUNK_SIZE`            | Controls how many results are sent in each chunk when sharing large evals |
-
-:::note Configuration Precedence
-
-When multiple configuration methods are present, promptfoo uses this priority order:
-
-1. Config file settings
-2. Environment variables
-3. Cloud settings (if logged in)
-4. Default values
-
+:::tip
+Self-hosted sharing doesn't require `promptfoo auth login` when these environment variables or config settings are present.
 :::
-
-For more detailed instructions on setting up a self-hosted instance, see [Self-hosting](./self-hosting.md).
 
 ## Disabling Sharing
 
-The "share" button in the web UI can be explicitly disabled in `promptfooconfig.yaml`:
+To disable sharing completely:
 
-```yaml
+```yaml title="promptfooconfig.yaml"
 sharing: false
 ```
-
-## Privacy Considerations
-
-Please consider the following privacy aspects of each sharing method:
-
-- **Default Cloud Sharing**: Creates a publicly accessible URL visible to anyone with the link. Data is automatically deleted after 2 weeks.
-- **Team Cloud Sharing**: Creates a private URL only visible to your organization members.
-- **Self-Hosted Sharing**: Privacy and retention depend on your self-hosted configuration.
 
 ## See Also
 

--- a/site/docs/usage/sharing.md
+++ b/site/docs/usage/sharing.md
@@ -102,5 +102,5 @@ sharing: false
 
 ## See Also
 
-- [Self-hosting](./self-hosting.md)
-- [Command Line Usage](./command-line.md)
+- [Self-hosting](/docs/usage/self-hosting.md)
+- [Command Line Usage](/docs/usage/command-line.md)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -114,6 +114,14 @@ export function authCommand(program: Command) {
     .command('logout')
     .description('Logout')
     .action(async () => {
+      const email = getUserEmail();
+      const apiKey = cloudConfig.getApiKey();
+
+      if (!email && !apiKey) {
+        logger.info(chalk.yellow("You're already logged out - no active session to terminate"));
+        return;
+      }
+
       await cloudConfig.delete();
       // Always unset email on logout
       setUserEmail('');

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -53,6 +53,12 @@ export function shareCommand(program: Command) {
       'Show username/password authentication information in the URL if exists',
       false,
     )
+    // NOTE: Added in 0.109.1 after migrating sharing to promptfoo.app in 0.108.0
+    .option(
+      '-y, --yes',
+      'Flag does nothing (maintained for backwards compatibility only - shares are now private by default)',
+      false,
+    )
     .action(
       async (
         evalId: string | undefined,

--- a/test/commands/auth.test.ts
+++ b/test/commands/auth.test.ts
@@ -206,14 +206,32 @@ describe('auth command', () => {
   describe('logout', () => {
     it('should unset email in config after logout', async () => {
       jest.mocked(getUserEmail).mockReturnValue('test@example.com');
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue('api-key');
 
       const logoutCmd = program.commands
         .find((cmd) => cmd.name() === 'auth')
         ?.commands.find((cmd) => cmd.name() === 'logout');
       await logoutCmd?.parseAsync(['node', 'test']);
 
+      expect(cloudConfig.delete).toHaveBeenCalledWith();
       expect(setUserEmail).toHaveBeenCalledWith('');
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged out'));
+    });
+
+    it('should show "already logged out" message when no session exists', async () => {
+      jest.mocked(getUserEmail).mockReturnValue(null);
+      jest.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
+
+      const logoutCmd = program.commands
+        .find((cmd) => cmd.name() === 'auth')
+        ?.commands.find((cmd) => cmd.name() === 'logout');
+      await logoutCmd?.parseAsync(['node', 'test']);
+
+      expect(cloudConfig.delete).not.toHaveBeenCalled();
+      expect(setUserEmail).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("You're already logged out"),
+      );
     });
   });
 

--- a/test/commands/share.test.ts
+++ b/test/commands/share.test.ts
@@ -42,7 +42,7 @@ describe('Share Command', () => {
   describe('createAndDisplayShareableUrl', () => {
     it('should return a URL and log it when successful', async () => {
       jest.mocked(isSharingEnabled).mockReturnValue(true);
-      const mockEval = { id: 'test-eval-id' } as any;
+      const mockEval = { id: 'test-eval-id' } as Eval;
       const mockUrl = 'https://app.promptfoo.dev/eval/test-eval-id';
 
       jest.mocked(createShareableUrl).mockResolvedValue(mockUrl);
@@ -55,7 +55,7 @@ describe('Share Command', () => {
     });
 
     it('should pass showAuth parameter correctly', async () => {
-      const mockEval = { id: 'test-eval-id' } as any;
+      const mockEval = { id: 'test-eval-id' } as Eval;
       const mockUrl = 'https://app.promptfoo.dev/eval/test-eval-id';
 
       jest.mocked(createShareableUrl).mockResolvedValue(mockUrl);
@@ -66,7 +66,7 @@ describe('Share Command', () => {
     });
 
     it('should show cloud instructions and return null when sharing is not enabled', async () => {
-      const mockEval = { id: 'test-eval-id' } as any;
+      const mockEval = { id: 'test-eval-id' } as Eval;
       jest.mocked(isSharingEnabled).mockReturnValue(false);
 
       const result = await createAndDisplayShareableUrl(mockEval, false);
@@ -79,7 +79,7 @@ describe('Share Command', () => {
     });
 
     it('should return null when createShareableUrl returns null', async () => {
-      const mockEval = { id: 'test-eval-id' } as any;
+      const mockEval = { id: 'test-eval-id' } as Eval;
 
       jest.mocked(isSharingEnabled).mockReturnValue(true);
       jest.mocked(createShareableUrl).mockResolvedValue(null);
@@ -115,7 +115,7 @@ describe('Share Command', () => {
     });
 
     it('should handle specific evalId not found', async () => {
-      jest.spyOn(Eval, 'findById').mockImplementation().mockResolvedValue(null);
+      jest.spyOn(Eval, 'findById').mockImplementation().mockResolvedValue(undefined);
 
       const shareCmd = program.commands.find((c) => c.name() === 'share');
       await shareCmd?.parseAsync(['node', 'test', 'non-existent-id']);
@@ -128,7 +128,7 @@ describe('Share Command', () => {
     });
 
     it('should handle no evals available', async () => {
-      jest.spyOn(Eval, 'latest').mockImplementation().mockResolvedValue(null);
+      jest.spyOn(Eval, 'latest').mockImplementation().mockResolvedValue(undefined);
 
       const shareCmd = program.commands.find((c) => c.name() === 'share');
       await shareCmd?.parseAsync(['node', 'test']);
@@ -139,7 +139,7 @@ describe('Share Command', () => {
     });
 
     it('should handle eval with empty prompts', async () => {
-      const mockEval = { id: 'test-eval-id', prompts: [] };
+      const mockEval = { prompts: [] } as unknown as Eval;
       jest.spyOn(Eval, 'latest').mockImplementation().mockResolvedValue(mockEval);
 
       const shareCmd = program.commands.find((c) => c.name() === 'share');
@@ -151,27 +151,21 @@ describe('Share Command', () => {
     });
 
     it('should accept -y flag for backwards compatibility', async () => {
-      const mockEval = { id: 'test-eval-id', prompts: ['test'] };
+      const mockEval = { prompts: ['test'] } as unknown as Eval;
 
-      // Mock Eval.latest to return a mock eval
       jest.spyOn(Eval, 'latest').mockImplementation().mockResolvedValue(mockEval);
-
-      // Mock isSharingEnabled and createShareableUrl
       jest.mocked(isSharingEnabled).mockReturnValue(true);
       jest.mocked(createShareableUrl).mockResolvedValue('https://example.com/share');
 
       const shareCmd = program.commands.find((c) => c.name() === 'share');
       await shareCmd?.parseAsync(['node', 'test', '-y']);
 
-      // Verify the command executed successfully with the -y flag
       expect(Eval.latest).toHaveBeenCalledWith();
       expect(createShareableUrl).toHaveBeenCalledWith(mockEval, false);
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('View results:'));
     });
 
-    // Test just the hostname determination logic directly
     it('should use promptfoo.app by default if no environment variables are set', () => {
-      // Mock environment variables to return undefined
       jest.mocked(envars.getEnvString).mockImplementation(() => '');
 
       const baseUrl =
@@ -183,7 +177,6 @@ describe('Share Command', () => {
     });
 
     it('should use PROMPTFOO_SHARING_APP_BASE_URL for hostname when set', () => {
-      // Mock PROMPTFOO_SHARING_APP_BASE_URL
       jest.mocked(envars.getEnvString).mockImplementation((key) => {
         if (key === 'PROMPTFOO_SHARING_APP_BASE_URL') {
           return 'https://custom-domain.com';
@@ -200,7 +193,6 @@ describe('Share Command', () => {
     });
 
     it('should use PROMPTFOO_REMOTE_APP_BASE_URL for hostname when PROMPTFOO_SHARING_APP_BASE_URL is not set', () => {
-      // Mock PROMPTFOO_REMOTE_APP_BASE_URL
       jest.mocked(envars.getEnvString).mockImplementation((key) => {
         if (key === 'PROMPTFOO_REMOTE_APP_BASE_URL') {
           return 'https://self-hosted-domain.com';
@@ -217,7 +209,6 @@ describe('Share Command', () => {
     });
 
     it('should prioritize PROMPTFOO_SHARING_APP_BASE_URL over PROMPTFOO_REMOTE_APP_BASE_URL', () => {
-      // Mock both environment variables
       jest.mocked(envars.getEnvString).mockImplementation((key) => {
         if (key === 'PROMPTFOO_SHARING_APP_BASE_URL') {
           return 'https://sharing-domain.com';


### PR DESCRIPTION
Fixes the issue where the '-y' flag in the share command was not recognized, ensuring backward compatibility. Resolves GitHub issue #3639.