### PR TITLE
docs: add truncation markers to blog posts

### DIFF
--- a/site/blog/SOC2-compliance.md
+++ b/site/blog/SOC2-compliance.md
@@ -1,17 +1,33 @@
 ---
 title: 'Promptfoo Achieves SOC 2 Type II and ISO 27001 Certification: Strengthening Trust in AI Security'
-description: Promptfoo achieves SOC2 Type II and ISO 27001 compliance
+description: 'Promptfoo achieves SOC 2 Type II and ISO 27001 compliance, demonstrating enterprise-grade security for AI red teaming and LLM evaluation tools.'
 image: /img/blog/soc2-compliance.png
-keywords: [promptfoo, AI security, red teaming, LLM evaluation, prompt engineering, AI agents]
+keywords:
+  [
+    promptfoo,
+    SOC2 Type II,
+    ISO 27001,
+    AI security,
+    red teaming,
+    LLM evaluation,
+    prompt engineering,
+    AI agents,
+    enterprise security,
+    compliance,
+    information security,
+  ]
 date: 2025-07-11
 authors: [vanessa]
+tags: [security, compliance, enterprise, certification]
 ---
 
 # Promptfoo Achieves SOC 2 Type II and ISO 27001 Certification: Strengthening Trust in AI Security
 
-We’re proud to announce that Promptfoo is now SOC 2 Type II compliant and ISO 27001 certified — two globally recognized milestones that affirm our commitment to the highest standards in information security, privacy, and risk management.
+We're proud to announce that Promptfoo is now SOC 2 Type II compliant and ISO 27001 certified — two globally recognized milestones that affirm our commitment to the highest standards in information security, privacy, and risk management.
 
 At Promptfoo, we help organizations secure their generative AI applications by proactively identifying and fixing vulnerabilities through adversarial emulation and red teaming. These new certifications reflect our continued investment in building secure, trustworthy AI systems — not only in our technology, but across our entire organization.
+
+<!-- truncate -->
 
 ## Why This Matters
 

--- a/site/blog/promptfoo-vs-pyrit.md
+++ b/site/blog/promptfoo-vs-pyrit.md
@@ -1,5 +1,4 @@
 ---
-title: 'Promptfoo vs PyRIT: A Practical Comparison of LLM Red Teaming Tools'
 description: "Detailed comparison of Promptfoo and Microsoft's PyRIT for LLM security testing. Covers attack methods, RAG testing, CI/CD integration, and selection criteria."
 image: /img/blog/pyrit/promptfoo-vs-pyrit.jpg
 keywords:

--- a/site/blog/promptfoo-vs-pyrit.md
+++ b/site/blog/promptfoo-vs-pyrit.md
@@ -1,8 +1,23 @@
 ---
+title: 'Promptfoo vs PyRIT: A Practical Comparison of LLM Red Teaming Tools'
 description: "Detailed comparison of Promptfoo and Microsoft's PyRIT for LLM security testing. Covers attack methods, RAG testing, CI/CD integration, and selection criteria."
 image: /img/blog/pyrit/promptfoo-vs-pyrit.jpg
+keywords:
+  [
+    promptfoo,
+    PyRIT,
+    LLM security,
+    AI red teaming,
+    prompt injection,
+    RAG testing,
+    CI/CD integration,
+    AI security comparison,
+    Microsoft PyRIT,
+    LLM vulnerability testing,
+  ]
 date: 2025-06-27
 authors: [ian]
+tags: [comparison, security, red-teaming, tools]
 ---
 
 # Promptfoo vs PyRIT: A Practical Comparison of LLM Red Teaming Tools


### PR DESCRIPTION
## Description

This PR fixes Docusaurus warnings by adding truncation markers to blog posts and improves SEO optimization.

## Changes Made

- Added truncation markers after lead paragraphs in:
  - site/blog/SOC2-compliance.md
  - site/blog/promptfoo-vs-pyrit.md
  
- Enhanced SEO front matter:
  - Added more comprehensive and relevant keywords
  - Improved meta descriptions for better search engine visibility
  - Added title field to promptfoo-vs-pyrit.md for consistent metadata
  - Added tags for better content categorization

## Why These Changes

1. **Truncation Markers**: Docusaurus requires these markers to properly display blog post summaries on listing pages
2. **SEO Optimization**: Better meta tags improve search engine visibility and click-through rates

## Testing

- Ran npm run f to ensure proper formatting
- Changes follow Docusaurus best practices