### PR TITLE
fix: support snake_case fields in python assertions

### DIFF
--- a/src/assertions/python.ts
+++ b/src/assertions/python.ts
@@ -69,7 +69,20 @@ ${
       }
       return parsed;
     } else if (typeof result === 'object') {
-      if (!isGradingResult(result)) {
+      const obj: Record<string, any> = result as any;
+
+      // Support snake_case keys from Python dataclass
+      if (obj.pass_ !== undefined && obj.pass === undefined) {
+        obj.pass = obj.pass_;
+      }
+      if (obj.named_scores && obj.namedScores === undefined) {
+        obj.namedScores = obj.named_scores;
+      }
+      if (obj.component_results && obj.componentResults === undefined) {
+        obj.componentResults = obj.component_results;
+      }
+
+      if (!isGradingResult(obj)) {
         throw new Error(
           `Python assertion must return a boolean, number, or {pass, score, reason} object. Got instead:\n${JSON.stringify(
             result,
@@ -78,7 +91,7 @@ ${
           )}`,
         );
       }
-      const pythonGradingResult = result as Omit<GradingResult, 'assertion'>;
+      const pythonGradingResult = obj as Omit<GradingResult, 'assertion'>;
       if (assertion.threshold && pythonGradingResult.score < assertion.threshold) {
         pythonGradingResult.pass = false;
         const scoreMessage = `Python score ${pythonGradingResult.score} is less than threshold ${assertion.threshold}`;

--- a/test/assertions/python.test.ts
+++ b/test/assertions/python.test.ts
@@ -397,4 +397,36 @@ describe('Python file references', () => {
       score: 0,
     });
   });
+
+  it('should map snake_case keys returned from python', async () => {
+    const pythonResult = {
+      pass_: true,
+      score: 1,
+      reason: 'ok',
+      named_scores: { accuracy: 0.9 },
+    };
+
+    jest.mocked(runPython).mockResolvedValueOnce(pythonResult as any);
+
+    const fileAssertion: Assertion = {
+      type: 'python',
+      value: 'file:///path/to/assert.py',
+    };
+    const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
+    const providerResponse = { output: 'Expected output' };
+
+    const result: GradingResult = await runAssertion({
+      prompt: 'A prompt',
+      provider,
+      assertion: fileAssertion,
+      test: {} as AtomicTestCase,
+      providerResponse,
+    });
+
+    expect(result).toMatchObject({
+      pass: true,
+      score: 1,
+      namedScores: { accuracy: 0.9 },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- map `named_scores` and other snake_case fields returned from Python
- test that Python assertions handle snake_case keys

## Testing
- `npm run f`
- `npm run l`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848435f55b083328c16ba278f1c2236