### PR TITLE
ci: increase build job timeout from 4 to 5 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
     name: Build on Node ${{ matrix.node }}
     env:
       PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
-    timeout-minutes: 4
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR increases the timeout for the build job in the CI workflow from 4 to 5 minutes to allow more time for the build process to complete.