### PR TITLE
fix(webui): fix hard-coded light mode colors in model audit interface

### DIFF
--- a/src/app/src/pages/model-audit/ModelAudit.tsx
+++ b/src/app/src/pages/model-audit/ModelAudit.tsx
@@ -143,7 +143,8 @@ export default function ModelAudit() {
             borderBottom: 1,
             borderColor: 'divider',
             px: 3,
-            bgcolor: 'grey.50',
+            bgcolor: (theme) =>
+              theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[50],
           }}
         >
           <Tab label="Configuration" />

--- a/src/app/src/pages/model-audit/components/PathSelector.tsx
+++ b/src/app/src/pages/model-audit/components/PathSelector.tsx
@@ -227,7 +227,16 @@ export default function PathSelector({
 
           <Grid container spacing={3}>
             <Grid item xs={12} md={4}>
-              <Paper sx={{ p: 3, textAlign: 'center', bgcolor: 'grey.50' }}>
+              <Paper
+                sx={{
+                  p: 3,
+                  textAlign: 'center',
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.grey[800]
+                      : theme.palette.grey[50],
+                }}
+              >
                 <CloudUploadIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
                 <Typography variant="subtitle1" gutterBottom>
                   AWS S3
@@ -241,7 +250,16 @@ export default function PathSelector({
               </Paper>
             </Grid>
             <Grid item xs={12} md={4}>
-              <Paper sx={{ p: 3, textAlign: 'center', bgcolor: 'grey.50' }}>
+              <Paper
+                sx={{
+                  p: 3,
+                  textAlign: 'center',
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.grey[800]
+                      : theme.palette.grey[50],
+                }}
+              >
                 <CloudIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
                 <Typography variant="subtitle1" gutterBottom>
                   Azure Blob
@@ -255,7 +273,16 @@ export default function PathSelector({
               </Paper>
             </Grid>
             <Grid item xs={12} md={4}>
-              <Paper sx={{ p: 3, textAlign: 'center', bgcolor: 'grey.50' }}>
+              <Paper
+                sx={{
+                  p: 3,
+                  textAlign: 'center',
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.grey[800]
+                      : theme.palette.grey[50],
+                }}
+              >
                 <CloudIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
                 <Typography variant="subtitle1" gutterBottom>
                   Google Cloud
@@ -383,7 +410,10 @@ export default function PathSelector({
                   </IconButton>
                 }
                 sx={{
-                  bgcolor: 'grey.50',
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.grey[800]
+                      : theme.palette.grey[50],
                   borderRadius: 2,
                   mb: 1,
                 }}

--- a/src/app/src/pages/model-audit/components/SecurityFindings.tsx
+++ b/src/app/src/pages/model-audit/components/SecurityFindings.tsx
@@ -178,7 +178,17 @@ export default function SecurityFindings({
                   )}
                   {issue.details && (
                     <Collapse in={true}>
-                      <Paper sx={{ p: 2, mt: 2, bgcolor: 'grey.50' }} variant="outlined">
+                      <Paper
+                        sx={{
+                          p: 2,
+                          mt: 2,
+                          bgcolor: (theme) =>
+                            theme.palette.mode === 'dark'
+                              ? theme.palette.grey[800]
+                              : theme.palette.grey[50],
+                        }}
+                        variant="outlined"
+                      >
                         <Typography
                           variant="caption"
                           component="pre"
@@ -204,8 +214,10 @@ export default function SecurityFindings({
           <Paper
             sx={{
               p: 2,
-              bgcolor: 'grey.900',
-              color: 'grey.100',
+              bgcolor: (theme) =>
+                theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[50],
+              color: (theme) =>
+                theme.palette.mode === 'dark' ? theme.palette.grey[100] : theme.palette.grey[900],
               overflow: 'auto',
               maxHeight: 400,
               fontFamily: 'monospace',


### PR DESCRIPTION
## Description

This PR fixes dark mode styling issues in the Model Audit interface where components had hard-coded light mode colors that didn't adapt to the theme.

## Changes

- Replace hard-coded `grey.50` backgrounds with theme-aware colors
- Use `grey[800]` for dark mode and `grey[50]` for light mode  
- Fix raw output colors to invert properly in dark mode
- Ensure all Paper and ListItem components respect theme mode

## Components Updated

- `ModelAudit.tsx` - Fixed Tabs background color
- `PathSelector.tsx` - Fixed cloud storage Paper components and selected items ListItem
- `SecurityFindings.tsx` - Fixed issue details Paper and raw output colors

## Testing

Please test in both light and dark modes to ensure proper contrast and readability.