### PR TITLE
chore: Clean up providers for redteam generate

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -51,6 +51,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
 
   async cleanup(): Promise<void> {
     if (this.mcpClient) {
+      await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
     }

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -30,6 +30,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
 
   async cleanup(): Promise<void> {
     if (this.mcpClient) {
+      await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
     }

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -341,6 +341,7 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
 
   async cleanup(): Promise<void> {
     if (this.mcpClient) {
+      await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
     }

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -733,6 +733,7 @@ export class VertexChatProvider extends VertexGenericProvider {
 
   async cleanup(): Promise<void> {
     if (this.mcpClient) {
+      await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
     }

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -62,7 +62,7 @@ export class MCPClient {
         throw new Error('Either command+args or path must be specified for MCP server');
       }
 
-      const client = new Client({ name: 'promptfoo-anthropic', version: '1.0.0' });
+      const client = new Client({ name: 'promptfoo-MCP', version: '1.0.0' });
       client.connect(transport);
 
       // List available tools

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -41,8 +41,10 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     this.mcpClient = new MCPClient(this.config.mcp!);
     await this.mcpClient.initialize();
   }
+
   async cleanup(): Promise<void> {
     if (this.mcpClient) {
+      await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
     }

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -277,6 +277,19 @@ export async function doGenerateRedteam(
     const relativeOutputPath = path.relative(process.cwd(), options.output);
     logger.info(`Wrote ${redteamTests.length} test cases to ${relativeOutputPath}`);
     if (!options.inRedteamRun) {
+      // Provider cleanup step
+      try {
+        const provider = testSuite.providers[0] as ApiProvider;
+        if (provider && typeof provider.cleanup === 'function') {
+          const cleanupResult = provider.cleanup();
+          if (cleanupResult instanceof Promise) {
+            await cleanupResult;
+          }
+        }
+      } catch (cleanupErr) {
+        logger.warn(`Error during provider cleanup: ${cleanupErr}`);
+      }
+
       const commandPrefix = isRunningUnderNpx() ? 'npx promptfoo' : 'promptfoo';
       logger.info(
         '\n' +

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3,12 +3,28 @@ import { APIError } from '@anthropic-ai/sdk';
 import dedent from 'dedent';
 import { clearCache, disableCache, enableCache, getCache } from '../../../src/cache';
 import { AnthropicMessagesProvider } from '../../../src/providers/anthropic/messages';
+import { MCPClient } from '../../../src/providers/mcp/client';
 
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));
 
+jest.mock('../../../src/providers/mcp/client');
+
 describe('AnthropicMessagesProvider', () => {
+  let provider: AnthropicMessagesProvider;
+  let mockMCPClient: jest.Mocked<MCPClient>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockMCPClient = {
+      initialize: jest.fn(),
+      cleanup: jest.fn(),
+      getAllTools: jest.fn().mockReturnValue([]),
+    } as any;
+    jest.mocked(MCPClient).mockImplementation(() => mockMCPClient);
+  });
+
   afterEach(async () => {
     jest.clearAllMocks();
     await clearCache();
@@ -587,6 +603,63 @@ describe('AnthropicMessagesProvider', () => {
           'anthropic-beta': 'output-128k-2025-02-19,another-beta-feature',
         },
       });
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should await initialization before cleanup', async () => {
+      provider = new AnthropicMessagesProvider('claude-3-sonnet', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      // Simulate initialization in progress
+      const initPromise = Promise.resolve();
+      provider['initializationPromise'] = initPromise;
+
+      await provider.cleanup();
+
+      // Verify cleanup was called after initialization
+      expect(mockMCPClient.cleanup).toHaveBeenCalledWith();
+    });
+
+    it('should handle cleanup when MCP is not enabled', async () => {
+      provider = new AnthropicMessagesProvider('claude-3-sonnet', {
+        config: {
+          mcp: {
+            enabled: false,
+          },
+        },
+      });
+
+      await provider.cleanup();
+
+      expect(mockMCPClient.cleanup).not.toHaveBeenCalled();
+    });
+
+    it('should handle cleanup errors gracefully', async () => {
+      provider = new AnthropicMessagesProvider('claude-3-sonnet', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mockMCPClient.cleanup.mockRejectedValueOnce(new Error('Cleanup failed'));
+
+      await expect(provider.cleanup()).rejects.toThrow('Cleanup failed');
     });
   });
 });

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -175,6 +175,33 @@ describe('MCPClient', () => {
         { name: 'tool2', description: 'desc2', inputSchema: {} },
       ]);
     });
+
+    it('should initialize with correct client name', async () => {
+      const mockClient = {
+        _clientInfo: {},
+        _capabilities: {},
+        registerCapabilities: jest.fn(),
+        assertCapability: jest.fn(),
+        connect: jest.fn(),
+        listTools: jest.fn().mockResolvedValue({
+          tools: [{ name: 'tool1', description: 'desc1', inputSchema: {} }],
+        }),
+        close: jest.fn(),
+      };
+      jest.mocked(Client).mockImplementation(() => mockClient as any);
+
+      mcpClient = new MCPClient({
+        enabled: true,
+        server: {
+          command: 'npm',
+          args: ['start'],
+        },
+      });
+
+      await mcpClient.initialize();
+
+      expect(Client).toHaveBeenCalledWith({ name: 'promptfoo-MCP', version: '1.0.0' });
+    });
   });
 
   describe('callTool', () => {


### PR DESCRIPTION
Fix cleanup race condition with MCP server initialization

Resolve issue where cleanup calls fail because providers haven't completed MCP server initialization. This initialization happens during provider loading for redteam generate, even when providers aren't explicitly called.

This minimal fix addresses the race condition. An alternative approach could be preventing MCP server instantiation during generate-only calls, but the current solution is sufficient and safe.