### PR TITLE
fix: Resolve paths relative to promptfooconfig when not cloud config

### DIFF
--- a/src/providers/scriptBasedProvider.ts
+++ b/src/providers/scriptBasedProvider.ts
@@ -46,7 +46,7 @@ export function createScriptBasedProviderFactory(
 
       // If using a cloud config, always use process.cwd() instead of context.basePath
       const isCloudConfig = providerOptions.config?.isCloudConfig === true;
-      const resolvedPath = getResolvedRelativePath(scriptPath, context.basePath, isCloudConfig);
+      const resolvedPath = getResolvedRelativePath(scriptPath, isCloudConfig);
 
       return new providerConstructor(resolvedPath, providerOptions);
     },

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -81,15 +81,10 @@ export function maybeLoadFromExternalFile(filePath: string | object | Function |
  * When using a cloud configuration, the current working directory is always used instead of the context's base path.
  *
  * @param filePath - The relative or absolute file path to resolve.
- * @param contextBasePath - The base path from the context (typically the directory containing the config file).
  * @param isCloudConfig - Whether this is a cloud configuration.
  * @returns The resolved absolute file path.
  */
-export function getResolvedRelativePath(
-  filePath: string,
-  contextBasePath?: string,
-  isCloudConfig?: boolean,
-): string {
+export function getResolvedRelativePath(filePath: string, isCloudConfig?: boolean): string {
   // If it's already an absolute path, or not a cloud config, return it as is
   if (path.isAbsolute(filePath) || !isCloudConfig) {
     return filePath;

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -90,14 +90,11 @@ export function getResolvedRelativePath(
   contextBasePath?: string,
   isCloudConfig?: boolean,
 ): string {
-  // If it's already an absolute path, return it as is
-  if (path.isAbsolute(filePath)) {
+  // If it's already an absolute path, or not a cloud config, return it as is
+  if (path.isAbsolute(filePath) || !isCloudConfig) {
     return filePath;
   }
 
-  // If using a cloud config, always use process.cwd() instead of contextBasePath
-  const basePath = isCloudConfig === true ? process.cwd() : contextBasePath || process.cwd();
-
   // Join the basePath and filePath to get the resolved path
-  return path.join(basePath, filePath);
+  return path.join(process.cwd(), filePath);
 }

--- a/test/providers/scriptBasedProvider.test.ts
+++ b/test/providers/scriptBasedProvider.test.ts
@@ -61,7 +61,7 @@ describe('scriptBasedProvider', () => {
       const factory = createScriptBasedProviderFactory('test', null, MockProvider as any);
       const provider = await factory.create('test:script.js', mockProviderOptions, mockContext);
 
-      expect(getResolvedRelativePath).toHaveBeenCalledWith('script.js', '/base/path', false);
+      expect(getResolvedRelativePath).toHaveBeenCalledWith('script.js', false);
       expect((provider as any).scriptPath).toBe('script.js/resolved');
     });
 
@@ -73,7 +73,7 @@ describe('scriptBasedProvider', () => {
         mockContext,
       );
 
-      expect(getResolvedRelativePath).toHaveBeenCalledWith('path/script.js', '/base/path', false);
+      expect(getResolvedRelativePath).toHaveBeenCalledWith('path/script.js', false);
       expect((provider as any).scriptPath).toBe('path/script.js/resolved');
     });
 
@@ -86,7 +86,7 @@ describe('scriptBasedProvider', () => {
       const factory = createScriptBasedProviderFactory('test', null, MockProvider as any);
       await factory.create('test:script.js', cloudOptions, mockContext);
 
-      expect(getResolvedRelativePath).toHaveBeenCalledWith('script.js', '/base/path', true);
+      expect(getResolvedRelativePath).toHaveBeenCalledWith('script.js', true);
     });
   });
 });

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -224,23 +224,11 @@ describe('file utilities', () => {
 
     it('returns absolute path unchanged', () => {
       const absolutePath = path.resolve('/absolute/path/file.txt');
-      expect(getResolvedRelativePath(absolutePath, '/some/base/path')).toBe(absolutePath);
-    });
-
-    it('resolves relative path with contextBasePath', () => {
-      expect(getResolvedRelativePath('relative/file.txt', '/base/path')).toBe(
-        path.join('/base/path', 'relative/file.txt'),
-      );
+      expect(getResolvedRelativePath(absolutePath, false)).toBe(absolutePath);
     });
 
     it('uses process.cwd() when isCloudConfig is true', () => {
-      expect(getResolvedRelativePath('relative/file.txt', '/base/path', true)).toBe(
-        path.join('/mock/cwd', 'relative/file.txt'),
-      );
-    });
-
-    it('uses process.cwd() when contextBasePath is undefined', () => {
-      expect(getResolvedRelativePath('relative/file.txt')).toBe(
+      expect(getResolvedRelativePath('relative/file.txt', true)).toBe(
         path.join('/mock/cwd', 'relative/file.txt'),
       );
     });


### PR DESCRIPTION
Should resolve https://github.com/promptfoo/promptfoo/issues/3991

## Summary
The changes in https://github.com/promptfoo/promptfoo/pull/3805 resolved file paths to cwd for cloud configs, but also for relative paths when not a cloud config, if a config.basePath was not set. This should've only applied for cloud configs, since path resolution is done already in https://github.com/promptfoo/promptfoo/blob/6bf829bb5f4214909c96e9dba94793ea8ba98b0e/src/util/index.ts#L415 for scripts. As a result, we would now be applying the base path twice, causing some weird effects, as seen in the issue. 

<details>
<summary>Test Process</summary>

input:
```
providers:
  - id: 'file://providers/example.py'
  - id: 'file://../providers/example.py'
  - id: 'file://../../providers/example.py'
  - id: 'file://../../../providers/example.py'
```

file structure:
```
├── evaluation
│   └── promptfooconfig.yaml
└── providers
    └── example.py
```

When evaluating from `/workspace/promptfoo`,

Previous resolution behaviour:
```
*current*
filePath /workspace/promptfoo/evaluation/evaluation/providers/example.py
filePath /workspace/promptfoo/evaluation/providers/example.py
filePath /workspace/promptfoo/providers/example.py
filePath /workspace/providers/example.py
```

With this PR: (i.e. now relative to promptfooconfig.yaml, as previously)
```
filePath /workspace/promptfoo/evaluation/providers/example.py
filePath /workspace/promptfoo/providers/example.py
filePath /workspace/providers/example.py
filePath /providers/example.py
```
</details>