### PR TITLE
docs(site): improve NLP metric explanations and add SEO metadata

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -522,6 +522,7 @@ Note that `latency` requires that the [cache is disabled](/docs/configuration/ca
 The `levenshtein` assertion checks if the LLM output is within a given edit distance from an expected value.
 
 Levenshtein distance measures the number of single-character edits (insertions, deletions, or substitutions) required to change one string into another. This metric is useful for:
+
 - **Fuzzy matching**: When you want to allow minor typos or variations (e.g., "color" vs "colour")
 - **Name matching**: When checking if the model outputs names correctly with some tolerance for spelling
 - **Code generation**: When verifying that generated code is close to expected output
@@ -555,17 +556,20 @@ tests:
 Perplexity measures how "surprised" a language model is by its own output. It's calculated from the log probabilities of the tokens the model generated - essentially measuring how likely the model thinks its own output is.
 
 **How it works in promptfoo:**
+
 - The LLM returns log probabilities for each token it generates
 - Perplexity = exp(-average(log probabilities))
 - Lower perplexity = model assigned higher probabilities to its tokens = more confident
 - Higher perplexity = model assigned lower probabilities to its tokens = less confident
 
 **When to use perplexity:**
+
 - **Quality control**: Reject outputs where the model seems uncertain (high perplexity often correlates with hallucination or confusion)
 - **Consistency checking**: Ensure the model is confident about its outputs in your domain
 - **Debugging**: Unusually high perplexity can indicate prompt issues or out-of-distribution requests
 
 **Example interpretation:**
+
 - Perplexity = 1.0: Perfect confidence (model assigned 100% probability to each token)
 - Perplexity = 2.0: Model is choosing between ~2 equally likely options per token
 - Perplexity = 10.0: Model is very uncertain, choosing between ~10 options per token
@@ -813,6 +817,7 @@ ROUGE-N is a **recall-oriented** metric that measures how much of the reference 
 **What "recall-oriented" means:** ROUGE-N asks "How much of what should be there is actually there?" - perfect for summarization tasks where you want to ensure key information isn't missed.
 
 **When to use ROUGE-N:**
+
 - **Summarization**: Ensure summaries include key points from source text
 - **Information extraction**: Verify that important facts are captured
 - **Content coverage**: Check if the output mentions all required elements
@@ -851,11 +856,13 @@ BLEU (Bilingual Evaluation Understudy) is a **precision-oriented** metric origin
 **What "precision-oriented" means:** BLEU checks if the words in the generated output actually appear in the reference - it penalizes made-up or incorrect content.
 
 **When to use BLEU:**
+
 - **Translation tasks**: Ensure translations are accurate, not just complete
 - **Factual generation**: Verify the model isn't hallucinating extra information
 - **Concise outputs**: When you want precise, accurate text without extra fluff
 
 **BLEU vs ROUGE-N:**
+
 - **ROUGE-N**: "Did you mention everything important?" (good for summaries)
 - **BLEU**: "Is what you said actually correct?" (good for translations)
 
@@ -891,17 +898,20 @@ tests:
 GLEU (Google-BLEU) is designed specifically for evaluating **individual sentences**, fixing a major limitation of BLEU which was designed for large documents.
 
 **Why GLEU instead of BLEU for sentences:**
+
 - **No weird edge cases**: BLEU can give misleading scores for short sentences due to its brevity penalty
 - **Balanced evaluation**: GLEU considers both precision AND recall, taking the minimum of both
 - **Symmetrical**: Swapping reference and output gives the same score (unlike BLEU)
 - **Better for real-time evaluation**: More reliable for evaluating single responses in chatbots or QA systems
 
 **How GLEU works differently:**
+
 - Records all n-grams (1-4 word sequences) from both texts
 - Calculates both precision (like BLEU) AND recall (like ROUGE)
 - Final score = minimum(precision, recall)
 
 **When to use GLEU:**
+
 - **Single response evaluation**: Evaluating individual chatbot or model responses
 - **Short text comparison**: When comparing headlines, titles, or short answers
 - **Balanced accuracy needs**: When both precision and recall matter equally
@@ -945,12 +955,14 @@ assert:
 METEOR (Metric for Evaluation of Translation with Explicit ORdering) is the most sophisticated text similarity metric, going beyond simple word matching to understand meaning.
 
 **What makes METEOR special:**
+
 - **Understands synonyms**: Recognizes that "good" and "nice" mean similar things
 - **Handles word forms**: Knows that "running" and "ran" are the same verb
 - **Considers word order**: Unlike other metrics, it penalizes scrambled sentences
 - **Balanced scoring**: Combines precision, recall, AND word order into a single score
 
 **When to use METEOR:**
+
 - **High-quality translation**: When semantic accuracy matters more than exact wording
 - **Natural language understanding**: Evaluating if the model truly "gets" the meaning
 - **Flexible matching**: When there are many valid ways to express the same idea
@@ -1055,11 +1067,13 @@ Note: Actual scores may vary based on the specific METEOR implementation and par
 F-score (also F1 score) is used for measuring classification accuracy when you need to balance between being correct and being complete.
 
 **Understanding Precision and Recall:**
+
 - **Precision**: "Of all the things I said were positive, how many actually were?" (avoiding false alarms)
 - **Recall**: "Of all the things that were positive, how many did I catch?" (avoiding missed cases)
 - **F-score**: The harmonic mean that balances both - high only when BOTH are good
 
 **When to use F-score:**
+
 - **Classification tasks**: Sentiment analysis, intent detection, category assignment
 - **Imbalanced datasets**: When some categories are rare and you can't just optimize for accuracy
 - **Quality + Coverage**: When you need the model to be both accurate AND comprehensive

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -37,7 +37,7 @@ These metrics are created by logical tests that are run on LLM output.
 | [perplexity](#perplexity)                                       | Perplexity is below a threshold                                    |
 | [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                      |
 | [regex](#regex)                                                 | output matches regex                                               |
-| rouge-n                                                         | Rouge-N score is above a given threshold                           |
+| [rouge-n](#rouge-n)                                             | Rouge-N score is above a given threshold                           |
 | [starts-with](#starts-with)                                     | output starts with string                                          |
 | [trace-span-count](#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
 | [trace-span-duration](#trace-span-duration)                     | Check span durations with percentile support                       |
@@ -521,6 +521,8 @@ Note that `latency` requires that the [cache is disabled](/docs/configuration/ca
 
 The `levenshtein` assertion checks if the LLM output is within a given edit distance from an expected value.
 
+Levenshtein distance measures the number of single-character edits required to change one string into another. [Learn more on Wikipedia](https://en.wikipedia.org/wiki/Levenshtein_distance).
+
 Example:
 
 ```yaml
@@ -546,6 +548,8 @@ tests:
 ### Perplexity
 
 Perplexity is a measurement used in natural language processing to quantify how well a language model predicts a sample of text. It's essentially a measure of the model's uncertainty.
+
+See the [Wikipedia article on perplexity](https://en.wikipedia.org/wiki/Perplexity) for a more detailed explanation of the concept.
 
 **High perplexity** suggests it is less certain about its predictions, often because the text is very diverse or the model is not well-tuned to the task at hand.
 
@@ -783,6 +787,8 @@ The `rouge-n` assertion checks if the Rouge-N score between the LLM output and e
 
 Rouge-N is a recall-oriented metric that measures the overlap of n-grams between the LLM output and the expected text. The score ranges from 0 (no overlap) to 1 (perfect match).
 
+ROUGE stands for **Recall-Oriented Understudy for Gisting Evaluation**, a family of metrics commonly used for summarization quality. [Learn more on Wikipedia](<https://en.wikipedia.org/wiki/ROUGE_(metric)>).
+
 Example:
 
 ```yaml
@@ -810,7 +816,7 @@ tests:
 
 ### BLEU
 
-BLEU (Bilingual Evaluation Understudy) is a precision-oriented metric that measures the quality of text by comparing it to one or more reference texts. The score ranges from 0 (no match) to 1 (perfect match). It considers exact matches of words and phrases (n-grams) between the output and reference text.
+BLEU (Bilingual Evaluation Understudy) is a precision-oriented metric that measures the quality of text by comparing it to one or more reference texts. The score ranges from 0 (no match) to 1 (perfect match). It considers exact matches of words and phrases (n-grams) between the output and reference text. [See Wikipedia](https://en.wikipedia.org/wiki/BLEU) for more background on the metric.
 
 While Rouge-N focuses on recall (how much of the reference text is captured), BLEU focuses on precision (how accurate the generated text is).
 
@@ -842,6 +848,8 @@ tests:
 ### GLEU
 
 The BLEU score has some undesirable properties when used for single sentences, as it was designed to be a corpus measure. To address these concerns, the 'GLEU (Google-BLEU) score' was introduced as a variant that better correlates with human judgments on sentence-level evaluation.
+
+GLEU was introduced to address BLEU's limitations for sentence-level evaluation, particularly in reinforcement learning experiments for neural machine translation.
 
 For the GLEU score, we record all sub-sequences of 1, 2, 3 or 4 tokens in output and target sequence (n-grams). We then compute:
 
@@ -887,6 +895,8 @@ assert:
 ### METEOR
 
 METEOR (Metric for Evaluation of Translation with Explicit ORdering) is an automatic metric for evaluating machine-generated text against reference text. It's particularly useful for assessing translation quality and text generation accuracy.
+
+For additional context, read about the metric on [Wikipedia](https://en.wikipedia.org/wiki/METEOR).
 
 > **Note:** METEOR requires the `natural` package. If you want to use METEOR assertions, install it using: `npm install natural@latest`
 
@@ -990,6 +1000,8 @@ Note: Actual scores may vary based on the specific METEOR implementation and par
 ### F-Score
 
 F-score (also F1 score) is a measure of accuracy that considers both precision and recall. It is the harmonic mean of precision and recall, providing a single score that balances both metrics. The score ranges from 0 (worst) to 1 (best).
+
+You can read more about the F-score on [Wikipedia](https://en.wikipedia.org/wiki/F1_score).
 
 F-score uses the [named metrics](/docs/configuration/expected-outputs/#defining-named-metrics) and [derived metrics](/docs/configuration/expected-outputs/#creating-derived-metrics) features.
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -552,12 +552,23 @@ tests:
 
 ### Perplexity
 
-Perplexity measures how "surprised" or "confused" a language model is by the text it's generating. Think of it as the model's confidence score - but inverted. Lower perplexity means the model is more confident in its predictions.
+Perplexity measures how "surprised" a language model is by its own output. It's calculated from the log probabilities of the tokens the model generated - essentially measuring how likely the model thinks its own output is.
+
+**How it works in promptfoo:**
+- The LLM returns log probabilities for each token it generates
+- Perplexity = exp(-average(log probabilities))
+- Lower perplexity = model assigned higher probabilities to its tokens = more confident
+- Higher perplexity = model assigned lower probabilities to its tokens = less confident
 
 **When to use perplexity:**
-- **Quality control**: Set a maximum perplexity threshold to reject outputs where the model seems uncertain or confused
-- **Style consistency**: Ensure outputs match expected patterns (e.g., formal writing should have consistently low perplexity)
-- **Prompt debugging**: High perplexity might indicate your prompt is causing confusion
+- **Quality control**: Reject outputs where the model seems uncertain (high perplexity often correlates with hallucination or confusion)
+- **Consistency checking**: Ensure the model is confident about its outputs in your domain
+- **Debugging**: Unusually high perplexity can indicate prompt issues or out-of-distribution requests
+
+**Example interpretation:**
+- Perplexity = 1.0: Perfect confidence (model assigned 100% probability to each token)
+- Perplexity = 2.0: Model is choosing between ~2 equally likely options per token
+- Perplexity = 10.0: Model is very uncertain, choosing between ~10 options per token
 
 The assertion passes when perplexity is **below** the threshold, ensuring the model is confident in its output.
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -1,8 +1,27 @@
 ---
 sidebar_position: 6
 title: Deterministic Metrics for LLM Output Validation
-description: Learn about logical tests that validate LLM outputs with exact matching, pattern recognition, and structural validation
-keywords: [metrics, assertions, testing, validation, contains, regex, json, levenshtein]
+description: Learn how to validate LLM outputs using deterministic logical tests including exact matching, regex patterns, JSON/XML validation, and text similarity metrics
+keywords:
+  [
+    metrics,
+    assertions,
+    testing,
+    validation,
+    contains,
+    regex,
+    json,
+    levenshtein,
+    LLM testing,
+    output validation,
+    deterministic tests,
+    rouge,
+    bleu,
+    perplexity,
+    webhook,
+    sql validation,
+    xml validation,
+  ]
 ---
 
 # Deterministic metrics
@@ -553,34 +572,15 @@ tests:
 
 ### Perplexity
 
-Perplexity measures how "surprised" a language model is by its own output. It's calculated from the log probabilities of the tokens the model generated - essentially measuring how likely the model thinks its own output is.
+Perplexity measures how "surprised" a language model is by its own output. It's calculated from the log probabilities of tokens, where lower values indicate higher model confidence.
 
-**How it works in promptfoo:**
+**Key points:**
 
-- The LLM returns log probabilities for each token it generates
-- Perplexity = exp(-average(log probabilities))
-- Lower perplexity = model assigned higher probabilities to its tokens = more confident
-- Higher perplexity = model assigned lower probabilities to its tokens = less confident
+- **Low perplexity** = high confidence (model thinks its output is likely)
+- **High perplexity** = low confidence (often correlates with hallucination or confusion)
+- Useful for quality control and detecting when the model is uncertain
 
-**When to use perplexity:**
-
-- **Quality control**: Reject outputs where the model seems uncertain (high perplexity often correlates with hallucination or confusion)
-- **Consistency checking**: Ensure the model is confident about its outputs in your domain
-- **Debugging**: Unusually high perplexity can indicate prompt issues or out-of-distribution requests
-
-**Example interpretation:**
-
-- Perplexity = 1.0: Perfect confidence (model assigned 100% probability to each token)
-- Perplexity = 2.0: Model is choosing between ~2 equally likely options per token
-- Perplexity = 10.0: Model is very uncertain, choosing between ~10 options per token
-
-The assertion passes when perplexity is **below** the threshold, ensuring the model is confident in its output.
-
-See the [Wikipedia article on perplexity](https://en.wikipedia.org/wiki/Perplexity) for mathematical details.
-
-**High perplexity** suggests it is less certain about its predictions, often because the text is very diverse or the model is not well-tuned to the task at hand.
-
-**Low perplexity** means the model predicts the text with greater confidence, implying it's better at understanding and generating text similar to its training data.
+The assertion passes when perplexity is **below** the threshold.
 
 To specify a perplexity threshold, use the `perplexity` assertion type:
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -554,15 +554,12 @@ tests:
 
 Perplexity measures how "surprised" or "confused" a language model is by the text it's generating. Think of it as the model's confidence score - but inverted. Lower perplexity means the model is more confident in its predictions.
 
-**In practical terms:**
-- **Low perplexity (1-10)**: The model thinks this text is very natural and expected
-- **Medium perplexity (10-100)**: The model finds the text somewhat unusual but plausible
-- **High perplexity (100+)**: The model thinks this text is very unusual or unlikely
-
 **When to use perplexity:**
-- **Quality control**: Detect when the model generates nonsensical or highly unusual text
-- **Style consistency**: Ensure outputs match expected patterns (e.g., formal writing should have consistent perplexity)
+- **Quality control**: Set a maximum perplexity threshold to reject outputs where the model seems uncertain or confused
+- **Style consistency**: Ensure outputs match expected patterns (e.g., formal writing should have consistently low perplexity)
 - **Prompt debugging**: High perplexity might indicate your prompt is causing confusion
+
+The assertion passes when perplexity is **below** the threshold, ensuring the model is confident in its output.
 
 See the [Wikipedia article on perplexity](https://en.wikipedia.org/wiki/Perplexity) for mathematical details.
 
@@ -574,7 +571,7 @@ To specify a perplexity threshold, use the `perplexity` assertion type:
 
 ```yaml
 assert:
-  # Fail if the LLM is below perplexity threshold
+  # Fail if the LLM perplexity is above threshold (i.e., model is too confused)
   - type: perplexity
     threshold: 1.5
 ```
@@ -809,11 +806,6 @@ ROUGE-N is a **recall-oriented** metric that measures how much of the reference 
 - **Information extraction**: Verify that important facts are captured
 - **Content coverage**: Check if the output mentions all required elements
 
-**Score interpretation:**
-- **0.7-1.0**: Excellent coverage - most key content is included
-- **0.4-0.7**: Good coverage - main points are there but some details missing
-- **0.0-0.4**: Poor coverage - significant content is missing
-
 ROUGE stands for **Recall-Oriented Understudy for Gisting Evaluation**. [Learn more on Wikipedia](<https://en.wikipedia.org/wiki/ROUGE_(metric)>).
 
 Example:
@@ -855,11 +847,6 @@ BLEU (Bilingual Evaluation Understudy) is a **precision-oriented** metric origin
 **BLEU vs ROUGE-N:**
 - **ROUGE-N**: "Did you mention everything important?" (good for summaries)
 - **BLEU**: "Is what you said actually correct?" (good for translations)
-
-**Score interpretation:**
-- **0.6-1.0**: Excellent - very accurate translation/generation
-- **0.3-0.6**: Good - mostly accurate with some differences
-- **0.0-0.3**: Poor - significant inaccuracies or differences
 
 BLEU also includes a brevity penalty to discourage overly short outputs. [See Wikipedia](https://en.wikipedia.org/wiki/BLEU) for more background.
 
@@ -907,10 +894,6 @@ GLEU (Google-BLEU) is designed specifically for evaluating **individual sentence
 - **Single response evaluation**: Evaluating individual chatbot or model responses
 - **Short text comparison**: When comparing headlines, titles, or short answers
 - **Balanced accuracy needs**: When both precision and recall matter equally
-
-**Score interpretation:**
-- Same as BLEU (0-1 scale), but more reliable for individual sentences
-- Generally produces slightly lower scores than BLEU due to the min(precision, recall) calculation
 
 ```yaml
 assert:
@@ -986,13 +969,7 @@ assert:
     value: hello world # Reference text to compare against
 ```
 
-By default, METEOR uses a threshold of 0.5. Scores range from 0.0 (no match) to 1.0 (perfect match), with typical interpretations:
-
-- 0.0-0.2: Poor match
-- 0.2-0.4: Fair match
-- 0.4-0.6: Good match
-- 0.6-0.8: Very good match
-- 0.8-1.0: Excellent match
+By default, METEOR uses a threshold of 0.5. Scores range from 0.0 (no match) to 1.0 (perfect match).
 
 #### Custom Threshold
 
@@ -1050,10 +1027,10 @@ tests:
   - description: 'Testing various outputs'
     vars:
       outputs:
-        - 'The weather is beautiful today' # Score: 1.0 (exact match)
-        - "Today's weather is beautiful" # Score: ~0.85 (reordered)
-        - 'The weather is nice today' # Score: ~0.7 (synonym)
-        - 'It is sunny outside' # Score: ~0.3 (different words)
+        - 'The weather is beautiful today' # Exact match
+        - "Today's weather is beautiful" # Reordered words
+        - 'The weather is nice today' # Uses synonym
+        - 'It is sunny outside' # Different phrasing
     assert:
       - type: meteor
         value: '{{reference}}'
@@ -1075,11 +1052,6 @@ F-score (also F1 score) is used for measuring classification accuracy when you n
 - **Classification tasks**: Sentiment analysis, intent detection, category assignment
 - **Imbalanced datasets**: When some categories are rare and you can't just optimize for accuracy
 - **Quality + Coverage**: When you need the model to be both accurate AND comprehensive
-
-**Example scenario:** In sentiment analysis:
-- High precision, low recall = Only labels obvious cases as positive (misses subtle ones)
-- Low precision, high recall = Labels everything as positive (many false positives)
-- Good F-score = Correctly identifies most positive cases without too many false alarms
 
 See [Wikipedia](https://en.wikipedia.org/wiki/F1_score) for mathematical details.
 


### PR DESCRIPTION
Add detailed explanations for text similarity metrics (ROUGE-N, BLEU, GLEU, METEOR) and improve SEO front matter.