### PR TITLE
feat: add copy as markdown button to doc pages

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+/static/docs
 
 # Misc
 .DS_Store

--- a/site/README.md
+++ b/site/README.md
@@ -36,3 +36,17 @@ These files are generated to support LLM-based tools that need to analyze or sea
 ### Usage
 
 No additional configuration is needed. The plugin runs automatically during the build process, and the files are created in the root of the build output directory.
+
+## Copy Page Button Feature
+
+A "Copy page" button is injected at the top of every documentation page. It provides a dropdown with:
+
+- **Copy as Markdown**: Copies the current page's markdown source to the clipboard.
+- **View Markdown**: Opens a modal displaying the markdown source.
+
+This is implemented via:
+
+- `src/components/CopyPageButton.tsx` (the button and modal logic)
+- `src/theme/DocItem/index.js` (theme swizzle to inject the button)
+
+The button fetches the markdown source from `/docs/[slug].md` based on the current page URL. If the markdown is not available, it shows an error message.

--- a/site/package.json
+++ b/site/package.json
@@ -3,10 +3,9 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "prebuild": "rm -rf static/docs && cp -r docs static/docs && sed -i '' '/---/,/---/d' static/docs/**/*.md",
     "docusaurus": "docusaurus",
-    "start": "npm run prebuild && NODE_ENV=development docusaurus start --port ${PORT:-3100}",
-    "build": "npm run prebuild && docusaurus build",
+    "start": "NODE_ENV=development docusaurus start --port ${PORT:-3100}",
+    "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/site/package.json
+++ b/site/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
+    "prebuild": "rm -rf static/docs && cp -r docs static/docs && sed -i '' '/---/,/---/d' static/docs/**/*.md",
     "docusaurus": "docusaurus",
-    "start": "NODE_ENV=development docusaurus start --port ${PORT:-3100}",
-    "build": "docusaurus build",
+    "start": "npm run prebuild && NODE_ENV=development docusaurus start --port ${PORT:-3100}",
+    "build": "npm run prebuild && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/site/src/components/CopyPageButton.module.css
+++ b/site/src/components/CopyPageButton.module.css
@@ -1,0 +1,76 @@
+.buttonContainer {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.copyButton {
+  display: flex;
+  align-items: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+  padding: 0 14px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  height: 36px;
+  min-width: 110px;
+}
+
+.buttonContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.iconContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.copyIcon {
+  font-size: 14px !important;
+  opacity: 1;
+  position: absolute;
+  transition: all 0.2s ease-in-out;
+  width: 14px !important;
+  height: 14px !important;
+}
+
+.checkIcon {
+  font-size: 14px !important;
+  opacity: 0;
+  position: absolute;
+  color: #22c55e;
+  transition: all 0.2s ease-in-out;
+  width: 14px !important;
+  height: 14px !important;
+}
+
+.copied .copyIcon {
+  opacity: 0;
+}
+
+.copied .checkIcon {
+  opacity: 1;
+}
+
+/* Dark theme styles */
+[data-theme='dark'] .copyButton {
+  border-color: #4a4a4a;
+  background: #2d2d2d;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  color: #e6e6e6;
+}
+
+[data-theme='dark'] .copyIcon {
+  color: #e6e6e6;
+}

--- a/site/src/components/CopyPageButton.tsx
+++ b/site/src/components/CopyPageButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useLocation } from '@docusaurus/router';
+import { useColorMode } from '@docusaurus/theme-common';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
@@ -30,6 +31,8 @@ const fetchMarkdown = async (pathname: string) => {
 const CopyPageButton: React.FC = () => {
   const location = useLocation();
   const [copied, setCopied] = useState(false);
+  const { colorMode } = useColorMode();
+  const isDarkTheme = colorMode === 'dark';
 
   const handleCopy = async () => {
     if (copied) {
@@ -49,26 +52,30 @@ const CopyPageButton: React.FC = () => {
     }
   };
 
+  // Define theme-specific styles
+  const buttonStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    border: `1px solid ${isDarkTheme ? '#4a4a4a' : '#e5e7eb'}`,
+    borderRadius: '18px',
+    background: isDarkTheme ? '#2d2d2d' : '#fff',
+    boxShadow: isDarkTheme ? '0 1px 2px rgba(0,0,0,0.1)' : '0 1px 2px rgba(0,0,0,0.03)',
+    padding: '0 14px',
+    fontSize: 15,
+    fontWeight: 500,
+    cursor: 'pointer',
+    height: 36,
+    minWidth: 110, // Fixed minimum width instead of dynamic measurement
+    color: isDarkTheme ? '#e6e6e6' : 'inherit',
+  };
+
   return (
     <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
       <button
         onClick={handleCopy}
         aria-label={copied ? 'Copied markdown to clipboard' : 'Copy markdown to clipboard'}
         aria-live="polite"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          border: '1px solid #e5e7eb',
-          borderRadius: '18px',
-          background: '#fff',
-          boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
-          padding: '0 14px',
-          fontSize: 15,
-          fontWeight: 500,
-          cursor: 'pointer',
-          height: 36,
-          minWidth: 110, // Fixed minimum width instead of dynamic measurement
-        }}
+        style={buttonStyle}
       >
         <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
           <span
@@ -87,6 +94,7 @@ const CopyPageButton: React.FC = () => {
                 opacity: copied ? 0 : 1,
                 position: 'absolute',
                 transition: 'all 0.2s ease-in-out',
+                color: isDarkTheme ? '#e6e6e6' : 'inherit',
               }}
             />
             <CheckIcon

