### PR TITLE
docs(blog): add truncation markers to articles without them

### DIFF
--- a/site/blog/mcp-proxy-announcement.md
+++ b/site/blog/mcp-proxy-announcement.md
@@ -10,6 +10,8 @@ image: /img/blog/mcp/mcp-proxy-hero.png
 Model Context Protocol (MCP) adoption is skyrocketing, [NPM installations are up to 4.7m](https://www.npmjs.com/package/@modelcontextprotocol/sdk) for the week of July 7th, 2025. Today we're announcing the Promptfoo MCP Proxy to manage the security risks for enterprises using MCP servers.
 MCP servers aren't inherently insecure, but the way they're being used creates huge vulnerabilities. Through our work with some of the world's largest companies, we've discovered alarmingly insecure patterns.
 
+<!-- truncate -->
+
 ## What Are MCP Servers?
 
 MCP servers are wrappers around existing APIs, just like an SDK. No magic, no AI. A "Slack MCP server" takes Slack's existing API endpoints (like [these](https://api.slack.com/docs)) and packages them as tools an LLM can use.

--- a/site/blog/promptfoo-vs-pyrit.md
+++ b/site/blog/promptfoo-vs-pyrit.md
@@ -36,6 +36,8 @@ As enterprises deploy AI applications at scale, red teaming has become essential
 | **Learning Curve**    | Low                              | High                     |
 | **Best For**          | Continuous security testing      | Custom deep-dives        |
 
+<!-- truncate -->
+
 PyRIT interface:
 
 ![pyrit](/img/blog/pyrit/pyrit.png)

--- a/site/static/js/scripts.js
+++ b/site/static/js/scripts.js
@@ -1,21 +1,21 @@
 !(function (t) {
   if (window.ko) return;
-  (window.ko = []),
+  ((window.ko = []),
     ['identify', 'track', 'removeListeners', 'open', 'on', 'off', 'qualify', 'ready'].forEach(
       function (t) {
         ko[t] = function () {
           var n = [].slice.call(arguments);
-          return n.unshift(t), ko.push(n), ko;
+          return (n.unshift(t), ko.push(n), ko);
         };
       },
-    );
+    ));
   var n = document.createElement('script');
-  (n.async = !0),
+  ((n.async = !0),
     n.setAttribute(
       'src',
       'https://cdn.getkoala.com/v1/pk_27d6c47cb0df11c274749db81d01a49ddee8/sdk.js',
     ),
-    (document.body || document.head).appendChild(n);
+    (document.body || document.head).appendChild(n));
 
   document.addEventListener('copy', function () {
     const content = window.getSelection().toString();
@@ -48,9 +48,9 @@
     }
     if (((e.vector = t), !t.loaded)) {
       var i = r.createElement('script');
-      (i.type = 'text/javascript'), (i.async = !0), (i.src = 'https://cdn.vector.co/pixel.js');
+      ((i.type = 'text/javascript'), (i.async = !0), (i.src = 'https://cdn.vector.co/pixel.js'));
       var l = r.getElementsByTagName('script')[0];
-      l.parentNode.insertBefore(i, l), (t.loaded = !0);
+      (l.parentNode.insertBefore(i, l), (t.loaded = !0));
     }
   } catch (e) {
     console.error('Error loading Vector:', e);
@@ -66,23 +66,23 @@ vector.load('18d08a7d-45cf-4805-b8b1-978305be5dd4');
     (e.init = function (i, s, a) {
       function g(t, e) {
         var o = e.split('.');
-        2 == o.length && ((t = t[o[0]]), (e = o[1])),
+        (2 == o.length && ((t = t[o[0]]), (e = o[1])),
           (t[e] = function () {
             t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-          });
+          }));
       }
-      ((p = t.createElement('script')).type = 'text/javascript'),
+      (((p = t.createElement('script')).type = 'text/javascript'),
         (p.async = !0),
         (p.src =
           s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-        (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
+        (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r));
       var u = e;
       for (
         void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
           u.people = u.people || [],
           u.toString = function (t) {
             var e = 'posthog';
-            return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
+            return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e);
           },
           u.people.toString = function () {
             return u.toString(1) + '.people (stub)';
@@ -108,14 +108,14 @@ posthog.init('phc_gOS5ctlYqd64vmJtYVpAU0W5iew7OopcETkyYNpkyYP', {
 /* Reo */
 !(function () {
   var e, t, n;
-  (e = '59f3ca4439de16d'),
+  ((e = '59f3ca4439de16d'),
     (t = function () {
       Reo.init({ clientID: '59f3ca4439de16d' });
     }),
     ((n = document.createElement('script')).src = 'https://static.reo.dev/' + e + '/reo.js'),
     (n.defer = !0),
     (n.onload = t),
-    document.head.appendChild(n);
+    document.head.appendChild(n));
 })();
 
 /* Google */

--- a/site/static/js/scripts.js
+++ b/site/static/js/scripts.js
@@ -1,21 +1,21 @@
 !(function (t) {
   if (window.ko) return;
-  ((window.ko = []),
+  (window.ko = []),
     ['identify', 'track', 'removeListeners', 'open', 'on', 'off', 'qualify', 'ready'].forEach(
       function (t) {
         ko[t] = function () {
           var n = [].slice.call(arguments);
-          return (n.unshift(t), ko.push(n), ko);
+          return n.unshift(t), ko.push(n), ko;
         };
       },
-    ));
+    );
   var n = document.createElement('script');
-  ((n.async = !0),
+  (n.async = !0),
     n.setAttribute(
       'src',
       'https://cdn.getkoala.com/v1/pk_27d6c47cb0df11c274749db81d01a49ddee8/sdk.js',
     ),
-    (document.body || document.head).appendChild(n));
+    (document.body || document.head).appendChild(n);
 
   document.addEventListener('copy', function () {
     const content = window.getSelection().toString();
@@ -48,9 +48,9 @@
     }
     if (((e.vector = t), !t.loaded)) {
       var i = r.createElement('script');
-      ((i.type = 'text/javascript'), (i.async = !0), (i.src = 'https://cdn.vector.co/pixel.js'));
+      (i.type = 'text/javascript'), (i.async = !0), (i.src = 'https://cdn.vector.co/pixel.js');
       var l = r.getElementsByTagName('script')[0];
-      (l.parentNode.insertBefore(i, l), (t.loaded = !0));
+      l.parentNode.insertBefore(i, l), (t.loaded = !0);
     }
   } catch (e) {
     console.error('Error loading Vector:', e);
@@ -66,23 +66,23 @@ vector.load('18d08a7d-45cf-4805-b8b1-978305be5dd4');
     (e.init = function (i, s, a) {
       function g(t, e) {
         var o = e.split('.');
-        (2 == o.length && ((t = t[o[0]]), (e = o[1])),
+        2 == o.length && ((t = t[o[0]]), (e = o[1])),
           (t[e] = function () {
             t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-          }));
+          });
       }
-      (((p = t.createElement('script')).type = 'text/javascript'),
+      ((p = t.createElement('script')).type = 'text/javascript'),
         (p.async = !0),
         (p.src =
           s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-        (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r));
+        (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
       var u = e;
       for (
         void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
           u.people = u.people || [],
           u.toString = function (t) {
             var e = 'posthog';
-            return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e);
+            return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
           },
           u.people.toString = function () {
             return u.toString(1) + '.people (stub)';
@@ -108,14 +108,14 @@ posthog.init('phc_gOS5ctlYqd64vmJtYVpAU0W5iew7OopcETkyYNpkyYP', {
 /* Reo */
 !(function () {
   var e, t, n;
-  ((e = '59f3ca4439de16d'),
+  (e = '59f3ca4439de16d'),
     (t = function () {
       Reo.init({ clientID: '59f3ca4439de16d' });
     }),
     ((n = document.createElement('script')).src = 'https://static.reo.dev/' + e + '/reo.js'),
     (n.defer = !0),
     (n.onload = t),
-    document.head.appendChild(n));
+    document.head.appendChild(n);
 })();
 
 /* Google */


### PR DESCRIPTION
This PR adds truncation markers to blog posts that were missing them:
- `blog/mcp-proxy-announcement.md` - Added truncation marker after the introduction
- `blog/promptfoo-vs-pyrit.md` - Added truncation marker after the comparison table

These markers help improve the blog listing page by showing only the introduction of each article, allowing readers to get a preview before clicking through to read the full post.

The formatter also made minor style changes to `site/static/js/scripts.js` which are included in this PR.