### PR TITLE
Add o3-pro model support

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -73,7 +73,7 @@ Supported parameters include:
 | `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                                                                                                                                                                 |
 | `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                                                                                                                              |
 | `headers`               | Additional headers to include in the request.                                                                                                                                                                                                                                                     |
-| `max_tokens`            | Controls the maximum length of the output in tokens. Not valid for reasoning models (o1, o3-mini).                                                                                                                                                                                                |
+| `max_tokens`            | Controls the maximum length of the output in tokens. Not valid for reasoning models (o1, o3-mini, o3-pro).                                                                                                                                                                                                |
 | `organization`          | Your OpenAI organization key.                                                                                                                                                                                                                                                                     |
 | `passthrough`           | A flexible object that allows passing arbitrary parameters directly to the OpenAI API request body. Useful for experimental, new, or provider-specific parameters not yet explicitly supported in promptfoo. This parameter is merged into the final API request and can override other settings. |
 | `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                                                                                                                                                     |
@@ -84,7 +84,7 @@ Supported parameters include:
 | `tool_choice`           | Controls whether the AI should use a tool. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                         |
 | `tools`                 | Allows you to define custom tools. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                                 |
 | `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                                                                                                                                                     |
-| `max_completion_tokens` | Maximum number of tokens to generate for reasoning models (o1, o3-mini).                                                                                                                                                                                                                          |
+| `max_completion_tokens` | Maximum number of tokens to generate for reasoning models (o1, o3-mini, o3-pro).                                                                                                                                                                                                                          |
 | `reasoning_effort`      | Allows you to control how long the reasoning model thinks before answering, 'low', 'medium' or 'high'.                                                                                                                                                                                            |
 
 Here are the type declarations of `config` parameters:
@@ -166,9 +166,9 @@ providers:
   - id: openai:chat:gpt-4.1-nano-2025-04-14 # Nano
 ```
 
-### Reasoning Models (o1, o3-mini)
+### Reasoning Models (o1, o3-mini, o3-pro)
 
-Reasoning models, like `o1` and `o3-mini`, are new large language models trained with reinforcement learning to perform complex reasoning. These models excel in complex problem solving, coding, scientific reasoning, and multi-step planning for agentic workflows.
+Reasoning models, like `o1`, `o3-mini`, and `o3-pro`, are new large language models trained with reinforcement learning to perform complex reasoning. These models excel in complex problem solving, coding, scientific reasoning, and multi-step planning for agentic workflows.
 
 When using reasoning models, there are important differences in how tokens are handled:
 
@@ -925,6 +925,7 @@ The Responses API supports a wide range of models, including:
 - `o1` - Powerful reasoning model
 - `o1-mini` - Smaller, more affordable reasoning model
 - `o1-pro` - Enhanced reasoning model with more compute
+- `o3-pro` - Highest-tier reasoning model
 - `o3` - OpenAI's most powerful reasoning model
 - `o3-mini` - Smaller, more affordable reasoning model
 - `o4-mini` - Latest fast, cost-effective reasoning model
@@ -1082,7 +1083,7 @@ npx promptfoo@latest init --example openai-mcp
 
 ### Reasoning Models
 
-When using reasoning models like `o1`, `o1-pro`, `o3`, `o3-mini`, or `o4-mini`, you can control the reasoning effort:
+When using reasoning models like `o1`, `o1-pro`, `o3`, `o3-pro`, `o3-mini`, or `o4-mini`, you can control the reasoning effort:
 
 ```yaml title="promptfooconfig.yaml"
 providers:

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -25,6 +25,8 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'o1-preview',
     'o1-mini',
     'o1-pro',
+    'o3-pro',
+    'o3-pro-2025-04-16',
     'o3',
     'o3-2025-04-16',
     'o4-mini',

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -107,6 +107,13 @@ export const OPENAI_CHAT_MODELS = [
       output: 12 / 1e6,
     },
   })),
+  ...['o3-pro', 'o3-pro-2025-04-16'].map((model) => ({
+    id: model,
+    cost: {
+      input: 150 / 1e6,
+      output: 600 / 1e6,
+    },
+  })),
   ...['o3-mini', 'o3-mini-2025-01-31'].map((model) => ({
     id: model,
     cost: {

--- a/test/providers/openai/responses.test.ts
+++ b/test/providers/openai/responses.test.ts
@@ -24,6 +24,7 @@ describe('OpenAiResponsesProvider', () => {
 
   it('should support various model names', () => {
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('o1-pro');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('o3-pro');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-4o');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('o3-mini');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-4.1');
@@ -1629,6 +1630,53 @@ describe('OpenAiResponsesProvider', () => {
     expect(body.reasoning).toEqual({ effort: 'high' });
     expect(body.max_output_tokens).toBe(2000);
     expect(body.temperature).toBeUndefined(); // o3 model should not have temperature
+  });
+
+  it('should configure o3-pro model correctly with reasoning parameters', async () => {
+    const mockApiResponse = {
+      id: 'resp_abc123',
+      status: 'completed',
+      model: 'o3-pro',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Response from o3-pro model',
+            },
+          ],
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 10, total_tokens: 20 },
+    };
+
+    jest.mocked(cache.fetchWithCache).mockResolvedValue({
+      data: mockApiResponse,
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = new OpenAiResponsesProvider('o3-pro', {
+      config: {
+        apiKey: 'test-key',
+        reasoning_effort: 'high',
+        max_output_tokens: 2000,
+      },
+    });
+
+    await provider.callApi('Test prompt');
+
+    const mockCall = jest.mocked(cache.fetchWithCache).mock.calls[0];
+    const reqOptions = mockCall[1] as { body: string };
+    const body = JSON.parse(reqOptions.body);
+
+    expect(body.model).toBe('o3-pro');
+    expect(body.reasoning).toEqual({ effort: 'high' });
+    expect(body.max_output_tokens).toBe(2000);
+    expect(body.temperature).toBeUndefined(); // o3-pro model should not have temperature
   });
 
   it('should configure o4-mini model correctly with reasoning parameters', async () => {

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -233,8 +233,18 @@ describe('calculateOpenAICost', () => {
     expect(cost).toBeCloseTo((1000 * 150 + 500 * 600) / 1e6, 6);
   });
 
+  it('should calculate cost correctly for o3-pro', () => {
+    const cost = calculateOpenAICost('o3-pro', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 150 + 500 * 600) / 1e6, 6);
+  });
+
   it('should calculate cost correctly for o1-pro-2025-03-19', () => {
     const cost = calculateOpenAICost('o1-pro-2025-03-19', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 150 + 500 * 600) / 1e6, 6);
+  });
+
+  it('should calculate cost correctly for o3-pro-2025-04-16', () => {
+    const cost = calculateOpenAICost('o3-pro-2025-04-16', {}, 1000, 500);
     expect(cost).toBeCloseTo((1000 * 150 + 500 * 600) / 1e6, 6);
   });
 


### PR DESCRIPTION
## Summary
- support new `o3-pro` and snapshot model
- document o3-pro usage and config options
- test cost calculations and Responses provider behavior for o3-pro

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489491a7e48333b082109515c9a97c