### PR TITLE
fix(cli): Read `.env` file prior to calling env var getters

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import cliState from './cliState';
 import type { EnvOverrides } from './types/env';
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,6 +1,6 @@
 import compression from 'compression';
 import cors from 'cors';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import type { Request, Response } from 'express';
 import express from 'express';
 import http from 'node:http';
@@ -36,8 +36,6 @@ import { evalRouter } from './routes/eval';
 import { providersRouter } from './routes/providers';
 import { redteamRouter } from './routes/redteam';
 import { userRouter } from './routes/user';
-
-dotenv.config();
 
 // Prompts cache
 let allPrompts: PromptWithMetadata[] | null = null;

--- a/test/globalConfig.test.ts
+++ b/test/globalConfig.test.ts
@@ -58,9 +58,6 @@ describe('Global Config', () => {
 
       it('should read and parse the existing config file', () => {
         const result = globalConfig.readGlobalConfig();
-
-        expect(fs.existsSync).toHaveBeenCalledTimes(1);
-        expect(fs.readFileSync).toHaveBeenCalledTimes(1);
         expect(fs.readFileSync).toHaveBeenCalledWith(
           expect.stringContaining('promptfoo.yaml'),
           'utf-8',


### PR DESCRIPTION
I encountered an issue where values in my `.env` were not being read e.g. `LOG_LEVEL=debug`.  I traced this case to `src/logger.ts` and logged `getEnvString('LOG_LEVEL')` which returned `undefined` because my `.env` file had not been read prior to `getEnvString`'s call.  This change ensures the `.env` file is _always_ read prior to getter calls.

## Summary by Sourcery

Bug Fixes:
- Fixed issue where environment variables from `.env` file were not being read before being accessed