### PR TITLE
feat(redteam): expose generate function in redteam namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { runDbMigrations } from './migrate';
 import Eval from './models/eval';
 import { readProviderPromptMap, processPrompts } from './prompts';
 import { loadApiProvider, loadApiProviders, resolveProvider } from './providers';
+import { doGenerateRedteam } from './redteam/commands/generate';
 import { extractEntities } from './redteam/extraction/entities';
 import { extractMcpToolsInfo } from './redteam/extraction/mcpTools';
 import { extractSystemPurpose } from './redteam/extraction/purpose';
@@ -130,6 +131,7 @@ const redteam = {
     Plugin: RedteamPluginBase,
     Grader: RedteamGraderBase,
   },
+  generate: doGenerateRedteam,
 };
 
 export { assertions, cache, doRedteamRun, evaluate, guardrails, loadApiProvider, redteam };

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,14 +132,14 @@ const redteam = {
     Grader: RedteamGraderBase,
   },
   generate: doGenerateRedteam,
+  run: doRedteamRun,
 };
 
-export { assertions, cache, doRedteamRun, evaluate, guardrails, loadApiProvider, redteam };
+export { assertions, cache, evaluate, guardrails, loadApiProvider, redteam };
 
 export default {
   assertions,
   cache,
-  doRedteamRun,
   evaluate,
   guardrails,
   loadApiProvider,

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -220,3 +220,9 @@ export interface BaseRedteamMetadata {
   stopReason: string;
   redteamHistory?: { prompt: string; output: string }[];
 }
+
+/**
+ * Options for generating red team tests via the public API
+ * This is a cleaner subset of RedteamCliGenerateOptions for external use
+ */
+export type RedteamGenerateOptions = Partial<RedteamCliGenerateOptions>;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -115,6 +115,7 @@ describe('index.ts exports', () => {
       Graders: expect.any(Object),
       Plugins: expect.any(Object),
       Strategies: expect.any(Object),
+      generate: expect.any(Function),
     });
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -43,7 +43,6 @@ describe('index.ts exports', () => {
   const expectedNamedExports = [
     'assertions',
     'cache',
-    'doRedteamRun',
     'evaluate',
     'generateTable',
     'guardrails',
@@ -116,6 +115,7 @@ describe('index.ts exports', () => {
       Plugins: expect.any(Object),
       Strategies: expect.any(Object),
       generate: expect.any(Function),
+      run: expect.any(Function),
     });
   });
 
@@ -123,7 +123,6 @@ describe('index.ts exports', () => {
     expect(index.default).toEqual({
       assertions: index.assertions,
       cache: index.cache,
-      doRedteamRun: index.doRedteamRun,
       evaluate: index.evaluate,
       guardrails: index.guardrails,
       loadApiProvider: index.loadApiProvider,

--- a/test/redteam/types.test.ts
+++ b/test/redteam/types.test.ts
@@ -10,6 +10,7 @@ import type {
   RedteamRunOptions,
   SavedRedteamConfig,
   BaseRedteamMetadata,
+  RedteamGenerateOptions,
 } from '../../src/redteam/types';
 import type { ApiProvider } from '../../src/types/providers';
 
@@ -225,5 +226,34 @@ describe('redteam types', () => {
     expect(metadata.redteamFinalPrompt).toBe('final prompt');
     expect(metadata.messages).toHaveLength(1);
     expect(metadata.stopReason).toBe('complete');
+  });
+
+  it('should create valid RedteamGenerateOptions', () => {
+    const emptyOptions: RedteamGenerateOptions = {};
+    const partialOptions: RedteamGenerateOptions = {
+      cache: true,
+      plugins: [
+        {
+          id: 'test-plugin',
+          numTests: 5,
+        },
+      ],
+      maxConcurrency: 3,
+      injectVar: 'test_var',
+      language: 'en',
+      purpose: 'test purpose',
+      remote: false,
+      sharing: true,
+      testGenerationInstructions: 'test instructions',
+    };
+
+    expect(emptyOptions).toBeDefined();
+    expect(partialOptions.cache).toBe(true);
+    expect(partialOptions.plugins?.length).toBe(1);
+    expect(partialOptions.maxConcurrency).toBe(3);
+    expect(partialOptions.language).toBe('en');
+    expect(partialOptions.remote).toBe(false);
+    expect(partialOptions.sharing).toBe(true);
+    expect(partialOptions.testGenerationInstructions).toBe('test instructions');
   });
 });


### PR DESCRIPTION
Exposes doGenerateRedteam as redteam.generate in the public API for programmatic test generation.