### PR TITLE
fix: Run redteam from UI without email

### DIFF
--- a/src/app/src/hooks/useEmailVerification.ts
+++ b/src/app/src/hooks/useEmailVerification.ts
@@ -62,52 +62,32 @@ export function useEmailVerification() {
     }
   }, []);
 
-  const setEmailAndConsent = useCallback(
-    async (email: string): Promise<{ success: boolean; error?: string }> => {
-      try {
-        // First set the email
-        const emailResponse = await callApi('/user/email', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ email }),
-        });
+  const saveEmail = useCallback(async (email: string): Promise<{ error?: string }> => {
+    try {
+      // First set the email
+      const emailResponse = await callApi('/user/email', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email }),
+      });
 
-        if (!emailResponse.ok) {
-          const errorData = await emailResponse.json();
-          return { success: false, error: errorData.error || 'Failed to set email' };
-        }
-
-        // Then save consent
-        const consentResponse = await callApi('/user/consent', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            email,
-            metadata: { source: 'webui_redteam' },
-          }),
-        });
-
-        if (!consentResponse.ok) {
-          const errorData = await consentResponse.json();
-          return { success: false, error: errorData.error || 'Failed to save consent' };
-        }
-
-        return { success: true };
-      } catch (error) {
-        console.error('Error setting email and consent:', error);
-        return { success: false, error: 'Failed to set email and consent. Please try again.' };
+      if (!emailResponse.ok) {
+        const errorData = await emailResponse.json();
+        return { error: errorData.error || 'Failed to set email' };
       }
-    },
-    [],
-  );
+
+      return {};
+    } catch (error) {
+      console.error('Error setting email:', error);
+      return { error: `Failed to set email: ${error}` };
+    }
+  }, []);
 
   return {
     checkEmailStatus,
-    setEmailAndConsent,
+    saveEmail,
     isChecking,
   };
 }

--- a/src/app/src/hooks/useEmailVerification.ts
+++ b/src/app/src/hooks/useEmailVerification.ts
@@ -1,0 +1,113 @@
+import { useState, useCallback } from 'react';
+import { callApi } from '@app/utils/api';
+
+interface EmailStatus {
+  hasEmail: boolean;
+  email?: string;
+  status: 'ok' | 'exceeded_limit' | 'show_usage_warning' | 'no_email';
+  message?: string;
+}
+
+interface EmailVerificationResult {
+  canProceed: boolean;
+  needsEmail: boolean;
+  status: EmailStatus | null;
+  error: string | null;
+}
+
+export function useEmailVerification() {
+  const [isChecking, setIsChecking] = useState(false);
+
+  const checkEmailStatus = useCallback(async (): Promise<EmailVerificationResult> => {
+    setIsChecking(true);
+    try {
+      const response = await callApi('/user/email/status');
+      const status: EmailStatus = await response.json();
+
+      if (!status.hasEmail) {
+        return {
+          canProceed: false,
+          needsEmail: true,
+          status,
+          error: null,
+        };
+      }
+
+      if (status.status === 'exceeded_limit') {
+        return {
+          canProceed: false,
+          needsEmail: false,
+          status,
+          error:
+            'You have exceeded the maximum cloud inference limit. Please contact inquiries@promptfoo.dev to upgrade your account.',
+        };
+      }
+
+      return {
+        canProceed: true,
+        needsEmail: false,
+        status,
+        error: null,
+      };
+    } catch (error) {
+      console.error('Error checking email status:', error);
+      return {
+        canProceed: false,
+        needsEmail: false,
+        status: null,
+        error: 'Failed to check email verification status. Please try again.',
+      };
+    } finally {
+      setIsChecking(false);
+    }
+  }, []);
+
+  const setEmailAndConsent = useCallback(
+    async (email: string): Promise<{ success: boolean; error?: string }> => {
+      try {
+        // First set the email
+        const emailResponse = await callApi('/user/email', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ email }),
+        });
+
+        if (!emailResponse.ok) {
+          const errorData = await emailResponse.json();
+          return { success: false, error: errorData.error || 'Failed to set email' };
+        }
+
+        // Then save consent
+        const consentResponse = await callApi('/user/consent', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email,
+            metadata: { source: 'webui_redteam' },
+          }),
+        });
+
+        if (!consentResponse.ok) {
+          const errorData = await consentResponse.json();
+          return { success: false, error: errorData.error || 'Failed to save consent' };
+        }
+
+        return { success: true };
+      } catch (error) {
+        console.error('Error setting email and consent:', error);
+        return { success: false, error: 'Failed to set email and consent. Please try again.' };
+      }
+    },
+    [],
+  );
+
+  return {
+    checkEmailStatus,
+    setEmailAndConsent,
+    isChecking,
+  };
+}

