### PR TITLE
docs: move discovery under tools

### DIFF
--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -181,10 +181,6 @@ const sidebars = {
       id: 'red-team/owasp-llm-top-10',
     },
     {
-      type: 'doc',
-      id: 'red-team/discovery',
-    },
-    {
       type: 'category',
       label: 'Plugins',
       collapsed: true,
@@ -319,6 +315,10 @@ const sidebars = {
       label: 'Tools',
       collapsed: true,
       items: [
+        {
+          type: 'doc',
+          id: 'red-team/discovery',
+        },
         {
           type: 'doc',
           id: 'red-team/guardrails',


### PR DESCRIPTION
its not important enough to merit a top level entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Moved the "discovery" document from a top-level sidebar entry to the "Tools" category for improved organization in the sidebar navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->