### PR TITLE
fix(redteam): fix open handle in video test

### DIFF
--- a/src/redteam/strategies/simpleVideo.ts
+++ b/src/redteam/strategies/simpleVideo.ts
@@ -1,26 +1,25 @@
 import { SingleBar, Presets } from 'cli-progress';
-import { getEnvString } from '../../envars';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import cliState from '../../cliState';
 import logger from '../../logger';
 import type { TestCase } from '../../types';
 import invariant from '../../util/invariant';
 import { neverGenerateRemote } from '../remoteGeneration';
 
-// Cache for the ffmpeg module to avoid repeated dynamic imports
 let ffmpegCache: any = null;
 
-/**
- * Dynamically imports the fluent-ffmpeg library
- * @returns The fluent-ffmpeg module
- * @throws Error if fluent-ffmpeg is not installed
- */
-async function importFfmpeg(): Promise<any> {
-  // Return the cached module if available
+function shouldShowProgressBar(): boolean {
+  return !cliState.webUI && logger.level !== 'debug';
+}
+
+export async function importFfmpeg(): Promise<any> {
   if (ffmpegCache) {
     return ffmpegCache;
   }
 
   try {
-    // Dynamic import of fluent-ffmpeg
     ffmpegCache = await import('fluent-ffmpeg');
     return ffmpegCache;
   } catch (error) {
@@ -35,198 +34,230 @@ async function importFfmpeg(): Promise<any> {
   }
 }
 
-/**
- * Creates a simple video with text using fluent-ffmpeg and converts to base64
- * This implementation creates a video with a white background and black text
- */
-export async function textToVideo(text: string): Promise<string> {
-  // Special case for test environment - avoid actually generating video
-  if (getEnvString('NODE_ENV') === 'test' || getEnvString('JEST_WORKER_ID')) {
-    // Return a small dummy base64 string representing a minimal video
-    return 'AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAAu1tZGF0AAAAMm1vb3YAAABsbXZoZAAAAAAAAAAAAAAAAAAAA+gAAAAAAAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAIYdHJhawAAAFx0a2hkAAAAAwAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAABNG1kaWEAAAAgbWRoZAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAQQAAAAIAQAABkAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAAAAQAAAAAAAAABAAAAAQAAAAAAAbRtZHhyAAAAAAAAAAEAAAABAAAAQAAAAAAAAAAAAAAEAAAAAK9tZXRhAAAAAAABAAAAJGhtZGEAAAABAAAAAAABJIICSgJYCAAASG1tZXRhZGF0YQosAggADgBMAEkAUwBUAPEAAABpbHN0AP8AAAAbAQAAAG1pbmYBAAAAAAAQAAgAIAASACMAGgAkACUAFAAaABoAHgAeAAcAGQAjABkAGAAVABEAGAAdABgAHQAjAAQACAALABkAAAAgAAgAHwBMAEkAUwBUAHQAAABzdHNkACYAAACac3RzYwAAAAAAAQAAAAsAAAACAAAAAgAAAAEAAAAjAAAAAgAAAAAAAQAAAAEAAAABAAAAIwAAAAEAAAABAAAAAAAAAAEAAAABAAAAAgAAAAIAAAAEAAAAAAAAAAgAAAAEAQAAAIVzdHNzAAAAAAAAAAEAAAAEAAAB4AAAAAkAAAM0c3RzegAAAAAAAAQ+AAAAAQAAAAEAAAHgAAAAAQAAAAEAAAGBAAAAAQAAAAEAAAGkAAAAAQAAAAEAAAGyAAAAAQAAAAEAAAHNAAAAAQAAAAEAAAB7AAABJnN0Y28AAAAAAAAAAQAAACgAAAAYc3RzegAAAAAAAAUAAAAEAAAAJgAAAAIAAAACAAAAAgAAAAEAAAABAAAAAAAAAAABgAAAAQAAAAEAAAAyAAAAAQAAAAEAAAByAAAAAQAAAAIAAACzAAAAAQAAAAMAAABQAAAAAQAAAAMAAABwAAAAAQAAAAMAAADiAAAB+HN0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAA+gAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAUqZGF0YQAAAARMbGF2YwEAAAcAGgA6WCCwACWmgQgJLUAQFoQAAACNAYXWMXjJFgdGRGF0YQAQSZLIwAW+xXLybCo=';
+export async function createTempVideoEnvironment(text: string): Promise<{
+  tempDir: string;
+  textFilePath: string;
+  outputPath: string;
+  cleanup: () => void;
+}> {
+  const tempDir = path.join(os.tmpdir(), 'promptfoo-video');
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir, { recursive: true });
   }
 
-  try {
-    // Check if remote generation is disabled
-    if (neverGenerateRemote()) {
-      // For simplicity in this initial implementation, we'll create a local video
-      // This will be a very basic implementation that doesn't require external services
+  const textFilePath = path.join(tempDir, 'text.txt');
+  const outputPath = path.join(tempDir, 'output-video.mp4');
 
-      const ffmpegModule = await importFfmpeg();
+  fs.writeFileSync(textFilePath, text);
 
-      const fs = await import('fs');
-      const os = await import('os');
-      const path = await import('path');
-
-      // Create temporary directory for video creation
-      const tempDir = path.join(os.tmpdir(), 'promptfoo-video');
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
+  const cleanup = () => {
+    try {
+      if (fs.existsSync(textFilePath)) {
+        fs.unlinkSync(textFilePath);
       }
+      if (fs.existsSync(outputPath)) {
+        fs.unlinkSync(outputPath);
+      }
+    } catch (error) {
+      logger.warn(`Failed to clean up temporary files: ${error}`);
+    }
+  };
 
-      // Create a text file with the content
-      const textFilePath = path.join(tempDir, 'text.txt');
-      fs.writeFileSync(textFilePath, text);
+  return { tempDir, textFilePath, outputPath, cleanup };
+}
 
-      // Create output video file path
-      const outputPath = path.join(tempDir, 'output-video.mp4');
+export function getFallbackBase64(text: string): string {
+  return Buffer.from(text).toString('base64');
+}
 
-      // Create a promise to handle the ffmpeg process
+export async function textToVideo(text: string): Promise<string> {
+  try {
+    if (neverGenerateRemote()) {
+      const ffmpegModule = await importFfmpeg();
+      const { textFilePath, outputPath, cleanup } = await createTempVideoEnvironment(text);
+
       return new Promise((resolve, reject) => {
-        // Create a simple video with the text
         ffmpegModule()
-          .input('color=white:s=640x480:d=5') // White background, 5 seconds
+          .input('color=white:s=640x480:d=5')
           .inputFormat('lavfi')
           .input(textFilePath)
-          .inputOptions(['-f', 'concat']) // Use text as input
+          .inputOptions(['-f', 'concat'])
           .complexFilter([
             `[0:v]drawtext=fontfile=/System/Library/Fonts/Helvetica.ttc:text='${text.replace(/'/g, "\\'")}':fontcolor=black:fontsize=24:x=(w-text_w)/2:y=(h-text_h)/2[v]`,
           ])
           .outputOptions(['-map', '[v]'])
           .save(outputPath)
           .on('end', async () => {
-            // Read the video file and convert to base64
-            const videoData = fs.readFileSync(outputPath);
-            const base64Video = videoData.toString('base64');
-
-            // Clean up temporary files
             try {
-              fs.unlinkSync(textFilePath);
-              fs.unlinkSync(outputPath);
+              const videoData = fs.readFileSync(outputPath);
+              const base64Video = videoData.toString('base64');
+              cleanup();
+              resolve(base64Video);
             } catch (error) {
-              logger.warn(`Failed to clean up temporary files: ${error}`);
+              logger.error(`Error processing video output: ${error}`);
+              cleanup();
+              reject(error);
             }
-
-            resolve(base64Video);
           })
           .on('error', (err: Error) => {
             logger.error(`Error creating video: ${err}`);
+            cleanup();
             reject(err);
           });
       });
     } else {
-      // In the future, this could use a remote API for more sophisticated video generation
-      // Similar to the audio strategy
       throw new Error(
         'Local video generation requires fluent-ffmpeg. Future versions may support remote generation.',
       );
     }
   } catch (error) {
     logger.error(`Error generating video from text: ${error}`);
-    // Return fallback if video generation fails
-    return Buffer.from(text).toString('base64');
+    return getFallbackBase64(text);
   }
 }
 
-/**
- * Adds video encoding to test cases
- */
-export async function addVideoToBase64(
-  testCases: TestCase[],
-  injectVar: string,
-): Promise<TestCase[]> {
-  const videoTestCases: TestCase[] = [];
-
+export function createProgressBar(total: number): {
+  increment: () => void;
+  stop: () => void;
+} {
   let progressBar: SingleBar | undefined;
-  if (logger.level !== 'debug') {
-    progressBar = new SingleBar(
-      {
-        format: 'Converting to Videos {bar} {percentage}% | ETA: {eta}s | {value}/{total}',
-        hideCursor: true,
-      },
-      Presets.shades_classic,
-    );
-    progressBar.start(testCases.length, 0);
-  }
 
-  for (const testCase of testCases) {
-    invariant(
-      testCase.vars,
-      `Video encoding: testCase.vars is required, but got ${JSON.stringify(testCase)}`,
-    );
+  if (shouldShowProgressBar()) {
+    try {
+      progressBar = new SingleBar(
+        {
+          format: 'Converting to Videos {bar} {percentage}% | ETA: {eta}s | {value}/{total}',
+          hideCursor: true,
+        },
+        Presets.shades_classic,
+      );
 
-    const originalText = String(testCase.vars[injectVar]);
-
-    // Convert text to video and then to base64
-    const base64Video = await textToVideo(originalText);
-
-    videoTestCases.push({
-      ...testCase,
-      assert: testCase.assert?.map((assertion) => ({
-        ...assertion,
-        metric: assertion.type?.startsWith('promptfoo:redteam:')
-          ? `${assertion.type?.split(':').pop() || assertion.metric}/Video-Encoded`
-          : assertion.metric,
-      })),
-      vars: {
-        ...testCase.vars,
-        [injectVar]: base64Video,
-        video_text: originalText, // Store the original text for reference
-      },
-      metadata: {
-        ...testCase.metadata,
-        strategyId: 'video',
-      },
-    });
-
-    if (progressBar) {
-      progressBar.increment(1);
-    } else {
-      logger.debug(`Processed ${videoTestCases.length} of ${testCases.length}`);
+      try {
+        progressBar.start(total, 0);
+      } catch (error) {
+        logger.warn(`Failed to start progress bar: ${error}`);
+        progressBar = undefined;
+      }
+    } catch (error) {
+      logger.warn(`Failed to create progress bar: ${error}`);
     }
   }
 
-  if (progressBar) {
-    progressBar.stop();
-  }
-
-  return videoTestCases;
+  return {
+    increment: () => {
+      if (progressBar) {
+        try {
+          progressBar.increment(1);
+        } catch (error) {
+          logger.warn(`Failed to increment progress bar: ${error}`);
+          progressBar = undefined;
+        }
+      }
+    },
+    stop: () => {
+      if (progressBar) {
+        try {
+          progressBar.stop();
+        } catch (error) {
+          logger.warn(`Failed to stop progress bar: ${error}`);
+        }
+      }
+    },
+  };
 }
 
-// Main function for direct testing via: npx tsx simpleVideo.ts "Text to convert to video"
-async function main() {
-  // Get text from command line arguments or use default
+export async function addVideoToBase64(
+  testCases: TestCase[],
+  injectVar: string,
+  videoGenerator: (text: string) => Promise<string> = textToVideo,
+): Promise<TestCase[]> {
+  const videoTestCases: TestCase[] = [];
+  const progress = createProgressBar(testCases.length);
+
+  try {
+    for (const testCase of testCases) {
+      try {
+        invariant(
+          testCase.vars,
+          `Video encoding: testCase.vars is required, but got ${JSON.stringify(testCase)}`,
+        );
+
+        const originalText = String(testCase.vars[injectVar]);
+        const base64Video = await videoGenerator(originalText);
+
+        videoTestCases.push({
+          ...testCase,
+          assert: testCase.assert?.map((assertion) => ({
+            ...assertion,
+            metric: assertion.type?.startsWith('promptfoo:redteam:')
+              ? `${assertion.type?.split(':').pop() || assertion.metric}/Video-Encoded`
+              : assertion.metric,
+          })),
+          vars: {
+            ...testCase.vars,
+            [injectVar]: base64Video,
+            video_text: originalText,
+          },
+          metadata: {
+            ...testCase.metadata,
+            strategyId: 'video',
+          },
+        });
+      } catch (error) {
+        logger.error(`Error processing test case: ${error}`);
+        throw error;
+      } finally {
+        progress.increment();
+
+        if (logger.level === 'debug') {
+          logger.debug(`Processed ${videoTestCases.length} of ${testCases.length}`);
+        }
+      }
+    }
+
+    return videoTestCases;
+  } finally {
+    progress.stop();
+  }
+}
+
+export async function writeVideoFile(base64Video: string, outputFilePath: string): Promise<void> {
+  try {
+    const videoBuffer = Buffer.from(base64Video, 'base64');
+    fs.writeFileSync(outputFilePath, videoBuffer);
+    logger.info(`Video file written to: ${outputFilePath}`);
+  } catch (error) {
+    logger.error(`Failed to write video file: ${error}`);
+    throw error;
+  }
+}
+
+export async function main(): Promise<void> {
   const textToConvert = process.argv[2] || 'This is a test of the video encoding strategy.';
 
   logger.info(`Converting text to video: "${textToConvert}"`);
 
   try {
-    // Convert text to video
     const base64Video = await textToVideo(textToConvert);
 
-    // Log the first 100 characters of the base64 video to avoid terminal clutter
     logger.info(`Base64 video (first 100 chars): ${base64Video.substring(0, 100)}...`);
     logger.info(`Total base64 video length: ${base64Video.length} characters`);
 
-    // Create a simple test case
     const testCase = {
       vars: {
         prompt: textToConvert,
       },
     };
 
-    // Process the test case
     const processedTestCases = await addVideoToBase64([testCase], 'prompt');
 
     logger.info('Test case processed successfully.');
     logger.info(`Original prompt length: ${textToConvert.length} characters`);
-    // Add type assertion to ensure TypeScript knows this is a string
     const processedPrompt = processedTestCases[0].vars?.prompt as string;
     logger.info(`Processed prompt length: ${processedPrompt.length} characters`);
 
-    // Check if we're running this directly (not being imported)
     if (require.main === module) {
-      // Write to a file for testing with video players
-      const fs = await import('fs');
-      const outputFilePath = 'test-video.mp4';
-
-      // Decode base64 back to binary
-      const videoBuffer = Buffer.from(base64Video, 'base64');
-
-      // Write binary data to file
-      fs.writeFileSync(outputFilePath, videoBuffer);
-
-      logger.info(`Video file written to: ${outputFilePath}`);
+      await writeVideoFile(base64Video, 'test-video.mp4');
       logger.info(`You can open it with any video player to verify the conversion.`);
     }
   } catch (error) {
@@ -234,9 +265,6 @@ async function main() {
   }
 }
 
-// Run the main function if this file is executed directly
 if (require.main === module) {
   main();
 }
-
-export { ffmpegCache, importFfmpeg, main };

--- a/test/redteam/strategies/simpleVideo.test.ts
+++ b/test/redteam/strategies/simpleVideo.test.ts
@@ -1,118 +1,223 @@
-import { getEnvString } from '../../../src/envars';
-import { neverGenerateRemote } from '../../../src/redteam/remoteGeneration';
-import { addVideoToBase64, textToVideo } from '../../../src/redteam/strategies/simpleVideo';
+/**
+ * Test file for simpleVideo strategy
+ *
+ * Tests core functionality with proper mocks to avoid depending on fs, ffmpeg, etc.
+ */
+import fs from 'fs';
+import logger from '../../../src/logger';
+import {
+  addVideoToBase64,
+  getFallbackBase64,
+  createProgressBar,
+  writeVideoFile,
+} from '../../../src/redteam/strategies/simpleVideo';
 import type { TestCase } from '../../../src/types';
 
-// Mock the dependencies
-jest.mock('../../../src/envars');
-jest.mock('../../../src/redteam/remoteGeneration');
-jest.mock('fluent-ffmpeg', () => {
-  // Since we always run in test environment, this should never be called
-  return jest.fn();
+// Mock for dummy video data
+const DUMMY_VIDEO_BASE64 = 'AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAAu1tZGF0';
+
+// Mock video generator function
+const mockVideoGenerator = jest.fn().mockImplementation(() => {
+  return Promise.resolve(DUMMY_VIDEO_BASE64);
 });
 
-describe('simpleVideo', () => {
+// Mock required dependencies
+jest.mock('../../../src/logger', () => ({
+  level: 'info',
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('../../../src/cliState', () => ({
+  webUI: false,
+}));
+
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(),
+  unlinkSync: jest.fn(),
+}));
+
+// Mock for progress bar
+jest.mock('cli-progress', () => ({
+  SingleBar: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    increment: jest.fn(),
+    stop: jest.fn(),
+  })),
+  Presets: { shades_classic: {} },
+}));
+
+describe('simpleVideo strategy', () => {
   beforeEach(() => {
-    // Always run tests in test environment to avoid ffmpeg calls
-    jest.mocked(getEnvString).mockImplementation((key: string, defaultValue?: string) => {
-      if (key === 'NODE_ENV') {
-        return 'test';
-      } else if (key === 'JEST_WORKER_ID') {
-        return '1';
-      }
-      return defaultValue ?? '';
-    });
-    jest.mocked(neverGenerateRemote).mockReturnValue(true);
+    jest.clearAllMocks();
+    mockVideoGenerator.mockClear();
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
+  describe('getFallbackBase64', () => {
+    it('converts text to base64', () => {
+      const input = 'Test text';
+      const result = getFallbackBase64(input);
+
+      // Decode the base64 and verify it matches the original text
+      const decoded = Buffer.from(result, 'base64').toString();
+      expect(decoded).toBe(input);
+    });
   });
 
-  describe('textToVideo', () => {
-    it('returns a base64 string in test environment', async () => {
-      const result = await textToVideo('test text');
-      expect(typeof result).toBe('string');
-      expect(result.length).toBeGreaterThan(0);
-      // In test env, should return the predefined test video data
-      expect(result.startsWith('AAAAI')).toBe(true);
+  describe('createProgressBar', () => {
+    it('creates a progress bar with increment and stop methods', () => {
+      const progressBar = createProgressBar(10);
+
+      expect(progressBar).toHaveProperty('increment');
+      expect(progressBar).toHaveProperty('stop');
+      expect(typeof progressBar.increment).toBe('function');
+      expect(typeof progressBar.stop).toBe('function');
     });
 
-    it('returns test environment video when JEST_WORKER_ID is set', async () => {
-      const result = await textToVideo('test text');
-      expect(typeof result).toBe('string');
-      expect(result.startsWith('AAAAI')).toBe(true);
+    it('handles errors when incrementing progress', () => {
+      const progressBar = createProgressBar(10);
+
+      // Call increment and make sure it doesn't throw an error
+      expect(() => {
+        progressBar.increment();
+      }).not.toThrow();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('handles errors when stopping progress', () => {
+      const progressBar = createProgressBar(10);
+
+      // Call stop and make sure it doesn't throw an error
+      expect(() => {
+        progressBar.stop();
+      }).not.toThrow();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('writeVideoFile', () => {
+    it('writes a base64 video to a file', async () => {
+      await writeVideoFile(DUMMY_VIDEO_BASE64, 'test.mp4');
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith('test.mp4', expect.any(Buffer));
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Video file written to'));
+    });
+
+    it('throws an error if writing fails', async () => {
+      const mockError = new Error('Write failed');
+      jest.mocked(fs.writeFileSync).mockImplementationOnce(() => {
+        throw mockError;
+      });
+
+      await expect(writeVideoFile(DUMMY_VIDEO_BASE64, 'test.mp4')).rejects.toThrow('Write failed');
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to write video file'),
+      );
     });
   });
 
   describe('addVideoToBase64', () => {
-    it('processes test cases correctly', async () => {
-      const testCases: TestCase[] = [
-        {
-          vars: {
-            prompt: 'test prompt',
-          },
-          assert: [
-            {
-              type: 'promptfoo:redteam:test',
-              metric: 'test-metric',
-            },
-          ],
+    it('processes test cases correctly using mock generator', async () => {
+      // Create a test case
+      const testCase: TestCase = {
+        vars: {
+          prompt: 'test prompt',
         },
-      ];
+        assert: [
+          {
+            type: 'promptfoo:redteam:test',
+            metric: 'test-metric',
+          },
+        ],
+      };
 
-      const result = await addVideoToBase64(testCases, 'prompt');
+      // Process the test case
+      const result = await addVideoToBase64([testCase], 'prompt', mockVideoGenerator);
 
+      // Verify the structure and content of the result
       expect(result).toHaveLength(1);
-      expect(result[0].vars?.prompt).toBeDefined();
-      expect(typeof result[0].vars?.prompt).toBe('string');
+      expect(result[0].vars?.prompt).toBe(DUMMY_VIDEO_BASE64);
       expect(result[0].vars?.video_text).toBe('test prompt');
       expect(result[0].metadata?.strategyId).toBe('video');
       expect(result[0].assert?.[0].metric).toBe('test/Video-Encoded');
+
+      // Verify the mock generator was called
+      expect(mockVideoGenerator).toHaveBeenCalledTimes(1);
     });
 
     it('throws an error if vars is missing', async () => {
-      const testCases = [{}] as TestCase[];
-      await expect(addVideoToBase64(testCases, 'prompt')).rejects.toThrow(
+      const emptyTestCase = {} as TestCase;
+
+      await expect(addVideoToBase64([emptyTestCase], 'prompt', mockVideoGenerator)).rejects.toThrow(
         'Video encoding: testCase.vars is required',
       );
     });
 
     it('preserves non-redteam assertion metrics', async () => {
-      const testCases: TestCase[] = [
-        {
-          vars: {
-            prompt: 'test prompt',
-          },
-          assert: [
-            {
-              // @ts-expect-error: Testing non-redteam type
-              type: 'other',
-              metric: 'test-metric',
-            },
-          ],
-        },
-      ];
-
-      const result = await addVideoToBase64(testCases, 'prompt');
-      expect(result[0].assert?.[0].metric).toBe('test-metric');
-    });
-
-    it('handles multiple test cases with progress bar', async () => {
-      const testCases: TestCase[] = Array(3).fill({
+      const testCase: TestCase = {
         vars: {
           prompt: 'test prompt',
         },
+        assert: [
+          {
+            // @ts-expect-error: Testing non-redteam type
+            type: 'other',
+            metric: 'test-metric',
+          },
+        ],
+      };
+
+      const result = await addVideoToBase64([testCase], 'prompt', mockVideoGenerator);
+
+      expect(result[0].assert?.[0].metric).toBe('test-metric');
+    });
+
+    it('handles multiple test cases', async () => {
+      const testCases: TestCase[] = [
+        { vars: { prompt: 'test prompt 1' } },
+        { vars: { prompt: 'test prompt 2' } },
+        { vars: { prompt: 'test prompt 3' } },
+      ];
+
+      const result = await addVideoToBase64(testCases, 'prompt', mockVideoGenerator);
+
+      expect(result).toHaveLength(3);
+      expect(mockVideoGenerator).toHaveBeenCalledTimes(3);
+    });
+
+    it('logs debug messages when logger.level is debug', async () => {
+      // Set logger level to debug
+      Object.defineProperty(logger, 'level', { get: () => 'debug' });
+
+      const testCase: TestCase = {
+        vars: { prompt: 'test prompt' },
+      };
+
+      await addVideoToBase64([testCase], 'prompt', mockVideoGenerator);
+
+      // Verify debug was called
+      expect(logger.debug).toHaveBeenCalledWith('Processed 1 of 1');
+    });
+
+    it('handles errors during processing', async () => {
+      const errorCase: TestCase = {
+        vars: { prompt: 'error prompt' },
+      };
+
+      // Mock generator that throws an error
+      const errorGenerator = jest.fn().mockImplementation(() => {
+        throw new Error('Test error');
       });
 
-      const result = await addVideoToBase64(testCases, 'prompt');
-      expect(result).toHaveLength(3);
-      result.forEach((testCase) => {
-        expect(testCase.vars?.prompt).toBeDefined();
-        expect(testCase.metadata?.strategyId).toBe('video');
-      });
+      // Expect the function to reject with the error
+      await expect(addVideoToBase64([errorCase], 'prompt', errorGenerator)).rejects.toThrow(
+        'Test error',
+      );
     });
   });
-
-  // Skip importFfmpeg test since we're ensuring it's never called in our tests
 });


### PR DESCRIPTION
This PR fixes open handles in the video strategy test, ensuring the progress bar is always cleaned up properly when errors occur. The implementation now uses proper try/finally blocks for resource cleanup.