### PR TITLE
Feature/modify matcher templates to support both string and non string objects

### DIFF
--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -29,7 +29,7 @@ defaultTest:
           "role": "user",
           "content": [
             {"type": "image_url", "image_url": {"url": "{{image_url}}"}},
-            {"type": "text", "text": "Answer: {{output if output === output|string else output|dump}}\nCriteria: {{rubric if rubric === rubric|string else rubric|dump}}"}
+            {"type": "text", "text": "Answer: {{ output if output === output|string else output|dump }}\nCriteria: {{ rubric if rubric === rubric|string else rubric|dump }}"}
           ]
         }
       ]

--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -29,7 +29,7 @@ defaultTest:
           "role": "user",
           "content": [
             {"type": "image_url", "image_url": {"url": "{{image_url}}"}},
-            {"type": "text", "text": "Answer: {{ output }}\nCriteria: {{ rubric }}"}
+            {"type": "text", "text": "Answer: {{ output if output === output|string else output|dump  }}\nCriteria: {{ rubric if rubric === rubric|string else rubric|dump  }}"}
           ]
         }
       ]

--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -29,7 +29,7 @@ defaultTest:
           "role": "user",
           "content": [
             {"type": "image_url", "image_url": {"url": "{{image_url}}"}},
-            {"type": "text", "text": "Answer: {{ output if output === output|string else output|dump  }}\nCriteria: {{ rubric if rubric === rubric|string else rubric|dump  }}"}
+            {"type": "text", "text": "Answer: {{output if output === output|string else output|dump}}\nCriteria: {{rubric if rubric === rubric|string else rubric|dump}}"}
           ]
         }
       ]

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -267,7 +267,7 @@ defaultTest:
           "role": "user",
           "content": [
             { "type": "image_url", "image_url": { "url": "{{image_url}}" } },
-            { "type": "text", "text": "Output: {{ output if output === output|string else output|dump  }}\nRubric: {{ rubric if rubric === rubric|string else rubric|dump  }}" }
+            { "type": "text", "text": "Output: {{ output if output === output|string else output|dump }}\nRubric: {{ rubric if rubric === rubric|string else rubric|dump }}" }
           ]
         }
       ]

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -267,7 +267,7 @@ defaultTest:
           "role": "user",
           "content": [
             { "type": "image_url", "image_url": { "url": "{{image_url}}" } },
-            { "type": "text", "text": "Output: {{ output }}\nRubric: {{ rubric }}" }
+            { "type": "text", "text": "Output: {{ output if output === output|string else output|dump  }}\nRubric: {{ rubric if rubric === rubric|string else rubric|dump  }}" }
           ]
         }
       ]

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -382,9 +382,6 @@ async function loadRubricPrompt(
 }
 
 function tryParse(content: string) {
-  // if (typeof content === 'object') {
-  //   return content;
-  // }
 
   try {
     return JSON.parse(content);
@@ -400,24 +397,7 @@ export async function renderLlmRubricPrompt(
   rubricPrompt: string,
   context: Record<string, string | object>,
 ) {
-  // Process the context to ensure objects are properly stringified for nunjucks
-  const processedContext = Object.fromEntries(
-    Object.entries(context).map(([key, value]) => {
-      if (value && typeof value === 'object') {
-        // For arrays, stringify individual elements
-        if (Array.isArray(value)) {
-          return [
-            key,
-            value.map((item) => (typeof item === 'object' ? JSON.stringify(item) : item)),
-          ];
-        }
-        // For objects, stringify the entire object
-        return [key, JSON.stringify(value)];
-      }
-      return [key, value];
-    }),
-  );
-
+  
   try {
     // Render every string scalar within the JSON
     // Does not render object keys (only values)

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -346,7 +346,7 @@ export async function matchesClassification(
   };
 }
 
-export async function loadRubricPrompt(
+async function loadRubricPrompt(
   rubricPrompt: string | object | undefined,
   defaultPrompt: string,
 ): Promise<string> {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -346,7 +346,7 @@ export async function matchesClassification(
   };
 }
 
-async function loadRubricPrompt(
+export async function loadRubricPrompt(
   rubricPrompt: string | object | undefined,
   defaultPrompt: string,
 ): Promise<string> {
@@ -381,10 +381,10 @@ async function loadRubricPrompt(
   return rubricPrompt;
 }
 
-function tryParse(content: string | object) {
-  if (typeof content === 'object') {
-    return content;
-  }
+function tryParse(content: string) {
+  // if (typeof content === 'object') {
+  //   return content;
+  // }
 
   try {
     return JSON.parse(content);
@@ -422,7 +422,7 @@ export async function renderLlmRubricPrompt(
     // Render every string scalar within the JSON
     // Does not render object keys (only values)
     const parsed = JSON.parse(rubricPrompt, (k, v) =>
-      typeof v === 'string' ? nunjucks.renderString(v, processedContext) : v,
+      typeof v === 'string' ? nunjucks.renderString(v, context) : v,
     );
     return JSON.stringify(parsed);
   } catch {
@@ -431,7 +431,7 @@ export async function renderLlmRubricPrompt(
   }
 
   // Legacy rendering for non-JSON prompts
-  return nunjucks.renderString(rubricPrompt, processedContext);
+  return nunjucks.renderString(rubricPrompt, context);
 }
 
 export async function matchesLlmRubric(

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -25,7 +25,7 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   {
     role: 'user',
     content:
-      '<Output>\n{{ output if output === output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric === rubric|string else rubric|dump  }}\n</Rubric>',
+      '<Output>\n{{output if output === output|string else output|dump}}\n</Output>\n<Rubric>\n{{rubric if rubric === rubric|string else rubric|dump}}\n</Rubric>',
   },
 ]);
 
@@ -62,15 +62,15 @@ export const PROMPTFOO_FACTUALITY_PROMPT = JSON.stringify([
       I need you to compare these answers:
 
       <question>
-      {{input if input === input|string else input|dump }}
+      {{input if input === input|string else input|dump}}
       </question>
 
       <expert_answer>
-      {{ideal if ideal === ideal|string else ideal|dump }}
+      {{ideal if ideal === ideal|string else ideal|dump}}
       </expert_answer>
 
       <submitted_answer>
-      {{completion if completion === completion|string else completion|dump }}
+      {{completion if completion === completion|string else completion|dump}}
       </submitted_answer>
 
       Please analyze the factual relationship between these answers according to the categories you've been given.`,
@@ -83,11 +83,11 @@ export const OPENAI_CLOSED_QA_PROMPT = JSON.stringify([
     content: `You are assessing a submitted answer on a given task based on a criterion. Here is the data:
 [BEGIN DATA]
 ***
-[Task]: {{input if input === input|string else input|dump }}
+[Task]: {{input if input === input|string else input|dump}}
 ***
-[Submission]: {{completion if completion === completion|string else completion|dump }}
+[Submission]: {{completion if completion === completion|string else completion|dump}}
 ***
-[Criterion]: {{criteria if criteria === criteria|string else criteria|dump }}
+[Criterion]: {{criteria if criteria === criteria|string else criteria|dump}}
 ***
 [END DATA]
 Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -25,7 +25,7 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   {
     role: 'user',
     content:
-      '<Output>\n{{output if output === output|string else output|dump}}\n</Output>\n<Rubric>\n{{rubric if rubric === rubric|string else rubric|dump}}\n</Rubric>',
+      '<Output>\n{{ output if output === output|string else output|dump }}\n</Output>\n<Rubric>\n{{ rubric if rubric === rubric|string else rubric|dump }}\n</Rubric>',
   },
 ]);
 

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -12,7 +12,7 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
     role: 'system',
     content: dedent`You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond with a JSON object with this structure: {reason: string, pass: boolean, score: number}
 
-    Examples: 
+    Examples:
 
     <Output>Hello world</Output>
     <Rubric>Content contains a greeting</Rubric>
@@ -24,7 +24,8 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   },
   {
     role: 'user',
-    content: '<Output>\n{{ output if output === output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric === rubric|string else rubric|dump  }}\n</Rubric>',
+    content:
+      '<Output>\n{{ output if output === output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric === rubric|string else rubric|dump  }}\n</Rubric>',
   },
 ]);
 

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -10,9 +10,9 @@ export * from './external/ragas';
 export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   {
     role: 'system',
-    content: dedent`You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond
+    content: dedent`You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond with a JSON object with this structure: {reason: string, pass: boolean, score: number}
 
-    Examples: with a JSON object with this structure: {reason: string, pass: boolean, score: number}
+    Examples: 
 
     <Output>Hello world</Output>
     <Rubric>Content contains a greeting</Rubric>

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -10,9 +10,9 @@ export * from './external/ragas';
 export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   {
     role: 'system',
-    content: dedent`You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond with a JSON object with this structure: {reason: string, pass: boolean, score: number}
+    content: dedent`You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond
 
-    Examples:
+    Examples: with a JSON object with this structure: {reason: string, pass: boolean, score: number}
 
     <Output>Hello world</Output>
     <Rubric>Content contains a greeting</Rubric>
@@ -24,7 +24,7 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   },
   {
     role: 'user',
-    content: '<Output>\n{{ output if output == output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric == rubric|string else rubric|dump  }}\n</Rubric>',
+    content: '<Output>\n{{ output if output === output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric === rubric|string else rubric|dump  }}\n</Rubric>',
   },
 ]);
 
@@ -61,15 +61,15 @@ export const PROMPTFOO_FACTUALITY_PROMPT = JSON.stringify([
       I need you to compare these answers:
 
       <question>
-      {{input if input == input|string else input|dump }}
+      {{input if input === input|string else input|dump }}
       </question>
 
       <expert_answer>
-      {{ideal if ideal == ideal|string else ideal|dump }}
+      {{ideal if ideal === ideal|string else ideal|dump }}
       </expert_answer>
 
       <submitted_answer>
-      {{completion if completion == completion|string else completion|dump }}
+      {{completion if completion === completion|string else completion|dump }}
       </submitted_answer>
 
       Please analyze the factual relationship between these answers according to the categories you've been given.`,
@@ -82,11 +82,11 @@ export const OPENAI_CLOSED_QA_PROMPT = JSON.stringify([
     content: `You are assessing a submitted answer on a given task based on a criterion. Here is the data:
 [BEGIN DATA]
 ***
-[Task]: {{input if input == input|string else input|dump }}
+[Task]: {{input if input === input|string else input|dump }}
 ***
-[Submission]: {{completion if completion == completion|string else completion|dump }}
+[Submission]: {{completion if completion === completion|string else completion|dump }}
 ***
-[Criterion]: {{criteria if criteria == criteria|string else criteria|dump }}
+[Criterion]: {{criteria if criteria === criteria|string else criteria|dump }}
 ***
 [END DATA]
 Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.
@@ -113,7 +113,7 @@ Here are the pieces of text:
 
 {% for output in outputs %}
 <Text index="{{ loop.index0 }}">
-{{ output if output == output|string else output|dump }}
+{{ output if output === output|string else output|dump }}
 </Text>
 {% endfor %}
 

--- a/src/prompts/grading.ts
+++ b/src/prompts/grading.ts
@@ -24,7 +24,7 @@ export const DEFAULT_GRADING_PROMPT = JSON.stringify([
   },
   {
     role: 'user',
-    content: '<Output>\n{{ output }}\n</Output>\n<Rubric>\n{{ rubric }}\n</Rubric>',
+    content: '<Output>\n{{ output if output == output|string else output|dump  }}\n</Output>\n<Rubric>\n{{ rubric if rubric == rubric|string else rubric|dump  }}\n</Rubric>',
   },
 ]);
 
@@ -61,15 +61,15 @@ export const PROMPTFOO_FACTUALITY_PROMPT = JSON.stringify([
       I need you to compare these answers:
 
       <question>
-      {{input}}
+      {{input if input == input|string else input|dump }}
       </question>
 
       <expert_answer>
-      {{ideal}}
+      {{ideal if ideal == ideal|string else ideal|dump }}
       </expert_answer>
 
       <submitted_answer>
-      {{completion}}
+      {{completion if completion == completion|string else completion|dump }}
       </submitted_answer>
 
       Please analyze the factual relationship between these answers according to the categories you've been given.`,
@@ -82,11 +82,11 @@ export const OPENAI_CLOSED_QA_PROMPT = JSON.stringify([
     content: `You are assessing a submitted answer on a given task based on a criterion. Here is the data:
 [BEGIN DATA]
 ***
-[Task]: {{input}}
+[Task]: {{input if input == input|string else input|dump }}
 ***
-[Submission]: {{completion}}
+[Submission]: {{completion if completion == completion|string else completion|dump }}
 ***
-[Criterion]: {{criteria}}
+[Criterion]: {{criteria if criteria == criteria|string else criteria|dump }}
 ***
 [END DATA]
 Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.
@@ -113,7 +113,7 @@ Here are the pieces of text:
 
 {% for output in outputs %}
 <Text index="{{ loop.index0 }}">
-{{ output }}
+{{ output if output == output|string else output|dump }}
 </Text>
 {% endfor %}
 

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -330,7 +330,7 @@ describe('matchesLlmRubric', () => {
     const rubric = { prompt: 'Describe the image' };
     const output = 'Sample output';
     const options: GradingConfig = {
-      rubricPrompt: 'Grade: {{rubric if rubric === rubric|string else rubric|dump}}',
+      rubricPrompt: 'Grade: {{ rubric if rubric === rubric|string else rubric|dump }}',
       provider: {
         id: () => 'test-provider',
         callApi: jest.fn().mockResolvedValue({

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -2226,7 +2226,6 @@ describe('tryParse and renderLlmRubricPrompt', () => {
 
     const result = await renderLlmRubricPrompt(template, { input: objects });
     console.log(result);
-    // With our fix, this should properly stringify the objects
     expect(result).not.toContain('[object Object]');
     expect(result).toBe('red');
   });

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -17,8 +17,7 @@ import {
   matchesContextRecall,
   matchesContextFaithfulness,
   renderLlmRubricPrompt,
-  matchesGEval,
-  loadRubricPrompt
+  matchesGEval
 } from '../src/matchers';
 import { 
   ANSWER_RELEVANCY_GENERATE,

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -330,7 +330,7 @@ describe('matchesLlmRubric', () => {
     const rubric = { prompt: 'Describe the image' };
     const output = 'Sample output';
     const options: GradingConfig = {
-      rubricPrompt: 'Grade: {{ rubric if rubric === rubric|string else rubric|dump  }}',
+      rubricPrompt: 'Grade: {{rubric if rubric === rubric|string else rubric|dump}}',
       provider: {
         id: () => 'test-provider',
         callApi: jest.fn().mockResolvedValue({
@@ -2193,7 +2193,7 @@ describe('tryParse and renderLlmRubricPrompt', () => {
   });
 
   it('should properly stringify objects', async () => {
-    const template = 'Source Text:\n{{input if input === input|string else input|dump  }}';
+    const template = 'Source Text:\n{{ input if input === input|string else input|dump }}';
     // Create objects that would typically cause the [object Object] issue
     const objects = [
       { name: 'Object 1', properties: { color: 'red', size: 'large' } },
@@ -2209,7 +2209,7 @@ describe('tryParse and renderLlmRubricPrompt', () => {
   });
 
   it('should make it possible to access nested object attributes', async () => {
-    const template = '{{  input[0].properties.color  }}';
+    const template = '{{input[0].properties.color}}';
     const objects = [
       { name: 'Object 1', properties: { color: 'red', size: 'large' } },
       { name: 'Object 2', properties: { color: 'blue', size: 'small' } },
@@ -2222,7 +2222,7 @@ describe('tryParse and renderLlmRubricPrompt', () => {
   });
 
   it('should handle mixed arrays of objects and primitives', async () => {
-    const template = 'Items: {{ items if items === items|string else items|dump }}';
+    const template = 'Items: {{items if items === items|string else items|dump}}';
     const mixedArray = ['string item', { name: 'Object item' }, 42, [1, 2, 3]];
 
     const result = await renderLlmRubricPrompt(template, { items: mixedArray });

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -41,9 +41,6 @@ import type {
 } from '../src/types';
 import { TestGrader } from './util/utils';
 
-
-import { log, error } from 'console';
-
 jest.mock('../src/database', () => ({
   getDb: jest.fn().mockImplementation(() => {
     throw new TypeError('The "original" argument must be of type function. Received undefined');

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -17,12 +17,12 @@ import {
   matchesContextRecall,
   matchesContextFaithfulness,
   renderLlmRubricPrompt,
-  matchesGEval
+  matchesGEval,
 } from '../src/matchers';
 import { 
-  ANSWER_RELEVANCY_GENERATE,
-  DEFAULT_GRADING_PROMPT
- } from '../src/prompts';
+  ANSWER_RELEVANCY_GENERATE, 
+  DEFAULT_GRADING_PROMPT,
+} from '../src/prompts';
 import { HuggingfaceTextClassificationProvider } from '../src/providers/huggingface';
 import { OpenAiChatCompletionProvider } from '../src/providers/openai/chat';
 import { DefaultEmbeddingProvider, DefaultGradingProvider } from '../src/providers/openai/defaults';
@@ -2183,7 +2183,7 @@ describe('tryParse and renderLlmRubricPrompt', () => {
 
   it('should render default grading prompts correctly', async () => {
     const template = DEFAULT_GRADING_PROMPT;
-    const complexObject = { output: 'bar', rubric: {reasoning: '123', priority: 'high'}};
+    const complexObject = { output: 'bar', rubric: { reasoning: '123', priority: 'high' } };
     const result = await renderLlmRubricPrompt(template, complexObject);
     const parsed = JSON.parse(result);
     const userMessage = parsed.find((m: any) => m.role === 'user');
@@ -2191,7 +2191,6 @@ describe('tryParse and renderLlmRubricPrompt', () => {
     expect(userMessage.content).toContain('bar');
     expect(userMessage.content).toContain('{"reasoning":"123","priority":"high"}');
   });
-
 
   it('should properly stringify objects', async () => {
     const template = 'Source Text:\n{{input if input === input|string else input|dump  }}';
@@ -2211,7 +2210,6 @@ describe('tryParse and renderLlmRubricPrompt', () => {
 
   it('should make it possible to access nested object attributes', async () => {
     const template = '{{  input[0].properties.color  }}';
-    // Create objects that would typically cause the [object Object] issue
     const objects = [
       { name: 'Object 1', properties: { color: 'red', size: 'large' } },
       { name: 'Object 2', properties: { color: 'blue', size: 'small' } },
@@ -2223,10 +2221,8 @@ describe('tryParse and renderLlmRubricPrompt', () => {
     expect(result).toBe('red');
   });
 
-
-
   it('should handle mixed arrays of objects and primitives', async () => {
-    const template = 'Items: {{  items if items === items|string else items|dump }}';
+    const template = 'Items: {{ items if items === items|string else items|dump }}';
     const mixedArray = ['string item', { name: 'Object item' }, 42, [1, 2, 3]];
 
     const result = await renderLlmRubricPrompt(template, { items: mixedArray });

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -22,10 +22,7 @@ import {
 } from '../src/matchers';
 import { 
   ANSWER_RELEVANCY_GENERATE,
-  DEFAULT_GRADING_PROMPT,
-  OPENAI_CLOSED_QA_PROMPT,
-  PROMPTFOO_FACTUALITY_PROMPT,
-  SELECT_BEST_PROMPT
+  DEFAULT_GRADING_PROMPT
  } from '../src/prompts';
 import { HuggingfaceTextClassificationProvider } from '../src/providers/huggingface';
 import { OpenAiChatCompletionProvider } from '../src/providers/openai/chat';


### PR DESCRIPTION
Instead of force stringifying JSON objects in template rendering, we would like to support both string and non-string objects. This re-does the change in #3746 while keeping it non-breaking for the use case in #3896 .