### PR TITLE
fix: divergent behviour http

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -511,12 +511,8 @@ export function determineRequestBody(
 }
 
 export async function createValidateStatus(
-  validator: string | ((status: number) => boolean) | undefined,
+  validator: string | ((status: number) => boolean),
 ): Promise<(status: number) => boolean> {
-  if (!validator) {
-    return (status: number) => true;
-  }
-
   if (typeof validator === 'function') {
     return validator;
   }
@@ -584,7 +580,9 @@ export class HttpProvider implements ApiProvider {
     );
     this.sessionParser = createSessionParser(this.config.sessionParser);
     this.transformRequest = createTransformRequest(this.config.transformRequest);
-    this.validateStatus = createValidateStatus(this.config.validateStatus);
+    this.validateStatus = createValidateStatus(
+      this.config.validateStatus || 'status >= 200 && status < 300',
+    );
     if (this.config.request) {
       this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
     } else {

--- a/test/providers/http-fetch-interactions.test.ts
+++ b/test/providers/http-fetch-interactions.test.ts
@@ -50,7 +50,7 @@ describe('error handling', () => {
     );
   });
 
-  it('does not throw an error when validateStatus is not set nor retry configued', async () => {
+  it('throws not throw an error when validateStatus is not set nor retry configued', async () => {
     const provider = new HttpProvider('http://test.com', {
       config: {
         method: 'POST',
@@ -60,7 +60,9 @@ describe('error handling', () => {
       },
     });
 
-    await expect(provider.callApi('test')).resolves.not.toThrow();
+    await expect(provider.callApi('test')).rejects.toThrow(
+      'HTTP call failed with status 500 Bad Request: {\"data\":\"Error message\"}',
+    );
   });
 
   it('throws an error when validateStatus is set nor retry configued', async () => {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -2115,7 +2115,7 @@ describe('error handling', () => {
 
 describe('validateStatus', () => {
   describe('default behavior', () => {
-    it('should accept all status codes when validateStatus is not provided', async () => {
+    it('should only accept 200 - 300 validateStatus is not provided', async () => {
       const provider = new HttpProvider('http://test.com', {
         config: {
           method: 'POST',
@@ -2139,8 +2139,18 @@ describe('validateStatus', () => {
         };
         jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-        const result = await provider.callApi('test');
-        expect(result.output).toEqual({ result: 'success' });
+        if (status === 200) {
+          const result = await provider.callApi('test');
+          expect(result.output).toEqual({ result: 'success' });
+        } else if (status === 400) {
+          await expect(provider.callApi('test')).rejects.toThrow(
+            'HTTP call failed with status 400 Bad Request: {\"result\":\"success\"}',
+          );
+        } else {
+          await expect(provider.callApi('test')).rejects.toThrow(
+            'HTTP call failed with status 500 Server Error: {\"result\":\"success\"}',
+          );
+        }
       }
     });
   });


### PR DESCRIPTION
This pr is more about having a conversation with examples depending on the outcome it can be closed or merged, i have also added descriptions to the commits explaining some specifics.

I have split the work into two commits.
   1. indicating what the current behavior is.
   2. Changing the behavior to the recommendation of the pr.

When i was using prompt foo i put a lot of effort to return correct status codes so that the behavior was as expected. and was surprised when 500 was not reflecting correctly, i figured it was because of `validateStatus`.

But while exploring the code i had a hunch that if i mess with `PROMPTFOO_RETRY_5XX` it will have a divergent behavior.

I do think that http provider should respect HTTP status codes as they are intended, if a developer wants do other stuff with 500 they can. 

i found the pr that makes the change https://github.com/promptfoo/promptfoo/pull/2712, but it does not explain why this change was made?