### PR TITLE
docs(site): reorganize configuration documentation structure

### DIFF
--- a/site/docs/configuration/caching.md
+++ b/site/docs/configuration/caching.md
@@ -1,5 +1,19 @@
 ---
-sidebar_position: 40
+sidebar_position: 41
+sidebar_label: Caching
+title: Caching Configuration - Performance Optimization
+description: Configure caching for faster LLM evaluations. Learn cache strategies, storage options, and performance optimization for prompt testing workflows.
+keywords:
+  [
+    LLM caching,
+    performance optimization,
+    evaluation speed,
+    cache configuration,
+    response caching,
+    testing efficiency,
+  ]
+pagination_prev: configuration/chat
+pagination_next: configuration/telemetry
 ---
 
 # Caching

--- a/site/docs/configuration/chat.md
+++ b/site/docs/configuration/chat.md
@@ -1,9 +1,20 @@
 ---
 sidebar_label: Chat threads
-sidebar_position: 10
+sidebar_position: 32
 title: Chat Conversations and Multi-Turn Threads
-description: Learn how to create and manage chat conversations, multi-turn threads, and conversation history in promptfoo
-keywords: [chat, conversations, threads, multi-turn, history, messages, _conversation]
+description: Configure chat conversations and multi-turn threads for LLM evaluation. Learn conversation history, multi-shot prompts, and chat flow testing.
+keywords:
+  [
+    chat conversations,
+    multi-turn evaluation,
+    conversation history,
+    chat threads,
+    dialogue testing,
+    conversational AI,
+    chat flow,
+  ]
+pagination_prev: configuration/outputs
+pagination_next: configuration/caching
 ---
 
 # Chat conversations / threads

--- a/site/docs/configuration/datasets.md
+++ b/site/docs/configuration/datasets.md
@@ -1,5 +1,20 @@
 ---
-sidebar_position: 25
+sidebar_position: 21
+sidebar_label: Dataset generation
+title: Dataset Generation - Automated Test Data Creation
+description: Generate comprehensive test datasets automatically using promptfoo. Create diverse test cases, personas, and edge cases for thorough LLM evaluation.
+keywords:
+  [
+    dataset generation,
+    automated testing,
+    test data creation,
+    LLM datasets,
+    evaluation data,
+    test automation,
+    synthetic data,
+  ]
+pagination_prev: configuration/scenarios
+pagination_next: configuration/outputs
 ---
 
 # Dataset generation

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -1,6 +1,18 @@
 ---
-sidebar_position: 5
-sidebar_label: Overview
+sidebar_position: 22
+sidebar_label: Assertions & metrics
+title: Assertions and Metrics - LLM Output Validation
+description: Configure assertions and metrics to validate LLM outputs. Learn deterministic tests, model-graded evaluation, custom scoring, and performance metrics.
+keywords:
+  [
+    LLM assertions,
+    evaluation metrics,
+    output validation,
+    model grading,
+    deterministic testing,
+    performance metrics,
+    accuracy measurement,
+  ]
 ---
 
 # Assertions & metrics

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -1,6 +1,18 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: Guide
+title: Configuration Guide - Getting Started with Promptfoo
+description: Complete guide to configuring promptfoo for LLM evaluation. Learn prompts, providers, test cases, assertions, and advanced features with examples.
+keywords:
+  [
+    promptfoo configuration,
+    LLM evaluation setup,
+    prompt testing,
+    AI model comparison,
+    evaluation framework,
+    getting started,
+  ]
+pagination_next: configuration/reference
 ---
 
 # Configuration

--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -1,6 +1,20 @@
 ---
-sidebar_position: 7
+sidebar_position: 31
 sidebar_label: Output Formats
+title: Output Formats - Results Export and Analysis
+description: Configure output formats for LLM evaluation results. Export to HTML, JSON, CSV, and YAML formats for analysis, reporting, and data processing.
+keywords:
+  [
+    output formats,
+    evaluation results,
+    export options,
+    HTML reports,
+    JSON export,
+    CSV analysis,
+    result visualization,
+  ]
+pagination_prev: configuration/datasets
+pagination_next: configuration/chat
 ---
 
 # Output Formats

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -1,6 +1,19 @@
 ---
