### PR TITLE
chore: remove assertion-used event

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -20,7 +20,6 @@ import {
 } from '../matchers';
 import { isPackagePath, loadFromPackage } from '../providers/packageParser';
 import { runPython } from '../python/pythonUtils';
-import telemetry from '../telemetry';
 import type {
   AssertionParams,
   AssertionValueFunctionContext,
@@ -123,10 +122,6 @@ export async function runAssertion({
   const baseType = inverse
     ? (assertion.type.slice(4) as AssertionType)
     : (assertion.type as AssertionType);
-
-  telemetry.record('assertion_used', {
-    type: baseType,
-  });
 
   if (assertion.transform) {
     output = await transform(assertion.transform, output, {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removed 'assertion_used' telemetry event from assertion processing