### PR TITLE
docs(providers): update model IDs to latest versions

### DIFF
--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -8,16 +8,18 @@ Here's a basic example of configuring providers in your promptfoo YAML config:
 
 ```yaml
 providers:
-  - openai:gpt-4o-mini
   - anthropic:messages:claude-3-7-sonnet-20250219
-  - vertex:gemini-pro
+  - openai:gpt-4.1-mini
+  - openai:o3-mini
+  - google:gemini-2.5-flash-preview-04-17
+  - vertex:gemini-2.5-flash-preview-04-17
 ```
 
 ## Available Providers
 
 | Api Providers                                       | Description                                       | Syntax & Example                                   |
 | --------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
-| [OpenAI](./openai.md)                               | GPT models including GPT-4 and GPT-3.5            | `openai:o1-preview`                                |
+| [OpenAI](./openai.md)                               | GPT models including GPT-4.1 and reasoning models | `openai:o3-mini`                                   |
 | [Anthropic](./anthropic.md)                         | Claude models                                     | `anthropic:messages:claude-3-7-sonnet-latest`      |
 | [HTTP](./http.md)                                   | Generic HTTP-based providers                      | `https://api.example.com/v1/chat/completions`      |
 | [Javascript](./custom-api.md)                       | Custom - JavaScript file                          | `file://path/to/custom_provider.js`                |
@@ -35,10 +37,10 @@ providers:
 | [fal.ai](./fal.md)                                  | Image Generation Provider                         | `fal:image:fal-ai/fast-sdxl`                       |
 | [Fireworks AI](./fireworks.md)                      | Various hosted models                             | `fireworks:accounts/fireworks/models/qwen-v2p5-7b` |
 | [GitHub](./github.md)                               | GitHub AI Gateway                                 | `github:gpt-4o-mini`                               |
-| [Google AI Studio](./google.md)                     | Gemini models                                     | `google:gemini-2.0-flash-thinking-exp`             |
-| [Google Vertex AI](./vertex.md)                     | Google Cloud's AI platform                        | `vertex:gemini-pro`                                |
+| [Google AI Studio](./google.md)                     | Gemini models                                     | `google:gemini-2.5-flash-preview-04-17`            |
+| [Google Vertex AI](./vertex.md)                     | Google Cloud's AI platform                        | `vertex:gemini-2.5-flash-preview-04-17`            |
 | [Groq](./groq.md)                                   | High-performance inference API                    | `groq:llama-3.3-70b-versatile`                     |
-| [Hyperbolic](./hyperbolic.md)                       | OpenAI-compatible Llama 3 provider                | `hyperbolic:meta-llama/Meta-Llama-3-70B-Instruct`  |
+| [Hyperbolic](./hyperbolic.md)                       | OpenAI-compatible Llama 3 provider                | `hyperbolic:meta-llama/Llama-3.3-70B-Instruct`     |
 | [Hugging Face](./huggingface.md)                    | Access thousands of models                        | `huggingface:text-generation:gpt2`                 |
 | [IBM BAM](./ibm-bam.md)                             | IBM's foundation models                           | `bam:chat:ibm/granite-13b-chat-v2`                 |
 | [JFrog ML](./jfrog.md)                              | JFrog's LLM Model Library                         | `jfrog:llama_3_8b_instruct`                        |
@@ -66,7 +68,7 @@ providers:
 | [Sequence](./sequence.md)                           | Custom - Multi-prompt sequencing                  | `sequence` with config.inputs array                |
 | [Simulated User](./simulated-user.md)               | Custom - Conversation simulator                   | `promptfoo:simulated-user`                         |
 | [WatsonX](./watsonx.md)                             | IBM's WatsonX                                     | `watsonx:ibm/granite-13b-chat-v2`                  |
-| [X.AI](./xai.md)                                    | X.AI's models                                     | `xai:grok-2`                                       |
+| [X.AI](./xai.md)                                    | X.AI's models                                     | `xai:grok-3-beta`                                  |
 
 ## Provider Syntax
 
@@ -78,7 +80,7 @@ Providers are specified using various syntax options:
    provider_name:model_name
    ```
 
-   Example: `openai:gpt-4o-mini` or `anthropic:claude-3-sonnet-20240229`
+   Example: `openai:gpt-4.1-mini` or `anthropic:claude-3-7-sonnet-20250219`
 
 2. Object format with configuration:
 
@@ -92,7 +94,7 @@ Providers are specified using various syntax options:
    Example:
 
    ```yaml
-   - id: openai:gpt-4o-mini
+   - id: openai:gpt-4.1-mini
      config:
        temperature: 0.7
        max_tokens: 150
@@ -103,7 +105,7 @@ Providers are specified using various syntax options:
    Load a single provider:
 
    ```yaml title="provider.yaml"
-   id: openai:chat:gpt-4o-mini
+   id: openai:chat:gpt-4.1-mini
    config:
      temperature: 0.7
    ```
@@ -111,7 +113,7 @@ Providers are specified using various syntax options:
    Or multiple providers:
 
    ```yaml title="providers.yaml"
-   - id: openai:gpt-4o-mini
+   - id: openai:gpt-4.1-mini
      config:
        temperature: 0.7
    - id: anthropic:messages:claude-3-7-sonnet-20250219
@@ -140,7 +142,7 @@ You can also specify API keys in your configuration file:
 
 ```yaml
 providers:
-  - id: openai:gpt-4o-mini
+  - id: openai:gpt-4.1-mini
     config:
       apiKey: your_api_key_here
 ```
@@ -211,7 +213,7 @@ Example:
 
 ```yaml
 providers:
-  - id: openai:gpt-4o-mini
+  - id: openai:gpt-4.1-mini
     config:
       temperature: 0.7
       max_tokens: 150

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -19,7 +19,7 @@ providers:
 
 | Api Providers                                       | Description                                       | Syntax & Example                                   |
 | --------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
-| [OpenAI](./openai.md)                               | GPT models including GPT-4.1 and reasoning models | `openai:o3-mini`                                   |
+| [OpenAI](./openai.md)                               | GPT models including GPT-4.1 and reasoning models | `openai:gpt-4.1-mini` or `openai:o3-mini`          |
 | [Anthropic](./anthropic.md)                         | Claude models                                     | `anthropic:messages:claude-3-7-sonnet-latest`      |
 | [HTTP](./http.md)                                   | Generic HTTP-based providers                      | `https://api.example.com/v1/chat/completions`      |
 | [Javascript](./custom-api.md)                       | Custom - JavaScript file                          | `file://path/to/custom_provider.js`                |


### PR DESCRIPTION
This PR updates model references in the providers documentation to use the latest versions available from:

- OpenAI: Add gpt-4.1-mini and o3-mini models
- Google AI: Update to gemini-2.5-flash-preview-04-17
- Vertex AI: Update to gemini-2.5-flash-preview-04-17
- Hyperbolic: Update to Llama-3.3-70B-Instruct
- X.AI: Update to grok-3-beta

These changes ensure the documentation reflects current state-of-the-art models.
