### PR TITLE
fix(cli): Use correct url for sharing validation

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -448,7 +448,7 @@ export async function createShareableUrl(
 export async function hasEvalBeenShared(eval_: Eval): Promise<boolean> {
   try {
     // GET /api/results/:id
-    const res = await makeCloudRequest(`/${eval_.id}`, 'GET');
+    const res = await makeCloudRequest(`results/${eval_.id}`, 'GET');
     switch (res.status) {
       // 200: Eval already exists i.e. it has been shared before.
       case 200:


### PR DESCRIPTION
https://github.com/promptfoo/promptfoo/pull/3653/commits/033658a90f84cad122c4b977745bc2938d0a12b6 incorrectly changed the target API endpoint but this error was masked until https://github.com/promptfoo/promptfoo/commit/98f0adab22203aae2ec6ce0dd1a3c1cb23971045.