### PR TITLE
refactor: centralize readline utilities to fix Jest open handle issues

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import dedent from 'dedent';
-import readline from 'readline';
 import { fetchWithProxy } from './fetch';
 import { getUserEmail } from './globalConfig/accounts';
 import logger from './logger';
+import { promptUser } from './util/readline';
 
 /**
  * Send feedback to the promptfoo API
@@ -37,23 +37,6 @@ export async function sendFeedback(feedback: string) {
 }
 
 /**
- * Simple readline prompt that returns a promise
- */
-function prompt(question: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
-  });
-}
-
-/**
  * Gather and send user feedback
  */
 export async function gatherFeedback(message?: string) {
@@ -71,7 +54,7 @@ export async function gatherFeedback(message?: string) {
     console.log(chalk.dim('─'.repeat(40)));
 
     // Get feedback message
-    const feedbackText = await prompt(
+    const feedbackText = await promptUser(
       dedent`
       ${chalk.gray('Share your thoughts, bug reports, or feature requests:')}
       ${chalk.bold('> ')}
@@ -90,7 +73,7 @@ export async function gatherFeedback(message?: string) {
     if (userEmail) {
       contactInfo = userEmail;
     } else {
-      const contactResponse = await prompt(
+      const contactResponse = await promptUser(
         chalk.gray("Email address (optional, if you'd like a response): "),
       );
       contactInfo = contactResponse.trim();

--- a/src/util/readline.ts
+++ b/src/util/readline.ts
@@ -1,0 +1,52 @@
+import readline from 'readline';
+
+/**
+ * Factory function for creating readline interface.
+ * This abstraction makes it easier to mock in tests and prevents open handles.
+ */
+export function createReadlineInterface(): readline.Interface {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+/**
+ * Prompts the user with a question and returns their answer.
+ * Automatically handles cleanup of the readline interface.
+ */
+export async function promptUser(question: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    try {
+      const rl = createReadlineInterface();
+
+      rl.question(question, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+
+      // Handle errors
+      rl.on('error', (err) => {
+        rl.close();
+        reject(err);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Prompts the user with a yes/no question and returns a boolean.
+ * @param question The question to ask
+ * @param defaultYes If true, empty response defaults to yes. If false, defaults to no.
+ */
+export async function promptYesNo(question: string, defaultYes = false): Promise<boolean> {
+  const suffix = defaultYes ? '(Y/n): ' : '(y/N): ';
+  const answer = await promptUser(`${question} ${suffix}`);
+
+  if (defaultYes) {
+    return !answer.toLowerCase().startsWith('n');
+  }
+  return answer.toLowerCase().startsWith('y');
+} 

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -1,7 +1,7 @@
 import opener from 'opener';
-import readline from 'readline';
 import { VERSION, getDefaultPort } from '../constants';
 import logger from '../logger';
+import { promptYesNo } from './readline';
 
 export enum BrowserBehavior {
   ASK = 0,
@@ -9,40 +9,6 @@ export enum BrowserBehavior {
   SKIP = 2,
   OPEN_TO_REPORT = 3,
   OPEN_TO_REDTEAM_CREATE = 4,
-}
-
-/**
- * Prompts the user with a question and returns a Promise that resolves with their answer
- */
-export async function promptUser(question: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    try {
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-
-      rl.question(question, (answer) => {
-        rl.close();
-        resolve(answer);
-      });
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Prompts the user with a yes/no question and returns a Promise that resolves with a boolean
- */
-export async function promptYesNo(question: string, defaultYes = false): Promise<boolean> {
-  const suffix = defaultYes ? '(Y/n): ' : '(y/N): ';
-  const answer = await promptUser(`${question} ${suffix}`);
-
-  if (defaultYes) {
-    return !answer.toLowerCase().startsWith('n');
-  }
-  return answer.toLowerCase().startsWith('y');
 }
 
 export async function checkServerRunning(port = getDefaultPort()): Promise<boolean> {


### PR DESCRIPTION
## Description

This PR refactors readline interface creation into a centralized utility module to fix Jest open handle warnings and improve code reuse.

## Problem

- Multiple files were creating readline interfaces independently
- Jest tests were showing TTYWRAP open handle warnings
- Duplicate code for prompting users across the codebase
- Difficult to mock readline consistently in tests

## Solution

- Created new `src/util/readline.ts` module with centralized utilities:
  - `createReadlineInterface()` - Factory function for creating readline interfaces
  - `promptUser(question)` - General purpose prompt that returns a string
  - `promptYesNo(question, defaultYes?)` - Yes/no prompt that returns a boolean
- Updated all files to use the new centralized utilities
- Removed redundant `promptConfirm` function (was just a wrapper around `promptYesNo`)
- Updated tests to mock the new utilities module instead of readline directly

## Changes

- ✨ **New file**: `src/util/readline.ts` - Centralized readline utilities
- 📝 **Modified**: `src/util/server.ts` - Use new readline utilities
- 📝 **Modified**: `src/feedback.ts` - Use new readline utilities  
- 📝 **Modified**: `src/evaluator.ts` - Use new readline utilities
- 🧪 **Modified**: `test/util/server.test.ts` - Mock new utilities
- 🧪 **Modified**: `test/feedback.test.ts` - Mock new utilities

## Benefits

- ✅ Eliminates Jest TTYWRAP open handle warnings
- ✅ Improves code reuse and maintainability
- ✅ Simplifies testing with consistent mocking
- ✅ Cleaner API with just 3 focused functions
- ✅ All tests passing without open handles

## Testing

- All existing tests pass
- No more open handle warnings when running `npx jest --detectOpenHandles`
- Verified readline functionality works correctly in all affected modules 