### PR TITLE
chore: Add README for missing examples

### DIFF
--- a/examples/colab-notebook/README.md
+++ b/examples/colab-notebook/README.md
@@ -1,0 +1,17 @@
+# colab-notebook (Colab Notebook)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example colab-notebook
+```
+
+This example walks through running **promptfoo** inside a Google Colab notebook.
+
+## Quick Start
+
+Open [promptfoo_example.ipynb](./promptfoo_example.ipynb) in Google Colab and run each cell. The notebook installs promptfoo, sets up API keys, and demonstrates a few evaluations.
+
+## Environment Variables
+
+- `OPENAI_API_KEY` or other provider keys as required

--- a/examples/colab-notebook/README.md
+++ b/examples/colab-notebook/README.md
@@ -8,10 +8,22 @@ npx promptfoo@latest init --example colab-notebook
 
 This example walks through running **promptfoo** inside a Google Colab notebook.
 
+## Prerequisites
+
+- Google Colab account (free tier is sufficient)
+- API keys for LLM providers:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+
 ## Quick Start
 
 Open [promptfoo_example.ipynb](./promptfoo_example.ipynb) in Google Colab and run each cell. The notebook installs promptfoo, sets up API keys, and demonstrates a few evaluations.
 
-## Environment Variables
+## Expected Results
 
-- `OPENAI_API_KEY` or other provider keys as required
+The notebook will:
+
+- Install promptfoo in the Colab environment
+- Run sample evaluations comparing different models
+- Display evaluation results and metrics
+- Show how to export results for further analysis

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -8,6 +8,29 @@ npx promptfoo@latest init --example github-action
 
 This folder contains a standalone GitHub Action that runs **promptfoo** when a pull request modifies prompts.
 
+## Prerequisites
+
+- GitHub repository with Actions enabled
+- API keys for LLM providers set as repository secrets:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+
+### Setting up GitHub Secrets:
+
+1. Go to your repository → Settings → Secrets and variables → Actions
+2. Click "New repository secret"
+3. Add `OPENAI_API_KEY` with your OpenAI API key as the value
+4. Repeat for other provider keys as needed
+
 ## Usage
 
-Edit [standalone-action.yaml](./standalone-action.yaml) as needed and add it to your repository's workflow. Set the `OPENAI_API_KEY` secret so the action can evaluate your prompts.
+Edit [standalone-action.yaml](./standalone-action.yaml) as needed and add it to your repository's `.github/workflows/` directory. The action will automatically run when pull requests modify prompt files.
+
+## Expected Results
+
+When triggered, the action will:
+
+- Install promptfoo in the GitHub runner environment
+- Run evaluations on the modified prompts
+- Post results as PR comments or check results
+- Fail the check if evaluations don't meet configured thresholds

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -1,0 +1,13 @@
+# github-action (GitHub Action)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example github-action
+```
+
+This folder contains a standalone GitHub Action that runs **promptfoo** when a pull request modifies prompts.
+
+## Usage
+
+Edit [standalone-action.yaml](./standalone-action.yaml) as needed and add it to your repository's workflow. Set the `OPENAI_API_KEY` secret so the action can evaluate your prompts.

--- a/examples/node-package-typescript/README.md
+++ b/examples/node-package-typescript/README.md
@@ -1,0 +1,25 @@
+# node-package-typescript (Node Package TypeScript)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example node-package-typescript
+```
+
+This example demonstrates using promptfoo from a TypeScript script.
+
+## Running the Example
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Execute the script:
+
+```bash
+npx ts-node src/full-eval.ts
+```
+
+Results are written to `output.json`. View them with `promptfoo view`.

--- a/examples/node-package-typescript/README.md
+++ b/examples/node-package-typescript/README.md
@@ -8,6 +8,21 @@ npx promptfoo@latest init --example node-package-typescript
 
 This example demonstrates using promptfoo from a TypeScript script.
 
+## Prerequisites
+
+- Node.js (version 18 or higher)
+- TypeScript and ts-node (installed via npm dependencies)
+- API keys for LLM providers set as environment variables:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+
+You can set these in a `.env` file:
+
+```
+OPENAI_API_KEY=sk-your-key-here
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+```
+
 ## Running the Example
 
 1. Install dependencies:
@@ -22,4 +37,13 @@ npm install
 npx ts-node src/full-eval.ts
 ```
 
-Results are written to `output.json`. View them with `promptfoo view`.
+## Expected Results
+
+The TypeScript script will:
+
+- Run evaluations with full type safety using the promptfoo API
+- Save results to `output.json`
+- Display evaluation metrics in the console
+- Demonstrate TypeScript integration patterns for promptfoo
+
+View detailed results with `promptfoo view`.