--- a/site/src/components/CopyPageButton.tsx
+++ b/site/src/components/CopyPageButton.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { useLocation } from '@docusaurus/router';
+import CheckIcon from '@mui/icons-material/Check';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+const getMarkdownUrl = (pathname: string) => {
+  // Assumes docs are served as /docs/slug and source is available at /docs/slug.md
+  // Adjust if your routing is different
+  let docPath = pathname.replace(/^\/docs\//, '').replace(/\/$/, '');
+  if (!docPath) {
+    docPath = 'index';
+  }
+  return `/docs/${docPath}.md`;
+};
+
+const fetchMarkdown = async (pathname: string) => {
+  const url = getMarkdownUrl(pathname);
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error('Not found');
+    }
+    return await res.text();
+  } catch {
+    return 'Markdown source not available.';
+  }
+};
+
+const CopyPageButton: React.FC = () => {
+  const location = useLocation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (copied) {
+      return;
+    }
+
+    const md = await fetchMarkdown(location.pathname);
+    try {
+      await navigator.clipboard.writeText(md);
+
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    } catch {
+      // Handle copy failure if needed
+    }
+  };
+
+  return (
+    <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+      <button
+        onClick={handleCopy}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          border: '1px solid #e5e7eb',
+          borderRadius: '18px',
+          background: '#fff',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+          padding: '0 14px',
+          fontSize: 15,
+          fontWeight: 500,
+          cursor: 'pointer',
+          height: 36,
+          minWidth: 110, // Fixed minimum width instead of dynamic measurement
+        }}
+        aria-label="Copy page as markdown"
+      >
+        <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
+          <span
+            style={{
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 18,
+              height: 18,
+            }}
+          >
+            <ContentCopyIcon
+              style={{
+                fontSize: 14,
+                opacity: copied ? 0 : 1,
+                position: 'absolute',
+                transition: 'all 0.2s ease-in-out',
+              }}
+            />
+            <CheckIcon
+              style={{
+                fontSize: 14,
+                opacity: copied ? 1 : 0,
+                position: 'absolute',
+                color: '#22c55e',
+                transition: 'all 0.2s ease-in-out',
+              }}
+            />
+          </span>
+          <span>Copy page</span>
+        </span>
+      </button>
+    </div>
+  );
+};
+
+export default CopyPageButton;

--- a/site/src/components/CopyPageButton.tsx
+++ b/site/src/components/CopyPageButton.tsx
@@ -53,6 +53,8 @@ const CopyPageButton: React.FC = () => {
     <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
       <button
         onClick={handleCopy}
+        aria-label={copied ? 'Copied markdown to clipboard' : 'Copy markdown to clipboard'}
+        aria-live="polite"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -67,7 +69,6 @@ const CopyPageButton: React.FC = () => {
           height: 36,
           minWidth: 110, // Fixed minimum width instead of dynamic measurement
         }}
-        aria-label="Copy page as markdown"
       >
         <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
           <span

