### PR TITLE
fix: incorrect evalId socket mode /evals

### DIFF
--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -122,13 +122,10 @@ export default function Eval({
         setTableFromResultsFile(data);
         setConfig(data?.config);
         setAuthor(data?.author || null);
-        fetchRecentFileEvals().then((newRecentEvals) => {
-          if (newRecentEvals && newRecentEvals.length > 0) {
-            setDefaultEvalId(newRecentEvals[0]?.evalId);
-            setEvalId(newRecentEvals[0]?.evalId);
-            console.log('setting default eval id', newRecentEvals[0]?.evalId);
-          }
-        });
+        const latestEvalId = data.id;
+        setDefaultEvalId(latestEvalId);
+        setEvalId(latestEvalId);
+        console.log('setting default eval id', latestEvalId);
       });
 
       socket.on('update', (data) => {
@@ -136,15 +133,10 @@ export default function Eval({
         setTableFromResultsFile(data);
         setConfig(data.config);
         setAuthor(data.author || null);
-        fetchRecentFileEvals().then((newRecentEvals) => {
-          if (newRecentEvals && newRecentEvals.length > 0) {
-            const newId = newRecentEvals[0]?.evalId;
-            if (newId) {
-              setDefaultEvalId(newId);
-              setEvalId(newId);
-            }
-          }
-        });
+        const latestEvalId = data.id;
+        setDefaultEvalId(latestEvalId);
+        setEvalId(latestEvalId);
+        console.log('setting default eval id', latestEvalId);
       });
 
       return () => {

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -493,6 +493,7 @@ export default class Eval {
 
   async toResultsFile(): Promise<ResultsFile> {
     const results: ResultsFile = {
+      id: this.id,
       version: this.version(),
       createdAt: new Date(this.createdAt).toISOString(),
       results: await this.toEvaluateSummary(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -934,6 +934,7 @@ export interface SharedResults {
 
 // promptfoo's internal results format
 export interface ResultsFile {
+  id?: string;
   version: number;
   createdAt: string;
   results: EvaluateSummaryV3 | EvaluateSummaryV2;


### PR DESCRIPTION
eval data is fetched separately then the latest evalId,

evalId is fetch using /results and evalData uses the socket init. /results is not sorted by created at, this means that the ui can have a random evalId based on sqllite default ordering while the data is correct.

this commits update the source of truth to be the same for the data and the eval by returning the evalId along side the data.

but the latest eval for non socket instances will also be wrong since it relies on the same ordering

eval grid is unaffected as the table does local ordering but would break if it was server paginated