-sidebar_position: 4
-sidebar_label: Overview - Prompts, tests, outputs
+sidebar_position: 3
+sidebar_label: Overview
+title: Configuration Overview - Prompts, Tests, and Outputs
+description: Quick overview of promptfoo's core configuration concepts including prompts, test cases, outputs, and common patterns for LLM evaluation.
+keywords:
+  [
+    promptfoo overview,
+    configuration basics,
+    prompt setup,
+    test cases,
+    output formats,
+    evaluation workflow,
+  ]
+pagination_prev: configuration/reference
+pagination_next: configuration/prompts
 ---
 
 # Prompts, tests, and outputs

--- a/site/docs/configuration/prompts.md
+++ b/site/docs/configuration/prompts.md
@@ -1,6 +1,19 @@
 ---
-sidebar_position: 5
+sidebar_position: 11
 sidebar_label: Prompts
+title: Prompt Configuration - Text, Chat, and Dynamic Prompts
+description: Configure prompts for LLM evaluation including text prompts, chat conversations, file-based prompts, and dynamic prompt generation with variables.
+keywords:
+  [
+    prompt configuration,
+    LLM prompts,
+    chat conversations,
+    dynamic prompts,
+    template variables,
+    prompt engineering,
+  ]
+pagination_prev: configuration/parameters
+pagination_next: configuration/test-cases
 ---
 
 # Prompt Configuration

--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -1,5 +1,19 @@
 ---
 sidebar_position: 2
+sidebar_label: Reference
+title: Configuration Reference - Complete API Documentation
+description: Comprehensive reference for all promptfoo configuration options, properties, and settings. Complete API documentation for evaluation setup.
+keywords:
+  [
+    promptfoo reference,
+    configuration API,
+    evaluation options,
+    provider settings,
+    test configuration,
+    assertion types,
+  ]
+pagination_prev: configuration/guide
+pagination_next: configuration/parameters
 ---
 
 # Reference

--- a/site/docs/configuration/scenarios.md
+++ b/site/docs/configuration/scenarios.md
@@ -1,6 +1,19 @@
 ---
-sidebar_position: 26
+sidebar_position: 13
 sidebar_label: Scenarios
+title: Scenario Configuration - Grouping Tests and Data
+description: Configure scenarios to group test data with evaluation tests. Learn how to organize and run multiple test combinations efficiently in promptfoo.
+keywords:
+  [
+    test scenarios,
+    grouped testing,
+    test organization,
+    data combinations,
+    evaluation scenarios,
+    test management,
+  ]
+pagination_prev: configuration/test-cases
+pagination_next: configuration/datasets
 ---
 
 # Scenarios

--- a/site/docs/configuration/telemetry.md
+++ b/site/docs/configuration/telemetry.md
@@ -1,5 +1,20 @@
 ---
-sidebar_position: 200
+sidebar_position: 42
+sidebar_label: Telemetry
+title: Telemetry Configuration - Usage Analytics and Monitoring
+description: Configure telemetry and analytics for promptfoo usage monitoring. Learn data collection settings, privacy controls, and usage tracking options.
+keywords:
+  [
+    telemetry configuration,
+    usage analytics,
+    monitoring,
+    data collection,
+    privacy settings,
+    usage tracking,
+    analytics setup,
+  ]
+pagination_prev: configuration/caching
+pagination_next: null
 ---
 
 # Telemetry

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -1,6 +1,21 @@
 ---
-sidebar_position: 6
+sidebar_position: 12
 sidebar_label: Test Cases
+title: Test Case Configuration - Variables, Assertions, and Data
+description: Configure test cases for LLM evaluation with variables, assertions, CSV data, and dynamic generation. Learn inline tests, external files, and media support.
+keywords:
+  [
+    test cases,
+    LLM testing,
+    evaluation data,
+    assertions,
+    CSV tests,
+    variables,
+    dynamic testing,
+    test automation,
+  ]
+pagination_prev: configuration/prompts
+pagination_next: configuration/scenarios
 ---
 
 # Test Case Configuration


### PR DESCRIPTION
Reorganizes configuration documentation into logical learning sections with clear progression from basic to advanced topics. Improves navigation with pagination links and better sidebar organization.

**Changes:**
- Restructured sidebar positions into logical groups
- Added pagination navigation between related pages  
- Improved page titles and descriptions
- Simplified category page (removed custom index.md)