### PR TITLE
fix(cli): esm provider loading

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -29,8 +29,24 @@ export async function importModule(modulePath: string, functionName?: string) {
     }
 
     const resolvedPath = pathToFileURL(safeResolve(modulePath));
-    logger.debug(`Attempting ESM import from: ${resolvedPath.toString()}`);
-    const importedModule = await import(resolvedPath.toString());
+    const resolvedPathStr = resolvedPath.toString();
+    logger.debug(`Attempting ESM import from: ${resolvedPathStr}`);
+
+    // IMPORTANT: Use eval() to bypass ts-node's dynamic import interception
+    // 
+    // Problem: When running under ts-node, `await import()` statements get intercepted
+    // by @cspotcode/source-map-support and converted to `require()` calls during 
+    // transpilation. This breaks ES module loading because:
+    // 1. require() can't load ES modules (throws ERR_REQUIRE_ESM)
+    // 2. require() doesn't understand file:// URLs (throws MODULE_NOT_FOUND)
+    //
+    // Solution: eval() executes the import at runtime, after static analysis is complete,
+    // so ts-node can't intercept and transform it. This ensures the import goes through
+    // Node.js's native ES module loader instead of being converted to require().
+    //
+    // This works in plain Node.js because there's no transpilation/interception layer.
+    const importedModule = await eval(`import('${resolvedPathStr}')`);
+      
     const mod = importedModule?.default?.default || importedModule?.default || importedModule;
     logger.debug(
       `Successfully imported module: ${JSON.stringify({ resolvedPath, moduleId: modulePath })}`,

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -59,6 +59,12 @@ export async function importModule(modulePath: string, functionName?: string) {
   } catch (err) {
     // If ESM import fails, try CommonJS require as fallback
     logger.debug(`ESM import failed: ${err}`);
+
+    // If error has a callstack, log it:
+    if ((err as any).stack) {
+      logger.debug((err as any).stack);
+    }
+    
     logger.debug('Attempting CommonJS require fallback...');
     try {
       const importedModule = require(safeResolve(modulePath));

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -33,11 +33,11 @@ export async function importModule(modulePath: string, functionName?: string) {
     logger.debug(`Attempting ESM import from: ${resolvedPathStr}`);
 
     // IMPORTANT: Use eval() to bypass dynamic import interception in both dev and production
-    // 
+    //
     // Problem: Dynamic imports get converted to require() calls by:
     // 1. ts-node during development (@cspotcode/source-map-support)
     // 2. TypeScript compiler during production build (when module: "commonjs")
-    // 
+    //
     // This breaks ES module loading because:
     // 1. require() can't load ES modules (throws ERR_REQUIRE_ESM)
     // 2. require() doesn't understand file:// URLs (throws MODULE_NOT_FOUND)
@@ -46,7 +46,7 @@ export async function importModule(modulePath: string, functionName?: string) {
     // so neither ts-node nor the TypeScript compiler can intercept and transform it.
     // This ensures the import goes through Node.js's native ES module loader.
     const importedModule = await eval(`import('${resolvedPathStr}')`);
-      
+
     const mod = importedModule?.default?.default || importedModule?.default || importedModule;
     logger.debug(
       `Successfully imported module: ${JSON.stringify({ resolvedPath, moduleId: modulePath })}`,
@@ -64,7 +64,7 @@ export async function importModule(modulePath: string, functionName?: string) {
     if ((err as any).stack) {
       logger.debug((err as any).stack);
     }
-    
+
     logger.debug('Attempting CommonJS require fallback...');
     try {
       const importedModule = require(safeResolve(modulePath));

--- a/test/__fixtures__/testModule.cjs
+++ b/test/__fixtures__/testModule.cjs
@@ -1,0 +1,8 @@
+// CommonJS test module
+module.exports = {
+  testFunction: () => 'cjs test result',
+  namedExport: 'cjs named export',
+  default: {
+    testFunction: () => 'cjs default test result',
+  },
+};

--- a/test/__fixtures__/testModule.js
+++ b/test/__fixtures__/testModule.js
@@ -1,0 +1,8 @@
+// JavaScript test module (CommonJS format)
+module.exports = {
+  testFunction: () => 'js test result',
+  namedExport: 'js named export',
+  default: {
+    testFunction: () => 'js default test result',
+  },
+}; 

--- a/test/__fixtures__/testModule.js
+++ b/test/__fixtures__/testModule.js
@@ -5,4 +5,4 @@ module.exports = {
   default: {
     testFunction: () => 'js default test result',
   },
-}; 
+};

--- a/test/__fixtures__/testModule.mjs
+++ b/test/__fixtures__/testModule.mjs
@@ -1,0 +1,8 @@
+// ESM test module
+export const testFunction = () => 'esm test result';
+export const namedExport = 'esm named export';
+
+export default {
+  testFunction: () => 'esm default test result',
+  defaultProp: 'esm default property',
+};

--- a/test/__fixtures__/testModule.ts
+++ b/test/__fixtures__/testModule.ts
@@ -1,0 +1,15 @@
+// TypeScript test module (ESM format)
+export const testFunction = (): string => 'ts test result';
+export const namedExport: string = 'ts named export';
+
+interface TestModule {
+  testFunction: () => string;
+  defaultProp: string;
+}
+
+const defaultExport: TestModule = {
+  testFunction: () => 'ts default test result',
+  defaultProp: 'ts default property',
+};
+
+export default defaultExport; 

--- a/test/__fixtures__/testModule.ts
+++ b/test/__fixtures__/testModule.ts
@@ -12,4 +12,4 @@ const defaultExport: TestModule = {
   defaultProp: 'ts default property',
 };
 
-export default defaultExport; 
+export default defaultExport;

--- a/test/__fixtures__/testModuleSimple.js
+++ b/test/__fixtures__/testModuleSimple.js
@@ -1,0 +1,4 @@
+// Simple JavaScript module without nested defaults
+module.exports = function simpleFunction() {
+  return 'simple function result';
+}; 

--- a/test/__fixtures__/testModuleSimple.js
+++ b/test/__fixtures__/testModuleSimple.js
@@ -1,4 +1,4 @@
 // Simple JavaScript module without nested defaults
 module.exports = function simpleFunction() {
   return 'simple function result';
-}; 
+};

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -19,61 +19,138 @@ describe('ESM utilities', () => {
 
   describe('importModule', () => {
     it('imports JavaScript modules', async () => {
-      const modulePath = path.resolve(__dirname, 'fixtures/testModule.js');
-
-      // Mock the file system module
-      jest.mock('fs', () => ({
-        existsSync: jest.fn().mockReturnValue(true),
-        readFileSync: jest
-          .fn()
-          .mockReturnValue('module.exports = { testFunction: () => "test result" }'),
-      }));
-
-      // Mock the module
-      jest.doMock(
-        modulePath,
-        () => ({
-          default: { testFunction: () => 'test result' },
-        }),
-        { virtual: true },
-      );
-
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
+      
       const result = await importModule(modulePath);
-      expect(result).toEqual({ testFunction: expect.any(Function) });
+      // importModule extracts the nested default from CommonJS modules
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+      });
+      expect(result.testFunction()).toBe('js default test result');
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('Successfully required module'),
       );
     });
 
     it('imports TypeScript modules', async () => {
-      const modulePath = path.resolve(__dirname, 'fixtures/testModule.ts');
-      jest.doMock(
-        modulePath,
-        () => ({
-          default: { testFunction: () => 'test result' },
-        }),
-        { virtual: true },
-      );
-
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.ts');
+      
       const result = await importModule(modulePath);
-      expect(result).toEqual({ testFunction: expect.any(Function) });
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+        defaultProp: 'ts default property',
+      });
+      expect(result.testFunction()).toBe('ts default test result');
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('TypeScript/ESM module detected'),
       );
     });
 
-    it('handles absolute paths', async () => {
-      const absolutePath = path.resolve('/absolute/path/module.js');
-      jest.doMock(
-        absolutePath,
-        () => ({
-          default: { testFunction: () => 'absolute path result' },
-        }),
-        { virtual: true },
-      );
+    it('imports CommonJS modules', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.cjs');
+      
+      const result = await importModule(modulePath);
+      // importModule extracts the nested default from CommonJS modules
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+      });
+      expect(result.testFunction()).toBe('cjs default test result');
+    });
 
+    it('imports ESM modules', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.mjs');
+      
+      const result = await importModule(modulePath);
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+        defaultProp: 'esm default property',
+      });
+      expect(result.testFunction()).toBe('esm default test result');
+    });
+
+    it('imports simple modules without nested defaults', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModuleSimple.js');
+      
+      const result = await importModule(modulePath);
+      expect(result).toEqual(expect.any(Function));
+      expect(result()).toBe('simple function result');
+    });
+
+    it('returns named function when functionName is specified', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
+      
+      const result = await importModule(modulePath, 'testFunction');
+      expect(result).toEqual(expect.any(Function));
+      expect(result()).toBe('js default test result');
+      expect(logger.debug).toHaveBeenCalledWith('Returning named export: testFunction');
+    });
+
+    it('returns named function from TypeScript module', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.ts');
+      
+      const result = await importModule(modulePath, 'testFunction');
+      expect(result).toEqual(expect.any(Function));
+      expect(result()).toBe('ts default test result');
+    });
+
+    it('handles absolute paths', async () => {
+      const absolutePath = path.resolve(__dirname, '__fixtures__/testModule.js');
+      
       const result = await importModule(absolutePath);
-      expect(result).toEqual({ testFunction: expect.any(Function) });
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+      });
+      expect(result.testFunction()).toBe('js default test result');
+    });
+
+    it('throws error for non-existent module', async () => {
+      const nonExistentPath = path.resolve(__dirname, '__fixtures__/nonExistent.js');
+      
+      await expect(importModule(nonExistentPath)).rejects.toThrow();
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('ESM import failed'),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('CommonJS require also failed'),
+      );
+    });
+
+    it('logs debug information during import process', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
+      
+      await importModule(modulePath);
+      
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Attempting to import module'),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Attempting ESM import from'),
+      );
+    });
+
+    it('falls back to CommonJS when ESM import fails', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.cjs');
+      
+      const result = await importModule(modulePath);
+      expect(result).toEqual({
+        testFunction: expect.any(Function),
+      });
+      
+      // Should try ESM first, then fall back to CommonJS
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('ESM import failed'),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Successfully required module'),
+      );
+    });
+
+    it('extracts named export from ESM module', async () => {
+      const modulePath = path.resolve(__dirname, '__fixtures__/testModule.mjs');
+      
+      const result = await importModule(modulePath, 'testFunction');
+      expect(result).toEqual(expect.any(Function));
+      expect(result()).toBe('esm default test result');
     });
   });
 });

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -20,7 +20,7 @@ describe('ESM utilities', () => {
   describe('importModule', () => {
     it('imports JavaScript modules', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
-      
+
       const result = await importModule(modulePath);
       // importModule extracts the nested default from CommonJS modules
       expect(result).toEqual({
@@ -34,7 +34,7 @@ describe('ESM utilities', () => {
 
     it('imports TypeScript modules', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.ts');
-      
+
       const result = await importModule(modulePath);
       expect(result).toEqual({
         testFunction: expect.any(Function),
@@ -48,7 +48,7 @@ describe('ESM utilities', () => {
 
     it('imports CommonJS modules', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.cjs');
-      
+
       const result = await importModule(modulePath);
       // importModule extracts the nested default from CommonJS modules
       expect(result).toEqual({
@@ -59,7 +59,7 @@ describe('ESM utilities', () => {
 
     it('imports ESM modules', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.mjs');
-      
+
       const result = await importModule(modulePath);
       expect(result).toEqual({
         testFunction: expect.any(Function),
@@ -70,7 +70,7 @@ describe('ESM utilities', () => {
 
     it('imports simple modules without nested defaults', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModuleSimple.js');
-      
+
       const result = await importModule(modulePath);
       expect(result).toEqual(expect.any(Function));
       expect(result()).toBe('simple function result');
@@ -78,7 +78,7 @@ describe('ESM utilities', () => {
 
     it('returns named function when functionName is specified', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
-      
+
       const result = await importModule(modulePath, 'testFunction');
       expect(result).toEqual(expect.any(Function));
       expect(result()).toBe('js default test result');
@@ -87,7 +87,7 @@ describe('ESM utilities', () => {
 
     it('returns named function from TypeScript module', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.ts');
-      
+
       const result = await importModule(modulePath, 'testFunction');
       expect(result).toEqual(expect.any(Function));
       expect(result()).toBe('ts default test result');
@@ -95,7 +95,7 @@ describe('ESM utilities', () => {
 
     it('handles absolute paths', async () => {
       const absolutePath = path.resolve(__dirname, '__fixtures__/testModule.js');
-      
+
       const result = await importModule(absolutePath);
       expect(result).toEqual({
         testFunction: expect.any(Function),
@@ -105,11 +105,9 @@ describe('ESM utilities', () => {
 
     it('throws error for non-existent module', async () => {
       const nonExistentPath = path.resolve(__dirname, '__fixtures__/nonExistent.js');
-      
+
       await expect(importModule(nonExistentPath)).rejects.toThrow();
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('ESM import failed'),
-      );
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('ESM import failed'));
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('CommonJS require also failed'),
       );
@@ -117,9 +115,9 @@ describe('ESM utilities', () => {
 
     it('logs debug information during import process', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.js');
-      
+
       await importModule(modulePath);
-      
+
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('Attempting to import module'),
       );
@@ -130,16 +128,14 @@ describe('ESM utilities', () => {
 
     it('falls back to CommonJS when ESM import fails', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.cjs');
-      
+
       const result = await importModule(modulePath);
       expect(result).toEqual({
         testFunction: expect.any(Function),
       });
-      
+
       // Should try ESM first, then fall back to CommonJS
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('ESM import failed'),
-      );
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('ESM import failed'));
       expect(logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('Successfully required module'),
       );
@@ -147,7 +143,7 @@ describe('ESM utilities', () => {
 
     it('extracts named export from ESM module', async () => {
       const modulePath = path.resolve(__dirname, '__fixtures__/testModule.mjs');
-      
+
       const result = await importModule(modulePath, 'testFunction');
       expect(result).toEqual(expect.any(Function));
       expect(result()).toBe('esm default test result');


### PR DESCRIPTION
- https://linear.app/promptfooo/issue/PF-1057/support-es-modules-for-custom-providers
- This PR fixes a bug where `import` statements get converted to `require`, breaking ESM imports.
- Adds error callstack logging to make debugging future errors easier for end users.