### PR TITLE
fix: reset defaultTest on setup page

### DIFF
--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
@@ -45,7 +45,19 @@ function ErrorFallback({
 const EvaluateTestSuiteCreator: React.FC = () => {
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
-  const { setDescription, providers, setProviders, prompts, setPrompts, setTestCases } = useStore();
+  const {
+    setDescription,
+    providers,
+    setProviders,
+    prompts,
+    setPrompts,
+    setTestCases,
+    setDefaultTest,
+    setEnv,
+    setEvaluateOptions,
+    setScenarios,
+    setExtensions,
+  } = useStore();
 
   useEffect(() => {
     useStore.persist.rehydrate();
@@ -71,6 +83,11 @@ const EvaluateTestSuiteCreator: React.FC = () => {
     setDescription('');
     setProviders([]);
     setPrompts([]);
+    setDefaultTest({});
+    setEnv({});
+    setEvaluateOptions({});
+    setScenarios([]);
+    setExtensions([]);
     setTestCases([]);
     setResetDialogOpen(false);
   };


### PR DESCRIPTION
## Summary
- reset all fields including `defaultTest` when using Reset on setup page

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ProxyAgent expected vs received, smithy peer dependency missing)*


------
https://chatgpt.com/codex/tasks/task_e_6841c0dbfebc8332b6bb0bcc940ff628