### PR TITLE
refactor: remove if string check

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -226,9 +226,6 @@ export async function createTransformResponse(
     return (data, text, context) => {
       try {
         const result = parser(data, text, context);
-        if (typeof result === 'string') {
-          return { output: result };
-        }
         return { output: result };
       } catch (err) {
         logger.error(`Error in response transform function: ${String(err)}`);


### PR DESCRIPTION
I was exploring the HTTP Provider to see points of extensibility specifically propagating metadata / usage tokens, i noticed that the if statement was not required (probably was used in the past)

Thought i would clean it up in the mean time.