### PR TITLE
fix: additional checking on llm-rubric response

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -543,15 +543,21 @@ export async function matchesLlmRubric(
     );
   }
 
-  if(!Array.isArray(jsonObjects) || jsonObjects.length === 0) {
-    return fail(`llm-rubric produced malformed response - We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`, resp.tokenUsage);
+  if (!Array.isArray(jsonObjects) || jsonObjects.length === 0) {
+    return fail(
+      `llm-rubric produced malformed response - We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`,
+      resp.tokenUsage,
+    );
   }
 
   // expects properties pass, score, and reason
   const parsed = jsonObjects[0] as Partial<GradingResult>;
 
-  if(typeof parsed !== 'object' || parsed === null || parsed === undefined) {
-    return fail(`llm-rubric produced malformed response. We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`, resp.tokenUsage);
+  if (typeof parsed !== 'object' || parsed === null || parsed === undefined) {
+    return fail(
+      `llm-rubric produced malformed response. We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`,
+      resp.tokenUsage,
+    );
   }
 
   let pass = parsed.pass ?? true;

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -538,13 +538,21 @@ export async function matchesLlmRubric(
     jsonObjects = [resp.output];
   } else {
     return fail(
-      'llm-rubric produced malformed response - output must be string or object',
+      `llm-rubric produced malformed response - output must be string or object. Output: ${JSON.stringify(resp.output)}`,
       resp.tokenUsage,
     );
   }
 
+  if(!Array.isArray(jsonObjects) || jsonObjects.length === 0) {
+    return fail(`llm-rubric produced malformed response - We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`, resp.tokenUsage);
+  }
+
   // expects properties pass, score, and reason
   const parsed = jsonObjects[0] as Partial<GradingResult>;
+
+  if(typeof parsed !== 'object' || parsed === null || parsed === undefined) {
+    return fail(`llm-rubric produced malformed response. We were not able to parse the response as JSON. Output: ${JSON.stringify(resp.output)}`, resp.tokenUsage);
+  }
 
   let pass = parsed.pass ?? true;
   if (typeof pass !== 'boolean') {

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -153,7 +153,8 @@ describe('matchesLlmRubric', () => {
       assertion: undefined,
       pass: false,
       score: 0,
-      reason: 'llm-rubric produced malformed response - output must be string or object. Output: 42',
+      reason:
+        'llm-rubric produced malformed response - output must be string or object. Output: 42',
       tokensUsed: {
         total: 10,
         prompt: 5,
@@ -338,7 +339,6 @@ describe('matchesLlmRubric', () => {
       },
     });
   });
-
 
   it('should fail when the grading provider returns a failing result', async () => {
     const expected = 'Expected output';

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -153,7 +153,7 @@ describe('matchesLlmRubric', () => {
       assertion: undefined,
       pass: false,
       score: 0,
-      reason: 'llm-rubric produced malformed response - output must be string or object',
+      reason: 'llm-rubric produced malformed response - output must be string or object. Output: 42',
       tokensUsed: {
         total: 10,
         prompt: 5,
@@ -221,6 +221,124 @@ describe('matchesLlmRubric', () => {
       },
     });
   });
+
+  it('should fail when string output contains only empty JSON array', async () => {
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const options: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: 'Here is the result: []',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    await expect(matchesLlmRubric(expected, output, options)).resolves.toEqual({
+      assertion: undefined,
+      pass: false,
+      score: 0,
+      reason: 'Could not extract JSON from llm-rubric response',
+      tokensUsed: {
+        total: 10,
+        prompt: 5,
+        completion: 5,
+        cached: 0,
+        completionDetails: undefined,
+      },
+    });
+  });
+
+  it('should fail when string contains only null', async () => {
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const options: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: 'Result: null',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    // Since extractJsonObjects only looks for objects starting with {, this returns no objects
+    await expect(matchesLlmRubric(expected, output, options)).resolves.toEqual({
+      assertion: undefined,
+      pass: false,
+      score: 0,
+      reason: 'Could not extract JSON from llm-rubric response',
+      tokensUsed: {
+        total: 10,
+        prompt: 5,
+        completion: 5,
+        cached: 0,
+        completionDetails: undefined,
+      },
+    });
+  });
+
+  it('should fail when string contains only a JSON string primitive', async () => {
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const options: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: '"just a string"',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    await expect(matchesLlmRubric(expected, output, options)).resolves.toEqual({
+      assertion: undefined,
+      pass: false,
+      score: 0,
+      reason: 'Could not extract JSON from llm-rubric response',
+      tokensUsed: {
+        total: 10,
+        prompt: 5,
+        completion: 5,
+        cached: 0,
+        completionDetails: undefined,
+      },
+    });
+  });
+
+  it('should fail when string contains only a number', async () => {
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const options: GradingConfig = {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: jest.fn().mockResolvedValue({
+          output: 'Result: 123',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    };
+
+    await expect(matchesLlmRubric(expected, output, options)).resolves.toEqual({
+      assertion: undefined,
+      pass: false,
+      score: 0,
+      reason: 'Could not extract JSON from llm-rubric response',
+      tokensUsed: {
+        total: 10,
+        prompt: 5,
+        completion: 5,
+        cached: 0,
+        completionDetails: undefined,
+      },
+    });
+  });
+
 
   it('should fail when the grading provider returns a failing result', async () => {
     const expected = 'Expected output';


### PR DESCRIPTION
Additional logging and error handling for bad llm-rubric responses