### PR TITLE
chore: add headers support for url remote mcp servers

### DIFF
--- a/site/docs/integrations/mcp.md
+++ b/site/docs/integrations/mcp.md
@@ -32,6 +32,12 @@ providers:
   - `command`: The command to launch the MCP server (e.g., `npx`).
   - `args`: Arguments to pass to the command (e.g., `['-y', '@modelcontextprotocol/server-memory']`).
   - `name`: (Optional) A name for the server instance.
+  - `url`: URL for connecting to a remote MCP server.
+  - `headers`: (Optional) Custom HTTP headers to send when connecting to a remote MCP server (only applies to `url`-based connections).
+  - `auth`: (Optional) Authentication configuration for the server.
+    - `type`: Authentication type, either `'bearer'` or `'api_key'`.
+    - `token`: Token for bearer authentication.
+    - `api_key`: API key for api_key authentication.
 - You can also connect to a remote MCP server by specifying a `url` instead of `command`/`args`.
 
 MCP servers can be run locally or accessed remotely. For development and testing, a local server is often simplest, while production environments may use a centralized remote server.
@@ -48,6 +54,29 @@ providers:
         server:
           url: http://localhost:8000
 ```
+
+#### Example: Using Custom Headers with a Remote MCP Server
+
+```yaml
+providers:
+  - id: openai:chat:gpt-4.1
+    config:
+      apiKey: <your-api-key>
+      mcp:
+        enabled: true
+        server:
+          url: http://localhost:8000
+          headers:
+            X-API-Key: your-custom-api-key
+            Authorization: Bearer your-token
+            X-Custom-Header: custom-value
+```
+
+This can be useful when:
+
+- The MCP server requires an API key or authentication token
+- You need to provide custom identifiers or session information
+- The server needs specific headers for configuration or tracking
 
 ## Connecting a Single Provider to Multiple MCP Servers
 
@@ -67,11 +96,14 @@ providers:
             name: server_a
           - url: http://localhost:8001
             name: server_b
+            headers:
+              X-API-Key: your-api-key
 ```
 
 - Use the `servers:` array (not just `server:`) to specify multiple MCP servers.
 - Each entry can be a local launch or a remote URL (if supported).
 - All tools from all servers will be available to the provider.
+- You can specify different headers for each server when using URL connections.
 
 ## Using Multiple MCP Servers
 
@@ -97,6 +129,8 @@ providers:
         server:
           url: http://localhost:8001
           name: openai-memory
+          headers:
+            X-API-Key: openai-server-api-key
 
   - id: anthropic:messages:claude-3-5-sonnet-20241022
     config:
@@ -105,6 +139,8 @@ providers:
         server:
           url: http://localhost:8002
           name: anthropic-memory
+          headers:
+            Authorization: Bearer anthropic-server-token
 ```
 
 In this example:
@@ -112,6 +148,7 @@ In this example:
 - The Gemini provider launches a local MCP server using `npx`.
 - The OpenAI and Anthropic providers connect to different remote MCP servers running on different ports.
 - Each provider can have its own memory, tool set, and context, isolated from the others.
+- Custom headers are specified for the remote servers to handle authentication or other requirements.
 
 This setup is useful for testing, benchmarking, or running isolated agentic workflows in parallel.
 
@@ -127,6 +164,7 @@ MCP is supported by most major providers in Promptfoo, including:
 
 - Ensure your MCP server is running and accessible.
 - Check your provider logs for MCP connection errors.
+- Verify that your custom headers are correctly formatted if you're having authentication issues.
 
 ## See Also
 

--- a/site/docs/integrations/mcp.md
+++ b/site/docs/integrations/mcp.md
@@ -34,7 +34,7 @@ providers:
   - `name`: (Optional) A name for the server instance.
   - `url`: URL for connecting to a remote MCP server.
   - `headers`: (Optional) Custom HTTP headers to send when connecting to a remote MCP server (only applies to `url`-based connections).
-  - `auth`: (Optional) Authentication configuration for the server.
+  - `auth`: (Optional) Authentication configuration for the server. Can be used to automatically set auth headers for all connection types.
     - `type`: Authentication type, either `'bearer'` or `'api_key'`.
     - `token`: Token for bearer authentication.
     - `api_key`: API key for api_key authentication.

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -73,17 +73,27 @@ export class MCPClient {
         });
         await client.connect(transport);
       } else if (server.url) {
+        // Get auth headers and combine with custom headers
+        const authHeaders = this.getAuthHeaders(server);
+        const headers = {
+          ...authHeaders,
+          ...(server.headers || {}),
+        };
+
+        // Only set options if we have headers
+        const options = Object.keys(headers).length > 0 ? { requestInit: { headers } } : undefined;
+
         try {
           const { StreamableHTTPClientTransport } = await import(
             '@modelcontextprotocol/sdk/client/streamableHttp.js'
           );
-          transport = new StreamableHTTPClientTransport(new URL(server.url));
+          transport = new StreamableHTTPClientTransport(new URL(server.url), options);
           await client.connect(transport);
           logger.debug('Connected using Streamable HTTP transport');
         } catch (error) {
           logger.error(`Failed to connect to MCP server ${serverKey}: ${error}`);
           const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
-          transport = new SSEClientTransport(new URL(server.url));
+          transport = new SSEClientTransport(new URL(server.url), options);
           await client.connect(transport);
           logger.debug('Connected using SSE transport');
         }

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -76,8 +76,8 @@ export class MCPClient {
         // Get auth headers and combine with custom headers
         const authHeaders = this.getAuthHeaders(server);
         const headers = {
-          ...authHeaders,
           ...(server.headers || {}),
+          ...authHeaders,
         };
 
         // Only set options if we have headers

--- a/src/providers/mcp/types.ts
+++ b/src/providers/mcp/types.ts
@@ -9,6 +9,7 @@ export interface MCPServerConfig {
   name?: string; // Optional name to reference specific tools
   url?: string; // URL for remote server (not currently supported)
   auth?: MCPServerAuth; // Authentication configuration
+  headers?: Record<string, string>; // Additional HTTP headers for URL-based servers
 }
 
 export interface MCPServerAuth {

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -1103,7 +1103,7 @@ export const riskCategorySeverityMap: Record<Plugin, Severity> = {
   bfla: Severity.High,
   bola: Severity.High,
   cca: Severity.High,
-  mcp: Severity.Low,
+  mcp: Severity.High,
   competitors: Severity.Low,
   contracts: Severity.Medium,
   'cross-session-leak': Severity.Medium,

--- a/test/redteam/constants.test.ts
+++ b/test/redteam/constants.test.ts
@@ -178,7 +178,7 @@ describe('constants', () => {
   });
 
   it('should have correct severity for MCP plugin', () => {
-    expect(riskCategorySeverityMap['mcp']).toBe(Severity.Low);
+    expect(riskCategorySeverityMap['mcp']).toBe(Severity.High);
   });
 
   it('should have correct alias for MCP plugin', () => {


### PR DESCRIPTION
Adding an option to specify headers, and passing those into the http & sse MCP clients