### PR TITLE
fix: handle null table.body in DownloadMenu disabled prop

### DIFF
--- a/src/app/src/pages/eval/components/DownloadMenu.test.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.test.tsx
@@ -295,4 +295,115 @@ describe('DownloadMenu', () => {
     expect(screen.getByText('Table Data')).toBeInTheDocument();
     expect(screen.getByText('Advanced Options')).toBeInTheDocument();
   });
+
+  describe('Failed Tests Config Button disabled state', () => {
+    it('disables the button when table is null', async () => {
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: null,
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('disables the button when table.body is null', async () => {
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: {
+          head: mockTable.head,
+          body: null as any,
+        },
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('disables the button when table.body is undefined', async () => {
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: {
+          head: mockTable.head,
+          body: undefined as any,
+        },
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('disables the button when all tests pass', async () => {
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: {
+          ...mockTable,
+          body: [
+            {
+              test: { vars: { testVar: 'value' } },
+              vars: ['value1', 'value2'],
+              outputs: [{ pass: true, text: 'passed output' }],
+            },
+            {
+              test: { vars: { testVar: 'value2' } },
+              vars: ['value3', 'value4'],
+              outputs: [{ pass: true, text: 'another passed output' }],
+            },
+          ],
+        },
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('enables the button when there are failed tests', async () => {
+      // Using the default mockTable which has failed tests
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: mockTable,
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    it('handles edge case with empty body array', async () => {
+      (useResultsViewStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        table: {
+          ...mockTable,
+          body: [],
+        },
+        config: mockConfig,
+        evalId: mockEvalId,
+      });
+
+      render(<DownloadMenu />);
+      await userEvent.click(screen.getByText('Download'));
+
+      const button = screen.getByRole('button', { name: /Download Failed Tests Config/i });
+      // Empty body means no tests, so should be disabled
+      expect(button).toBeDisabled();
+    });
+  });
 });

--- a/src/app/src/pages/eval/components/DownloadMenu.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.tsx
@@ -196,10 +196,8 @@ function DownloadMenu() {
       return;
     }
 
-    type TableRow = (typeof table.body)[number];
-
     const humanEvalCases = table.body
-      .filter((row): row is TableRow => row.outputs.some((output) => output != null))
+      .filter((row) => row.outputs.some((output) => output != null))
       .map((row) => ({
         vars: {
           ...row.test.vars,
@@ -440,7 +438,9 @@ function DownloadMenu() {
                 color="secondary"
                 fullWidth
                 disabled={
-                  !table || table.body.every((row) => row.outputs.every((output) => output?.pass))
+                  !table ||
+                  !table.body ||
+                  table.body.every((row) => row.outputs.every((output) => output?.pass))
                 }
               >
                 Download Failed Tests Config


### PR DESCRIPTION
## Summary
Fixes the "z is null" error that occurs when accessing the Download menu in the eval view before table data is fully loaded.

## Problem
The error occurred because the `disabled` prop on the "Download Failed Tests Config" button was trying to call `.every()` on `table.body` without checking if `table.body` itself was null or undefined. While the code had `!table || table.body.every(...)`, there was an edge case where `table` exists but `table.body` is null/undefined.

## Solution
Added an explicit check for `!table.body` in the disabled prop:
```typescript
disabled={
  !table || !table.body || table.body.every((row) => row.outputs.every((output) => output?.pass))
}
```

## Tests
Added comprehensive test coverage for all edge cases:
- When `table` is null
- When `table.body` is null
- When `table.body` is undefined
- When all tests pass (button should be disabled)
- When there are failed tests (button should be enabled)
- When body is an empty array

All 21 tests are passing ✅

## Why This Approach?
The table initialization flow can have intermediate states where `table` exists but `table.body` might not be populated yet. This can happen during:
1. Initial component render before data loads
2. Transitions between different eval results
3. Error states during data fetching

This defensive check makes the component robust against all these scenarios without requiring complex changes to the upstream data flow. 