--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -88,6 +88,11 @@ export function EmailVerificationDialog({
       maxWidth="sm"
       fullWidth
       disableEscapeKeyDown={isSubmitting}
+      slotProps={{
+        backdrop: {
+          onClick: isSubmitting ? (event) => event.stopPropagation() : undefined,
+        },
+      }}
     >
       <DialogTitle>Email Required</DialogTitle>
       <DialogContent>
@@ -103,7 +108,7 @@ export function EmailVerificationDialog({
             type="email"
             value={email}
             onChange={handleEmailChange}
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyPress}
             error={!!emailError}
             helperText={emailError}
             disabled={isSubmitting}

--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -63,12 +63,15 @@ export function EmailVerificationDialog({
 
       if (result.error) {
         setEmailError(result.error || 'Failed to verify email');
+        return;
       }
-      showToast('Email saved succesfully, starting redteam.');
+      showToast('Email saved successfully, starting redteam.');
       onSuccess();
     } catch (error) {
       console.error('Error submitting email:', error);
-      setEmailError(`An unexpected error occurred: ${error}.`);
+      setEmailError(
+        `An unexpected error occurred: ${error instanceof Error ? error.message : error}.`,
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { useEmailVerification } from '@app/hooks/useEmailVerification';
+import { useToast } from '@app/hooks/useToast';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+interface EmailVerificationDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  message?: string;
+}
+
+export function EmailVerificationDialog({
+  open,
+  onClose,
+  onSuccess,
+  message = 'Redteam evals require email verification. Please enter your work email:',
+}: EmailVerificationDialogProps) {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { setEmailAndConsent } = useEmailVerification();
+  const { showToast } = useToast();
+
+  const validateEmail = (email: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newEmail = event.target.value;
+    setEmail(newEmail);
+
+    if (emailError && newEmail && validateEmail(newEmail)) {
+      setEmailError('');
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!email.trim()) {
+      setEmailError('Email is required');
+      return;
+    }
+
+    if (!validateEmail(email)) {
+      setEmailError('Please enter a valid email address');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setEmailError('');
+
+    try {
+      const result = await setEmailAndConsent(email);
+
+      if (result.success) {
+        showToast('Email verified successfully', 'success');
+        onSuccess();
+      } else {
+        setEmailError(result.error || 'Failed to verify email');
+      }
+    } catch (error) {
+      console.error('Error submitting email:', error);
+      setEmailError('An unexpected error occurred. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' && !isSubmitting) {
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      disableEscapeKeyDown={isSubmitting}
+    >
+      <DialogTitle>Email Required</DialogTitle>
+      <DialogContent>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            {message}
+          </Typography>
+
+          <TextField
+            autoFocus
+            fullWidth
+            label="Work Email Address"
+            type="email"
+            value={email}
+            onChange={handleEmailChange}
+            onKeyPress={handleKeyPress}
+            error={!!emailError}
+            helperText={emailError}
+            disabled={isSubmitting}
+            placeholder="your.email@company.com"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={isSubmitting || !email.trim()}
+          startIcon={isSubmitting ? <CircularProgress size={20} /> : null}
+        >
+          {isSubmitting ? 'Verifying...' : 'Verify Email'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -27,7 +27,7 @@ export function EmailVerificationDialog({
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const { setEmailAndConsent } = useEmailVerification();
+  const { saveEmail } = useEmailVerification();
   const { showToast } = useToast();
 
   const validateEmail = (email: string): boolean => {
@@ -59,17 +59,16 @@ export function EmailVerificationDialog({
     setEmailError('');
 
     try {
-      const result = await setEmailAndConsent(email);
+      const result = await saveEmail(email);
 
-      if (result.success) {
-        showToast('Email verified successfully', 'success');
-        onSuccess();
-      } else {
+      if (result.error) {
         setEmailError(result.error || 'Failed to verify email');
       }
+      showToast('Email saved succesfully, starting redteam.');
+      onSuccess();
     } catch (error) {
       console.error('Error submitting email:', error);
-      setEmailError('An unexpected error occurred. Please try again.');
+      setEmailError(`An unexpected error occurred: ${error}.`);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/globalConfig/accounts.ts
+++ b/src/globalConfig/accounts.ts
@@ -34,8 +34,8 @@ export interface EmailStatusResult {
  * Shared function to check email status with the promptfoo API
  * Used by both CLI and server routes
  */
-export async function checkEmailStatus(email?: string): Promise<EmailStatusResult> {
-  const userEmail = email || (isCI() ? 'ci-placeholder@promptfoo.dev' : getUserEmail());
+export async function checkEmailStatus(): Promise<EmailStatusResult> {
+  const userEmail = isCI() ? 'ci-placeholder@promptfoo.dev' : getUserEmail();
 
   if (!userEmail) {
     return {

--- a/src/globalConfig/accounts.ts
+++ b/src/globalConfig/accounts.ts
@@ -47,7 +47,7 @@ export async function checkEmailStatus(email?: string): Promise<EmailStatusResul
 
   try {
     const resp = await fetchWithTimeout(
-      `https://api.promptfoo.app/api/users/status?email=${userEmail}`,
+      `https://api.promptfoo.app/api/users/status?email=${encodeURIComponent(userEmail)}`,
       undefined,
       500,
     );

--- a/src/globalConfig/accounts.ts
+++ b/src/globalConfig/accounts.ts
@@ -23,6 +23,58 @@ export function getAuthor(): string | null {
   return getEnvString('PROMPTFOO_AUTHOR') || getUserEmail() || null;
 }
 
+export interface EmailStatusResult {
+  status: 'ok' | 'exceeded_limit' | 'show_usage_warning' | 'no_email';
+  message?: string;
+  email?: string;
+  hasEmail: boolean;
+}
+
+/**
+ * Shared function to check email status with the promptfoo API
+ * Used by both CLI and server routes
+ */
+export async function checkEmailStatus(email?: string): Promise<EmailStatusResult> {
+  const userEmail = email || (isCI() ? 'ci-placeholder@promptfoo.dev' : getUserEmail());
+
+  if (!userEmail) {
+    return {
+      status: 'no_email',
+      hasEmail: false,
+      message: 'Redteam evals require email verification. Please enter your work email:',
+    };
+  }
+
+  try {
+    const resp = await fetchWithTimeout(
+      `https://api.promptfoo.app/api/users/status?email=${userEmail}`,
+      undefined,
+      500,
+    );
+    const data = (await resp.json()) as {
+      status: 'ok' | 'exceeded_limit' | 'show_usage_warning';
+      message?: string;
+      error?: string;
+    };
+
+    return {
+      status: data.status,
+      message: data.message,
+      email: userEmail,
+      hasEmail: true,
+    };
+  } catch (e) {
+    logger.debug(`Failed to check user status: ${e}`);
+    // If we can't check status, assume it's OK but log the issue
+    return {
+      status: 'ok',
+      message: 'Unable to verify email status, but proceeding',
+      email: userEmail,
+      hasEmail: true,
+    };
+  }
+}
+
 export async function promptForEmailUnverified() {
   let email = isCI() ? 'ci-placeholder@promptfoo.dev' : getUserEmail();
   if (!email) {
@@ -48,35 +100,19 @@ export async function promptForEmailUnverified() {
 }
 
 export async function checkEmailStatusOrExit() {
-  const email = isCI() ? 'ci-placeholder@promptfoo.dev' : getUserEmail();
-  if (!email) {
-    logger.debug('Skipping email status check because email is not set');
-    return;
-  }
-  try {
-    const resp = await fetchWithTimeout(
-      `https://api.promptfoo.app/api/users/status?email=${email}`,
-      undefined,
-      500,
+  const result = await checkEmailStatus();
+
+  if (result.status === 'exceeded_limit') {
+    logger.error(
+      'You have exceeded the maximum cloud inference limit. Please contact inquiries@promptfoo.dev to upgrade your account.',
     );
-    const data = (await resp.json()) as {
-      status: 'ok' | 'exceeded_limit' | 'show_usage_warning';
-      message?: string;
-      error?: string;
-    };
-    if (data?.status === 'exceeded_limit') {
-      logger.error(
-        'You have exceeded the maximum cloud inference limit. Please contact inquiries@promptfoo.dev to upgrade your account.',
-      );
-      process.exit(1);
-    }
-    if (data?.status === 'show_usage_warning' && data?.message) {
-      const border = '='.repeat(TERMINAL_MAX_WIDTH);
-      logger.info(chalk.yellow(border));
-      logger.warn(chalk.yellow(data.message));
-      logger.info(chalk.yellow(border));
-    }
-  } catch (e) {
-    logger.debug(`Failed to check user status: ${e}`);
+    process.exit(1);
+  }
+
+  if (result.status === 'show_usage_warning' && result.message) {
+    const border = '='.repeat(TERMINAL_MAX_WIDTH);
+    logger.info(chalk.yellow(border));
+    logger.warn(chalk.yellow(result.message));
+    logger.info(chalk.yellow(border));
   }
 }

--- a/src/server/apiSchemas.ts
+++ b/src/server/apiSchemas.ts
@@ -18,6 +18,14 @@ export const ApiSchemas = {
         message: z.string(),
       }),
     },
+    EmailStatus: {
+      Response: z.object({
+        hasEmail: z.boolean(),
+        email: EmailSchema.optional(),
+        status: z.enum(['ok', 'exceeded_limit', 'show_usage_warning', 'no_email']),
+        message: z.string().optional(),
+      }),
+    },
   },
   Eval: {
     UpdateAuthor: {

--- a/src/server/apiSchemas.ts
+++ b/src/server/apiSchemas.ts
@@ -19,9 +19,6 @@ export const ApiSchemas = {
       }),
     },
     EmailStatus: {
-      Request: z.object({
-        email: EmailSchema.optional(),
-      }),
       Response: z.object({
         hasEmail: z.boolean(),
         email: EmailSchema.optional(),

--- a/src/server/apiSchemas.ts
+++ b/src/server/apiSchemas.ts
@@ -19,6 +19,9 @@ export const ApiSchemas = {
       }),
     },
     EmailStatus: {
+      Request: z.object({
+        email: EmailSchema.optional(),
+      }),
       Response: z.object({
         hasEmail: z.boolean(),
         email: EmailSchema.optional(),

--- a/src/server/routes/user.ts
+++ b/src/server/routes/user.ts
@@ -55,7 +55,10 @@ userRouter.post('/email', async (req: Request, res: Response): Promise<void> => 
 
 userRouter.get('/email/status', async (req: Request, res: Response): Promise<void> => {
   try {
-    const result = await checkEmailStatus();
+    // Validate query parameters
+    const { email: queryEmail } = ApiSchemas.User.EmailStatus.Request.parse(req.query);
+
+    const result = await checkEmailStatus(queryEmail);
 
     res.json(
       ApiSchemas.User.EmailStatus.Response.parse({
@@ -67,7 +70,11 @@ userRouter.get('/email/status', async (req: Request, res: Response): Promise<voi
     );
   } catch (error) {
     logger.error(`Error checking email status: ${error}`);
-    res.status(500).json({ error: 'Failed to check email status' });
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: fromError(error).toString() });
+    } else {
+      res.status(500).json({ error: 'Failed to check email status' });
+    }
   }
 });
 

--- a/test/globalConfig/accounts.test.ts
+++ b/test/globalConfig/accounts.test.ts
@@ -190,7 +190,7 @@ describe('accounts', () => {
       await checkEmailStatusOrExit();
 
       expect(fetchWithTimeout).toHaveBeenCalledWith(
-        'https://api.promptfoo.app/api/users/status?email=ci-placeholder@promptfoo.dev',
+        'https://api.promptfoo.app/api/users/status?email=ci-placeholder%40promptfoo.dev',
         undefined,
         500,
       );
@@ -211,7 +211,7 @@ describe('accounts', () => {
       await checkEmailStatusOrExit();
 
       expect(fetchWithTimeout).toHaveBeenCalledWith(
-        'https://api.promptfoo.app/api/users/status?email=test@example.com',
+        'https://api.promptfoo.app/api/users/status?email=test%40example.com',
         undefined,
         500,
       );
@@ -306,7 +306,7 @@ describe('accounts', () => {
       const result = await checkEmailStatus();
 
       expect(fetchWithTimeout).toHaveBeenCalledWith(
-        'https://api.promptfoo.app/api/users/status?email=ci-placeholder@promptfoo.dev',
+        'https://api.promptfoo.app/api/users/status?email=ci-placeholder%40promptfoo.dev',
         undefined,
         500,
       );
@@ -316,54 +316,6 @@ describe('accounts', () => {
         email: 'ci-placeholder@promptfoo.dev',
         message: undefined,
       });
-    });
-
-    it('should use provided email parameter', async () => {
-      const testEmail = 'custom@example.com';
-      const mockResponse = new Response(JSON.stringify({ status: 'ok' }), {
-        status: 200,
-        statusText: 'OK',
-      });
-      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-
-      const result = await checkEmailStatus(testEmail);
-
-      expect(fetchWithTimeout).toHaveBeenCalledWith(
-        'https://api.promptfoo.app/api/users/status?email=custom@example.com',
-        undefined,
-        500,
-      );
-      expect(result).toEqual({
-        status: 'ok',
-        hasEmail: true,
-        email: testEmail,
-        message: undefined,
-      });
-    });
-
-    it('should prioritize provided email parameter over stored email', async () => {
-      // Set up stored email
-      jest.mocked(isCI).mockReturnValue(false);
-      jest.mocked(readGlobalConfig).mockReturnValue({
-        account: { email: 'stored@example.com' },
-      });
-
-      const customEmail = 'custom@example.com';
-      const mockResponse = new Response(JSON.stringify({ status: 'ok' }), {
-        status: 200,
-        statusText: 'OK',
-      });
-      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-
-      const result = await checkEmailStatus(customEmail);
-
-      // Should use the provided email, not the stored one
-      expect(fetchWithTimeout).toHaveBeenCalledWith(
-        'https://api.promptfoo.app/api/users/status?email=custom@example.com',
-        undefined,
-        500,
-      );
-      expect(result.email).toBe(customEmail);
     });
 
     it('should return exceeded_limit status', async () => {

--- a/test/globalConfig/accounts.test.ts
+++ b/test/globalConfig/accounts.test.ts
@@ -341,6 +341,31 @@ describe('accounts', () => {
       });
     });
 
+    it('should prioritize provided email parameter over stored email', async () => {
+      // Set up stored email
+      jest.mocked(isCI).mockReturnValue(false);
+      jest.mocked(readGlobalConfig).mockReturnValue({
+        account: { email: 'stored@example.com' },
+      });
+
+      const customEmail = 'custom@example.com';
+      const mockResponse = new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        statusText: 'OK',
+      });
+      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
+
+      const result = await checkEmailStatus(customEmail);
+
+      // Should use the provided email, not the stored one
+      expect(fetchWithTimeout).toHaveBeenCalledWith(
+        'https://api.promptfoo.app/api/users/status?email=custom@example.com',
+        undefined,
+        500,
+      );
+      expect(result.email).toBe(customEmail);
+    });
+
     it('should return exceeded_limit status', async () => {
       jest.mocked(isCI).mockReturnValue(false);
       jest.mocked(readGlobalConfig).mockReturnValue({

--- a/test/globalConfig/accounts.test.ts
+++ b/test/globalConfig/accounts.test.ts
@@ -8,6 +8,7 @@ import {
   getAuthor,
   promptForEmailUnverified,
   checkEmailStatusOrExit,
+  checkEmailStatus,
 } from '../../src/globalConfig/accounts';
 import { readGlobalConfig, writeGlobalConfigPartial } from '../../src/globalConfig/globalConfig';
 import logger from '../../src/logger';
@@ -272,6 +273,140 @@ describe('accounts', () => {
         'Failed to check user status: Error: Network error',
       );
       expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkEmailStatus', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return no_email status when no email is provided', async () => {
+      jest.mocked(isCI).mockReturnValue(false);
+      jest.mocked(readGlobalConfig).mockReturnValue({});
+
+      const result = await checkEmailStatus();
+
+      expect(result).toEqual({
+        status: 'no_email',
+        hasEmail: false,
+        message: 'Redteam evals require email verification. Please enter your work email:',
+      });
+    });
+
+    it('should use CI email when in CI environment', async () => {
+      jest.mocked(isCI).mockReturnValue(true);
+
+      const mockResponse = new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        statusText: 'OK',
+      });
+      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
+
+      const result = await checkEmailStatus();
+
+      expect(fetchWithTimeout).toHaveBeenCalledWith(
+        'https://api.promptfoo.app/api/users/status?email=ci-placeholder@promptfoo.dev',
+        undefined,
+        500,
+      );
+      expect(result).toEqual({
+        status: 'ok',
+        hasEmail: true,
+        email: 'ci-placeholder@promptfoo.dev',
+        message: undefined,
+      });
+    });
+
+    it('should use provided email parameter', async () => {
+      const testEmail = 'custom@example.com';
+      const mockResponse = new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        statusText: 'OK',
+      });
+      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
+
+      const result = await checkEmailStatus(testEmail);
+
+      expect(fetchWithTimeout).toHaveBeenCalledWith(
+        'https://api.promptfoo.app/api/users/status?email=custom@example.com',
+        undefined,
+        500,
+      );
+      expect(result).toEqual({
+        status: 'ok',
+        hasEmail: true,
+        email: testEmail,
+        message: undefined,
+      });
+    });
+
+    it('should return exceeded_limit status', async () => {
+      jest.mocked(isCI).mockReturnValue(false);
+      jest.mocked(readGlobalConfig).mockReturnValue({
+        account: { email: 'test@example.com' },
+      });
+
+      const mockResponse = new Response(JSON.stringify({ status: 'exceeded_limit' }), {
+        status: 200,
+        statusText: 'OK',
+      });
+      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
+
+      const result = await checkEmailStatus();
+
+      expect(result).toEqual({
+        status: 'exceeded_limit',
+        hasEmail: true,
+        email: 'test@example.com',
+        message: undefined,
+      });
+    });
+
+    it('should return show_usage_warning status with message', async () => {
+      jest.mocked(isCI).mockReturnValue(false);
+      jest.mocked(readGlobalConfig).mockReturnValue({
+        account: { email: 'test@example.com' },
+      });
+
+      const warningMessage = 'You are approaching your usage limit';
+      const mockResponse = new Response(
+        JSON.stringify({ status: 'show_usage_warning', message: warningMessage }),
+        {
+          status: 200,
+          statusText: 'OK',
+        },
+      );
+      jest.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
+
+      const result = await checkEmailStatus();
+
+      expect(result).toEqual({
+        status: 'show_usage_warning',
+        hasEmail: true,
+        email: 'test@example.com',
+        message: warningMessage,
+      });
+    });
+
+    it('should handle fetch errors gracefully', async () => {
+      jest.mocked(isCI).mockReturnValue(false);
+      jest.mocked(readGlobalConfig).mockReturnValue({
+        account: { email: 'test@example.com' },
+      });
+      jest.mocked(fetchWithTimeout).mockRejectedValue(new Error('Network error'));
+
+      const result = await checkEmailStatus();
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Failed to check user status: Error: Network error',
+      );
+      expect(result).toEqual({
+        status: 'ok',
+        hasEmail: true,
+        email: 'test@example.com',
+        message: 'Unable to verify email status, but proceeding',
+      });
     });
   });
 });


### PR DESCRIPTION
Running a redteam in the UI for the first time would hang because an email hadn't been collected.

This adds a new flow to collect the user's email so they can conduct the redteam.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds email verification flow for running redteam from the UI, including new hooks, dialog components, server endpoints, and tests.
> 
>   - **Behavior**:
>     - Adds `useEmailVerification` hook in `useEmailVerification.ts` to check and set email status.
>     - Introduces `EmailVerificationDialog` in `EmailVerificationDialog.tsx` for email input and verification.
>     - Updates `Review.tsx` to handle email verification before running redteam.
>   - **Server**:
>     - Adds `/email/status` endpoint in `user.ts` to check email status.
>     - Updates `checkEmailStatus` function in `accounts.ts` to handle email verification logic.
>   - **Tests**:
>     - Adds tests for `checkEmailStatus` in `accounts.test.ts` to cover new email verification scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=promptfoo%2Fpromptfoo&utm_source=github&utm_medium=referral)<sup> for 4c8479fc43a0bf24e853fd8275f4f3c0a41ee29c. You can [customize](https://app.ellipsis.dev/promptfoo/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->