### PR TITLE
docs: add docs about returning object for custom parser

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -358,22 +358,92 @@ This expression will be evaluated with three variables available:
 
 #### Function parser
 
-When using promptfoo as a Node.js library, you can provide a function as the response parser:
+When using promptfoo as a Node.js library, you can provide a function as the response. You may return a string or an object of type `ProviderResponse`.
+
+parser:
 
 ```javascript
 {
   providers: [{
     id: 'https',
     config: {
-      url: 'https://example.com/generate',
+      url: 'https://example.com/generate_response',
       transformResponse: (json, text) => {
-        // Custom parsing logic
+        // Custom parsing logic that returns string
         return json.choices[0].message.content;
+      },
+    }
+  },
+  {
+    id: 'https',
+    config: {
+      url: 'https://example.com/generate_with_tokens',
+      transformResponse: (json, text) => {
+        // Custom parsing logic that returns object
+        {
+          output: json.output,
+          tokenUsage: {
+            prompt: json.usage.input_tokens,
+            completion: json.usage.output_tokens,
+            total: json.usage.input_tokens + json.usage.output_tokens,
+          }
+        }
       },
     }
   }],
 }
 ```
+
+<details>
+<summary>Type definition</summary>
+
+```typescript
+interface ProviderResponse {
+  cached?: boolean;
+  cost?: number;
+  error?: string;
+  logProbs?: number[];
+  metadata?: {
+    redteamFinalPrompt?: string;
+    [key: string]: any;
+  };
+  raw?: string | any;
+  output?: string | any;
+  tokenUsage?: TokenUsage;
+  isRefusal?: boolean;
+  sessionId?: string;
+  guardrails?: GuardrailResponse;
+  audio?: {
+    id?: string;
+    expiresAt?: number;
+    data?: string; // base64 encoded audio data
+    transcript?: string;
+    format?: string;
+  };
+}
+
+export type TokenUsage = z.infer<typeof TokenUsageSchema>;
+
+export const TokenUsageSchema = BaseTokenUsageSchema.extend({
+  assertions: BaseTokenUsageSchema.optional(),
+});
+
+export const BaseTokenUsageSchema = z.object({
+  // Core token counts
+  prompt: z.number().optional(),
+  completion: z.number().optional(),
+  cached: z.number().optional(),
+  total: z.number().optional(),
+
+  // Request metadata
+  numRequests: z.number().optional(),
+
+  // Detailed completion information
+  completionDetails: CompletionTokenDetailsSchema.optional(),
+});
+```
+
+</details>
 
 #### File-based parser
 


### PR DESCRIPTION
I enabled the feature in https://github.com/promptfoo/promptfoo/pull/3824. this commit adds the documentation

# Before
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/fc542bd7-6513-4018-a3eb-88fabe56a769" />

# After
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/a047ee88-0843-46e0-8436-014bf58d7f90" />
<img width="818" alt="image" src="https://github.com/user-attachments/assets/13d03d75-205d-4532-8cb1-b0bed98a57b4" />

## Summary by Sourcery

Add documentation for custom parser response types in HTTP providers

New Features:
- Support for returning complex response objects from custom parser functions
- Documented the full structure of ProviderResponse interface

Documentation:
- Expanded documentation for HTTP provider's transformResponse function to explain returning string or ProviderResponse object
- Added detailed type definitions for ProviderResponse interface
- Included examples of parsing responses with different return types