### PR TITLE
Improve redteam plugin error messaging

### DIFF
--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -43,8 +43,13 @@ export const RedteamPluginObjectSchema = z.object({
           });
         }
       }),
-      z.string().startsWith('file://', {
-        message: 'Custom plugins must start with file:// (or use one of the built-in plugins)',
+      z.string().superRefine((val, ctx) => {
+        if (!val.startsWith('file://')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid plugin id "${val}". Custom plugins must start with file:// or be one of the built-in plugins: ${pluginOptions.join(', ')}`,
+          });
+        }
       }),
     ])
     .describe('Name of the plugin'),
@@ -74,8 +79,13 @@ export const RedteamPluginSchema = z.union([
           });
         }
       }),
-      z.string().startsWith('file://', {
-        message: 'Custom plugins must start with file:// (or use one of the built-in plugins)',
+      z.string().superRefine((val, ctx) => {
+        if (!val.startsWith('file://')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid plugin id "${val}". Custom plugins must start with file:// or be one of the built-in plugins: ${pluginOptions.join(', ')}`,
+          });
+        }
       }),
     ])
     .describe('Name of the plugin or path to custom plugin'),

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -114,6 +114,8 @@ describe('fetchWithProxy', () => {
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
     delete process.env.http_proxy;
+    delete process.env.npm_config_https_proxy;
+    delete process.env.npm_config_http_proxy;
   });
 
   afterEach(() => {
@@ -921,6 +923,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
     delete process.env.http_proxy;
+    delete process.env.npm_config_https_proxy;
+    delete process.env.npm_config_http_proxy;
     delete process.env.NO_PROXY;
     delete process.env.no_proxy;
   });
@@ -930,6 +934,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
     delete process.env.http_proxy;
+    delete process.env.npm_config_https_proxy;
+    delete process.env.npm_config_http_proxy;
     delete process.env.NO_PROXY;
     delete process.env.no_proxy;
     jest.resetAllMocks();

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -38,6 +38,12 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.AWS_BEDROCK_MAX_RETRIES;
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.npm_config_http_proxy;
+    delete process.env.npm_config_https_proxy;
   });
 
   afterEach(() => {

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -170,7 +170,7 @@ describe('redteamPluginSchema', () => {
     }
 
     const errorMessage = result.error.errors[0].message;
-    expect(errorMessage).toContain('Custom plugins must start with file://');
+    expect(errorMessage).toContain('Invalid plugin id');
     expect(errorMessage).toContain('built-in plugins');
   });
 
@@ -183,7 +183,7 @@ describe('redteamPluginSchema', () => {
     }
 
     const errorMessage = result.error.errors[0].message;
-    expect(errorMessage).toContain('Custom plugins must start with file://');
+    expect(errorMessage).toContain('Invalid plugin id');
     expect(errorMessage).toContain('built-in plugins');
   });
 
@@ -199,7 +199,7 @@ describe('redteamPluginSchema', () => {
     }
 
     const errorMessage = result.error.errors[0].message;
-    expect(errorMessage).toContain('Custom plugins must start with file://');
+    expect(errorMessage).toContain('Invalid plugin id');
     expect(errorMessage).toContain('built-in plugins');
   });
 });
@@ -1071,23 +1071,7 @@ describe('RedteamConfigSchema transform', () => {
         RedteamConfigSchema.parse({
           plugins: ['custom/path/without/file/protocol.js'],
         }),
-      ).toThrow(
-        JSON.stringify(
-          [
-            {
-              code: 'invalid_string',
-              validation: {
-                startsWith: 'file://',
-              },
-              message:
-                'Custom plugins must start with file:// (or use one of the built-in plugins)',
-              path: ['plugins', 0],
-            },
-          ],
-          null,
-          2,
-        ),
-      );
+      ).toThrow(/Invalid plugin id/);
     });
   });
 

--- a/test/validators/redteam.test.ts
+++ b/test/validators/redteam.test.ts
@@ -109,9 +109,7 @@ describe('RedteamConfigSchema', () => {
       plugins: ['invalid-plugin-name'],
     };
 
-    expect(() => RedteamConfigSchema.parse(config)).toThrow(
-      /Custom plugins must start with file:\/\//,
-    );
+    expect(() => RedteamConfigSchema.parse(config)).toThrow(/Invalid plugin id/);
   });
 
   it('should handle numTests override', () => {


### PR DESCRIPTION
## Summary
- clarify validation message for custom redteam plugins
- update tests to expect new message
- clean proxy-related env vars in tests to avoid false positives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840cf572108833288fc00e1bdbe86d5