### PR TITLE
chore: minor telemetry changes

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -104,10 +104,13 @@ export type EnvVars = {
   JEST_WORKER_ID?: string;
   NODE_EXTRA_CA_CERTS?: string;
   NODE_TLS_REJECT_UNAUTHORIZED?: string;
-  POSTHOG_KEY?: string;
   REQUEST_TIMEOUT_MS?: number;
   RESULT_HISTORY_LENGTH?: number;
   WEBHOOK_TIMEOUT?: number;
+
+  // Posthog
+  PROMPTFOO_POSTHOG_KEY?: string;
+  PROMPTFOO_POSTHOG_HOST?: string;
 
   //=========================================================================
   // UI configuration

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -46,8 +46,11 @@ jest.mock('../src/envars', () => ({
     return false;
   }),
   getEnvString: jest.fn().mockImplementation((key) => {
-    if (key === 'POSTHOG_KEY') {
-      return process.env.POSTHOG_KEY || undefined;
+    if (key === 'PROMPTFOO_POSTHOG_KEY') {
+      return process.env.PROMPTFOO_POSTHOG_KEY || undefined;
+    }
+    if (key === 'PROMPTFOO_POSTHOG_HOST') {
+      return process.env.PROMPTFOO_POSTHOG_HOST || undefined;
     }
     if (key === 'NODE_ENV') {
       return process.env.NODE_ENV || undefined;
@@ -64,7 +67,7 @@ describe('Telemetry', () => {
   beforeEach(() => {
     originalEnv = process.env;
     process.env = { ...originalEnv };
-    process.env.POSTHOG_KEY = 'test-key';
+    process.env.PROMPTFOO_POSTHOG_KEY = 'test-key';
 
     // Setup fetch mock
     mockFetch = jest.fn().mockResolvedValue({ ok: true });


### PR DESCRIPTION
- ensure consistent key name (we were using `PROMPTFOO_POSTHOG_KEY` and `POSTHOG_KEY`)
- allow overwriting host
- adds debug logging