### PR TITLE
refactor: remove unused token usage utilities

### DIFF
--- a/src/util/tokenUsage.ts
+++ b/src/util/tokenUsage.ts
@@ -1,5 +1,4 @@
 import logger from '../logger';
-import type { ApiProvider } from '../types/providers';
 import type { TokenUsage } from '../types/shared';
 
 /**
@@ -174,61 +173,4 @@ export class TokenUsageTracker {
 
     return result;
   }
-}
-
-/**
- * Decorator function to wrap a provider's callApi method to track token usage
- * @param provider The provider to instrument
- * @returns The instrumented provider
- */
-export function withTokenTracking<T extends ApiProvider>(provider: T): T {
-  const originalCallApi = provider.callApi;
-
-  provider.callApi = async (...args) => {
-    const response = await originalCallApi.apply(provider, args);
-    if (response.tokenUsage) {
-      const providerId = provider.id();
-      // Include the provider's class in the tracking ID
-      const trackingId = provider.constructor?.name
-        ? `${providerId} (${provider.constructor.name})`
-        : providerId;
-
-      TokenUsageTracker.getInstance().trackUsage(trackingId, response.tokenUsage);
-    }
-    return response;
-  };
-
-  return provider;
-}
-
-/**
- * Get the cumulative token usage from a provider
- * @param provider The provider to get token usage from
- * @returns The cumulative token usage
- */
-export function getCumulativeTokenUsage(provider: ApiProvider): TokenUsage | undefined {
-  return TokenUsageTracker.getInstance().getProviderUsage(provider.id());
-}
-
-/**
- * Reset the cumulative token usage for a provider
- * @param provider The provider to reset token usage for
- */
-export function resetCumulativeTokenUsage(provider: ApiProvider): void {
-  TokenUsageTracker.getInstance().resetProviderUsage(provider.id());
-}
-
-/**
- * Get the total token usage across all providers
- * @returns The total token usage
- */
-export function getTotalTokenUsage(): TokenUsage {
-  return TokenUsageTracker.getInstance().getTotalUsage();
-}
-
-/**
- * Reset token usage for all providers
- */
-export function resetAllProviderTokenUsage(): void {
-  TokenUsageTracker.getInstance().resetAllUsage();
 }

--- a/test/util/tokenUsage.test.ts
+++ b/test/util/tokenUsage.test.ts
@@ -1,0 +1,188 @@
+import type { TokenUsage } from '../../src/types/shared';
+import { TokenUsageTracker } from '../../src/util/tokenUsage';
+
+describe('TokenUsageTracker', () => {
+  let tracker: TokenUsageTracker;
+
+  beforeEach(() => {
+    tracker = TokenUsageTracker.getInstance();
+    tracker.resetAllUsage();
+  });
+
+  afterEach(() => {
+    tracker.cleanup();
+  });
+
+  it('should track token usage for a provider', () => {
+    const usage: TokenUsage = {
+      total: 100,
+      prompt: 50,
+      completion: 50,
+      cached: 10,
+      numRequests: 1,
+      completionDetails: {
+        reasoning: 20,
+        acceptedPrediction: 15,
+        rejectedPrediction: 5,
+      },
+      assertions: {
+        total: 30,
+        prompt: 10,
+        completion: 15,
+        cached: 5,
+      },
+    };
+
+    tracker.trackUsage('test-provider', usage);
+    const tracked = tracker.getProviderUsage('test-provider');
+
+    expect(tracked).toEqual(usage);
+  });
+
+  it('should handle undefined token usage', () => {
+    tracker.trackUsage('test-provider', undefined);
+    expect(tracker.getProviderUsage('test-provider')).toBeUndefined();
+  });
+
+  it('should merge token usage for the same provider', () => {
+    const usage1: TokenUsage = {
+      total: 100,
+      prompt: 50,
+      completion: 50,
+      cached: 10,
+      numRequests: 1,
+      completionDetails: {
+        reasoning: 20,
+        acceptedPrediction: 15,
+        rejectedPrediction: 5,
+      },
+      assertions: {
+        total: 30,
+        prompt: 10,
+        completion: 15,
+        cached: 5,
+      },
+    };
+
+    const usage2: TokenUsage = {
+      total: 200,
+      prompt: 100,
+      completion: 100,
+      cached: 20,
+      numRequests: 2,
+      completionDetails: {
+        reasoning: 40,
+        acceptedPrediction: 30,
+        rejectedPrediction: 10,
+      },
+      assertions: {
+        total: 60,
+        prompt: 20,
+        completion: 30,
+        cached: 10,
+      },
+    };
+
+    tracker.trackUsage('test-provider', usage1);
+    tracker.trackUsage('test-provider', usage2);
+
+    const merged = tracker.getProviderUsage('test-provider');
+    expect(merged).toEqual({
+      total: 300,
+      prompt: 150,
+      completion: 150,
+      cached: 30,
+      numRequests: 3,
+      completionDetails: {
+        reasoning: 60,
+        acceptedPrediction: 45,
+        rejectedPrediction: 15,
+      },
+      assertions: {
+        total: 90,
+        prompt: 30,
+        completion: 45,
+        cached: 15,
+      },
+    });
+  });
+
+  it('should get provider IDs', () => {
+    tracker.trackUsage('provider1', { total: 100 });
+    tracker.trackUsage('provider2', { total: 200 });
+
+    expect(tracker.getProviderIds()).toEqual(['provider1', 'provider2']);
+  });
+
+  it('should get total usage across all providers', () => {
+    tracker.trackUsage('provider1', {
+      total: 100,
+      prompt: 50,
+      completion: 50,
+      cached: 10,
+      numRequests: 1,
+      completionDetails: {
+        reasoning: 20,
+        acceptedPrediction: 15,
+        rejectedPrediction: 5,
+      },
+      assertions: {
+        total: 30,
+        prompt: 10,
+        completion: 15,
+        cached: 5,
+      },
+    });
+
+    tracker.trackUsage('provider2', {
+      total: 200,
+      prompt: 100,
+      completion: 100,
+      cached: 20,
+      numRequests: 2,
+      completionDetails: {
+        reasoning: 40,
+        acceptedPrediction: 30,
+        rejectedPrediction: 10,
+      },
+      assertions: {
+        total: 60,
+        prompt: 20,
+        completion: 30,
+        cached: 10,
+      },
+    });
+
+    expect(tracker.getTotalUsage()).toEqual({
+      total: 300,
+      prompt: 150,
+      completion: 150,
+      cached: 30,
+      numRequests: 3,
+      completionDetails: {
+        reasoning: 60,
+        acceptedPrediction: 45,
+        rejectedPrediction: 15,
+      },
+      assertions: {
+        total: 90,
+        prompt: 30,
+        completion: 45,
+        cached: 15,
+      },
+    });
+  });
+
+  it('should reset provider usage', () => {
+    tracker.trackUsage('provider1', { total: 100 });
+    tracker.resetProviderUsage('provider1');
+    expect(tracker.getProviderUsage('provider1')).toBeUndefined();
+  });
+
+  it('should reset all usage', () => {
+    tracker.trackUsage('provider1', { total: 100 });
+    tracker.trackUsage('provider2', { total: 200 });
+    tracker.resetAllUsage();
+    expect(tracker.getProviderIds()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- clean up unused exports from `tokenUsage`

## Testing
- `npm run f`
- `npm run l`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bbc9972208332871f310b76dbf294