### PR TITLE
fix: allow escaping of {{ }} placeholders in prompts

### DIFF
--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -251,7 +251,9 @@ export async function renderPrompt(
     // Recursively walk the JSON structure. If we find a string, render it with nunjucks.
     return JSON.stringify(renderVarsInObject(parsed, vars), null, 2);
   } catch {
-    return renderVarsInObject(nunjucks.renderString(basePrompt, vars), vars);
+    // Use `renderString` instead of `renderVarsInObject` because `getNunjucksEngine` checks for
+    // disabled templating and the `renderVarsInObject` calls this method when passed a string:
+    return nunjucks.renderString(basePrompt, vars);
   }
 }
 

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -265,6 +265,18 @@ describe('renderPrompt', () => {
     expect(renderedPrompt).toBe('{{ var1 }}');
   });
 
+  it('should respect Nunjucks escaped strings when variable is provided as a template string', async () => {
+    const prompt = toPrompt(`{{ '{{ var1 }}' }}`);
+    const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' }, {});
+    expect(renderedPrompt).toBe('{{ var1 }}');
+  });
+
+  it('should respect Nunjucks escaped strings when no variables are provided', async () => {
+    const prompt = toPrompt(`{{ '{{ var1 }}' }}`);
+    const renderedPrompt = await renderPrompt(prompt, {}, {});
+    expect(renderedPrompt).toBe('{{ var1 }}');
+  });
+
   it('should render variables that are template strings', async () => {
     const prompt = toPrompt('{{ var1 }}');
     const renderedPrompt = await renderPrompt(prompt, { var1: '{{ var2 }}', var2: 'value2' }, {});

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -252,6 +252,24 @@ describe('renderPrompt', () => {
     expect(renderedPrompt).toBe('Test prompt value1');
     delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
   });
+
+  it('should respect Nunjucks raw tags when variable is provided as a string', async () => {
+    const prompt = toPrompt('{% raw %}{{ var1 }}{% endraw %}');
+    const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' }, {});
+    expect(renderedPrompt).toBe('{{ var1 }}');
+  });
+
+  it('should respect Nunjucks raw tags when no variables are provided', async () => {
+    const prompt = toPrompt('{% raw %}{{ var1 }}{% endraw %}');
+    const renderedPrompt = await renderPrompt(prompt, {}, {});
+    expect(renderedPrompt).toBe('{{ var1 }}');
+  });
+
+  it('should render variables that are template strings', async () => {
+    const prompt = toPrompt('{{ var1 }}');
+    const renderedPrompt = await renderPrompt(prompt, { var1: '{{ var2 }}', var2: 'value2' }, {});
+    expect(renderedPrompt).toBe('value2');
+  });
 });
 
 describe('renderPrompt with prompt functions', () => {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Modify template rendering to correctly process Nunjucks templates with placeholders