### PR TITLE
fix: Ollama token usage

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -311,8 +311,11 @@ function EvalOutputCell({
     );
   }
 
-  if (output.tokenUsage?.completion) {
-    const tokPerSec = output.tokenUsage.completion / (output.latencyMs / 1000);
+  // Check for token usage in both output.tokenUsage and output.response?.tokenUsage
+  const tokenUsage = output.tokenUsage || output.response?.tokenUsage;
+
+  if (tokenUsage?.completion) {
+    const tokPerSec = tokenUsage.completion / (output.latencyMs / 1000);
     tokPerSecDisplay = (
       <span>{Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(tokPerSec)}</span>
     );
@@ -322,29 +325,29 @@ function EvalOutputCell({
     costDisplay = <span>${output.cost.toPrecision(2)}</span>;
   }
 
-  if (output.response?.tokenUsage?.cached) {
+  if (tokenUsage?.cached) {
     tokenUsageDisplay = (
       <span>
         {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-          output.response?.tokenUsage?.cached ?? 0,
+          tokenUsage.cached ?? 0,
         )}{' '}
         (cached)
       </span>
     );
-  } else if (output.response?.tokenUsage?.total) {
+  } else if (tokenUsage?.total) {
     const promptTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response?.tokenUsage?.prompt ?? 0,
+      tokenUsage.prompt ?? 0,
     );
     const completionTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response?.tokenUsage?.completion ?? 0,
+      tokenUsage.completion ?? 0,
     );
     const totalTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-      output.response?.tokenUsage?.total ?? 0,
+      tokenUsage.total ?? 0,
     );
 
-    if (output.response?.tokenUsage?.completionDetails?.reasoning) {
+    if (tokenUsage.completionDetails?.reasoning) {
       const reasoningTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-        output.response.tokenUsage.completionDetails.reasoning ?? 0,
+        tokenUsage.completionDetails.reasoning ?? 0,
       );
 
       tokenUsageDisplay = (

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -328,9 +328,7 @@ function EvalOutputCell({
   if (tokenUsage?.cached) {
     tokenUsageDisplay = (
       <span>
-        {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-          tokenUsage.cached ?? 0,
-        )}{' '}
+        {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(tokenUsage.cached ?? 0)}{' '}
         (cached)
       </span>
     );

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -9,6 +9,7 @@ import type {
   CallApiContextParams,
   ProviderEmbeddingResponse,
   ProviderResponse,
+  TokenUsage,
 } from '../types';
 
 interface OllamaCompletionOptions {

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -310,11 +310,13 @@ export class OllamaChatProvider implements ApiProvider {
     }
 
     try {
-      const output = response.data
+      const lines = response.data
         .split('\n')
         .filter((line: string) => line.trim() !== '')
-        .map((line: string) => {
-          const parsed = JSON.parse(line) as OllamaChatJsonL;
+        .map((line: string) => JSON.parse(line) as OllamaChatJsonL);
+
+      const output = lines
+        .map((parsed: OllamaChatJsonL) => {
           if (parsed.message?.content) {
             return parsed.message.content;
           }
@@ -323,8 +325,23 @@ export class OllamaChatProvider implements ApiProvider {
         .filter((s: string | null) => s !== null)
         .join('');
 
+      // Extract token usage from the final chunk (where done: true)
+      const finalChunk = lines.find((chunk: OllamaChatJsonL) => chunk.done);
+      let tokenUsage: Partial<TokenUsage> | undefined;
+      
+      if (finalChunk && (finalChunk.prompt_eval_count !== undefined || finalChunk.eval_count !== undefined)) {
+        const promptTokens = finalChunk.prompt_eval_count || 0;
+        const completionTokens = finalChunk.eval_count || 0;
+        tokenUsage = {
+          prompt: promptTokens,
+          completion: completionTokens,
+          total: promptTokens + completionTokens,
+        };
+      }
+
       return {
         output,
+        ...(tokenUsage && { tokenUsage }),
       };
     } catch (err) {
       return {

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -211,8 +211,11 @@ export class OllamaCompletionProvider implements ApiProvider {
       // Extract token usage from the final chunk (where done: true)
       const finalChunk = lines.find((chunk: OllamaCompletionJsonL) => chunk.done);
       let tokenUsage: Partial<TokenUsage> | undefined;
-      
-      if (finalChunk && (finalChunk.prompt_eval_count !== undefined || finalChunk.eval_count !== undefined)) {
+
+      if (
+        finalChunk &&
+        (finalChunk.prompt_eval_count !== undefined || finalChunk.eval_count !== undefined)
+      ) {
         const promptTokens = finalChunk.prompt_eval_count || 0;
         const completionTokens = finalChunk.eval_count || 0;
         tokenUsage = {
@@ -328,8 +331,11 @@ export class OllamaChatProvider implements ApiProvider {
       // Extract token usage from the final chunk (where done: true)
       const finalChunk = lines.find((chunk: OllamaChatJsonL) => chunk.done);
       let tokenUsage: Partial<TokenUsage> | undefined;
-      
-      if (finalChunk && (finalChunk.prompt_eval_count !== undefined || finalChunk.eval_count !== undefined)) {
+
+      if (
+        finalChunk &&
+        (finalChunk.prompt_eval_count !== undefined || finalChunk.eval_count !== undefined)
+      ) {
         const promptTokens = finalChunk.prompt_eval_count || 0;
         const completionTokens = finalChunk.eval_count || 0;
         tokenUsage = {

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -83,6 +83,7 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
       pass: result.success,
       failureReason: result.failureReason,
       cost: result.cost || 0,
+      tokenUsage: result.tokenUsage,
       audio: result.response?.audio
         ? {
             id: result.response.audio.id,

--- a/test/providers/ollama.test.ts
+++ b/test/providers/ollama.test.ts
@@ -114,6 +114,97 @@ describe('OllamaCompletionProvider', () => {
     const provider = new OllamaCompletionProvider('llama2');
     expect(provider.toString()).toBe('[Ollama Completion Provider llama2]');
   });
+
+  it('should extract token usage from response', async () => {
+    const mockResponse = {
+      data: '{"response":"test response","done":false,"prompt_eval_count":26}\n{"response":" more","done":true,"prompt_eval_count":26,"eval_count":259}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaCompletionProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response more',
+      tokenUsage: {
+        prompt: 26,
+        completion: 259,
+        total: 285,
+      },
+    });
+  });
+
+  it('should handle missing token usage gracefully', async () => {
+    const mockResponse = {
+      data: '{"response":"test response","done":true}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaCompletionProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+    });
+  });
+
+  it('should handle partial token usage (only prompt_eval_count)', async () => {
+    const mockResponse = {
+      data: '{"response":"test response","done":true,"prompt_eval_count":26}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaCompletionProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+      tokenUsage: {
+        prompt: 26,
+        completion: 0,
+        total: 26,
+      },
+    });
+  });
+
+  it('should handle partial token usage (only eval_count)', async () => {
+    const mockResponse = {
+      data: '{"response":"test response","done":true,"eval_count":259}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaCompletionProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+      tokenUsage: {
+        prompt: 0,
+        completion: 259,
+        total: 259,
+      },
+    });
+  });
 });
 
 describe('OllamaChatProvider', () => {
@@ -277,6 +368,97 @@ describe('OllamaChatProvider', () => {
     expect(jest.mocked(fetchWithCache).mock.calls[0]).toBeDefined();
     const call = jest.mocked(fetchWithCache).mock.calls[0] as any;
     expect(call[4]).toBe(true);
+  });
+
+  it('should extract token usage from chat response', async () => {
+    const mockResponse = {
+      data: '{"message":{"role":"assistant","content":"test response","images":null},"done":false,"prompt_eval_count":26}\n{"message":{"role":"assistant","content":" more","images":null},"done":true,"prompt_eval_count":26,"eval_count":259}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaChatProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response more',
+      tokenUsage: {
+        prompt: 26,
+        completion: 259,
+        total: 285,
+      },
+    });
+  });
+
+  it('should handle missing token usage gracefully in chat', async () => {
+    const mockResponse = {
+      data: '{"message":{"role":"assistant","content":"test response","images":null},"done":true}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaChatProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+    });
+  });
+
+  it('should handle partial token usage in chat (only prompt_eval_count)', async () => {
+    const mockResponse = {
+      data: '{"message":{"role":"assistant","content":"test response","images":null},"done":true,"prompt_eval_count":26}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaChatProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+      tokenUsage: {
+        prompt: 26,
+        completion: 0,
+        total: 26,
+      },
+    });
+  });
+
+  it('should handle partial token usage in chat (only eval_count)', async () => {
+    const mockResponse = {
+      data: '{"message":{"role":"assistant","content":"test response","images":null},"done":true,"eval_count":259}\n',
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    };
+
+    jest.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new OllamaChatProvider('llama2');
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toEqual({
+      output: 'test response',
+      tokenUsage: {
+        prompt: 0,
+        completion: 259,
+        total: 259,
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
I noticed that Ollama outputs don't show token information like other models.

This PR adds token usage support for Ollama providers, allowing users to see token counts in the evaluation UI and in the CLI.

## Changes
- **Add TokenUsage import** to Ollama provider
- **Extract token usage** from Ollama API responses (both completion and chat providers)
- **Map Ollama fields** to standard format:
  - `prompt_eval_count` → `prompt_tokens`
  - `eval_count` → `completion_tokens`
  - Calculate `total_tokens` as sum
- **Fix UI display** to check both `output.tokenUsage` and `output.response.tokenUsage`
- **Fix token usage conversion** in `convertEvalResultsToTable`
- **Add comprehensive tests** for all token usage scenarios

## Testing
- ✅ Token usage displays correctly in CLI output
- ✅ Token usage displays correctly in web UI
- ✅ Works with both completion and chat providers
- ✅ Handles missing/partial token usage gracefully
- ✅ All tests pass