### PR TITLE
chore: Revert "feat(cli): Adds global `--verbose` option"

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -29,14 +29,6 @@ The `promptfoo` command line utility supports the following subcommands:
 - `import <filepath>` - Import an eval file from JSON format.
 - `export <evalId>` - Export an eval record to JSON format.
 
-## Global Options
-
-The following options can be used with any command by running `promptfoo <options> <cmd>`.
-
-| Option          | Description     |
-| --------------- | --------------- |
-| `-v, --verbose` | Show debug logs |
-
 ## `promptfoo eval`
 
 By default the `eval` command will read the `promptfooconfig.yaml` configuration file in your current directory. But, if you're looking to override certain parameters you can supply optional arguments:

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { modelScanCommand } from './commands/modelScan';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
 import { viewCommand } from './commands/view';
-import logger, { setLogLevel } from './logger';
+import logger from './logger';
 import { runDbMigrations } from './migrate';
 import { redteamGenerateCommand } from './redteam/commands/generate';
 import { initCommand as redteamInitCommand } from './redteam/commands/init';
@@ -45,8 +45,6 @@ async function main() {
       program.help();
       process.exitCode = 1;
     });
-
-  program.option('-v, --verbose', 'Show debug logs', false);
 
   // Main commands
   evalCommand(program, defaultConfig, defaultConfigPath);
@@ -88,11 +86,6 @@ async function main() {
   redteamPluginsCommand(redteamBaseCommand);
 
   program.parse();
-
-  const globalOpts = program.opts();
-  if (globalOpts.verbose) {
-    setLogLevel('debug');
-  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Reverts promptfoo/promptfoo#3931 

We discussed and don't want to add a flag that goes before the sub commands