### PR TITLE
feat(eval): add warning for redteam config without test cases

### DIFF
--- a/examples/redteam-multi-modal/promptfooconfig.unsafebench.yaml
+++ b/examples/redteam-multi-modal/promptfooconfig.unsafebench.yaml
@@ -27,6 +27,6 @@ redteam:
     You are a visual analysis assistant that provides information about images while maintaining ethical boundaries.
     You should refuse to engage with harmful imagery and prioritize safety over user compliance.
   injectVar: image
-  numTests: 25
+  numTests: 100
   plugins:
     - id: unsafebench

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -156,6 +156,20 @@ export async function doEval(
 
     ({ config, testSuite, basePath: _basePath } = await resolveConfigs(cmdObj, defaultConfig));
 
+    // Check if config has redteam section but no test cases
+    if (
+      config.redteam &&
+      (!testSuite.tests || testSuite.tests.length === 0) &&
+      (!testSuite.scenarios || testSuite.scenarios.length === 0)
+    ) {
+      logger.warn(
+        chalk.yellow(dedent`
+        Warning: Config file has a redteam section but no test cases.
+        Did you mean to run ${chalk.bold('promptfoo redteam generate')} instead?
+        `),
+      );
+    }
+
     // Ensure evaluateOptions from the config file are applied
     if (config.evaluateOptions) {
       evaluateOptions = {

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -53,8 +53,8 @@ jest.mock('../../../src/models/eval', () => {
 
 describe('redteam warning in eval command', () => {
   beforeEach(() => {
-    // Mock logger.warn
-    jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    // Mock logger.warn - return the logger object to maintain chaining
+    jest.spyOn(logger, 'warn').mockImplementation(() => logger);
   });
 
   afterEach(() => {

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -80,10 +80,10 @@ describe('redteam warning in eval command', () => {
     // Call doEval
     await doEval(mockCmd, mockDefaultConfig, mockDefaultConfigPath, mockEvaluateOptions);
 
-    // Verify that logger.warn was called with a message containing "redteam generate"
-    expect(logger.warn).toHaveBeenCalled();
-    const warningCall = logger.warn.mock.calls[0][0];
-    expect(warningCall).toContain('redteam section but no test cases');
-    expect(warningCall).toContain('promptfoo redteam generate');
+    // Verify that logger.warn was called with a message containing the expected text
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('redteam section but no test cases'),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('promptfoo redteam generate'));
   });
 });

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -1,0 +1,89 @@
+import { doEval } from '../../../src/commands/eval';
+import logger from '../../../src/logger';
+
+// Mock util/config/default.ts
+jest.mock('../../../src/util/config/default', () => ({
+  loadDefaultConfig: jest.fn().mockResolvedValue({
+    defaultConfig: {},
+    defaultConfigPath: null,
+  }),
+  clearConfigCache: jest.fn(),
+}));
+
+jest.mock('../../../src/util/config/load', () => ({
+  resolveConfigs: jest.fn().mockResolvedValue({
+    config: {
+      redteam: {
+        purpose: 'Test red team purpose',
+      },
+    },
+    testSuite: {
+      prompts: [],
+      providers: [],
+      tests: [], // Empty tests array
+    },
+    basePath: '',
+  }),
+}));
+
+jest.mock('../../../src/evaluator', () => ({
+  evaluate: jest.fn().mockResolvedValue({}),
+  DEFAULT_MAX_CONCURRENCY: 4,
+}));
+
+// Mock other dependencies to prevent actual execution
+jest.mock('../../../src/migrate', () => ({
+  runDbMigrations: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../../src/models/eval', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      addResult: jest.fn().mockResolvedValue({}),
+      addPrompts: jest.fn().mockResolvedValue({}),
+      getTable: jest.fn().mockResolvedValue({ body: [] }),
+      resultsCount: 0,
+      prompts: [],
+      persisted: false,
+      results: [],
+    })),
+  };
+});
+
+describe('redteam warning in eval command', () => {
+  beforeEach(() => {
+    // Mock logger.warn
+    jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should warn when config has redteam section but no test cases', async () => {
+    // Mock command object
+    const mockCmd = {
+      config: ['test-config.yaml'],
+      write: false, // Prevent database operations
+    };
+
+    // Mock defaultConfig
+    const mockDefaultConfig = {};
+
+    // Mock defaultConfigPath
+    const mockDefaultConfigPath = 'test-config.yaml';
+
+    // Mock evaluateOptions
+    const mockEvaluateOptions = {};
+
+    // Call doEval
+    await doEval(mockCmd, mockDefaultConfig, mockDefaultConfigPath, mockEvaluateOptions);
+
+    // Verify that logger.warn was called with a message containing "redteam generate"
+    expect(logger.warn).toHaveBeenCalled();
+    const warningCall = logger.warn.mock.calls[0][0];
+    expect(warningCall).toContain('redteam section but no test cases');
+    expect(warningCall).toContain('promptfoo redteam generate');
+  });
+});


### PR DESCRIPTION
Add a warning in the eval command when a redteam section exists in the config but no test cases are defined.
- Updated eval.ts to include the warning logic.
- Added corresponding unit tests to verify the warning behavior.