### PR TITLE
feat(app/eval): Display context values in eval results

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -51,6 +51,32 @@ const textContentTypographySx = {
   wordBreak: 'break-word',
 };
 
+/**
+ * Returns the value of the assertion.
+ * For context-related assertions, read the context value from metadata, if it exists.
+ * Otherwise, return the assertion value.
+ * @param result - The grading result.
+ * @returns The value of the assertion.
+ */
+function getValue(result: GradingResult) {
+  // For context-related assertions, read the context value from metadata, if it exists
+  if (
+    result.assertion?.type &&
+    // prettier-ignore
+    ['context-faithfulness', 'context-recall', 'context-relevance'].includes(result.assertion.type) &&
+    result.metadata?.context
+  ) {
+    return result.metadata?.context;
+  }
+
+  // Otherwise, return the assertion value
+  return result.assertion?.value
+    ? typeof result.assertion.value === 'object'
+      ? JSON.stringify(result.assertion.value, null, 2)
+      : String(result.assertion.value)
+    : '-';
+}
+
 // Code display component
 interface CodeDisplayProps {
   content: string;
@@ -196,17 +222,7 @@ function AssertionResults({ gradingResults }: { gradingResults?: GradingResult[]
                 return null;
               }
 
-              const value =
-                // For context-related assertions, read the context value from metadata, if it exists
-                ['context-faithfulness', 'context-recall', 'context-relevance'].includes(
-                  result.assertion?.type ?? '',
-                ) && result.metadata?.context
-                  ? result.metadata?.context
-                  : result.assertion?.value
-                    ? typeof result.assertion.value === 'object'
-                      ? JSON.stringify(result.assertion.value, null, 2)
-                      : String(result.assertion.value)
-                    : '-';
+              const value = getValue(result);
               const truncatedValue = ellipsize(value, 300);
               const isExpanded = expandedValues[i] || false;
               const valueKey = `value-${i}`;

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -195,11 +195,18 @@ function AssertionResults({ gradingResults }: { gradingResults?: GradingResult[]
               if (!result) {
                 return null;
               }
-              const value = result.assertion?.value
-                ? typeof result.assertion.value === 'object'
-                  ? JSON.stringify(result.assertion.value, null, 2)
-                  : String(result.assertion.value)
-                : '-';
+
+              const value =
+                // For context-related assertions, read the context value from metadata, if it exists
+                ['context-faithfulness', 'context-recall', 'context-relevance'].includes(
+                  result.assertion?.type ?? '',
+                ) && result.metadata?.context
+                  ? result.metadata?.context
+                  : result.assertion?.value
+                    ? typeof result.assertion.value === 'object'
+                      ? JSON.stringify(result.assertion.value, null, 2)
+                      : String(result.assertion.value)
+                    : '-';
               const truncatedValue = ellipsize(value, 300);
               const isExpanded = expandedValues[i] || false;
               const valueKey = `value-${i}`;

--- a/src/assertions/contextFaithfulness.ts
+++ b/src/assertions/contextFaithfulness.ts
@@ -48,5 +48,8 @@ export async function handleContextFaithfulness({
       assertion.threshold ?? 0,
       test.options,
     )),
+    metadata: {
+      context,
+    },
   };
 }

--- a/src/assertions/contextRecall.ts
+++ b/src/assertions/contextRecall.ts
@@ -38,5 +38,8 @@ export const handleContextRecall = async ({
       test.options,
       test.vars,
     )),
+    metadata: {
+      context,
+    },
   };
 };

--- a/src/assertions/contextRelevance.ts
+++ b/src/assertions/contextRelevance.ts
@@ -43,5 +43,8 @@ export const handleContextRelevance = async ({
       assertion.threshold ?? 0,
       test.options,
     )),
+    metadata: {
+      context,
+    },
   };
 };

