### PR TITLE
chore(webui): Metrics filtering improvements

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -580,7 +580,7 @@ export default function ResultsView({
                   anchorEl={filtersButtonRef.current}
                 />
               </>
-            ) : filters.options.metric.length > 0 ? (
+            ) : filters.options.metric.length > 1 ? (
               <MetricFilterSelector />
             ) : null}
 


### PR DESCRIPTION
- [x] Don't show metrics selector unless there are >1 metrics to filter by
- [ ] Fixes incorrect metric result "X out of Y" counts (X is the number of rows while Y is calculated by the number of test cases * prompts)
