### PR TITLE
fix(eval): handle undefined maxConcurrency with proper fallbacks

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -178,7 +178,8 @@ export async function doEval(
       };
     }
 
-    let maxConcurrency = cmdObj.maxConcurrency;
+    let maxConcurrency =
+      cmdObj.maxConcurrency ?? evaluateOptions.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
     const delay = cmdObj.delay ?? 0;
 
     if (delay > 0) {

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -4,6 +4,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import cliState from '../../cliState';
 import { CLOUD_PROVIDER_PREFIX } from '../../constants';
+import { DEFAULT_MAX_CONCURRENCY } from '../../evaluator';
 import logger from '../../logger';
 import telemetry from '../../telemetry';
 import { setupEnv } from '../../util';
@@ -34,8 +35,11 @@ export function redteamRunCommand(program: Command) {
       'Path to output file for generated tests. Defaults to redteam.yaml in the same directory as the configuration file.',
     )
     .option('--no-cache', 'Do not read or write results to disk cache', false)
-    .option('-j, --max-concurrency <number>', 'Maximum number of concurrent API calls', (val) =>
-      Number.parseInt(val, 10),
+    .option(
+      '-j, --max-concurrency <number>',
+      'Maximum number of concurrent API calls',
+      (val) => Number.parseInt(val, 10),
+      DEFAULT_MAX_CONCURRENCY,
     )
     .option('--delay <number>', 'Delay in milliseconds between API calls', (val) =>
       Number.parseInt(val, 10),

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -186,6 +186,32 @@ describe('evalCommand', () => {
       expect.objectContaining({ maxConcurrency: 5 }),
     );
   });
+
+  it('should fallback to evaluateOptions.maxConcurrency when cmdObj.maxConcurrency is undefined', async () => {
+    const cmdObj = {}; // No maxConcurrency set
+    const evaluateOptions = { maxConcurrency: 3 };
+
+    await doEval(cmdObj, defaultConfig, defaultConfigPath, evaluateOptions);
+
+    expect(evaluate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ maxConcurrency: 3 }),
+    );
+  });
+
+  it('should fallback to DEFAULT_MAX_CONCURRENCY when both cmdObj and evaluateOptions maxConcurrency are undefined', async () => {
+    const cmdObj = {}; // No maxConcurrency set
+    const evaluateOptions = {}; // No maxConcurrency set
+
+    await doEval(cmdObj, defaultConfig, defaultConfigPath, evaluateOptions);
+
+    expect(evaluate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ maxConcurrency: 4 }), // DEFAULT_MAX_CONCURRENCY is 4 in the mock
+    );
+  });
 });
 
 describe('formatTokenUsage', () => {


### PR DESCRIPTION
Fixes a bug where maxConcurrency could be undefined when running promptfoo redteam run. Added proper fallback chain and improved consistency between eval and redteam commands. Includes comprehensive test coverage for all scenarios.