### PR TITLE
feat: persist search in url

### DIFF
--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { IS_RUNNING_LOCALLY } from '@app/constants';
 import { ShiftKeyProvider } from '@app/contexts/ShiftKeyContext';
@@ -74,17 +74,22 @@ export default function Eval({
     },
     [setTable, setConfig, setEvalId, setAuthor],
   );
+  const [searchParams] = useSearchParams();
+  const searchEvalId = searchParams.get('evalId');
 
-  const handleRecentEvalSelection = async (id: string) => {
-    navigate(`/eval/?evalId=${encodeURIComponent(id)}`);
-  };
+  const handleRecentEvalSelection = useCallback(
+    async (id: string) => {
+      navigate({
+        pathname: `/eval/${encodeURIComponent(id)}`,
+        search: searchParams.toString(),
+      });
+    },
+    [searchParams, navigate],
+  );
 
   const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
     defaultEvalIdProp || recentEvals[0]?.evalId,
   );
-
-  const [searchParams] = useSearchParams();
-  const searchEvalId = searchParams.get('evalId');
 
   React.useEffect(() => {
     const evalId = searchEvalId || fetchId;

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '@app/contexts/ToastContext';
+import * as api from '@app/utils/api';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ResultsView from './ResultsView';
 
@@ -11,18 +12,22 @@ const mockRecentEvals = [
     label: 'Eval 1',
     description: 'Description 1',
     evalId: '1',
+    isRedteam: false,
     datasetId: 'd1',
     createdAt: new Date('2023-01-01').getTime(),
     numTests: 10,
+    passRate: 0.8,
   },
   {
     id: '2',
     label: 'Eval 2',
     description: 'Description 2',
     evalId: '2',
+    isRedteam: false,
     datasetId: 'd2',
     createdAt: new Date('2023-01-02').getTime(),
     numTests: 15,
+    passRate: 0.9,
   },
 ];
 
@@ -30,6 +35,28 @@ const mockColumnState = {
   selectedColumns: ['Variable 1', 'Prompt 1'],
   columnVisibility: { 'Variable 1': true, 'Prompt 1': true },
 };
+
+vi.mock('@app/utils/api', () => ({
+  ...api,
+  callApi: vi.fn(() => {
+    JSON.stringify({ data: mockRecentEvals });
+  }),
+}));
+
+vi.mock('@app/utils/api', async (importOriginal) => ({
+  // this is required to partially mock the module
+  // https://vitest.dev/guide/mocking.html#mock-part-of-a-module
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  ...(await importOriginal<typeof import('@app/utils/api')>()),
+  callApi: vi.fn(() => {
+    return {
+      ok: true,
+      async json() {
+        return { data: mockRecentEvals };
+      },
+    };
+  }),
+}));
 
 vi.mock('./store', () => ({
   useStore: vi.fn().mockImplementation(() => ({
@@ -43,6 +70,7 @@ vi.mock('./store', () => ({
     evalId: '1',
     author: '',
     recentEvals: mockRecentEvals,
+    evals: mockRecentEvals,
   })),
   useResultsViewSettingsStore: vi.fn().mockImplementation(() => ({
     stickyHeader: true,
@@ -83,7 +111,7 @@ describe('ResultsView', () => {
     expect(screen.getByPlaceholderText('Search or select an eval...')).toBeInTheDocument();
   });
 
-  it('setting search param updates input', () => {
+  it('shows search query param in input', async () => {
     render(
       <MemoryRouter initialEntries={['/?search=hello_world']}>
         <ToastProvider>
@@ -94,6 +122,38 @@ describe('ResultsView', () => {
         </ToastProvider>
       </MemoryRouter>,
     );
+
+    expect(screen.queryByText('Description 2')).not.toBeInTheDocument();
     expect(screen.getByDisplayValue('hello_world')).toBeInTheDocument();
+  });
+
+  it('search parameter is not lost when navigating', async () => {
+    render(
+      <MemoryRouter initialEntries={['/?search=hello_world']}>
+        <ToastProvider>
+          <ResultsView
+            recentEvals={mockRecentEvals}
+            onRecentEvalSelected={mockOnRecentEvalSelected}
+          />
+        </ToastProvider>
+      </MemoryRouter>,
+    );
+
+    const input = screen.getByPlaceholderText('Search or select an eval...');
+    act(() => {
+      input.focus();
+      input.click();
+    });
+
+    const links = await screen.findAllByRole('link');
+    const eval2Link = links.find((link) => link.getAttribute('href') === '/eval/2');
+    if (eval2Link) {
+      act(() => {
+        eval2Link.click();
+      });
+      // this assertion doesnt really check the qp but just ensures that the state is correct
+      expect(screen.getByDisplayValue('hello_world')).toBeInTheDocument();
+      expect(screen.getByText('Description 2')).toBeInTheDocument();
+    }
   });
 });

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -82,4 +82,18 @@ describe('ResultsView', () => {
     expect(screen.getByText('Table Settings')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Search or select an eval...')).toBeInTheDocument();
   });
+
+  it('setting search param updates input', () => {
+    render(
+      <MemoryRouter initialEntries={['/?search=hello_world']}>
+        <ToastProvider>
+          <ResultsView
+            recentEvals={mockRecentEvals}
+            onRecentEvalSelected={mockOnRecentEvalSelected}
+          />
+        </ToastProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByDisplayValue('hello_world')).toBeInTheDocument();
+  });
 });

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -158,7 +158,7 @@ export default function ResultsView({
   defaultEvalId,
 }: ResultsViewProps) {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { author, table, setTable, config, setConfig, evalId, setAuthor } = useResultsViewStore();
 
   const {
@@ -174,9 +174,13 @@ export default function ResultsView({
   const { showToast } = useToast();
   const [searchText, setSearchText] = React.useState(searchParams.get('search') || '');
   const [debouncedSearchText] = useDebounce(searchText, 200);
-  const handleSearchTextChange = React.useCallback((text: string) => {
-    setSearchText(text);
-  }, []);
+  const handleSearchTextChange = React.useCallback(
+    (text: string) => {
+      setSearchParams((prev) => ({ ...prev, search: text }));
+      setSearchText(text);
+    },
+    [searchParams],
+  );
 
   const [failureFilter, setFailureFilter] = React.useState<{ [key: string]: boolean }>({});
   const handleFailureFilterToggle = React.useCallback(
@@ -190,6 +194,7 @@ export default function ResultsView({
   const { head } = table;
 
   const [filterMode, setFilterMode] = React.useState<FilterMode>('all');
+
   const handleFilterModeChange = (event: SelectChangeEvent<unknown>) => {
     const mode = event.target.value as FilterMode;
     setFilterMode(mode);


### PR DESCRIPTION
# Problem
Currently, search state is maintained during navigation but is not reflected in the URL. This creates two issues:

We can't share links with specific search parameters
LLMs cannot easily extract search information from the page URL

# Solution
Implement URL-based search state persistence by adding search parameters to the URL.

While the search state is not lost during navigation, if i want to for example link the page to someone else with the correct search state, or get a LLM to extract data from the page.

# Implementation Details

- Modified navigation to use URL fragments instead of query parameters for a cleaner URL structure and requires less work merging the evalId qp and search qp
- When updating search parameters, we include previous parameters with Object.fromEntries(searchParams.entries()) this is only so that we do not loose existing evalId qp

# Questions
Why does page support evalId in both query parameter format and URL fragment format? is there a desired approach, i see most of the code relies on the qp format. personally i would prefer deprecating the qp format

somewhat related to this https://github.com/promptfoo/promptfoo/pull/3715.

