### PR TITLE
docs: standardize file references to use file:// scheme

### DIFF
--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -2,8 +2,8 @@
 description: 'Claude vs GPT Image Analysis'
 
 prompts:
-  - ./prompt.py:format_image_prompt
-  - ./prompt.js:formatImagePrompt
+  - file://./prompt.py:format_image_prompt
+  - file://./prompt.js:formatImagePrompt
 
 providers:
   - id: bedrock:anthropic.claude-3-sonnet-20240229-v1:0

--- a/examples/custom-prompt-function/promptfooconfig.yaml
+++ b/examples/custom-prompt-function/promptfooconfig.yaml
@@ -19,9 +19,9 @@ prompts:
     label: prompt_yaml
   - file://prompt.yaml
 
-  - id: subfolder/prompt.json
+  - id: file://subfolder/prompt.json
     label: prompt_json
-  - subfolder/prompt.json
+  - file://subfolder/prompt.json
 
   - file://./subfolder/*.json
 

--- a/examples/google-live/promptfooconfig.statefulapi.yaml
+++ b/examples/google-live/promptfooconfig.statefulapi.yaml
@@ -8,7 +8,7 @@ providers:
     config:
       tools: file://tools.json
       functionToolStatefulApi:
-        file: examples/google-live/counter_api.py
+        file: file://examples/google-live/counter_api.py
         url: http://127.0.0.1:8765
         # Optionally specify a custom Python executable path
         # pythonExecutable: '/usr/local/bin/python3'

--- a/examples/langchain-python/promptfooconfig.yaml
+++ b/examples/langchain-python/promptfooconfig.yaml
@@ -2,7 +2,7 @@
 description: LangChain Python integration for prompt evaluation
 
 prompts:
-  - prompt.txt
+  - file://prompt.txt
 providers:
   - openai:chat:gpt-4o
   - file://langchain_example.py

--- a/examples/ollama-comparison/promptfooconfig.yaml
+++ b/examples/ollama-comparison/promptfooconfig.yaml
@@ -4,7 +4,7 @@ description: Comparing local Ollama models with different prompts
 prompts:
   - id: file://prompts/openai_prompt.json
     label: openai_prompt
-  - id: prompts/llama_prompt.txt
+  - id: file://prompts/llama_prompt.txt
     label: llama_prompt
 
 providers:

--- a/examples/openai-multiline-yaml/promptfooconfig.yaml
+++ b/examples/openai-multiline-yaml/promptfooconfig.yaml
@@ -2,7 +2,7 @@
 description: OpenAI evaluation with multiline YAML prompt formatting
 
 prompts:
-  - prompt.yaml
+  - file://prompt.yaml
 providers:
   - openai:chat:gpt-4.1-mini
 

--- a/examples/redteam-deepseek/promptfooconfig.yaml
+++ b/examples/redteam-deepseek/promptfooconfig.yaml
@@ -23,4 +23,4 @@ providers:
       passthrough:
         include_reasoning: true
 
-tests: tests.csv
+tests: file://tests.csv

--- a/examples/simple-test/promptfooconfig.yaml
+++ b/examples/simple-test/promptfooconfig.yaml
@@ -51,7 +51,7 @@ tests:
       # $ref can be used as a shorthand to include reusable templates
       - $ref: '#/assertionTemplates/containsPirateNoise'
 
-outputPath: output.csv
+outputPath: file://output.csv
 
 assertionTemplates:
   containsPirateNoise:

--- a/site/blog/deepseek-censorship.md
+++ b/site/blog/deepseek-censorship.md
@@ -36,7 +36,7 @@ description: 'DeepSeek Sensitive Prompts'
 providers:
   - 'openrouter:deepseek/deepseek-r1'
 
-tests: tests.csv
+tests: file://tests.csv
 ```
 
 We'll encounter refusals very quickly, as the first topic in the dataset is Taiwanese independence.
@@ -72,7 +72,7 @@ providers:
       passthrough:
         include_reasoning: true
 
-tests: tests.csv
+tests: file://tests.csv
 ```
 
 Running it via Promptfoo eval shows that **about 85% of this dataset is censored by DeepSeek**:

--- a/site/docs/guides/compare-llama2-vs-gpt.md
+++ b/site/docs/guides/compare-llama2-vs-gpt.md
@@ -98,8 +98,8 @@ Now, let's go back to `promptfooconfig.yaml` and add our prompts. We'll name the
 
 ```yaml title="promptfooconfig.yaml"
 prompts:
-  prompts/chat_prompt.json: chat_prompt
-  prompts/llama_prompt.txt: llama_prompt
+  file://prompts/chat_prompt.json: chat_prompt
+  file://prompts/llama_prompt.txt: llama_prompt
 
 providers:
   - id: openai:gpt-4.1

--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -140,7 +140,7 @@ Think carefully and respond to the user concisely and accurately.
 Now that we've constructed a prompt, let's set up some test cases. In this example, the eval will format each of these test cases using the prompt template and send it to the LLM API:
 
 ```yaml title="promptfooconfig.yaml"