--- a/test/assertions/contextFaithfulness.test.ts
+++ b/test/assertions/contextFaithfulness.test.ts
@@ -57,6 +57,8 @@ describe('handleContextFaithfulness', () => {
     expect(result.pass).toBe(true);
     expect(result.score).toBe(0.9);
     expect(result.reason).toBe('Content is faithful to context');
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.context).toBe('test context');
     expect(matchers.matchesContextFaithfulness).toHaveBeenCalledWith(
       'What is the capital of France?',
       'The capital of France is Paris.',
@@ -113,6 +115,8 @@ describe('handleContextFaithfulness', () => {
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0.3);
     expect(result.reason).toBe('Content contains hallucinations');
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.context).toBe('test context');
     expect(matchers.matchesContextFaithfulness).toHaveBeenCalledWith(
       'What is the capital of France?',
       'The capital of France is Paris and it has a population of 50 million.',
@@ -246,7 +250,7 @@ describe('handleContextFaithfulness', () => {
       providerResponse: null,
     } as any;
 
-    await handleContextFaithfulness(params);
+    const result = await handleContextFaithfulness(params);
 
     expect(contextUtils.resolveContext).toHaveBeenCalledWith(
       params.assertion,
@@ -263,5 +267,7 @@ describe('handleContextFaithfulness', () => {
       0,
       {},
     );
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.context).toBe('from-transform');
   });
 });

--- a/test/assertions/contextRecall.test.ts
+++ b/test/assertions/contextRecall.test.ts
@@ -49,6 +49,8 @@ describe('handleContextRecall', () => {
     expect(result.pass).toBe(true);
     expect(result.score).toBe(0.9);
     expect(result.reason).toBe('Context contains expected information');
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.context).toBe('test context');
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test context',
       'Expected fact',
@@ -94,6 +96,8 @@ describe('handleContextRecall', () => {
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0.3);
     expect(result.reason).toBe('Context missing expected information');
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.context).toBe('test context');
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test context',
       'Missing fact',
@@ -134,8 +138,10 @@ describe('handleContextRecall', () => {
       providerResponse: {} as ProviderResponse,
     };
 
-    await handleContextRecall(params);
+    const result = await handleContextRecall(params);
 
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.context).toBe('test context');
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test context',
       'test value',
@@ -176,8 +182,10 @@ describe('handleContextRecall', () => {
       providerResponse: {} as ProviderResponse,
     };
 
-    await handleContextRecall(params);
+    const result = await handleContextRecall(params);
 
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.context).toBe('test prompt');
     expect(contextUtils.resolveContext).toHaveBeenCalledWith(
       params.assertion,
       params.test,
@@ -217,8 +225,10 @@ describe('handleContextRecall', () => {
       providerResponse: {} as ProviderResponse,
     };
 
-    await handleContextRecall(params);
+    const result = await handleContextRecall(params);
 
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.context).toBe('ctx');
     expect(contextUtils.resolveContext).toHaveBeenCalledWith(
       params.assertion,
       params.test,

--- a/test/assertions/contextRelevance.test.ts
+++ b/test/assertions/contextRelevance.test.ts
@@ -55,6 +55,9 @@ describe('handleContextRelevance', () => {
     expect(result.pass).toBe(true);
     expect(result.score).toBe(0.9);
     expect(result.reason).toBe('Context is highly relevant');
+    expect(result.metadata).toEqual({
+      context: 'test context',
+    });
     expect(matchesContextRelevance).toHaveBeenCalledWith(
       'What is the capital of France?',
       'test context',
@@ -108,6 +111,9 @@ describe('handleContextRelevance', () => {
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0.3);
     expect(result.reason).toBe('Context not relevant to query');
+    expect(result.metadata).toEqual({
+      context: 'irrelevant context',
+    });
     expect(matchesContextRelevance).toHaveBeenCalledWith(
       'What is the capital of France?',
       'irrelevant context',
@@ -121,7 +127,7 @@ describe('handleContextRelevance', () => {
     jest.mocked(matchesContextRelevance).mockResolvedValue(mockResult);
     jest.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
 
-    await handleContextRelevance({
+    const result = await handleContextRelevance({
       assertion: {
         type: 'context-relevance',
       },
@@ -149,6 +155,9 @@ describe('handleContextRelevance', () => {
     } as any);
 
     expect(matchesContextRelevance).toHaveBeenCalledWith('test query', 'test context', 0, {});
+    expect(result.metadata).toEqual({
+      context: 'test context',
+    });
   });
 
   it('should throw error when test.vars is missing', async () => {
@@ -212,7 +221,7 @@ describe('handleContextRelevance', () => {
     jest.mocked(matchesContextRelevance).mockResolvedValue(mockResult);
     jest.mocked(contextUtils.resolveContext).mockResolvedValue('cx');
 
-    await handleContextRelevance({
+    const result = await handleContextRelevance({
       assertion: {
         type: 'context-relevance',
         contextTransform: 'expr',
@@ -246,5 +255,8 @@ describe('handleContextRelevance', () => {
       { output: 'out', tokenUsage: {} },
     );
     expect(matchesContextRelevance).toHaveBeenCalledWith('q', 'cx', 0, {});
+    expect(result.metadata).toEqual({
+      context: 'cx',
+    });
   });
 });

--- a/test/assertions/runAssertion.test.ts
+++ b/test/assertions/runAssertion.test.ts
@@ -2652,6 +2652,9 @@ describe('runAssertion', () => {
         score: 1,
         reason: 'Mocked reason',
         assertion,
+        metadata: {
+          context: 'Paris is the capital of France.',
+        },
       });
     });
 
@@ -2740,6 +2743,9 @@ describe('runAssertion', () => {
         score: 1,
         reason: 'Mocked reason',
         assertion,
+        metadata: {
+          context: 'Paris is the capital of France.',
+        },
       });
     });
 


### PR DESCRIPTION
**Before**

<img width="1167" height="236" alt="image" src="https://github.com/user-attachments/assets/5579dc5b-eff4-47cf-a787-7e3b42081bcf" />

**After**

<img width="1212" height="237" alt="image" src="https://github.com/user-attachments/assets/975d4813-f92b-44c6-a644-aa0199b29e8c" />