### PR TITLE
feat: add Tau simulated user strategy

### DIFF
--- a/site/docs/_shared/data/strategies.ts
+++ b/site/docs/_shared/data/strategies.ts
@@ -136,6 +136,16 @@ export const strategies: Strategy[] = [
     link: '/docs/red-team/strategies/goat/',
   },
   {
+    category: 'Multi-turn',
+    strategy: 'tau',
+    displayName: 'Tau',
+    description: 'Simulated user conversations',
+    longDescription: 'Simulates a user over multiple turns using Tau-bench style instructions',
+    cost: 'High',
+    asrIncrease: '60-80%',
+    link: '/docs/red-team/strategies/tau/',
+  },
+  {
     category: 'Static (Single-Turn)',
     strategy: 'video',
     displayName: 'Video Encoding',

--- a/site/docs/guides/chatbase-redteam.md
+++ b/site/docs/guides/chatbase-redteam.md
@@ -83,6 +83,9 @@ strategies:
   - id: 'crescendo'
     config:
       stateful: true
+  - id: 'tau'
+    config:
+      stateful: true
 ```
 
 ## Test Execution

--- a/site/docs/red-team/agents.md
+++ b/site/docs/red-team/agents.md
@@ -103,6 +103,7 @@ redteam:
   strategies:
     - 'jailbreak'
     - 'crescendo' # Multi-turn strategy that gradually builds up an attack
+    - 'tau' # Simulated user conversations
 ```
 
 The Memory Poisoning plugin creates scenarios with specific "memories" the agent should maintain, sends a poisoned message attempting to corrupt this established memory, and then tests the effectiveness of the attack with a follow-up question that relies on the original memory.

--- a/site/docs/red-team/strategies/index.md
+++ b/site/docs/red-team/strategies/index.md
@@ -98,6 +98,7 @@ redteam:
   strategies:
     - goat
     - crescendo
+    - tau
 ```
 
 ## Implementation Guide

--- a/site/docs/red-team/strategies/multi-turn.md
+++ b/site/docs/red-team/strategies/multi-turn.md
@@ -17,6 +17,7 @@ You can use it with the following configuration:
 ```yaml title="promptfooconfig.yaml"
 strategies:
   - crescendo
+  - tau
 ```
 
 Or tune it with the following parameters:
@@ -28,6 +29,9 @@ strategies:
       maxTurns: 5
       maxBacktracks: 5
       stateful: false # Sends the entire conversation history with each turn (Default)
+  - id: tau
+    config:
+      maxTurns: 5
 ```
 
 Increasing the number of turns and backtracks will make the strategy more aggressive, but it will also take longer to complete and cost more.
@@ -73,6 +77,7 @@ The backtracking automation also saves an enormous amount of time compared to ma
 ## Related Concepts
 
 - [GOAT Strategy](goat.md) - Another multi-turn jailbreaking approach
+- [Tau Strategy](tau.md) - Multi-turn conversations with a simulated user
 - [Iterative Jailbreaks](iterative.md) - Single-turn version of this approach
 - [Tree-based Jailbreaks](tree.md) - Alternative approach to jailbreaking
 - [The Crescendo Attack](https://crescendo-the-multiturn-jailbreak.github.io//) from Microsoft Research

--- a/site/docs/red-team/strategies/tau.md
+++ b/site/docs/red-team/strategies/tau.md
@@ -1,0 +1,30 @@
+---
+sidebar_label: Tau
+title: Tau Simulated User Strategy
+description: Multi-turn red teaming strategy that simulates a user conversation
+---
+
+# Tau Simulated User Strategy
+
+The **Tau** strategy uses the simulated user provider to create a multi-turn conversation with your application. It is inspired by the [Tau-bench](https://github.com/sierra-research/tau-bench) approach.
+
+## Implementation
+
+Enable it in your `promptfooconfig.yaml`:
+
+```yaml title="promptfooconfig.yaml"
+strategies:
+  - id: tau
+    config:
+      maxTurns: 5
+```
+
+The strategy sends user instructions stored in the variable specified by `injectVar` to your target model over multiple turns. The conversation stops when the maximum number of turns is reached or the agent responds with `###STOP###`.
+
+## Related Concepts
+
+- [Multi-turn Jailbreaks](multi-turn.md)
+- [GOAT Strategy](goat.md)
+- [Crescendo Strategy](multi-turn.md)
+
+For more information on the provider itself, see [Simulated User Provider](/docs/providers/simulated-user).

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1017,6 +1017,17 @@ export const providerMap: ProviderFactory[] = [
     },
   },
   {
+    test: (providerPath: string) => providerPath === 'promptfoo:redteam:tau',
+    create: async (
+      providerPath: string,
+      providerOptions: ProviderOptions,
+      context: LoadApiProviderContext,
+    ) => {
+      const { default: RedteamTauProvider } = await import('../redteam/providers/tau');
+      return new RedteamTauProvider(providerOptions.config);
+    },
+  },
+  {
     test: (providerPath: string) => providerPath === 'promptfoo:redteam:iterative',
     create: async (
       providerPath: string,

--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -810,12 +810,13 @@ export type FrameworkComplianceId = (typeof FRAMEWORK_COMPLIANCE_IDS)[number];
 export const DEFAULT_STRATEGIES = ['basic', 'jailbreak', 'jailbreak:composite'] as const;
 export type DefaultStrategy = (typeof DEFAULT_STRATEGIES)[number];
 
-export const MULTI_TURN_STRATEGIES = ['crescendo', 'goat'] as const;
+export const MULTI_TURN_STRATEGIES = ['crescendo', 'goat', 'tau'] as const;
 export type MultiTurnStrategy = (typeof MULTI_TURN_STRATEGIES)[number];
 
 export const AGENTIC_STRATEGIES = [
   'crescendo',
   'goat',
+  'tau',
   'jailbreak',
   'jailbreak:tree',
   'pandamonium',
@@ -841,6 +842,7 @@ export const ADDITIONAL_STRATEGIES = [
   'crescendo',
   'gcg',
   'goat',
+  'tau',
   'hex',
   'homoglyph',
   'image',
@@ -902,6 +904,7 @@ export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
   foundation: 'Tests a collection of plugins designed to run against foundation models',
   gcg: 'Greedy Coordinate Gradient adversarial suffix attack',
   goat: 'Dynamic multi-turn attack generation using adversarial techniques',
+  tau: 'Simulated user conversations over multiple turns',
   hallucination: 'Tests for fabrication of false or misleading information',
   harmbench: 'Tests for harmful content using the HarmBench dataset',
   harmful: 'Tests handling of malicious content across multiple categories',
@@ -1012,6 +1015,7 @@ export const displayNameOverrides: Record<Plugin | Strategy, string> = {
   gcg: 'Greedy Coordinate Gradient',
   mcp: 'Model Context Protocol',
   goat: 'Generative Offensive Agent Tester',
+  tau: 'Tau Simulated User',
   hallucination: 'False Information (Hallucination)',
   harmbench: 'HarmBench Dataset',
   harmful: 'Malicious Content Suite',
@@ -1477,6 +1481,7 @@ export const strategyDescriptions: Record<Strategy, string> = {
   default: 'Applies standard security testing methodology',
   gcg: 'Greedy Coordinate Gradient adversarial suffix attack',
   goat: 'Deploys dynamic attack generation using advanced adversarial techniques',
+  tau: 'Multi-turn conversations using a simulated user',
   hex: 'Tests detection and handling of hex-encoded malicious payloads',
   homoglyph:
     'Tests detection and handling of text with homoglyphs (visually similar Unicode characters)',
@@ -1512,6 +1517,7 @@ export const strategyDisplayNames: Record<Strategy, string> = {
   default: 'Basic',
   gcg: 'Greedy Coordinate Gradient',
   goat: 'Generative Offensive Agent Tester',
+  tau: 'Tau Simulated User',
   hex: 'Hex Encoding',
   homoglyph: 'Homoglyph Encoding',
   image: 'Image',

--- a/src/redteam/providers/tau.ts
+++ b/src/redteam/providers/tau.ts
@@ -1,0 +1,42 @@
+import { SimulatedUser } from '../../providers/simulatedUser';
+import type {
+  ApiProvider,
+  CallApiContextParams,
+  CallApiOptionsParams,
+  ProviderOptions,
+  ProviderResponse,
+} from '../../types';
+import invariant from '../../util/invariant';
+
+export default class RedteamTauProvider implements ApiProvider {
+  private readonly injectVar: string;
+  private readonly maxTurns?: number;
+  private readonly userProvider?: ProviderOptions;
+
+  constructor(config: ProviderOptions['config'] & { injectVar: string }) {
+    invariant(config.injectVar, 'Expected injectVar to be set');
+    this.injectVar = config.injectVar;
+    this.maxTurns = config.maxTurns as number | undefined;
+    this.userProvider = config.userProvider as ProviderOptions | undefined;
+  }
+
+  id() {
+    return 'promptfoo:redteam:tau';
+  }
+
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    const provider = new SimulatedUser({
+      id: this.id(),
+      config: {
+        instructions: `{{${this.injectVar}}}`,
+        maxTurns: this.maxTurns,
+        userProvider: this.userProvider,
+      },
+    });
+    return provider.callApi(prompt, context, options);
+  }
+}

--- a/src/redteam/strategies/index.ts
+++ b/src/redteam/strategies/index.ts
@@ -28,6 +28,7 @@ import { addAudioToBase64 } from './simpleAudio';
 import { addImageToBase64 } from './simpleImage';
 import { addVideoToBase64 } from './simpleVideo';
 import { addCompositeTestCases } from './singleTurnComposite';
+import { addTau } from './tau';
 
 export interface Strategy {
   id: string;
@@ -107,6 +108,15 @@ export const Strategies: Strategy[] = [
       logger.debug(`Adding GOAT to ${testCases.length} test cases`);
       const newTestCases = await addGoatTestCases(testCases, injectVar, config);
       logger.debug(`Added ${newTestCases.length} GOAT test cases`);
+      return newTestCases;
+    },
+  },
+  {
+    id: 'tau',
+    action: async (testCases, injectVar, config) => {
+      logger.debug(`Adding Tau to ${testCases.length} test cases`);
+      const newTestCases = addTau(testCases, injectVar, config);
+      logger.debug(`Added ${newTestCases.length} Tau test cases`);
       return newTestCases;
     },
   },

--- a/src/redteam/strategies/tau.ts
+++ b/src/redteam/strategies/tau.ts
@@ -1,0 +1,26 @@
+import type { TestCase } from '../../types';
+
+export function addTau(
+  testCases: TestCase[],
+  injectVar: string,
+  config: Record<string, any>,
+): TestCase[] {
+  return testCases.map((testCase) => ({
+    ...testCase,
+    provider: {
+      id: 'promptfoo:redteam:tau',
+      config: {
+        injectVar,
+        ...config,
+      },
+    },
+    assert: testCase.assert?.map((assertion) => ({
+      ...assertion,
+      metric: `${assertion.metric}/Tau`,
+    })),
+    metadata: {
+      ...testCase.metadata,
+      strategyId: 'tau',
+    },
+  }));
+}

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -162,6 +162,7 @@ describe('Provider Registry', () => {
         'promptfoo:redteam:best-of-n',
         'promptfoo:redteam:crescendo',
         'promptfoo:redteam:goat',
+        'promptfoo:redteam:tau',
         'promptfoo:redteam:iterative',
         'promptfoo:redteam:iterative:image',
         'promptfoo:redteam:iterative:tree',

--- a/test/redteam/strategies/strategyId.test.ts
+++ b/test/redteam/strategies/strategyId.test.ts
@@ -94,6 +94,7 @@ describe('Strategy IDs', () => {
       'prompt-injection': 'promptInjections/index.ts',
       retry: 'retry.ts',
       rot13: 'rot13.ts',
+      tau: 'tau.ts',
       video: 'simpleVideo.ts',
     };
 

--- a/test/redteam/strategies/tau.test.ts
+++ b/test/redteam/strategies/tau.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from '@jest/globals';
+import { addTau } from '../../../src/redteam/strategies/tau';
+import type { TestCase } from '../../../src/types';
+
+describe('Tau Strategy', () => {
+  it('should add Tau configuration to test cases', () => {
+    const testCases: TestCase[] = [
+      {
+        vars: { instructions: 'hi' },
+        assert: [{ type: 'contains', metric: 'exactMatch', value: 'expected' }],
+      },
+    ];
+
+    const result = addTau(testCases, 'instructions', { maxTurns: 3 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].provider).toEqual({
+      id: 'promptfoo:redteam:tau',
+      config: { injectVar: 'instructions', maxTurns: 3 },
+    });
+    expect(result[0].assert?.[0].metric).toBe('exactMatch/Tau');
+    expect(result[0].metadata).toEqual({ strategyId: 'tau' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement Tau strategy using SimulatedUser provider
- expose redteam provider `promptfoo:redteam:tau`
- document Tau in strategy docs and presets
- support Tau in redteam setup UI
- add unit tests

## Testing
- `npx prettier -w ...`
- `npx eslint ...`
- `npm test` *(fails: AwsBedrock tests due to missing deps)*