### PR TITLE
chore: Respect Max text length for variable cells in results table

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -487,7 +487,7 @@ function ResultsTable({
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>{truncatedValue}</ReactMarkdown>
                       </MarkdownErrorBoundary>
                     ) : (
-                      <>{value}</>
+                      <TruncatedText text={value} maxLength={maxTextLength} />
                     )}
                   </div>
                 );


### PR DESCRIPTION
Previously, the entire value was shown, which wasn't using the maxtextlength property from the table.

## Summary by Sourcery

Chores:
- Updated rendering of table cell values to use TruncatedText component