### PR TITLE
fix(providers): Preserve text formatting when no images present for Google provider

### DIFF
--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -930,6 +930,333 @@ describe('util', () => {
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
       expect(systemInstruction).toEqual({ parts: [{ text: 'system instruction' }] });
     });
+
+    describe('support for images in contents', () => {
+      const validBase64Image =
+        '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A/9k=';
+
+      it('should preserve text formatting when no images are present', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Hello world!\n\n  This is indented text.\n\nAnd this has multiple\n\n\nEmpty lines.',
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          someVar: 'not an image',
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Hello world!\n\n  This is indented text.\n\nAnd this has multiple\n\n\nEmpty lines.',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should preserve text formatting when no context variables are provided', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Hello world!\n\n  This is indented text.\n\nAnd this has multiple\n\n\nEmpty lines.',
+              },
+            ],
+          },
+        ]);
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Hello world!\n\n  This is indented text.\n\nAnd this has multiple\n\n\nEmpty lines.',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should convert base64 images from context variables while preserving other text', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `Here is some text before the image:\n\n${validBase64Image}\n\nAnd here is some text after the image.`,
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: validBase64Image,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Here is some text before the image:\n',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/jpeg',
+                  data: validBase64Image,
+                },
+              },
+              {
+                text: 'And here is some text after the image.',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should handle multiple images mixed with text', () => {
+        const image1 = validBase64Image;
+        const image2 =
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAGA5w5EQwA7BHigu/QKBgAAAABJRU5ErkJggg==';
+
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `First line of text.\n${image1}\nMiddle text line.\n${image2}\nLast line of text.`,
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: image1,
+          image2: image2,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'First line of text.',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/jpeg',
+                  data: image1,
+                },
+              },
+              {
+                text: 'Middle text line.',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/png',
+                  data: image2,
+                },
+              },
+              {
+                text: 'Last line of text.',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should preserve complex formatting with whitespace and empty lines', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Title\n\n    Indented paragraph with spaces\n\n\n    Another indented paragraph\n        with more indentation\n\n',
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          notAnImage: 'just text',
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Title\n\n    Indented paragraph with spaces\n\n\n    Another indented paragraph\n        with more indentation\n\n',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should handle edge case with image at the beginning', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `${validBase64Image}\nText after image`,
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: validBase64Image,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                inlineData: {
+                  mimeType: 'image/jpeg',
+                  data: validBase64Image,
+                },
+              },
+              {
+                text: 'Text after image',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should handle edge case with image at the end', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `Text before image\n${validBase64Image}`,
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: validBase64Image,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Text before image',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/jpeg',
+                  data: validBase64Image,
+                },
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should handle non-text parts without modification', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Some text',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/png',
+                  data: 'existing-image-data',
+                },
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: validBase64Image,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'Some text',
+              },
+              {
+                inlineData: {
+                  mimeType: 'image/png',
+                  data: 'existing-image-data',
+                },
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should handle empty text parts', () => {
+        const prompt = JSON.stringify([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: '',
+              },
+            ],
+          },
+        ]);
+
+        const contextVars = {
+          image1: validBase64Image,
+        };
+
+        const { contents } = geminiFormatAndSystemInstructions(prompt, contextVars);
+
+        expect(contents).toEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: '',
+              },
+            ],
+          },
+        ]);
+      });
+    });
   });
 
   describe('normalizeTools', () => {


### PR DESCRIPTION
Fixes `processImagesInContents` to only modify text parts that actually contain base64 images, preserving original formatting for text-only content.

#4767 introduced a regression where text-only parts were split by newline and each line was trimmed and sent as a separate part, breaking use cases that relied on original text layout.

Now only processes text when base64 images are actually found in the content, leaving other text formatting intact.