### PR TITLE
test: fix hyperbolic provider tests failing due to env variable pollution

### DIFF
--- a/test/providers/hyperbolic/audio.test.ts
+++ b/test/providers/hyperbolic/audio.test.ts
@@ -59,6 +59,8 @@ describe('HyperbolicAudioProvider', () => {
 
   describe('callApi', () => {
     it('should throw error if API key is not set', async () => {
+      // Ensure no API key is set in environment
+      delete process.env.HYPERBOLIC_API_KEY;
       const provider = new HyperbolicAudioProvider('melo');
       await expect(provider.callApi('test')).rejects.toThrow('Hyperbolic API key is not set');
     });

--- a/test/providers/hyperbolic/image.test.ts
+++ b/test/providers/hyperbolic/image.test.ts
@@ -68,6 +68,8 @@ describe('HyperbolicImageProvider', () => {
 
   describe('callApi', () => {
     it('should throw error if no API key', async () => {
+      // Ensure no API key is set in environment
+      delete process.env.HYPERBOLIC_API_KEY;
       const provider = new HyperbolicImageProvider('test');
       await expect(provider.callApi('test prompt')).rejects.toThrow(
         'Hyperbolic API key is not set',


### PR DESCRIPTION
## Description

This PR fixes 2 failing tests in the Hyperbolic provider test suite that were caused by environment variable pollution between test files.

## Problem

- Tests in  and  were expecting errors when no API key is set
- However, the main  file sets  in its  hook
- Since Jest runs all test files in the same process, this environment variable persisted across test files
- This caused the 'no API key' tests to pass the API key check and proceed to make actual API calls instead of throwing expected errors

## Solution

- Added explicit  in the specific tests that expect no API key
- This ensures these tests run in a clean state where no API key is available
- Tests now properly validate the error handling logic

## Testing

- All 5139 tests now pass ✅
- Previously failing tests:
  -  - 'should throw error if API key is not set'
  -  - 'should throw error if no API key'

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement