### PR TITLE
refactor: inline MEMORY_POISONING_PLUGIN_ID constant

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2,7 +2,6 @@ import dedent from 'dedent';
 import path from 'path';
 import { importModule } from '../esm';
 import logger from '../logger';
-import { MEMORY_POISONING_PLUGIN_ID } from '../redteam/plugins/agentic/constants';
 import { MemoryPoisoningProvider } from '../redteam/providers/agentic/memoryPoisoning';
 import RedteamBestOfNProvider from '../redteam/providers/bestOfN';
 import RedteamCrescendoProvider from '../redteam/providers/crescendo';
@@ -105,7 +104,7 @@ export const providerMap: ProviderFactory[] = [
   createScriptBasedProviderFactory('golang', 'go', GolangProvider),
   createScriptBasedProviderFactory('python', 'py', PythonProvider),
   {
-    test: (providerPath: string) => providerPath === MEMORY_POISONING_PLUGIN_ID,
+    test: (providerPath: string) => providerPath === 'agentic:memory-poisoning',
     create: async (
       providerPath: string,
       providerOptions: ProviderOptions,

--- a/src/redteam/constants/frameworks.ts
+++ b/src/redteam/constants/frameworks.ts
@@ -1,4 +1,3 @@
-import { MEMORY_POISONING_PLUGIN_ID } from '../plugins/agentic/constants';
 import type { Plugin } from './plugins';
 import { FOUNDATION_PLUGINS, PII_PLUGINS } from './plugins';
 import type { Strategy } from './strategies';
@@ -195,7 +194,7 @@ export const OWASP_AGENTIC_REDTEAM_MAPPING: Record<
   { plugins: Plugin[]; strategies: Strategy[] }
 > = {
   'owasp:agentic:t01': {
-    plugins: [MEMORY_POISONING_PLUGIN_ID],
+    plugins: ['agentic:memory-poisoning'],
     strategies: [],
   },
 };

--- a/src/redteam/constants/metadata.ts
+++ b/src/redteam/constants/metadata.ts
@@ -1,9 +1,8 @@
-import { MEMORY_POISONING_PLUGIN_ID } from '../plugins/agentic/constants';
 import type { Plugin } from './plugins';
 import type { Strategy } from './strategies';
 
 export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
-  [MEMORY_POISONING_PLUGIN_ID]: 'Tests whether an agent is vulnerable to memory poisoning attacks',
+  ['agentic:memory-poisoning']: 'Tests whether an agent is vulnerable to memory poisoning attacks',
   aegis: "Tests content safety handling using NVIDIA's Aegis dataset",
   'ascii-smuggling': 'Tests vulnerability to Unicode tag-based instruction smuggling attacks',
   audio: 'Tests handling of audio content',
@@ -142,7 +141,7 @@ export const subCategoryDescriptions: Record<Plugin | Strategy, string> = {
 
 // These names are displayed in risk cards and in the table
 export const displayNameOverrides: Record<Plugin | Strategy, string> = {
-  [MEMORY_POISONING_PLUGIN_ID]: 'Agentic Memory Poisoning',
+  ['agentic:memory-poisoning']: 'Agentic Memory Poisoning',
   aegis: 'Aegis Dataset',
   'ascii-smuggling': 'ASCII Smuggling',
   audio: 'Audio Content',
@@ -283,7 +282,7 @@ export const severityDisplayNames: Record<Severity, string> = {
  * Use getRiskCategorySeverityMap() whenever possible to respect the user's severity settings.
  */
 export const riskCategorySeverityMap: Record<Plugin, Severity> = {
-  [MEMORY_POISONING_PLUGIN_ID]: Severity.High,
+  ['agentic:memory-poisoning']: Severity.High,
   aegis: Severity.Medium,
   'ascii-smuggling': Severity.Low,
   beavertails: Severity.Low,
@@ -403,7 +402,7 @@ export const riskCategories: Record<string, Plugin[]> = {
     'pii',
     'prompt-extraction',
 
-    MEMORY_POISONING_PLUGIN_ID,
+    'agentic:memory-poisoning',
   ],
 
   'Compliance & Legal': [
@@ -502,7 +501,7 @@ export const categoryLabels = Object.keys(categoryMapReverse);
 
 // Map from plugin name to metric name or harm category
 export const categoryAliases: Record<Plugin, string> = {
-  [MEMORY_POISONING_PLUGIN_ID]: 'AgenticMemoryPoisoning',
+  ['agentic:memory-poisoning']: 'AgenticMemoryPoisoning',
   aegis: 'Aegis',
   'ascii-smuggling': 'AsciiSmuggling',
   beavertails: 'BeaverTails',
@@ -605,7 +604,7 @@ export const categoryAliasesReverse = Object.entries(categoryAliases).reduce(
 );
 
 export const pluginDescriptions: Record<Plugin, string> = {
-  [MEMORY_POISONING_PLUGIN_ID]: 'Tests whether an agent is vulnerable to memory poisoning attacks',
+  ['agentic:memory-poisoning']: 'Tests whether an agent is vulnerable to memory poisoning attacks',
   aegis: "Tests content safety handling using NVIDIA's Aegis dataset",
   'ascii-smuggling': 'Tests for ASCII-based prompt smuggling vulnerabilities',
   beavertails: 'Tests handling of malicious prompts from the BeaverTails dataset',

--- a/src/redteam/constants/plugins.ts
+++ b/src/redteam/constants/plugins.ts
@@ -1,5 +1,3 @@
-import { MEMORY_POISONING_PLUGIN_ID } from '../plugins/agentic/constants';
-
 export const DEFAULT_NUM_TESTS_PER_PLUGIN = 5;
 
 // Redteam configuration defaults
@@ -139,7 +137,7 @@ export const GUARDRAILS_EVALUATION_PLUGINS = [
   'harmful:privacy',
 ] as const;
 
-export const AGENTIC_PLUGINS = [MEMORY_POISONING_PLUGIN_ID] as const;
+export const AGENTIC_PLUGINS = ['agentic:memory-poisoning'] as const;
 export type AgenticPlugin = (typeof AGENTIC_PLUGINS)[number];
 
 export const COLLECTIONS = [
@@ -275,7 +273,7 @@ export type ConfigRequiredPlugin = (typeof CONFIG_REQUIRED_PLUGINS)[number];
 // Agentic plugins that don't use strategies (standalone agentic plugins)
 export const AGENTIC_EXEMPT_PLUGINS = [
   'system-prompt-override',
-  MEMORY_POISONING_PLUGIN_ID,
+  'agentic:memory-poisoning',
 ] as const;
 
 // Dataset plugins that don't use strategies (standalone dataset plugins)

--- a/src/redteam/plugins/agentic/constants.ts
+++ b/src/redteam/plugins/agentic/constants.ts
@@ -1,3 +1,1 @@
-export const MEMORY_POISONING_PLUGIN_ID = 'agentic:memory-poisoning';
-
-export const REDTEAM_MEMORY_POISONING_PLUGIN_ID = `promptfoo:redteam:${MEMORY_POISONING_PLUGIN_ID}`;
+export const REDTEAM_MEMORY_POISONING_PLUGIN_ID = 'promptfoo:redteam:agentic:memory-poisoning';

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -20,7 +20,6 @@ import {
 } from '../remoteGeneration';
 import { getShortPluginId } from '../util';
 import { AegisPlugin } from './aegis';
-import { MEMORY_POISONING_PLUGIN_ID } from './agentic/constants';
 import { type RedteamPluginBase } from './base';
 import { BeavertailsPlugin } from './beavertails';
 import { ContractPlugin } from './contracts';
@@ -295,7 +294,7 @@ function createRemotePlugin<T extends PluginConfig>(
   };
 }
 const remotePlugins: PluginFactory[] = [
-  MEMORY_POISONING_PLUGIN_ID,
+  'agentic:memory-poisoning',
   'ascii-smuggling',
   'bfla',
   'bola',

--- a/test/redteam/constants.test.ts
+++ b/test/redteam/constants.test.ts
@@ -201,7 +201,7 @@ describe('constants', () => {
     );
   });
 
-  it('should have MEMORY_POISONING_PLUGIN_ID in Security & Access Control category', () => {
+  it('should have agentic:memory-poisoning in Security & Access Control category', () => {
     expect(riskCategories['Security & Access Control']).toBeDefined();
     expect(riskCategories['Security & Access Control']).toContain('agentic:memory-poisoning');
   });

--- a/test/redteam/constants/frameworks.test.ts
+++ b/test/redteam/constants/frameworks.test.ts
@@ -13,7 +13,6 @@ import {
   ALIASED_PLUGINS,
   ALIASED_PLUGIN_MAPPINGS,
 } from '../../../src/redteam/constants/frameworks';
-import { MEMORY_POISONING_PLUGIN_ID } from '../../../src/redteam/plugins/agentic/constants';
 
 describe('Framework Constants', () => {
   describe('FRAMEWORK_NAMES', () => {
@@ -74,7 +73,7 @@ describe('Framework Constants', () => {
   describe('OWASP_AGENTIC_REDTEAM_MAPPING', () => {
     it('should have correct mapping for memory poisoning', () => {
       expect(OWASP_AGENTIC_REDTEAM_MAPPING['owasp:agentic:t01'].plugins).toContain(
-        MEMORY_POISONING_PLUGIN_ID,
+        'agentic:memory-poisoning',
       );
       expect(OWASP_AGENTIC_REDTEAM_MAPPING['owasp:agentic:t01'].strategies).toHaveLength(0);
     });

--- a/test/redteam/constants/metadata.test.ts
+++ b/test/redteam/constants/metadata.test.ts
@@ -18,7 +18,6 @@ import {
 } from '../../../src/redteam/constants/metadata';
 import type { Plugin } from '../../../src/redteam/constants/plugins';
 import type { Strategy } from '../../../src/redteam/constants/strategies';
-import { MEMORY_POISONING_PLUGIN_ID } from '../../../src/redteam/plugins/agentic/constants';
 
 describe('metadata constants', () => {
   describe('Severity enum and display names', () => {
@@ -39,7 +38,7 @@ describe('metadata constants', () => {
     });
 
     it('should include memory poisoning plugin with high severity', () => {
-      expect(riskCategorySeverityMap[MEMORY_POISONING_PLUGIN_ID]).toBe(Severity.High);
+      expect(riskCategorySeverityMap['agentic:memory-poisoning']).toBe(Severity.High);
     });
   });
 
@@ -122,7 +121,7 @@ describe('metadata constants', () => {
 
   describe('Display name overrides', () => {
     it('should have display names for memory poisoning plugin', () => {
-      expect(displayNameOverrides[MEMORY_POISONING_PLUGIN_ID]).toBe('Agentic Memory Poisoning');
+      expect(displayNameOverrides['agentic:memory-poisoning']).toBe('Agentic Memory Poisoning');
     });
 
     it('should have matching subcategory descriptions', () => {

--- a/test/redteam/constants/plugins.test.ts
+++ b/test/redteam/constants/plugins.test.ts
@@ -20,7 +20,6 @@ import {
   STRATEGY_EXEMPT_PLUGINS,
   UNALIGNED_PROVIDER_HARM_PLUGINS,
 } from '../../../src/redteam/constants/plugins';
-import { MEMORY_POISONING_PLUGIN_ID } from '../../../src/redteam/plugins/agentic/constants';
 
 describe('plugins constants', () => {
   it('should define DEFAULT_NUM_TESTS_PER_PLUGIN', () => {
@@ -65,7 +64,7 @@ describe('plugins constants', () => {
   });
 
   it('should define AGENTIC_PLUGINS with memory poisoning plugin', () => {
-    expect(AGENTIC_PLUGINS).toEqual([MEMORY_POISONING_PLUGIN_ID]);
+    expect(AGENTIC_PLUGINS).toEqual(['agentic:memory-poisoning']);
   });
 
   it('should define COLLECTIONS array', () => {
@@ -120,7 +119,7 @@ describe('plugins constants', () => {
   });
 
   it('should define AGENTIC_EXEMPT_PLUGINS array', () => {
-    expect(AGENTIC_EXEMPT_PLUGINS).toEqual(['system-prompt-override', MEMORY_POISONING_PLUGIN_ID]);
+    expect(AGENTIC_EXEMPT_PLUGINS).toEqual(['system-prompt-override', 'agentic:memory-poisoning']);
   });
 
   it('should define DATASET_EXEMPT_PLUGINS array', () => {


### PR DESCRIPTION
## Summary

This PR completes the migration from using the `MEMORY_POISONING_PLUGIN_ID` constant to using the literal string `'agentic:memory-poisoning'` directly throughout the codebase.

## Changes

- Replaced all instances of `MEMORY_POISONING_PLUGIN_ID` with the literal `'agentic:memory-poisoning'`
- Removed the now-unused `MEMORY_POISONING_PLUGIN_ID` export from `src/redteam/plugins/agentic/constants.ts`
- Kept `REDTEAM_MEMORY_POISONING_PLUGIN_ID` as it's still used in graders and providers
- Updated all tests to use the literal string instead of the constant
- Updated test descriptions to reflect the change

## Migration Details

The following files were updated:
- `src/providers/registry.ts`
- `src/redteam/constants/frameworks.ts`
- `src/redteam/constants/metadata.ts`
- `src/redteam/constants/plugins.ts`
- `src/redteam/plugins/agentic/constants.ts`
- `src/redteam/plugins/index.ts`
- `test/redteam/constants.test.ts`
- `test/redteam/constants/frameworks.test.ts`
- `test/redteam/constants/metadata.test.ts`
- `test/redteam/constants/plugins.test.ts`

## Breaking Changes

⚠️ **BREAKING CHANGE**: The `MEMORY_POISONING_PLUGIN_ID` constant has been removed. Any external code using this constant should be updated to use `'agentic:memory-poisoning'` directly.

## Testing

All existing tests pass without modification (except for updating the test descriptions).

## Notes

The lists in the metadata file are currently not sorted alphabetically. This could be addressed in a follow-up PR to maintain consistency.