### PR TITLE
feat: Add metadata filtering to eval results

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -182,6 +182,7 @@ export default function ResultsView({
     totalResultsCount,
     highlightedResultsCount,
     filters,
+    removeFilter,
   } = useTableStore();
 
   const {
@@ -669,6 +670,27 @@ export default function ResultsView({
                       sx={{ marginLeft: '4px', height: '20px', fontSize: '0.75rem' }}
                     />
                   )}
+                  {filters.appliedCount > 0 && Object.values(filters.values).map((filter) => {
+                    if (!filter.value) {
+                      return null;
+                    }
+                    const truncatedValue = filter.value.length > 50 
+                      ? filter.value.slice(0, 50) + '...' 
+                      : filter.value;
+                    const label = filter.type === 'metric' 
+                      ? `Metric: ${truncatedValue}`
+                      : `${filter.field} ${filter.operator.replace('_', ' ')} "${truncatedValue}"`;
+                    return (
+                      <Chip
+                        key={filter.id}
+                        size="small"
+                        label={label}
+                        title={filter.value} // Show full value on hover
+                        onDelete={() => removeFilter(filter.id)}
+                        sx={{ marginLeft: '4px', height: '20px', fontSize: '0.75rem' }}
+                      />
+                    );
+                  })}
                 </>
               ) : (
                 <>{filteredResultsCount} results</>


### PR DESCRIPTION
## Summary
- Adds comprehensive metadata filtering capabilities to evaluation results
- Extends existing filter system to support metadata fields with multiple operators (equals, contains, not contains)
- Improves UX with persistent action buttons and better filter management

## Changes
- **Filter Types**: Added `metadata` as a new filter type alongside existing `metric` filters
- **Operators**: Implemented `equals`, `contains`, and `not_contains` operators for metadata filtering
- **UI Improvements**:
  - Debounced text input for metadata filter values (500ms delay)
  - Persistent copy/filter buttons in metadata table with tooltips
  - Active filter pills show truncated values (50 chars) with full value on hover
  - Improved alignment for mixed filter types
- **Backend**: Updated SQL queries to handle metadata filtering with proper JSON extraction
- **UX Enhancements**:
  - Filter button in metadata table replaces all existing filters for quick filtering
  - Closing popover when removing last filter
  - Clear visual feedback with light gray buttons that darken on hover

## Test plan
- [ ] Add metadata filters through the FiltersForm
- [ ] Test all three operators (equals, contains, not contains) with metadata fields
- [ ] Apply filters from metadata table and verify existing filters are replaced
- [ ] Verify debouncing works when typing filter values
- [ ] Check that long filter values are truncated in pills
- [ ] Test mixed metric and metadata filters together
- [ ] Verify backend properly filters results based on metadata criteria

🤖 Generated with [Claude Code](https://claude.ai/code)