--- a/site/src/components/CopyPageButton.tsx
+++ b/site/src/components/CopyPageButton.tsx
@@ -4,13 +4,14 @@ import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 const getMarkdownUrl = (pathname: string) => {
-  // Assumes docs are served as /docs/slug and source is available at /docs/slug.md
-  // Adjust if your routing is different
+  // Extract the path and map to the new markdown directory structure
   let docPath = pathname.replace(/^\/docs\//, '').replace(/\/$/, '');
   if (!docPath) {
     docPath = 'index';
   }
-  return `/docs/${docPath}.md`;
+  // Use .md extension regardless of original file type
+  // Files are now in /markdown/ directory instead of /docs/
+  return `/markdown/${docPath}.md`;
 };
 
 const fetchMarkdown = async (pathname: string) => {

--- a/site/src/components/CopyPageButton.tsx
+++ b/site/src/components/CopyPageButton.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useLocation } from '@docusaurus/router';
-import { useColorMode } from '@docusaurus/theme-common';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import styles from './CopyPageButton.module.css';
 
 const getMarkdownUrl = (pathname: string) => {
   // Extract the path and map to the new markdown directory structure
@@ -10,6 +10,7 @@ const getMarkdownUrl = (pathname: string) => {
   if (!docPath) {
     docPath = 'index';
   }
+
   // Use .md extension regardless of original file type
   // Files are now in /markdown/ directory instead of /docs/
   return `/markdown/${docPath}.md`;
@@ -31,8 +32,6 @@ const fetchMarkdown = async (pathname: string) => {
 const CopyPageButton: React.FC = () => {
   const location = useLocation();
   const [copied, setCopied] = useState(false);
-  const { colorMode } = useColorMode();
-  const isDarkTheme = colorMode === 'dark';
 
   const handleCopy = async () => {
     if (copied) {
@@ -52,60 +51,18 @@ const CopyPageButton: React.FC = () => {
     }
   };
 
-  // Define theme-specific styles
-  const buttonStyle = {
-    display: 'flex',
-    alignItems: 'center',
-    border: `1px solid ${isDarkTheme ? '#4a4a4a' : '#e5e7eb'}`,
-    borderRadius: '18px',
-    background: isDarkTheme ? '#2d2d2d' : '#fff',
-    boxShadow: isDarkTheme ? '0 1px 2px rgba(0,0,0,0.1)' : '0 1px 2px rgba(0,0,0,0.03)',
-    padding: '0 14px',
-    fontSize: 15,
-    fontWeight: 500,
-    cursor: 'pointer',
-    height: 36,
-    minWidth: 110, // Fixed minimum width instead of dynamic measurement
-    color: isDarkTheme ? '#e6e6e6' : 'inherit',
-  };
-
   return (
-    <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+    <div className={styles.buttonContainer}>
       <button
         onClick={handleCopy}
         aria-label={copied ? 'Copied markdown to clipboard' : 'Copy markdown to clipboard'}
         aria-live="polite"
-        style={buttonStyle}
+        className={styles.copyButton}
       >
-        <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
-          <span
-            style={{
-              position: 'relative',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 18,
-              height: 18,
-            }}
-          >
-            <ContentCopyIcon
-              style={{
-                fontSize: 14,
-                opacity: copied ? 0 : 1,
-                position: 'absolute',
-                transition: 'all 0.2s ease-in-out',
-                color: isDarkTheme ? '#e6e6e6' : 'inherit',
-              }}
-            />
-            <CheckIcon
-              style={{
-                fontSize: 14,
-                opacity: copied ? 1 : 0,
-                position: 'absolute',
-                color: '#22c55e',
-                transition: 'all 0.2s ease-in-out',
-              }}
-            />
+        <span className={styles.buttonContent}>
+          <span className={`${styles.iconContainer} ${copied ? styles.copied : ''}`}>
+            <ContentCopyIcon className={styles.copyIcon} />
+            <CheckIcon className={styles.checkIcon} />
           </span>
           <span>Copy page</span>
         </span>

--- a/site/src/theme/DocItem/index.js
+++ b/site/src/theme/DocItem/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { DocProvider } from '@docusaurus/plugin-content-docs/client';
+import { HtmlClassNameProvider } from '@docusaurus/theme-common';
+import DocItemLayout from '@theme/DocItem/Layout';
+import DocItemMetadata from '@theme/DocItem/Metadata';
+import CopyPageButton from '../../components/CopyPageButton';
+
+export default function DocItem(props) {
+  const docHtmlClassName = `docs-doc-id-${props.content.metadata.id}`;
+  const MDXComponent = props.content;
+  return (
+    <DocProvider content={props.content}>
+      <HtmlClassNameProvider className={docHtmlClassName}>
+        <DocItemMetadata />
+        <DocItemLayout>
+          <div style={{ marginBottom: 24 }}>
+            <CopyPageButton />
+          </div>
+          <MDXComponent />
+        </DocItemLayout>
+      </HtmlClassNameProvider>
+    </DocProvider>
+  );
+}


### PR DESCRIPTION
<img width="1218" alt="Screenshot 2025-05-16 at 10 03 19 AM" src="https://github.com/user-attachments/assets/152392f2-217b-4e81-949a-474c11c20a4b" />

https://github.com/user-attachments/assets/5300665e-c16a-4c84-89b9-c09738dbcb88

dark mode:
<img width="1219" alt="Screenshot 2025-05-18 at 11 56 29 PM" src="https://github.com/user-attachments/assets/c818685d-4ebb-4f9c-ad4e-1fb33a178bfa" />
