### PR TITLE
fix: bias:gender plugin generation

### DIFF
--- a/src/redteam/constants.ts
+++ b/src/redteam/constants.ts
@@ -103,6 +103,7 @@ export const UNALIGNED_PROVIDER_HARM_PLUGINS = {
   'harmful:illegal-drugs:meth': 'Methamphetamine',
   'harmful:weapons:ied': 'Improvised Explosive Devices',
   'harmful:cybercrime:malicious-code': 'Malicious Code',
+  'bias:gender': 'Gender Bias',
 
   // Commented out
   //'harmful:privacy-violations': 'Privacy violations & data exploitation',  // redundant with MLCommons category

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -22,6 +22,7 @@ import {
   Severity,
   STRATEGY_COLLECTIONS,
   STRATEGY_EXEMPT_PLUGINS,
+  BIAS_PLUGINS,
 } from './constants';
 import { extractEntities } from './extraction/entities';
 import { extractSystemPurpose } from './extraction/purpose';
@@ -142,6 +143,7 @@ export function resolvePluginConfig(config: Record<string, any> | undefined): Re
 const categories = {
   foundation: FOUNDATION_PLUGINS,
   harmful: Object.keys(HARM_PLUGINS),
+  bias: Object.keys(BIAS_PLUGINS),
   pii: PII_PLUGINS,
 } as const;
 
@@ -571,6 +573,15 @@ export async function synthesize({
   };
 
   plugins.forEach((plugin) => {
+    // First check if this is a direct plugin that should not be expanded
+    // This is for plugins like bias:gender that have a prefix matching an alias
+    const isDirectPlugin = Plugins.some((p) => p.key === plugin.id);
+
+    if (isDirectPlugin) {
+      expandedPlugins.push(plugin);
+      return;
+    }
+
     const mappingKey = Object.keys(ALIASED_PLUGIN_MAPPINGS).find(
       (key) => plugin.id === key || plugin.id.startsWith(`${key}:`),
     );

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -257,7 +257,7 @@ function createRemotePlugin<T extends PluginConfig>(
         },
       }));
 
-      if (key.startsWith('harmful:')) {
+      if (key.startsWith('harmful:') || key.startsWith('bias:')) {
         return testsWithMetadata.map((testCase) => ({
           ...testCase,
           assert: getHarmfulAssertions(key as HarmPlugin),


### PR DESCRIPTION
Fixes an issue where:
1. `bias:gender` would include other plugins, `politics`, `religion`, and `bias:gender`
- I added a check to see if the plugin id was a direct plugin, or a reference to a plugin collection.
2. Generation for `bias:gender` would fail. 
- Since `bias:gender` was using the harmful plugin base class for generation, I added the plugin to a few constants where it was required to be present in order for promptfoo to treat it as a harmful plugin. 

<details>
<summary>
Example config
</summary>

```
description: Travel agent red team

prompts:
  - file://prompt.json

providers:
  - id: openai:gpt-4o-mini
    config:
      tools: file://tools.yaml

redteam:
  numTests: 5

  plugins:
    - bias:gender

  strategies:
    - jailbreak
    - jailbreak:composite
    - jailbreak:tree
    - prompt-injection
    - goat
    - crescendo
```

</details>

Eval/Report: https://www.promptfoo.app/eval/eval-MEV-2025-05-22T15:34:51

