### PR TITLE
fix: remove deprecated login flow

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,37 +1,11 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import dedent from 'dedent';
-import readline from 'readline';
 import { fetchWithProxy } from '../fetch';
 import { getUserEmail, setUserEmail } from '../globalConfig/accounts';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
 import telemetry from '../telemetry';
-
-async function promptForInput(question: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  try {
-    return await new Promise((resolve) => {
-      rl.question(question, (answer) => {
-        resolve(answer.trim());
-      });
-    });
-  } finally {
-    rl.close();
-  }
-}
-
-async function promptForToken(): Promise<string> {
-  return promptForInput('Please enter your API token: ');
-}
-
-async function promptForEmail(): Promise<string> {
-  return promptForInput('Please enter your email: ');
-}
 
 export function authCommand(program: Command) {
   const authCommand = program.command('auth').description('Manage authentication');
@@ -48,59 +22,36 @@ export function authCommand(program: Command) {
     .action(async (cmdObj: { orgId: string; host: string; apiKey: string }) => {
       let token: string | undefined;
       const apiHost = cmdObj.host || cloudConfig.getApiHost();
-
+      telemetry.record('command_used', {
+        name: 'auth login',
+      });
+      await telemetry.send();
       try {
         if (cmdObj.apiKey) {
           token = cmdObj.apiKey;
-        } else {
-          const email = await promptForEmail();
-
-          // Send login request
-
-          const loginResponse = await fetchWithProxy(`${apiHost}/users/login?fromCLI=true`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ email, organizationId: cmdObj.orgId }),
-          });
-
-          if (!loginResponse.ok) {
-            throw new Error('Failed to send login request: ' + loginResponse.statusText);
+          const { user } = await cloudConfig.validateAndSetApiToken(token, apiHost);
+          // Store token in global config and handle email sync
+          const existingEmail = getUserEmail();
+          if (existingEmail && existingEmail !== user.email) {
+            logger.info(
+              chalk.yellow(
+                `Updating local email configuration from ${existingEmail} to ${user.email}`,
+              ),
+            );
           }
-
+          setUserEmail(user.email);
+          logger.info(chalk.green('Successfully logged in'));
+          return;
+        } else {
           logger.info(
-            chalk.green(
-              `A login link has been sent to ${email}. Click the link to login and then copy your authentication token.`,
-            ),
+            `Please login or sign up at ${chalk.green('https://promptfoo.app')} to get an API key.`,
           );
 
           logger.info(
-            chalk.yellow(
-              "If you did not get an email it's because the user does not exist or your not part of the the organization specified.",
-            ),
-          );
-
-          // Prompt for token
-          token = await promptForToken();
-        }
-        const { user } = await cloudConfig.validateAndSetApiToken(token, apiHost);
-
-        // Store token in global config and handle email sync
-        const existingEmail = getUserEmail();
-        if (existingEmail && existingEmail !== user.email) {
-          logger.info(
-            chalk.yellow(
-              `Updating local email configuration from ${existingEmail} to ${user.email}`,
-            ),
+            `After logging in, you can get your api token at ${chalk.green('https://promptfoo.app/welcome')}`,
           );
         }
-        setUserEmail(user.email);
 
-        telemetry.record('command_used', {
-          name: 'auth login',
-        });
-        await telemetry.send();
         return;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/test/commands/auth.test.ts
+++ b/test/commands/auth.test.ts
@@ -49,21 +49,15 @@ describe('auth command', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
     program = new Command();
     authCommand(program);
 
-    // Mock validateAndSetApiToken to emit the success message
-    jest.mocked(cloudConfig.validateAndSetApiToken).mockImplementation(async () => {
-      logger.info(expect.stringContaining('Successfully logged in'));
-      logger.info(expect.any(String)); // 'Logged in as:'
-      logger.info(expect.any(String)); // User
-      logger.info(expect.any(String)); // Organization
-      logger.info(expect.any(String)); // App URL
-      return {
-        user: mockCloudUser,
-        organization: mockOrganization,
-        app: mockApp,
-      };
+    // Set up a basic mock that just returns the expected data
+    jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValue({
+      user: mockCloudUser,
+      organization: mockOrganization,
+      app: mockApp,
     });
   });
 
@@ -76,12 +70,6 @@ describe('auth command', () => {
         }),
       );
 
-      jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValueOnce({
-        user: mockCloudUser,
-        organization: mockOrganization,
-        app: mockApp,
-      });
-
       const loginCmd = program.commands
         .find((cmd) => cmd.name() === 'auth')
         ?.commands.find((cmd) => cmd.name() === 'login');
@@ -92,52 +80,22 @@ describe('auth command', () => {
         expect.any(String),
         undefined,
       );
-    });
-
-    it('should handle interactive login flow successfully', async () => {
-      jest.mocked(fetchWithProxy).mockResolvedValueOnce(
-        createMockResponse({
-          ok: true,
-          body: {},
-        }),
-      );
-
-      jest.mocked(cloudConfig.validateAndSetApiToken).mockResolvedValueOnce({
-        user: mockCloudUser,
-        organization: mockOrganization,
-        app: mockApp,
-      });
-
-      const loginCmd = program.commands
-        .find((cmd) => cmd.name() === 'auth')
-        ?.commands.find((cmd) => cmd.name() === 'login');
-      await loginCmd?.parseAsync(['node', 'test']);
-
-      expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining('A login link has been sent'),
-      );
-      expect(setUserEmail).toHaveBeenCalledWith('test@example.com');
-      expect(cloudConfig.validateAndSetApiToken).toHaveBeenCalledWith(
-        expect.any(String),
-        undefined,
-      );
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged in'));
     });
 
     it('should handle login request failure', async () => {
-      jest.mocked(fetchWithProxy).mockResolvedValueOnce(
-        createMockResponse({
-          ok: false,
-          statusText: 'Bad Request',
-        }),
-      );
+      // Mock fetchWithProxy to reject with an error
+      jest
+        .mocked(cloudConfig.validateAndSetApiToken)
+        .mockRejectedValueOnce(new Error('Bad Request'));
 
       const loginCmd = program.commands
         .find((cmd) => cmd.name() === 'auth')
         ?.commands.find((cmd) => cmd.name() === 'login');
-      await loginCmd?.parseAsync(['node', 'test']);
+      await loginCmd?.parseAsync(['node', 'test', '--api-key', 'test-key']);
 
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to send login request: Bad Request'),
+        expect.stringContaining('Authentication failed: Bad Request'),
       );
       expect(process.exitCode).toBe(1);
     });
@@ -157,7 +115,7 @@ describe('auth command', () => {
       const loginCmd = program.commands
         .find((cmd) => cmd.name() === 'auth')
         ?.commands.find((cmd) => cmd.name() === 'login');
-      await loginCmd?.parseAsync(['node', 'test']);
+      await loginCmd?.parseAsync(['node', 'test', '--api-key', 'test-key']);
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Authentication failed: Invalid token'),
@@ -229,7 +187,7 @@ describe('auth command', () => {
           ok: true,
           body: {
             user: mockCloudUser,
-            organization: { name: 'Test Org' },
+            organization: mockOrganization,
           },
         }),
       );


### PR DESCRIPTION
Login via email address is deprecated with the new cloud auth, pointing towards the website to login and get the token.