### PR TITLE
refactor: unify React import style

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import {
   createBrowserRouter,
   createRoutesFromElements,

--- a/src/app/src/components/ApiSettingsModal.tsx
+++ b/src/app/src/components/ApiSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useApiHealth, type ApiHealthStatus } from '@app/hooks/useApiHealth';
 import useApiConfig from '@app/stores/apiConfig';
 import CircleIcon from '@mui/icons-material/Circle';

--- a/src/app/src/components/LoggedInAs.tsx
+++ b/src/app/src/components/LoggedInAs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';

--- a/src/app/src/contexts/ShiftKeyContext.tsx
+++ b/src/app/src/contexts/ShiftKeyContext.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import React, { useState, useEffect } from 'react';
+import React, { type ReactNode, useState, useEffect } from 'react';
 import { ShiftKeyContext } from './ShiftKeyContextDef';
 
 export const ShiftKeyProvider: React.FC<{ children: ReactNode }> = ({ children }) => {

--- a/src/app/src/contexts/ShiftKeyContextDef.ts
+++ b/src/app/src/contexts/ShiftKeyContextDef.ts
@@ -1,3 +1,3 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 
 export const ShiftKeyContext = createContext<boolean | undefined>(undefined);

--- a/src/app/src/contexts/ToastContextDef.ts
+++ b/src/app/src/contexts/ToastContextDef.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 import type { AlertColor } from '@mui/material';
 
 export interface ToastContextType {

--- a/src/app/src/contexts/UserContextDef.ts
+++ b/src/app/src/contexts/UserContextDef.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 
 interface UserContextType {
   email: string | null;

--- a/src/app/src/hooks/useApiHealth.tsx
+++ b/src/app/src/hooks/useApiHealth.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { callApi } from '@app/utils/api';
 import { useDebounce } from 'use-debounce';
 

--- a/src/app/src/hooks/useEmailVerification.ts
+++ b/src/app/src/hooks/useEmailVerification.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { callApi } from '@app/utils/api';
 
 interface EmailStatus {

--- a/src/app/src/hooks/useShiftKey.tsx
+++ b/src/app/src/hooks/useShiftKey.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { ShiftKeyContext } from '@app/contexts/ShiftKeyContextDef';
 
 export const useShiftKey = () => {

--- a/src/app/src/hooks/useTelemetry.tsx
+++ b/src/app/src/hooks/useTelemetry.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { callApi } from '@app/utils/api';
 import type { EventProperties, TelemetryEventTypes } from '@promptfoo/telemetry';
 

--- a/src/app/src/hooks/useToast.tsx
+++ b/src/app/src/hooks/useToast.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { ToastContext } from '@app/contexts/ToastContextDef';
 
 export const useToast = () => {

--- a/src/app/src/hooks/useUser.tsx
+++ b/src/app/src/hooks/useUser.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { UserContext } from '@app/contexts/UserContextDef';
 
 export function useUser() {

--- a/src/app/src/main.tsx
+++ b/src/app/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';

--- a/src/app/src/pages/eval/components/AuthorChip.tsx
+++ b/src/app/src/pages/eval/components/AuthorChip.tsx
@@ -1,5 +1,4 @@
-import type { KeyboardEvent } from 'react';
-import React, { useState, useEffect } from 'react';
+import React, { type KeyboardEvent, useState, useEffect } from 'react';
 import EditIcon from '@mui/icons-material/Edit';
 import EmailIcon from '@mui/icons-material/Email';
 import InfoIcon from '@mui/icons-material/Info';

--- a/src/app/src/pages/eval/components/Citations.tsx
+++ b/src/app/src/pages/eval/components/Citations.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DescriptionIcon from '@mui/icons-material/Description';

--- a/src/app/src/pages/eval/components/CompareEvalMenuItem.tsx
+++ b/src/app/src/pages/eval/components/CompareEvalMenuItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import CompareIcon from '@mui/icons-material/Compare';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/src/app/src/pages/eval/components/CustomMetrics.tsx
+++ b/src/app/src/pages/eval/components/CustomMetrics.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import './CustomMetrics.css';
 

--- a/src/app/src/pages/eval/components/DownloadMenu.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DownloadIcon from '@mui/icons-material/Download';

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useShiftKey } from '@app/hooks/useShiftKey';
 import Tooltip from '@mui/material/Tooltip';

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Box from '@mui/material/Box';

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -4,8 +4,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import { useToast } from '@app/hooks/useToast';

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { IS_RUNNING_LOCALLY } from '@app/constants';
 import { useToast } from '@app/hooks/useToast';

--- a/src/app/src/pages/eval/components/TableCommentDialog.tsx
+++ b/src/app/src/pages/eval/components/TableCommentDialog.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';

--- a/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
+++ b/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { useResultsViewSettingsStore } from '../../store';
 
 export interface SettingsState {

--- a/src/app/src/pages/eval/components/TruncatedText.tsx
+++ b/src/app/src/pages/eval/components/TruncatedText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 function textLength(node: React.ReactNode): number {
   if (typeof node === 'string' || typeof node === 'number') {

--- a/src/app/src/pages/evals/components/EvalsDataGrid.tsx
+++ b/src/app/src/pages/evals/components/EvalsDataGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState, useRef, forwardRef } from 'react';
+import React, { useMemo, useEffect, useState, useRef, forwardRef } from 'react';
 import { callApi } from '@app/utils/api';
 import { Box, Typography, Paper, CircularProgress, useTheme, Link } from '@mui/material';
 import {

--- a/src/app/src/pages/evals/page.tsx
+++ b/src/app/src/pages/evals/page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container } from '@mui/material';
 import EvalsDataGrid from './components/EvalsDataGrid';

--- a/src/app/src/pages/history/History.tsx
+++ b/src/app/src/pages/history/History.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';

--- a/src/app/src/pages/launcher/page.tsx
+++ b/src/app/src/pages/launcher/page.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import logoPanda from '@app/assets/logo-panda.svg';
 import useApiConfig from '@app/stores/apiConfig';

--- a/src/app/src/pages/login.tsx
+++ b/src/app/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useUserStore } from '@app/stores/userStore';
 import { callApi } from '@app/utils/api';

--- a/src/app/src/pages/redteam/report/page.tsx
+++ b/src/app/src/pages/redteam/report/page.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CrispChat from '@app/components/CrispChat';
 import { UserProvider } from '@app/contexts/UserContext';

--- a/src/app/src/pages/redteam/setup/components/CustomIntentPluginSection.tsx
+++ b/src/app/src/pages/redteam/setup/components/CustomIntentPluginSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FileUploadIcon from '@mui/icons-material/FileUpload';

--- a/src/app/src/pages/redteam/setup/components/PluginConfigDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginConfigDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import Box from '@mui/material/Box';

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';

--- a/src/app/src/pages/redteam/setup/components/Prompts.tsx
+++ b/src/app/src/pages/redteam/setup/components/Prompts.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Typography, TextField, IconButton, Button } from '@mui/material';

--- a/src/app/src/pages/redteam/setup/components/Strategies.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomPoliciesSection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomPoliciesSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, memo } from 'react';
+import React, { useState, useEffect, useCallback, memo } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';

--- a/src/app/src/pages/redteam/setup/hooks/usePlugins.ts
+++ b/src/app/src/pages/redteam/setup/hooks/usePlugins.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { categoryLabels } from '@promptfoo/redteam/constants';
 
 export function usePlugins() {

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import CrispChat from '@app/components/CrispChat';
 import { useTelemetry } from '@app/hooks/useTelemetry';


### PR DESCRIPTION
## Summary
- use default React import with named hooks
- clean up duplicate React imports in React components and hooks

## Testing
- `npm run f` *(fails: ambiguous argument 'origin/main')*
- `npm run l` *(fails: ambiguous argument 'origin/main')*