### PR TITLE
chore(providers): support templated URLs in http

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -722,7 +722,7 @@ Supported config options:
 
 | Option            | Type                    | Description                                                                                                                                                                         |
 | ----------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url               | string                  | The URL to send the HTTP request to. Supports Nunjucks templates. If not provided, the `id` of the provider will be used as the URL.                                                                             |
+| url               | string                  | The URL to send the HTTP request to. Supports Nunjucks templates. If not provided, the `id` of the provider will be used as the URL.                                                |
 | request           | string                  | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                                                                   |
 | method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
 | headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -166,6 +166,17 @@ providers:
       // highlight-end
 ```
 
+## Dynamic URLs
+
+Both the provider `id` and the `url` field support Nunjucks templates. Variables in your test `vars` will be rendered before sending the request.
+
+```yaml
+providers:
+  - id: https://api.example.com/users/{{userId}}/profile
+    config:
+      method: 'GET'
+```
+
 ## Using as a library
 
 If you are using promptfoo as a [node library](/docs/usage/node-package/), you can provide the equivalent provider config:
@@ -711,7 +722,7 @@ Supported config options:
 
 | Option            | Type                    | Description                                                                                                                                                                         |
 | ----------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url               | string                  | The URL to send the HTTP request to. If not provided, the `id` of the provider will be used as the URL.                                                                             |
+| url               | string                  | The URL to send the HTTP request to. Supports Nunjucks templates. If not provided, the `id` of the provider will be used as the URL.                                                                             |
 | request           | string                  | A raw HTTP request to send. This will override the `url`, `method`, `headers`, `body`, and `queryParams` options.                                                                   |
 | method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
 | headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -736,7 +736,7 @@ export class HttpProvider implements ApiProvider {
     );
 
     const renderedConfig: Partial<HttpProviderConfig> = {
-      url: this.url,
+      url: getNunjucksEngine().renderString(this.url, vars),
       method: getNunjucksEngine().renderString(this.config.method || 'GET', vars),
       headers,
       body: determineRequestBody(
@@ -762,7 +762,7 @@ export class HttpProvider implements ApiProvider {
     invariant(typeof headers === 'object', 'Expected headers to be an object');
 
     // Template the base URL first, then construct URL with query parameters
-    let url = getNunjucksEngine().renderString(this.url, vars);
+    let url = renderedConfig.url as string;
     if (renderedConfig.queryParams) {
       const queryString = new URLSearchParams(renderedConfig.queryParams).toString();
       url = `${url}?${queryString}`;

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -764,8 +764,19 @@ export class HttpProvider implements ApiProvider {
     // Template the base URL first, then construct URL with query parameters
     let url = renderedConfig.url as string;
     if (renderedConfig.queryParams) {
-      const queryString = new URLSearchParams(renderedConfig.queryParams).toString();
-      url = `${url}?${queryString}`;
+      try {
+        const urlObj = new URL(url);
+        // Add each query parameter to the URL object
+        Object.entries(renderedConfig.queryParams).forEach(([key, value]) => {
+          urlObj.searchParams.append(key, value);
+        });
+        url = urlObj.toString();
+      } catch (err) {
+        // Fallback for potentially malformed URLs
+        logger.warn(`[HTTP Provider]: Failed to construct URL object: ${String(err)}`);
+        const queryString = new URLSearchParams(renderedConfig.queryParams).toString();
+        url = `${url}${url.includes('?') ? '&' : '?'}${queryString}`;
+      }
     }
 
     logger.debug(

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1420,6 +1420,75 @@ describe('HttpProvider', () => {
       2,
     );
   });
+
+  it('should handle query parameters correctly when the URL already has query parameters', async () => {
+    const urlWithQueryParams = 'http://example.com/api?existing=param';
+    provider = new HttpProvider(urlWithQueryParams, {
+      config: {
+        method: 'GET',
+        queryParams: {
+          additional: 'parameter',
+          another: 'value',
+        },
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi('test prompt');
+
+    // URL should contain both the existing and new query parameters
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /http:\/\/example\.com\/api\?existing=param&additional=parameter&another=value/,
+      ),
+      expect.any(Object),
+      expect.any(Number),
+      'text',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('should handle URL construction fallback for potentially malformed URLs', async () => {
+    // Create a URL with variable that when rendered doesn't fully qualify as a URL
+    const malformedUrl = 'relative/path/{{var}}';
+
+    provider = new HttpProvider(malformedUrl, {
+      config: {
+        method: 'GET',
+        queryParams: {
+          param: 'value',
+        },
+      },
+    });
+
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    };
+    jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi('test prompt', { vars: { var: 'test' } });
+
+    // Should use the fallback mechanism to append query parameters
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      'relative/path/test?param=value',
+      expect.any(Object),
+      expect.any(Number),
+      'text',
+      undefined,
+      undefined,
+    );
+  });
 });
 
 describe('createTransformRequest', () => {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1477,7 +1477,10 @@ describe('HttpProvider', () => {
     };
     jest.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
 
-    await provider.callApi('test prompt', { vars: { var: 'test' } });
+    await provider.callApi('test prompt', {
+      prompt: { raw: 'test prompt', label: 'test' },
+      vars: { var: 'test' },
+    });
 
     // Should use the fallback mechanism to append query parameters
     expect(fetchWithCache).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- render Nunjucks templates for HTTP provider URLs
- document dynamic URLs in HTTP provider docs

## Testing
- `npx jest test/providers/http.test.ts --runInBand`
- `npm test`