### PR TITLE
chore(cli/redteam/run): Default to outputting generated Redteam config in same dir as input config

### DIFF
--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -21,7 +21,7 @@ export function redteamRunCommand(program: Command) {
     )
     .option(
       '-o, --output [path]',
-      'Path to output file for generated tests. Defaults to redteam.yaml',
+      'Path to output file for generated tests. Defaults to redteam.yaml in the same directory as the configuration file.',
     )
     .option('--no-cache', 'Do not read or write results to disk cache', false)
     .option('--env-file, --env-path <path>', 'Path to .env file')

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -20,8 +20,16 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
     setLogCallback(options.logCallback);
   }
 
-  let configPath: string | undefined = options.config || 'promptfooconfig.yaml';
-  let redteamPath = options.output || 'redteam.yaml';
+  let configPath: string = options.config ?? 'promptfooconfig.yaml';
+
+  // If output filepath is not provided, locate the out file in the same directory as the config file:
+  let redteamPath;
+  if (options.output) {
+    redteamPath = options.output;
+  } else {
+    const configDir = path.dirname(configPath);
+    redteamPath = path.join(configDir, 'redteam.yaml');
+  }
 
   if (options.liveRedteamConfig) {
     // Write liveRedteamConfig to a temporary file


### PR DESCRIPTION
If a value is not provided for `--output` when running `promptfoo redteam run` the default is to create a `redteam.yaml` in the current working directory.  This PR changes the default to create the `redteam.yaml` in the same directory as the given config file (i.e. `promptfooconfig.yaml`) if the latter is provided  i.e. `promptfoo redteam run -c ~/attack/config.yaml` will generate `~/attack/redteam.yaml`.

This change fixes an downstream bug that I encountered: a `promptfooconfig.yaml` that contains relative filepaths e.g.

```yaml
targets:
  - file://./targets/chat.yaml
```

will result in a `redteam.yaml` that breaks at runtime unless `.` is the current working directory.