### PR TITLE
fix(cli): Fixes support for `context?.fetchWithCache`

### DIFF
--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -153,7 +153,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
         data: responseData,
         cached: isCached,
         status,
-      } = await fetchWithCache(
+      } = await (context?.fetchWithCache ?? fetchWithCache)(
         url,
         {
           method: 'POST',

--- a/src/providers/azure/completion.ts
+++ b/src/providers/azure/completion.ts
@@ -46,7 +46,7 @@ export class AzureCompletionProvider extends AzureGenericProvider {
     let data;
     let cached = false;
     try {
-      ({ data, cached } = (await fetchWithCache(
+      ({ data, cached } = (await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiBaseUrl()}/openai/deployments/${
           this.deploymentName
         }/completions?api-version=${this.config.apiVersion || DEFAULT_AZURE_API_VERSION}`,

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -164,7 +164,7 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
     let data,
       cached = false;
     try {
-      ({ data, cached } = (await fetchWithCache(
+      ({ data, cached } = (await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiUrl()}/v1beta3/models/${
           this.modelName
         }:generateMessage?key=${this.getApiKey()}`,
@@ -281,7 +281,7 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
     let data;
     let cached = false;
     try {
-      ({ data, cached } = (await fetchWithCache(
+      ({ data, cached } = (await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiUrl()}/${apiVersion}/models/${
           this.modelName
         }:generateContent?key=${this.getApiKey()}`,

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -848,7 +848,7 @@ export class HttpProvider implements ApiProvider {
       `[HTTP Provider]: Calling ${url} with config: ${safeJsonStringify(renderedConfig)}`,
     );
 
-    const response = await fetchWithCache(
+    const response = await (context?.fetchWithCache ?? fetchWithCache)(
       url,
       {
         method: renderedConfig.method,
@@ -950,7 +950,7 @@ export class HttpProvider implements ApiProvider {
     logger.debug(
       `[HTTP Provider]: Calling ${url} with raw request: ${parsedRequest.method}  ${safeJsonStringify(parsedRequest.body)} \n headers: ${safeJsonStringify(parsedRequest.headers)}`,
     );
-    const response = await fetchWithCache(
+    const response = await (context?.fetchWithCache ?? fetchWithCache)(
       url,
       {
         method: parsedRequest.method,

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -262,7 +262,7 @@ export class OllamaChatProvider implements ApiProvider {
     logger.debug(`Calling Ollama API: ${JSON.stringify(params)}`);
     let response;
     try {
-      response = await fetchWithCache(
+      response = await (context?.fetchWithCache ?? fetchWithCache)(
         `${getEnvString('OLLAMA_BASE_URL') || 'http://localhost:11434'}/api/chat`,
         {
           method: 'POST',

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -174,7 +174,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     let data, status, statusText;
     let cached = false;
     try {
-      ({ data, cached, status, statusText } = await fetchWithCache(
+      ({ data, cached, status, statusText } = await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiUrl()}/chat/completions`,
         {
           method: 'POST',

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -69,7 +69,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
     let data,
       cached = false;
     try {
-      ({ data, cached } = (await fetchWithCache(
+      ({ data, cached } = (await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiUrl()}/completions`,
         {
           method: 'POST',

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -188,7 +188,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     let data, status, statusText;
     let cached = false;
     try {
-      ({ data, cached, status, statusText } = await fetchWithCache(
+      ({ data, cached, status, statusText } = await (context?.fetchWithCache ?? fetchWithCache)(
         `${this.getApiUrl()}/responses`,
         {
           method: 'POST',


### PR DESCRIPTION
Provider instances of `callApi(prompt: string, context?: CallApiContextParams, ...)` should prefer `context?.fetchWithCache` when defined.  Amongst other things, this enables [cache busting](https://www.promptfoo.dev/docs/configuration/caching/#cache-busting).