### PR TITLE
chore: expose doRedteamRun in package exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { extractSystemPurpose } from './redteam/extraction/purpose';
 import { GRADERS } from './redteam/graders';
 import { Plugins } from './redteam/plugins';
 import { RedteamPluginBase, RedteamGraderBase } from './redteam/plugins/base';
+import { doRedteamRun } from './redteam/shared';
 import { Strategies } from './redteam/strategies';
 import type { EvaluateOptions, EvaluateTestSuite, Scenario, TestSuite } from './types';
 import type { ApiProvider } from './types/providers';
@@ -129,13 +130,14 @@ const redteam = {
   },
 };
 
-export { assertions, cache, evaluate, loadApiProvider, redteam, guardrails };
+export { assertions, cache, doRedteamRun, evaluate, guardrails, loadApiProvider, redteam };
 
 export default {
   assertions,
   cache,
+  doRedteamRun,
   evaluate,
+  guardrails,
   loadApiProvider,
   redteam,
-  guardrails,
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -43,6 +43,7 @@ describe('index.ts exports', () => {
   const expectedNamedExports = [
     'assertions',
     'cache',
+    'doRedteamRun',
     'evaluate',
     'generateTable',
     'guardrails',
@@ -120,6 +121,7 @@ describe('index.ts exports', () => {
     expect(index.default).toEqual({
       assertions: index.assertions,
       cache: index.cache,
+      doRedteamRun: index.doRedteamRun,
       evaluate: index.evaluate,
       guardrails: index.guardrails,
       loadApiProvider: index.loadApiProvider,


### PR DESCRIPTION
Expose `doRedteamRun` for programmatic use.

Fixes #4749