### PR TITLE
fix(eval): Fix RangeError on progress bar var replace with large strings

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1186,26 +1186,28 @@ class Evaluator {
             try {
               // Constants for progress bar display
               // Limit individual var values
-              const MAX_VAR_VALUE_LENGTH = 50; 
-              // Limit total vars string length 
+              const MAX_VAR_VALUE_LENGTH = 50;
+              // Limit total vars string length
               // Maybe this should vary based on terminal size??
-              const MAX_TOTAL_LENGTH = 200; 
-              
+              const MAX_TOTAL_LENGTH = 200;
+
               const entries = Object.entries(evalStep.test.vars || {});
-              
+
               const truncatedEntries = entries.map(([k, v]) => {
                 const valueStr = String(v);
-                const truncatedValue = valueStr.length > MAX_VAR_VALUE_LENGTH
-                  ? valueStr.substring(0, MAX_VAR_VALUE_LENGTH) + '...'
-                  : valueStr;
+                const truncatedValue =
+                  valueStr.length > MAX_VAR_VALUE_LENGTH
+                    ? valueStr.substring(0, MAX_VAR_VALUE_LENGTH) + '...'
+                    : valueStr;
                 return `${k}=${truncatedValue}`;
               });
-              
+
               const joined = truncatedEntries.join(' ');
-              const result = joined.length > MAX_TOTAL_LENGTH
-                ? joined.substring(0, MAX_TOTAL_LENGTH) + '...'
-                : joined;
-              
+              const result =
+                joined.length > MAX_TOTAL_LENGTH
+                  ? joined.substring(0, MAX_TOTAL_LENGTH) + '...'
+                  : joined;
+
               // Remove newlines from the final result so we don't break the progress bar
               return result.replace(/\n/g, ' ');
             } catch (error) {

--- a/src/evaluatorHelpers.test.ts
+++ b/src/evaluatorHelpers.test.ts
@@ -4,7 +4,7 @@ describe('resolveVariables RangeError fix', () => {
   it('should handle extremely large variable replacements without throwing RangeError', () => {
     // Create a large string that exceeds our 10MB limit
     const hugeString = 'A'.repeat(15 * 1024 * 1024); // 15MB string
-    
+
     const variables = {
       template: 'Process this data: {{code}}',
       code: hugeString,
@@ -15,12 +15,18 @@ describe('resolveVariables RangeError fix', () => {
       const result = resolveVariables(variables);
       expect(result).toBeDefined();
       expect(typeof result.template).toBe('string');
-      
+
       // Debug: log the actual result to see what we get
       console.log('Result template length:', result.template.toString().length);
-      console.log('Result template (first 200 chars):', result.template.toString().substring(0, 200));
-      console.log('Result template (last 200 chars):', result.template.toString().substring(result.template.toString().length - 200));
-      
+      console.log(
+        'Result template (first 200 chars):',
+        result.template.toString().substring(0, 200),
+      );
+      console.log(
+        'Result template (last 200 chars):',
+        result.template.toString().substring(result.template.toString().length - 200),
+      );
+
       // Should be handled safely without RangeError (main goal achieved)
       expect(result.template).toBeDefined();
     }).not.toThrow();
@@ -50,15 +56,15 @@ describe('resolveVariables RangeError fix', () => {
       // Should be summarized since it exceeds the 50MB limit
       expect(
         result.template.toString().includes('chars - showing first/last') ||
-        result.template.toString().includes('...[truncated to fit size limits]') ||
-        result.template === '[data: content too large for processing]'
+          result.template.toString().includes('...[truncated to fit size limits]') ||
+          result.template === '[data: content too large for processing]',
       ).toBe(true);
     }).not.toThrow();
   });
 
   it('should handle nested variable replacements with large data', () => {
     const hugeString = 'B'.repeat(5 * 1024 * 1024); // 5MB string - under limit
-    
+
     const variables = {
       template: 'Start: {{middle}}',
       middle: 'Middle: {{data}}',

--- a/src/evaluatorHelpers.test.ts
+++ b/src/evaluatorHelpers.test.ts
@@ -1,0 +1,75 @@
+import { resolveVariables } from './evaluatorHelpers';
+
+describe('resolveVariables RangeError fix', () => {
+  it('should handle extremely large variable replacements without throwing RangeError', () => {
+    // Create a large string that exceeds our 10MB limit
+    const hugeString = 'A'.repeat(15 * 1024 * 1024); // 15MB string
+    
+    const variables = {
+      template: 'Process this data: {{code}}',
+      code: hugeString,
+    };
+
+    // This should not throw RangeError
+    expect(() => {
+      const result = resolveVariables(variables);
+      expect(result).toBeDefined();
+      expect(typeof result.template).toBe('string');
+      
+      // Debug: log the actual result to see what we get
+      console.log('Result template length:', result.template.toString().length);
+      console.log('Result template (first 200 chars):', result.template.toString().substring(0, 200));
+      console.log('Result template (last 200 chars):', result.template.toString().substring(result.template.toString().length - 200));
+      
+      // Should be handled safely without RangeError (main goal achieved)
+      expect(result.template).toBeDefined();
+    }).not.toThrow();
+  });
+
+  it('should handle normal variable replacements without truncation', () => {
+    const variables = {
+      template: 'Hello {{name}}!',
+      name: 'World',
+    };
+
+    const result = resolveVariables(variables);
+    expect(result.template).toBe('Hello World!');
+    expect(result.template.toString()).not.toContain('...[truncated due to size]');
+  });
+
+  it('should use safe fallback when RangeError still occurs', () => {
+    // Create variables that exceed our 50MB limit to trigger summary
+    const variables = {
+      template: '{{data}}',
+      data: 'A'.repeat(60 * 1024 * 1024), // 60MB - exceeds our 50MB limit
+    };
+
+    expect(() => {
+      const result = resolveVariables(variables);
+      expect(result).toBeDefined();
+      // Should be summarized since it exceeds the 50MB limit
+      expect(
+        result.template.toString().includes('chars - showing first/last') ||
+        result.template.toString().includes('...[truncated to fit size limits]') ||
+        result.template === '[data: content too large for processing]'
+      ).toBe(true);
+    }).not.toThrow();
+  });
+
+  it('should handle nested variable replacements with large data', () => {
+    const hugeString = 'B'.repeat(5 * 1024 * 1024); // 5MB string - under limit
+    
+    const variables = {
+      template: 'Start: {{middle}}',
+      middle: 'Middle: {{data}}',
+      data: hugeString,
+    };
+
+    expect(() => {
+      const result = resolveVariables(variables);
+      expect(result).toBeDefined();
+      expect(typeof result.template).toBe('string');
+      expect(typeof result.middle).toBe('string');
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Occasionally you can get a crash when the progress bar attempts to load too big of a vars string into memory.

This manifest's like so: 
`RangeError: Invalid string length
    at Array.join (<anonymous>)
    at Object.options.progressCallback (/usr/local/lib/node_modules/promptfoo/src/evaluator.ts:1187:14)
    at processEvalStep (/usr/local/lib/node_modules/promptfoo/src/evaluator.ts:1030:19)
    at /usr/local/lib/node_modules/promptfoo/src/evaluator.ts:1291:9`
    
   ## Solution
   
   Attempt to fix this by truncating the vars in the progress bar. Also set a suitable fallback if the RangeError still occurs. 
   
   ## Testing
   
   Wrote a unit test for this behavior with ~60MB strings. Also checked that the styling is not altered by running the vars-referencing-vars config. 