### PR TITLE
fix(webui): Displaying pagination

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1123,7 +1123,10 @@ function ResultsTable({
           })}
         </tbody>
       </table>
-      {pageCount > 1 && (
+
+      {
+      // 10 is the smallest page size i.e. smaller result-sets cannot be paginated.
+      filteredResultsCount > 10 && (
         <Box
           className="pagination"
           mx={1}


### PR DESCRIPTION
Currently pagination will not be displayed on result sets with less than 50 results; this should not be the case, as we provide the user with the option to lower the page size to 10 results per, which is a valid configuration with a dataset >10 results.