### PR TITLE
fix(redteam): Prevent redteam run from hanging when using an mcp client

### DIFF
--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -414,20 +414,23 @@ export async function doGenerateRedteam(
     printBorder();
     const relativeOutputPath = path.relative(process.cwd(), options.output);
     logger.info(`Wrote ${redteamTests.length} test cases to ${relativeOutputPath}`);
-    if (!options.inRedteamRun) {
-      // Provider cleanup step
-      try {
-        const provider = testSuite.providers[0] as ApiProvider;
-        if (provider && typeof provider.cleanup === 'function') {
-          const cleanupResult = provider.cleanup();
-          if (cleanupResult instanceof Promise) {
-            await cleanupResult;
-          }
-        }
-      } catch (cleanupErr) {
-        logger.warn(`Error during provider cleanup: ${cleanupErr}`);
-      }
 
+    // Provider cleanup step. Note that this should always be run,
+    // since the providers are re-initialized when running the red team,
+    // hence it's safe and necessary to clean-up, particularly for MCP servers
+    try {
+      const provider = testSuite.providers[0] as ApiProvider;
+      if (provider && typeof provider.cleanup === 'function') {
+        const cleanupResult = provider.cleanup();
+        if (cleanupResult instanceof Promise) {
+          await cleanupResult;
+        }
+      }
+    } catch (cleanupErr) {
+      logger.warn(`Error during provider cleanup: ${cleanupErr}`);
+    }
+
+    if (!options.inRedteamRun) {
       const commandPrefix = isRunningUnderNpx() ? 'npx promptfoo' : 'promptfoo';
       logger.info(
         '\n' +


### PR DESCRIPTION
### Summary

I observed an issue where when an mcp server was configured, and `redteam run` was being run, the server would be initialized twice, and the process would hang once the test was over. This seems to be because the providers are initialized once during the redteam generate step, and then once again during eval. By always doing a cleanup at the end of generate, rather than only when we're not in a `redteam run` like before, this issue is fixed. 

Ideally we wouldn't initialize providers twice, but I think it's okay, since it's fairly harmless and possibly cleaner to isolate the two commands.