--- a/examples/node-package/README.md
+++ b/examples/node-package/README.md
@@ -1,0 +1,25 @@
+# node-package (Node Package)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example node-package
+```
+
+This example demonstrates using promptfoo from a Node.js script.
+
+## Running the Example
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Execute the script:
+
+```bash
+node full-eval.js
+```
+
+Results are saved in `output.json`. View them with `promptfoo view`.

--- a/examples/node-package/README.md
+++ b/examples/node-package/README.md
@@ -8,6 +8,20 @@ npx promptfoo@latest init --example node-package
 
 This example demonstrates using promptfoo from a Node.js script.
 
+## Prerequisites
+
+- Node.js (version 18 or higher)
+- API keys for LLM providers set as environment variables:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+
+You can set these in a `.env` file:
+
+```
+OPENAI_API_KEY=sk-your-key-here
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+```
+
 ## Running the Example
 
 1. Install dependencies:
@@ -22,4 +36,11 @@ npm install
 node full-eval.js
 ```
 
-Results are saved in `output.json`. View them with `promptfoo view`.
+## Expected Results
+
+The script will:
+
+- Run evaluations programmatically using the promptfoo Node.js API
+- Save results to `output.json`
+- Display evaluation metrics in the console
+- Allow you to view detailed results with `promptfoo view`

--- a/examples/redteam-bestOfN-strategy/README.md
+++ b/examples/redteam-bestOfN-strategy/README.md
@@ -1,0 +1,13 @@
+# redteam-bestOfN-strategy (Redteam: Best-of-N Strategy)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example redteam-bestOfN-strategy
+```
+
+This example runs a red team using the `best-of-n` attack strategy to generate multiple adversarial prompts.
+
+```bash
+promptfoo redteam run
+```

--- a/examples/redteam-bestOfN-strategy/README.md
+++ b/examples/redteam-bestOfN-strategy/README.md
@@ -8,6 +8,26 @@ npx promptfoo@latest init --example redteam-bestOfN-strategy
 
 This example runs a red team using the `best-of-n` attack strategy to generate multiple adversarial prompts.
 
+## Prerequisites
+
+- API keys for LLM providers set as environment variables:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+- A target application or system to test (configured in `promptfooconfig.yaml`)
+
+## Quick Start
+
+Run the red team evaluation:
+
 ```bash
 promptfoo redteam run
 ```
+
+## Expected Results
+
+The red team evaluation will:
+
+- Generate multiple adversarial prompts using the best-of-N strategy
+- Test your target system with various attack vectors
+- Produce a detailed report showing vulnerabilities found
+- Save results that can be viewed with `promptfoo view`

--- a/examples/redteam-minimal/README.md
+++ b/examples/redteam-minimal/README.md
@@ -1,0 +1,13 @@
+# redteam-minimal (Redteam: Minimal)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example redteam-minimal
+```
+
+A minimal red team setup demonstrating basic configuration and strategies.
+
+```bash
+promptfoo redteam run
+```

--- a/examples/redteam-minimal/README.md
+++ b/examples/redteam-minimal/README.md
@@ -8,6 +8,26 @@ npx promptfoo@latest init --example redteam-minimal
 
 A minimal red team setup demonstrating basic configuration and strategies.
 
+## Prerequisites
+
+- API keys for LLM providers set as environment variables:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+- A target application or system to test (configured in `promptfooconfig.yaml`)
+
+## Quick Start
+
+Run the red team evaluation:
+
 ```bash
 promptfoo redteam run
 ```
+
+## Expected Results
+
+The minimal red team evaluation will:
+
+- Run basic adversarial tests against your target system
+- Check for common vulnerabilities like prompt injection and jailbreaking
+- Generate a security report with findings
+- Demonstrate the foundation for more advanced red team testing

--- a/examples/websockets/README.md
+++ b/examples/websockets/README.md
@@ -8,9 +8,16 @@ npx promptfoo@latest init --example websockets
 
 This example shows how to connect promptfoo to a WebSocket-based LLM service.
 
+## Prerequisites
+
+- Node.js (version 18 or higher)
+- API keys for LLM providers set as environment variables:
+  - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
+  - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)
+
 ## Quick Start
 
-1. Start the test server:
+1. Start the test server (simulates a WebSocket LLM service):
 
 ```bash
 cd test-server
@@ -18,8 +25,18 @@ npm install
 node server.js
 ```
 
-2. Run the evaluation:
+2. In a new terminal, run the evaluation:
 
 ```bash
 promptfoo eval
 ```
+
+## Expected Results
+
+This example will:
+
+- Start a mock WebSocket server that simulates an LLM service
+- Connect promptfoo to the WebSocket server using the custom provider
+- Run evaluations through the WebSocket connection
+- Demonstrate how to integrate promptfoo with custom WebSocket-based APIs
+- Save results that can be viewed with `promptfoo view`

--- a/examples/websockets/README.md
+++ b/examples/websockets/README.md
@@ -1,0 +1,25 @@
+# websockets (Websockets Provider Example)
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example websockets
+```
+
+This example shows how to connect promptfoo to a WebSocket-based LLM service.
+
+## Quick Start
+
+1. Start the test server:
+
+```bash
+cd test-server
+npm install
+node server.js
+```
+
+2. Run the evaluation:
+
+```bash
+promptfoo eval
+```


### PR DESCRIPTION
- **Documentation**
  - Added new README files for various examples, including Colab notebook, GitHub Action, Node.js package (JavaScript and TypeScript), red team strategies, and WebSockets integration.
  - Each README provides setup instructions, prerequisites, usage steps, and outlines expected results for running and evaluating promptfoo in different environments and use cases.