### PR TITLE
fix: update HTTP config generator endpoint to use v1 API

### DIFF
--- a/site/src/components/HttpConfigGenerator/index.tsx
+++ b/site/src/components/HttpConfigGenerator/index.tsx
@@ -53,7 +53,7 @@ Content-Type: application/json
     setLoading(true);
     setError('');
     try {
-      const res = await fetch('https://api.promptfoo.app/api/http-provider-generator', {
+      const res = await fetch('https://api.promptfoo.app/api/v1/http-provider-generator', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Fixed HTTP configuration generator component to use the correct API endpoint
- Updated endpoint from `/api/http-provider-generator` to `/api/v1/http-provider-generator`

## Test plan
- [ ] Test the HTTP configuration generator on the documentation site
- [ ] Verify it correctly calls the v1 API endpoint
- [ ] Ensure configuration generation works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)