### PR TITLE
refactor: unused code after migration from nextui

### DIFF
--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -7,7 +7,7 @@ import useApiConfig from '@app/stores/apiConfig';
 import { callApi } from '@app/utils/api';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import type { SharedResults, ResultLightweightWithLabel, ResultsFile } from '@promptfoo/types';
+import type { ResultLightweightWithLabel, ResultsFile } from '@promptfoo/types';
 import { io as SocketIOClient } from 'socket.io-client';
 import EmptyState from './EmptyState';
 import ResultsView from './ResultsView';
@@ -16,17 +16,9 @@ import './Eval.css';
 
 interface EvalOptions {
   fetchId: string | null;
-  preloadedData?: SharedResults;
-  recentEvals?: ResultLightweightWithLabel[];
-  defaultEvalId?: string;
 }
 
-export default function Eval({
-  fetchId,
-  preloadedData,
-  recentEvals: recentEvalsProp,
-  defaultEvalId: defaultEvalIdProp,
-}: EvalOptions) {
+export default function Eval({ fetchId }: EvalOptions) {
   const navigate = useNavigate();
   const { apiBaseUrl } = useApiConfig();
 
@@ -45,9 +37,7 @@ export default function Eval({
 
   const [loaded, setLoaded] = React.useState(false);
   const [failed, setFailed] = React.useState(false);
-  const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>(
-    recentEvalsProp || [],
-  );
+  const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>([]);
 
   const fetchRecentFileEvals = async () => {
     const resp = await callApi(`/results`, { cache: 'no-store' });
@@ -88,9 +78,7 @@ export default function Eval({
     [searchParams, navigate],
   );
 
-  const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
-    defaultEvalIdProp || recentEvals[0]?.evalId,
-  );
+  const [defaultEvalId, setDefaultEvalId] = React.useState<string>('');
 
   React.useEffect(() => {
     if (fetchId) {
@@ -103,12 +91,6 @@ export default function Eval({
         fetchRecentFileEvals();
       };
       run();
-    } else if (preloadedData) {
-      console.log('Eval init: Using preloaded data');
-      setTableFromResultsFile(preloadedData.data);
-      setConfig(preloadedData.data.config);
-      setAuthor(preloadedData.data.author || null);
-      setLoaded(true);
     } else if (IS_RUNNING_LOCALLY) {
       console.log('Eval init: Using local server websocket');
 
@@ -182,7 +164,6 @@ export default function Eval({
     setAuthor,
     setEvalId,
     fetchEvalById,
-    preloadedData,
     setDefaultEvalId,
     setInComparisonMode,
   ]);

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -145,12 +145,6 @@ export default function Eval({ fetchId }: EvalOptions) {
           setLoaded(true);
           setDefaultEvalId(defaultEvalId);
           setEvalId(defaultEvalId);
-        } else {
-          return (
-            <div className="notice">
-              No evals yet. Share some evals to this server and they will appear here.
-            </div>
-          );
         }
       };
       run();


### PR DESCRIPTION
Exploring refactoring this code as commented in https://github.com/promptfoo/promptfoo/pull/3825, after the migration nextui -> react + 8months of coding caused all this code to exist even though its not used. https://github.com/promptfoo/promptfoo/pull/1637

Best thing to do is to delete and move on. if it is used please let me know how and close this pr
preloaded data was originally used using what is now known as fetchId 2 years ago 4ebb21d72fc4d98c26a1d00b0461bb9bb13d69fa

recentEvals is now loaded using fetchRecentEvals
defaultEvalId is now being set during one of the load sequances

I also cant see where this component is being used outside of `src/app/src/pages/eval/page.tsx`

## Summary by Sourcery

Remove unused and deprecated code related to preloaded data and eval initialization from the Eval component

Enhancements:
- Simplify component interface by removing unused parameters

Chores:
- Remove deprecated props and state management for preloadedData, recentEvals, and defaultEvalId