### PR TITLE
chore(eval): remove redundant 'Done.' message from evaluation output

### DIFF
--- a/examples/assistant-cli/output.txt
+++ b/examples/assistant-cli/output.txt
@@ -148,4 +148,3 @@ Evaluation complete: {
     "completion": 1222
   }
 }
-Done.

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -659,11 +659,8 @@ export async function doEval(
             ),
           );
         }
-        logger.info('\nDone.');
         process.exitCode = Number.isSafeInteger(failedTestExitCode) ? failedTestExitCode : 100;
         return ret;
-      } else {
-        logger.info('\nDone.');
       }
     }
     if (testSuite.redteam) {


### PR DESCRIPTION
This PR removes the redundant 'Done.' message that was being printed after evaluation completion. The message was appearing in two different code paths and has been removed from both locations to clean up the output.