### PR TITLE
docs: how to create inline assertions for pacakge users

### DIFF
--- a/site/docs/configuration/expected-outputs/javascript.md
+++ b/site/docs/configuration/expected-outputs/javascript.md
@@ -273,6 +273,21 @@ module.exports = (output, context) => {
 };
 ```
 
+## Inline assertions
+
+If you are using promptfoo as a JS package, you can build your assertion inline:
+
+```js
+{
+  type:"javascript",
+  value: (output, context) => {
+    return output.includes("specific text");
+  }
+}
+```
+
+output will always be a string, so if your [custom response parser](/docs/providers/http/#function-parser)returned an object, you can use `JSON.parse(output)` to convert it the value back to an object.
+
 ### ES modules
 
 ES modules are supported, but must have a `.mjs` file extension. Alternatively, if you are transpiling Javascript or Typescript, we recommend pointing promptfoo to the transpiled plain Javascript output.


### PR DESCRIPTION
As a user i would prefere to define my assertions inline versus in a seperate file imported using a path.

This makes the code cleaner and allows me to do things like currying the assertion fuction

in order to do this i had to read through the code, so to simplify for the next user i added documentation

coersion happens here:
https://github.com/promptfoo/promptfoo/blob/46e784ec001d29920bac5bfeb25903265c4d6d65/src/assertions/index.ts#L220