### PR TITLE
chore: remove redundant test comments

### DIFF
--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -1,13 +1,10 @@
 import readline from 'readline';
-// Import *after* mocking
 import { sendFeedback, gatherFeedback } from '../src/feedback';
 import { fetchWithProxy } from '../src/fetch';
 import logger from '../src/logger';
 
-// Store the original implementation to reference in mocks
 const actualFeedback = jest.requireActual('../src/feedback');
 
-// Mock dependencies
 jest.mock('../src/fetch', () => ({
   fetchWithProxy: jest.fn(),
 }));
@@ -21,10 +18,8 @@ jest.mock('../src/globalConfig/accounts', () => ({
   getUserEmail: jest.fn(),
 }));
 
-// Create a type for our mocked question function
 type MockQuestionFn = jest.Mock<void, [string, (answer: string) => void]>;
 
-// Create a partial readline Interface mock
 const createMockInterface = () => {
   return {
     question: jest.fn((query: string, callback: (answer: string) => void) => {
@@ -32,7 +27,6 @@ const createMockInterface = () => {
     }) as MockQuestionFn,
     close: jest.fn(),
     on: jest.fn(),
-    // Add minimum required properties to satisfy the Interface type
     line: '',
     cursor: 0,
     setPrompt: jest.fn(),
@@ -52,7 +46,6 @@ jest.mock('readline', () => ({
   createInterface: jest.fn(() => createMockInterface()),
 }));
 
-// Mock feedback module
 jest.mock('../src/feedback', () => {
   return {
     sendFeedback: jest.fn(),
@@ -60,7 +53,6 @@ jest.mock('../src/feedback', () => {
   };
 });
 
-// Helper to create a mock Response
 const createMockResponse = (data: any): Response => {
   return {
     ok: data.ok,
@@ -82,29 +74,23 @@ const createMockResponse = (data: any): Response => {
 };
 
 describe('Feedback Module', () => {
-  // Store original console.log
   const originalConsoleLog = console.log;
 
   beforeEach(() => {
-    // Reset all mocks before each test
     jest.clearAllMocks();
-    // Silence console output during tests
     jest.spyOn(console, 'log').mockImplementation();
   });
 
   afterEach(() => {
-    // Restore console.log after each test
     console.log = originalConsoleLog;
   });
 
   describe('sendFeedback', () => {
-    // Add the actual implementation for these tests
     beforeEach(() => {
       jest.mocked(sendFeedback).mockImplementation(actualFeedback.sendFeedback);
     });
 
     it('should send feedback successfully', async () => {
-      // Mock a successful API response
       const mockResponse = createMockResponse({ ok: true });
       jest.mocked(fetchWithProxy).mockResolvedValueOnce(mockResponse);
 
@@ -120,12 +106,10 @@ describe('Feedback Module', () => {
         }),
       );
 
-      // Verify success message was logged
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Feedback sent'));
     });
 
     it('should handle API failure', async () => {
-      // Mock a failed API response
       const mockResponse = createMockResponse({ ok: false, status: 500 });
       jest.mocked(fetchWithProxy).mockResolvedValueOnce(mockResponse);
 
@@ -135,7 +119,6 @@ describe('Feedback Module', () => {
     });
 
     it('should handle network errors', async () => {
-      // Mock a network error
       jest.mocked(fetchWithProxy).mockRejectedValueOnce(new Error('Network error'));
 
       await sendFeedback('Test feedback');
@@ -146,56 +129,45 @@ describe('Feedback Module', () => {
     it('should not send empty feedback', async () => {
       await sendFeedback('');
 
-      // Verify that fetch was not called
       expect(fetchWithProxy).not.toHaveBeenCalled();
     });
   });
 
   describe('gatherFeedback', () => {
     it('should send feedback directly if a message is provided', async () => {
-      // Create a simplified implementation for this test
       jest.mocked(gatherFeedback).mockImplementation(async (message) => {
         if (message) {
           await sendFeedback(message);
         }
       });
 
-      // Reset sendFeedback to be a jest function we can track
       jest.mocked(sendFeedback).mockReset();
 
-      // Run the test
       await gatherFeedback('Direct feedback');
 
-      // Verify sendFeedback was called with the direct message
       expect(sendFeedback).toHaveBeenCalledWith('Direct feedback');
     });
 
     it('should handle empty feedback input', async () => {
-      // Setup readline to return empty feedback
       const mockInterface = createMockInterface();
-      // Override the default behavior for this test
       (mockInterface.question as MockQuestionFn).mockImplementationOnce(
         (_: string, callback: (answer: string) => void) => callback('   '),
       );
 
       jest.mocked(readline.createInterface).mockReturnValue(mockInterface);
 
-      // Use real implementation for gatherFeedback
       jest.mocked(gatherFeedback).mockImplementation(actualFeedback.gatherFeedback);
 
       await gatherFeedback();
 
-      // Verify sendFeedback was not called due to empty input
       expect(sendFeedback).not.toHaveBeenCalled();
     });
 
     it('should handle errors during feedback gathering', async () => {
-      // Mock readline to throw an error
       jest.mocked(readline.createInterface).mockImplementation(() => {
         throw new Error('Test error');
       });
 
-      // Use real implementation for gatherFeedback
       jest.mocked(gatherFeedback).mockImplementation(actualFeedback.gatherFeedback);
 
       await gatherFeedback();

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -278,11 +278,9 @@ describe('synthesize', () => {
     });
 
     it('should expand strategy collections into individual strategies', async () => {
-      // Mock plugin to generate test cases
       const mockPluginAction = jest.fn().mockResolvedValue([{ test: 'case' }]);
       jest.spyOn(Plugins, 'find').mockReturnValue({ action: mockPluginAction, key: 'mockPlugin' });
 
-      // Mock strategy actions
       const mockStrategyAction = jest.fn().mockReturnValue([{ test: 'strategy case' }]);
       jest.spyOn(Strategies, 'find').mockImplementation((s: any) => {
         if (['morse', 'piglatin'].includes(s.id)) {
@@ -291,7 +289,6 @@ describe('synthesize', () => {
         return undefined;
       });
 
-      // Use the other-encodings collection
       await synthesize({
         language: 'en',
         numTests: 1,
@@ -306,9 +303,6 @@ describe('synthesize', () => {
         targetLabels: ['test-provider'],
       });
 
-      // Just verify validateStrategies was called
-      // The mock implementation might not be executed in the test context,
-      // but we can confirm the expansion mechanism is working
       expect(validateStrategies).toHaveBeenCalledWith(expect.any(Array));
     });
 
@@ -368,25 +362,21 @@ describe('synthesize', () => {
         targetLabels: ['test-provider'],
       });
 
-      // Should log a warning for unknown strategy collection
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('unknown-collection not registered'),
       );
     });
 
     it('should skip plugins that fail validation and not throw', async () => {
-      // Plugin 1: will fail validation
       const failingPlugin = {
         id: 'fail-plugin',
         numTests: 1,
       };
-      // Plugin 2: will succeed
       const passingPlugin = {
         id: 'pass-plugin',
         numTests: 1,
       };
 
-      // Mock Plugins.find to return a plugin with a validate method that throws for fail-plugin
       jest
         .spyOn(Plugins, 'find')
         .mockReturnValueOnce({
@@ -526,7 +516,6 @@ describe('synthesize', () => {
       callApi: jest.fn().mockResolvedValue({ output: 'test output' }),
     });
 
-    // Mock plugin to generate a test case
     const mockPlugin = {
       id: 'test-plugin',
       numTests: 1,
@@ -568,11 +557,9 @@ describe('synthesize', () => {
 
   describe('Direct plugin handling', () => {
     it('should recognize and not expand direct plugins like bias:gender', async () => {
-      // Mock the Plugins.find method to recognize bias:gender as a direct plugin
       const mockPluginAction = jest.fn().mockImplementation(({ n }) => {
         return Array(n).fill({ test: 'bias:gender case' });
       });
-      // Use mockReturnValue with a pre-created object that matches what's returned in the actual code
       jest.spyOn(Plugins, 'find').mockReturnValue({ key: 'bias:gender', action: mockPluginAction });
 
       const result = await synthesize({
@@ -604,9 +591,7 @@ describe('synthesize', () => {
     });
 
     it('should still expand category plugins with new bias category', async () => {
-      // Mock for any plugin to return test cases
       const mockPluginAction = jest.fn().mockResolvedValue([{ test: 'case' }]);
-      // Use mockReturnValue with a generic mock that will work for all plugins
       jest.spyOn(Plugins, 'find').mockReturnValue({ key: 'mockPlugin', action: mockPluginAction });
 
       const result = await synthesize({

--- a/test/redteam/plugins/pluginId.test.ts
+++ b/test/redteam/plugins/pluginId.test.ts
@@ -114,7 +114,6 @@ describe('Plugin IDs', () => {
     uniqueIds.forEach((id) => {
       if (id === 'policy') {
         // This is a special case where the ID is not prefixed in the code
-        console.log("Note: Found 'policy' ID without prefix - this is a special case");
       }
     });
 

--- a/test/site/markdown.test.ts
+++ b/test/site/markdown.test.ts
@@ -30,31 +30,25 @@ Multiple newlines above.
   it('should sanitize markdown with sane defaults', () => {
     const result = sanitizeMarkdown(sampleMarkdown);
 
-    // Should remove frontmatter
     expect(result).not.toContain('---');
     expect(result).not.toContain('title: Test Document');
     expect(result).not.toContain('author: Test Author');
 
-    // Should remove images
     expect(result).not.toContain('![an image](image.jpg)');
     expect(result).not.toContain('<img src="test.jpg"');
 
-    // Should remove HTML comments
     expect(result).not.toContain('<!-- This is a comment -->');
 
-    // Should remove styled divs but preserve content
     expect(result).not.toContain('<div style="color: red;">');
     expect(result).toContain('Styled content');
 
-    // Should preserve code blocks and links (sane defaults)
     expect(result).toContain('console.log');
     expect(result).toContain('```javascript');
     expect(result).toContain('`inline code`');
     expect(result).toContain('[link](https://example.com)');
 
-    // Should normalize whitespace
     expect(result).not.toMatch(/\n\n\n/);
-    expect(result).toMatch(/^# Main Title/); // Should be trimmed
+    expect(result).toMatch(/^# Main Title/);
   });
 
   it('should handle empty string', () => {


### PR DESCRIPTION
## Summary
- trim comments in feedback test suite
- remove superficial comments in markdown and plugin tests
- remove logging notes in redteam test suite

## Testing
- `npx prettier --write test/feedback.test.ts test/site/markdown.test.ts test/redteam/plugins/pluginId.test.ts test/redteam/index.test.ts`
- `npx eslint --max-warnings=0 --fix test/feedback.test.ts test/site/markdown.test.ts test/redteam/plugins/pluginId.test.ts test/redteam/index.test.ts` *(fails: Parsing error)*
- `npm test` *(fails: The @smithy/node-http-handler package is required)*