### PR TITLE
build: update Tusk vitest reporter

### DIFF
--- a/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
@@ -96,7 +96,7 @@ jobs:
             npx tsc --project $TMP_TSCONFIG --skipLibCheck --noEmit
 
           # The script to run Vitest tests for individual files
-          testScript: 'npx vitest run {{file}}'
+          testScript: 'npx vitest run {{file}} --reporter=basic'
 
           # The runner may run tests in parallel.
           # Set this value to 1 if you know that your tests should not be run concurrently.


### PR DESCRIPTION
Use `--reporter=basic` when running tests to prevent GitHub actions reporter comments (https://vitest.dev/guide/reporters.html#github-actions-reporter)