### PR TITLE
fix: support derived metrics in eval config uploaded via WebUI

### DIFF
--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.test.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useStore } from '@app/stores/evalConfig';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import type {
+  DerivedMetric,
   ProviderOptions,
   TestCase,
   EvaluateOptions,
@@ -65,6 +66,7 @@ const defaultStoreValues = {
   prompts: [] as any[],
   testCases: [] as TestCase[],
   defaultTest: {} as TestCase,
+  derivedMetrics: [] as DerivedMetric[],
   env: {} as EnvOverrides,
   evaluateOptions: {} as EvaluateOptions,
   scenarios: [] as Scenario[],
@@ -146,6 +148,7 @@ describe('EvaluateTestSuiteCreator', () => {
       prompts: ['Test Prompt {{var}}'],
       testCases: [{ vars: { var: 'value' } }] as TestCase[],
       defaultTest: { assert: [{ type: 'equals', value: 'expected' }] } as TestCase,
+      derivedMetrics: [{ name: 'precision', value: 'formula' }] as DerivedMetric[],
       env: { OPENAI_API_KEY: 'testkey' } as EnvOverrides,
       evaluateOptions: { maxConcurrency: 5 } as EvaluateOptions,
       scenarios: [{ description: 'Test Scenario', config: [], tests: [] }] as Scenario[],
@@ -172,6 +175,7 @@ describe('EvaluateTestSuiteCreator', () => {
     expect(currentState.prompts).toEqual(defaultStoreValues.prompts);
     expect(currentState.testCases).toEqual(defaultStoreValues.testCases);
     expect(currentState.defaultTest).toEqual(defaultStoreValues.defaultTest);
+    expect(currentState.derivedMetrics).toEqual(defaultStoreValues.derivedMetrics);
     expect(currentState.env).toEqual(defaultStoreValues.env);
     expect(currentState.evaluateOptions).toEqual(defaultStoreValues.evaluateOptions);
     expect(currentState.scenarios).toEqual(defaultStoreValues.scenarios);
@@ -186,6 +190,7 @@ describe('EvaluateTestSuiteCreator', () => {
       prompts: ['Test Prompt {{var}}'],
       testCases: [{ vars: { var: 'value' } }] as TestCase[],
       defaultTest: { assert: [{ type: 'equals', value: 'expected' }] } as TestCase,
+      derivedMetrics: [{ name: 'precision', value: 'formula' }] as DerivedMetric[],
       env: { OPENAI_API_KEY: 'testkey' } as EnvOverrides,
       evaluateOptions: { maxConcurrency: 5 } as EvaluateOptions,
       scenarios: [{ description: 'Test Scenario', config: [], tests: [] }] as Scenario[],
@@ -212,6 +217,7 @@ describe('EvaluateTestSuiteCreator', () => {
     expect(currentState.prompts).toEqual(defaultStoreValues.prompts);
     expect(currentState.testCases).toEqual(defaultStoreValues.testCases);
     expect(currentState.defaultTest).toEqual(defaultStoreValues.defaultTest);
+    expect(currentState.derivedMetrics).toEqual(defaultStoreValues.derivedMetrics);
     expect(currentState.env).toEqual(defaultStoreValues.env);
     expect(currentState.evaluateOptions).toEqual(defaultStoreValues.evaluateOptions);
     expect(currentState.scenarios).toEqual(defaultStoreValues.scenarios);

--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
@@ -53,6 +53,7 @@ const EvaluateTestSuiteCreator: React.FC = () => {
     setPrompts,
     setTestCases,
     setDefaultTest,
+    setDerivedMetrics,
     setEnv,
     setEvaluateOptions,
     setScenarios,
@@ -84,6 +85,7 @@ const EvaluateTestSuiteCreator: React.FC = () => {
     setProviders([]);
     setPrompts([]);
     setDefaultTest({});
+    setDerivedMetrics([]);
     setEnv({});
     setEvaluateOptions({});
     setScenarios([]);

--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
@@ -9,6 +9,7 @@ const RunTestSuiteButton: React.FC = () => {
   const navigate = useNavigate();
   const {
     defaultTest,
+    derivedMetrics,
     description,
     env,
     evaluateOptions,
@@ -25,6 +26,7 @@ const RunTestSuiteButton: React.FC = () => {
 
     const testSuite = {
       defaultTest,
+      derivedMetrics,
       description,
       env,
       evaluateOptions,

--- a/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
@@ -206,6 +206,28 @@ describe('YamlEditor', () => {
     expect(editor.value).toContain('does not describe self as an AI, model, or chatbot');
   });
 
+  it('includes derivedMetrics from store in YAML', () => {
+    mockGetTestSuite.mockReturnValueOnce({
+      description: 'Test suite',
+      providers: [{ id: 'test-provider' }],
+      prompts: ['test prompt'],
+      tests: [{ description: 'test case' }],
+      derivedMetrics: [
+        {
+          name: 'precision',
+          value: 'tp / (tp + fp)',
+        },
+      ],
+    });
+
+    render(<YamlEditorComponent />);
+
+    const editor = screen.getByTestId('yaml-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('derivedMetrics');
+    expect(editor.value).toContain('name: precision');
+    expect(editor.value).toContain('value: tp / (tp + fp)');
+  });
+
   it('respects readOnly prop', () => {
     render(<YamlEditorComponent readOnly={true} />);
 

--- a/src/app/src/pages/eval-creator/components/YamlEditor.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.tsx
@@ -100,6 +100,10 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
             newState.defaultTest = parsedConfig.defaultTest;
           }
 
+          if (parsedConfig.derivedMetrics !== undefined) {
+            newState.derivedMetrics = parsedConfig.derivedMetrics;
+          }
+
           if (parsedConfig.evaluateOptions !== undefined) {
             newState.evaluateOptions = parsedConfig.evaluateOptions;
           }

--- a/src/app/src/stores/evalConfig.ts
+++ b/src/app/src/stores/evalConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  DerivedMetric,
   EnvOverrides,
   EvaluateOptions,
   EvaluateTestSuiteWithEvaluateOptions,
@@ -17,6 +18,7 @@ export interface State {
   providers: ProviderOptions[];
   prompts: any[];
   defaultTest: TestCase;
+  derivedMetrics: DerivedMetric[];
   evaluateOptions: EvaluateOptions;
   scenarios: Scenario[];
   extensions: string[];
@@ -26,6 +28,7 @@ export interface State {
   setProviders: (providers: ProviderOptions[]) => void;
   setPrompts: (prompts: any[]) => void;
   setDefaultTest: (testCase: TestCase) => void;
+  setDerivedMetrics: (derivedMetrics: DerivedMetric[]) => void;
   setEvaluateOptions: (options: EvaluateOptions) => void;
   setScenarios: (scenarios: Scenario[]) => void;
   setStateFromConfig: (config: Partial<UnifiedConfig>) => void;
@@ -43,6 +46,7 @@ export const useStore = create<State>()(
       prompts: [],
       extensions: [],
       defaultTest: {},
+      derivedMetrics: [],
       evaluateOptions: {},
       scenarios: [],
       setEnv: (env) => set({ env }),
@@ -51,6 +55,7 @@ export const useStore = create<State>()(
       setProviders: (providers) => set({ providers }),
       setPrompts: (prompts) => set({ prompts }),
       setDefaultTest: (testCase) => set({ defaultTest: testCase }),
+      setDerivedMetrics: (derivedMetrics) => set({ derivedMetrics }),
       setEvaluateOptions: (options) => set({ evaluateOptions: options }),
       setScenarios: (scenarios) => set({ scenarios }),
       setExtensions: (extensions) => set({ extensions }),
@@ -77,6 +82,9 @@ export const useStore = create<State>()(
         if (config.defaultTest) {
           updates.defaultTest = config.defaultTest;
         }
+        if (config.derivedMetrics) {
+          updates.derivedMetrics = config.derivedMetrics;
+        }
         if (config.evaluateOptions) {
           updates.evaluateOptions = config.evaluateOptions;
         }
@@ -99,6 +107,7 @@ export const useStore = create<State>()(
           testCases,
           evaluateOptions,
           defaultTest,
+          derivedMetrics,
         } = get();
         return {
           description,
@@ -110,6 +119,7 @@ export const useStore = create<State>()(
           tests: testCases,
           evaluateOptions,
           defaultTest,
+          derivedMetrics,
         };
       },
     }),


### PR DESCRIPTION
Fixes #4611 

This fix populates derived metrics config from WebUI to the JS data store and the eval job submitted.

Added unit tests and verified that the submitted eval job contains the derived metrics.