### PR TITLE
chore(webui): Improvements to pagination "go to" functionality

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1267,18 +1267,25 @@ function ResultsTable({
                 <TextField
                   size="small"
                   type="number"
-                  defaultValue={1}
                   onChange={(e) => {
-                    const page = e.target.value ? Number(e.target.value) - 1 : 0;
-                    setPagination((prev) => ({
-                      ...prev,
-                      pageIndex: Math.min(Math.max(page, 0), pageCount - 1),
-                    }));
-                    clearRowIdFromUrl();
+                    const page = e.target.value ? Number(e.target.value) - 1 : null;
+                    if (page) {
+                      setPagination((prev) => ({
+                        ...prev,
+                        pageIndex: Math.min(Math.max(page, 0), pageCount - 1),
+                      }));
+                      clearRowIdFromUrl();
+                    }
                   }}
                   sx={{
                     width: '60px',
                     textAlign: 'center',
+                  }}
+                  slotProps={{
+                    htmlInput: {
+                      min: 1,
+                      max: pageCount,
+                    },
                   }}
                 />
               </Typography>

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1269,7 +1269,7 @@ function ResultsTable({
                   type="number"
                   onChange={(e) => {
                     const page = e.target.value ? Number(e.target.value) - 1 : null;
-                    if (page) {
+                    if (page !== null && page >= 0 && page < pageCount) {
                       setPagination((prev) => ({
                         ...prev,
                         pageIndex: Math.min(Math.max(page, 0), pageCount - 1),


### PR DESCRIPTION
- Don't display a default value; this can be confusing and lead the user to believe it's the current page number
- Ensures the user cannot set a value higher than the max page count or a value lower than 1