### PR TITLE
docs: fix button clickability issue on hero sections

### DIFF
--- a/site/src/pages/llm-vulnerability-scanner.module.css
+++ b/site/src/pages/llm-vulnerability-scanner.module.css
@@ -68,6 +68,8 @@ section {
   display: flex;
   justify-content: center;
   gap: 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 .buttonPrimary {
@@ -136,6 +138,8 @@ section {
     rgba(255, 255, 255, 0.02) 70px
   );
   animation: diagonalMove 20s linear infinite;
+  z-index: 0; /* Ensure overlay is behind content */
+  pointer-events: none; /* Allow clicks to pass through */
 }
 
 @keyframes diagonalMove {


### PR DESCRIPTION
## Description

Fixed buttons (Request Demo, Get Started) not being clickable on multiple documentation pages due to CSS overlay blocking mouse events.

## Affected Pages
- 
- 
- 
- 

## Root Cause
The hero banner sections had a decorative animated overlay () that was intercepting mouse clicks, preventing users from clicking the buttons.

## Solution
Updated :
- Added `pointer-events: none` to the overlay to allow clicks to pass through
- Added `z-index: 0` to ensure overlay stays in background
- Added `position: relative` and `z-index: 1` to `.buttons` class for proper stacking

## Testing
- Built site successfully with `npm run build`
- Tested in development mode
- All buttons on affected pages are now clickable