### PR TITLE
chore: show provider breakdown only for multiple providers

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -467,7 +467,7 @@ export async function doEval(
       // Provider breakdown
       const tracker = TokenUsageTracker.getInstance();
       const providerIds = tracker.getProviderIds();
-      if (providerIds.length > 0) {
+      if (providerIds.length > 1) {
         logger.info(`\n  ${chalk.cyan.bold('Provider Breakdown:')}`);
 
         // Sort providers by total token usage (descending)


### PR DESCRIPTION
no point in breakdown for a single one