-prompts: [prompt1.txt]
+prompts: [file://prompt1.txt]
 providers: [openai:gpt-4.1-mini]
 tests:
   - vars:
@@ -279,7 +279,7 @@ defaultTest:
 Here's the final config:
 
 ```yaml title="promptfooconfig.yaml"
-prompts: [prompt1.txt]
+prompts: [file://prompt1.txt]
 providers: [openai:gpt-4.1-mini, openai:gpt-4.1, ollama:llama3.1]
 defaultTest:
   assert:
@@ -322,7 +322,7 @@ The way to do this is similar to the "Evaluating document retrieval" step above.
 
 ```yaml title="promptfooconfig.yaml"
 # Test different prompts to find the best
-prompts: [prompt1.txt, prompt2.txt]
+prompts: [file://prompt1.txt, file://prompt2.txt]
 
 # Test different retrieval and generation methods to find the best
 providers:

--- a/site/docs/guides/llama2-uncensored-benchmark-ollama.md
+++ b/site/docs/guides/llama2-uncensored-benchmark-ollama.md
@@ -72,8 +72,8 @@ Let's add the prompts to the config and match them with each provider:
 
 ```yaml title="promptfooconfig.yaml"
 prompts:
-  prompts/openai_prompt.json: openai_prompt
-  prompts/llama_prompt.txt: llama_prompt
+  file://prompts/openai_prompt.json: openai_prompt
+  file://prompts/llama_prompt.txt: llama_prompt
 
 providers:
   - id: ollama:llama2
@@ -119,8 +119,8 @@ tests:
 // highlight-end
 
 prompts:
-  prompts/openai_prompt.json: openai_prompt
-  prompts/llama_prompt.txt: llama_prompt
+  file://prompts/openai_prompt.json: openai_prompt
+  file://prompts/llama_prompt.txt: llama_prompt
 
 providers:
   - id: ollama:llama2

--- a/site/docs/guides/mistral-vs-llama.md
+++ b/site/docs/guides/mistral-vs-llama.md
@@ -76,13 +76,13 @@ Now, let's go back to `promptfooconfig.yaml` and add our prompts. We'll name the
 
 ````yaml title="promptfooconfig.yaml"
 prompts:
-  prompts/mistral_prompt.txt: mistral_prompt
-  prompts/llama_prompt.txt: llama_prompt
+  file://prompts/mistral_prompt.txt: mistral_prompt
+  file://prompts/llama_prompt.txt: llama_prompt
 
 ```yaml title="promptfooconfig.yaml"
 prompts:
-  prompts/mistral_prompt.txt: mistral_prompt
-  prompts/llama_prompt.txt: llama_prompt
+  file://prompts/mistral_prompt.txt: mistral_prompt
+  file://prompts/llama_prompt.txt: llama_prompt
 
 providers:
   - id: huggingface:text-generation:mistralai/Mistral-7B-Instruct-v0.1

--- a/site/docs/guides/prevent-llm-hallucations.md
+++ b/site/docs/guides/prevent-llm-hallucations.md
@@ -97,7 +97,7 @@ Once you've set up a few prompts, add them to the config file:
 
 ```yaml title="promptfooconfig.yaml"
 // highlight-next-line
-prompts: [prompt1.txt, prompt2.txt]
+prompts: [file://prompt1.txt, file://prompt2.txt]
 tests:
   - vars:
       question: What's the weather in New York?

--- a/site/docs/guides/sandboxed-code-evals.md
+++ b/site/docs/guides/sandboxed-code-evals.md
@@ -38,7 +38,7 @@ docker pull python:3.9-alpine
 Create a file named `promptfooconfig.yaml`:
 
 ```yaml
-prompts: code_generation_prompt.txt
+prompts: file://code_generation_prompt.txt
 
 providers:
   - ollama:chat:llama3:70b

--- a/site/docs/guides/testing-llm-chains.md
+++ b/site/docs/guides/testing-llm-chains.md
@@ -59,7 +59,7 @@ python langchain_example.py "What is 2+2?"
 Now, let's configure promptfoo to run this LangChain script with a bunch of test cases:
 
 ```yaml
-prompts: prompt.txt
+prompts: file://prompt.txt
 providers:
   - openai:chat:gpt-4.1
   - exec:python langchain_example.py

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -109,8 +109,8 @@ like `llm-rubric` or `similar`. To do this, override the default LLM grader by a
 
 ```yaml
 prompts:
-  - prompt1.txt
-  - prompt2.txt
+  - file://prompt1.txt
+  - file://prompt2.txt
 providers:
   - anthropic:messages:claude-3-5-sonnet-20241022
   - openai:chat:gpt-4.1-mini


### PR DESCRIPTION
## Summary

This PR standardizes file references across examples and documentation to consistently use the `file://` scheme.

## Changes Made

- **Examples**: Updated configuration files in multiple example directories to use `file://` scheme for file references
- **Documentation**: Updated guides and blog posts to maintain consistency with the new scheme
- **Bug Fixes**: Corrected incorrect `file://./` patterns to use proper `file://` format

## Files Changed

### Example Configurations
- `examples/claude-vs-gpt-image/promptfooconfig.yaml`
- `examples/custom-prompt-function/promptfooconfig.yaml`
- `examples/google-live/promptfooconfig.statefulapi.yaml`
- `examples/langchain-python/promptfooconfig.yaml`
- `examples/ollama-comparison/promptfooconfig.yaml`
- `examples/openai-multiline-yaml/promptfooconfig.yaml`
- `examples/redteam-deepseek/promptfooconfig.yaml`
- `examples/simple-test/promptfooconfig.yaml`

### Documentation
- `site/blog/deepseek-censorship.md`
- Multiple guide files in `site/docs/guides/`
- `site/docs/integrations/google-sheets.md`

## Impact

This change improves consistency and makes file reference patterns explicit across the codebase. Users following examples will now see a consistent approach to file references. 