### PR TITLE
feat: enable custom response parser to optionally return provider response

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -226,7 +226,11 @@ export async function createTransformResponse(
     return (data, text, context) => {
       try {
         const result = parser(data, text, context);
-        return { output: result };
+        if (typeof result === 'object') {
+          return result;
+        } else {
+          return { output: result };
+        }
       } catch (err) {
         logger.error(`Error in response transform function: ${String(err)}`);
         throw err;


### PR DESCRIPTION
## Summary
Allow function based repsponseTransformer return more fields then just output for ProviderResponse

## Thoughts
there are 3 ways to parse response from the api

1. string pattern
2. inlineFunction 
3. fileFunction

currently both 1 and 2 return the result like this `{ output: resp };` 3 allows you to do anything you want, as it does not do anything with the returned result.

because 1 is just a string pattern makes sense to only support `{ output: resp };`, but 2 and 3 should have similar behavior if a user wants to provide more information in the provider response.

this pr brings the two closer, by not transforming the returned object into the output key, but this would cause a breaking change, if developers have been expecting

{ output : {<my_object} } as now it would return { <my_object }

## Result
with this transformer:
```
        transformResponse: (json) => {
          return {
            output: json.classification,
            metadata: { response: json.prompt_response },
            tokenUsage: {
              prompt: json.usage.input_tokens,
              completion: json.usage.output_tokens,
              total: json.usage.input_tokens + json.usage.output_tokens,
            },
          };
        },
 ```
I can get these results with the platform

<img width="807" alt="image" src="https://github.com/user-attachments/assets/3743d9ce-5045-418f-b3a1-9481b3eee169" />

<img width="349" alt="image" src="https://github.com/user-attachments/assets/4b420d19-9bc5-4d63-a8a3-65eb336ad8f1" />


## Moving forward 
function and the file based transformer are misaligned, because if the function transformer returns a string, it gets wrapped as { output: string} where as the file based transformer just returns a string

I think there is value in aligning the behavior as i do not see a good rational to have the behavior be misaligned.