### PR TITLE
feat: add telemetry logging when tracing is enabled

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1643,6 +1643,13 @@ class Evaluator {
     // Start OTLP receiver if tracing is enabled
     await startOtlpReceiverIfNeeded(this.testSuite);
 
+    // Log telemetry if tracing is enabled
+    if (isOtlpReceiverStarted()) {
+      telemetry.record('feature_used', {
+        feature: 'tracing',
+      });
+    }
+
     // Wrap the rest of the evaluation in try-finally to ensure OTLP receiver cleanup
     try {
       return await this._runEvaluation();

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1640,26 +1640,16 @@ class Evaluator {
   }
 
   async evaluate(): Promise<Eval> {
-    // Start OTLP receiver if tracing is enabled
     await startOtlpReceiverIfNeeded(this.testSuite);
 
-    // Log telemetry if tracing is enabled
-    if (isOtlpReceiverStarted()) {
-      telemetry.record('feature_used', {
-        feature: 'tracing',
-      });
-    }
-
-    // Wrap the rest of the evaluation in try-finally to ensure OTLP receiver cleanup
     try {
       return await this._runEvaluation();
     } finally {
-      // Add a delay to allow providers to finish exporting spans
       if (isOtlpReceiverStarted()) {
+        // Add a delay to allow providers to finish exporting spans
         logger.debug('[Evaluator] Waiting for span exports to complete...');
-        await sleep(1000); // Wait 1 second for any remaining spans to be exported
+        await sleep(1000);
       }
-      // Stop OTLP receiver if it was started
       await stopOtlpReceiverIfNeeded();
     }
   }

--- a/src/tracing/evaluatorTracing.ts
+++ b/src/tracing/evaluatorTracing.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'crypto';
 import logger from '../logger';
 import type { TestCase, TestSuite } from '../types';
+import telemetry from '../telemetry';
 
 // Track whether OTLP receiver has been started
 let otlpReceiverStarted = false;
@@ -55,6 +56,9 @@ export async function startOtlpReceiverIfNeeded(testSuite: TestSuite): Promise<v
     testSuite.tracing?.otlp?.http?.enabled &&
     !otlpReceiverStarted
   ) {
+    telemetry.record('feature_used', {
+      feature: 'tracing',
+    });
     try {
       logger.debug('[EvaluatorTracing] Tracing configuration detected, starting OTLP receiver');
       const { startOTLPReceiver } = await import('./otlpReceiver');


### PR DESCRIPTION
## Summary
- Added telemetry logging to track when tracing feature is used during evaluations
- Logs a 'feature_used' event with feature 'tracing' when OTLP receiver is started

## Test plan
- [ ] Run an evaluation with tracing enabled (e.g., `promptfoo eval --trace`)
- [ ] Verify that telemetry event is recorded with feature 'tracing'
- [ ] Run an evaluation without tracing
- [ ] Verify that no tracing telemetry event is recorded

🤖 Generated with [Claude Code](https://claude.ai/code)