### PR TITLE
fix(providers): implement callEmbeddingApi for LiteLLM embedding provider

### DIFF
--- a/src/providers/litellm.ts
+++ b/src/providers/litellm.ts
@@ -5,6 +5,8 @@ import type {
   CallApiContextParams,
   CallApiOptionsParams,
   ProviderResponse,
+  ApiEmbeddingProvider,
+  ProviderEmbeddingResponse,
 } from '../types/providers';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
@@ -103,13 +105,20 @@ class LiteLLMCompletionProvider extends LiteLLMProviderWrapper {
 /**
  * LiteLLM Embedding Provider
  */
-class LiteLLMEmbeddingProvider extends LiteLLMProviderWrapper {
+class LiteLLMEmbeddingProvider extends LiteLLMProviderWrapper implements ApiEmbeddingProvider {
+  private embeddingProvider: OpenAiEmbeddingProvider;
+
   constructor(modelName: string, options: ProviderOptions) {
     const provider = new OpenAiEmbeddingProvider(modelName, options);
     super(provider, 'embedding');
+    this.embeddingProvider = provider;
     if (provider.getApiKey) {
       this.getApiKey = provider.getApiKey.bind(provider);
     }
+  }
+
+  async callEmbeddingApi(text: string): Promise<ProviderEmbeddingResponse> {
+    return this.embeddingProvider.callEmbeddingApi(text);
   }
 }
 

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -42,6 +42,7 @@ import RedteamIterativeProvider from '../../src/redteam/providers/iterative';
 import RedteamImageIterativeProvider from '../../src/redteam/providers/iterativeImage';
 import RedteamIterativeTreeProvider from '../../src/redteam/providers/iterativeTree';
 import type { ProviderOptionsMap, ProviderFunction } from '../../src/types';
+import { createLiteLLMProvider } from '../../src/providers/litellm';
 
 jest.mock('fs');
 
@@ -612,6 +613,40 @@ describe('loadApiProvider', () => {
     );
     expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
     expect(provider.id()).toBe('meta/meta-llama/Meta-Llama-3-8B-Instruct');
+  });
+
+  it('loadApiProvider with litellm default (chat)', async () => {
+    const provider = await loadApiProvider('litellm:gpt-4');
+    expect(provider.id()).toBe('litellm:gpt-4');
+    expect(provider.toString()).toBe('[LiteLLM Provider gpt-4]');
+    expect(provider.config.apiBaseUrl).toBe('http://0.0.0.0:4000');
+    expect(provider.config.apiKeyEnvar).toBe('LITELLM_API_KEY');
+  });
+
+  it('loadApiProvider with litellm:chat', async () => {
+    const provider = await loadApiProvider('litellm:chat:gpt-4');
+    expect(provider.id()).toBe('litellm:gpt-4');
+    expect(provider.toString()).toBe('[LiteLLM Provider gpt-4]');
+  });
+
+  it('loadApiProvider with litellm:completion', async () => {
+    const provider = await loadApiProvider('litellm:completion:gpt-3.5-turbo-instruct');
+    expect(provider.id()).toBe('litellm:completion:gpt-3.5-turbo-instruct');
+    expect(provider.toString()).toBe('[LiteLLM Provider completion gpt-3.5-turbo-instruct]');
+  });
+
+  it('loadApiProvider with litellm:embedding', async () => {
+    const provider = await loadApiProvider('litellm:embedding:text-embedding-3-small');
+    expect(provider.id()).toBe('litellm:embedding:text-embedding-3-small');
+    expect(provider.toString()).toBe('[LiteLLM Provider embedding text-embedding-3-small]');
+    expect('callEmbeddingApi' in provider).toBe(true);
+  });
+
+  it('loadApiProvider with litellm:embeddings (alias)', async () => {
+    const provider = await loadApiProvider('litellm:embeddings:text-embedding-3-small');
+    expect(provider.id()).toBe('litellm:embedding:text-embedding-3-small');
+    expect(provider.toString()).toBe('[LiteLLM Provider embedding text-embedding-3-small]');
+    expect('callEmbeddingApi' in provider).toBe(true);
   });
 
   it('loadApiProvider with voyage', async () => {

--- a/test/providers/litellm.test.ts
+++ b/test/providers/litellm.test.ts
@@ -179,7 +179,7 @@ describe('LiteLLM Provider', () => {
     it('should be recognized as a valid embedding provider', () => {
       const provider = createLiteLLMProvider('litellm:embedding:text-embedding-3-small', {});
       // Check that it has either callEmbeddingApi or callSimilarityApi (matching the validation in matchers.ts)
-      const isValidEmbeddingProvider = 
+      const isValidEmbeddingProvider =
         'callEmbeddingApi' in provider || 'callSimilarityApi' in provider;
       expect(isValidEmbeddingProvider).toBe(true);
     });

--- a/test/providers/litellm.test.ts
+++ b/test/providers/litellm.test.ts
@@ -169,4 +169,49 @@ describe('LiteLLM Provider', () => {
       });
     });
   });
+
+  describe('Embedding Provider Functionality', () => {
+    it('should have callEmbeddingApi method', () => {
+      const provider = createLiteLLMProvider('litellm:embedding:text-embedding-3-small', {});
+      expect(typeof provider.callEmbeddingApi).toBe('function');
+    });
+
+    it('should be recognized as a valid embedding provider', () => {
+      const provider = createLiteLLMProvider('litellm:embedding:text-embedding-3-small', {});
+      // Check that it has either callEmbeddingApi or callSimilarityApi (matching the validation in matchers.ts)
+      const isValidEmbeddingProvider = 
+        'callEmbeddingApi' in provider || 'callSimilarityApi' in provider;
+      expect(isValidEmbeddingProvider).toBe(true);
+    });
+
+    it('should not have callEmbeddingApi method for chat providers', () => {
+      const provider = createLiteLLMProvider('litellm:chat:gpt-4', {});
+      expect('callEmbeddingApi' in provider).toBe(false);
+    });
+
+    it('should not have callEmbeddingApi method for completion providers', () => {
+      const provider = createLiteLLMProvider('litellm:completion:gpt-3.5-turbo-instruct', {});
+      expect('callEmbeddingApi' in provider).toBe(false);
+    });
+
+    it('should pass through custom configuration to embedding provider', () => {
+      const customConfig = {
+        apiBaseUrl: 'https://custom.litellm.com',
+        apiKey: 'custom-key',
+        temperature: 0.5,
+      };
+      const provider = createLiteLLMProvider('litellm:embedding:text-embedding-3-small', {
+        config: {
+          config: customConfig,
+        },
+      });
+      expect(provider.config).toMatchObject(customConfig);
+    });
+
+    it('should handle model names with colons for embedding providers', () => {
+      const provider = createLiteLLMProvider('litellm:embedding:custom:embedding:model:v1', {});
+      expect(provider.id()).toBe('litellm:embedding:custom:embedding:model:v1');
+      expect(typeof provider.callEmbeddingApi).toBe('function');
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes an issue where LiteLLM embedding providers were not recognized as valid embedding providers.

## Problem

When using `litellm:embedding:...` providers, they were rejected with the error "is not a valid embedding provider". This was because the `LiteLLMEmbeddingProvider` class wasn't properly exposing the `callEmbeddingApi` method required for embedding providers.

## Solution

- Made `LiteLLMEmbeddingProvider` implement the `ApiEmbeddingProvider` interface
- Added a private property to store the wrapped `OpenAiEmbeddingProvider` instance
- Exposed the `callEmbeddingApi` method that delegates to the wrapped provider
- Fixed type imports to use the correct `ProviderEmbeddingResponse` type

## Testing

- Added comprehensive unit tests for embedding provider functionality
- Added integration tests for loading LiteLLM providers through `loadApiProvider`
- All tests pass successfully

## Changes

- **src/providers/litellm.ts**: Fixed the LiteLLM embedding provider implementation
- **test/providers/litellm.test.ts**: Added unit tests for embedding functionality
- **test/providers/index.test.ts**: Added integration tests for loading LiteLLM providers

Fixes #[issue-number]