### PR TITLE
fix(site): Landing page content jumping on step switch

### DIFF
--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -117,7 +117,7 @@
 }
 
 .walkthroughTab {
-  padding: 1rem 1rem;
+  padding: 1rem 1rem calc(1rem - 2px) 1rem;
   border: none;
   background: none;
   font-size: 1.25rem;
@@ -125,10 +125,11 @@
   transition: all 0.3s ease;
   white-space: normal;
   text-align: center;
+  border-bottom: 2px solid transparent;
 }
 
 .walkthroughTabActive {
-  border-bottom: 2px solid #1890ff;
+  border-color: #1890ff;
   color: #1890ff;
 }
 


### PR DESCRIPTION
This PR fixes changing border height on button click causing the content height to noticeably shift.

<img width="689" alt="image" src="https://github.com/user-attachments/assets/30a1a3d3-7f69-41c8-b2e2-d897add2abb2" />
