### PR TITLE
fix: results api returns elements ordered by date

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -539,6 +539,7 @@ export async function getEvalSummaries(datasetId?: string): Promise<EvalSummary[
     .from(evalsTable)
     .leftJoin(evalsToDatasetsTable, eq(evalsTable.id, evalsToDatasetsTable.evalId))
     .where(datasetId ? eq(evalsToDatasetsTable.datasetId, datasetId) : undefined)
+    .orderBy(desc(evalsTable.createdAt))
     .all();
 
   /**


### PR DESCRIPTION
when not running in socket mode, the ui makes an api call to get the latest evals and uses the eval at index 0 as the latest order, but this is not garunteed to be the case as the api does not order the evals

this does not affect eval data grid as it orders elements locally