### PR TITLE
chore: prevent testGenerationInstructions from being serialized if not present

### DIFF
--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -291,7 +291,9 @@ export async function doGenerateRedteam(
     sharing: redteamConfig?.sharing || options.sharing,
     excludeTargetOutputFromAgenticAttackGeneration:
       redteamConfig?.excludeTargetOutputFromAgenticAttackGeneration,
-    testGenerationInstructions: redteamConfig?.testGenerationInstructions,
+    ...(redteamConfig?.testGenerationInstructions
+      ? { testGenerationInstructions: redteamConfig.testGenerationInstructions }
+      : {}),
   };
   const parsedConfig = RedteamConfigSchema.safeParse(config);
   if (!parsedConfig.success) {
@@ -306,7 +308,7 @@ export async function doGenerateRedteam(
 
   // Extract MCP tools information and add to purpose
   let enhancedPurpose = parsedConfig.data.purpose || '';
-  let augmentedTestGenerationInstructions = config.testGenerationInstructions || '';
+  let augmentedTestGenerationInstructions = config.testGenerationInstructions ?? '';
   try {
     const mcpToolsInfo = await extractMcpToolsInfo(testSuite.providers);
     if (mcpToolsInfo) {

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -654,7 +654,7 @@ export async function synthesize({
         registeredPlugin.validate({
           language,
           modifiers: {
-            testGenerationInstructions,
+            ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
             ...(plugin.config?.modifiers || {}),
           },
           ...resolvePluginConfig(plugin.config),
@@ -751,7 +751,7 @@ export async function synthesize({
         config: {
           language,
           modifiers: {
-            testGenerationInstructions,
+            ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
             ...(plugin.config?.modifiers || {}),
           },
           ...resolvePluginConfig(plugin.config),


### PR DESCRIPTION
Really minor change, but I prefer to keep our payloads clean.