### PR TITLE
chore: better error message for missing plugins

### DIFF
--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -43,8 +43,13 @@ export const RedteamPluginObjectSchema = z.object({
           });
         }
       }),
-      z.string().startsWith('file://', {
-        message: 'Custom plugins must start with file:// (or use one of the built-in plugins)',
+      z.string().superRefine((val, ctx) => {
+        if (!val.startsWith('file://')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Custom plugins must start with file:// (or use one of the built-in plugins). Received: "${val}"`,
+          });
+        }
       }),
     ])
     .describe('Name of the plugin'),
@@ -74,8 +79,13 @@ export const RedteamPluginSchema = z.union([
           });
         }
       }),
-      z.string().startsWith('file://', {
-        message: 'Custom plugins must start with file:// (or use one of the built-in plugins)',
+      z.string().superRefine((val, ctx) => {
+        if (!val.startsWith('file://')) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Custom plugins must start with file:// (or use one of the built-in plugins). Received: "${val}"`,
+          });
+        }
       }),
     ])
     .describe('Name of the plugin or path to custom plugin'),


### PR DESCRIPTION
```
Invalid configuration file /Users/steve/tmp/datadog/promptfooconfig.yaml:
Validation error: Custom plugins must start with file:// (or use one of the built-in plugins). Received: "not-real-plugin" at "redteam.plugins[27].id"
```