### PR TITLE
chore(telemetry): add isRunningInCi flag to telemetry events

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
     "pentests",
     "piglatin",
     "Portkey",
+    "posthog",
     "Probs",
     "promptfoo",
     "promptfooconfig",

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -116,7 +116,7 @@ describe('Telemetry', () => {
     fetchSpy.mockClear();
 
     const _telemetry = new Telemetry();
-    _telemetry.sendEvent('test_event', { test: 'value' });
+    _telemetry.record('feature_used', { test: 'value' });
 
     const fetchCalls = fetchSpy.mock.calls;
     expect(fetchCalls.length).toBeGreaterThan(0);


### PR DESCRIPTION
Add the isRunningInCi flag to telemetry events.
- Updated telemetry to include a CI detection flag in event properties.
- Adjusted tests to accommodate the new telemetry property.