### PR TITLE
docs(assertions): improve Pi scorer documentation

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -143,19 +143,20 @@ These metrics are model-assisted, and rely on LLMs or other machine learning mod
 
 See [Model-graded evals](/docs/configuration/expected-outputs/model-graded), [classification](/docs/configuration/expected-outputs/classifier), and [similarity](/docs/configuration/expected-outputs/similar) docs for more information.
 
-| Assertion Type                                                                        | Method                                                                          |
-| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [similar](/docs/configuration/expected-outputs/similar)                               | Embeddings and cosine similarity are above a threshold                          |
-| [classifier](/docs/configuration/expected-outputs/classifier)                         | Run LLM output through a classifier                                             |
-| [llm-rubric](/docs/configuration/expected-outputs/model-graded)                       | LLM output matches a given rubric, using a Language Model to grade output       |
-| [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                    | Chain-of-thought evaluation based on custom criteria using the G-Eval framework |
-| [answer-relevance](/docs/configuration/expected-outputs/model-graded)                 | Ensure that LLM output is related to original query                             |
-| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)             | Ensure that LLM output uses the context                                         |
-| [context-recall](/docs/configuration/expected-outputs/model-graded)                   | Ensure that ground truth appears in context                                     |
-| [context-relevance](/docs/configuration/expected-outputs/model-graded)                | Ensure that context is relevant to original query                               |
-| [factuality](/docs/configuration/expected-outputs/model-graded)                       | LLM output adheres to the given facts, using Factuality method from OpenAI eval |
-| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to given criteria, using Closed QA method from OpenAI eval   |
-| [select-best](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded) | Compare multiple outputs for a test case and pick the best one                  |
+| Assertion Type                                                                        | Method                                                                           |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [similar](/docs/configuration/expected-outputs/similar)                               | Embeddings and cosine similarity are above a threshold                           |
+| [classifier](/docs/configuration/expected-outputs/classifier)                         | Run LLM output through a classifier                                              |
+| [llm-rubric](/docs/configuration/expected-outputs/model-graded)                       | LLM output matches a given rubric, using a Language Model to grade output        |
+| [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                    | Chain-of-thought evaluation based on custom criteria using the G-Eval framework  |
+| [answer-relevance](/docs/configuration/expected-outputs/model-graded)                 | Ensure that LLM output is related to original query                              |
+| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)             | Ensure that LLM output uses the context                                          |
+| [context-recall](/docs/configuration/expected-outputs/model-graded)                   | Ensure that ground truth appears in context                                      |
+| [context-relevance](/docs/configuration/expected-outputs/model-graded)                | Ensure that context is relevant to original query                                |
+| [factuality](/docs/configuration/expected-outputs/model-graded)                       | LLM output adheres to the given facts, using Factuality method from OpenAI eval  |
+| [model-graded-closedqa](/docs/configuration/expected-outputs/model-graded)            | LLM output adheres to given criteria, using Closed QA method from OpenAI eval    |
+| [pi](/docs/configuration/expected-outputs/model-graded/pi)                            | Alternative scoring approach that uses a dedicated model for evaluating criteria |
+| [select-best](https://promptfoo.dev/docs/configuration/expected-outputs/model-graded) | Compare multiple outputs for a test case and pick the best one                   |
 
 ## Weighted assertions
 

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -13,6 +13,7 @@ Output-based:
 - [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - a factual consistency eval which, given a completion `A` and reference answer `B` evaluates whether A is a subset of B, A is a superset of B, A and B are equivalent, A and B disagree, or A and B differ, but that the difference doesn't matter from the perspective of factuality. It uses the prompt from OpenAI's public evals.
 - [`g-eval`](/docs/configuration/expected-outputs/model-graded/g-eval) - uses chain-of-thought prompting to evaluate outputs based on custom criteria, following the G-Eval framework.
 - [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - ensure that LLM output is related to original query
+- [`pi`](/docs/configuration/expected-outputs/model-graded/pi) - an alternative scoring approach that uses a dedicated model for evaluating inputs/outputs against criteria.
 - [`classifier`](/docs/configuration/expected-outputs/classifier) - see classifier grading docs.
 - [`moderation`](/docs/configuration/expected-outputs/moderation) - see moderation grading docs.
 - [`select-best`](/docs/configuration/expected-outputs/model-graded/select-best) - compare outputs from multiple test cases and choose a winner
@@ -41,6 +42,16 @@ assert:
   - type: factuality
     # Make sure the LLM output is consistent with this statement:
     value: Sacramento is the capital of California
+```
+
+Example of pi scorer:
+
+```yaml
+assert:
+  - type: pi
+    # Evaluate output based on this criteria:
+    value: Is not apologetic and provides a clear, concise answer
+    threshold: 0.8 # Requires a score of 0.8 or higher to pass
 ```
 
 For more information on factuality, see the [guide on LLM factuality](/docs/guides/factuality-eval).

--- a/site/docs/configuration/expected-outputs/model-graded/pi.md
+++ b/site/docs/configuration/expected-outputs/model-graded/pi.md
@@ -1,39 +1,73 @@
+---
+sidebar_position: 8
+---
+
 # Pi Scorer
 
-`pi` is a more accurate alternative to "LLM as a judge" evaluation. It can quickly, and accurately,
-evaluate input and output pairs against any criteria.
+`pi` is an alternative approach to model grading that uses a dedicated scoring model instead of the "LLM as a judge" technique. It can evaluate input and output pairs against criteria.
+
+:::note
+**Important**: Unlike `llm-rubric` which works with your existing providers, Pi requires a separate external API key from Pi Labs.
+:::
+
+## Alternative Approach
+
+Pi offers a different approach to evaluation with some distinct characteristics:
+
+- Uses a dedicated scoring model rather than prompting an LLM to act as a judge
+- Focuses on highly accurate numeric scoring without providing detailed reasoning
+- Aims for consistency in scoring the same inputs
+- Requires a separate API key and integration
+
+Each approach has different strengths, and you may want to experiment with both to determine which best suits your specific evaluation needs.
+
+## Prerequisites
+
+To use Pi, you **must** first:
+
+1. Create a Pi API key from [Pi Labs](https://build.withpi.ai/account/keys)
+2. Set the `WITHPI_API_KEY` environment variable
+
+```bash
+export WITHPI_API_KEY=your_api_key_here
+```
+
+or set
+
+```yaml
+env:
+  WITHPI_API_KEY: your_api_key_here
+```
+
+in your promptfoo config
 
 ## How to use it
 
-To use the `pi` assertion type, add it to your test configuration like this:
+To use the `pi` assertion type, add it to your test configuration:
 
 ```yaml
 assert:
   - type: pi
-    # Specify the criteria for grading the LLM output.  Criteria can be a string
+    # Specify the criteria for grading the LLM output
     value: Is the response not apologetic and provides a clear, concise answer?
 ```
 
-This assertion will use the pi scorer to grade the output based on the specified criteria.
-
-Make sure to set the `WITHPI_API_KEY` in your environment variables. You can create a key for free here:
-https://build.withpi.ai/account/keys
+This assertion will use the Pi scorer to grade the output based on the specified criteria.
 
 ## How it works
 
-Under the hood, the `pi` assertion uses the `withpi` sdk to call the to evaluate the output based on the criteria you provide.
+Under the hood, the `pi` assertion uses the `withpi` SDK to evaluate the output based on the criteria you provide.
 
 Compared to LLM as a judge:
 
 - The inputs of the eval are the same: `llm_input` and `llm_output`
 - Pi does not need a system prompt, and is pretrained to score
 - Pi always generates the same score, when given the same input
+- Pi requires a separate API key (see Prerequisites section)
 
 ## Threshold Support
 
-The `pi` assertion type supports an optional `threshold` property that sets a minimum score requirement. When specified, the output must achieve a score greater than or equal to the threshold to pass. For example:
-
-The default threshold is `.5`
+The `pi` assertion type supports an optional `threshold` property that sets a minimum score requirement. When specified, the output must achieve a score greater than or equal to the threshold to pass.
 
 ```yaml
 assert:
@@ -42,12 +76,39 @@ assert:
     threshold: 0.8 # Requires a score of 0.8 or higher to pass
 ```
 
+:::info
+The default threshold is `0.5` if not specified.
+:::
+
 ## Metrics Brainstorming
 
-You can optionally use the [Pi Labs Copilot](https://build.withpi.ai) to interactively brainstorm
-representative metrics for your application. Additionally, it can help
-you test your Pi metrics out on generated examples before integrating into your stack.
+You can use the [Pi Labs Copilot](https://build.withpi.ai) to interactively brainstorm representative metrics for your application. It helps you:
 
-## Further reading
+1. Generate effective evaluation criteria
+2. Test metrics on example outputs before integration
+3. Find the optimal threshold values for your use case
 
-See [Pi Documentation](https://docs.withpi.ai) for more options, scorer configuration, and calibration.
+## Example Configuration
+
+```yaml
+prompts:
+  - 'Explain {{concept}} in simple terms.'
+providers:
+  - openai:gpt-4o
+tests:
+  - vars:
+      concept: quantum computing
+    assert:
+      - type: pi
+        value: Is the explanation easy to understand without technical jargon?
+        threshold: 0.7
+      - type: pi
+        value: Does the response correctly explain the fundamental principles?
+        threshold: 0.8
+```
+
+## See Also
+
+- [LLM Rubric](/docs/configuration/expected-outputs/model-graded/llm-rubric)
+- [Model-graded metrics](/docs/configuration/expected-outputs/model-graded)
+- [Pi Documentation](https://docs.withpi.ai) for more options, configuration, and calibration details


### PR DESCRIPTION
## Summary by Sourcery

Improve documentation for the Pi scorer, providing more detailed and comprehensive guidance on its usage, prerequisites, and configuration.

New Features:
- Added sidebar position for the Pi scorer documentation
- Introduced a note about Pi's external API key requirement

Enhancements:
- Clarified the differences between Pi and LLM as a judge approach
- Improved explanation of how Pi scoring works
- Added more context about using Pi Labs Copilot for metric brainstorming

Documentation:
- Expanded documentation for Pi scorer with more detailed explanations
- Added prerequisites and setup instructions
- Included an example configuration
- Updated model-graded metrics index to include Pi scorer