### PR TITLE
fix: remove ts-ignore for tsx import

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -24,7 +24,6 @@ export async function importModule(modulePath: string, functionName?: string) {
   try {
     if (modulePath.endsWith('.ts') || modulePath.endsWith('.mjs')) {
       logger.debug('TypeScript/ESM module detected, importing tsx/cjs');
-      // @ts-ignore: It actually works
       await import('tsx/cjs');
     }
 

--- a/typings/tsx-cjs.d.ts
+++ b/typings/tsx-cjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'tsx/cjs';


### PR DESCRIPTION
## Summary
- add type declaration for `tsx/cjs`
- clean up ignore in `importModule`

## Testing
- `npx eslint src/esm.ts typings/tsx-cjs.d.ts`
- `npm test -- -b` *(fails: fetch.test.ts, bedrock knowledge base tests)*