### PR TITLE
fix(prompts): splitting when PROMPTFOO_PROMPT_SEPARATOR is contained within a string with text files

### DIFF
--- a/src/prompts/processors/text.ts
+++ b/src/prompts/processors/text.ts
@@ -10,13 +10,31 @@ import { PROMPT_DELIMITER } from '../constants';
  */
 export function processTxtFile(filePath: string, { label }: Partial<Prompt>): Prompt[] {
   const fileContent = fs.readFileSync(filePath, 'utf-8');
-  return fileContent // handle leading/trailing delimiters and empty lines
-    .split(PROMPT_DELIMITER)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
-    .map((prompt) => ({
-      raw: prompt,
-      label: label ? `${label}: ${filePath}: ${prompt}` : `${filePath}: ${prompt}`,
-      // no config
-    }));
+
+  const lines = fileContent.split(/\r?\n/);
+  const prompts: Prompt[] = [];
+  let buffer: string[] = [];
+
+  const flush = () => {
+    const raw = buffer.join('\n').trim();
+    if (raw.length > 0) {
+      prompts.push({
+        raw,
+        label: label ? `${label}: ${filePath}: ${raw}` : `${filePath}: ${raw}`,
+        // no config
+      });
+    }
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    if (line.trim() === PROMPT_DELIMITER) {
+      flush();
+    } else {
+      buffer.push(line);
+    }
+  }
+  flush();
+
+  return prompts;
 }

--- a/test/prompts/processors/text.test.ts
+++ b/test/prompts/processors/text.test.ts
@@ -38,7 +38,7 @@ describe('processTxtFile', () => {
   });
 
   it('should process a text file with multiple prompts and a label', () => {
-    const fileContent = `Prompt 1${PROMPT_DELIMITER}Prompt 2${PROMPT_DELIMITER}Prompt 3`;
+    const fileContent = `Prompt 1\n${PROMPT_DELIMITER}\nPrompt 2\n${PROMPT_DELIMITER}\nPrompt 3`;
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processTxtFile('file.txt', { label: 'Label' })).toEqual([
       {
@@ -59,7 +59,7 @@ describe('processTxtFile', () => {
 
   it('should handle text file with leading and trailing delimiters', () => {
     const filePath = 'file.txt';
-    const fileContent = `${PROMPT_DELIMITER}Prompt 1${PROMPT_DELIMITER}Prompt 2${PROMPT_DELIMITER}`;
+    const fileContent = `${PROMPT_DELIMITER}\nPrompt 1\n${PROMPT_DELIMITER}\nPrompt 2\n${PROMPT_DELIMITER}`;
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processTxtFile(filePath, {})).toEqual([
       {
@@ -76,7 +76,7 @@ describe('processTxtFile', () => {
 
   it('should return an empty array for a file with only delimiters', () => {
     const filePath = 'file.txt';
-    const fileContent = `${PROMPT_DELIMITER}${PROMPT_DELIMITER}`;
+    const fileContent = `${PROMPT_DELIMITER}\n${PROMPT_DELIMITER}`;
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processTxtFile(filePath, {})).toEqual([]);
     expect(mockReadFileSync).toHaveBeenCalledWith(filePath, 'utf-8');
@@ -87,6 +87,19 @@ describe('processTxtFile', () => {
     const fileContent = '';
     mockReadFileSync.mockReturnValue(fileContent);
     expect(processTxtFile(filePath, {})).toEqual([]);
+    expect(mockReadFileSync).toHaveBeenCalledWith(filePath, 'utf-8');
+  });
+
+  it('should not split on lines that contain repeated hyphens', () => {
+    const filePath = 'file.txt';
+    const fileContent = 'Line 1\n-----------------------------------\nLine 2';
+    mockReadFileSync.mockReturnValue(fileContent);
+    expect(processTxtFile(filePath, {})).toEqual([
+      {
+        raw: 'Line 1\n-----------------------------------\nLine 2',
+        label: `${filePath}: Line 1\n-----------------------------------\nLine 2`,
+      },
+    ]);
     expect(mockReadFileSync).toHaveBeenCalledWith(filePath, 'utf-8');
   });
 });


### PR DESCRIPTION
Resolves https://github.com/promptfoo/promptfoo/issues/4141