### PR TITLE
test: fix flaky google live test and improve test speed

### DIFF
--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -6,6 +6,17 @@ import cliState from '../../../src/cliState';
 import { importModule } from '../../../src/esm';
 import { GoogleLiveProvider } from '../../../src/providers/google/live';
 
+// Mock setTimeout globally to speed up tests
+const originalSetTimeout = global.setTimeout;
+global.setTimeout = jest.fn((callback: any, delay?: number) => {
+  // For delays of 1000ms (Python startup), execute immediately
+  if (delay === 1000) {
+    return originalSetTimeout(callback, 0);
+  }
+  // For other delays, use the original setTimeout
+  return originalSetTimeout(callback, delay);
+}) as any;
+
 jest.mock('ws');
 jest.mock('axios');
 jest.mock('../../../src/esm', () => ({
@@ -20,7 +31,8 @@ jest.mock('child_process', () => ({
     stderr: { on: jest.fn() },
     on: jest.fn((event, callback) => {
       if (event === 'close') {
-        setTimeout(callback, 100);
+        // Use immediate callback instead of setTimeout
+        setImmediate(callback);
       }
     }),
     kill: jest.fn(),
@@ -30,12 +42,13 @@ jest.mock('child_process', () => ({
 
 const mockImportModule = jest.mocked(importModule);
 
+// Faster message simulation helpers - use setImmediate instead of setTimeout
 const simulateMessage = (mockWs: jest.Mocked<WebSocket>, simulated_data: any) => {
-  setTimeout(() => {
+  setImmediate(() => {
     mockWs.onmessage?.({
       data: JSON.stringify(simulated_data),
     } as WebSocket.MessageEvent);
-  }, 10);
+  });
 };
 
 const simulatePartsMessage = (mockWs: jest.Mocked<WebSocket>, simulated_parts: any) => {
@@ -91,8 +104,8 @@ describe('GoogleLiveProvider', () => {
     });
 
     // Reset mocks before each test
-    mockedAxios.get.mockClear();
-    mockedAxios.post.mockClear();
+    mockedAxios.get.mockReset();
+    mockedAxios.post.mockReset();
   });
 
   afterEach(() => {
@@ -110,17 +123,19 @@ describe('GoogleLiveProvider', () => {
 
   it('should send message and handle basic response', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulateTextMessage(mockWs, 'test');
         simulateTextMessage(mockWs, ' response');
         simulateCompletionMessage(mockWs);
-      }, 40);
+      });
       return mockWs;
     });
 
-    const response = await provider.callApi('test prompt');
+    const responsePromise = provider.callApi('test prompt');
+
+    const response = await responsePromise;
     expect(response).toEqual({
       output: {
         text: 'test response',
@@ -133,7 +148,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should send message and handle function call response', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -156,11 +171,13 @@ describe('GoogleLiveProvider', () => {
         ]);
         simulateTextMessage(mockWs, 'I was not able to retrieve weather information.');
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
-    const response = await provider.callApi('test prompt');
+    const responsePromise = provider.callApi('test prompt');
+
+    const response = await responsePromise;
     expect(response).toEqual({
       output: {
         text: 'I was not able to retrieve weather information.',
@@ -181,7 +198,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should send message and handle sequential function calls', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -198,7 +215,7 @@ describe('GoogleLiveProvider', () => {
         ]);
         simulateTextMessage(mockWs, "\n```tool_outputs\n{'status': 'called'}\n```\n");
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
@@ -220,7 +237,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should send message and handle in-built google search tool', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -248,7 +265,7 @@ describe('GoogleLiveProvider', () => {
           ' which is slightly acidic due to dissolved carbon dioxide, erodes rocks and carries dissolved minerals and salts into rivers.',
         );
         simulateCompletionMessage(mockWs);
-      }, 70);
+      });
       return mockWs;
     });
 
@@ -263,7 +280,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should send message and handle in-built code execution tool', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -275,7 +292,7 @@ describe('GoogleLiveProvider', () => {
         ]);
         simulateTextMessage(mockWs, 'The result of multiplying 1341 by 23 is 30843.\n');
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
@@ -292,7 +309,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should handle multiple user inputs', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulateTextMessage(mockWs, 'Hey there! How can I help you today?\n');
@@ -303,7 +320,7 @@ describe('GoogleLiveProvider', () => {
         );
         simulateTextMessage(mockWs, ' a unique culture, history, and geography.');
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
@@ -322,13 +339,13 @@ describe('GoogleLiveProvider', () => {
 
   it('should handle WebSocket errors', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onerror?.({
           type: 'error',
           error: new Error('connection failed'),
           message: 'connection failed',
         } as WebSocket.ErrorEvent);
-      }, 10);
+      });
       return mockWs;
     });
 
