### PR TITLE
chore(webui): display currently selected eval in eval dialogue

### DIFF
--- a/src/app/src/pages/evals/components/EvalsDataGrid.tsx
+++ b/src/app/src/pages/evals/components/EvalsDataGrid.tsx
@@ -177,22 +177,25 @@ export default function EvalsDataGrid({
           field: 'evalId',
           headerName: 'ID',
           flex: 1,
-          renderCell: (params: GridRenderCellParams<Eval>) => (
-            <Link
-              href={`/eval/${params.row.evalId}`}
-              /**
-               * Prevent the default behavior of the link, which is to navigate to the href.
-               * Instead, we want to call the onEvalSelected callback which may or may not navigate.
-               */
-              onClick={(e) => {
-                e.preventDefault();
-                onEvalSelected(params.row.evalId);
-                return false;
-              }}
-            >
-              {params.row.evalId}
-            </Link>
-          ),
+          renderCell: (params: GridRenderCellParams<Eval>) =>
+            params.row.evalId === focusedEvalId ? (
+              params.row.evalId
+            ) : (
+              <Link
+                href={`/eval/${params.row.evalId}`}
+                /**
+                 * Prevent the default behavior of the link, which is to navigate to the href.
+                 * Instead, we want to call the onEvalSelected callback which may or may not navigate.
+                 */
+                onClick={(e) => {
+                  e.preventDefault();
+                  onEvalSelected(params.row.evalId);
+                  return false;
+                }}
+              >
+                {params.row.evalId}
+              </Link>
+            ),
         },
         {
           field: 'createdAt',
@@ -314,7 +317,12 @@ export default function EvalsDataGrid({
             focusQuickFilterOnMount,
           },
         }}
-        onCellClick={handleCellClick}
+        onCellClick={(params) => {
+          if (params.id !== focusedEvalId) {
+            handleCellClick(params);
+          }
+        }}
+        getRowClassName={(params) => (params.id === focusedEvalId ? 'focused-row' : '')}
         sx={{
           border: 'none',
           '& .MuiDataGrid-row': {
@@ -322,6 +330,18 @@ export default function EvalsDataGrid({
             transition: 'background-color 0.2s ease',
             '&:hover': {
               backgroundColor: 'action.hover',
+            },
+          },
+          '& .MuiDataGrid-row--disabled': {
+            cursor: 'default',
+            opacity: 0.7,
+            pointerEvents: 'none',
+          },
+          '& .focused-row': {
+            backgroundColor: 'action.selected',
+            cursor: 'default',
+            '&:hover': {
+              backgroundColor: 'action.selected',
             },
           },
           '& .MuiDataGrid-cell': {
@@ -347,6 +367,7 @@ export default function EvalsDataGrid({
           },
         }}
         pageSizeOptions={[10, 25, 50, 100]}
+        isRowSelectable={(params) => params.id !== focusedEvalId}
       />
     </Paper>
   );

--- a/src/app/src/pages/evals/components/EvalsDataGrid.tsx
+++ b/src/app/src/pages/evals/components/EvalsDataGrid.tsx
@@ -159,8 +159,6 @@ export default function EvalsDataGrid({
       const focusedEval = rows_.find(({ evalId }: Eval) => evalId === focusedEvalId);
       invariant(focusedEval, 'focusedEvalId is not a valid eval ID');
 
-      rows_ = rows_.filter(({ evalId }: Eval) => evalId !== focusedEvalId);
-
       // Filter by dataset ID if enabled
       if (filterByDatasetId) {
         rows_ = rows_.filter(({ datasetId }: Eval) => datasetId === focusedEval.datasetId);


### PR DESCRIPTION
I noticed that when you go to select an eval, the currently selected eval wasn't present in the table, which was confusing. This removes that filter, and now the current eval is visible and highlighted, as expected. Added a disabled state too:

<img width="1265" alt="Screenshot 2025-05-19 at 12 15 58 PM" src="https://github.com/user-attachments/assets/0b553c85-1420-4851-aa88-4a292b6319db" />

