### PR TITLE
feat: add validate command

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,0 +1,67 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import dedent from 'dedent';
+import { fromError } from 'zod-validation-error';
+import logger from '../logger';
+import telemetry from '../telemetry';
+import type { UnifiedConfig } from '../types';
+import { TestSuiteSchema, UnifiedConfigSchema } from '../types';
+import { setupEnv } from '../util';
+import { resolveConfigs } from '../util/config/load';
+
+interface ValidateOptions {
+  config?: string[];
+  envPath?: string;
+}
+
+export async function doValidate(
+  opts: ValidateOptions,
+  defaultConfig: Partial<UnifiedConfig>,
+  defaultConfigPath: string | undefined,
+): Promise<void> {
+  setupEnv(opts.envPath);
+  const configPaths = opts.config || (defaultConfigPath ? [defaultConfigPath] : undefined);
+  try {
+    const { config, testSuite } = await resolveConfigs(
+      { ...opts, config: configPaths },
+      defaultConfig,
+    );
+    const configParse = UnifiedConfigSchema.safeParse(config);
+    if (!configParse.success) {
+      logger.error(
+        dedent`Configuration validation error:\n${fromError(configParse.error).message}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const suiteParse = TestSuiteSchema.safeParse(testSuite);
+    if (!suiteParse.success) {
+      logger.error(dedent`Test suite validation error:\n${fromError(suiteParse.error).message}`);
+      process.exitCode = 1;
+      return;
+    }
+    logger.info(chalk.green('Configuration is valid.'));
+  } catch (err) {
+    logger.error(`Failed to validate configuration: ${err instanceof Error ? err.message : err}`);
+    process.exitCode = 1;
+  }
+}
+
+export function validateCommand(
+  program: Command,
+  defaultConfig: Partial<UnifiedConfig>,
+  defaultConfigPath: string | undefined,
+) {
+  program
+    .command('validate')
+    .description('Validate a promptfoo configuration file')
+    .option(
+      '-c, --config <paths...>',
+      'Path to configuration file. Automatically loads promptfooconfig.yaml',
+    )
+    .action(async (opts: ValidateOptions) => {
+      telemetry.record('command_used', { name: 'validate' });
+      await telemetry.send();
+      await doValidate(opts, defaultConfig, defaultConfigPath);
+    });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { listCommand } from './commands/list';
 import { modelScanCommand } from './commands/modelScan';
 import { shareCommand } from './commands/share';
 import { showCommand } from './commands/show';
+import { validateCommand } from './commands/validate';
 import { viewCommand } from './commands/view';
 import logger, { setLogLevel } from './logger';
 import { runDbMigrations } from './migrate';
@@ -103,6 +104,7 @@ async function main() {
   importCommand(program);
   listCommand(program);
   modelScanCommand(program);
+  validateCommand(program, defaultConfig, defaultConfigPath);
   showCommand(program);
 
   generateDatasetCommand(generateCommand, defaultConfig, defaultConfigPath);


### PR DESCRIPTION
## Summary
- add a new `validate` command for verifying promptfoo configs
- register the command in the CLI

## Testing
- `npm run lint`
- `npm test` *(fails: The @smithy/node-http-handler package is required as a peer dependency)*