### PR TITLE
docs: unify formatting across site

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Answer Relevance
+---
+
 # Answer Relevance
 
 The `answer-relevance` assertion evaluates whether an LLM's output is relevant to the original query. It uses a combination of embedding similarity and LLM evaluation to determine relevance.

--- a/site/docs/configuration/expected-outputs/model-graded/context-faithfulness.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-faithfulness.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Context Faithfulness
+---
+
 # Context Faithfulness
 
 The `context-faithfulness` assertion evaluates whether the LLM's output is faithful to the provided context, ensuring that the response doesn't include information or claims that aren't supported by the context. This is essential for RAG (Retrieval-Augmented Generation) applications to prevent hallucination.

--- a/site/docs/configuration/expected-outputs/model-graded/context-recall.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-recall.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Context Recall
+---
+
 # Context Recall
 
 The `context-recall` assertion evaluates whether key information from a ground truth statement appears in the provided context. This is particularly useful for RAG (Retrieval-Augmented Generation) applications to ensure that important facts are being retrieved.

--- a/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Context Relevance
+---
+
 # Context Relevance
 
 The `context-relevance` assertion evaluates whether the retrieved context is relevant to the original query. This is crucial for RAG (Retrieval-Augmented Generation) applications to ensure that the retrieved information is actually useful for answering the question.

