### PR TITLE
test: add vitest coverage for frontend pages

### DIFF
--- a/src/app/src/components/Navigation.test.tsx
+++ b/src/app/src/components/Navigation.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Navigation from './Navigation';
+
+const useUIStoreMock = vi.fn();
+vi.mock('../stores/uiStore', () => ({
+  useUIStore: (...args: any[]) => useUIStoreMock(...args),
+}));
+
+vi.mock('./InfoModal', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div>InfoModal</div> : null),
+}));
+
+vi.mock('./ApiSettingsModal', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div>ApiSettingsModal</div> : null),
+}));
+
+vi.mock('./DarkMode', () => ({
+  default: ({ onToggleDarkMode }: { onToggleDarkMode: () => void }) => (
+    <button onClick={onToggleDarkMode}>Dark</button>
+  ),
+}));
+
+vi.mock('./Logo', () => ({
+  default: () => <div>Logo</div>,
+}));
+
+vi.mock('@app/constants', () => ({
+  IS_RUNNING_LOCALLY: true,
+}));
+
+describe('Navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when navbar is hidden', () => {
+    useUIStoreMock.mockImplementation((selector: any) => selector({ isNavbarVisible: false }));
+
+    const { container } = render(
+      <MemoryRouter>
+        <Navigation darkMode={false} onToggleDarkMode={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders links and opens modals', () => {
+    useUIStoreMock.mockImplementation((selector: any) => selector({ isNavbarVisible: true }));
+
+    render(
+      <MemoryRouter>
+        <Navigation darkMode={false} onToggleDarkMode={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Prompts')).toBeInTheDocument();
+    expect(screen.getByText('Datasets')).toBeInTheDocument();
+    expect(screen.getByText('History')).toBeInTheDocument();
+
+    const infoButton = screen.getByTestId('InfoIcon').closest('button')!;
+    fireEvent.click(infoButton);
+    expect(screen.getByText('InfoModal')).toBeInTheDocument();
+
+    const settingsButton = screen.getByTestId('EngineeringIcon').closest('button')!;
+    fireEvent.click(settingsButton);
+    expect(screen.getByText('ApiSettingsModal')).toBeInTheDocument();
+  });
+});

--- a/src/app/src/pages/datasets/page.test.tsx
+++ b/src/app/src/pages/datasets/page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import DatasetsPage from './page';
+
+const callApiMock = vi.fn();
+vi.mock('@app/utils/api', () => ({
+  callApi: (...args: any[]) => callApiMock(...args),
+}));
+
+describe('DatasetsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches datasets and displays them', async () => {
+    callApiMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'abc123456',
+            testCases: [],
+            prompts: [],
+            count: 0,
+            recentEvalDate: '2024-01-01',
+            recentEvalId: 'eval1',
+          },
+        ],
+      }),
+    } as Response);
+
+    render(
+      <MemoryRouter>
+        <DatasetsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('abc123')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when fetch fails', async () => {
+    callApiMock.mockRejectedValueOnce(new Error('network'));
+
+    render(
+      <MemoryRouter>
+        <DatasetsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load datasets. Please try again.')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/src/pages/login.test.tsx
+++ b/src/app/src/pages/login.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LoginPage from './login';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ search: '' }),
+  };
+});
+
+const useUserStoreMock = vi.fn();
+vi.mock('@app/stores/userStore', () => ({
+  useUserStore: (...args: any[]) => useUserStoreMock(...args),
+}));
+
+const callApiMock = vi.fn();
+vi.mock('@app/utils/api', () => ({
+  callApi: (...args: any[]) => callApiMock(...args),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner when loading', () => {
+    useUserStoreMock.mockReturnValue({
+      email: null,
+      isLoading: true,
+      fetchEmail: vi.fn(),
+      setEmail: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('submits email and redirects on success', async () => {
+    const setEmail = vi.fn();
+    useUserStoreMock.mockReturnValue({
+      email: null,
+      isLoading: false,
+      fetchEmail: vi.fn(),
+      setEmail,
+    });
+
+    callApiMock.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email Address/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByText('Login'));
+
+    await waitFor(() => expect(callApiMock).toHaveBeenCalledTimes(2));
+
+    expect(callApiMock).toHaveBeenCalledWith('/user/email', expect.any(Object));
+    expect(setEmail).toHaveBeenCalledWith('test@example.com');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## Summary
- add LoginPage tests
- add DatasetsPage tests
- add Navigation component tests

## Testing
- `npm run test:app`

------
https://chatgpt.com/codex/tasks/task_e_683ce9aee93c83328e711e845c8713a9