### PR TITLE
fix(cli): Overriding plugin severity

### DIFF
--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_PLUGINS as REDTEAM_DEFAULT_PLUGINS,
   DEFAULT_STRATEGIES,
   REDTEAM_MODEL,
+  type Severity,
 } from '../constants';
 import { shouldGenerateRemote, neverGenerateRemote } from '../remoteGeneration';
 import type {
@@ -207,6 +208,7 @@ export async function doGenerateRedteam(
         id: string;
         numTests: number | undefined;
         config?: Record<string, any>;
+        severity?: Severity;
       } = {
         // Handle both string-style ('pluginName') and object-style ({ id: 'pluginName' }) plugins
         id: typeof plugin === 'string' ? plugin : plugin.id,
@@ -218,8 +220,13 @@ export async function doGenerateRedteam(
       };
 
       // If plugin has additional config options, include them
-      if (typeof plugin === 'object' && plugin.config) {
-        pluginConfig.config = plugin.config;
+      if (typeof plugin === 'object') {
+        if (plugin.config) {
+          pluginConfig.config = plugin.config;
+        }
+        if (plugin.severity) {
+          pluginConfig.severity = plugin.severity;
+        }
       }
 
       return pluginConfig;


### PR DESCRIPTION
Setting severity levels [as detailed in the docs](https://www.promptfoo.dev/docs/red-team/configuration/#severity-levels) doesn't work.