### PR TITLE
fix(eval): prevent RangeError in progress bar variable display

### DIFF
--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -5,6 +5,7 @@ import { FILE_METADATA_KEY } from '../src/constants';
 import {
   calculateThreadsPerBar,
   evaluate,
+  formatVarsForDisplay,
   generateVarCombinations,
   isAllowedPrompt,
   newTokenUsage,
@@ -2797,75 +2798,120 @@ describe('calculateThreadsPerBar', () => {
   });
 });
 
-describe('progress bar vars handling', () => {
-  it('handles extremely large vars without throwing', async () => {
-    const bigStr = 'x'.repeat(5 * 1024 * 1024);
-    const vars: Record<string, string> = {};
-    for (let i = 0; i < 20; i++) {
-      vars[`var${i}`] = bigStr;
-    }
-
-    const testSuite: TestSuite = {
-      providers: [mockApiProvider],
-      prompts: [toPrompt('Test prompt')],
-      tests: [
-        {
-          vars,
-        },
-      ],
-    };
-
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
-
-    await expect(
-      evaluate(testSuite, evalRecord, { showProgressBar: true, maxConcurrency: 1 }),
-    ).resolves.not.toThrow();
+describe('formatVarsForDisplay', () => {
+  it('should return empty string for empty or undefined vars', () => {
+    expect(formatVarsForDisplay({}, 50)).toBe('');
+    expect(formatVarsForDisplay(undefined, 50)).toBe('');
+    expect(formatVarsForDisplay(null as any, 50)).toBe('');
   });
 
-  it('handles various variable types efficiently', async () => {
-    const complexVars: Record<string, any> = {
-      string: 'simple string',
-      longString: 'x'.repeat(1000),
+  it('should format simple variables correctly', () => {
+    const vars = { name: 'John', age: 25, city: 'NYC' };
+    const result = formatVarsForDisplay(vars, 50);
+
+    expect(result).toBe('name=John age=25 city=NYC');
+  });
+
+  it('should handle different variable types', () => {
+    const vars = {
+      string: 'hello',
       number: 42,
       boolean: true,
       nullValue: null,
       undefinedValue: undefined,
-      object: { nested: { deep: 'value' } },
-      array: [1, 2, 3, 'long string that should be truncated'],
+      object: { nested: 'value' },
+      array: [1, 2, 3],
     };
 
-    const testSuite: TestSuite = {
-      providers: [mockApiProvider],
-      prompts: [toPrompt('Test prompt')],
-      tests: [
-        {
-          vars: complexVars,
-        },
-      ],
-    };
+    const result = formatVarsForDisplay(vars, 200);
 
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
-
-    await expect(
-      evaluate(testSuite, evalRecord, { showProgressBar: true, maxConcurrency: 1 }),
-    ).resolves.not.toThrow();
+    expect(result).toContain('string=hello');
+    expect(result).toContain('number=42');
+    expect(result).toContain('boolean=true');
+    expect(result).toContain('nullValue=null');
+    expect(result).toContain('undefinedValue=undefined');
+    expect(result).toContain('object=[object Object]');
+    expect(result).toContain('array=1,2,3');
   });
 
-  it('formats empty and undefined vars gracefully', async () => {
-    const testCases = [{ vars: {} }, { vars: undefined }, {}];
+  it('should truncate individual values to prevent memory issues', () => {
+    const bigValue = 'x'.repeat(200);
+    const vars = { bigVar: bigValue };
 
-    for (const testCase of testCases) {
-      const testSuite: TestSuite = {
-        providers: [mockApiProvider],
-        prompts: [toPrompt('Test prompt')],
-        tests: [testCase],
-      };
+    const result = formatVarsForDisplay(vars, 200);
 
-      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    // Should truncate the value to 100 chars
+    expect(result).toBe(`bigVar=${'x'.repeat(100)}`);
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
 
-      await expect(
-        evaluate(testSuite, evalRecord, { showProgressBar: true, maxConcurrency: 1 }),
-      ).resolves.not.toThrow();
-    }
+  it('should handle extremely large vars without crashing', () => {
+    // This would have caused RangeError before the fix
+    const megaString = 'x'.repeat(5 * 1024 * 1024); // 5MB string
+    const vars = {
+      mega1: megaString,
+      mega2: megaString,
+      small: 'normal',
+    };
+
+    expect(() => formatVarsForDisplay(vars, 50)).not.toThrow();
+
+    const result = formatVarsForDisplay(vars, 50);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeLessThanOrEqual(50);
+  });
+
+  it('should truncate final result to maxLength', () => {
+    const vars = {
+      var1: 'value1',
+      var2: 'value2',
+      var3: 'value3',
+      var4: 'value4',
+    };
+
+    const result = formatVarsForDisplay(vars, 20);
+
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result).toBe('var1=value1 var2=val');
+  });
+
+  it('should replace newlines with spaces', () => {
+    const vars = {
+      multiline: 'line1\nline2\nline3',
+    };
+
+    const result = formatVarsForDisplay(vars, 100);
+
+    expect(result).toBe('multiline=line1 line2 line3');
+    expect(result).not.toContain('\n');
+  });
+
+  it('should return fallback message on any error', () => {
+    // Create a problematic object that might throw during String() conversion
+    const problematicVars = {
+      badProp: {
+        toString() {
+          throw new Error('Cannot convert to string');
+        },
+      },
+    };
+
+    const result = formatVarsForDisplay(problematicVars, 50);
+
+    expect(result).toBe('[vars unavailable]');
+  });
+
+  it('should handle multiple variables with space distribution', () => {
+    const vars = {
+      a: 'short',
+      b: 'medium_value',
+      c: 'a_very_long_value_that_exceeds_normal_length',
+    };
+
+    const result = formatVarsForDisplay(vars, 30);
+
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result).toContain('a=short');
+    // Should fit as much as possible within the limit
   });
 });


### PR DESCRIPTION
This PR provides an alternative implementation to #4465 for fixing RangeError crashes in progress bar variable display.