### PR TITLE
fix: Increase timeout for python path validation

### DIFF
--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -20,7 +20,7 @@ export async function tryPath(path: string): Promise<string | null> {
     const result = await Promise.race([
       execAsync(`${path} --version`),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Command timed out')), 250),
+        setTimeout(() => reject(new Error('Command timed out')), 2500),
       ),
     ]);
     const versionOutput = (result as { stdout: string }).stdout.trim();

--- a/test/python/python.integration.test.ts
+++ b/test/python/python.integration.test.ts
@@ -74,7 +74,7 @@ describe('pythonUtils Integration Tests', () => {
       message: 'Hello, World!',
       success: true,
     });
-  });
+  }, 10000);
 
   it('should handle multiple arguments', async () => {
     const result = await runPython(path.join(scriptsDir, 'simple.py'), 'main', [

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -65,14 +65,14 @@ describe('pythonUtils', () => {
       jest.useFakeTimers();
       jest.mocked(execAsync).mockImplementation(() => {
         const promise = new Promise((resolve) => {
-          setTimeout(() => resolve({ stdout: 'Python 3.8.10\n', stderr: '' }), 500);
+          setTimeout(() => resolve({ stdout: 'Python 3.8.10\n', stderr: '' }), 3000);
         }) as any;
         promise.child = { kill: jest.fn() };
         return promise;
       });
 
       const resultPromise = pythonUtils.tryPath('/usr/bin/python3');
-      jest.advanceTimersByTime(251);
+      jest.advanceTimersByTime(2501);
       const result = await resultPromise;
 
       expect(result).toBeNull();


### PR DESCRIPTION
The python path validation is causing flakiness on my computer, depending on level of concurrency.  The default concurrency (4) gives med about 90% success rate, the rest gets "Error: Python 3 not found". If I turn up the concurrency to 10 I get 0% success.

This is mostly for redteam plugins, regular "evals" are fine.

I'm using a MacBook Pro from 2021 with a M1 Pro CPU, and I use asdf and pyenv.

## Summary by Sourcery

Increase timeout for Python path validation to improve reliability

Bug Fixes:
- Increased timeout for Python path detection to reduce flaky validation errors

Enhancements:
- Extended timeout from 250ms to 2500ms to accommodate slower systems and environments