### PR TITLE
fix: improve model-audit installation check dark mode display

### DIFF
--- a/src/app/src/pages/model-audit/components/InstallationCheck.tsx
+++ b/src/app/src/pages/model-audit/components/InstallationCheck.tsx
@@ -13,7 +13,7 @@ export default function InstallationCheck() {
         <Typography variant="body1" color="text.secondary" paragraph>
           The ModelAudit Python package is required to scan ML models for security vulnerabilities.
         </Typography>
-        <Paper sx={{ p: 3, bgcolor: 'grey.100', maxWidth: 500, mx: 'auto', my: 3 }}>
+        <Paper sx={{ p: 3, bgcolor: 'action.hover', maxWidth: 500, mx: 'auto', my: 3 }}>
           <Typography variant="body1" fontFamily="monospace" fontWeight={500}>
             pip install modelaudit
           </Typography>


### PR DESCRIPTION
## Summary
- Fixed dark mode display issue in the ModelAudit installation check component
- Changed Paper background color from `grey.100` to `action.hover` for proper dark mode support

## Test plan
- [ ] Verify the installation check component displays correctly in light mode
- [ ] Verify the installation check component displays correctly in dark mode
- [ ] Ensure the pip install command box has appropriate contrast in both themes

🤖 Generated with [Claude Code](https://claude.ai/code)