### PR TITLE
chore: respect redteam commandLineOptions from config

### DIFF
--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -69,6 +69,7 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
   logger.info('Generating test cases...');
   const redteamConfig = await doGenerateRedteam({
     ...options,
+    ...(options.liveRedteamConfig?.commandLineOptions || {}),
     config: configPath,
     output: redteamPath,
     force: options.force,


### PR DESCRIPTION
Going to use this to pass in command line args from cloud configs