### PR TITLE
fix: Test target in http provider setup with non 200 status codes

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/index.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/index.tsx
@@ -317,7 +317,10 @@ export default function Targets({ onNext, onBack, setupModalOpen }: TargetsProps
       const data = (await response.json()) as ProviderTestResponse;
 
       // Handle Target Server Errors:
-      if (data.providerResponse?.metadata?.http?.status !== 200) {
+      if (
+        !data.providerResponse?.metadata?.http?.status ||
+        data.providerResponse?.metadata?.http?.status >= 400
+      ) {
         let errorMessage = 'Target Server Error: ';
 
         if (data.providerResponse.raw) {


### PR DESCRIPTION
HTTP 200 is too specific and any 2xx/3xx codes can be valid- loosening this requirement will prevent false negatives with the test target button.