### PR TITLE
chore: Throw error option for LLM Rubric if provider doesn't return a result or errors out

### DIFF
--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -437,6 +437,48 @@ describe('matchesLlmRubric', () => {
     });
   });
 
+  it('should throw error when throwOnError is true and provider returns an error', async () => {
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const grading: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          error: 'Provider error',
+          output: null,
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    // With throwOnError: true - should throw
+    await expect(
+      matchesLlmRubric(rubric, llmOutput, grading, {}, null, { throwOnError: true }),
+    ).rejects.toThrow('Provider error');
+  });
+
+  it('should throw error when throwOnError is true and provider returns no result', async () => {
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const grading: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          error: null,
+          output: null,
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    // With throwOnError: true - should throw
+    await expect(
+      matchesLlmRubric(rubric, llmOutput, grading, {}, null, { throwOnError: true }),
+    ).rejects.toThrow('No output');
+  });
+
   it('should use the overridden llm rubric grading config', async () => {
     const expected = 'Expected output';
     const output = 'Sample output';


### PR DESCRIPTION
## Summary by Sourcery

Add an option to throw an error when an LLM Rubric provider fails to return a result or encounters an error

New Features:
- Add throwOnError option to matchesLlmRubric function to control error handling behavior

Enhancements:
- Create a custom LlmRubricProviderError for more specific error handling

Tests:
- Add test cases to verify error throwing behavior when provider fails or returns no output