### PR TITLE
chore(webui): fix text length reset value to use reasonable default

### DIFF
--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -40,8 +40,10 @@ const SettingsPanel: React.FC = () => {
   } = useResultsViewSettingsStore();
 
   // Local state for slider
+  const sanitizedMaxTextLength =
+    Number.isFinite(maxTextLength) && maxTextLength >= 25 ? maxTextLength : 500;
   const [localMaxTextLength, setLocalMaxTextLength] = useState(
-    maxTextLength === Number.POSITIVE_INFINITY ? 1001 : maxTextLength,
+    sanitizedMaxTextLength === Number.POSITIVE_INFINITY ? 1001 : sanitizedMaxTextLength,
   );
 
   // Handle slider changes

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -41,7 +41,11 @@ const SettingsPanel: React.FC = () => {
 
   // Local state for slider
   const sanitizedMaxTextLength =
-    Number.isFinite(maxTextLength) && maxTextLength >= 25 ? maxTextLength : 500;
+    maxTextLength === Number.POSITIVE_INFINITY
+      ? Number.POSITIVE_INFINITY
+      : Number.isFinite(maxTextLength) && maxTextLength >= 25
+        ? maxTextLength
+        : 500;
   const [localMaxTextLength, setLocalMaxTextLength] = useState(
     sanitizedMaxTextLength === Number.POSITIVE_INFINITY ? 1001 : sanitizedMaxTextLength,
   );

--- a/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
+++ b/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
@@ -39,8 +39,10 @@ export const useSettingsState = (isOpen: boolean) => {
     setMaxImageHeight,
   } = store;
 
+  const sanitizedMaxTextLength =
+    Number.isFinite(maxTextLength) && maxTextLength >= 25 ? maxTextLength : 500;
   const [localMaxTextLength, setLocalMaxTextLength] = useState(
-    maxTextLength === Number.POSITIVE_INFINITY ? 1001 : maxTextLength,
+    sanitizedMaxTextLength === Number.POSITIVE_INFINITY ? 1001 : sanitizedMaxTextLength,
   );
 
   const initialStateRef = useRef<SettingsState>({

--- a/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
+++ b/src/app/src/pages/eval/components/TableSettings/hooks/useSettingsState.ts
@@ -40,7 +40,11 @@ export const useSettingsState = (isOpen: boolean) => {
   } = store;
 
   const sanitizedMaxTextLength =
-    Number.isFinite(maxTextLength) && maxTextLength >= 25 ? maxTextLength : 500;
+    maxTextLength === Number.POSITIVE_INFINITY
+      ? Number.POSITIVE_INFINITY
+      : Number.isFinite(maxTextLength) && maxTextLength >= 25
+        ? maxTextLength
+        : 500;
   const [localMaxTextLength, setLocalMaxTextLength] = useState(
     sanitizedMaxTextLength === Number.POSITIVE_INFINITY ? 1001 : sanitizedMaxTextLength,
   );


### PR DESCRIPTION
Added sanitizedMaxTextLength that defaults to 500 when current setting is invalid, ensuring the slider never resets to unreasonably low values like 0/25. Applied same sanitization in useSettingsState hook for consistency.