### PR TITLE
feat(providers): Add new AIMLAPI provider

### DIFF
--- a/examples/aimlapi/README.md
+++ b/examples/aimlapi/README.md
@@ -1,0 +1,15 @@
+# aimlapi
+
+Example configuration for the AI/ML API provider.
+
+Set your API key:
+
+```bash
+export AIML_API_KEY=your_api_key_here
+```
+
+Run the example:
+
+```bash
+npx promptfoo@latest eval -c promptfooconfig.yaml
+```

--- a/examples/aimlapi/promptfooconfig.yaml
+++ b/examples/aimlapi/promptfooconfig.yaml
@@ -1,0 +1,4 @@
+providers:
+  - aimlapi:gpt-3.5-turbo
+prompts:
+  - What is the capital of France?

--- a/site/docs/providers/aimlapi.md
+++ b/site/docs/providers/aimlapi.md
@@ -1,0 +1,44 @@
+---
+sidebar_label: AI/ML API
+---
+
+# AI/ML API
+
+The `aimlapi` provider lets you use the AI/ML API via OpenAI-compatible endpoints.
+
+## Setup
+
+Set your API key in the `AIML_API_KEY` environment variable:
+
+```bash
+export AIML_API_KEY=your_api_key_here
+```
+
+## Provider Usage
+
+The provider follows the syntax `aimlapi:<type>:<model>` where `<type>` can be `chat`, `completion`, or `embedding`. Or you can use `aimlapi:<model>` for default (as a chat-completion).
+
+Example configuration comparing three models:
+
+```yaml
+providers:
+  - aimlapi:chat:my-chat-model
+  - aimlapi:completion:my-completion-model
+  - aimlapi:gpt-3.5-turbo
+```
+
+You can customize options supported by OpenAI such as `temperature` or `max_tokens`.
+
+## Available Models
+
+To fetch the latest list of available models, call the `/models` endpoint:
+
+```bash
+curl https://api.aimlapi.com/models
+```
+
+## Environment Variables
+
+| Variable            | Description                                   |
+| ------------------- | --------------------------------------------- |
+| `AIML_API_KEY`      | API key for authentication                    |

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -32,6 +32,7 @@ providers:
 | [Python](./python.md)                               | Custom - Python file                               | `file://path/to/custom_provider.py`                              |
 | [Shell Command](./custom-script.md)                 | Custom - script-based providers                    | `exec: python chain.py`                                          |
 | [AI21 Labs](./ai21.md)                              | Jurassic and Jamba models                          | `ai21:jamba-1.5-mini`                                            |
+| [AI/ML API](./aimlapi.md)                           | Tap into 300+ cutting-edge AI models with a single API | `aimlapi:chat:gpt-3.5-turbo`            |
 | [AWS Bedrock](./aws-bedrock.md)                     | AWS-hosted models from various providers           | `bedrock:us.meta.llama3-2-90b-instruct-v1:0`                     |
 | [Amazon SageMaker](./sagemaker.md)                  | Models deployed on SageMaker endpoints             | `sagemaker:my-endpoint-name`                                     |
 | [Azure OpenAI](./azure.md)                          | Azure-hosted OpenAI models                         | `azureopenai:gpt-4o-custom-deployment-name`                      |

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -66,6 +66,9 @@
                             "AI21_API_KEY": {
                               "type": "string"
                             },
+                            "AIML_API_KEY": {
+                              "type": "string"
+                            },
                             "ANTHROPIC_API_KEY": {
                               "type": "string"
                             },

--- a/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
+++ b/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
@@ -141,6 +141,18 @@ const ConfigureEnvButton: React.FC = () => {
               />
             </AccordionDetails>
           </Accordion>
+          <Accordion>
+            <AccordionSummary>AI/ML API</AccordionSummary>
+            <AccordionDetails>
+              <TextField
+                label="AI/ML API key"
+                fullWidth
+                margin="normal"
+                value={env.AIML_API_KEY}
+                onChange={(e) => setEnv({ ...env, AIML_API_KEY: e.target.value })}
+              />
+            </AccordionDetails>
+          </Accordion>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose} color="primary">

--- a/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
+++ b/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
@@ -582,6 +582,38 @@ const defaultProviders: ProviderOptions[] = (
       },
     },
   ])