--- a/site/docs/configuration/expected-outputs/model-graded/factuality.md
+++ b/site/docs/configuration/expected-outputs/model-graded/factuality.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Factuality
+---
+
 # Factuality
 
 The `factuality` assertion evaluates the factual consistency between an LLM output and a reference answer. It uses a structured prompt based on [OpenAI's evals](https://github.com/openai/evals/blob/main/evals/registry/modelgraded/fact.yaml) to determine if the output is factually consistent with the reference.

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: LLM Rubric
+---
+
 # LLM Rubric
 
 `llm-rubric` is promptfoo's general-purpose grader for "LLM as a judge" evaluation.

--- a/site/docs/configuration/expected-outputs/model-graded/model-graded-closedqa.md
+++ b/site/docs/configuration/expected-outputs/model-graded/model-graded-closedqa.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Model-graded Closed QA
+---
+
 # Model-graded Closed QA
 
 `model-graded-closedqa` is a criteria-checking evaluation that uses OpenAI's public evals prompt to determine if an LLM output meets specific requirements.

--- a/site/docs/configuration/expected-outputs/model-graded/select-best.md
+++ b/site/docs/configuration/expected-outputs/model-graded/select-best.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Select Best
+---
+
 # Select Best
 
 The `select-best` assertion compares multiple outputs in the same test case and selects the one that best meets a specified criterion. This is useful for comparing different prompt or model variations to determine which produces the best result.

--- a/site/docs/enterprise/webhooks.md
+++ b/site/docs/enterprise/webhooks.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Webhook Integration
+---
+
 # Webhook Integration
 
 Promptfoo Enterprise provides webhooks to notify external systems when issues are created or updated.

--- a/site/docs/guides/chatbase-redteam.md
+++ b/site/docs/guides/chatbase-redteam.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Red teaming a Chatbase Chatbot
+---
+
 # Red teaming a Chatbase Chatbot
 
 [Chatbase](https://www.chatbase.co) is a platform for building custom AI chatbots that can be embedded into websites for customer support, lead generation, and user engagement. These chatbots use RAG (Retrieval-Augmented Generation) to access your organization's knowledge base and maintain conversations with users.

--- a/site/docs/guides/evaluate-llm-temperature.md
+++ b/site/docs/guides/evaluate-llm-temperature.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Choosing the right temperature for your LLM
+---
+
 # Choosing the right temperature for your LLM
 
 The `temperature`` setting in language models is like a dial that adjusts how predictable or surprising the responses from the model will be, helping application developers fine-tune the AI's creativity to suit different tasks.

--- a/site/docs/guides/langchain-prompttemplate.md
+++ b/site/docs/guides/langchain-prompttemplate.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Using LangChain PromptTemplate with Promptfoo
+---
+
 # Using LangChain PromptTemplate with Promptfoo
 
 LangChain PromptTemplate is commonly used to format prompts with injecting variables. Promptfoo allows you to evaluate and test your prompts systematically. Combining the two can streamline your workflow, enabling you to test the prompts that use LangChain PromptTemplate in application code directly within Promptfoo.

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: How to red team LLM applications
+---
+
 # How to red team LLM applications
 
 Promptfoo is a popular open source evaluation framework that includes LLM red team and penetration testing capabilities.

--- a/site/docs/guides/sandboxed-code-evals.md
+++ b/site/docs/guides/sandboxed-code-evals.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Sandboxed Evaluations of LLM-Generated Code
+---
+
 # Sandboxed Evaluations of LLM-Generated Code
 
 You're using LLMs to generate code snippets, functions, or even entire programs. Blindly trusting and executing this generated code in our production environments - or even in development environments - can be a severe security risk.

--- a/site/docs/guides/text-to-sql-evaluation.md
+++ b/site/docs/guides/text-to-sql-evaluation.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Evaluating LLM text-to-SQL performance
+---
+
 # Evaluating LLM text-to-SQL performance
 
 Promptfoo is a command-line tool that allows you to test and validate text-to-SQL conversions.

--- a/site/docs/providers/adaline.md
+++ b/site/docs/providers/adaline.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Adaline Gateway
+---
+
 # Adaline Gateway
 
 Adaline Gateway is a fully local production-grade Super SDK that provides a simple, unified, and powerful interface for calling more than 200+ LLMs.

--- a/site/docs/providers/ai21.md
+++ b/site/docs/providers/ai21.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: AI21 Labs
+---
+
 # AI21 Labs
 
 The [AI21 Labs API](https://docs.ai21.com/reference/chat-completion) offers access to AI21 models such as `jamba-1.5-mini` and `jamba-1.5-large`.

--- a/site/docs/providers/alibaba.md
+++ b/site/docs/providers/alibaba.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Alibaba Cloud (Qwen)
+---
+
 # Alibaba Cloud (Qwen)
 
 [Alibaba Cloud's DashScope API](https://www.alibabacloud.com/help/en/model-studio/getting-started/models) provides OpenAI-compatible access to Qwen language models. Compatible with all [OpenAI provider](/docs/providers/openai/) options in promptfoo.

--- a/site/docs/providers/cerebras.md
+++ b/site/docs/providers/cerebras.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Cerebras
+---
+
 # Cerebras
 
 This provider enables you to use Cerebras models through their [Inference API](https://docs.cerebras.ai).

--- a/site/docs/providers/cloudflare-ai.md
+++ b/site/docs/providers/cloudflare-ai.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Cloudflare Workers AI
+---
+
 # Cloudflare Workers AI
 
 This provider supports the [models](https://developers.cloudflare.com/workers-ai/models/) provided by Cloudflare Workers AI, a serverless edge embedding and inference runtime.

--- a/site/docs/providers/cohere.md
+++ b/site/docs/providers/cohere.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Cohere
+---
+
 # Cohere
 
 The `cohere` provider is an interface to Cohere AI's [chat inference API](https://docs.cohere.com/reference/chat), with models such as Command R that are optimized for RAG and tool usage.

--- a/site/docs/providers/deepseek.md
+++ b/site/docs/providers/deepseek.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: DeepSeek
+---
+
 # DeepSeek
 
 [DeepSeek](https://platform.deepseek.com/) provides an OpenAI-compatible API for their language models, with specialized models for both general chat and advanced reasoning tasks. The DeepSeek provider is compatible with all the options provided by the [OpenAI provider](/docs/providers/openai/).

--- a/site/docs/providers/f5.md
+++ b/site/docs/providers/f5.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: F5
+---
+
 # F5
 
 [F5](https://f5.ai/) provides an interface for a handful of LLM APIs.

--- a/site/docs/providers/fireworks.md
+++ b/site/docs/providers/fireworks.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Fireworks AI
+---
+
 # Fireworks AI
 
 [Fireworks AI](https://fireworks.ai) offers access to a diverse range of language models through an API that is fully compatible with the OpenAI interface.

--- a/site/docs/providers/github.md
+++ b/site/docs/providers/github.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Github
+---
+
 # Github
 
 [Github Models](https://github.com/marketplace/models/) provides an interface for a handful of LLM APIs.

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Google AI / Gemini
+---
+
 # Google AI / Gemini
 
 The `google` provider enables integration with Google AI Studio and the Gemini API. It provides access to Google's state-of-the-art language models with support for text, images, and video inputs.

--- a/site/docs/providers/groq.md
+++ b/site/docs/providers/groq.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Groq
+---
+
 # Groq
 
 [Groq](https://wow.groq.com) is an extremely fast inference API compatible with all the options provided by Promptfoo's [OpenAI provider](/docs/providers/openai/). See openai specific documentation for configuration details.

--- a/site/docs/providers/huggingface.md
+++ b/site/docs/providers/huggingface.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: HuggingFace
+---
+
 # HuggingFace
 
 promptfoo includes support for the [HuggingFace Inference API](https://huggingface.co/inference-api), for text generation, classification, and embeddings related tasks, as well as [HuggingFace Datasets](https://huggingface.co/docs/datasets).

--- a/site/docs/providers/ibm-bam.md
+++ b/site/docs/providers/ibm-bam.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: IBM BAM
+---
+
 # IBM BAM
 
 The `bam` provider integrates with IBM's BAM API, allowing access to various models like `meta-llama/llama-2-70b-chat` and `ibm/granite-13b-chat-v2`.

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: LLM Providers
+---
+
 # LLM Providers
 
 Providers in promptfoo are the interfaces to various language models and AI services. This guide will help you understand how to configure and use providers in your promptfoo evaluations.

--- a/site/docs/providers/lambdalabs.md
+++ b/site/docs/providers/lambdalabs.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Lambda Labs
+---
+
 # Lambda Labs
 
 This provider enables you to use Lambda Labs models through their [Inference API](https://docs.lambda.ai/public-cloud/lambda-inference-api/).

--- a/site/docs/providers/litellm.md
+++ b/site/docs/providers/litellm.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: LiteLLM
+---
+
 # LiteLLM
 
 The [LiteLLM](https://docs.litellm.ai/docs/) provides access to hundreds of LLMs.

--- a/site/docs/providers/llama.cpp.md
+++ b/site/docs/providers/llama.cpp.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Llama.cpp
+---
+
 # Llama.cpp
 
 The `llama` provider is compatible with the HTTP server bundled with [llama.cpp](https://github.com/ggerganov/llama.cpp). This allows you to leverage the power of `llama.cpp` models within Promptfoo.

--- a/site/docs/providers/llamafile.md
+++ b/site/docs/providers/llamafile.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: llamafile
+---
+
 # llamafile
 
 Llamafile has an [OpenAI-compatible HTTP endpoint](https://github.com/Mozilla-Ocho/llamafile?tab=readme-ov-file#json-api-quickstart), so you can override the [OpenAI provider](/docs/providers/openai/) to talk to your llamafile server.

--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Mistral AI
+---
+
 # Mistral AI
 
 The [Mistral AI API](https://docs.mistral.ai/api/) offers access to various Mistral models.

--- a/site/docs/providers/ollama.md
+++ b/site/docs/providers/ollama.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Ollama
+---
+
 # Ollama
 
 The `ollama` provider is compatible with [Ollama](https://github.com/jmorganca/ollama), which enables access to Llama, Mixtral, Mistral, and more.

--- a/site/docs/providers/openllm.md
+++ b/site/docs/providers/openllm.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: OpenLLM
+---
+
 # OpenLLM
 
 To use [OpenLLM](https://github.com/bentoml/OpenLLM) with promptfoo, we take advantage of OpenLLM's support for [OpenAI-compatible endpoint](https://colab.research.google.com/github/bentoml/OpenLLM/blob/main/examples/openllm-llama2-demo/openllm_llama2_demo.ipynb#scrollTo=0G5clTYV_M8J&line=3&uniqifier=1).

--- a/site/docs/providers/openrouter.md
+++ b/site/docs/providers/openrouter.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: OpenRouter
+---
+
 # OpenRouter
 
 [OpenRouter](https://openrouter.ai/) provides a unified interface for accessing various LLM APIs, including models from OpenAI, Meta, Perplexity, and others. It follows the OpenAI API format - see our [OpenAI provider documentation](/docs/providers/openai/) for base API details.

--- a/site/docs/providers/perplexity.md
+++ b/site/docs/providers/perplexity.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Perplexity
+---
+
 # Perplexity
 
 The [Perplexity API](https://blog.perplexity.ai/blog/introducing-pplx-api) provides chat completion models with built-in search capabilities, citations, and structured output support. Perplexity models retrieve information from the web in real-time, enabling up-to-date responses with source citations.

--- a/site/docs/providers/replicate.md
+++ b/site/docs/providers/replicate.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Replicate
+---
+
 # Replicate
 
 Replicate is an API for machine learning models. It currently hosts models like [Llama v2](https://replicate.com/replicate/llama70b-v2-chat), [Gemma](https://replicate.com/google-deepmind/gemma-7b-it), and [Mistral/Mixtral](https://replicate.com/mistralai/mixtral-8x7b-instruct-v0.1).

--- a/site/docs/providers/simulated-user.md
+++ b/site/docs/providers/simulated-user.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Simulated User
+---
+
 # Simulated User
 
 The Simulated User Provider enables testing of multi-turn conversations between an AI agent and a simulated user. This is useful for testing chatbots, virtual assistants, and other conversational AI applications.

--- a/site/docs/providers/togetherai.md
+++ b/site/docs/providers/togetherai.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Together AI
+---
+
 # Together AI
 
 [Together AI](https://www.together.ai/) provides access to open-source models through an API compatible with OpenAI's interface.

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Google Vertex
+---
+
 # Google Vertex
 
 The `vertex` provider enables integration with Google's [Vertex AI](https://cloud.google.com/vertex-ai) platform, which provides access to foundation models including Gemini, PaLM (Bison), Llama, Claude, and specialized models for text, code, and embeddings.

--- a/site/docs/providers/vllm.md
+++ b/site/docs/providers/vllm.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: vllm
+---
+
 # vllm
 
 vllm's [OpenAI-compatible server](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server) offers access to many [supported models](https://docs.vllm.ai/en/latest/models/supported_models.html) for local inference from Huggingface Transformers.

--- a/site/docs/providers/voyage.md
+++ b/site/docs/providers/voyage.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Voyage AI
+---
+
 # Voyage AI
 
 [Voyage AI](https://www.voyageai.com/) is Anthropic's [recommended](https://docs.anthropic.com/en/docs/embeddings) embeddings provider. It supports [all models](https://docs.voyageai.com/docs/embeddings). As of time of writing:

--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: WatsonX
+---
+
 # WatsonX
 
 [IBM WatsonX](https://www.ibm.com/watsonx) offers a range of enterprise-grade foundation models optimized for various business use cases. This provider supports several powerful models from the `Granite` and `Llama` series, along with additional models for code generation, multilingual tasks, vision processing, and more.

--- a/site/docs/providers/webhook.md
+++ b/site/docs/providers/webhook.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Generic webhook
+---
+
 # Generic webhook
 
 The webhook provider can be useful for triggering more complex flows or prompt chains end to end in your app.

--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: WebSockets
+---
+
 # WebSockets
 
 The WebSocket provider allows you to connect to a WebSocket endpoint for inference. This is useful for real-time, bidirectional communication with a server that supports WebSocket connections.

--- a/site/docs/red-team/plugins/rag-document-exfiltration.md
+++ b/site/docs/red-team/plugins/rag-document-exfiltration.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: RAG Document Exfiltration Plugin
+---
+
 # RAG Document Exfiltration Plugin
 
 The RAG Document Exfiltration plugin is designed to identify vulnerabilities where an AI model might inadvertently expose entire documents during retrieval-augmented generation processes. RAGs often contain internal documents, and it is crucial to ensure these are not exposed without proper authorization, as they may contain sensitive or proprietary information.


### PR DESCRIPTION
## Summary
- add frontmatter to docs missing it for consistent formatting

## Testing
- `npm run f` *(fails: ambiguous origin/main)*
- `npm run l` *(fails: ambiguous origin/main)*
- `npm test` *(fails: 21 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_683b5045d03883329f1be1f65ffdd404