### PR TITLE
fix: Save sessionId for multi-turn strategies

### DIFF
--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -518,7 +518,6 @@ export class CrescendoProvider implements ApiProvider {
 
     this.logChatHistory(this.targetConversationId);
     this.logChatHistory(this.redTeamingChatConversationId);
-    delete vars['sessionId'];
 
     // Determine final exit reason and result
     const hasSuccessfulAttacks = this.successfulAttacks.length > 0;

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -324,7 +324,6 @@ export default class GoatProvider implements ApiProvider {
         logger.error(`Error in GOAT turn ${turn}: ${err}`);
       }
     }
-    delete context?.vars?.sessionId;
 
     return {
       output: getLastMessageContent(messages, 'assistant') || '',


### PR DESCRIPTION
SessionId's are now saved in Vars for multi-turn strategies

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/cbd0b51c-2b6d-4c59-a4da-fd184de7f4e0" />
