### PR TITLE
fix(webui): defaultTest shown in webui YAML editor

### DIFF
--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
@@ -63,9 +63,9 @@ const RunTestSuiteButton: React.FC = () => {
           if (progressData.status === 'complete') {
             clearInterval(intervalId);
             setIsRunning(false);
-
-            // TODO(ian): This just redirects to the eval page, which shows the most recent eval.  Redirect to this specific eval to avoid race.
-            navigate('/eval');
+            if (progressData.evalId) {
+              navigate(`/eval/${progressData.evalId}`);
+            }
           } else if (['failed', 'error'].includes(progressData.status)) {
             clearInterval(intervalId);
             setIsRunning(false);

--- a/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
@@ -181,6 +181,31 @@ describe('YamlEditor', () => {
     expect(editor.value).toContain('repeat: 3');
   });
 
+  it('includes defaultTest from store in YAML', () => {
+    mockGetTestSuite.mockReturnValueOnce({
+      description: 'Test suite',
+      providers: [{ id: 'test-provider' }],
+      prompts: ['test prompt'],
+      tests: [{ description: 'test case' }],
+      defaultTest: {
+        assert: [
+          {
+            type: 'llm-rubric',
+            value: 'does not describe self as an AI, model, or chatbot',
+          },
+        ],
+      },
+    });
+
+    render(<YamlEditorComponent />);
+
+    const editor = screen.getByTestId('yaml-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('defaultTest');
+    expect(editor.value).toContain('assert:');
+    expect(editor.value).toContain('type: llm-rubric');
+    expect(editor.value).toContain('does not describe self as an AI, model, or chatbot');
+  });
+
   it('respects readOnly prop', () => {
     render(<YamlEditorComponent readOnly={true} />);
 

--- a/src/app/src/stores/evalConfig.ts
+++ b/src/app/src/stores/evalConfig.ts
@@ -98,6 +98,7 @@ export const useStore = create<State>()(
           scenarios,
           testCases,
           evaluateOptions,
+          defaultTest,
         } = get();
         return {
           description,
@@ -108,6 +109,7 @@ export const useStore = create<State>()(
           scenarios,
           tests: testCases,
           evaluateOptions,
+          defaultTest,
         };
       },
     }),


### PR DESCRIPTION
Relates to https://github.com/promptfoo/promptfoo/issues/4031

Additionally noted during testing:
- Default ordering of the config is confusing, with defaultTest being at the bottom in edit YAML
- evaluateOptions is not shown in the specific eval page -> View YAML
- defaultTest recent addition is visible in the top in the specific eval page -> View YAML (description should be the top)