### PR TITLE
docs(site): reduce sidebar padding

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -51,6 +51,10 @@ code p {
   font-weight: 600;
 }
 
+.theme-doc-sidebar-container > div > div {
+  padding-top: 1rem !important;
+}
+
 .navbar__brand {
   font-family: var(--ifm-font-family-monospace);
 }


### PR DESCRIPTION
before
<img width="759" alt="Screenshot 2025-05-25 at 12 33 50 AM" src="https://github.com/user-attachments/assets/3f95c1c0-0d13-4b5a-928a-6d103dbe1a6f" />


now

<img width="782" alt="Screenshot 2025-05-25 at 12 33 41 AM" src="https://github.com/user-attachments/assets/c9d2f042-5465-4f81-b37f-cbecabecd8a5" />

