### PR TITLE
chore: Update prompt suffix help text

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -612,7 +612,7 @@ export function evalCommand(
     )
     .option(
       '--prompt-suffix <path>',
-      'This suffix is append to every prompt',
+      'This suffix is appended to every prompt.',
       defaultConfig.defaultTest?.options?.suffix,
     )
     .option(


### PR DESCRIPTION
## Summary
- tweak wording for `--prompt-suffix` flag description

## Testing
- `npm run build` *(fails: Cannot find type definition file)*