### PR TITLE
fix(openrouter): unpack passthrough at the root level

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -740,7 +740,7 @@ export const providerMap: ProviderFactory[] = [
             ...(providerOptions.config.models && { models: providerOptions.config.models }),
             ...(providerOptions.config.route && { route: providerOptions.config.route }),
             ...(providerOptions.config.provider && { provider: providerOptions.config.provider }),
-            ...providerOptions.config.passthrough,
+            ...(providerOptions.config.passthrough || {}),
           },
         },
       });

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -740,9 +740,7 @@ export const providerMap: ProviderFactory[] = [
             ...(providerOptions.config.models && { models: providerOptions.config.models }),
             ...(providerOptions.config.route && { route: providerOptions.config.route }),
             ...(providerOptions.config.provider && { provider: providerOptions.config.provider }),
-            ...(providerOptions.config.passthrough && {
-              passthrough: providerOptions.config.passthrough,
-            }),
+            ...providerOptions.config.passthrough,
           },
         },
       });


### PR DESCRIPTION
The passthrough is not functioning correctly for OpenRouter because it isn't adding the keys at the root level.

```yaml
providers:
  - id: openrouter:google/gemini-2.5-flash
    config:
      passthrough:
        reasoning:
          enabled: true

prompts:
  - 'What is 1+1?'
```

Actual request:

```json
{
  "model": "google/gemini-2.5-flash",
  "messages": [
    {
      "role": "user",
      "content": "What is 1+1?"
    }
  ],
  "max_tokens": 1024,
  "passthrough": {
    "reasoning": {
      "enabled": true
    }
  }
}
```

Expected request:

```json
{
  "model": "google/gemini-2.5-flash",
  "messages": [
    {
      "role": "user",
      "content": "What is 1+1?"
    }
  ],
  "max_tokens": 1024,
  "reasoning": {
    "enabled": true
  }
}
```