### PR TITLE
feat(openai): add support for o4-mini reasoning model

### DIFF
--- a/examples/openai-responses/README.md
+++ b/examples/openai-responses/README.md
@@ -9,7 +9,7 @@ This example demonstrates how to use OpenAI's Responses API to generate model ou
 - Image input processing
 - Web search integration
 - Function/tool calling
-- Mathematical reasoning with o-series models
+- Mathematical reasoning with o-series models (o1, o3, o4-mini)
 
 ## Environment Variables
 
@@ -43,8 +43,8 @@ This example includes several configuration files, each demonstrating a differen
 1. **Structured JSON Output** (`promptfooconfig.yaml`): Generates a structured story in JSON format with a schema
 2. **Image Input** (`promptfooconfig.image.yaml`): Processes images with structured JSON input
 3. **Web Search** (`promptfooconfig.web-search.yaml`): Retrieves recent information from the web using `gpt-4o`
-4. **Function Calling** (`promptfooconfig.function-call.yaml`): Calls a weather function with parameters using `o1-pro`
-5. **Mathematical Reasoning** (`promptfooconfig.reasoning.yaml`): Solves math problems step-by-step using `o3-mini`
+4. **Function Calling** (`promptfooconfig.function-call.yaml`): Calls a weather function with parameters using various reasoning models (o1-pro, o3, o4-mini)
+5. **Mathematical Reasoning** (`promptfooconfig.reasoning.yaml`): Solves math problems step-by-step using OpenAI's reasoning models (o3-mini, o3, o4-mini)
 
 ## Key Differences from Chat Completions API
 
@@ -59,4 +59,5 @@ This example includes several configuration files, each demonstrating a differen
 
 - `openai:responses:gpt-4o` - Vision-capable model
 - `openai:responses:o1-mini`, `openai:responses:o1`, `openai:responses:o1-pro` - Reasoning models
-- `openai:responses:o3-mini`, `openai:responses:o3` - Latest reasoning models
+- `openai:responses:o3-mini`, `openai:responses:o3` - High-performance reasoning models
+- `openai:responses:o4-mini` - Latest fast, cost-effective reasoning model

--- a/examples/openai-responses/promptfooconfig.function-call.yaml
+++ b/examples/openai-responses/promptfooconfig.function-call.yaml
@@ -5,8 +5,51 @@ prompts:
 
 providers:
   - id: openai:responses:o1-pro
+    label: o1-pro
     config:
       temperature: 0.7
+      max_output_tokens: 300
+      tool_choice: auto
+      tools:
+        - type: function
+          name: get_current_weather
+          description: 'Get the current weather in a given location'
+          parameters:
+            type: object
+            properties:
+              location:
+                type: string
+                description: 'The city and state, e.g. San Francisco, CA'
+              unit:
+                type: string
+                enum: ['celsius', 'fahrenheit']
+            required: ['location', 'unit']
+
+  - id: openai:responses:o3
+    label: o3
+    config:
+      reasoning_effort: 'medium'
+      max_output_tokens: 300
+      tool_choice: auto
+      tools:
+        - type: function
+          name: get_current_weather
+          description: 'Get the current weather in a given location'
+          parameters:
+            type: object
+            properties:
+              location:
+                type: string
+                description: 'The city and state, e.g. San Francisco, CA'
+              unit:
+                type: string
+                enum: ['celsius', 'fahrenheit']
+            required: ['location', 'unit']
+
+  - id: openai:responses:o4-mini
+    label: o4-mini
+    config:
+      reasoning_effort: 'low'
       max_output_tokens: 300
       tool_choice: auto
       tools:
@@ -27,6 +70,12 @@ providers:
 tests:
   - vars:
       location: Boston, MA
+    assert:
+      - type: contains
+        value: 'get_current_weather'
+
+  - vars:
+      location: San Francisco, CA
     assert:
       - type: contains
         value: 'get_current_weather'

--- a/examples/openai-responses/promptfooconfig.reasoning.yaml
+++ b/examples/openai-responses/promptfooconfig.reasoning.yaml
@@ -7,11 +7,22 @@ prompts:
 
 providers:
   - id: openai:responses:o3-mini
+    label: o3-mini-reasoning
     config:
-      temperature: 0.7
       max_output_tokens: 1000
-      reasoning:
-        effort: high
+      reasoning_effort: 'high'
+
+  - id: openai:responses:o3
+    label: o3-reasoning
+    config:
+      max_output_tokens: 2000
+      reasoning_effort: 'high'
+
+  - id: openai:responses:o4-mini
+    label: o4-mini-reasoning
+    config:
+      max_output_tokens: 1000
+      reasoning_effort: 'medium'
 
 tests:
   - vars:

