### PR TITLE
fix(matchers): score results correctly with trailing newlines.

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -380,6 +380,10 @@ function tryParse(content: string) {
   return content;
 }
 
+function splitIntoSentences(text: string) {
+  return text.split('\n').filter((sentence) => sentence.trim() !== '');
+}
+
 export async function renderLlmRubricPrompt(
   rubricPrompt: string,
   context: Record<string, string | object>,
@@ -958,7 +962,7 @@ export async function matchesContextRecall(
   }
 
   invariant(typeof resp.output === 'string', 'context-recall produced malformed response');
-  const sentences = resp.output.split('\n');
+  const sentences = splitIntoSentences(resp.output);
   const numerator = sentences.reduce(
     (acc, sentence) => acc + (sentence.includes(CONTEXT_RECALL_ATTRIBUTED_TOKEN) ? 1 : 0),
     0,
@@ -1010,7 +1014,7 @@ export async function matchesContextRelevance(
   }
 
   invariant(typeof resp.output === 'string', 'context-relevance produced malformed response');
-  const sentences = resp.output.split('\n');
+  const sentences = splitIntoSentences(resp.output);
   const numerator = sentences.reduce(
     (acc, sentence) => acc + (sentence.includes(CONTEXT_RELEVANCE_BAD) ? 0 : 1),
     0,
@@ -1077,7 +1081,7 @@ export async function matchesContextFaithfulness(
 
   invariant(typeof resp.output === 'string', 'context-faithfulness produced malformed response');
 
-  const statements = resp.output.split('\n');
+  const statements = splitIntoSentences(resp.output);
   promptText = await renderLlmRubricPrompt(nliPrompt, {
     context,
     statements,

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -1768,7 +1768,7 @@ describe('matchesContextRelevance', () => {
 
     const mockCallApi = jest.fn().mockImplementation(() => {
       return Promise.resolve({
-        output: 'foo\nbar\nbaz Insufficient Information',
+        output: 'foo\nbar\nbaz Insufficient Information\n',
         tokenUsage: { total: 10, prompt: 5, completion: 5 },
       });
     });
@@ -1837,7 +1837,7 @@ describe('matchesContextFaithfulness', () => {
       .fn()
       .mockImplementationOnce(() => {
         return Promise.resolve({
-          output: 'Statement 1\nStatement 2\nStatement 3',
+          output: 'Statement 1\nStatement 2\nStatement 3\n',
           tokenUsage: { total: 10, prompt: 5, completion: 5 },
         });
       })
@@ -1918,7 +1918,7 @@ describe('matchesContextRecall', () => {
 
     const mockCallApi = jest.fn().mockImplementation(() => {
       return Promise.resolve({
-        output: 'foo [Attributed]\nbar [Not attributed]\nbaz [Attributed]',
+        output: 'foo [Attributed]\nbar [Not attributed]\nbaz [Attributed]\n',
         tokenUsage: { total: 10, prompt: 5, completion: 5 },
       });
     });


### PR DESCRIPTION
In trying to use the context-recall matcher I was getting unexpected results. It turned out that the response included a newline at the end, causing the matcher to count one extra failed sentence. (This was using Gemini 2.0 Flash for grading.)

To correct, I added a function that splits on new lines and filters empty lines and it worked as expected for me after.