### PR TITLE
docs(blog): correct author attribution in DeepSeek censorship post

### DIFF
--- a/site/blog/deepseek-censorship.md
+++ b/site/blog/deepseek-censorship.md
@@ -14,7 +14,7 @@ keywords:
     political AI filtering,
   ]
 date: 2025-01-28
-authors: [vanessa]
+authors: [ian]
 tags: [research-analysis]
 ---
 


### PR DESCRIPTION
This PR corrects the author attribution in the DeepSeek censorship blog post from 'vanessa' to 'ian'.