### PR TITLE
chore(providers): update default openai models for openai:chat alias

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -671,10 +671,7 @@ export const providerMap: ProviderFactory[] = [
       const modelName = splits.slice(2).join(':');
 
       if (modelType === 'chat') {
-        return new OpenAiChatCompletionProvider(
-          modelName || 'gpt-4.1-2025-04-14',
-          providerOptions,
-        );
+        return new OpenAiChatCompletionProvider(modelName || 'gpt-4.1-2025-04-14', providerOptions);
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {
         return new OpenAiEmbeddingProvider(modelName || 'text-embedding-3-large', providerOptions);
@@ -692,10 +689,7 @@ export const providerMap: ProviderFactory[] = [
         );
       }
       if (modelType === 'responses') {
-        return new OpenAiResponsesProvider(
-          modelName || 'gpt-4.1-2025-04-14',
-          providerOptions,
-        );
+        return new OpenAiResponsesProvider(modelName || 'gpt-4.1-2025-04-14', providerOptions);
       }
       if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODEL_NAMES.includes(modelType)) {
         return new OpenAiChatCompletionProvider(modelType, providerOptions);

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -671,7 +671,10 @@ export const providerMap: ProviderFactory[] = [
       const modelName = splits.slice(2).join(':');
 
       if (modelType === 'chat') {
-        return new OpenAiChatCompletionProvider(modelName || 'gpt-4o-mini', providerOptions);
+        return new OpenAiChatCompletionProvider(
+          modelName || 'gpt-4.1-2025-04-14',
+          providerOptions,
+        );
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {
         return new OpenAiEmbeddingProvider(modelName || 'text-embedding-3-large', providerOptions);
@@ -689,7 +692,10 @@ export const providerMap: ProviderFactory[] = [
         );
       }
       if (modelType === 'responses') {
-        return new OpenAiResponsesProvider(modelName || 'gpt-4o', providerOptions);
+        return new OpenAiResponsesProvider(
+          modelName || 'gpt-4.1-2025-04-14',
+          providerOptions,
+        );
       }
       if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODEL_NAMES.includes(modelType)) {
         return new OpenAiChatCompletionProvider(modelType, providerOptions);

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -110,14 +110,17 @@ describe('loadApiProvider', () => {
   });
 
   it('should load OpenAI chat provider', async () => {
-    const provider = await loadApiProvider('openai:chat:gpt-4');
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('gpt-4', expect.any(Object));
+    const provider = await loadApiProvider('openai:chat:gpt-4.1');
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('gpt-4.1', expect.any(Object));
     expect(provider).toBeDefined();
   });
 
   it('should load OpenAI chat provider with default model', async () => {
     const provider = await loadApiProvider('openai:chat');
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('gpt-4o-mini', expect.any(Object));
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
+      'gpt-4.1-2025-04-14',
+      expect.any(Object),
+    );
     expect(provider).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary
- update OpenAI defaults to GPT 4.1 models in `registry.ts`

## Testing
- `npm run f` *(fails: Cannot find package '/workspace/promptfoo/node_modules/@trivago/prettier-plugin-sort-imports/' imported from /workspace/promptfoo/noop.js)*
- `npm run l` *(fails: Cannot find package '/workspace/promptfoo/node_modules/eslint-plugin-react-hooks/index.js')*
- `npm test` *(fails: jest: not found)*