### PR TITLE
fix(app/eval results): Welcome component should not render while loading eval data

### DIFF
--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -124,7 +124,10 @@ export default function Eval({ fetchId }: EvalOptions) {
 
       const socket = SocketIOClient(apiBaseUrl || '');
 
-      async function onSocketEvent(data: ResultsFile) {
+      /**
+       * Populates the table store with the most recent eval result.
+       */
+      async function handleResultsFile(data: ResultsFile) {
         // NOTE: Constructing the table is a time-expensive operation; therefore `setLoaded(true)` is not called
         // until after the table is constructed. Otherwise, `loaded` will be true before the table is defined resulting
         // in a race condition.
@@ -143,11 +146,15 @@ export default function Eval({ fetchId }: EvalOptions) {
       socket
         .on('init', async (data) => {
           console.log('Initialized socket connection', data);
-          await onSocketEvent(data);
+          await handleResultsFile(data);
         })
+        /**
+         * The user has run `promptfoo eval` and a new latest eval
+         * result has been received.
+         */
         .on('update', async (data) => {
           console.log('Received data update', data);
-          await onSocketEvent(data);
+          await handleResultsFile(data);
         });
 
       return () => {

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import EnterpriseBanner from '@app/components/EnterpriseBanner';
 import { IS_RUNNING_LOCALLY } from '@app/constants';
@@ -49,13 +49,13 @@ export default function Eval({
   // State
   // ================================
 
-  const [loaded, setLoaded] = React.useState(false);
-  const [failed, setFailed] = React.useState(false);
-  const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>(
+  const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [recentEvals, setRecentEvals] = useState<ResultLightweightWithLabel[]>(
     recentEvalsProp || [],
   );
 
-  const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
+  const [defaultEvalId, setDefaultEvalId] = useState<string>(
     defaultEvalIdProp || recentEvals[0]?.evalId,
   );
 
@@ -79,7 +79,7 @@ export default function Eval({
    *
    * @returns {Boolean} Whether the eval was loaded successfully.
    */
-  const loadEvalById = React.useCallback(
+  const loadEvalById = useCallback(
     async (id: string) => {
       try {
         setEvalId(id);
@@ -117,7 +117,7 @@ export default function Eval({
   // Effects
   // ================================
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (fetchId) {
       console.log('Eval init: Fetching eval by id', { fetchId });
       const run = async () => {
@@ -214,7 +214,7 @@ export default function Eval({
   /**
    * Set the document title to the eval description or eval id.
    */
-  React.useEffect(() => {
+  useEffect(() => {
     document.title = `${config?.description || evalId || 'Eval'} | promptfoo`;
   }, [config, evalId]);
 

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -74,6 +74,11 @@ export default function Eval({
     return body.data;
   };
 
+  /**
+   * Triggers the fetching of a specific eval by id. Eval data is populated in the table store.
+   *
+   * @returns {Boolean} Whether the eval was loaded successfully.
+   */
   const loadEvalById = React.useCallback(
     async (id: string) => {
       try {
@@ -95,6 +100,9 @@ export default function Eval({
     [fetchEvalData, setFailed, setEvalId],
   );
 
+  /**
+   * Updates the URL with the selected eval id, triggering a re-render of the Eval component.
+   */
   const handleRecentEvalSelection = useCallback(
     async (id: string) => {
       navigate({

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import EnterpriseBanner from '@app/components/EnterpriseBanner';
 import { IS_RUNNING_LOCALLY } from '@app/constants';
@@ -137,7 +137,9 @@ export default function Eval({
 
       socket.on('init', (data) => {
         console.log('Initialized socket connection', data);
-        setLoaded(true);
+        // NOTE: Constructing the table is a time-expensive operation; therefore `setLoaded(true)` is not called
+        // until after the table is constructed. Otherwise, `loaded` will be true before the table is defined resulting
+        // in a race condition.
         setTableFromResultsFile(data);
         setConfig(data?.config);
         setAuthor(data?.author || null);
@@ -215,6 +217,15 @@ export default function Eval({
   React.useEffect(() => {
     document.title = `${config?.description || evalId || 'Eval'} | promptfoo`;
   }, [config, evalId]);
+
+  /**
+   * If loading is waiting for the table to be populated, set loaded to true.
+   */
+  useEffect(() => {
+    if (table && !loaded) {
+      setLoaded(true);
+    }
+  }, [table, loaded]);
 
   // ================================
   // Rendering

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -19,15 +19,9 @@ interface EvalOptions {
    * ID of a specific eval to load.
    */
   fetchId: string | null;
-  recentEvals?: ResultLightweightWithLabel[];
-  defaultEvalId?: string;
 }
 
-export default function Eval({
-  fetchId,
-  recentEvals: recentEvalsProp,
-  defaultEvalId: defaultEvalIdProp,
-}: EvalOptions) {
+export default function Eval({ fetchId }: EvalOptions) {
   const navigate = useNavigate();
   const { apiBaseUrl } = useApiConfig();
   const [searchParams] = useSearchParams();
@@ -51,13 +45,8 @@ export default function Eval({
 
   const [loaded, setLoaded] = useState(false);
   const [failed, setFailed] = useState(false);
-  const [recentEvals, setRecentEvals] = useState<ResultLightweightWithLabel[]>(
-    recentEvalsProp || [],
-  );
-
-  const [defaultEvalId, setDefaultEvalId] = useState<string>(
-    defaultEvalIdProp || recentEvals[0]?.evalId,
-  );
+  const [recentEvals, setRecentEvals] = useState<ResultLightweightWithLabel[]>([]);
+  const [defaultEvalId, setDefaultEvalId] = useState<string | undefined>(undefined);
 
   // ================================
   // Handlers
@@ -147,7 +136,6 @@ export default function Eval({
           if (newRecentEvals && newRecentEvals.length > 0) {
             setDefaultEvalId(newRecentEvals[0]?.evalId);
             setEvalId(newRecentEvals[0]?.evalId);
-            console.log('setting default eval id', newRecentEvals[0]?.evalId);
             loadEvalById(newRecentEvals[0]?.evalId);
           }
         });
@@ -160,12 +148,10 @@ export default function Eval({
         setAuthor(data.author || null);
         fetchRecentFileEvals().then((newRecentEvals) => {
           if (newRecentEvals && newRecentEvals.length > 0) {
-            const newId = newRecentEvals[0]?.evalId;
-            if (newId) {
-              setDefaultEvalId(newId);
-              setEvalId(newId);
-              loadEvalById(newId);
-            }
+            const newId = newRecentEvals[0].evalId;
+            setDefaultEvalId(newId);
+            setEvalId(newId);
+            loadEvalById(newId);
           }
         });
       });

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -128,9 +128,6 @@ export default function Eval({ fetchId }: EvalOptions) {
        * Populates the table store with the most recent eval result.
        */
       async function handleResultsFile(data: ResultsFile) {
-        // NOTE: Constructing the table is a time-expensive operation; therefore `setLoaded(true)` is not called
-        // until after the table is constructed. Otherwise, `loaded` will be true before the table is defined resulting
-        // in a race condition.
         setTableFromResultsFile(data);
         setConfig(data.config);
         setAuthor(data.author ?? null);
@@ -206,7 +203,11 @@ export default function Eval({ fetchId }: EvalOptions) {
   }, [config, evalId]);
 
   /**
-   * If loading is waiting for the table to be populated, set loaded to true.
+   * If and when a table is available, set loaded to true.
+   *
+   * Constructing the table is a time-expensive operation; therefore `setLoaded(true)` is not called
+   * immediately after `setTableFromResultsFile` is called. Otherwise, `loaded` will be true before
+   * the table is defined resulting in a race condition.
    */
   useEffect(() => {
     if (table && !loaded) {

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -15,6 +15,9 @@ import { useResultsViewSettingsStore, useTableStore } from './store';
 import './Eval.css';
 
 interface EvalOptions {
+  /**
+   * ID of a specific eval to load.
+   */
   fetchId: string | null;
   preloadedData?: SharedResults;
   recentEvals?: ResultLightweightWithLabel[];
@@ -29,6 +32,7 @@ export default function Eval({
 }: EvalOptions) {
   const navigate = useNavigate();
   const { apiBaseUrl } = useApiConfig();
+  const [searchParams] = useSearchParams();
 
   const {
     table,
@@ -43,11 +47,23 @@ export default function Eval({
 
   const { setInComparisonMode, setComparisonEvalIds } = useResultsViewSettingsStore();
 
+  // ================================
+  // State
+  // ================================
+
   const [loaded, setLoaded] = React.useState(false);
   const [failed, setFailed] = React.useState(false);
   const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>(
     recentEvalsProp || [],
   );
+
+  const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
+    defaultEvalIdProp || recentEvals[0]?.evalId,
+  );
+
+  // ================================
+  // Handlers
+  // ================================
 
   const fetchRecentFileEvals = async () => {
     const resp = await callApi(`/results`, { cache: 'no-store' });
@@ -81,8 +97,6 @@ export default function Eval({
     [fetchEvalData, setFailed, setEvalId],
   );
 
-  const [searchParams] = useSearchParams();
-
   const handleRecentEvalSelection = useCallback(
     async (id: string) => {
       navigate({
@@ -93,9 +107,9 @@ export default function Eval({
     [searchParams, navigate],
   );
 
-  const [defaultEvalId, setDefaultEvalId] = React.useState<string>(
-    defaultEvalIdProp || recentEvals[0]?.evalId,
-  );
+  // ================================
+  // Effects
+  // ================================
 
   React.useEffect(() => {
     if (fetchId) {
@@ -196,9 +210,16 @@ export default function Eval({
     preloadedData,
   ]);
 
+  /**
+   * Set the document title to the eval description or eval id.
+   */
   React.useEffect(() => {
     document.title = `${config?.description || evalId || 'Eval'} | promptfoo`;
   }, [config, evalId]);
+
+  // ================================
+  // Rendering
+  // ================================
 
   if (failed) {
     return <div className="notice">404 Eval not found</div>;

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -129,29 +129,15 @@ export default function Eval({ fetchId }: EvalOptions) {
         // until after the table is constructed. Otherwise, `loaded` will be true before the table is defined resulting
         // in a race condition.
         setTableFromResultsFile(data);
-        setConfig(data?.config);
-        setAuthor(data?.author || null);
-        fetchRecentFileEvals().then((newRecentEvals) => {
-          if (newRecentEvals && newRecentEvals.length > 0) {
-            setDefaultEvalId(newRecentEvals[0]?.evalId);
-            setEvalId(newRecentEvals[0]?.evalId);
-            loadEvalById(newRecentEvals[0]?.evalId);
-          }
-        });
-      });
-
-      socket.on('update', (data) => {
-        console.log('Received data update', data);
-        setTableFromResultsFile(data);
         setConfig(data.config);
         setAuthor(data.author ?? null);
         const newRecentEvals = await fetchRecentFileEvals();
-          if (newRecentEvals && newRecentEvals.length > 0) {
-            const newId = newRecentEvals[0].evalId;
-            setDefaultEvalId(newId);
-            setEvalId(newId);
-            loadEvalById(newId);
-          }
+        if (newRecentEvals && newRecentEvals.length > 0) {
+          const newId = newRecentEvals[0].evalId;
+          setDefaultEvalId(newId);
+          setEvalId(newId);
+          loadEvalById(newId);
+        }
       }
 
       socket
@@ -162,7 +148,7 @@ export default function Eval({ fetchId }: EvalOptions) {
         .on('update', async (data) => {
           console.log('Received data update', data);
           await onSocketEvent(data);
-      });
+        });
 
       return () => {
         socket.disconnect();
@@ -229,10 +215,6 @@ export default function Eval({ fetchId }: EvalOptions) {
     return <div className="notice">404 Eval not found</div>;
   }
 
-  if (loaded && !table) {
-    return <EmptyState />;
-  }
-
   if (!loaded || !table) {
     return (
       <div className="notice">
@@ -242,6 +224,10 @@ export default function Eval({ fetchId }: EvalOptions) {
         <div>Waiting for eval data</div>
       </div>
     );
+  }
+
+  if (loaded && !table) {
+    return <EmptyState />;
   }
 
   // Check if this is a redteam eval

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -7,7 +7,7 @@ import useApiConfig from '@app/stores/apiConfig';
 import { callApi } from '@app/utils/api';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import type { SharedResults, ResultLightweightWithLabel } from '@promptfoo/types';
+import type { ResultLightweightWithLabel } from '@promptfoo/types';
 import { io as SocketIOClient } from 'socket.io-client';
 import EmptyState from './EmptyState';
 import ResultsView from './ResultsView';
@@ -19,14 +19,12 @@ interface EvalOptions {
    * ID of a specific eval to load.
    */
   fetchId: string | null;
-  preloadedData?: SharedResults;
   recentEvals?: ResultLightweightWithLabel[];
   defaultEvalId?: string;
 }
 
 export default function Eval({
   fetchId,
-  preloadedData,
   recentEvals: recentEvalsProp,
   defaultEvalId: defaultEvalIdProp,
 }: EvalOptions) {
@@ -124,12 +122,6 @@ export default function Eval({
         }
       };
       run();
-    } else if (preloadedData) {
-      console.log('Eval init: Using preloaded data');
-      setTableFromResultsFile(preloadedData.data);
-      setConfig(preloadedData.data.config);
-      setAuthor(preloadedData.data.author || null);
-      setLoaded(true);
     } else if (IS_RUNNING_LOCALLY) {
       console.log('Eval init: Using local server websocket');
 
@@ -207,7 +199,6 @@ export default function Eval({
     setDefaultEvalId,
     setInComparisonMode,
     setComparisonEvalIds,
-    preloadedData,
   ]);
 
   /**


### PR DESCRIPTION
This PR also applies some basic housekeeping that makes the `<Eval/>` component easier to grok.