### PR TITLE
docs: instructions on how to run the documentation

### DIFF
--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -367,6 +367,13 @@ While promptfoo is primarily written in TypeScript, we support custom Python pro
 
 If you're adding new features or changing existing ones, please update the relevant documentation. We use [Docusaurus](https://docusaurus.io/) for our documentation. We strongly encourage examples and guides as well.
 
+To run the documentation
+
+```bash
+cd site
+npm start
+```
+
 ## Advanced Topics
 
 ### Database


### PR DESCRIPTION
I had to figure this out as when i looked at the docs there were no instructions