### PR TITLE
fix(cli/redteam/poison): Write docs to the output dir

### DIFF
--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import yaml from 'js-yaml';
 import * as path from 'path';
 import { getUserEmail } from '../../globalConfig/accounts';
-import logger from '../../logger';
+import logger, { setLogLevel } from '../../logger';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
 import { getRemoteGenerationUrl } from '../remoteGeneration';
@@ -154,12 +154,17 @@ export function poisonCommand(program: Command) {
       'poisoned-documents',
     )
     .option('--env-file, --env-path <path>', 'Path to .env file')
-    .action(async (documents: string[], opts: Omit<PoisonOptions, 'documents'>) => {
+    .option('-v, --verbose', 'Verbose output')
+    .action(async (documents: DocumentLike[], opts: Omit<PoisonOptions, 'documents'>) => {
       setupEnv(opts.envPath);
       telemetry.record('command_used', {
         name: 'redteam poison',
       });
       await telemetry.send();
+
+      if (opts.verbose) {
+        setLogLevel('debug');
+      }
 
       try {
         await doPoisonDocuments({


### PR DESCRIPTION
Fixes a minor bug where passing a directory for `<documents...>` and an `--output-dir` copies the input directory tree rather than writing to the output dir.

**Before**

```sh
> ls ~/test
docs

> ls ~/test/docs
all engineering execs hr sales

> promptfoo redteam poison ~/test/docs --output-dir ~/test/poisoned-docs

> ls ~/test
docs poisoned-docs test

# I expect that docs are written to the output dir
> ls ~/test/poisoned-docs
# < no output >

# Where docs are actually written:
> ls ~/test/test/docs
all engineering execs hr sales
```

**After**

```sh
> ls ~/test
docs

> ls ~/test/docs
all engineering execs hr sales

> promptfoo redteam poison ~/test/docs --output-dir ~/test/poisoned-docs

> ls ~/test
docs poisoned-docs

> ls ~/test/poisoned-docs
all engineering execs hr sales
```

Also improves understandability by adding types for `<documents...>` (because it can be file paths, directory paths, or file contents) and adds a `--verbose` flag to enable debug logging.