### PR TITLE
fix: improve logging when inheriting from OpenAiChatCompletionProvider

### DIFF
--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -164,12 +164,12 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     }
     if (this.requiresApiKey() && !this.getApiKey()) {
       throw new Error(
-        'OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
+        `API key is not set. Set the ${this.config.apiKeyEnvar} environment variable or add \`apiKey\` to the provider config.`,
       );
     }
 
     const { body, config } = this.getOpenAiBody(prompt, context, callApiOptions);
-    logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
+    logger.debug(`Calling ${this.getApiUrl()} API: ${JSON.stringify(body)}`);
 
     let data, status, statusText;
     let cached = false;
@@ -202,7 +202,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       };
     }
 
-    logger.debug(`\tOpenAI chat completions API response: ${JSON.stringify(data)}`);
+    logger.debug(`\tcompletions API response: ${JSON.stringify(data)}`);
     if (data.error) {
       await data.deleteFromCache?.();
       return {


### PR DESCRIPTION
There are many classes that extend from OpenAiChatCompletionsProvider, but all the logging is openai this openai that, which causes users to be confused because they set a provider that is not open ai.

This commit tries to make it align the output with what the user would expect

I have some failing tests but those require more work due to the environment setup

# Before
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/87041e8f-f885-4703-a14e-a0df9bfc9a9e" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4338bcc9-dd90-42c5-9eb7-50aa0c3d3f17" />

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/f8c34cff-86aa-4f90-93a8-ad5db904d293" />


# After
<img width="1375" alt="image" src="https://github.com/user-attachments/assets/73a9da82-8c5e-48fc-bde2-e7ac164fc3e9" />

<img width="1599" alt="image" src="https://github.com/user-attachments/assets/e20ef73a-cb99-41bc-872b-29c17f6b5fab" />

<img width="971" alt="image" src="https://github.com/user-attachments/assets/48aa044d-7f92-4dbd-983a-11230fa9d72a" />


