### PR TITLE
docs: Improve mobile tab spacing

### DIFF
--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -574,22 +574,24 @@
 
   .walkthroughTabs {
     width: 100%;
-    padding: 0;
-    gap: 0;
+    padding: 0.25rem;
+    gap: 0.25rem;
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    flex-wrap: wrap;
   }
 
   .walkthroughTab {
-    padding: 0.75rem 0.25rem;
-    font-size: 0.9rem;
-    flex: 1;
+    padding: 0.6rem 0.8rem;
+    font-size: 0.85rem;
+    flex: 0 1 auto;
     min-width: 0;
     display: flex;
     justify-content: center;
     align-items: center;
     word-break: keep-all;
     white-space: nowrap;
+    margin: 0.125rem;
   }
 }
 


### PR DESCRIPTION
Improve mobile responsiveness of tabs in `index.module.css` to prevent cramping and improve usability on small screens.