### PR TITLE
fix: Gemini MCP integration - can not parse $schema field

### DIFF
--- a/src/providers/mcp/transform.ts
+++ b/src/providers/mcp/transform.ts
@@ -51,7 +51,9 @@ export function transformMCPToolsToGoogle(tools: MCPTool[]): GoogleTool[] {
     const schema: MCPToolInputSchema = tool.inputSchema;
     let parameters: GoogleSchema = { type: 'OBJECT', properties: {} };
     if (schema && typeof schema === 'object' && 'properties' in schema) {
-      parameters = { type: 'OBJECT', ...schema };
+      // Remove $schema field if present
+      const { $schema: _$schema, ...cleanSchema } = schema;
+      parameters = { type: 'OBJECT', ...cleanSchema };
     } else {
       parameters = {
         type: 'OBJECT',


### PR DESCRIPTION
MCP integration was failing with Google Gemini models, causing two specific errors. Described in [Discord question](https://discord.com/channels/1153767083381903389/1374551152460566649):
  - Google AI Studio: Error: Expected one candidate in API response
  - Google Vertex: Invalid JSON payload received. Unknown name "$schema"

**Root Cause**

MCP servers can include $schema fields in their tool definitions (following JSON Schema conventions), but Google's API rejects these fields as invalid. [Reference for general MCP format: MCP Specs](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#protocol-messages)

**Solution**

Added one line to remove $schema field from MCP tool schemas before sending to Google API

  **Testing**

  - ✅ Made sure the issue stems from `$schema` field by making an MCP server and (un)commenting `$schema` in JSON responses and testing with different build versions
  - ✅ New test specifically validates $schema field removal
  - ✅ Now tests cover OpenAI, Anthropic, and Google transforms

  **References**

  - https://ai.google.dev/gemini-api/docs/function-calling

Likely will need to review in the future with the evolving MCP protocols for similar optional fields.