### PR TITLE
chore(cli): improve color of Redteam test generation table headers

### DIFF
--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -76,7 +76,9 @@ function generateReport(
   strategyResults: Record<string, { requested: number; generated: number }>,
 ): string {
   const table = new Table({
-    head: ['#', 'Type', 'ID', 'Requested', 'Generated', 'Status'],
+    head: ['#', 'Type', 'ID', 'Requested', 'Generated', 'Status'].map((h) =>
+      chalk.dim(chalk.white(h)),
+    ),
     colWidths: [5, 10, 40, 12, 12, 14],
   });
 


### PR DESCRIPTION
#### Before

<img width="740" alt="image" src="https://github.com/user-attachments/assets/c1157e9f-f413-43a6-bf2e-d82696954bd2" />

#### After

<img width="741" alt="image" src="https://github.com/user-attachments/assets/9852b1a5-74b2-4421-8723-dcceb3bb54f3" />
