### PR TITLE
chore: add vision grading example

### DIFF
--- a/examples/claude-vs-gpt-image/README.md
+++ b/examples/claude-vs-gpt-image/README.md
@@ -8,11 +8,11 @@ npx promptfoo@latest init --example claude-vs-gpt-image
 
 This example compares an image analysis task using:
 
-- gpt-4o via OpenAI
+- gpt-4.1 via OpenAI
 - claude-3 via Amazon Bedrock
 - claude-3.5 via Anthropic
 
-GPT-4o and Claude have different prompt formats. We use custom provider functions in Python and JavaScript to dynamically format the prompt based on context about the provider.
+GPT-4.1 and Claude have different prompt formats. We use custom provider functions in Python and JavaScript to dynamically format the prompt based on context about the provider. The responses are scored using `llm-rubric` with a vision-capable OpenAI model.
 
 To get started, set your environment variables:
 

--- a/examples/claude-vs-gpt-image/prompt.js
+++ b/examples/claude-vs-gpt-image/prompt.js
@@ -76,7 +76,7 @@ async function formatImagePrompt(context) {
     ];
   }
   // We can use the label if provided in the config.
-  if (context.provider.label === 'custom label for gpt-4o') {
+  if (context.provider.label === 'custom label for gpt-4.1') {
     return [
       {
         role: 'system',

--- a/examples/claude-vs-gpt-image/prompt.py
+++ b/examples/claude-vs-gpt-image/prompt.py
@@ -74,7 +74,7 @@ def format_image_prompt(context: PromptFunctionContext) -> list[dict[str, typing
             },
         ]
     # label might not exist
-    if context["provider"].get("label") == "custom label for gpt-4o":
+    if context["provider"].get("label") == "custom label for gpt-4.1":
         return [
             {
                 "role": "system",

--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -8,8 +8,8 @@ prompts:
 providers:
   - id: bedrock:anthropic.claude-3-sonnet-20240229-v1:0
   - id: anthropic:claude-3-5-sonnet-20241022
-  - id: openai:gpt-4o
-    label: custom label for gpt-4o
+  - id: openai:gpt-4.1
+    label: custom label for gpt-4.1
 
 tests:
   - vars:
@@ -17,6 +17,22 @@ tests:
       label: Great Wave off Kanagawa
 
 defaultTest:
+  options:
+    provider: openai:gpt-4.1
+    rubricPrompt: |
+      [
+        {
+          "role": "system",
+          "content": "You are a meticulous grader. Evaluate how accurately the answer describes the provided image. Respond in JSON {reason:string, pass:boolean, score:number}"
+        },
+        {
+          "role": "user",
+          "content": [
+            {"type": "image_url", "image_url": {"url": "{{image_url}}"}},
+            {"type": "text", "text": "Answer: {{ output }}\nCriteria: {{ rubric }}"}
+          ]
+        }
+      ]
   assert:
     - type: llm-rubric
       value: Is a detailed description of the image '{{label}}'

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -252,6 +252,27 @@ defaultTest:
 
 See the [full example](https://github.com/promptfoo/promptfoo/blob/main/examples/custom-grading-prompt/promptfooconfig.yaml).
 
+### Image-based rubric prompts
+
+`llm-rubric` can also grade responses that reference images. Provide a `rubricPrompt` in OpenAI chat format that includes an image and use a vision-capable provider such as `openai:gpt-4.1`.
+
+```yaml
+defaultTest:
+  options:
+    provider: openai:gpt-4.1
+    rubricPrompt: |
+      [
+        { "role": "system", "content": "Evaluate if the answer matches the image. Respond with JSON {reason:string, pass:boolean, score:number}" },
+        {
+          "role": "user",
+          "content": [
+            { "type": "image_url", "image_url": { "url": "{{image_url}}" } },
+            { "type": "text", "text": "Output: {{ output }}\nRubric: {{ rubric }}" }
+          ]
+        }
+      ]
+```
+
 #### select-best rubric prompt
 
 For control over the `select-best` rubric prompt, you may use the variables `{{outputs}}` (list of strings) and `{{criteria}}` (string). It expects the LLM output to contain the index of the winning output.

--- a/src/assertions/llmRubric.ts
+++ b/src/assertions/llmRubric.ts
@@ -9,8 +9,10 @@ export const handleLlmRubric = ({
   test,
 }: AssertionParams): Promise<GradingResult> => {
   invariant(
-    typeof renderedValue === 'string' || typeof renderedValue === 'undefined',
-    '"llm-rubric" assertion type must have a string value',
+    typeof renderedValue === 'string' ||
+      typeof renderedValue === 'object' ||
+      typeof renderedValue === 'undefined',
+    '"llm-rubric" assertion type must have a string or object value',
   );
   if (test.options?.rubricPrompt && typeof test.options.rubricPrompt === 'object') {
     test.options.rubricPrompt = JSON.stringify(test.options.rubricPrompt);

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -435,7 +435,7 @@ export async function renderLlmRubricPrompt(
 }
 
 export async function matchesLlmRubric(
-  rubric: string,
+  rubric: string | object,
   llmOutput: string,
   grading?: GradingConfig,
   vars?: Record<string, string | object>,

--- a/test/assertions/llmRubric.test.ts
+++ b/test/assertions/llmRubric.test.ts
@@ -1,0 +1,402 @@
+import { handleLlmRubric } from '../../src/assertions/llmRubric';
+import { matchesLlmRubric } from '../../src/matchers';
+import type { Assertion, AssertionParams, GradingResult } from '../../src/types';
+
+jest.mock('../../src/matchers');
+
+describe('handleLlmRubric', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const mockMatchesLlmRubric = jest.mocked(matchesLlmRubric);
+
+  const defaultParams: AssertionParams = {
+    assertion: {
+      type: 'llm-rubric',
+      value: 'test rubric',
+    } as Assertion,
+    baseType: 'llm-rubric',
+    context: {
+      prompt: 'test prompt',
+      vars: {},
+      test: {
+        vars: {},
+      },
+      logProbs: undefined,
+      provider: undefined,
+      providerResponse: undefined,
+    },
+    inverse: false,
+    output: 'test output',
+    outputString: 'test output string',
+    test: {
+      vars: {},
+    },
+    providerResponse: {},
+  };
+
+  it('should handle string rendered value', async () => {
+    const params = {
+      ...defaultParams,
+      renderedValue: 'test rendered value',
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'test reason',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(mockMatchesLlmRubric).toHaveBeenCalledWith(
+      'test rendered value',
+      'test output string',
+      undefined,
+      {},
+      params.assertion,
+    );
+  });
+
+  it('should handle object rendered value', async () => {
+    const params = {
+      ...defaultParams,
+      renderedValue: { test: 'value' },
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'test reason',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(mockMatchesLlmRubric).toHaveBeenCalledWith(
+      { test: 'value' },
+      'test output string',
+      undefined,
+      {},
+      params.assertion,
+    );
+  });
+
+  it('should handle undefined rendered value', async () => {
+    const params = {
+      ...defaultParams,
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'test reason',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(mockMatchesLlmRubric).toHaveBeenCalledWith(
+      '',
+      'test output string',
+      undefined,
+      {},
+      params.assertion,
+    );
+  });
+
+  it('should stringify object rubricPrompt', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        // Using a valid structure for rubricPrompt as per type definition
+        options: {
+          rubricPrompt: [{ role: 'system', content: 'test prompt' }],
+        },
+      },
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'test reason',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(params.test.options?.rubricPrompt).toBe(
+      JSON.stringify([{ role: 'system', content: 'test prompt' }]),
+    );
+  });
+
+  it('should use assertion.value if present, otherwise use test.options.rubricPrompt', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'llm-rubric',
+        value: undefined,
+      } as Assertion,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: 'rubric from options',
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 2,
+      reason: 'used options rubric',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(params.assertion.value).toBe('rubric from options');
+  });
+
+  it('should not overwrite assertion.value if already set', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'llm-rubric',
+        value: 'already set',
+      } as Assertion,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: 'rubric from options',
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: false,
+      score: 0,
+      reason: 'assertion.value was set',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(params.assertion.value).toBe('already set');
+  });
+
+  it('should throw error for invalid rendered value type', async () => {
+    // purposely passing an invalid type
+    const params = {
+      ...defaultParams,
+      renderedValue: 123 as unknown as string,
+    };
+
+    await expect(() => handleLlmRubric(params)).toThrow(
+      'Invariant failed: "llm-rubric" assertion type must have a string or object value',
+    );
+  });
+
+  it('should stringify rubricPrompt if it is an object (not stringified yet)', async () => {
+    const rubricPromptObj = [{ role: 'user', content: 'bar' }];
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: rubricPromptObj,
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'rubricPrompt object stringified',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    await handleLlmRubric(params);
+
+    expect(params.test.options?.rubricPrompt).toBe(JSON.stringify(rubricPromptObj));
+  });
+
+  it('should not re-stringify rubricPrompt if it is already a string', async () => {
+    const rubricPromptStr = '[{"role":"system","content":"already stringified"}]';
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: rubricPromptStr,
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'rubricPrompt already stringified',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    await handleLlmRubric(params);
+
+    expect(params.test.options?.rubricPrompt).toBe(rubricPromptStr);
+  });
+
+  it('should work if test.options is undefined', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        // options is undefined
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'no options',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  // Additional edge case: rubricPrompt is an empty object
+  it('should stringify rubricPrompt if it is an empty object', async () => {
+    // rubricPrompt as empty array of objects (valid for type)
+    const rubricPromptObj: { role: string; content: string }[] = [];
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: rubricPromptObj,
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'rubricPrompt empty object stringified',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    await handleLlmRubric(params);
+
+    expect(params.test.options?.rubricPrompt).toBe(JSON.stringify(rubricPromptObj));
+  });
+
+  // Additional: assertion.value and test.options.rubricPrompt are both undefined
+  it('should set assertion.value to undefined if both assertion.value and test.options.rubricPrompt are undefined', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'llm-rubric',
+        value: undefined,
+      } as Assertion,
+      test: {
+        vars: {},
+        // options is undefined
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 3,
+      reason: 'assertion.value and rubricPrompt undefined',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(params.assertion.value).toBeUndefined();
+  });
+
+  // New test: rubricPrompt is a plain object (not an array), should stringify as object
+  it('should stringify rubricPrompt if it is a plain object (not an array)', async () => {
+    const rubricPromptObj: any = { foo: 'bar', baz: 3 };
+    const params: AssertionParams = {
+      ...defaultParams,
+      test: {
+        vars: {},
+        options: {
+          rubricPrompt: rubricPromptObj,
+        },
+      },
+      renderedValue: undefined,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 1,
+      reason: 'rubricPrompt plain object stringified',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    await handleLlmRubric(params);
+
+    expect(params.test.options?.rubricPrompt).toBe(JSON.stringify(rubricPromptObj));
+  });
+
+  // New test: renderedValue is an array (should be allowed, since typeof [] === 'object')
+  it('should handle renderedValue as an array', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      renderedValue: ['foo', 'bar'] as unknown as string,
+    };
+
+    const expectedResult: GradingResult = {
+      pass: true,
+      score: 4,
+      reason: 'renderedValue is array',
+    };
+
+    mockMatchesLlmRubric.mockResolvedValue(expectedResult);
+
+    const result = await handleLlmRubric(params);
+
+    expect(result).toEqual(expectedResult);
+    expect(mockMatchesLlmRubric).toHaveBeenCalledWith(
+      ['foo', 'bar'],
+      'test output string',
+      undefined,
+      {},
+      params.assertion,
+    );
+  });
+});

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -323,6 +323,27 @@ describe('matchesLlmRubric', () => {
     });
   });
 
+  it('should render rubric when provided as an object', async () => {
+    const rubric = { prompt: 'Describe the image' };
+    const output = 'Sample output';
+    const options: GradingConfig = {
+      rubricPrompt: 'Grade: {{ rubric }}',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          tokenUsage: { total: 1, prompt: 1, completion: 1 },
+        }),
+      },
+    };
+
+    await matchesLlmRubric(rubric, output, options);
+
+    expect(options.provider.callApi).toHaveBeenCalledWith(
+      expect.stringContaining(JSON.stringify(rubric)),
+    );
+  });
+
   it('should fail when output is neither string nor object', async () => {
     const expected = 'Expected output';
     const output = 'Sample output';


### PR DESCRIPTION
## Summary
- allow llm-rubric assertion values to be objects
- switch claude image example to gpt-4.1 with better rubric prompt
- document using gpt-4.1 for image-based grading
- test object rubric handling

## Testing
- `npx prettier --write examples/claude-vs-gpt-image/README.md examples/claude-vs-gpt-image/prompt.js examples/claude-vs-gpt-image/promptfooconfig.yaml site/docs/configuration/expected-outputs/model-graded/index.md test/matchers.test.ts`
- `npx eslint --max-warnings=0 --fix test/matchers.test.ts`
- `npm test` *(fails: The @smithy/node-http-handler package is required, fetchWithProxy expectation mismatch)*