### PR TITLE
fix(docs): Fix issue with docs links not scrolling to the top

### DIFF
--- a/site/src/pages/llm-vulnerability-scanner.module.css
+++ b/site/src/pages/llm-vulnerability-scanner.module.css
@@ -835,7 +835,6 @@ section {
 /* Carousel-specific overflow - only apply to carousel containers */
 .actionOrientedSection {
   padding: 4rem 0;
-  /* Remove overflow-x hidden that interferes with page scroll */
 }
 
 /* Only apply overflow hidden to carousel container specifically */

--- a/site/src/pages/llm-vulnerability-scanner.module.css
+++ b/site/src/pages/llm-vulnerability-scanner.module.css
@@ -837,7 +837,6 @@ section {
   padding: 4rem 0;
 }
 
-/* Only apply overflow hidden to carousel container specifically */
 .carouselContainer {
   overflow: hidden !important;
 }

--- a/site/src/pages/llm-vulnerability-scanner.module.css
+++ b/site/src/pages/llm-vulnerability-scanner.module.css
@@ -832,12 +832,14 @@ section {
   padding: 25px 0 0;
 }
 
+/* Carousel-specific overflow - only apply to carousel containers */
 .actionOrientedSection {
-  overflow-x: hidden !important;
   padding: 4rem 0;
+  /* Remove overflow-x hidden that interferes with page scroll */
 }
 
-.container {
+/* Only apply overflow hidden to carousel container specifically */
+.carouselContainer {
   overflow: hidden !important;
 }
 
@@ -977,14 +979,6 @@ section {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
-/* Override any parent container that might clip our carousel */
-:global(.mainContent),
-:global(main),
-:global(section),
-:global(.container) {
-  overflow: visible !important;
-}
-
 /* Add some extra space on mobile */
 @media (max-width: 768px) {
   .processCarousel {
@@ -1014,19 +1008,6 @@ section {
   padding-left: 0 !important;
   padding-right: 0 !important;
   max-width: 100% !important;
-}
-
-/* Make sure page main content doesn't clip */
-.pageContainer {
-  overflow: visible !important;
-}
-
-/* Make sure page doesn't scroll horizontally */
-:global(html),
-:global(body),
-:global(#__docusaurus),
-:global(#__docusaurus > div) {
-  overflow-x: hidden !important;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
There was an issue moving between the homepage and the docs site- specifically, the scroll height would be maintained between links, and clicking an image to expand wouldn't work. After some digging, I found the offending commit https://github.com/promptfoo/promptfoo/pull/3733 and was able to identify two conflicting global css styles that were causing these issues.

## Demo

https://github.com/user-attachments/assets/90abd6f5-9c7e-4a07-8996-9f5bef64ce7f

