### PR TITLE
fix(site): dark mode style on redteam setup ui 

### DIFF
--- a/src/app/src/pages/redteam/setup/components/DefaultTestVariables.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/DefaultTestVariables.test.tsx
@@ -244,6 +244,14 @@ describe('DefaultTestVariables Component', () => {
         );
       });
     });
+
+    it('renders the empty state container with correct background and border colors', () => {
+      render(<DefaultTestVariables />);
+
+      const emptyStateContainer = screen.getByText('No test variables configured').closest('div');
+      expect(emptyStateContainer).toHaveStyle('background-color: rgba(0, 0, 0, 0.04)');
+      expect(emptyStateContainer).toHaveStyle('border-color: rgba(0, 0, 0, 0.12)');
+    });
   });
 
   describe('Edge Cases', () => {

--- a/src/app/src/pages/redteam/setup/components/DefaultTestVariables.tsx
+++ b/src/app/src/pages/redteam/setup/components/DefaultTestVariables.tsx
@@ -192,9 +192,9 @@ export default function DefaultTestVariables() {
               py: 6,
               px: 3,
               borderRadius: 2,
-              bgcolor: 'grey.50',
+              bgcolor: 'action.hover',
               border: '1px dashed',
-              borderColor: 'grey.300',
+              borderColor: 'divider',
             }}
           >
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>


### PR DESCRIPTION
Now: 

<img width="1014" height="438" alt="Screenshot 2025-07-19 at 4 14 58 PM" src="https://github.com/user-attachments/assets/2e940cdc-38da-43b1-9336-7e4be977d703" />

before: 

<img width="999" height="446" alt="Screenshot 2025-07-19 at 4 16 15 PM" src="https://github.com/user-attachments/assets/bcdbc943-1194-43c2-99fa-6e904e647a99" />
