### PR TITLE
chore(webui): capitalize 'Red Team' in navigation menu for consistency

### DIFF
--- a/src/app/src/components/Navigation.tsx
+++ b/src/app/src/components/Navigation.tsx
@@ -108,7 +108,7 @@ function CreateDropdown() {
           Eval
         </MenuItem>
         <MenuItem onClick={handleClose} component={RouterLink} to="/redteam/setup">
-          Red team
+          Red Team
         </MenuItem>
       </Menu>
     </>


### PR DESCRIPTION
This PR capitalizes 'Red team' to 'Red Team' in the navigation dropdown menu to maintain consistency with proper naming conventions throughout the application.