### PR TITLE
fix: add thinking token tracking for Google Gemini models

### DIFF
--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -195,20 +195,29 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
 
     try {
       const output = data.candidates[0].content;
+      const tokenUsage = cached
+        ? {
+            cached: data.usageMetadata?.totalTokenCount,
+            total: data.usageMetadata?.totalTokenCount,
+            numRequests: 0,
+          }
+        : {
+            prompt: data.usageMetadata?.promptTokenCount,
+            completion: data.usageMetadata?.candidatesTokenCount,
+            total: data.usageMetadata?.totalTokenCount,
+            numRequests: 1,
+            ...(data.usageMetadata?.thoughtsTokenCount && {
+              completionDetails: {
+                reasoning: data.usageMetadata.thoughtsTokenCount,
+                acceptedPrediction: 0,
+                rejectedPrediction: 0,
+              },
+            }),
+          };
+
       return {
         output,
-        tokenUsage: cached
-          ? {
-              cached: data.usageMetadata?.totalTokenCount,
-              total: data.usageMetadata?.totalTokenCount,
-              numRequests: 0,
-            }
-          : {
-              prompt: data.usageMetadata?.promptTokenCount,
-              completion: data.usageMetadata?.candidatesTokenCount,
-              total: data.usageMetadata?.totalTokenCount,
-              numRequests: 1,
-            },
+        tokenUsage,
         raw: data,
         cached,
       };
@@ -333,20 +342,29 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
         };
       }
 
+      const tokenUsage = cached
+        ? {
+            cached: data.usageMetadata?.totalTokenCount,
+            total: data.usageMetadata?.totalTokenCount,
+            numRequests: 0,
+          }
+        : {
+            prompt: data.usageMetadata?.promptTokenCount,
+            completion: data.usageMetadata?.candidatesTokenCount,
+            total: data.usageMetadata?.totalTokenCount,
+            numRequests: 1,
+            ...(data.usageMetadata?.thoughtsTokenCount && {
+              completionDetails: {
+                reasoning: data.usageMetadata.thoughtsTokenCount,
+                acceptedPrediction: 0,
+                rejectedPrediction: 0,
+              },
+            }),
+          };
+
       return {
         output,
-        tokenUsage: cached
-          ? {
-              cached: data.usageMetadata?.totalTokenCount,
-              total: data.usageMetadata?.totalTokenCount,
-              numRequests: 0,
-            }
-          : {
-              prompt: data.usageMetadata?.promptTokenCount,
-              completion: data.usageMetadata?.candidatesTokenCount,
-              total: data.usageMetadata?.totalTokenCount,
-              numRequests: 1,
-            },
+        tokenUsage,
         raw: data,
         cached,
         ...(guardrails && { guardrails }),

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -53,6 +53,7 @@ interface GeminiUsageMetadata {
   promptTokenCount: number;
   candidatesTokenCount?: number;
   totalTokenCount: number;
+  thoughtsTokenCount?: number;
 }
 
 export interface GeminiErrorResponse {
@@ -79,6 +80,7 @@ interface GeminiPromptFeedback {
 interface GeminiUsageMetadata {
   promptTokenCount: number;
   totalTokenCount: number;
+  thoughtsTokenCount?: number;
 }
 
 interface GeminiBlockedResponse {

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -402,6 +402,13 @@ export class VertexChatProvider extends VertexGenericProvider {
           total: lastData.usageMetadata?.totalTokenCount || 0,
           prompt: lastData.usageMetadata?.promptTokenCount || 0,
           completion: lastData.usageMetadata?.candidatesTokenCount || 0,
+          ...(lastData.usageMetadata?.thoughtsTokenCount && {
+            completionDetails: {
+              reasoning: lastData.usageMetadata.thoughtsTokenCount,
+              acceptedPrediction: 0,
+              rejectedPrediction: 0,
+            },
+          }),
         };
         response = {
           cached: false,


### PR DESCRIPTION
## Description

This PR fixes the bug where reasoning/thinking tokens were not being tracked for Google Gemini models, even though they support thinking capabilities via `thinkingConfig`.

## Problem
The token usage summary showed reasoning tokens for xAI models but not for Google Gemini models. For example:
```
Provider Breakdown:
  xai:grok-4: 783,752
    (159,519 prompt, 67,023 completion, 14,322 cached, 542,888 reasoning)
  google:gemini-2.5-flash: 772,280
    (143,192 prompt, 41,093 completion, 11,523 cached)  # <-- missing reasoning tokens
```

## Solution
- Updated the `GeminiUsageMetadata` interface to include the optional `thoughtsTokenCount` field
- Modified AI Studio provider to extract and map `thoughtsTokenCount` to `completionDetails.reasoning`
- Modified Vertex provider to extract and map `thoughtsTokenCount` to `completionDetails.reasoning`
- Added comprehensive unit tests for both providers

## Testing
- Added unit tests that verify thinking token extraction for both AI Studio and Vertex providers
- Tests cover scenarios with and without thinking tokens in the API response
- Manually tested with a real Gemini model to confirm the fix works:

```
Provider Breakdown:
  google:gemini-2.5-flash: 457
    (35 prompt, 90 completion, 332 reasoning)  # <-- reasoning tokens now tracked!
  xai:grok-3-mini: 383
    (40 prompt, 130 completion, 213 reasoning)
```

## Related
- The `thoughtsTokenCount` field is part of the Gemini API response when thinking is enabled via `thinkingConfig`
- This aligns with how other providers (like xAI) track reasoning tokens in `completionDetails.reasoning`