### PR TITLE
fix: resolve env variables in renderVarsInObject (issue #4143)

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -5,7 +5,6 @@ import deepEqual from 'fast-deep-equal';
 import * as fs from 'fs';
 import { globSync } from 'glob';
 import yaml from 'js-yaml';
-import nunjucks from 'nunjucks';
 import * as path from 'path';
 import { TERMINAL_MAX_WIDTH } from '../constants';
 import { getEnvBool, getEnvString } from '../envars';
@@ -375,7 +374,8 @@ export function renderVarsInObject<T>(obj: T, vars?: Record<string, string | obj
     return obj;
   }
   if (typeof obj === 'string') {
-    return nunjucks.renderString(obj, vars) as unknown as T;
+    const nunjucksEngine = getNunjucksEngine();
+    return nunjucksEngine.renderString(obj, vars) as unknown as T;
   }
   if (Array.isArray(obj)) {
     return obj.map((item) => renderVarsInObject(item, vars)) as unknown as T;

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -147,6 +147,25 @@ describe('renderPrompt', () => {
     expect(renderedPrompt).toBe(JSON.stringify({ text: 'value1' }, null, 2));
   });
 
+  it('should render environment variables in JSON prompts', async () => {
+    process.env.TEST_ENV_VAR = 'env_value';
+    const prompt = toPrompt('{"text": "{{ env.TEST_ENV_VAR }}"}');
+    console.log('Original prompt:', prompt.raw);
+    console.log('Environment variable value:', process.env.TEST_ENV_VAR);
+    const renderedPrompt = await renderPrompt(prompt, {}, {});
+    console.log('Rendered prompt:', renderedPrompt);
+    expect(renderedPrompt).toBe(JSON.stringify({ text: 'env_value' }, null, 2));
+    delete process.env.TEST_ENV_VAR;
+  });
+
+  it('should render environment variables in non-JSON prompts', async () => {
+    process.env.TEST_ENV_VAR = 'env_value';
+    const prompt = toPrompt('Test prompt {{ env.TEST_ENV_VAR }}');
+    const renderedPrompt = await renderPrompt(prompt, {}, {});
+    expect(renderedPrompt).toBe('Test prompt env_value');
+    delete process.env.TEST_ENV_VAR;
+  });
+
   it('should handle complex variable substitutions in JSON prompts', async () => {
     const prompt = toPrompt('{"message": "{{ var1[var2] }}"}');
     const renderedPrompt = await renderPrompt(

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -22,6 +22,7 @@ import {
   writeMultipleOutputs,
   writeOutput,
   maybeLoadToolsFromExternalFile,
+  renderVarsInObject,
 } from '../../src/util';
 import { TestGrader } from './utils';
 
@@ -671,5 +672,16 @@ describe('setupEnv', () => {
     // Then load .env.production with override (should change NODE_ENV to 'production')
     setupEnv('.env.production');
     expect(process.env.NODE_ENV).toBe('production');
+  });
+});
+
+describe('renderVarsInObject', () => {
+  it('should render environment variables in objects', () => {
+    process.env.TEST_ENV_VAR = 'env_value';
+    const obj = { text: '{{ env.TEST_ENV_VAR }}' };
+    const rendered = renderVarsInObject(obj, {});
+    console.log('Rendered object:', rendered);
+    expect(rendered).toEqual({ text: 'env_value' });
+    delete process.env.TEST_ENV_VAR;
   });
 });


### PR DESCRIPTION
Fixes issue #4143 where {{env.variable}} syntax wasn't working in prompts during view mode and assertion eval. Updated renderVarsInObject() to use getNunjucksEngine() instead of raw nunjucks. All tests passed.