### PR TITLE
chore(vscode): Use Biome as default formatter of TS files in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -120,5 +120,8 @@
   ],
   "[shellscript]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }


### PR DESCRIPTION
Follows up on https://github.com/promptfoo/promptfoo/pull/4903 by setting Biome as the default formatter for Typescript files in VSCode (and forks e.g. Cursor).