### PR TITLE
chore(cli): Removes context schema validation from extension hooks

### DIFF
--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import yaml from 'js-yaml';
 import * as path from 'path';
-import { z } from 'zod';
 import cliState from './cliState';
 import { getEnvBool } from './envars';
 import { importModule } from './esm';
@@ -17,11 +16,9 @@ import {
   type ApiProvider,
   type NunjucksFilterMap,
   type Prompt,
-  TestCaseSchema,
   type TestSuite,
   type CompletedPrompt,
   type EvaluateResult,
-  TestSuiteSchema,
   type TestCase,
 } from './types';
 import { renderVarsInObject } from './util';

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -420,28 +420,6 @@ export async function runExtensionHook<HookName extends keyof HookContextMap>(
     return context;
   }
 
-  // Guard against runtime type drift by validating the context object matches the expected schema.
-  // This ensures that the context object is valid prior to passing it to the extension hook, upstreaming
-  // type errors.
-  switch (hookName) {
-    case 'beforeAll': {
-      const parsed = BeforeAllExtensionHookContextSchema.safeParse(context);
-      invariant(
-        parsed.success,
-        `Invalid context passed to beforeAll hook: ${parsed.error?.message}`,
-      );
-      break;
-    }
-    case 'beforeEach': {
-      const parsed = BeforeEachExtensionHookContextSchema.safeParse(context);
-      invariant(
-        parsed.success,
-        `Invalid context passed to beforeEach hook: ${parsed.error?.message}`,
-      );
-      break;
-    }
-  }
-
   // TODO(Will): It would be nice if this logged the hooks used.
   telemetry.recordOnce('feature_used', {
     feature: 'extension_hook',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -593,6 +593,7 @@ export const VarsSchema = z.record(
     z.array(z.union([z.string(), z.number(), z.boolean()])),
     z.record(z.string(), z.any()),
     z.array(z.any()),
+    z.date(),
   ]),
 );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -593,7 +593,6 @@ export const VarsSchema = z.record(
     z.array(z.union([z.string(), z.number(), z.boolean()])),
     z.record(z.string(), z.any()),
     z.array(z.any()),
-    z.date(),
   ]),
 );
 


### PR DESCRIPTION
- Removes runtime validation of `context` arg passed into the hook runner; it results in errors because our test suite zod schemas is a subset of the potential configuration values
- Removes runtime validation of `context` returned from hooks, also because of the subset.
  - Note: this change allows user code to mutate and return `context` such that it will break downstream execution. This is preferable because the user can correct the offending code within the hook definition.