### PR TITLE
chore(webui): add max concurrency as an option for run in browser

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -753,6 +753,7 @@ export default function Review() {
                       }
                     }}
                     disabled={isRunning || Number(maxConcurrency) > 1}
+                    inputProps={{ min: 0, step: 1 }}
                     InputProps={{
                       endAdornment: <Typography variant="caption">ms</Typography>,
                     }}
@@ -784,6 +785,7 @@ export default function Review() {
                       }
                     }}
                     disabled={isRunning || Number(delayMs) > 0}
+                    inputProps={{ min: 1, step: 1 }}
                     InputProps={{
                       endAdornment: <Typography variant="caption">instances</Typography>,
                     }}

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -44,13 +44,16 @@ redteamRouter.post('/run', async (req: Request, res: Response): Promise<void> =>
   // Set web UI mode
   cliState.webUI = true;
 
+  // Validate and normalize maxConcurrency
+  const normalizedMaxConcurrency = Math.max(1, Number(maxConcurrency || '1'));
+
   // Run redteam in background
   doRedteamRun({
     liveRedteamConfig: config,
     force,
     verbose,
     delay: Number(delay || '0'),
-    maxConcurrency: Number(maxConcurrency || '1'),
+    maxConcurrency: normalizedMaxConcurrency,
     logCallback: (message: string) => {
       if (currentJobId === id) {
         const job = evalJobs.get(id);


### PR DESCRIPTION
https://linear.app/promptfooo/issue/PF-565/add-concurrency-option-to-open-source-redteam-ui

<img width="549" alt="Screenshot 2025-05-23 at 3 11 36 PM" src="https://github.com/user-attachments/assets/d0909d06-2cf5-4b1c-a363-40fbf0fc1d5e" />
<img width="494" alt="Screenshot 2025-05-23 at 3 11 30 PM" src="https://github.com/user-attachments/assets/8e0b7843-0d9b-419e-9db1-ec27d5335671" />
<img width="612" alt="Screenshot 2025-05-23 at 3 09 13 PM" src="https://github.com/user-attachments/assets/f213132c-6972-4ca6-b1f1-42fc8c3e06a8" />
