### PR TITLE
fix: escape HTML special characters in output reports

### DIFF
--- a/src/tableOutput.html
+++ b/src/tableOutput.html
@@ -43,14 +43,14 @@
     <table>
       <thead>
         {% for header in table[0] %}
-        <th>{{ header }}</th>
+        <th>{{ header | escape }}</th>
         {% endfor %}
       </thead>
       <tbody>
         {% for row in table.slice(1) %}
         <tr>
           {% for cell in row %}
-          <td data-content="{{ cell | escape }}">{{ cell }}</td>
+          <td data-content="{{ cell | escape }}">{{ cell | escape }}</td>
           {% endfor %}
         </tr>
         {% endfor %}

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -234,13 +234,14 @@ describe('util', () => {
       const realFs = jest.requireActual('fs') as typeof fs;
       const templatePath = path.resolve(__dirname, '../../src/tableOutput.html');
       const templateContent = realFs.readFileSync(templatePath, 'utf-8');
-      
+
       // Check that the template has escape filters on all user-provided content
       expect(templateContent).toContain('{{ header | escape }}');
       expect(templateContent).toContain('{{ cell | escape }}');
-      
+
       // Ensure both data-content attribute and cell content are escaped
-      const cellRegex = /<td[^>]*data-content="\{\{ cell \| escape \}\}"[^>]*>\{\{ cell \| escape \}\}<\/td>/;
+      const cellRegex =
+        /<td[^>]*data-content="\{\{ cell \| escape \}\}"[^>]*>\{\{ cell \| escape \}\}<\/td>/;
       expect(templateContent).toMatch(cellRegex);
     });
 

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -229,6 +229,21 @@ describe('util', () => {
       expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
     });
 
+    it('writeOutput with HTML template escapes special characters', async () => {
+      // Use the real fs module to read the template
+      const realFs = jest.requireActual('fs') as typeof fs;
+      const templatePath = path.resolve(__dirname, '../../src/tableOutput.html');
+      const templateContent = realFs.readFileSync(templatePath, 'utf-8');
+      
+      // Check that the template has escape filters on all user-provided content
+      expect(templateContent).toContain('{{ header | escape }}');
+      expect(templateContent).toContain('{{ cell | escape }}');
+      
+      // Ensure both data-content attribute and cell content are escaped
+      const cellRegex = /<td[^>]*data-content="\{\{ cell \| escape \}\}"[^>]*>\{\{ cell \| escape \}\}<\/td>/;
+      expect(templateContent).toMatch(cellRegex);
+    });
+
     it('writes output to Google Sheets', async () => {
       const outputPath = 'https://docs.google.com/spreadsheets/d/1234567890/edit#gid=0';
 


### PR DESCRIPTION
## Summary
- Add Nunjucks escape filter to table headers and cell content in HTML output template
- Prevent invalid HTML generation when prompts or outputs contain special characters
- Add test to verify HTML escaping is properly applied

## Problem
When a prompt contains HTML special characters (e.g., `<`, `>`, `&`), these characters were copied into HTML reports verbatim, resulting in invalid HTML. For example, a prompt like "Is 1<2?" would generate `<th>[provider] Is 1<2?</th>` instead of the properly escaped `<th>[provider] Is 1&lt;2?</th>`.

## Solution
Added the `| escape` filter to:
- Table headers: `{{ header | escape }}`
- Cell content: `{{ cell | escape }}`

The `data-content` attribute already had the escape filter, but the actual cell content displayed to users did not.

## Test plan
- [x] Added unit test to verify the template contains proper escape filters
- [x] Manually tested with a prompt containing HTML special characters
- [x] Verified the generated HTML file properly escapes all special characters
- [x] All existing tests pass

Fixes #4550

🤖 Generated with [Claude Code](https://claude.ai/code)