--- a/examples/openai-tools-call/README.md
+++ b/examples/openai-tools-call/README.md
@@ -1,5 +1,57 @@
-This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+# openai-tools-call (OpenAI Tools Call Example)
 
+This example demonstrates how to use promptfoo to evaluate OpenAI's tools calling capabilities. It shows how to define and test tool usage with the Chat Completions API.
+
+## Features Demonstrated
+
+- Defining tools for AI models to use
+- Testing tool call outputs
+- Validating AI-generated function arguments
+- Transforming outputs for assertions
+
+## Environment Variables
+
+This example requires the following environment variables:
+
+- `OPENAI_API_KEY` - Your OpenAI API key
+
+You can set this in a `.env` file or directly in your environment.
+
+## Running the Example
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example openai-tools-call
+# and then
+cd openai-tools-call
+
+# Run the evaluation
+npx promptfoo eval
+
+# View the results
+npx promptfoo view
 ```
-promptfoo eval
-```
+
+## What This Example Does
+
+The configuration defines a custom tool for getting weather information. It then tests the model's ability to:
+
+1. Correctly call the weather function when asked about weather
+2. Pass the correct location parameter based on the city mentioned
+3. Handle various cities, including international ones
+4. Format responses consistently
+
+## Key Features
+
+- Uses `is-valid-openai-tools-call` assertion to validate the function call structure
+- Demonstrates output transformation to isolate and test specific parts of the response
+- Shows how to use JavaScript assertions for detailed validation
+- Tests with a variety of locations to ensure robust behavior
+
+## Documentation
+
+For more details, see:
+
+- [OpenAI Tools documentation](https://platform.openai.com/docs/guides/function-calling)
+- [promptfoo OpenAI Provider documentation](https://promptfoo.dev/docs/providers/openai#using-tools-and-functions)

--- a/examples/openai-vision/README.md
+++ b/examples/openai-vision/README.md
@@ -1,11 +1,57 @@
-To get started, set your OPENAI_API_KEY environment variable.
+# openai-vision (OpenAI Vision Model Example)
 
-Next, have a look at prompt.json and edit promptfooconfig.yaml.
+This example demonstrates how to use promptfoo to evaluate OpenAI's vision capabilities, allowing you to test models on their ability to analyze and describe images.
 
-Then run:
+## Features Demonstrated
 
+- Using OpenAI's GPT-4o with vision capabilities
+- Incorporating images in prompts using JSON format
+- Passing image URLs as variables
+- Testing vision model responses against expected content
+
+## Environment Variables
+
+This example requires the following environment variables:
+
+- `OPENAI_API_KEY` - Your OpenAI API key
+
+You can set this in a `.env` file or directly in your environment.
+
+## Running the Example
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example openai-vision
+# and then
+cd openai-vision
+
+# Run the evaluation
+npx promptfoo eval
+
+# View the results
+npx promptfoo view
 ```
-promptfoo eval
-```
 
-Afterwards, you can view the results by running `promptfoo view`
+## Example Configuration
+
+This example:
+
+1. Uses a JSON-formatted prompt that includes both text and image inputs
+2. Passes image URLs as variables that can be changed for each test case
+3. Tests the model's ability to accurately describe image content
+4. Demonstrates how to transform variables to generate markdown image tags
+
+## Key Technical Features
+
+- JSON prompt structure for multi-modal inputs
+- Image URL handling through variable substitution
+- Simple assertions to validate image content recognition
+- Variable transformation to generate additional context
+
+## Documentation
+
+For more information, see:
+
+- [OpenAI Vision API Documentation](https://platform.openai.com/docs/guides/vision)
+- [promptfoo OpenAI Provider Documentation](https://promptfoo.dev/docs/providers/openai#sending-images-in-prompts)

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -934,34 +934,34 @@ providers:
 
 Reasoning models "think before they answer," generating internal reasoning that isn't visible in the output but counts toward token usage and billing.
 
-### New o3 and o4-mini Models
+### o3 and o4-mini Models
 
-The latest OpenAI reasoning models include:
+OpenAI offers advanced reasoning models in the o-series:
 
-#### o3
+#### o3 and o4-mini
 
-OpenAI's most powerful reasoning model, designed for complex tasks requiring advanced mathematical, scientific, and coding capabilities.
+These reasoning models provide different performance and efficiency profiles:
 
-- 200,000 token context window
-- 100,000 max output tokens
-- May 31, 2024 knowledge cutoff
-- Pricing: $10.00 per 1M input tokens, $40.00 per 1M output tokens
+- **o3**: Powerful reasoning model, optimized for complex mathematical, scientific, and coding tasks
+- **o4-mini**: Efficient reasoning model with strong performance in coding and visual tasks at lower cost
 
-#### o4-mini
+Both models feature:
 
-A faster, more affordable reasoning model with efficient performance in coding and visual tasks.
+- Large context window (200,000 tokens)
+- High maximum output tokens (100,000 tokens)
 
-- 200,000 token context window
-- 100,000 max output tokens
-- May 31, 2024 knowledge cutoff
-- Pricing: $1.10 per 1M input tokens, $4.40 per 1M output tokens
+For current specifications and pricing information, refer to [OpenAI's pricing page](https://openai.com/pricing).
 
 Example configuration:
 
 ```yaml title="promptfooconfig.yaml"
 providers:
+  - id: openai:responses:o3
+    config:
+      reasoning_effort: 'high'
+      max_output_tokens: 2000
+
   - id: openai:responses:o4-mini
-    label: o4-mini-standard
     config:
       reasoning_effort: 'medium'
       max_output_tokens: 1000

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -888,7 +888,9 @@ The Responses API supports a wide range of models, including:
 - `o1` - Powerful reasoning model
 - `o1-mini` - Smaller, more affordable reasoning model
 - `o1-pro` - Enhanced reasoning model with more compute
-- `o3-mini` - Latest reasoning model with improved performance
+- `o3` - OpenAI's most powerful reasoning model
+- `o3-mini` - Smaller, more affordable reasoning model
+- `o4-mini` - Latest fast, cost-effective reasoning model
 
 ### Using the Responses API
 
@@ -917,6 +919,53 @@ The Responses API configuration supports these parameters in addition to standar
 | `store`                | Whether to store the response for later retrieval | true       | Boolean                             |
 | `truncation`           | Strategy to handle context window overflow        | 'disabled' | 'auto', 'disabled'                  |
 | `reasoning`            | Configuration for reasoning models                | None       | Object with `effort` field          |
+
+### Reasoning Models
+
+When using reasoning models like `o1`, `o1-pro`, `o3`, `o3-mini`, or `o4-mini`, you can control the reasoning effort:
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: openai:responses:o3
+    config:
+      reasoning_effort: 'medium' # Can be "low", "medium", or "high"
+      max_output_tokens: 1000
+```
+
+Reasoning models "think before they answer," generating internal reasoning that isn't visible in the output but counts toward token usage and billing.
+
+### New o3 and o4-mini Models
+
+The latest OpenAI reasoning models include:
+
+#### o3
+
+OpenAI's most powerful reasoning model, designed for complex tasks requiring advanced mathematical, scientific, and coding capabilities.
+
+- 200,000 token context window
+- 100,000 max output tokens
+- May 31, 2024 knowledge cutoff
+- Pricing: $10.00 per 1M input tokens, $40.00 per 1M output tokens
+
+#### o4-mini
+
+A faster, more affordable reasoning model with efficient performance in coding and visual tasks.
+
+- 200,000 token context window
+- 100,000 max output tokens
+- May 31, 2024 knowledge cutoff
+- Pricing: $1.10 per 1M input tokens, $4.40 per 1M output tokens
+
+Example configuration:
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: openai:responses:o4-mini
+    label: o4-mini-standard
+    config:
+      reasoning_effort: 'medium'
+      max_output_tokens: 1000
+```
 
 ### Sending Images in Prompts
 
@@ -965,20 +1014,6 @@ providers:
               required: ['location']
       tool_choice: 'auto'
 ```
-
-### Reasoning Models
-
-When using reasoning models like `o1`, `o1-pro`, or `o3-mini`, you can control the reasoning effort:
-
-```yaml title="promptfooconfig.yaml"
-providers:
-  - id: openai:responses:o1
-    config:
-      reasoning_effort: 'medium' # Can be "low", "medium", or "high"
-      max_output_tokens: 1000
-```
-
-Reasoning models "think before they answer," generating internal reasoning that isn't visible in the output but counts toward token usage and billing.
 
 ### Complete Example
 

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -33,7 +33,11 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
   }
 
   protected isReasoningModel(): boolean {
-    return this.modelName.startsWith('o1') || this.modelName.startsWith('o3');
+    return (
+      this.modelName.startsWith('o1') ||
+      this.modelName.startsWith('o3') ||
+      this.modelName.startsWith('o4')
+    );
   }
 
   protected supportsTemperature(): boolean {

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -84,9 +84,11 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     }
 
     const isReasoningModel = this.isReasoningModel();
-    const maxOutputTokens = isReasoningModel
-      ? (config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS'))
-      : (config.max_tokens ?? getEnvInt('OPENAI_MAX_TOKENS', 1024));
+    const maxOutputTokens =
+      config.max_output_tokens ??
+      (isReasoningModel
+        ? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS')
+        : getEnvInt('OPENAI_MAX_TOKENS', 1024));
 
     const temperature = this.supportsTemperature()
       ? (config.temperature ?? getEnvFloat('OPENAI_TEMPERATURE', 0))

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -29,7 +29,9 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'o1-mini',
     'o1-pro',
     'o3',
-    'o3-preview',
+    'o3-2025-04-16',
+    'o4-mini',
+    'o4-mini-2025-04-16',
     'o3-mini',
     'gpt-4.5-preview',
     'gpt-4.5-preview-2025-02-27',
@@ -46,7 +48,11 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
   }
 
   protected isReasoningModel(): boolean {
-    return this.modelName.startsWith('o1') || this.modelName.startsWith('o3');
+    return (
+      this.modelName.startsWith('o1') ||
+      this.modelName.startsWith('o3') ||
+      this.modelName.startsWith('o4')
+    );
   }
 
   protected supportsTemperature(): boolean {

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -52,7 +52,7 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
   modalities?: string[];
   audio?: {
     bitrate?: string;
-    format?: string;
+    format?: string | 'wav' | 'mp3' | 'flac' | 'opus' | 'pcm16' | 'aac';
     speed?: number;
     voice?: string;
   };

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -810,11 +810,15 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const o1Provider = new OpenAiChatCompletionProvider('o1-mini');
       const o3Provider = new OpenAiChatCompletionProvider('o3-mini');
       const o1PreviewProvider = new OpenAiChatCompletionProvider('o1-preview');
+      const o3StandardProvider = new OpenAiChatCompletionProvider('o3');
+      const o4MiniProvider = new OpenAiChatCompletionProvider('o4-mini');
 
       expect(regularProvider['isReasoningModel']()).toBe(false);
       expect(o1Provider['isReasoningModel']()).toBe(true);
       expect(o3Provider['isReasoningModel']()).toBe(true);
       expect(o1PreviewProvider['isReasoningModel']()).toBe(true);
+      expect(o3StandardProvider['isReasoningModel']()).toBe(true);
+      expect(o4MiniProvider['isReasoningModel']()).toBe(true);
     });
 
     it('should handle temperature support correctly', () => {
@@ -822,12 +826,14 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const o1Provider = new OpenAiChatCompletionProvider('o1-mini');
       const o3Provider = new OpenAiChatCompletionProvider('o3-mini');
       const o1PreviewProvider = new OpenAiChatCompletionProvider('o1-preview');
+      const o4MiniProvider = new OpenAiChatCompletionProvider('o4-mini');
       const gpt41Provider = new OpenAiChatCompletionProvider('gpt-4.1');
 
       expect(regularProvider['supportsTemperature']()).toBe(true);
       expect(o1Provider['supportsTemperature']()).toBe(false);
       expect(o3Provider['supportsTemperature']()).toBe(false);
       expect(o1PreviewProvider['supportsTemperature']()).toBe(false);
+      expect(o4MiniProvider['supportsTemperature']()).toBe(false);
       expect(gpt41Provider['supportsTemperature']()).toBe(true);
     });
 
@@ -927,6 +933,34 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const regularCall = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
       const regularBody = JSON.parse(regularCall[1].body);
       expect(regularBody.reasoning_effort).toBeUndefined();
+    });
+
+    it('should handle o4-mini with reasoning_effort and service_tier', async () => {
+      const mockResponse = {
+        data: {
+          choices: [{ message: { content: 'O4-mini response' } }],
+          usage: { total_tokens: 15, prompt_tokens: 8, completion_tokens: 7 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetchWithCache.mockResolvedValue(mockResponse);
+
+      // Test O4-mini model with reasoning_effort
+      const o4MiniProvider = new OpenAiChatCompletionProvider('o4-mini', {
+        config: {
+          reasoning_effort: 'medium',
+        } as any,
+      });
+      await o4MiniProvider.callApi('Test reasoning with o4-mini');
+
+      const o4Call = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
+      const o4Body = JSON.parse(o4Call[1].body);
+
+      expect(o4Body.reasoning_effort).toBe('medium');
+      expect(o4Body.temperature).toBeUndefined(); // o4-mini shouldn't have temperature
+      expect(o4Body.max_tokens).toBeUndefined(); // o4-mini shouldn't use max_tokens
     });
 
     it('should handle audio responses correctly', async () => {


### PR DESCRIPTION
This update introduces support for the new o4-mini reasoning model in the OpenAI provider.

- Added configuration and tests for o4-mini model.
- Updated documentation to include o4-mini details.