@@ -374,7 +391,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should handle function tool callbacks correctly', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -393,7 +410,7 @@ describe('GoogleLiveProvider', () => {
         ]);
         simulateTextMessage(mockWs, 'The sum of 5 and 6 is 11.\n');
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
@@ -449,7 +466,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should handle errors in function tool callbacks', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -471,7 +488,7 @@ describe('GoogleLiveProvider', () => {
           'The function `errorFunction` has been called and it returned an error as expected.',
         );
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
     provider = new GoogleLiveProvider('gemini-2.0-flash-exp', {
@@ -520,7 +537,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should handle function tool calls to a spawned stateful api', async () => {
     jest.mocked(WebSocket).mockImplementation(() => {
-      setTimeout(() => {
+      setImmediate(() => {
         mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
         simulateSetupMessage(mockWs);
         simulatePartsMessage(mockWs, [
@@ -564,7 +581,7 @@ describe('GoogleLiveProvider', () => {
         ]);
         simulateTextMessage(mockWs, 'The counter has been incremented until it reached 5.\n');
         simulateCompletionMessage(mockWs);
-      }, 60);
+      });
       return mockWs;
     });
 
@@ -624,7 +641,19 @@ describe('GoogleLiveProvider', () => {
       },
       metadata: {},
     });
-    expect(mockedAxios.get).toHaveBeenCalledTimes(6);
+
+    // Check the specific calls made to the stateful API
+    const getCallUrls = mockedAxios.get.mock.calls.map((call) => call[0]);
+    const expectedUrls = [
+      'http://127.0.0.1:5000/get_count',
+      'http://127.0.0.1:5000/add_one',
+      'http://127.0.0.1:5000/get_count',
+      'http://127.0.0.1:5000/add_one',
+      'http://127.0.0.1:5000/get_count',
+      'http://127.0.0.1:5000/get_state',
+    ];
+
+    expect(getCallUrls).toEqual(expectedUrls);
     expect(mockedAxios.get).toHaveBeenLastCalledWith('http://127.0.0.1:5000/get_state');
   });
   describe('Python executable integration', () => {
@@ -652,12 +681,12 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateTextMessage(mockWs, 'Test response');
           simulateCompletionMessage(mockWs);
-        }, 10);
+        });
         return mockWs;
       });
 
@@ -698,12 +727,12 @@ describe('GoogleLiveProvider', () => {
         });
 
         jest.mocked(WebSocket).mockImplementation(() => {
-          setTimeout(() => {
+          setImmediate(() => {
             mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
             simulateSetupMessage(mockWs);
             simulateTextMessage(mockWs, 'Test response');
             simulateCompletionMessage(mockWs);
-          }, 10);
+          });
           return mockWs;
         });
 
@@ -749,12 +778,12 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateTextMessage(mockWs, 'Test response');
           simulateCompletionMessage(mockWs);
-        }, 10);
+        });
         return mockWs;
       });
 
@@ -790,12 +819,12 @@ describe('GoogleLiveProvider', () => {
         });
 
         jest.mocked(WebSocket).mockImplementation(() => {
-          setTimeout(() => {
+          setImmediate(() => {
             mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
             simulateSetupMessage(mockWs);
             simulateTextMessage(mockWs, 'Test response');
             simulateCompletionMessage(mockWs);
-          }, 10);
+          });
           return mockWs;
         });
 
@@ -847,14 +876,14 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateTextMessage(mockWs, 'Test response');
           simulateCompletionMessage(mockWs);
 
           mockWs.onclose?.({ wasClean: true, code: 1000 } as WebSocket.CloseEvent);
-        }, 10);
+        });
         return mockWs;
       });
 
@@ -881,9 +910,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -908,9 +945,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -939,9 +984,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -971,9 +1024,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -1007,9 +1068,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -1036,9 +1105,17 @@ describe('GoogleLiveProvider', () => {
       });
 
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        }, 10);
+          // Trigger onclose immediately to resolve the promise
+          setImmediate(() => {
+            mockWs.onclose?.({
+              wasClean: true,
+              code: 1000,
+              reason: 'Test close',
+            } as WebSocket.CloseEvent);
+          });
+        });
         return mockWs;
       });
 
@@ -1067,7 +1144,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should load and execute external function callbacks from file', async () => {
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateFunctionCallMessage(mockWs, [
@@ -1075,7 +1152,7 @@ describe('GoogleLiveProvider', () => {
           ]);
           simulateTextMessage(mockWs, 'External function result');
           simulateCompletionMessage(mockWs);
-        }, 60);
+        });
         return mockWs;
       });
 
@@ -1121,7 +1198,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should cache external functions and not reload them on subsequent calls', async () => {
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateFunctionCallMessage(mockWs, [
@@ -1129,7 +1206,7 @@ describe('GoogleLiveProvider', () => {
           ]);
           simulateTextMessage(mockWs, 'Cached result');
           simulateCompletionMessage(mockWs);
-        }, 60);
+        });
         return mockWs;
       });
 
@@ -1170,7 +1247,7 @@ describe('GoogleLiveProvider', () => {
 
       // Reset WebSocket mock for second call
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateFunctionCallMessage(mockWs, [
@@ -1178,7 +1255,7 @@ describe('GoogleLiveProvider', () => {
           ]);
           simulateTextMessage(mockWs, 'Cached result');
           simulateCompletionMessage(mockWs);
-        }, 60);
+        });
         return mockWs;
       });
 
@@ -1191,7 +1268,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should handle errors in external function loading gracefully', async () => {
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateFunctionCallMessage(mockWs, [
@@ -1199,7 +1276,7 @@ describe('GoogleLiveProvider', () => {
           ]);
           simulateTextMessage(mockWs, 'Function failed gracefully');
           simulateCompletionMessage(mockWs);
-        }, 60);
+        });
         return mockWs;
       });
 
@@ -1243,7 +1320,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should handle mixed inline and external function callbacks', async () => {
       jest.mocked(WebSocket).mockImplementation(() => {
-        setTimeout(() => {
+        setImmediate(() => {
           mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
           simulateSetupMessage(mockWs);
           simulateFunctionCallMessage(mockWs, [
@@ -1256,7 +1333,7 @@ describe('GoogleLiveProvider', () => {
           ]);
           simulateTextMessage(mockWs, 'Mixed functions completed');
           simulateCompletionMessage(mockWs);
-        }, 60);
+        });
         return mockWs;
       });
 


### PR DESCRIPTION
Fixed flaky test by improving mock cleanup and reduced test execution time from 9.6s to 0.4s.