### PR TITLE
chore(cli): Allow env vars within sharing urls

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -7,5 +7,6 @@ process.env.HF_API_TOKEN = 'foo';
 process.env.IS_TESTING = 'true';
 process.env.OPENAI_API_KEY = 'foo';
 process.env.PROMPTFOO_CONFIG_DIR = TEST_CONFIG_DIR;
+process.env.DUMMY_VALUE = 'baz';
 
 delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;

--- a/src/share.ts
+++ b/src/share.ts
@@ -423,16 +423,6 @@ export async function createShareableUrl(
   // Handle email collection
   await handleEmailCollection(evalRecord);
 
-  // 2. Get API configuration
-  const { apiBaseUrl, url, sendInChunks } = await getApiConfig(evalRecord);
-
-  // 3. Determine if we can use new results format
-  const canUseNewResults =
-    cloudConfig.isEnabled() || (await targetHostCanUseNewResults(apiBaseUrl));
-  logger.debug(
-    `Sharing with ${url} canUseNewResults: ${canUseNewResults} Use old results: ${evalRecord.useOldResults()}`,
-  );
-
   // Interpolate environment variables in the sharing config
   // e.g. 'https://{{env.PROMPTFOO_USER}}:{{env.PROMPTFOO_PASSWORD}}@self-hosted-promptfoo.com' -> 'https://user:password@self-hosted-promptfoo.com'
   const nunjucks = getNunjucksEngine();

--- a/src/share.ts
+++ b/src/share.ts
@@ -420,7 +420,7 @@ export async function createShareableUrl(
   evalRecord: Eval,
   showAuth: boolean = false,
 ): Promise<string | null> {
-  // 1. Handle email collection
+  // Handle email collection
   await handleEmailCollection(evalRecord);
 
   // 2. Get API configuration
@@ -445,7 +445,17 @@ export async function createShareableUrl(
     }
   }
 
-  // 4. Process and send results
+  // Get API configuration
+  const { apiBaseUrl, url, sendInChunks } = await getApiConfig(evalRecord);
+
+  // Determine if we can use new results format
+  const canUseNewResults =
+    cloudConfig.isEnabled() || (await targetHostCanUseNewResults(apiBaseUrl));
+  logger.debug(
+    `Sharing with ${url} canUseNewResults: ${canUseNewResults} Use old results: ${evalRecord.useOldResults()}`,
+  );
+
+  //  Process and send results
   let evalId: string | null;
   if (!canUseNewResults || evalRecord.useOldResults()) {
     evalId = await handleLegacyResults(evalRecord, url);

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -523,6 +523,28 @@ describe('createShareableUrl', () => {
 
     expect(result).toBe(`${customDomain}/eval/?evalId=${mockEval.id}`);
   });
+
+  it('interpolates environment variables in `config.sharing.appBaseUrl`', async () => {
+    // Cloud config must be disabled to test interpolation
+    jest.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+
+    // Mock the environment variables
+    const mockEval: Partial<Eval> = {
+      author: 'test@example.com',
+      useOldResults: jest.fn().mockReturnValue(false),
+      loadResults: jest.fn().mockResolvedValue(undefined),
+      results: [{ id: '1' }, { id: '2' }] as EvalResult[],
+      save: jest.fn().mockResolvedValue(undefined),
+      toEvaluateSummary: jest.fn().mockResolvedValue({}),
+      getTable: jest.fn().mockResolvedValue([]),
+      config: { sharing: { appBaseUrl: 'https://{{env.DUMMY_VALUE}}.test.com' } },
+      id: randomUUID(),
+    };
+
+    const result = await createShareableUrl(mockEval as Eval);
+
+    expect(result).toBe(`https://baz.test.com/eval/${mockEval.id}`);
+  });
 });
 
 describe('hasEvalBeenShared', () => {


### PR DESCRIPTION
Addresses #3899.

## Summary by Sourcery

Add support for environment variable interpolation in sharing configuration URLs

Enhancements:
- Enable dynamic URL generation using environment variables in sharing configuration

Chores:
- Modify sharing URL generation to support Nunjucks template interpolation