### PR TITLE
chore(internals): remove python script result data type debug log

### DIFF
--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -196,12 +196,7 @@ export async function runPython(
       throw new Error('The Python script `call_api` function must return a dict with an `output`');
     }
 
-    // Add helpful logging about the data structure
-    if (result.data) {
-      logger.debug(
-        `Python script result data type: ${typeof result.data}, structure: ${result.data ? JSON.stringify(Object.keys(result.data)) : 'undefined'}`,
-      );
-    }
+
 
     return result.data;
   } catch (error) {

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -196,8 +196,6 @@ export async function runPython(
       throw new Error('The Python script `call_api` function must return a dict with an `output`');
     }
 
-
-
     return result.data;
   } catch (error) {
     logger.error(

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -419,9 +419,6 @@ describe('Python Utils', () => {
             `Python script ${path.resolve('testScript.py')} parsed output type: object`,
           ),
         );
-        expect(logger.debug).toHaveBeenCalledWith(
-          expect.stringContaining('Python script result data type: object'),
-        );
       });
     });
 


### PR DESCRIPTION
Removes debug logging of Python script return data type. In practice, I've found it to be noise that makes the logs more difficult to read, for example:

<img width="1775" alt="image" src="https://github.com/user-attachments/assets/11f7beee-c1b7-4ea2-89d4-f1813562cc16" />
