### PR TITLE
chore(providers): add GEMINI_API_KEY environment variable support

### DIFF
--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -27,16 +27,22 @@ You have three options for providing your API key:
 
 #### Option 1: Environment Variable (Recommended)
 
-Set the `GOOGLE_API_KEY` environment variable:
+Set the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variable:
 
 ```bash
 # Using export (Linux/macOS)
+export GEMINI_API_KEY="your_api_key_here"
+# or
 export GOOGLE_API_KEY="your_api_key_here"
 
 # Using set (Windows Command Prompt)
+set GEMINI_API_KEY=your_api_key_here
+# or
 set GOOGLE_API_KEY=your_api_key_here
 
 # Using $env (Windows PowerShell)
+$env:GEMINI_API_KEY="your_api_key_here"
+# or
 $env:GOOGLE_API_KEY="your_api_key_here"
 ```
 
@@ -46,6 +52,8 @@ Create a `.env` file in your project root:
 
 ```bash
 # .env
+GEMINI_API_KEY=your_api_key_here
+# or
 GOOGLE_API_KEY=your_api_key_here
 ```
 
@@ -68,7 +76,9 @@ providers:
 providers:
   - id: google:gemini-2.5-flash
     config:
-      apiKey: ${GOOGLE_API_KEY}
+      apiKey: ${GEMINI_API_KEY}
+      # or
+      # apiKey: ${GOOGLE_API_KEY}
 ```
 
 ### 3. Verify Authentication
@@ -153,7 +163,9 @@ tests:
 providers:
   - id: google:gemini-2.5-flash
     config:
-      apiKey: ${GOOGLE_API_KEY}
+      apiKey: ${GEMINI_API_KEY}
+      # or
+      # apiKey: ${GOOGLE_API_KEY}
       temperature: ${TEMPERATURE:-0.7} # Default to 0.7 if not set
 ```
 

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -189,6 +189,8 @@ For quick testing, you can use a temporary access token:
 ```bash
 # Get a temporary access token
 export VERTEX_API_KEY=$(gcloud auth print-access-token)
+# or use GEMINI_API_KEY
+export GEMINI_API_KEY=$(gcloud auth print-access-token)
 export VERTEX_PROJECT_ID="your-project-id"
 ```
 
@@ -204,6 +206,8 @@ VERTEX_PROJECT_ID=your-project-id
 VERTEX_REGION=us-central1
 # Optional: For direct API key authentication
 VERTEX_API_KEY=your-access-token
+# or
+GEMINI_API_KEY=your-access-token
 ```
 
 Remember to add `.env` to your `.gitignore` file to prevent accidentally committing sensitive information.
@@ -219,12 +223,13 @@ The following environment variables can be used to configure the Vertex AI provi
 | `VERTEX_PROJECT_ID`              | Your Google Cloud project ID                             | None           | Yes      |
 | `VERTEX_REGION`                  | The region for Vertex AI resources                       | `us-central1`  | No       |
 | `VERTEX_API_KEY`                 | Direct API token (from `gcloud auth print-access-token`) | None           | No\*     |
+| `GEMINI_API_KEY`                 | Alternative to VERTEX_API_KEY for API authentication     | None           | No\*     |
 | `VERTEX_PUBLISHER`               | Model publisher                                          | `google`       | No       |
 | `VERTEX_API_HOST`                | Override API host (e.g., for proxy)                      | Auto-generated | No       |
 | `VERTEX_API_VERSION`             | API version                                              | `v1`           | No       |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account credentials                      | None           | No\*     |
 
-\*At least one authentication method is required (ADC, service account, or API key)
+\*At least one authentication method is required (ADC, service account, or API key via VERTEX_API_KEY/GEMINI_API_KEY)
 
 ### Region Selection
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -162,6 +162,9 @@
                             "GOOGLE_API_KEY": {
                               "type": "string"
                             },
+                            "GEMINI_API_KEY": {
+                              "type": "string"
+                            },
                             "GROQ_API_KEY": {
                               "type": "string"
                             },

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -92,8 +92,10 @@ class AIStudioGenericProvider implements ApiProvider {
   getApiKey(): string | undefined {
     const apiKey =
       this.config.apiKey ||
+      this.env?.GEMINI_API_KEY ||
       this.env?.GOOGLE_API_KEY ||
       this.env?.PALM_API_KEY ||
+      getEnvString('GEMINI_API_KEY') ||
       getEnvString('GOOGLE_API_KEY') ||
       getEnvString('PALM_API_KEY');
     if (apiKey) {
@@ -136,7 +138,7 @@ export class AIStudioChatProvider extends AIStudioGenericProvider {
     }
     if (!this.getApiKey()) {
       throw new Error(
-        'Google API key is not set. Set the GOOGLE_API_KEY environment variable or add `apiKey` to the provider config.',
+        'Google API key is not set. Set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable or add `apiKey` to the provider config.',
       );
     }
 

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -82,7 +82,13 @@ class VertexGenericProvider implements ApiProvider {
   }
 
   getApiKey(): string | undefined {
-    return this.config.apiKey || this.env?.VERTEX_API_KEY || getEnvString('VERTEX_API_KEY');
+    return (
+      this.config.apiKey ||
+      this.env?.GEMINI_API_KEY ||
+      this.env?.VERTEX_API_KEY ||
+      getEnvString('GEMINI_API_KEY') ||
+      getEnvString('VERTEX_API_KEY')
+    );
   }
 
   getRegion(): string {

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -35,6 +35,7 @@ export const ProviderEnvOverridesSchema = z.object({
   GOOGLE_API_HOST: z.string().optional(),
   GOOGLE_API_BASE_URL: z.string().optional(),
   GOOGLE_API_KEY: z.string().optional(),
+  GEMINI_API_KEY: z.string().optional(),
   GROQ_API_KEY: z.string().optional(),
   HELICONE_API_KEY: z.string().optional(),
   HF_API_TOKEN: z.string().optional(),


### PR DESCRIPTION
## Description

This PR adds support for the `GEMINI_API_KEY` environment variable, which is the standard environment variable name used in Google's official Gemini API documentation.

## Changes

- Added `GEMINI_API_KEY` to `ProviderEnvOverridesSchema` in `src/types/env.ts`
- Updated Google AI Studio provider to check for `GEMINI_API_KEY` before falling back to `GOOGLE_API_KEY`
- Updated Google Vertex provider to check for `GEMINI_API_KEY` before falling back to `VERTEX_API_KEY`
- Updated documentation to mention both `GEMINI_API_KEY` and `GOOGLE_API_KEY` options
- Auto-generated config schema updates

## API Key Lookup Order

For Google AI Studio:
1. Provider config `apiKey`
2. `GEMINI_API_KEY` environment variable
3. `GOOGLE_API_KEY` environment variable
4. `PALM_API_KEY` environment variable (legacy)

For Google Vertex:
1. Provider config `apiKey`
2. `GEMINI_API_KEY` environment variable
3. `VERTEX_API_KEY` environment variable

## Backward Compatibility

This change maintains full backward compatibility - existing configurations using `GOOGLE_API_KEY` or `VERTEX_API_KEY` will continue to work as before.

## Testing

- [x] Code has been formatted with `npm run f`
- [x] Code has been linted with `npm run l`