### PR TITLE
fix: remove duplicate memory poisoning entry

### DIFF
--- a/src/redteam/constants/metadata.ts
+++ b/src/redteam/constants/metadata.ts
@@ -338,7 +338,6 @@ export const riskCategorySeverityMap: Record<Plugin, Severity> = {
 export const riskCategories: Record<string, Plugin[]> = {
   'Security & Access Control': [
     // System security
-    'agentic:memory-poisoning',
     'ascii-smuggling',
     'bfla',
     'bola',


### PR DESCRIPTION
remove extra 'agentic:memory-poisoning' entry from risk categories