### PR TITLE
docs(site): fix author reference on 2025-summer-new-redteam-agent blog post

### DIFF
--- a/site/blog/2025-summer-new-redteam-agent.md
+++ b/site/blog/2025-summer-new-redteam-agent.md
@@ -4,7 +4,7 @@ description: Promptfoo is introducing our revolutionary, next-generation red tea
 image: /img/blog/summer-2025-new-redteam-agent/title.jpg
 keywords: [promptfoo, AI security, red teaming, LLM evaluation, prompt engineering, AI agents]
 date: 2025-06-15
-author: 'Steven Klein, Principal Engineer at Promptfoo'
+authors: [steven]
 ---
 
 # The Next Generation of Red Teaming for LLM Agents


### PR DESCRIPTION
Fixes Docusaurus warning about undefined author by changing from inline author definition to proper authors array reference. Changes: Changed author: 'Steven Klein, Principal Engineer at Promptfoo' to authors: [steven]. This properly references the existing author definition in authors.yml and eliminates the Docusaurus build warning about undefined authors.