### PR TITLE
refactor(eval-config): modernize state management to eliminate boilerplate

### DIFF
--- a/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
+++ b/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
@@ -12,7 +12,8 @@ import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
 
 const ConfigureEnvButton: React.FC = () => {
-  const { env: defaultEnv, setEnv: saveEnv } = useStore();
+  const { config, updateConfig } = useStore();
+  const defaultEnv = config.env || {};
   const [dialogOpen, setDialogOpen] = useState(false);
   const [env, setEnv] = useState(defaultEnv);
 
@@ -25,7 +26,7 @@ const ConfigureEnvButton: React.FC = () => {
   };
 
   const handleSave = () => {
-    saveEnv(env);
+    updateConfig({ env });
     handleClose();
   };
 

--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.test.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import React from 'react';
-import { useStore } from '@app/stores/evalConfig';
+import { useStore, DEFAULT_CONFIG } from '@app/stores/evalConfig';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import type {
   DerivedMetric,
@@ -56,28 +56,11 @@ const renderWithTheme = (component: React.ReactNode) => {
   return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
 };
 
-// Capture the true initial state structure from the store, including functions
-const initialZustandState = useStore.getState();
-
-// Define the default values for state properties based on the store's definition
-const defaultStoreValues = {
-  description: '',
-  providers: [] as ProviderOptions[],
-  prompts: [] as any[],
-  testCases: [] as TestCase[],
-  defaultTest: {} as TestCase,
-  derivedMetrics: [] as DerivedMetric[],
-  env: {} as EnvOverrides,
-  evaluateOptions: {} as EvaluateOptions,
-  scenarios: [] as Scenario[],
-  extensions: [] as string[],
-};
-
 describe('EvaluateTestSuiteCreator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset store to its defined initial state before each test
-    useStore.setState({ ...initialZustandState, ...defaultStoreValues }, true);
+    // Reset store to its default state before each test
+    useStore.getState().reset();
   });
 
   it('should open the reset confirmation dialog when the Reset button is clicked', async () => {
@@ -123,7 +106,7 @@ describe('EvaluateTestSuiteCreator', () => {
   it('should update varsList to empty array after reset', async () => {
     // Arrange
     const initialPrompts = ['Test Prompt {{var}}'];
-    useStore.setState({ prompts: initialPrompts });
+    useStore.getState().updateConfig({ prompts: initialPrompts });
 
     renderWithTheme(<EvaluateTestSuiteCreator />);
 
@@ -146,7 +129,7 @@ describe('EvaluateTestSuiteCreator', () => {
       description: 'Test Description',
       providers: [{ id: 'provider1', label: 'Provider 1' }] as ProviderOptions[],
       prompts: ['Test Prompt {{var}}'],
-      testCases: [{ vars: { var: 'value' } }] as TestCase[],
+      tests: [{ vars: { var: 'value' } }] as TestCase[],
       defaultTest: { assert: [{ type: 'equals', value: 'expected' }] } as TestCase,
       derivedMetrics: [{ name: 'precision', value: 'formula' }] as DerivedMetric[],
       env: { OPENAI_API_KEY: 'testkey' } as EnvOverrides,
@@ -154,7 +137,7 @@ describe('EvaluateTestSuiteCreator', () => {
       scenarios: [{ description: 'Test Scenario', config: [], tests: [] }] as Scenario[],
       extensions: ['file://path/to/extension.py:function_name'] as string[],
     };
-    useStore.setState(nonEmptyState);
+    useStore.getState().updateConfig(nonEmptyState);
 
     renderWithTheme(<EvaluateTestSuiteCreator />);
 
@@ -168,18 +151,9 @@ describe('EvaluateTestSuiteCreator', () => {
     await userEvent.click(dialogResetButton);
 
     // Assert: Check if the store state has been reset to default values
-    const currentState = useStore.getState();
+    const currentConfig = useStore.getState().config;
 
-    expect(currentState.description).toBe(defaultStoreValues.description);
-    expect(currentState.providers).toEqual(defaultStoreValues.providers);
-    expect(currentState.prompts).toEqual(defaultStoreValues.prompts);
-    expect(currentState.testCases).toEqual(defaultStoreValues.testCases);
-    expect(currentState.defaultTest).toEqual(defaultStoreValues.defaultTest);
-    expect(currentState.derivedMetrics).toEqual(defaultStoreValues.derivedMetrics);
-    expect(currentState.env).toEqual(defaultStoreValues.env);
-    expect(currentState.evaluateOptions).toEqual(defaultStoreValues.evaluateOptions);
-    expect(currentState.scenarios).toEqual(defaultStoreValues.scenarios);
-    expect(currentState.extensions).toEqual(defaultStoreValues.extensions);
+    expect(currentConfig).toEqual(DEFAULT_CONFIG);
   });
 
   it('should clear persisted state when the Reset button is clicked', async () => {
@@ -188,7 +162,7 @@ describe('EvaluateTestSuiteCreator', () => {
       description: 'Test Description',
       providers: [{ id: 'provider1', label: 'Provider 1' }] as ProviderOptions[],
       prompts: ['Test Prompt {{var}}'],
-      testCases: [{ vars: { var: 'value' } }] as TestCase[],
+      tests: [{ vars: { var: 'value' } }] as TestCase[],
       defaultTest: { assert: [{ type: 'equals', value: 'expected' }] } as TestCase,
       derivedMetrics: [{ name: 'precision', value: 'formula' }] as DerivedMetric[],
       env: { OPENAI_API_KEY: 'testkey' } as EnvOverrides,
@@ -196,7 +170,7 @@ describe('EvaluateTestSuiteCreator', () => {
       scenarios: [{ description: 'Test Scenario', config: [], tests: [] }] as Scenario[],
       extensions: ['file://path/to/extension.py:function_name'] as string[],
     };
-    useStore.setState(nonEmptyState);
+    useStore.getState().updateConfig(nonEmptyState);
 
     renderWithTheme(<EvaluateTestSuiteCreator />);
 
@@ -210,18 +184,38 @@ describe('EvaluateTestSuiteCreator', () => {
     await userEvent.click(dialogResetButton);
 
     // Assert: Check if the store state has been reset to default values
-    const currentState = useStore.getState();
+    const currentConfig = useStore.getState().config;
 
-    expect(currentState.description).toBe(defaultStoreValues.description);
-    expect(currentState.providers).toEqual(defaultStoreValues.providers);
-    expect(currentState.prompts).toEqual(defaultStoreValues.prompts);
-    expect(currentState.testCases).toEqual(defaultStoreValues.testCases);
-    expect(currentState.defaultTest).toEqual(defaultStoreValues.defaultTest);
-    expect(currentState.derivedMetrics).toEqual(defaultStoreValues.derivedMetrics);
-    expect(currentState.env).toEqual(defaultStoreValues.env);
-    expect(currentState.evaluateOptions).toEqual(defaultStoreValues.evaluateOptions);
-    expect(currentState.scenarios).toEqual(defaultStoreValues.scenarios);
-    expect(currentState.extensions).toEqual(defaultStoreValues.extensions);
+    expect(currentConfig).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('should update state when interacting with components', async () => {
+    renderWithTheme(<EvaluateTestSuiteCreator />);
+
+    // Find the provider selector
+    const providerSelector = screen.getByTestId('mock-provider-selector');
+    expect(providerSelector).toHaveTextContent('0 providers');
+
+    // Click the clear providers button to trigger onChange
+    const clearButton = within(providerSelector).getByText('Mock Clear Providers');
+    await userEvent.click(clearButton);
+
+    // Verify the state was updated
+    expect(useStore.getState().config.providers).toEqual([]);
+  });
+
+  it('should handle new fields like derivedMetrics automatically', async () => {
+    // This demonstrates that new fields work without any store changes
+    const configWithNewField = {
+      derivedMetrics: [{ name: 'f1', value: '2 * precision * recall / (precision + recall)' }],
+      someNewFieldInFuture: 'This will work automatically!',
+    };
+
+    useStore.getState().updateConfig(configWithNewField);
+
+    const config = useStore.getState().config;
+    expect(config.derivedMetrics).toEqual(configWithNewField.derivedMetrics);
+    expect((config as any).someNewFieldInFuture).toBe('This will work automatically!');
   });
 
   // Future test scenarios will be added here

--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
@@ -38,20 +38,8 @@ function ErrorFallback({
 const EvaluateTestSuiteCreator: React.FC = () => {
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
-  const {
-    setDescription,
-    providers,
-    setProviders,
-    prompts,
-    setPrompts,
-    setTestCases,
-    setDefaultTest,
-    setDerivedMetrics,
-    setEnv,
-    setEvaluateOptions,
-    setScenarios,
-    setExtensions,
-  } = useStore();
+  const { config, updateConfig, reset } = useStore();
+  const { providers = [], prompts = [] } = config;
 
   useEffect(() => {
     useStore.persist.rehydrate();
@@ -71,19 +59,10 @@ const EvaluateTestSuiteCreator: React.FC = () => {
     return Array.from(varsSet);
   };
 
-  const varsList = extractVarsFromPrompts(prompts);
+  const varsList = extractVarsFromPrompts(prompts as string[]);
 
   const handleReset = () => {
-    setDescription('');
-    setProviders([]);
-    setPrompts([]);
-    setDefaultTest({});
-    setDerivedMetrics([]);
-    setEnv({});
-    setEvaluateOptions({});
-    setScenarios([]);
-    setExtensions([]);
-    setTestCases([]);
+    reset();
     setResetDialogOpen(false);
   };
 
@@ -106,7 +85,7 @@ const EvaluateTestSuiteCreator: React.FC = () => {
           label="Description"
           value={description}
           onChange={(e) => {
-            setDescription(e.target.value);
+            updateConfig({ description: e.target.value });
           }}
           fullWidth
           margin="normal"
@@ -117,12 +96,15 @@ const EvaluateTestSuiteCreator: React.FC = () => {
         <ErrorBoundary
           FallbackComponent={ErrorFallback}
           onReset={() => {
-            setProviders([]);
+            updateConfig({ providers: [] });
           }}
         >
           <Stack direction="column" spacing={2} justifyContent="space-between">
             <Typography variant="h5">Providers</Typography>
-            <ProviderSelector providers={providers} onChange={setProviders} />
+            <ProviderSelector
+              providers={providers}
+              onChange={(p) => updateConfig({ providers: p })}
+            />
           </Stack>
         </ErrorBoundary>
       </Box>
@@ -130,7 +112,7 @@ const EvaluateTestSuiteCreator: React.FC = () => {
       <ErrorBoundary
         FallbackComponent={ErrorFallback}
         onReset={() => {
-          setPrompts([]);
+          updateConfig({ prompts: [] });
         }}
       >
         <PromptsSection />
@@ -139,7 +121,7 @@ const EvaluateTestSuiteCreator: React.FC = () => {
       <ErrorBoundary
         FallbackComponent={ErrorFallback}
         onReset={() => {
-          setTestCases([]);
+          updateConfig({ tests: [] });
         }}
       >
         <TestCasesSection varsList={varsList} />

--- a/src/app/src/pages/eval-creator/components/PromptsSection.tsx
+++ b/src/app/src/pages/eval-creator/components/PromptsSection.tsx
@@ -28,7 +28,9 @@ const PromptsSection: React.FC = () => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [promptToDelete, setPromptToDelete] = useState<number | null>(null);
 
-  const { prompts, setPrompts } = useStore();
+  const { config, updateConfig } = useStore();
+  const prompts = (config.prompts || []) as string[];
+  const setPrompts = (p: string[]) => updateConfig({ prompts: p });
   const newPromptInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {

--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 
 const RunTestSuiteButton: React.FC = () => {
   const navigate = useNavigate();
+  const { config } = useStore();
   const {
     defaultTest,
     derivedMetrics,
@@ -16,8 +17,8 @@ const RunTestSuiteButton: React.FC = () => {
     prompts,
     providers,
     scenarios,
-    testCases,
-  } = useStore();
+    tests,
+  } = config;
   const [isRunning, setIsRunning] = useState(false);
   const [progressPercent, setProgressPercent] = useState(0);
 
@@ -33,7 +34,7 @@ const RunTestSuiteButton: React.FC = () => {
       prompts,
       providers,
       scenarios,
-      tests: testCases,
+      tests, // Note: This is 'tests' in the API, not 'testCases'
     };
 
     try {

--- a/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
+++ b/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
@@ -29,7 +29,9 @@ interface TestCasesSectionProps {
 }
 
 const TestCasesSection: React.FC<TestCasesSectionProps> = ({ varsList }) => {
-  const { testCases, setTestCases } = useStore();
+  const { config, updateConfig } = useStore();
+  const testCases = (config.tests || []) as TestCase[];
+  const setTestCases = (cases: TestCase[]) => updateConfig({ tests: cases });
   const [editingTestCaseIndex, setEditingTestCaseIndex] = React.useState<number | null>(null);
   const [testCaseDialogOpen, setTestCaseDialogOpen] = React.useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);

--- a/src/app/src/pages/eval-creator/components/YamlEditor.css
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.css
@@ -1,38 +1,12 @@
 .editor-container {
   position: relative;
-  border: 1px solid #ccc;
-  border-radius: 4px;
   overflow: hidden;
 }
 
-.glowing-border {
-  border-color: #1976d2;
-  box-shadow: 0 0 5px rgba(25, 118, 210, 0.5);
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-/* Add styles for the editor in both read and edit modes */
 .editor-readonly {
-  background-color: rgba(0, 0, 0, 0.03);
   cursor: not-allowed;
 }
 
 .editor-container pre {
   margin: 0;
-}
-
-/* Add a subtle editing indicator in the top right */
-.editing-indicator {
-  position: absolute;
-  top: 10px;
-  right: 40px;
-  font-size: 12px;
-  color: #1976d2;
-  background-color: rgba(255, 255, 255, 0.85);
-  padding: 2px 8px;
-  border-radius: 4px;
-  z-index: 1;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }

--- a/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
@@ -72,7 +72,8 @@ describe('YamlEditor', () => {
     render(<YamlEditorComponent />);
 
     expect(screen.getByText('Edit YAML')).toBeInTheDocument();
-    expect(screen.queryByText('Save Changes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
 
     const editor = screen.getByTestId('yaml-editor');
     expect(editor).toHaveAttribute('disabled');
@@ -81,15 +82,14 @@ describe('YamlEditor', () => {
   it('switches to edit mode when Edit button is clicked', () => {
     render(<YamlEditorComponent />);
 
-    fireEvent.click(screen.getByText('Edit YAML'));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit YAML' }));
 
-    expect(screen.getByText('Save Changes')).toBeInTheDocument();
-    expect(screen.queryByText('Edit YAML')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit YAML' })).not.toBeInTheDocument();
 
-    const editor = screen.getByTestId('yaml-editor');
-    expect(editor).not.toHaveAttribute('disabled');
-
-    expect(screen.getByText('Editing')).toBeInTheDocument();
+    const editor = screen.getByTestId('yaml-editor') as HTMLTextAreaElement;
+    expect(editor.disabled).toBe(false);
   });
 
   it.skip('handles file upload correctly', () => {

--- a/src/app/src/pages/eval-creator/components/YamlEditor.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.tsx
@@ -6,14 +6,18 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
 import UploadIcon from '@mui/icons-material/Upload';
+import CancelIcon from '@mui/icons-material/Cancel';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
 import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/system';
+import type { UnifiedConfig } from '@promptfoo/types';
 import yaml from 'js-yaml';
 // @ts-expect-error: No types available
 import { highlight, languages } from 'prismjs/components/prism-core';
@@ -39,7 +43,6 @@ const ensureSchemaComment = (yamlContent: string): string => {
   return yamlContent;
 };
 
-// Format YAML with schema comment
 const formatYamlWithSchema = (config: any): string => {
   const yamlContent = yaml.dump(config);
   return ensureSchemaComment(yamlContent);
@@ -57,16 +60,18 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
 }) => {
   const darkMode = useTheme().palette.mode === 'dark';
   const [code, setCode] = React.useState('');
-  // Always start in read-only mode on initial load, but respect the readOnly prop
-  const [isReadOnly, setIsReadOnly] = React.useState(true);
+  const [originalCode, setOriginalCode] = React.useState('');
+  const [isEditing, setIsEditing] = React.useState(false);
   const [parseError, setParseError] = React.useState<string | null>(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);
 
   const [notification, setNotification] = React.useState<{
     show: boolean;
     message: string;
-  }>({ show: false, message: '' });
+    severity?: 'success' | 'error' | 'warning' | 'info';
+  }>({ show: false, message: '', severity: 'info' });
 
-  const { getTestSuite } = useStore();
+  const { getTestSuite, updateConfig } = useStore();
 
   const parseAndUpdateStore = (yamlContent: string) => {
     try {
@@ -75,68 +80,28 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
       const parsedConfig = yaml.load(contentForParsing) as Record<string, any>;
 
       if (parsedConfig && typeof parsedConfig === 'object') {
-        useStore.setState((state) => {
-          const newState = {
-            ...state,
-          };
-
-          if (parsedConfig.description !== undefined) {
-            newState.description = parsedConfig.description;
-          }
-
-          if (parsedConfig.providers !== undefined) {
-            newState.providers = parsedConfig.providers;
-          }
-
-          if (parsedConfig.prompts !== undefined) {
-            newState.prompts = parsedConfig.prompts;
-          }
-
-          if (parsedConfig.tests !== undefined) {
-            newState.testCases = parsedConfig.tests;
-          }
-
-          if (parsedConfig.defaultTest !== undefined) {
-            newState.defaultTest = parsedConfig.defaultTest;
-          }
-
-          if (parsedConfig.derivedMetrics !== undefined) {
-            newState.derivedMetrics = parsedConfig.derivedMetrics;
-          }
-
-          if (parsedConfig.evaluateOptions !== undefined) {
-            newState.evaluateOptions = parsedConfig.evaluateOptions;
-          }
-
-          if (parsedConfig.scenarios !== undefined) {
-            newState.scenarios = parsedConfig.scenarios;
-          }
-
-          if (parsedConfig.extensions !== undefined) {
-            newState.extensions = parsedConfig.extensions;
-          }
-
-          if (parsedConfig.env !== undefined) {
-            newState.env = parsedConfig.env;
-          }
-
-          return newState;
-        });
+        // Simply update the config with the parsed YAML
+        // The store will handle the mapping
+        updateConfig(parsedConfig as Partial<UnifiedConfig>);
 
         setParseError(null);
-        setNotification({ show: true, message: 'Configuration saved successfully' });
+        setNotification({
+          show: true,
+          message: 'Configuration saved successfully',
+          severity: 'success',
+        });
         return true;
       } else {
         const errorMsg = 'Invalid YAML configuration';
         setParseError(errorMsg);
-        setNotification({ show: true, message: errorMsg });
+        setNotification({ show: true, message: errorMsg, severity: 'error' });
         return false;
       }
     } catch (err) {
       const errorMsg = `Failed to parse YAML: ${err instanceof Error ? err.message : String(err)}`;
       console.error(errorMsg, err);
       setParseError(errorMsg);
-      setNotification({ show: true, message: errorMsg });
+      setNotification({ show: true, message: errorMsg, severity: 'error' });
       return false;
     }
   };
@@ -147,51 +112,96 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
       const reader = new FileReader();
       reader.onload = (e) => {
         const content = e.target?.result as string;
-        // Ensure the schema comment is at the top
-        const contentWithSchema = ensureSchemaComment(content);
-        setCode(contentWithSchema);
-        if (isReadOnly) {
-          setIsReadOnly(false);
+        if (content) {
+          // If in edit mode, just update the code
+          if (isEditing) {
+            setCode(ensureSchemaComment(content));
+            setHasUnsavedChanges(true);
+            setNotification({ show: true, message: 'File loaded into editor', severity: 'info' });
+          } else {
+            // If not in edit mode, parse and save immediately
+            const tempCode = ensureSchemaComment(content);
+            if (parseAndUpdateStore(tempCode)) {
+              setCode(tempCode);
+              setOriginalCode(tempCode);
+            }
+          }
         }
-        parseAndUpdateStore(contentWithSchema);
       };
       reader.onerror = () => {
-        const errorMsg = 'Failed to read the uploaded file';
-        setParseError(errorMsg);
-        setNotification({ show: true, message: errorMsg });
-        setIsReadOnly(false);
+        setNotification({ show: true, message: 'Failed to read file', severity: 'error' });
       };
-      try {
-        reader.readAsText(file);
-      } catch (err) {
-        const errorMsg = `Error loading file: ${err instanceof Error ? err.message : String(err)}`;
-        setParseError(errorMsg);
-        setNotification({ show: true, message: errorMsg });
-        setIsReadOnly(false);
-      }
+      reader.readAsText(file);
     }
+    // Reset the input
+    event.target.value = '';
   };
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
-      setNotification({ show: true, message: 'YAML copied to clipboard' });
+      setNotification({ show: true, message: 'YAML copied to clipboard', severity: 'success' });
     } catch (err) {
-      console.error('Failed to copy text:', err);
+      console.error('Failed to copy:', err);
+      setNotification({ show: true, message: 'Failed to copy YAML', severity: 'error' });
     }
+  };
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setOriginalCode(code);
+    setHasUnsavedChanges(false);
+  };
+
+  const handleSave = () => {
+    const success = parseAndUpdateStore(code);
+    if (success) {
+      setIsEditing(false);
+      setOriginalCode(code);
+      setHasUnsavedChanges(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setCode(originalCode);
+    setIsEditing(false);
+    setHasUnsavedChanges(false);
+    setParseError(null);
+    setNotification({ show: true, message: 'Changes discarded', severity: 'info' });
+  };
+
+  const handleReset = () => {
+    const currentConfig = getTestSuite();
+    const newCode = formatYamlWithSchema(currentConfig);
+    setCode(newCode);
+    setHasUnsavedChanges(code !== newCode);
+    setNotification({ show: true, message: 'Reset to current configuration', severity: 'info' });
   };
 
   React.useEffect(() => {
     if (initialYaml) {
-      setCode(ensureSchemaComment(initialYaml));
+      const formattedCode = ensureSchemaComment(initialYaml);
+      setCode(formattedCode);
+      setOriginalCode(formattedCode);
     } else if (initialConfig) {
-      setCode(formatYamlWithSchema(initialConfig));
+      const formattedCode = formatYamlWithSchema(initialConfig);
+      setCode(formattedCode);
+      setOriginalCode(formattedCode);
     } else {
       const currentConfig = getTestSuite();
-      setCode(formatYamlWithSchema(currentConfig));
+      const formattedCode = formatYamlWithSchema(currentConfig);
+      setCode(formattedCode);
+      setOriginalCode(formattedCode);
     }
     // Deliberately omitting getTestSuite from dependencies to avoid potential re-render loops
   }, [initialYaml, initialConfig]);
+
+  // Track unsaved changes
+  React.useEffect(() => {
+    if (isEditing && code !== originalCode) {
+      setHasUnsavedChanges(true);
+    }
+  }, [code, originalCode, isEditing]);
 
   return (
     <Box>
@@ -223,67 +233,105 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
           </Typography>
         </Box>
         {!readOnly && (
-          <Button
-            variant={isReadOnly ? 'outlined' : 'contained'}
-            color="primary"
-            size="small"
-            startIcon={isReadOnly ? <EditIcon /> : <SaveIcon />}
-            onClick={() => {
-              if (isReadOnly) {
-                setIsReadOnly(false);
-              } else {
-                const parseSuccess = parseAndUpdateStore(code);
-                if (parseSuccess) {
-                  setIsReadOnly(true);
-                }
-              }
-            }}
-            sx={{ ml: 2, whiteSpace: 'nowrap' }}
-          >
-            {isReadOnly ? 'Edit YAML' : 'Save Changes'}
-          </Button>
+          <Stack direction="row" spacing={1}>
+            {!isEditing ? (
+              <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                startIcon={<EditIcon />}
+                onClick={handleEdit}
+              >
+                Edit YAML
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  startIcon={<SaveIcon />}
+                  onClick={handleSave}
+                  disabled={!hasUnsavedChanges}
+                >
+                  Save
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="inherit"
+                  size="small"
+                  startIcon={<CancelIcon />}
+                  onClick={handleCancel}
+                >
+                  Cancel
+                </Button>
+              </>
+            )}
+          </Stack>
         )}
       </Box>
-      {!readOnly && !isReadOnly && (
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <Box display="flex" gap={2}>
-            <Button variant="text" color="primary" startIcon={<UploadIcon />} component="label">
-              Upload YAML
-              <input type="file" hidden accept=".yaml,.yml" onChange={handleFileUpload} />
-            </Button>
-            <Button
-              variant="text"
-              color="warning"
-              onClick={() => {
-                const currentConfig = getTestSuite();
-                setCode(formatYamlWithSchema(currentConfig));
-                setNotification({ show: true, message: 'Reset to last saved configuration' });
-              }}
-            >
-              Reset
-            </Button>
-          </Box>
-          <Typography variant="caption" color="text.secondary">
-            Editing mode active - changes will be applied when you save
-          </Typography>
+
+      {/* Action bar - only show when editing */}
+      {!readOnly && isEditing && (
+        <Box sx={{ mb: 2 }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Stack direction="row" spacing={2}>
+              <Button
+                variant="text"
+                color="primary"
+                size="small"
+                startIcon={<UploadIcon />}
+                component="label"
+              >
+                Upload File
+                <input type="file" hidden accept=".yaml,.yml" onChange={handleFileUpload} />
+              </Button>
+              <Button variant="text" color="inherit" size="small" onClick={handleReset}>
+                Reset to Current
+              </Button>
+            </Stack>
+            {hasUnsavedChanges && (
+              <Typography variant="caption" color="warning.main" fontWeight="medium">
+                ● Unsaved changes
+              </Typography>
+            )}
+          </Stack>
         </Box>
       )}
+
+      {/* Error display */}
+      {parseError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setParseError(null)}>
+          {parseError}
+        </Alert>
+      )}
+
       <Box position="relative">
         <div
-          className={`editor-container ${
-            isReadOnly ? (readOnly ? '' : 'editor-readonly') : 'glowing-border'
-          }`}
+          className={`editor-container ${!isEditing ? 'editor-readonly' : ''}`}
+          style={{
+            opacity: isEditing ? 1 : 0.9,
+            border: isEditing ? '2px solid' : '1px solid',
+            borderColor: isEditing
+              ? darkMode
+                ? '#90caf9'
+                : '#1976d2'
+              : darkMode
+                ? 'rgba(255, 255, 255, 0.12)'
+                : 'rgba(0, 0, 0, 0.12)',
+            borderRadius: '4px',
+            transition: 'all 0.2s ease-in-out',
+          }}
         >
-          {!isReadOnly && <div className="editing-indicator">Editing</div>}
           <Editor
             autoCapitalize="off"
             value={code}
             onValueChange={(newCode) => {
-              if (!isReadOnly) {
+              if (isEditing) {
+                setCode(newCode);
                 if (parseError) {
                   setParseError(null);
                 }
-                setCode(newCode);
               }
             }}
             highlight={(code) => highlight(code, languages.yaml)}
@@ -292,8 +340,9 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
               fontFamily: '"Fira code", "Fira Mono", monospace',
               fontSize: 14,
               backgroundColor: darkMode ? '#1e1e1e' : '#fff',
+              minHeight: '400px',
             }}
-            disabled={isReadOnly}
+            disabled={!isEditing}
           />
         </div>
         <Tooltip title="Copy YAML">
@@ -313,13 +362,21 @@ const YamlEditorComponent: React.FC<YamlEditorProps> = ({
           </IconButton>
         </Tooltip>
       </Box>
+
       <Snackbar
         open={notification.show}
-        autoHideDuration={2000}
+        autoHideDuration={3000}
         onClose={() => setNotification({ ...notification, show: false })}
-        message={notification.message}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      />
+      >
+        <Alert
+          onClose={() => setNotification({ ...notification, show: false })}
+          severity={notification.severity}
+          sx={{ width: '100%' }}
+        >
+          {notification.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -184,7 +184,7 @@ export default function ResultsView({
     setComparisonEvalIds,
   } = useResultsViewSettingsStore();
 
-  const { setStateFromConfig } = useMainStore();
+  const { updateConfig } = useMainStore();
 
   const { showToast } = useToast();
   const [searchText, setSearchText] = React.useState(searchParams.get('search') || '');
@@ -657,7 +657,7 @@ export default function ResultsView({
                 <Tooltip title="Edit this eval in the web UI" placement="left">
                   <MenuItem
                     onClick={() => {
-                      setStateFromConfig(config);
+                      updateConfig(config);
                       navigate('/setup/');
                     }}
                   >

--- a/src/app/src/stores/__tests__/evalConfig.test.ts
+++ b/src/app/src/stores/__tests__/evalConfig.test.ts
@@ -1,20 +1,60 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useStore } from '../evalConfig';
+import { useStore, DEFAULT_CONFIG } from '../evalConfig';
 
 describe('evalConfig store', () => {
   beforeEach(() => {
     // Reset the store state before each test
-    useStore.setState({
-      env: {},
-      testCases: [],
-      description: '',
-      providers: [],
-      prompts: [],
-      extensions: [],
-      defaultTest: {},
-      derivedMetrics: [],
-      evaluateOptions: {},
-      scenarios: [],
+    useStore.getState().reset();
+  });
+
+  describe('config management', () => {
+    it('should initialize with default config', () => {
+      const { config } = useStore.getState();
+      expect(config).toEqual(DEFAULT_CONFIG);
+    });
+
+    it('should update config with updateConfig', () => {
+      const updates = {
+        description: 'Test Description',
+        providers: [{ id: 'openai:gpt-4' }],
+      };
+
+      useStore.getState().updateConfig(updates);
+
+      const { config } = useStore.getState();
+      expect(config.description).toBe('Test Description');
+      expect(config.providers).toEqual([{ id: 'openai:gpt-4' }]);
+      // Other fields should remain as defaults
+      expect(config.prompts).toEqual([]);
+    });
+
+    it('should replace entire config with setConfig', () => {
+      const newConfig = {
+        description: 'New Config',
+        providers: [{ id: 'anthropic:claude' }],
+        prompts: ['Test prompt'],
+      };
+
+      useStore.getState().setConfig(newConfig);
+
+      const { config } = useStore.getState();
+      expect(config).toEqual(newConfig);
+      // Note: fields not in newConfig are undefined, not defaults
+      expect(config.env).toBeUndefined();
+    });
+
+    it('should reset to default config', () => {
+      // First, modify the config
+      useStore.getState().updateConfig({
+        description: 'Modified',
+        providers: [{ id: 'test' }],
+      });
+
+      // Then reset
+      useStore.getState().reset();
+
+      const { config } = useStore.getState();
+      expect(config).toEqual(DEFAULT_CONFIG);
     });
   });
 
@@ -22,9 +62,9 @@ describe('evalConfig store', () => {
     it('should accept string defaultTest', () => {
       const stringDefaultTest = 'file://path/to/defaultTest.yaml';
 
-      useStore.getState().setDefaultTest(stringDefaultTest);
+      useStore.getState().updateConfig({ defaultTest: stringDefaultTest });
 
-      expect(useStore.getState().defaultTest).toBe(stringDefaultTest);
+      expect(useStore.getState().config.defaultTest).toBe(stringDefaultTest);
     });
 
     it('should accept object defaultTest', () => {
@@ -34,17 +74,17 @@ describe('evalConfig store', () => {
         options: { provider: 'openai:gpt-4' },
       };
 
-      useStore.getState().setDefaultTest(objectDefaultTest as any);
+      useStore.getState().updateConfig({ defaultTest: objectDefaultTest as any });
 
-      expect(useStore.getState().defaultTest).toEqual(objectDefaultTest);
+      expect(useStore.getState().config.defaultTest).toEqual(objectDefaultTest);
     });
 
     it('should handle undefined defaultTest', () => {
       // Set to undefined explicitly
-      useStore.getState().setDefaultTest(undefined as any);
+      useStore.getState().updateConfig({ defaultTest: undefined as any });
 
       // When set to undefined, it becomes undefined
-      expect(useStore.getState().defaultTest).toBeUndefined();
+      expect(useStore.getState().config.defaultTest).toBeUndefined();
     });
 
     it('should update from object to string defaultTest', () => {
@@ -53,28 +93,28 @@ describe('evalConfig store', () => {
         vars: { foo: 'bar' },
       };
 
-      useStore.getState().setDefaultTest(objectDefaultTest as any);
-      expect(useStore.getState().defaultTest).toEqual(objectDefaultTest);
+      useStore.getState().updateConfig({ defaultTest: objectDefaultTest as any });
+      expect(useStore.getState().config.defaultTest).toEqual(objectDefaultTest);
 
       const stringDefaultTest = 'file://new/path/defaultTest.yaml';
-      useStore.getState().setDefaultTest(stringDefaultTest);
+      useStore.getState().updateConfig({ defaultTest: stringDefaultTest });
 
-      expect(useStore.getState().defaultTest).toBe(stringDefaultTest);
+      expect(useStore.getState().config.defaultTest).toBe(stringDefaultTest);
     });
 
     it('should update from string to object defaultTest', () => {
       const stringDefaultTest = 'file://path/to/defaultTest.yaml';
 
-      useStore.getState().setDefaultTest(stringDefaultTest);
-      expect(useStore.getState().defaultTest).toBe(stringDefaultTest);
+      useStore.getState().updateConfig({ defaultTest: stringDefaultTest });
+      expect(useStore.getState().config.defaultTest).toBe(stringDefaultTest);
 
       const objectDefaultTest = {
         assert: [{ type: 'contains' as const, value: 'new' }],
         metadata: { suite: 'test' },
       };
-      useStore.getState().setDefaultTest(objectDefaultTest as any);
+      useStore.getState().updateConfig({ defaultTest: objectDefaultTest as any });
 
-      expect(useStore.getState().defaultTest).toEqual(objectDefaultTest);
+      expect(useStore.getState().config.defaultTest).toEqual(objectDefaultTest);
     });
   });
 
@@ -82,10 +122,12 @@ describe('evalConfig store', () => {
     it('should return config with string defaultTest', () => {
       const stringDefaultTest = 'file://shared/defaultTest.yaml';
 
-      useStore.getState().setDescription('Test config');
-      useStore.getState().setProviders([{ id: 'openai:gpt-4' }]);
-      useStore.getState().setPrompts(['Test prompt']);
-      useStore.getState().setDefaultTest(stringDefaultTest);
+      useStore.getState().updateConfig({
+        description: 'Test config',
+        providers: [{ id: 'openai:gpt-4' }],
+        prompts: ['Test prompt'],
+        defaultTest: stringDefaultTest,
+      });
 
       const config = useStore.getState().getTestSuite();
 
@@ -99,47 +141,39 @@ describe('evalConfig store', () => {
         vars: { foo: 'bar' },
       };
 
-      useStore.getState().setDescription('Test config');
-      useStore.getState().setProviders([{ id: 'openai:gpt-4' }]);
-      useStore.getState().setPrompts(['Test prompt']);
-      useStore.getState().setDefaultTest(objectDefaultTest as any);
+      useStore.getState().updateConfig({
+        description: 'Test config',
+        providers: [{ id: 'openai:gpt-4' }],
+        prompts: ['Test prompt'],
+        defaultTest: objectDefaultTest as any,
+      });
 
       const config = useStore.getState().getTestSuite();
 
       expect(config.defaultTest).toEqual(objectDefaultTest);
     });
-  });
 
-  describe('setStateFromConfig', () => {
-    it('should handle string defaultTest in config', () => {
-      const config = {
-        description: 'Test suite',
-        defaultTest: 'file://external/defaultTest.yaml',
-        providers: [{ id: 'openai:gpt-4' }],
-        prompts: ['Test prompt'],
-      };
+    it('should handle complex prompts configuration', () => {
+      // Test string prompts
+      useStore.getState().updateConfig({ prompts: ['Test prompt'] });
+      expect(useStore.getState().config.prompts).toEqual(['Test prompt']);
 
-      useStore.getState().setStateFromConfig(config);
-
-      expect(useStore.getState().defaultTest).toBe('file://external/defaultTest.yaml');
-      expect(useStore.getState().description).toBe('Test suite');
+      // Test array of prompts
+      const multiplePrompts = ['Prompt 1', 'Prompt 2'];
+      useStore.getState().updateConfig({ prompts: multiplePrompts });
+      expect(useStore.getState().config.prompts).toEqual(multiplePrompts);
     });
 
-    it('should handle object defaultTest in config', () => {
-      const defaultTestObj = {
-        assert: [{ type: 'equals' as const, value: 'expected' }],
-        vars: { test: 'value' },
-      };
+    it('should include new fields like derivedMetrics automatically', () => {
+      const derivedMetrics = [
+        { name: 'precision', value: 'tp / (tp + fp)' },
+        { name: 'recall', value: 'tp / (tp + fn)' },
+      ];
 
-      const config = {
-        description: 'Test suite',
-        defaultTest: defaultTestObj as any,
-        providers: [{ id: 'openai:gpt-4' }],
-      };
+      useStore.getState().updateConfig({ derivedMetrics });
 
-      useStore.getState().setStateFromConfig(config);
-
-      expect(useStore.getState().defaultTest).toEqual(defaultTestObj);
+      const testSuite = useStore.getState().getTestSuite();
+      expect(testSuite.derivedMetrics).toEqual(derivedMetrics);
     });
   });
 });

--- a/src/app/src/stores/evalConfig.ts
+++ b/src/app/src/stores/evalConfig.ts
@@ -1,126 +1,63 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type {
-  DerivedMetric,
-  EnvOverrides,
-  EvaluateOptions,
-  EvaluateTestSuiteWithEvaluateOptions,
-  ProviderOptions,
-  TestCase,
-  UnifiedConfig,
-  Scenario,
-} from '../../../types';
+import type { EvaluateTestSuiteWithEvaluateOptions, UnifiedConfig } from '../../../types';
 
-interface State {
-  env: EnvOverrides;
-  testCases: TestCase[];
-  description: string;
-  providers: ProviderOptions[];
-  prompts: any[];
-  defaultTest: TestCase | string;
-  derivedMetrics: DerivedMetric[];
-  evaluateOptions: EvaluateOptions;
-  scenarios: Scenario[];
-  extensions: string[];
-  setEnv: (env: EnvOverrides) => void;
-  setTestCases: (testCases: TestCase[]) => void;
-  setDescription: (description: string) => void;
-  setProviders: (providers: ProviderOptions[]) => void;
-  setPrompts: (prompts: any[]) => void;
-  setDefaultTest: (testCase: TestCase | string) => void;
-  setDerivedMetrics: (derivedMetrics: DerivedMetric[]) => void;
-  setEvaluateOptions: (options: EvaluateOptions) => void;
-  setScenarios: (scenarios: Scenario[]) => void;
-  setStateFromConfig: (config: Partial<UnifiedConfig>) => void;
+export interface EvalConfigState {
+  config: Partial<UnifiedConfig>;
+  /** Replace the entire config */
+  setConfig: (config: Partial<UnifiedConfig>) => void;
+  /** Merge updates into the existing config */
+  updateConfig: (updates: Partial<UnifiedConfig>) => void;
+  /** Reset config to defaults */
+  reset: () => void;
+  /** Get the test suite in the expected format */
   getTestSuite: () => EvaluateTestSuiteWithEvaluateOptions;
-  setExtensions: (extensions: string[]) => void;
 }
 
-export const useStore = create<State>()(
+export const DEFAULT_CONFIG: Partial<UnifiedConfig> = {
+  description: '',
+  providers: [],
+  prompts: [],
+  tests: [],
+  defaultTest: {},
+  derivedMetrics: [],
+  env: {},
+  evaluateOptions: {},
+  scenarios: [],
+  extensions: [],
+};
+
+export const useStore = create<EvalConfigState>()(
   persist(
     (set, get) => ({
-      env: {},
-      testCases: [],
-      description: '',
-      providers: [],
-      prompts: [],
-      extensions: [],
-      defaultTest: {},
-      derivedMetrics: [],
-      evaluateOptions: {},
-      scenarios: [],
-      setEnv: (env) => set({ env }),
-      setTestCases: (testCases) => set({ testCases }),
-      setDescription: (description) => set({ description }),
-      setProviders: (providers) => set({ providers }),
-      setPrompts: (prompts) => set({ prompts }),
-      setDefaultTest: (testCase) => set({ defaultTest: testCase }),
-      setDerivedMetrics: (derivedMetrics) => set({ derivedMetrics }),
-      setEvaluateOptions: (options) => set({ evaluateOptions: options }),
-      setScenarios: (scenarios) => set({ scenarios }),
-      setExtensions: (extensions) => set({ extensions }),
-      setStateFromConfig: (config: Partial<UnifiedConfig>) => {
-        const updates: Partial<State> = {};
-        if (config.description) {
-          updates.description = config.description || '';
-        }
-        if (config.tests) {
-          updates.testCases = config.tests as TestCase[];
-        }
-        if (config.providers) {
-          updates.providers = config.providers as ProviderOptions[];
-        }
-        if (config.prompts) {
-          if (typeof config.prompts === 'string') {
-            updates.prompts = [config.prompts];
-          } else if (Array.isArray(config.prompts)) {
-            updates.prompts = config.prompts;
-          } else {
-            console.warn('Invalid prompts config', config.prompts);
-          }
-        }
-        if (config.defaultTest) {
-          updates.defaultTest = config.defaultTest;
-        }
-        if (config.derivedMetrics) {
-          updates.derivedMetrics = config.derivedMetrics;
-        }
-        if (config.evaluateOptions) {
-          updates.evaluateOptions = config.evaluateOptions;
-        }
-        if (config.scenarios) {
-          updates.scenarios = config.scenarios as Scenario[];
-        }
-        if (config.extensions) {
-          updates.extensions = config.extensions;
-        }
-        set(updates);
-      },
+      config: { ...DEFAULT_CONFIG },
+
+      setConfig: (config) => set({ config }),
+
+      updateConfig: (updates) =>
+        set((state) => ({
+          config: { ...state.config, ...updates },
+        })),
+
+      reset: () => set({ config: { ...DEFAULT_CONFIG } }),
+
       getTestSuite: () => {
-        const {
-          description,
-          env,
-          extensions,
-          prompts,
-          providers,
-          scenarios,
-          testCases,
-          evaluateOptions,
-          defaultTest,
-          derivedMetrics,
-        } = get();
+        const { config } = get();
+
+        // Transform config to match the expected EvaluateTestSuiteWithEvaluateOptions format
+        // Note: The 'tests' field in UnifiedConfig maps to 'testCases' in the old store
         return {
-          description,
-          env,
-          extensions,
-          prompts,
-          providers,
-          scenarios,
-          tests: testCases,
-          evaluateOptions,
-          defaultTest,
-          derivedMetrics,
-        };
+          description: config.description,
+          env: config.env,
+          extensions: config.extensions,
+          prompts: config.prompts,
+          providers: config.providers,
+          scenarios: config.scenarios,
+          tests: config.tests || [], // This is what was 'testCases' before
+          evaluateOptions: config.evaluateOptions,
+          defaultTest: config.defaultTest,
+          derivedMetrics: config.derivedMetrics,
+        } as EvaluateTestSuiteWithEvaluateOptions;
       },
     }),
     {


### PR DESCRIPTION
## Summary

This PR refactors the evalConfig store to implement modern React state management patterns, addressing the issue highlighted in PR #4647 where adding a single field (derivedMetrics) required changes across 6 different files.

## Problem

The previous implementation required extensive boilerplate when adding new configuration fields:
- Adding the field to the store state interface
- Adding a setter function
- Updating all components that reset state
- Updating the YAML editor parsing logic
- Updating the getTestSuite function
- Updating all tests

## Solution

### 1. Single Config Object Pattern
- Replaced 10+ individual setters with just 3 methods: `updateConfig`, `setConfig`, and `reset`
- Store now manages a single `config` object instead of individual fields
- New fields in `UnifiedConfig` work automatically without store changes

### 2. Improved YAML Editor UX
- Separate Edit, Save, and Cancel buttons for clearer user actions
- Visual feedback for unsaved changes
- Better error handling with Alert components
- Improved styling with Material-UI best practices

## Changes

- **evalConfig.ts**: Refactored to use single config object with minimal API surface
- **All components**: Updated to use `updateConfig` instead of individual setters
- **YamlEditor**: Complete UX overhaul with better editing patterns
- **Tests**: Simplified to match new structure

## Benefits

1. **Zero boilerplate for new fields**: Adding a field to UnifiedConfig now "just works"
2. **Better DX**: Single updateConfig method is more intuitive than multiple setters
3. **Improved UX**: Clearer editing states and better visual feedback
4. **Future-proof**: Follows React 2025 best practices for state management

## Testing

- All existing tests updated and passing
- Manual testing of YAML editor functionality
- Verified that adding new fields requires no store changes

Fixes the underlying issue that led to PR #4647 and prevents similar PRs in the future.