### PR TITLE
fix(redteam): filter null values in harmful completion provider output

### DIFF
--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -80,10 +80,9 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       const data = await response.json();
       logger.debug(`[HarmfulCompletionProvider] API call response: ${JSON.stringify(data)}`);
 
-      // Filter out any null or undefined values in the output array
-      const outputArray = Array.isArray(data.output) ? data.output : [data.output];
-
-      const validOutputs: string[] = outputArray.filter(
+      const validOutputs: string[] = (
+        Array.isArray(data.output) ? data.output : [data.output]
+      ).filter(
         (item: string | null | undefined): item is string =>
           typeof item === 'string' && item.length > 0,
       );

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -79,8 +79,17 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
 
       const data = await response.json();
       logger.debug(`[HarmfulCompletionProvider] API call response: ${JSON.stringify(data)}`);
+
+      // Filter out any null or undefined values in the output array
+      const outputArray = Array.isArray(data.output) ? data.output : [data.output];
+
+      const validOutputs: string[] = outputArray.filter(
+        (item: string | null | undefined): item is string =>
+          typeof item === 'string' && item.length > 0,
+      );
+
       return {
-        output: [data.output].flat(),
+        output: validOutputs,
       };
     } catch (err) {
       logger.info(`[HarmfulCompletionProvider] ${err}`);

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -66,6 +66,33 @@ describe('PromptfooHarmfulCompletionProvider', () => {
     expect(result).toEqual({ output: ['test output'] });
   });
 
+  it('should filter out null and undefined values from output array', async () => {
+    const mockResponse = new Response(
+      JSON.stringify({ output: ['value1', null, 'value2', undefined] }),
+      {
+        status: 200,
+        statusText: 'OK',
+      },
+    );
+    jest.mocked(fetchWithRetries).mockResolvedValue(mockResponse);
+
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({ output: ['value1', 'value2'] });
+  });
+
+  it('should handle null output by returning empty array', async () => {
+    const mockResponse = new Response(JSON.stringify({ output: null }), {
+      status: 200,
+      statusText: 'OK',
+    });
+    jest.mocked(fetchWithRetries).mockResolvedValue(mockResponse);
+
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({ output: [] });
+  });
+
   it('should handle API error', async () => {
     const mockResponse = new Response('API Error', {
       status: 400,


### PR DESCRIPTION
## Summary by Sourcery

Improve handling of output from the harmful completion provider by filtering out null and undefined values

Bug Fixes:
- Prevent null and undefined values from being included in the API response output

Tests:
- Add test cases to verify filtering of null/undefined values
- Add test case for handling null output