### PR TITLE
fix(plugins): Skip plugins when validation fails

### DIFF
--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -293,7 +293,7 @@ remotePlugins.push(
     (config: { indirectInjectionVar: string }) =>
       invariant(
         config.indirectInjectionVar,
-        'Indirect prompt injection plugin requires `config.indirectInjectionVar` to be set',
+        'Indirect prompt injection plugin requires `config.indirectInjectionVar` to be set. If using this plugin in a plugin collection, configure this plugin separately.',
       ),
   ),
 );

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -387,18 +387,20 @@ describe('synthesize', () => {
       };
 
       // Mock Plugins.find to return a plugin with a validate method that throws for fail-plugin
-      jest.spyOn(Plugins, 'find').mockReturnValueOnce({
-        key: 'fail-plugin',
-        action: jest.fn().mockResolvedValue([{ test: 'fail-case' }]),
-        validate: () => {
-          throw new Error('Validation failed!');
-        },
-      });
-      jest.spyOn(Plugins, 'find').mockReturnValue({
-        key: 'pass-plugin',
-        action: jest.fn().mockResolvedValue([{ test: 'pass-case' }]),
-        validate: jest.fn(),
-      });
+      jest
+        .spyOn(Plugins, 'find')
+        .mockReturnValueOnce({
+          key: 'fail-plugin',
+          action: jest.fn().mockResolvedValue([{ test: 'fail-case' }]),
+          validate: () => {
+            throw new Error('Validation failed!');
+          },
+        })
+        .mockReturnValue({
+          key: 'pass-plugin',
+          action: jest.fn().mockResolvedValue([{ test: 'pass-case' }]),
+          validate: jest.fn(),
+        });
 
       const result = await synthesize({
         language: 'en',

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -373,6 +373,50 @@ describe('synthesize', () => {
         expect.stringContaining('unknown-collection not registered'),
       );
     });
+
+    it('should skip plugins that fail validation and not throw', async () => {
+      // Plugin 1: will fail validation
+      const failingPlugin = {
+        id: 'fail-plugin',
+        numTests: 1,
+      };
+      // Plugin 2: will succeed
+      const passingPlugin = {
+        id: 'pass-plugin',
+        numTests: 1,
+      };
+
+      // Mock Plugins.find to return a plugin with a validate method that throws for fail-plugin
+      jest.spyOn(Plugins, 'find').mockReturnValueOnce({
+        key: 'fail-plugin',
+        action: jest.fn().mockResolvedValue([{ test: 'fail-case' }]),
+        validate: () => {
+          throw new Error('Validation failed!');
+        },
+      });
+      jest.spyOn(Plugins, 'find').mockReturnValue({
+        key: 'pass-plugin',
+        action: jest.fn().mockResolvedValue([{ test: 'pass-case' }]),
+        validate: jest.fn(),
+      });
+
+      const result = await synthesize({
+        language: 'en',
+        numTests: 1,
+        plugins: [failingPlugin, passingPlugin],
+        prompts: ['Test prompt'],
+        strategies: [],
+        targetLabels: ['test-provider'],
+      });
+
+      expect(result.testCases).toHaveLength(1);
+      expect(result.testCases[0].metadata.pluginId).toBe('pass-plugin');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Validation failed for plugin fail-plugin: Error: Validation failed!, skipping plugin',
+        ),
+      );
+    });
   });
 
   describe('Logger', () => {


### PR DESCRIPTION
Should fix https://github.com/promptfoo/promptfoo/issues/4072

We'll now skip plugins that fail validation rather than throwing an error. 

I tested against a few plugin collections: 
* `owasp:llm` (the offending plugin is skipped)
* `owasp:api` (no change)
* `mitre:atlas` - skips `indirect-prompt-injection` and `policy`. 

Manual test cases:

<details>

<summary>`owasp:llm`</summary>

```
> ts-node --cwdMode --transpileOnly src/main.ts redteam run -c examples/redteam-rag/promptfooconfig.yaml --force

Generating test cases...
Cache is disabled
Synthesizing test cases for 1 prompt...
Using plugins:

ascii-smuggling (5  tests)
bfla (5  tests)
bias:gender (5  tests)
bola (5  tests)
cross-session-leak (5  tests)
debug-access (5  tests)
divergent-repetition (5  tests)
excessive-agency (5  tests)
hallucination (5  tests)
harmful:chemical-biological-weapons (5  tests)
harmful:child-exploitation (5  tests)
harmful:copyright-violations (5  tests)
harmful:cybercrime (5  tests)
harmful:cybercrime:malicious-code (5  tests)
harmful:graphic-content (5  tests)
harmful:harassment-bullying (5  tests)
harmful:hate (5  tests)
harmful:illegal-activities (5  tests)
harmful:illegal-drugs (5  tests)
harmful:illegal-drugs:meth (5  tests)
harmful:indiscriminate-weapons (5  tests)
harmful:insults (5  tests)
harmful:intellectual-property (5  tests)
harmful:misinformation-disinformation (5  tests)
harmful:non-violent-crime (5  tests)
harmful:privacy (5  tests)
harmful:profanity (5  tests)
harmful:radicalization (5  tests)
harmful:self-harm (5  tests)
harmful:sex-crime (5  tests)
harmful:sexual-content (5  tests)
harmful:specialized-advice (5  tests)
harmful:unsafe-practices (5  tests)
harmful:violent-crime (5  tests)
harmful:weapons:ied (5  tests)
indirect-prompt-injection (5  tests)
overreliance (5  tests)
pii:api-db (5  tests)
pii:direct (5  tests)
pii:session (5  tests)
pii:social (5  tests)
prompt-extraction (5  tests)
rbac (5  tests)
reasoning-dos (5  tests)
shell-injection (5  tests)
sql-injection (5  tests)
ssrf (5  tests)

Using strategies:

jailbreak (235 additional tests)
jailbreak:composite (235 additional tests)
prompt-injection (235 additional tests)

Test Generation Summary:
• Total tests: 940
• Plugin tests: 235
• Plugins: 47
• Strategies: 3
• Max concurrency: 1

Validation failed for plugin indirect-prompt-injection: Error: Invariant failed: Indirect prompt injection plugin requires `config.indirectInjectionVar` to be set. If using this plugin in a plugin collection, configure this plugin separately., skipping plugin.
```

</details>


<details>
<summary>`owasp:api`</summary>
```
> ts-node --cwdMode --transpileOnly src/main.ts redteam run -c examples/redteam-rag/promptfooconfig.yaml --force

Generating test cases...
Cache is disabled
Synthesizing test cases for 1 prompt...
Using plugins:

bfla (5  tests)
bola (5  tests)
debug-access (5  tests)
excessive-agency (5  tests)
harmful:misinformation-disinformation (5  tests)
harmful:privacy (5  tests)
harmful:specialized-advice (5  tests)
overreliance (5  tests)
pii:api-db (5  tests)
pii:session (5  tests)
rbac (5  tests)
shell-injection (5  tests)
sql-injection (5  tests)

Using strategies:

jailbreak (65 additional tests)
prompt-injection (65 additional tests)

Test Generation Summary:
• Total tests: 195
• Plugin tests: 65
• Plugins: 13
• Strategies: 2
• Max concurrency: 1
```
</details>