### PR TITLE
fix: Relax private key validation

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/HttpAdvancedConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/HttpAdvancedConfiguration.tsx
@@ -515,7 +515,7 @@ const HttpAdvancedConfiguration: React.FC<HttpAdvancedConfigurationProps> = ({
                             try {
                               const inputKey =
                                 selectedTarget.config.signatureAuth?.privateKey || '';
-                              const formattedKey = convertStringKeyToPem(inputKey);
+                              const formattedKey = await convertStringKeyToPem(inputKey);
                               updateCustomTarget('signatureAuth', {
                                 ...selectedTarget.config.signatureAuth,
                                 privateKey: formattedKey,

--- a/src/app/src/pages/redteam/setup/utils/crypto.ts
+++ b/src/app/src/pages/redteam/setup/utils/crypto.ts
@@ -1,162 +1,71 @@
-const BEGIN_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----';
-const END_PRIVATE_KEY = '-----END PRIVATE KEY-----';
-const BEGIN_RSA_PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----';
-const END_RSA_PRIVATE_KEY = '-----END RSA PRIVATE KEY-----';
-const BEGIN_EC_PRIVATE_KEY = '-----BEGIN EC PRIVATE KEY-----';
-const END_EC_PRIVATE_KEY = '-----END EC PRIVATE KEY-----';
-
-// EC key constants
-const EC_POINT_FORMAT_BYTE = 0x04;
-const EC_PUBLIC_KEY_LENGTH = 65; // Size in bytes of uncompressed EC public key
-const EC_TYPICAL_KEY_LENGTH = 132; // Common total size for EC private key in DER format
-
 /**
- * Converts a raw base64-encoded RSA private key string into PEM format
- * by adding PKCS8 headers and proper line breaks if needed
- *
- * @param input - The private key string, either raw base64 or already in PEM format
- * @returns The properly formatted PEM string
+ * Validates a private key format without restricting algorithms
+ * Since actual signing happens server-side with Node.js crypto (which supports more algorithms)
  */
-export function convertStringKeyToPem(input: string): string {
-  // Remove any leading/trailing whitespace
-  const trimmedInput = input.trim();
+async function validateKeyWithWebCrypto(pemKey: string): Promise<void> {
+  try {
+    // Extract base64 content
+    const base64Content = pemKey
+      .replace(/-----BEGIN[^-]+-----/g, '')
+      .replace(/-----END[^-]+-----/g, '')
+      .replace(/\s/g, '');
 
-  // If it's already a properly formatted PEM, return as-is
-  if (trimmedInput.startsWith(BEGIN_PRIVATE_KEY) && trimmedInput.endsWith(END_PRIVATE_KEY)) {
-    return trimmedInput;
+    // Basic validation: check if it's valid base64
+    atob(base64Content);
+
+    // That's enough validation - let the server handle algorithm-specific validation
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Invalid character')) {
+      throw new Error('Invalid base64 encoding in private key');
+    }
+    throw new Error(
+      `Invalid private key format. Ensure the key is a valid PEM-formatted private key (PKCS#8, PKCS#1, or SEC1 format). Details: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
   }
-
-  // Clean the key by removing any existing headers, footers, or whitespace
-  const cleanKey = trimmedInput
-    .replace(new RegExp(BEGIN_PRIVATE_KEY, 'g'), '')
-    .replace(new RegExp(END_PRIVATE_KEY, 'g'), '')
-    .replace(/[\s-]/g, '');
-
-  // Split into 64-character chunks
-  const chunks = cleanKey.match(/.{1,64}/g) || [];
-
-  return [BEGIN_PRIVATE_KEY, ...chunks, END_PRIVATE_KEY].join('\n');
 }
 
 /**
- * Validates a private key string by attempting to parse it as a PKCS8 key
+ * Converts a private key string to PEM format and validates it
+ * Uses basic format validation since actual signing happens server-side
  *
- * @param input - The private key string, either raw base64 or in PEM format
- * @returns The formatted PEM string if valid, throws error if invalid
+ * @param input - The private key string in various formats
+ * @returns The properly formatted PEM string
  */
-export async function validatePrivateKey(input: string): Promise<string> {
-  // Remove any leading/trailing whitespace
+export async function convertStringKeyToPem(input: string): Promise<string> {
   const trimmedInput = input.trim();
 
-  try {
-    // Format the key first
-    let formattedKey: string;
-    const isEcKey = trimmedInput.includes(BEGIN_EC_PRIVATE_KEY);
-
-    if (trimmedInput.startsWith(BEGIN_PRIVATE_KEY) && trimmedInput.endsWith(END_PRIVATE_KEY)) {
-      formattedKey = trimmedInput;
-    } else if (
-      trimmedInput.startsWith(BEGIN_RSA_PRIVATE_KEY) &&
-      trimmedInput.endsWith(END_RSA_PRIVATE_KEY)
-    ) {
-      formattedKey = trimmedInput;
-    } else if (
-      trimmedInput.startsWith(BEGIN_EC_PRIVATE_KEY) &&
-      trimmedInput.endsWith(END_EC_PRIVATE_KEY)
-    ) {
-      formattedKey = trimmedInput;
-    } else {
-      // Clean the key
-      const cleanKey = trimmedInput.replace(/[\s-]/g, '');
-      // Split into 64-character chunks
-      const chunks = cleanKey.match(/.{1,64}/g) || [];
-      formattedKey = [BEGIN_EC_PRIVATE_KEY, ...chunks, END_EC_PRIVATE_KEY].join('\n');
-    }
-
-    // Extract the base64 content
-    const base64Content = formattedKey
-      .replace(BEGIN_PRIVATE_KEY, '')
-      .replace(END_PRIVATE_KEY, '')
-      .replace(BEGIN_RSA_PRIVATE_KEY, '')
-      .replace(END_RSA_PRIVATE_KEY, '')
-      .replace(BEGIN_EC_PRIVATE_KEY, '')
-      .replace(END_EC_PRIVATE_KEY, '')
-      .replace(/\s/g, '');
-
-    // Convert base64 to binary
-    const binaryDer = atob(base64Content);
-    const der = new Uint8Array(binaryDer.length);
-    for (let i = 0; i < binaryDer.length; i++) {
-      der[i] = binaryDer.charCodeAt(i);
-    }
-
-    // For EC keys, try specific EC import
-    if (der.length === EC_TYPICAL_KEY_LENGTH || isEcKey) {
-      try {
-        // Find the actual key data by looking for the EC point format byte
-        let keyStart = -1;
-        for (let i = 0; i < der.length - EC_PUBLIC_KEY_LENGTH; i++) {
-          if (der[i] === EC_POINT_FORMAT_BYTE && der.length - i >= EC_PUBLIC_KEY_LENGTH) {
-            keyStart = i;
-            break;
-          }
-        }
-
-        if (keyStart === -1) {
-          throw new Error('Could not find EC key data');
-        }
-
-        // Try different EC curves
-        const curves = ['P-256', 'P-384', 'P-521'];
-        for (const curve of curves) {
-          try {
-            await window.crypto.subtle.importKey(
-              'raw',
-              der.slice(keyStart),
-              {
-                name: 'ECDSA',
-                namedCurve: curve,
-              },
-              true,
-              ['sign'],
-            );
-            return formattedKey;
-          } catch (error) {
-            console.log(`EC import error for ${curve}:`, error);
-            continue;
-          }
-        }
-      } catch (error) {
-        console.log('EC key parsing error:', error);
-      }
-    }
-
-    // Try PKCS8 verification with the raw key data as a fallback
-    const algorithms = [
-      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-      { name: 'RSA-PSS', hash: 'SHA-256' },
-      { name: 'ECDH', namedCurve: 'P-256' },
-      { name: 'ECDH', namedCurve: 'P-384' },
-      { name: 'ECDH', namedCurve: 'P-521' },
-      { name: 'ECDSA', namedCurve: 'P-256' },
-      { name: 'ECDSA', namedCurve: 'P-384' },
-      { name: 'ECDSA', namedCurve: 'P-521' },
-      { name: 'Ed25519' },
-    ];
-
-    for (const algorithm of algorithms) {
-      try {
-        const format = 'pkcs8';
-        await window.crypto.subtle.importKey(format, der, algorithm, true, ['sign']);
-        return formattedKey;
-      } catch (error) {
-        console.log('error:', error);
-        continue;
-      }
-    }
-
-    throw new Error('Key format is valid but algorithm type could not be determined');
-  } catch (error) {
-    throw new Error('Invalid private key format. Details: ' + error);
+  if (!trimmedInput) {
+    throw new Error('Private key cannot be empty');
   }
+
+  // If it's already in PEM format, validate it and return
+  if (trimmedInput.includes('-----BEGIN') && trimmedInput.includes('-----END')) {
+    await validateKeyWithWebCrypto(trimmedInput);
+    return trimmedInput;
+  }
+
+  // Try to format as PKCS8 PEM (assumes raw base64 is PKCS#8 format)
+  const cleanKey = trimmedInput.replace(/\s/g, '');
+  const chunks = cleanKey.match(/.{1,64}/g) || [];
+  const pemFormatted = ['-----BEGIN PRIVATE KEY-----', ...chunks, '-----END PRIVATE KEY-----'].join(
+    '\n',
+  );
+
+  // Validate the formatted key
+  await validateKeyWithWebCrypto(pemFormatted);
+  return pemFormatted;
+}
+
+/**
+ * Validates a private key string by attempting to parse it
+ *
+ * @param input - The private key string
+ */
+export async function validatePrivateKey(input: string): Promise<void> {
+  if (!input.trim()) {
+    throw new Error('Private key cannot be empty');
+  }
+
+  // Use the robust conversion function which includes validation
+  await convertStringKeyToPem(input);
 }


### PR DESCRIPTION
This validation logic was failing incorrectly. The idea that we're able to identify every valid combination was a little ambitious. We'll do some basic checks and then let the server decide.