### PR TITLE
feat(cli): Adds global `--verbose` option

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -29,7 +29,7 @@ The `promptfoo` command line utility supports the following subcommands:
 - `import <filepath>` - Import an eval file from JSON format.
 - `export <evalId>` - Export an eval record to JSON format.
 
-## Global Fl
+## Global Options
 
 The following options can be used with any command by running `promptfoo <options> <cmd>`.
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -29,6 +29,14 @@ The `promptfoo` command line utility supports the following subcommands:
 - `import <filepath>` - Import an eval file from JSON format.
 - `export <evalId>` - Export an eval record to JSON format.
 
+## Global Fl
+
+The following options can be used with any command by running `promptfoo <options> <cmd>`.
+
+| Option          | Description     |
+| --------------- | --------------- |
+| `-v, --verbose` | Show debug logs |
+
 ## `promptfoo eval`
 
 By default the `eval` command will read the `promptfooconfig.yaml` configuration file in your current directory. But, if you're looking to override certain parameters you can supply optional arguments:

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { modelScanCommand } from './commands/modelScan';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
 import { viewCommand } from './commands/view';
-import logger from './logger';
+import logger, { setLogLevel } from './logger';
 import { runDbMigrations } from './migrate';
 import { redteamGenerateCommand } from './redteam/commands/generate';
 import { initCommand as redteamInitCommand } from './redteam/commands/init';
@@ -45,6 +45,8 @@ async function main() {
       program.help();
       process.exitCode = 1;
     });
+
+  program.option('-v, --verbose', 'Show debug logs', false);
 
   // Main commands
   evalCommand(program, defaultConfig, defaultConfigPath);
@@ -86,6 +88,11 @@ async function main() {
   redteamPluginsCommand(redteamBaseCommand);
 
   program.parse();
+
+  const globalOpts = program.opts();
+  if (globalOpts.verbose) {
+    setLogLevel('debug');
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
- Support for the `--verbose` flag is inconsistent across the CLI commands. 
- This PR adds a global option while maintaining backwards compatibility by not modifying the existent, command level `--verbose` flags (i.e. `promptfoo --verbose eval --verbose` redundant yet valid).
- It is useful for scenarios where the user otherwise needs to `export LOG_LEVEL=debug && promptfoo <cmd>`.