### PR TITLE
docs(site): add FAQ section for offline environment usage

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -108,6 +108,20 @@ Remember that like all environment variables, these settings are specific to you
 
 Promptfoo can be integrated into CI/CD pipelines via [GitHub Action](https://github.com/promptfoo/promptfoo-action), used with testing frameworks like Jest and Vitest, and incorporated into various stages of the development process.
 
+### How can I use Promptfoo in a completely offline environment?
+
+Set the following environment variables before running the CLI to disable all outbound network requests:
+
+```bash
+export PROMPTFOO_DISABLE_TELEMETRY=1
+export PROMPTFOO_DISABLE_UPDATE=1
+export PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION=true
+export PROMPTFOO_DISABLE_SHARING=1
+export PROMPTFOO_SELF_HOSTED=1
+```
+
+Only configure local or self-hosted LLM providers (e.g., Ollama) so the CLI does not attempt to reach external APIs.
+
 ### Do you publish an LLMs.txt?
 
 Yes. The documentation website follows the [LLMs.txt specification](https://llmspec.ai/) so automated tools can easily index our content. You can access the files at:


### PR DESCRIPTION
This PR adds a new FAQ section to the documentation explaining how to configure Promptfoo for completely offline environments.

### Changes
- Added new FAQ section 'How can I use Promptfoo in a completely offline environment?'
- Provides environment variables to disable telemetry, updates, remote generation, and sharing
- Includes guidance on using only local/self-hosted LLM providers

### Testing
- [x] Documentation changes reviewed for accuracy
- [x] Formatting follows existing FAQ structure

Resolves #4612