### PR TITLE
chore: add global env-file option to all commands recursively

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -581,7 +581,6 @@ export function evalCommand(
       '-c, --config <paths...>',
       'Path to configuration file. Automatically loads promptfooconfig.yaml',
     )
-    .option('--env-file, --env-path <path>', 'Path to .env file')
 
     // Input sources
     .option('-a, --assertions <path>', 'Path to assertions file')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,7 +9,7 @@ import { VERSION } from '../constants';
 import logger from '../logger';
 import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
-import { isRunningUnderNpx, setupEnv } from '../util';
+import { isRunningUnderNpx } from '../util';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 
@@ -180,9 +180,6 @@ async function handleExampleDownload(
 interface InitCommandOptions {
   interactive: boolean;
   example: string | boolean | undefined;
-  envPath: string | undefined;
-  redteam: boolean;
-  custom: string;
 }
 
 export function initCommand(program: Command) {
@@ -191,14 +188,10 @@ export function initCommand(program: Command) {
     .description('Initialize project with dummy files or download an example')
     .option('--no-interactive', 'Do not run in interactive mode')
     .option('--example [name]', 'Download an example from the promptfoo repo')
-    .option('--redteam', 'Initialize a redteam configuration', false)
-    .option('--custom <module_or_url>', 'Use a custom starter template', '')
     .action(async (directory: string | null, cmdObj: InitCommandOptions) => {
       telemetry.record('command_used', {
         name: 'init - started',
       });
-      setupEnv(cmdObj.envPath);
-
       if (directory === 'redteam' && cmdObj.interactive) {
         const useRedteam = await confirm({
           message:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -181,6 +181,8 @@ interface InitCommandOptions {
   interactive: boolean;
   example: string | boolean | undefined;
   envPath: string | undefined;
+  redteam: boolean;
+  custom: string;
 }
 
 export function initCommand(program: Command) {
@@ -188,8 +190,9 @@ export function initCommand(program: Command) {
     .command('init [directory]')
     .description('Initialize project with dummy files or download an example')
     .option('--no-interactive', 'Do not run in interactive mode')
-    .option('--env-file, --env-path <path>', 'Path to .env file')
     .option('--example [name]', 'Download an example from the promptfoo repo')
+    .option('--redteam', 'Initialize a redteam configuration', false)
+    .option('--custom <module_or_url>', 'Use a custom starter template', '')
     .action(async (directory: string | null, cmdObj: InitCommandOptions) => {
       telemetry.record('command_used', {
         name: 'init - started',

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -44,7 +44,6 @@ export function shareCommand(program: Command) {
   program
     .command('share [evalId]')
     .description('Create a shareable URL of an eval (defaults to most recent)' + '\n\n')
-    .option('--env-file, --env-path <path>', 'Path to .env file')
     .option(
       '--show-auth',
       'Show username/password authentication information in the URL if exists',
@@ -56,6 +55,8 @@ export function shareCommand(program: Command) {
       'Flag does nothing (maintained for backwards compatibility only - shares are now private by default)',
       false,
     )
+    .option('--id <id>', 'Evaluation ID (default is latest)')
+    .option('--file <path>', 'Path to evaluation results file')
     .action(
       async (
         evalId: string | undefined,

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -8,7 +8,6 @@ import logger from '../logger';
 import Eval from '../models/eval';
 import { createShareableUrl, hasEvalBeenShared, isSharingEnabled, getShareableUrl } from '../share';
 import telemetry from '../telemetry';
-import { setupEnv } from '../util';
 import { loadDefaultConfig } from '../util/config/default';
 
 export function notCloudEnabledShareInstructions(): void {
@@ -55,14 +54,11 @@ export function shareCommand(program: Command) {
       'Flag does nothing (maintained for backwards compatibility only - shares are now private by default)',
       false,
     )
-    .option('--id <id>', 'Evaluation ID (default is latest)')
-    .option('--file <path>', 'Path to evaluation results file')
     .action(
       async (
         evalId: string | undefined,
         cmdObj: { yes: boolean; envPath?: string; showAuth: boolean } & Command,
       ) => {
-        setupEnv(cmdObj.envPath);
         telemetry.record('command_used', {
           name: 'share',
         });

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -391,7 +391,6 @@ export function redteamGenerateCommand(
       'Specify the language for generated tests. Defaults to English',
     )
     .option('--no-cache', 'Do not read or write results to disk cache', false)
-    .option('--env-file, --env-path <path>', 'Path to .env file')
     .option(
       '-j, --max-concurrency <number>',
       'Maximum number of concurrent API calls',

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -34,7 +34,6 @@ export function redteamRunCommand(program: Command) {
       'Path to output file for generated tests. Defaults to redteam.yaml in the same directory as the configuration file.',
     )
     .option('--no-cache', 'Do not read or write results to disk cache', false)
-    .option('--env-file, --env-path <path>', 'Path to .env file')
     .option('-j, --max-concurrency <number>', 'Maximum number of concurrent API calls', (val) =>
       Number.parseInt(val, 10),
     )

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -216,7 +216,7 @@ describe('init command', () => {
       expect(initCmd?.description()).toBe(
         'Initialize project with dummy files or download an example',
       );
-      expect(initCmd?.options).toHaveLength(3);
+      expect(initCmd?.options).toHaveLength(2);
     });
   });
 });

--- a/test/commands/share.test.ts
+++ b/test/commands/share.test.ts
@@ -99,7 +99,6 @@ describe('Share Command', () => {
 
       const options = cmd?.options;
       expect(options?.find((o) => o.long === '--show-auth')).toBeDefined();
-      expect(options?.find((o) => o.long === '--env-path')).toBeDefined();
       expect(options?.find((o) => o.long === '--yes')).toBeDefined();
     });
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,0 +1,113 @@
+import { Command } from 'commander';
+import { setupEnv } from '../src/util';
+import { addEnvFileOptionRecursively } from '../src/main';
+
+// Mock the dependencies
+jest.mock('../src/util', () => ({
+  setupEnv: jest.fn(),
+}));
+
+// Mock process.exit to prevent Commander from exiting the process
+const originalExit = process.exit;
+beforeAll(() => {
+  process.exit = jest.fn() as any;
+});
+
+afterAll(() => {
+  process.exit = originalExit;
+});
+
+describe('addEnvFileOptionRecursively', () => {
+  let program: Command;
+  let subCommand: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.action(() => {});
+    subCommand = program.command('subcommand');
+    subCommand.action(() => {});
+    jest.clearAllMocks();
+  });
+
+  it('should add env-file option to a command that does not have it', () => {
+    addEnvFileOptionRecursively(program);
+    
+    const hasEnvFileOption = program.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    expect(hasEnvFileOption).toBe(true);
+  });
+
+  it('should not add env-file option if it already exists', () => {
+    program.option('--env-file, --env-path <path>', 'Path to .env file');
+    const initialOptionsLength = program.options.length;
+    
+    addEnvFileOptionRecursively(program);
+    
+    expect(program.options.length).toBe(initialOptionsLength);
+  });
+
+  it('should add env-file option to subcommands', () => {
+    addEnvFileOptionRecursively(program);
+    
+    const hasSubcommandEnvFileOption = subCommand.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    expect(hasSubcommandEnvFileOption).toBe(true);
+  });
+  
+  it('should add env-file option to nested subcommands', () => {
+    // Create a deeper command structure
+    const subSubCommand = subCommand.command('subsubcommand');
+    subSubCommand.action(() => {});
+    const subSubSubCommand = subSubCommand.command('subsubsubcommand');
+    subSubSubCommand.action(() => {});
+    
+    addEnvFileOptionRecursively(program);
+    
+    // Check all levels of commands have the env-file option
+    const hasMainEnvFileOption = program.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    const hasSubCommandEnvFileOption = subCommand.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    const hasSubSubCommandEnvFileOption = subSubCommand.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
+      (option) => option.long === '--env-file' || option.long === '--env-path'
+    );
+    
+    expect(hasMainEnvFileOption).toBe(true);
+    expect(hasSubCommandEnvFileOption).toBe(true);
+    expect(hasSubSubCommandEnvFileOption).toBe(true);
+    expect(hasSubSubSubCommandEnvFileOption).toBe(true);
+  });
+  
+  it('should register the hook that calls setupEnv when receiving the env-file option', () => {
+    // Create a program with the option
+    program.option('--env-file, --env-path <path>', 'Path to .env file');
+    
+    // Create a fake action that manually mocks the Commander hook system
+    const mockHookRegister = jest.fn();
+    (program as any).hook = mockHookRegister;
+    
+    // Apply env-file option functionality
+    addEnvFileOptionRecursively(program);
+    
+    // Verify the hook was registered
+    expect(mockHookRegister).toHaveBeenCalledWith('preAction', expect.any(Function));
+    
+    // Get the hook function
+    const preActionFn = mockHookRegister.mock.calls.find(call => call[0] === 'preAction')?.[1];
+    
+    // Call the preAction hook with mock data
+    if (preActionFn) {
+      preActionFn({ opts: () => ({ envFile: '.env.test' }) });
+      
+      // Verify setupEnv was called with the right argument
+      expect(setupEnv).toHaveBeenCalledWith('.env.test');
+    }
+  });
+}); 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { addEnvFileOptionRecursively } from '../src/main';
+import { setLogLevel } from '../src/logger';
+import { addCommonOptionsRecursively } from '../src/main';
 import { setupEnv } from '../src/util';
 
 // Mock the dependencies
@@ -7,7 +8,13 @@ jest.mock('../src/util', () => ({
   setupEnv: jest.fn(),
 }));
 
-describe('addEnvFileOptionRecursively', () => {
+jest.mock('../src/logger', () => ({
+  __esModule: true,
+  default: { debug: jest.fn() },
+  setLogLevel: jest.fn(),
+}));
+
+describe('addCommonOptionsRecursively', () => {
   const originalExit = process.exit;
   let program: Command;
   let subCommand: Command;
@@ -28,86 +35,137 @@ describe('addEnvFileOptionRecursively', () => {
     process.exit = originalExit;
   });
 
-  it('should add env-file option to a command that does not have it', () => {
-    addEnvFileOptionRecursively(program);
+  it('should add both verbose and env-file options to a command', () => {
+    addCommonOptionsRecursively(program);
 
+    const hasVerboseOption = program.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    );
     const hasEnvFileOption = program.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
+
+    expect(hasVerboseOption).toBe(true);
     expect(hasEnvFileOption).toBe(true);
   });
 
-  it('should not add env-file option if it already exists', () => {
+  it('should not add duplicate options if they already exist', () => {
     program.option('--env-file, --env-path <path>', 'Path to .env file');
-    const initialOptionsLength = program.options.length;
+    program.option('-v, --verbose', 'Show debug logs', false);
 
-    addEnvFileOptionRecursively(program);
+    // Count options before
+    const envFileOptionsBefore = program.options.filter(
+      (option) => option.long === '--env-file' || option.long === '--env-path',
+    ).length;
 
-    expect(program.options).toHaveLength(initialOptionsLength);
+    const verboseOptionsBefore = program.options.filter(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    ).length;
+
+    addCommonOptionsRecursively(program);
+
+    // Count options after
+    const envFileOptionsAfter = program.options.filter(
+      (option) => option.long === '--env-file' || option.long === '--env-path',
+    ).length;
+
+    const verboseOptionsAfter = program.options.filter(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    ).length;
+
+    // Should still have the same number of options
+    expect(envFileOptionsAfter).toBe(envFileOptionsBefore);
+    expect(verboseOptionsAfter).toBe(verboseOptionsBefore);
   });
 
-  it('should add env-file option to subcommands', () => {
-    addEnvFileOptionRecursively(program);
+  it('should add options to subcommands', () => {
+    addCommonOptionsRecursively(program);
 
+    const hasSubcommandVerboseOption = subCommand.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    );
     const hasSubcommandEnvFileOption = subCommand.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
+
+    expect(hasSubcommandVerboseOption).toBe(true);
     expect(hasSubcommandEnvFileOption).toBe(true);
   });
 
-  it('should add env-file option to nested subcommands', () => {
+  it('should add options to nested subcommands', () => {
     // Create a deeper command structure
     const subSubCommand = subCommand.command('subsubcommand');
     subSubCommand.action(() => {});
     const subSubSubCommand = subSubCommand.command('subsubsubcommand');
     subSubSubCommand.action(() => {});
 
-    addEnvFileOptionRecursively(program);
+    addCommonOptionsRecursively(program);
 
-    // Check all levels of commands have the env-file option
+    // Check all levels of commands have the options
+    const hasMainVerboseOption = program.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    );
     const hasMainEnvFileOption = program.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
+    );
+
+    const hasSubCommandVerboseOption = subCommand.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
     );
     const hasSubCommandEnvFileOption = subCommand.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
+
+    const hasSubSubCommandVerboseOption = subSubCommand.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
+    );
     const hasSubSubCommandEnvFileOption = subSubCommand.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
+    );
+
+    const hasSubSubSubCommandVerboseOption = subSubSubCommand.options.some(
+      (option) => option.short === '-v' || option.long === '--verbose',
     );
     const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
 
+    expect(hasMainVerboseOption).toBe(true);
     expect(hasMainEnvFileOption).toBe(true);
+    expect(hasSubCommandVerboseOption).toBe(true);
     expect(hasSubCommandEnvFileOption).toBe(true);
+    expect(hasSubSubCommandVerboseOption).toBe(true);
     expect(hasSubSubCommandEnvFileOption).toBe(true);
+    expect(hasSubSubSubCommandVerboseOption).toBe(true);
     expect(hasSubSubSubCommandEnvFileOption).toBe(true);
   });
 
-  it('should register the hook that calls setupEnv when receiving the env-file option', () => {
-    // Create a program with the option
-    program.option('--env-file, --env-path <path>', 'Path to .env file');
-
+  it('should register a single hook that handles both options', () => {
     // Create a fake action that manually mocks the Commander hook system
     const mockHookRegister = jest.fn();
     (program as any).hook = mockHookRegister;
 
-    // Apply env-file option functionality
-    addEnvFileOptionRecursively(program);
+    // Apply common options
+    addCommonOptionsRecursively(program);
 
-    // Verify the hook was registered
+    // Verify the hook was registered only once
+    expect(mockHookRegister).toHaveBeenCalledTimes(1);
     expect(mockHookRegister).toHaveBeenCalledWith('preAction', expect.any(Function));
 
     // Get the hook function
-    const preActionFn = mockHookRegister.mock.calls.find((call) => call[0] === 'preAction')?.[1];
+    const preActionFn = mockHookRegister.mock.calls[0][1];
 
-    // Ensure preActionFn exists before testing it
-    expect(preActionFn).toBeDefined();
+    // Test verbose option
+    preActionFn({ opts: () => ({ verbose: true }) });
+    expect(setLogLevel).toHaveBeenCalledWith('debug');
 
-    // Call the preAction hook with mock data safely (no conditional expect)
-    preActionFn!({ opts: () => ({ envFile: '.env.test' }) });
-
-    // Verify setupEnv was called with the right argument
+    // Test env-file option
+    preActionFn({ opts: () => ({ envFile: '.env.test' }) });
     expect(setupEnv).toHaveBeenCalledWith('.env.test');
+
+    // Test both options together
+    preActionFn({ opts: () => ({ verbose: true, envFile: '.env.combined' }) });
+    expect(setLogLevel).toHaveBeenCalledWith('debug');
+    expect(setupEnv).toHaveBeenCalledWith('.env.combined');
   });
 });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
-import { setupEnv } from '../src/util';
 import { addEnvFileOptionRecursively } from '../src/main';
+import { setupEnv } from '../src/util';
 
 // Mock the dependencies
 jest.mock('../src/util', () => ({
@@ -11,11 +11,11 @@ describe('addEnvFileOptionRecursively', () => {
   const originalExit = process.exit;
   let program: Command;
   let subCommand: Command;
-  
+
   beforeAll(() => {
     process.exit = jest.fn() as any;
   });
-  
+
   beforeEach(() => {
     program = new Command();
     program.action(() => {});
@@ -30,9 +30,9 @@ describe('addEnvFileOptionRecursively', () => {
 
   it('should add env-file option to a command that does not have it', () => {
     addEnvFileOptionRecursively(program);
-    
+
     const hasEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     expect(hasEnvFileOption).toBe(true);
   });
@@ -40,73 +40,73 @@ describe('addEnvFileOptionRecursively', () => {
   it('should not add env-file option if it already exists', () => {
     program.option('--env-file, --env-path <path>', 'Path to .env file');
     const initialOptionsLength = program.options.length;
-    
+
     addEnvFileOptionRecursively(program);
-    
+
     expect(program.options).toHaveLength(initialOptionsLength);
   });
 
   it('should add env-file option to subcommands', () => {
     addEnvFileOptionRecursively(program);
-    
+
     const hasSubcommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     expect(hasSubcommandEnvFileOption).toBe(true);
   });
-  
+
   it('should add env-file option to nested subcommands', () => {
     // Create a deeper command structure
     const subSubCommand = subCommand.command('subsubcommand');
     subSubCommand.action(() => {});
     const subSubSubCommand = subSubCommand.command('subsubsubcommand');
     subSubSubCommand.action(() => {});
-    
+
     addEnvFileOptionRecursively(program);
-    
+
     // Check all levels of commands have the env-file option
     const hasMainEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubCommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubSubCommandEnvFileOption = subSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
-    
+
     expect(hasMainEnvFileOption).toBe(true);
     expect(hasSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubSubCommandEnvFileOption).toBe(true);
   });
-  
+
   it('should register the hook that calls setupEnv when receiving the env-file option', () => {
     // Create a program with the option
     program.option('--env-file, --env-path <path>', 'Path to .env file');
-    
+
     // Create a fake action that manually mocks the Commander hook system
     const mockHookRegister = jest.fn();
     (program as any).hook = mockHookRegister;
-    
+
     // Apply env-file option functionality
     addEnvFileOptionRecursively(program);
-    
+
     // Verify the hook was registered
     expect(mockHookRegister).toHaveBeenCalledWith('preAction', expect.any(Function));
-    
+
     // Get the hook function
-    const preActionFn = mockHookRegister.mock.calls.find(call => call[0] === 'preAction')?.[1];
-    
+    const preActionFn = mockHookRegister.mock.calls.find((call) => call[0] === 'preAction')?.[1];
+
     // Ensure preActionFn exists before testing it
     expect(preActionFn).toBeDefined();
-    
+
     // Call the preAction hook with mock data safely (no conditional expect)
     preActionFn!({ opts: () => ({ envFile: '.env.test' }) });
-    
+
     // Verify setupEnv was called with the right argument
     expect(setupEnv).toHaveBeenCalledWith('.env.test');
   });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
-import { setupEnv } from '../src/util';
 import { addEnvFileOptionRecursively } from '../src/main';
+import { setupEnv } from '../src/util';
 
 // Mock the dependencies
 jest.mock('../src/util', () => ({
@@ -31,9 +31,9 @@ describe('addEnvFileOptionRecursively', () => {
 
   it('should add env-file option to a command that does not have it', () => {
     addEnvFileOptionRecursively(program);
-    
+
     const hasEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     expect(hasEnvFileOption).toBe(true);
   });
@@ -41,73 +41,73 @@ describe('addEnvFileOptionRecursively', () => {
   it('should not add env-file option if it already exists', () => {
     program.option('--env-file, --env-path <path>', 'Path to .env file');
     const initialOptionsLength = program.options.length;
-    
+
     addEnvFileOptionRecursively(program);
-    
-    expect(program.options.length).toBe(initialOptionsLength);
+
+    expect(program.options).toHaveLength(initialOptionsLength);
   });
 
   it('should add env-file option to subcommands', () => {
     addEnvFileOptionRecursively(program);
-    
+
     const hasSubcommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     expect(hasSubcommandEnvFileOption).toBe(true);
   });
-  
+
   it('should add env-file option to nested subcommands', () => {
     // Create a deeper command structure
     const subSubCommand = subCommand.command('subsubcommand');
     subSubCommand.action(() => {});
     const subSubSubCommand = subSubCommand.command('subsubsubcommand');
     subSubSubCommand.action(() => {});
-    
+
     addEnvFileOptionRecursively(program);
-    
+
     // Check all levels of commands have the env-file option
     const hasMainEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubCommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubSubCommandEnvFileOption = subSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
     const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path'
+      (option) => option.long === '--env-file' || option.long === '--env-path',
     );
-    
+
     expect(hasMainEnvFileOption).toBe(true);
     expect(hasSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubSubCommandEnvFileOption).toBe(true);
   });
-  
+
   it('should register the hook that calls setupEnv when receiving the env-file option', () => {
     // Create a program with the option
     program.option('--env-file, --env-path <path>', 'Path to .env file');
-    
+
     // Create a fake action that manually mocks the Commander hook system
     const mockHookRegister = jest.fn();
     (program as any).hook = mockHookRegister;
-    
+
     // Apply env-file option functionality
     addEnvFileOptionRecursively(program);
-    
+
     // Verify the hook was registered
     expect(mockHookRegister).toHaveBeenCalledWith('preAction', expect.any(Function));
-    
+
     // Get the hook function
-    const preActionFn = mockHookRegister.mock.calls.find(call => call[0] === 'preAction')?.[1];
-    
+    const preActionFn = mockHookRegister.mock.calls.find((call) => call[0] === 'preAction')?.[1];
+
     // Call the preAction hook with mock data
     if (preActionFn) {
       preActionFn({ opts: () => ({ envFile: '.env.test' }) });
-      
+
       // Verify setupEnv was called with the right argument
       expect(setupEnv).toHaveBeenCalledWith('.env.test');
     }
   });
-}); 
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,26 +1,21 @@
 import { Command } from 'commander';
-import { addEnvFileOptionRecursively } from '../src/main';
 import { setupEnv } from '../src/util';
+import { addEnvFileOptionRecursively } from '../src/main';
 
 // Mock the dependencies
 jest.mock('../src/util', () => ({
   setupEnv: jest.fn(),
 }));
 
-// Mock process.exit to prevent Commander from exiting the process
-const originalExit = process.exit;
-beforeAll(() => {
-  process.exit = jest.fn() as any;
-});
-
-afterAll(() => {
-  process.exit = originalExit;
-});
-
 describe('addEnvFileOptionRecursively', () => {
+  const originalExit = process.exit;
   let program: Command;
   let subCommand: Command;
-
+  
+  beforeAll(() => {
+    process.exit = jest.fn() as any;
+  });
+  
   beforeEach(() => {
     program = new Command();
     program.action(() => {});
@@ -29,11 +24,15 @@ describe('addEnvFileOptionRecursively', () => {
     jest.clearAllMocks();
   });
 
+  afterAll(() => {
+    process.exit = originalExit;
+  });
+
   it('should add env-file option to a command that does not have it', () => {
     addEnvFileOptionRecursively(program);
-
+    
     const hasEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
     expect(hasEnvFileOption).toBe(true);
   });
@@ -41,73 +40,74 @@ describe('addEnvFileOptionRecursively', () => {
   it('should not add env-file option if it already exists', () => {
     program.option('--env-file, --env-path <path>', 'Path to .env file');
     const initialOptionsLength = program.options.length;
-
+    
     addEnvFileOptionRecursively(program);
-
+    
     expect(program.options).toHaveLength(initialOptionsLength);
   });
 
   it('should add env-file option to subcommands', () => {
     addEnvFileOptionRecursively(program);
-
+    
     const hasSubcommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
     expect(hasSubcommandEnvFileOption).toBe(true);
   });
-
+  
   it('should add env-file option to nested subcommands', () => {
     // Create a deeper command structure
     const subSubCommand = subCommand.command('subsubcommand');
     subSubCommand.action(() => {});
     const subSubSubCommand = subSubCommand.command('subsubsubcommand');
     subSubSubCommand.action(() => {});
-
+    
     addEnvFileOptionRecursively(program);
-
+    
     // Check all levels of commands have the env-file option
     const hasMainEnvFileOption = program.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
     const hasSubCommandEnvFileOption = subCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
     const hasSubSubCommandEnvFileOption = subSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
     const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
-      (option) => option.long === '--env-file' || option.long === '--env-path',
+      (option) => option.long === '--env-file' || option.long === '--env-path'
     );
-
+    
     expect(hasMainEnvFileOption).toBe(true);
     expect(hasSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubCommandEnvFileOption).toBe(true);
     expect(hasSubSubSubCommandEnvFileOption).toBe(true);
   });
-
+  
   it('should register the hook that calls setupEnv when receiving the env-file option', () => {
     // Create a program with the option
     program.option('--env-file, --env-path <path>', 'Path to .env file');
-
+    
     // Create a fake action that manually mocks the Commander hook system
     const mockHookRegister = jest.fn();
     (program as any).hook = mockHookRegister;
-
+    
     // Apply env-file option functionality
     addEnvFileOptionRecursively(program);
-
+    
     // Verify the hook was registered
     expect(mockHookRegister).toHaveBeenCalledWith('preAction', expect.any(Function));
-
+    
     // Get the hook function
-    const preActionFn = mockHookRegister.mock.calls.find((call) => call[0] === 'preAction')?.[1];
-
-    // Call the preAction hook with mock data
-    if (preActionFn) {
-      preActionFn({ opts: () => ({ envFile: '.env.test' }) });
-
-      // Verify setupEnv was called with the right argument
-      expect(setupEnv).toHaveBeenCalledWith('.env.test');
-    }
+    const preActionFn = mockHookRegister.mock.calls.find(call => call[0] === 'preAction')?.[1];
+    
+    // Ensure preActionFn exists before testing it
+    expect(preActionFn).toBeDefined();
+    
+    // Call the preAction hook with mock data safely (no conditional expect)
+    preActionFn!({ opts: () => ({ envFile: '.env.test' }) });
+    
+    // Verify setupEnv was called with the right argument
+    expect(setupEnv).toHaveBeenCalledWith('.env.test');
   });
 });


### PR DESCRIPTION
This PR adds a global `--env-file` (and its alias `--env-path`) option to all commands recursively, similar to how the global `--verbose` option was added in PR #3950. This enables users to specify a custom .env file path with any command.

## Changes

- Add `addEnvFileOptionRecursively` function in `src/main.ts` (similar to `addVerboseOptionRecursively`)
- Remove redundant `--env-file` options from individual command implementations
- Add tests for the global env-file option

## Testing

Added comprehensive tests in `test/main.test.ts` that verify:
- The option is added to commands that don't have it
- The option is not duplicated if it already exists
- The option is added to all subcommands recursively
- The hook correctly calls `setupEnv` with the provided path
