### PR TITLE
chore: Always include raw output from http provider, status code and status text

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -811,8 +811,9 @@ export class HttpProvider implements ApiProvider {
     );
 
     const ret: ProviderResponse = {};
+    ret.raw = response.data;
+
     if (context?.debug) {
-      ret.raw = response.data;
       ret.metadata = {
         headers: response.headers,
       };

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -812,11 +812,12 @@ export class HttpProvider implements ApiProvider {
 
     const ret: ProviderResponse = {};
     ret.raw = response.data;
-
+    ret.metadata = {
+      httpStatus: response.status,
+      httpStatusText: response.statusText,
+    };
     if (context?.debug) {
-      ret.metadata = {
-        headers: response.headers,
-      };
+      ret.metadata.headers = response.headers;
     }
 
     const rawText = response.data as string;

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -812,13 +812,11 @@ export class HttpProvider implements ApiProvider {
 
     const ret: ProviderResponse = {};
     ret.raw = response.data;
-    ret.metadata = {
-      httpStatus: response.status,
-      httpStatusText: response.statusText,
+    ret.http = {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers || {},
     };
-    if (context?.debug) {
-      ret.metadata.headers = response.headers;
-    }
 
     const rawText = response.data as string;
     let parsedData;

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -129,6 +129,11 @@ export interface ProviderResponse {
     transcript?: string;
     format?: string;
   };
+  http?: {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+  };
 }
 
 export interface ProviderEmbeddingResponse {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1339,7 +1339,11 @@ describe('HttpProvider', () => {
 
       const result = await provider.callApi('test');
 
-      expect(result).toEqual({ output: { chat_history: 'success' } });
+      expect(result).toEqual({
+        output: { chat_history: 'success' },
+        raw: JSON.stringify({ result: 'success' }),
+        http: { status: 200, statusText: 'OK', headers: {} },
+      });
     });
 
     it('should prefer transformResponse over responseParser when both are set', async () => {
@@ -1362,7 +1366,11 @@ describe('HttpProvider', () => {
 
       const result = await provider.callApi('test');
 
-      expect(result).toEqual({ output: { chat_history: 'from transformResponse' } });
+      expect(result).toEqual({
+        output: { chat_history: 'from transformResponse' },
+        raw: JSON.stringify({ result: 'success' }),
+        http: { status: 200, statusText: 'OK', headers: {} },
+      });
     });
 
     it('should handle string-based responseParser when transformResponse is not set', async () => {
@@ -1384,7 +1392,11 @@ describe('HttpProvider', () => {
 
       const result = await provider.callApi('test');
 
-      expect(result).toEqual({ output: 'success' });
+      expect(result).toEqual({
+        output: 'success',
+        raw: JSON.stringify({ result: 'success' }),
+        http: { status: 200, statusText: 'OK', headers: {} },
+      });
     });
   });
 
@@ -1926,8 +1938,10 @@ describe('response handling', () => {
       vars: {},
     });
 
-    expect(result.metadata).toEqual({
+    expect(result.http).toEqual({
       headers: mockHeaders,
+      status: 200,
+      statusText: 'OK',
     });
     expect(result.raw).toEqual(mockData);
   });
@@ -1983,7 +1997,7 @@ describe('response handling', () => {
     });
 
     expect(result.raw).toEqual(mockData);
-    expect(result.metadata).toHaveProperty('headers', mockHeaders);
+    expect(result.http).toHaveProperty('headers', mockHeaders);
     expect(result.output).toEqual({ foo: 'bar' });
   });
 
@@ -2048,7 +2062,7 @@ describe('response handling', () => {
     // Verify transformed response and debug info
     expect(result.output).toEqual({ transformed: true });
     expect(result.raw).toEqual(mockData);
-    expect(result.metadata).toHaveProperty('headers', mockHeaders);
+    expect(result.http).toHaveProperty('headers', mockHeaders);
   });
 });
 


### PR DESCRIPTION
Always include raw output from http provider, http status code and status text. This will make debugging much easier

<img width="1513" alt="image" src="https://github.com/user-attachments/assets/705f4fcc-8c62-40d9-9663-d619d1fe6213" />
