### PR TITLE
test: fix SIGSEGV caused by better-sqlite3 in test environment

### DIFF
--- a/test/assertions/runAssertion.test.ts
+++ b/test/assertions/runAssertion.test.ts
@@ -17,6 +17,9 @@ jest.mock('../../src/redteam/remoteGeneration', () => ({
   shouldGenerateRemote: jest.fn().mockReturnValue(false),
 }));
 
+// Causes a SIGSEGV in github actions.
+jest.mock('better-sqlite3');
+
 jest.mock('proxy-agent', () => ({
   ProxyAgent: jest.fn().mockImplementation(() => ({})),
 }));


### PR DESCRIPTION
This PR fixes a SIGSEGV error that occurs during test execution in certain environments.

## Problem
The test suite was failing with:
```
FAIL test/assertions/runAssertion.test.ts
  ● Test suite failed to run

    A jest worker process (pid=4992) was terminated by another process: signal=SIGSEGV, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)
```

## Solution
Mock the `better-sqlite3` module to prevent loading the native binary that causes SIGSEGV in certain test environments. This allows the tests to run without attempting to load the problematic native module.

## Changes
- Added `jest.mock('better-sqlite3')` to `test/assertions/runAssertion.test.ts`