### PR TITLE
chore(providers): Log flagged output for Azure chat models

### DIFF
--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -259,7 +259,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
         (filter: any) => filter.filtered,
       );
 
-      if (flaggedOutput && this.deploymentName.startsWith('gpt-4.1')) {
+      if (flaggedOutput) {
         logger.warn(
           `Azure model ${this.deploymentName} output was flagged by content filter: ${JSON.stringify(
             contentFilterResults,


### PR DESCRIPTION
## Summary
- warn when GPT-4.1 deployment output is filtered

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c3373c7b08330a2fb76652873a409