### PR TITLE
fix(redteam): skip goal extraction when remote generation is disabled

### DIFF
--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from '../cache';
 import logger from '../logger';
 import { REQUEST_TIMEOUT_MS } from '../providers/shared';
 import { pluginDescriptions } from './constants';
-import { getRemoteGenerationUrl } from './remoteGeneration';
+import { getRemoteGenerationUrl, neverGenerateRemote } from './remoteGeneration';
 
 /**
  * Normalizes different types of apostrophes to a standard single quote
@@ -216,6 +216,10 @@ export async function extractGoalFromPrompt(
   purpose: string,
   pluginId?: string,
 ): Promise<string | null> {
+  if (neverGenerateRemote()) {
+    logger.debug('Remote generation disabled, skipping goal extraction');
+    return null;
+  }
   // If we have a plugin ID, use the plugin description to generate a better goal
   // This helps with multi-variable attacks where the main prompt might be innocent
   const pluginDescription = pluginId

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -201,4 +201,13 @@ describe('extractGoalFromPrompt', () => {
       expect.any(Number),
     );
   });
+
+  it('should skip remote call when remote generation is disabled', async () => {
+    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+
+    const result = await extractGoalFromPrompt('test prompt', 'test purpose');
+
+    expect(result).toBeNull();
+    expect(fetchWithCache).not.toHaveBeenCalled();
+  });
 });

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -203,11 +203,20 @@ describe('extractGoalFromPrompt', () => {
   });
 
   it('should skip remote call when remote generation is disabled', async () => {
+    // Preserve original environment setting
+    const originalValue = process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION;
     process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
 
     const result = await extractGoalFromPrompt('test prompt', 'test purpose');
 
     expect(result).toBeNull();
     expect(fetchWithCache).not.toHaveBeenCalled();
+
+    // Cleanup: restore or delete the env var to avoid leaking into other tests
+    if (originalValue === undefined) {
+      delete process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION;
+    } else {
+      process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = originalValue;
+    }
   });
 });


### PR DESCRIPTION
Skip goal extraction when PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION is enabled

Relates to https://github.com/promptfoo/promptfoo/issues/4618