+  .concat([
+    {
+      id: 'aimlapi:openai/gpt-4o',
+      label: 'aimlapi: GPT 4o',
+      config: { temperature: 0.7, max_tokens: 128000 },
+    },
+    {
+      id: 'aimlapi:gpt-4o-mini',
+      label: 'aimlapi: GPT 4o Mini',
+      config: { temperature: 0.7, max_tokens: 128000 },
+    },
+    {
+      id: 'aimlapi:gpt-4-turbo',
+      label: 'aimlapi: GPT 4 Turbo',
+      config: { temperature: 0.7, max_tokens: 128000 },
+    },
+    {
+      id: 'aimlapi:chatgpt-4o-latest',
+      label: 'aimlapi: ChatGPT 4o Latest',
+      config: { temperature: 0.7, max_tokens: 128000 },
+    },
+    {
+      id: 'aimlapi:anthropic/claude-3-5-sonnet-20240620',
+      label: 'aimlapi: Claude 3.5 Sonnet',
+      config: { temperature: 0.7, max_tokens: 8192 },
+    },
+    {
+      id: 'aimlapi:google/gemini-pro-vision',
+      label: 'aimlapi: Gemini Pro Vision',
+      config: { temperature: 0.7, max_tokens: 1000000 },
+    },
+  ])
   .sort((a, b) => a.id.localeCompare(b.id));
 
 const PROVIDER_GROUPS: Record<string, string> = {
@@ -591,6 +623,7 @@ const PROVIDER_GROUPS: Record<string, string> = {
   'azure:': 'Azure',
   'openrouter:': 'OpenRouter',
   'replicate:': 'Replicate',
+  'aimlapi:': 'AI/ML API',
   'vertex:': 'Google Vertex AI',
 };
 

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -154,6 +154,9 @@ export type EnvVars = {
   AI21_API_BASE_URL?: string;
   AI21_API_KEY?: string;
 
+  // AIML API
+  AIML_API_KEY?: string;
+
   // Anthropic
   ANTHROPIC_API_KEY?: string;
   ANTHROPIC_MAX_TOKENS?: number;

--- a/src/providers/aimlapi.ts
+++ b/src/providers/aimlapi.ts
@@ -1,0 +1,85 @@
+import type { ApiProvider, ProviderOptions } from '../types';
+import type { EnvOverrides } from '../types/env';
+import { fetchWithCache } from '../cache';
+import { getEnvString } from '../envars';
+import logger from '../logger';
+import { OpenAiChatCompletionProvider } from './openai/chat';
+import { OpenAiCompletionProvider } from './openai/completion';
+import { OpenAiEmbeddingProvider } from './openai/embedding';
+import type { OpenAiCompletionOptions } from './openai/types';
+import { REQUEST_TIMEOUT_MS } from './shared';
+
+export interface AimlApiModel {
+  id: string;
+}
+
+let modelCache: AimlApiModel[] | null = null;
+
+export function clearAimlApiModelsCache() {
+  modelCache = null;
+}
+
+export async function fetchAimlApiModels(env?: EnvOverrides): Promise<AimlApiModel[]> {
+  if (modelCache) {
+    return modelCache;
+  }
+
+  try {
+    const apiKey = env?.AIML_API_KEY || getEnvString('AIML_API_KEY');
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+
+    const { data } = await fetchWithCache<any>(
+      'https://api.aimlapi.com/models',
+      { headers },
+      REQUEST_TIMEOUT_MS,
+    );
+
+    const models = data?.data || data?.models || data;
+    if (Array.isArray(models)) {
+      modelCache = models.map((m: any) => ({ id: m.id || m.model || m.name || m }));
+    } else {
+      modelCache = [];
+    }
+  } catch (err) {
+    logger.warn(`Failed to fetch aimlapi models: ${String(err)}`);
+    modelCache = [];
+  }
+
+  return modelCache;
+}
+
+/**
+ * Factory for creating AI/ML API providers using OpenAI-compatible endpoints.
+ */
+export function createAimlApiProvider(
+  providerPath: string,
+  options: { config?: ProviderOptions; id?: string; env?: EnvOverrides } = {},
+): ApiProvider {
+  const splits = providerPath.split(':');
+  const type = splits[1];
+  const modelName = splits.slice(2).join(':');
+
+  const openaiOptions = {
+    ...options,
+    config: {
+      ...(options.config || {}),
+      apiBaseUrl: 'https://api.aimlapi.com/v1',
+      apiKeyEnvar: 'AIML_API_KEY',
+    } as OpenAiCompletionOptions,
+  };
+
+  if (type === 'chat') {
+    return new OpenAiChatCompletionProvider(modelName, openaiOptions);
+  } else if (type === 'completion') {
+    return new OpenAiCompletionProvider(modelName, openaiOptions);
+  } else if (type === 'embedding' || type === 'embeddings') {
+    return new OpenAiEmbeddingProvider(modelName, openaiOptions);
+  }
+
+  // Default to chat provider when no type is specified
+  const defaultModel = splits.slice(1).join(':');
+  return new OpenAiChatCompletionProvider(defaultModel, openaiOptions);
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -830,6 +830,20 @@ export const providerMap: ProviderFactory[] = [
     },
   },
   {
+    test: (providerPath: string) => providerPath.startsWith('aimlapi:'),
+    create: async (
+      providerPath: string,
+      providerOptions: ProviderOptions,
+      context: LoadApiProviderContext,
+    ) => {
+      const { createAimlApiProvider } = await import('./aimlapi');
+      return createAimlApiProvider(providerPath, {
+        ...providerOptions,
+        env: context.env,
+      });
+    },
+  },
+  {
     test: (providerPath: string) => providerPath.startsWith('vertex:'),
     create: async (
       providerPath: string,

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const ProviderEnvOverridesSchema = z.object({
   AI21_API_BASE_URL: z.string().optional(),
   AI21_API_KEY: z.string().optional(),
+  AIML_API_KEY: z.string().optional(),
   ANTHROPIC_API_KEY: z.string().optional(),
   ANTHROPIC_BASE_URL: z.string().optional(),
   AWS_BEDROCK_REGION: z.string().optional(),

--- a/test/providers/aimlapi.test.ts
+++ b/test/providers/aimlapi.test.ts
@@ -1,0 +1,83 @@
+import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+import { OpenAiCompletionProvider } from '../../src/providers/openai/completion';
+import { OpenAiEmbeddingProvider } from '../../src/providers/openai/embedding';
+import {
+  createAimlApiProvider,
+  fetchAimlApiModels,
+  clearAimlApiModelsCache,
+} from '../../src/providers/aimlapi';
+import { fetchWithCache } from '../../src/cache';
+
+jest.mock('../../src/providers/openai');
+jest.mock('../../src/cache');
+
+describe('createAimlApiProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates chat completion provider when type is chat', () => {
+    const provider = createAimlApiProvider('aimlapi:chat:model-name');
+    expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('model-name', expect.any(Object));
+  });
+
+  it('creates completion provider when type is completion', () => {
+    const provider = createAimlApiProvider('aimlapi:completion:model-name');
+    expect(provider).toBeInstanceOf(OpenAiCompletionProvider);
+    expect(OpenAiCompletionProvider).toHaveBeenCalledWith('model-name', expect.any(Object));
+  });
+
+  it('creates embedding provider when type is embedding', () => {
+    const provider = createAimlApiProvider('aimlapi:embedding:model-name');
+    expect(provider).toBeInstanceOf(OpenAiEmbeddingProvider);
+    expect(OpenAiEmbeddingProvider).toHaveBeenCalledWith('model-name', expect.any(Object));
+  });
+
+  it('defaults to chat provider when no type specified', () => {
+    const provider = createAimlApiProvider('aimlapi:model-name');
+    expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('model-name', expect.any(Object));
+  });
+});
+
+describe('fetchAimlApiModels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAimlApiModelsCache();
+  });
+
+  it('fetches models from endpoint', async () => {
+    jest.mocked(fetchWithCache).mockResolvedValue({
+      data: { data: [{ id: 'model-a' }, { id: 'model-b' }] },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const models = await fetchAimlApiModels();
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      'https://api.aimlapi.com/models',
+      { headers: {} },
+      expect.any(Number),
+    );
+    expect(models).toEqual([{ id: 'model-a' }, { id: 'model-b' }]);
+  });
+
+  it('uses cache on subsequent calls', async () => {
+    jest.mocked(fetchWithCache).mockResolvedValue({
+      data: { data: [{ id: 'model-x' }] },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const first = await fetchAimlApiModels();
+    jest.mocked(fetchWithCache).mockClear();
+    const second = await fetchAimlApiModels();
+
+    expect(first).toEqual(second);
+    expect(fetchWithCache).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Introduces the 'aimlapi' provider for OpenAI-compatible AI/ML API endpoints, including provider implementation, documentation, environment variable support, UI integration, and tests. Updates provider registry, config schema, and adds example usage.

![image](https://github.com/user-attachments/assets/6c124fa2-abe9-4cc9-bf35-31f8cfa74092)

![image](https://github.com/user-attachments/assets/fc40bd30-2413-4ff2-82ba-624f4895c9d8)

![image](https://github.com/user-attachments/assets/9f5b8636-b3a2-4501-a353-25b8cbd42ea9)
