### PR TITLE
fix(huggingface): disable var expansion for huggingface datasets to prevent array field expansion

### DIFF
--- a/src/integrations/huggingfaceDatasets.ts
+++ b/src/integrations/huggingfaceDatasets.ts
@@ -112,7 +112,11 @@ export async function fetchHuggingFaceDataset(
         vars: {
           ...row,
         },
+        options: {
+          disableVarExpansion: true,
+        },
       };
+
       tests.push(test);
     }
 

--- a/test/integrations/huggingfaceDatasets.test.ts
+++ b/test/integrations/huggingfaceDatasets.test.ts
@@ -92,6 +92,13 @@ describe('huggingfaceDatasets', () => {
       act: 'Math Tutor',
       prompt: 'Solve 2+2',
     });
+
+    // Check that disableVarExpansion is set for all test cases
+    tests.forEach((test) => {
+      expect(test.options).toEqual({
+        disableVarExpansion: true,
+      });
+    });
   });
 
   it('should include auth token when HF_TOKEN is set', async () => {
@@ -185,6 +192,13 @@ describe('huggingfaceDatasets', () => {
 
     expect(tests).toHaveLength(3);
     expect(tests.map((t) => t.vars?.text)).toEqual(['First', 'Second', 'Third']);
+
+    // Check that disableVarExpansion is set for all test cases
+    tests.forEach((test) => {
+      expect(test.options).toEqual({
+        disableVarExpansion: true,
+      });
+    });
   });
 
   it('should handle API errors', async () => {
@@ -219,6 +233,13 @@ describe('huggingfaceDatasets', () => {
 
     expect(tests).toHaveLength(2);
     expect(tests.map((t) => t.vars?.text)).toEqual(['First', 'Second']);
+
+    // Check that disableVarExpansion is set for all test cases
+    tests.forEach((test) => {
+      expect(test.options).toEqual({
+        disableVarExpansion: true,
+      });
+    });
   });
 
   it('should handle limit larger than page size', async () => {
@@ -264,5 +285,12 @@ describe('huggingfaceDatasets', () => {
 
     expect(tests).toHaveLength(120);
     expect(tests[119].vars?.text).toBe('Item 120');
+
+    // Check that disableVarExpansion is set for all test cases
+    tests.forEach((test) => {
+      expect(test.options).toEqual({
+        disableVarExpansion: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
This PR fixes issue #3685 where Hugging Face datasets were incorrectly expanding array fields like 'choices' into multiple test cases.

When using Hugging Face datasets, particularly MMLU, each row should create a single test case, even when it contains array fields like 'choices'. Previously, these arrays were being expanded into multiple test cases, resulting in 4 test cases from a single MMLU row.

## Solution
Added `disableVarExpansion: true` to all test cases created from Hugging Face datasets. This prevents array fields from being expanded into combinations.

## Testing
- Updated the unit tests to verify that all Hugging Face dataset test cases have the `disableVarExpansion` option set
- Manually tested with MMLU datasets to confirm that a single row generates a single test case

Fixes #3685
