### PR TITLE
fix: --filter-failing not working with custom providers

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -980,6 +980,9 @@ export const providerMap: ProviderFactory[] = [
       providerOptions: ProviderOptions,
       context: LoadApiProviderContext,
     ) => {
+      // Preserve the original path as the provider ID
+      const providerId = providerOptions.id ?? providerPath;
+
       if (providerPath.startsWith('file://')) {
         providerPath = providerPath.slice('file://'.length);
       }
@@ -989,7 +992,7 @@ export const providerMap: ProviderFactory[] = [
         : path.join(context.basePath || process.cwd(), providerPath);
 
       const CustomApiProvider = await importModule(modulePath);
-      return new CustomApiProvider(providerOptions);
+      return new CustomApiProvider({ ...providerOptions, id: providerId });
     },
   },
   {

--- a/test/commands/eval/filterTests.test.ts
+++ b/test/commands/eval/filterTests.test.ts
@@ -2,6 +2,7 @@ import { filterTests } from '../../../src/commands/eval/filterTests';
 import Eval from '../../../src/models/eval';
 import type { TestSuite, TestCase } from '../../../src/types';
 import { ResultFailureReason } from '../../../src/types';
+import path from 'path';
 
 jest.mock('../../../src/models/eval', () => ({
   findById: jest.fn(),
@@ -122,6 +123,62 @@ describe('filterTests', () => {
       const result = await filterTests(mockTestSuite, { failing: 'eval-123' });
       expect(result).toHaveLength(2);
       expect(result.map((t: TestCase) => t.vars?.var1)).toEqual(['test1', 'test3']);
+    });
+
+    it('should match failing tests when provider paths differ', async () => {
+      jest.resetAllMocks();
+      const absPath = path.join(process.cwd(), 'provider.js');
+      const mockEval = {
+        id: 'eval-123',
+        createdAt: new Date().getTime(),
+        config: {},
+        results: [],
+        resultsCount: 0,
+        prompts: [],
+        persisted: true,
+        toEvaluateSummary: jest.fn().mockResolvedValue({
+          version: 2,
+          timestamp: new Date().toISOString(),
+          results: [
+            {
+              vars: { var1: 'test1' },
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              provider: { id: `file://${absPath}` },
+              testCase: mockTestSuite.tests![0],
+            },
+          ],
+          table: { head: { prompts: [], vars: [] }, body: [] },
+          stats: {
+            successes: 0,
+            failures: 0,
+            errors: 0,
+            tokenUsage: {
+              total: 0,
+              prompt: 0,
+              completion: 0,
+              cached: 0,
+              numRequests: 0,
+              completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+            },
+          },
+        }),
+      };
+
+      jest.mocked(Eval.findById).mockResolvedValue(mockEval as any);
+
+      const testSuite = {
+        ...mockTestSuite,
+        tests: [
+          {
+            ...mockTestSuite.tests![0],
+            provider: `file://./provider.js`,
+          },
+        ],
+      } as TestSuite;
+
+      const result = await filterTests(testSuite, { failing: 'eval-123' });
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -295,10 +295,8 @@ describe('util', () => {
   });
 
   describe('providerToIdentifier', () => {
-    it('works with string', () => {
-      const provider = 'openai:gpt-4';
-
-      expect(providerToIdentifier(provider)).toStrictEqual(provider);
+    it('works with provider string', () => {
+      expect(providerToIdentifier('gpt-3.5-turbo')).toStrictEqual('gpt-3.5-turbo');
     });
 
     it('works with provider id undefined', () => {
@@ -323,6 +321,49 @@ describe('util', () => {
       };
 
       expect(providerToIdentifier(providerOptions)).toStrictEqual(providerId);
+    });
+
+    it('uses label when present on ProviderOptions', () => {
+      const providerOptions = {
+        id: 'file://provider.js',
+        label: 'my-provider',
+      };
+
+      expect(providerToIdentifier(providerOptions)).toStrictEqual('my-provider');
+    });
+
+    it('canonicalizes relative file paths to absolute', () => {
+      const originalCwd = process.cwd();
+      expect(providerToIdentifier('file://./provider.js')).toStrictEqual(
+        `file://${path.join(originalCwd, 'provider.js')}`,
+      );
+    });
+
+    it('canonicalizes JavaScript files without file:// prefix', () => {
+      const originalCwd = process.cwd();
+      expect(providerToIdentifier('./provider.js')).toStrictEqual(
+        `file://${path.join(originalCwd, 'provider.js')}`,
+      );
+    });
+
+    it('preserves absolute file paths', () => {
+      expect(providerToIdentifier('file:///absolute/path/provider.js')).toStrictEqual(
+        'file:///absolute/path/provider.js',
+      );
+    });
+
+    it('canonicalizes exec: paths', () => {
+      const originalCwd = process.cwd();
+      expect(providerToIdentifier('exec:./script.py')).toStrictEqual(
+        `exec:${path.join(originalCwd, 'script.py')}`,
+      );
+    });
+
+    it('canonicalizes python: paths', () => {
+      const originalCwd = process.cwd();
+      expect(providerToIdentifier('python:./provider.py')).toStrictEqual(
+        `python:${path.join(originalCwd, 'provider.py')}`,
+      );
     });
   });
 
@@ -375,6 +416,43 @@ describe('util', () => {
       };
 
       expect(resultIsForTestCase(result, nonMatchTestCase)).toBe(false);
+    });
+
+    it('matches when test provider is label and result provider has label and id', () => {
+      const labelledResult = {
+        provider: { id: 'file://provider.js', label: 'provider' },
+        vars: { key: 'value' },
+      } as any as EvaluateResult;
+
+      expect(resultIsForTestCase(labelledResult, testCase)).toBe(true);
+    });
+
+    it('matches when test provider is relative path and result provider is absolute', () => {
+      const relativePathTestCase: TestCase = {
+        provider: 'file://./provider.js',
+        vars: { key: 'value' },
+      };
+
+      const absolutePathResult = {
+        provider: { id: `file://${path.join(process.cwd(), 'provider.js')}` },
+        vars: { key: 'value' },
+      } as any as EvaluateResult;
+
+      expect(resultIsForTestCase(absolutePathResult, relativePathTestCase)).toBe(true);
+    });
+
+    it('matches when test provider has no file:// prefix and result has absolute path', () => {
+      const noPathTestCase: TestCase = {
+        provider: './provider.js',
+        vars: { key: 'value' },
+      };
+
+      const absolutePathResult = {
+        provider: `file://${path.join(process.cwd(), 'provider.js')}`,
+        vars: { key: 'value' },
+      } as any as EvaluateResult;
+
+      expect(resultIsForTestCase(absolutePathResult, noPathTestCase)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR fixes the `--filter-failing` option that was not working correctly with custom JavaScript providers due to provider path mismatches.

## Problem

When using custom JavaScript providers with relative paths (e.g., `./provider.js`), the `--filter-failing` option would match 0 tests because:
- The config file uses relative paths
- The evaluation results store absolute paths  
- The provider matching logic didn't canonicalize paths for comparison

## Solution

1. **Path Canonicalization**: Added `canonicalizeProviderId()` function that:
   - Converts relative paths to absolute paths
   - Handles various provider formats (`file://`, `exec:`, `python:`, `golang:`)
   - Ensures consistent path representation for matching

2. **Preserve Original Provider ID**: Modified the JavaScript provider loading to preserve the original provider path as the ID

3. **Support Provider Labels**: Enhanced provider matching to prefer labels when available for more reliable matching

## Testing

- Added comprehensive unit tests for path canonicalization
- Added specific test case for the reported issue scenario
- Manually tested with various provider path formats

Fixes #4083