### PR TITLE
chore: Improve memory usage when sharing results

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -268,6 +268,8 @@ export async function doEval(
       abortSignal: evaluateOptions.abortSignal,
     });
 
+    evalRecord.clearResults();
+
     const wantsToShare = cmdObj.share && config.sharing;
 
     const shareableUrl =

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -268,6 +268,7 @@ export async function doEval(
       abortSignal: evaluateOptions.abortSignal,
     });
 
+    // Clear results from memory to avoid memory issues
     evalRecord.clearResults();
 
     const wantsToShare = cmdObj.share && config.sharing;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -988,13 +988,7 @@ class Evaluator {
         });
 
         if (options.progressCallback) {
-          options.progressCallback(
-            this.evalRecord.resultsCount,
-            runEvalOptions.length,
-            index,
-            evalStep,
-            metrics,
-          );
+          options.progressCallback(numComplete, runEvalOptions.length, index, evalStep, metrics);
         }
       }
     };
@@ -1086,7 +1080,7 @@ class Evaluator {
         // Progress callback
         if (options.progressCallback) {
           options.progressCallback(
-            this.evalRecord.resultsCount,
+            numComplete,
             runEvalOptions.length,
             typeof index === 'number' ? index : 0,
             evalStep,

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -69,6 +69,7 @@ export default class Eval {
   prompts: CompletedPrompt[];
   oldResults?: EvaluateSummaryV2;
   persisted: boolean;
+  _resultsLoaded: boolean;
 
   static async latest() {
     const db = getDb();
@@ -275,6 +276,7 @@ export default class Eval {
     this.prompts = opts?.prompts || [];
     this.datasetId = opts?.datasetId;
     this.persisted = opts?.persisted || false;
+    this._resultsLoaded = false;
   }
 
   version() {
@@ -412,11 +414,13 @@ export default class Eval {
       const db = getDb();
       await db.insert(evalResultsTable).values(results.map((r) => ({ ...r, evalId: this.id })));
     }
+    this._resultsLoaded = true;
   }
 
   async loadResults() {
     this.results = await EvalResult.findManyByEvalId(this.id);
     this.resultsCount = this.results.length;
+    this._resultsLoaded = true;
   }
 
   async getResults(): Promise<EvaluateResult[] | EvalResult[]> {
@@ -426,6 +430,12 @@ export default class Eval {
     }
     await this.loadResults();
     return this.results;
+    this._resultsLoaded = true;
+  }
+
+  clearResults() {
+    this.results = [];
+    this._resultsLoaded = false;
   }
 
   getStats(): EvaluateStats {

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -381,9 +381,6 @@ export default class Eval {
   }
 
   async getResultsCount(): Promise<number> {
-    if (this.resultsCount > 0) {
-      return this.resultsCount;
-    }
     const db = getDb();
     const result = await db
       .select({ count: sql<number>`count(*)` })
@@ -391,8 +388,7 @@ export default class Eval {
       .where(eq(evalResultsTable.evalId, this.id))
       .all();
     const count = result[0]?.count ?? 0;
-    this.resultsCount = Number(count);
-    return this.resultsCount;
+    return Number(count);
   }
 
   async fetchResultsByTestIdx(testIdx: number) {
@@ -429,8 +425,8 @@ export default class Eval {
       return this.oldResults.results;
     }
     await this.loadResults();
-    return this.results;
     this._resultsLoaded = true;
+    return this.results;
   }
 
   clearResults() {

--- a/src/share.ts
+++ b/src/share.ts
@@ -235,6 +235,7 @@ async function sendChunkedResults(evalRecord: Eval, url: string): Promise<string
         }
       }
     }
+    // Send final chunk
     if (currentChunk.length > 0) {
       await sendChunkOfResults(currentChunk, url, evalId, headers);
       progressBar.increment(currentChunk.length);
@@ -255,7 +256,8 @@ async function sendChunkedResults(evalRecord: Eval, url: string): Promise<string
 
 async function sendEvalResults(evalRecord: Eval, url: string): Promise<string | null> {
   await evalRecord.loadResults();
-  logger.debug(`Sending eval results to ${url} with ${evalRecord.results.length} results`);
+  const numResults = await evalRecord.getResultsCount();
+  logger.debug(`Sending eval results to ${url} with ${numResults} results`);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../../src/models/eval', () => {
     default: jest.fn().mockImplementation(() => ({
       addResult: jest.fn().mockResolvedValue({}),
       addPrompts: jest.fn().mockResolvedValue({}),
+      clearResults: jest.fn().mockReturnValue(undefined),
       getTable: jest.fn().mockResolvedValue({
         head: {
           prompts: [],

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -2121,7 +2121,6 @@ describe('evaluator', () => {
       id: 'mock-eval-id',
       results: [],
       prompts: [],
-      resultsCount: 0,
       persisted: false,
       config: {},
       addResult: mockAddResult,

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -356,22 +356,21 @@ describe('createShareableUrl', () => {
         getTable: jest.fn().mockResolvedValue([]),
         id: randomUUID(),
         getResultsCount: jest.fn().mockResolvedValue(2),
-        fetchSampleResults: jest.fn().mockResolvedValue([{ id: '1' }, { id: '2' }] as EvalResult[]),
         fetchResultsBatched: jest.fn().mockImplementation(() => {
-          return {
-            [Symbol.asyncIterator]: () => {
-              let called = false;
-              return {
-                next: async () => {
-                  if (!called) {
-                    called = true;
-                    return { done: false, value: [{ id: '1' }, { id: '2' }] as EvalResult[] };
-                  }
-                  return { done: true, value: undefined };
-                },
-              };
+          const iterator = {
+            called: false,
+            next: async () => {
+              if (!iterator.called) {
+                iterator.called = true;
+                return { done: false, value: [{ id: '1' }, { id: '2' }] as EvalResult[] };
+              }
+              return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+              return this;
             },
           };
+          return iterator;
         }),
       };
 
@@ -486,7 +485,6 @@ describe('createShareableUrl', () => {
       getTable: jest.fn().mockResolvedValue([]),
       id: randomUUID(),
       getResultsCount: jest.fn().mockResolvedValue(2),
-      fetchSampleResults: jest.fn().mockResolvedValue([{ id: '1' }, { id: '2' }] as EvalResult[]),
       fetchResultsBatched: jest.fn().mockImplementation(() => {
         return {
           [Symbol.asyncIterator]: () => {


### PR DESCRIPTION
## Summary
- add batched sample and counting helpers on `Eval`
- stream results in `sendChunkedResults`
