### PR TITLE
docs: prevent copy button from overlapping screenshot overlay

### DIFF
--- a/site/src/components/CopyPageButton.module.css
+++ b/site/src/components/CopyPageButton.module.css
@@ -2,7 +2,6 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  z-index: 100;
 }
 
 .copyButton {


### PR DESCRIPTION
<img width="1535" alt="image" src="https://github.com/user-attachments/assets/ed05a855-5eb5-4d56-b863-76cbe9ca41da" />
