### PR TITLE
chore: Increase max outuput tokens for `google:gemini-2.5-pro-exp-03-25` to 2048 in Gemini example

### DIFF
--- a/examples/google-aistudio-gemini/promptfooconfig.yaml
+++ b/examples/google-aistudio-gemini/promptfooconfig.yaml
@@ -13,11 +13,11 @@ providers:
         maxOutputTokens: 2048
         thinkingConfig:
           thinkingBudget: 1024
-g
+
   - google:gemini-2.0-flash-exp
 
   - google:gemini-2.0-flash-thinking-exp
-r
+
   - id: google:gemini-2.5-pro-exp-03-25
     config:
       temperature: 0.7

--- a/examples/google-aistudio-gemini/promptfooconfig.yaml
+++ b/examples/google-aistudio-gemini/promptfooconfig.yaml
@@ -13,13 +13,15 @@ providers:
         maxOutputTokens: 2048
         thinkingConfig:
           thinkingBudget: 1024
+g
   - google:gemini-2.0-flash-exp
-  - google:gemini-2.0-flash-thinking-exp
 
+  - google:gemini-2.0-flash-thinking-exp
+r
   - id: google:gemini-2.5-pro-exp-03-25
     config:
       temperature: 0.7
-      maxOutputTokens: 512
+      maxOutputTokens: 2048
 
   - id: google:gemini-1.5-pro
     config:


### PR DESCRIPTION
Current ceiling is insufficient for thinking and causes eval to fail.