### PR TITLE
fix: azure auth headers gets set to null in subclass

### DIFF
--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -14,7 +14,6 @@ import { calculateAzureCost } from './util';
 
 export class AzureChatCompletionProvider extends AzureGenericProvider {
   private mcpClient: MCPClient | null = null;
-  protected initializationPromise: Promise<void> | null = null;
 
   constructor(...args: ConstructorParameters<typeof AzureGenericProvider>) {
     super(...args);


### PR DESCRIPTION
When using Azure CLI authentication the following error occurs:

```
[ERROR] Error: Invariant failed: auth headers are not initialized
Error: Invariant failed: auth headers are not initialized
    at invariant (/usr/lib/node_modules/promptfoo/dist/src/util/invariant.js:24:11)
    at AzureChatCompletionProvider.callApi (/u...
```

The error appears to be caused by `AzureChatCompletionProvider` redeclaring `initializationPromise` and setting it to `null`. There is no need to declare `initializationPromise` as it has already been done in the base class. By removing this line the error is fixed.