### PR TITLE
chore: reset generated constants after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build:clean": "shx rm -rf dist",
     "build:watch": "tsc --watch",
     "build": "npm run generate-constants && tsc && shx cp src/*.html dist/src && shx cp src/python/wrapper.py dist/src/python && shx mkdir -p dist/src/golang && shx cp src/golang/wrapper.go dist/src/golang && shx rm -rf dist/drizzle && shx cp -r drizzle dist/drizzle && npm run build:app && shx chmod +x dist/src/main.js",
+    "postbuild": "git checkout -- src/generated-constants.ts",
     "citation:generate": "ts-node scripts/generateCitation.ts",
     "db:generate": "npx drizzle-kit generate",
     "db:migrate": "npx tsx src/migrate.ts",


### PR DESCRIPTION
## Summary
- ensure `src/generated-constants.ts` is restored after building

## Testing
- `npm run f`
- `npm run l`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864c48b24808332910e998fcac3070b