### PR TITLE
feat: hide diff option when single column

### DIFF
--- a/src/app/src/pages/eval/components/FilterModeSelector.test.tsx
+++ b/src/app/src/pages/eval/components/FilterModeSelector.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { FilterModeSelector } from './FilterModeSelector';
+
+const noop = () => {};
+
+describe('FilterModeSelector', () => {
+  it('hides different option when showDifferentOption is false', () => {
+    render(<FilterModeSelector filterMode="all" onChange={noop} showDifferentOption={false} />);
+    expect(screen.queryByText('Show different outputs')).not.toBeInTheDocument();
+  });
+
+  it('shows different option when showDifferentOption is true', () => {
+    render(<FilterModeSelector filterMode="all" onChange={noop} showDifferentOption />);
+    expect(screen.getByText('Show different outputs')).toBeInTheDocument();
+  });
+});

--- a/src/app/src/pages/eval/components/FilterModeSelector.tsx
+++ b/src/app/src/pages/eval/components/FilterModeSelector.tsx
@@ -8,9 +8,10 @@ import Select from '@mui/material/Select';
 interface FilterModeSelectorProps {
   filterMode: string;
   onChange: (event: SelectChangeEvent) => void;
+  showDifferentOption?: boolean;
 }
 
-const options = [
+const BASE_OPTIONS = [
   { value: 'all', label: 'Show all results' },
   { value: 'failures', label: 'Show failures only' },
   { value: 'errors', label: 'Show errors only' },
@@ -18,7 +19,16 @@ const options = [
   { value: 'highlights', label: 'Show highlights only' },
 ];
 
-export const FilterModeSelector: React.FC<FilterModeSelectorProps> = ({ filterMode, onChange }) => {
+export const FilterModeSelector: React.FC<FilterModeSelectorProps> = ({
+  filterMode,
+  onChange,
+  showDifferentOption = true,
+}) => {
+  const options = React.useMemo(
+    () =>
+      showDifferentOption ? BASE_OPTIONS : BASE_OPTIONS.filter((o) => o.value !== 'different'),
+    [showDifferentOption],
+  );
   return (
     <FormControl sx={{ minWidth: 180 }} size="small">
       <InputLabel id="filter-mode-label">Display</InputLabel>

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -192,6 +192,11 @@ function ResultsTable({
   invariant(table, 'Table should be defined');
   const { head, body } = table;
 
+  const visiblePromptCount = React.useMemo(
+    () => head.prompts.filter((_, idx) => columnVisibility[`Prompt ${idx + 1}`] !== false).length,
+    [head.prompts, columnVisibility],
+  );
+
   const [lightboxOpen, setLightboxOpen] = React.useState(false);
   const [lightboxImage, setLightboxImage] = React.useState<string | null>(null);
   const [pagination, setPagination] = React.useState<{ pageIndex: number; pageSize: number }>({
@@ -738,7 +743,7 @@ function ResultsTable({
                     output.id,
                   )}
                   firstOutput={getFirstOutput(info.row.index)}
-                  showDiffs={filterMode === 'different'}
+                  showDiffs={filterMode === 'different' && visiblePromptCount > 1}
                   searchText={debouncedSearchText}
                   showStats={showStats}
                 />

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -338,6 +338,14 @@ export default function ResultsView({
     columnVisibility: allColumns.reduce((acc, col) => ({ ...acc, [col]: true }), {}),
   };
 
+  const visiblePromptCount = React.useMemo(
+    () =>
+      head.prompts.filter(
+        (_, idx) => currentColumnState.columnVisibility[`Prompt ${idx + 1}`] !== false,
+      ).length,
+    [head.prompts, currentColumnState.columnVisibility],
+  );
+
   const updateColumnVisibility = React.useCallback(
     (columns: string[]) => {
       const newColumnVisibility: VisibilityState = {};
@@ -533,7 +541,11 @@ export default function ResultsView({
       </ResponsiveStack>
       <ResponsiveStack direction="row" spacing={1} alignItems="center" sx={{ gap: 2 }}>
         <Box>
-          <FilterModeSelector filterMode={filterMode} onChange={handleFilterModeChange} />
+          <FilterModeSelector
+            filterMode={filterMode}
+            onChange={handleFilterModeChange}
+            showDifferentOption={visiblePromptCount > 1}
+          />
         </Box>
         <Box>
           <SearchInputField


### PR DESCRIPTION
## Summary
- hide filter option "different outputs" if only one output column is displayed
- pass showDifferentOption prop to FilterModeSelector
- disable diff view when not enough columns
- add tests for FilterModeSelector behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: fetch.test.ts, AwsBedrockKnowledgeBaseProvider tests due to environment)*