### PR TITLE
fix(webui): Eval results histogram improvements

### DIFF
--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -51,8 +51,6 @@ vi.mock('@app/utils/api', () => ({
 
 describe('ResultsCharts', () => {
   const defaultProps = {
-    columnVisibility: {},
-    recentEvals: [],
     handleHideCharts: vi.fn(),
   };
 

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -331,7 +331,7 @@ describe('ResultsCharts', () => {
         fetchEvalData: vi.fn(),
       });
 
-      const { container } = render(<ResultsCharts {...defaultProps} recentEvals={[]} />);
+      const { container } = render(<ResultsCharts {...defaultProps} />);
 
       expect(container).toBeDefined();
 

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -103,6 +103,176 @@ describe('ResultsCharts', () => {
     expect(handleHideCharts).toHaveBeenCalled();
   });
 
+  it('should render without errors with a large number of providers', () => {
+    const numProviders = 12;
+    const prompts = Array.from({ length: numProviders }, (_, i) => ({
+      provider: `provider-${i + 1}`,
+      metrics: { namedScores: {} },
+    }));
+    const mockTable = {
+      head: {
+        prompts: prompts,
+        vars: [],
+      },
+      body: [
+        {
+          outputs: prompts.map((_, i) => ({
+            score: 0.5 + i * 0.04,
+            pass: true,
+            text: 'valid output',
+          })),
+          vars: [],
+        },
+        {
+          outputs: prompts.map((_, i) => ({
+            score: 0.6 + i * 0.03,
+            pass: true,
+            text: 'valid output',
+          })),
+          vars: [],
+        },
+      ],
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      table: mockTable,
+      evalId: 'test-eval',
+      config: { description: 'test config' },
+      setTable: vi.fn(),
+      fetchEvalData: vi.fn(),
+    });
+
+    const { container } = render(<ResultsCharts {...defaultProps} />);
+
+    expect(() => render(<ResultsCharts {...defaultProps} />)).not.toThrow();
+
+    const canvasElements = container.querySelectorAll('canvas');
+    expect(canvasElements.length).toBeGreaterThan(0);
+  });
+
+  it('should render without errors in a constrained space', () => {
+    const mockTable = {
+      head: {
+        prompts: [
+          { provider: 'test-provider-1', metrics: { namedScores: {} } },
+          { provider: 'test-provider-2', metrics: { namedScores: {} } },
+        ],
+        vars: [],
+      },
+      body: [
+        {
+          outputs: [
+            { score: 0.8, pass: true, text: 'valid output' },
+            { score: 0.9, pass: true, text: 'valid output' },
+          ],
+          vars: [],
+        },
+        {
+          outputs: [
+            { score: 0.6, pass: true, text: 'another valid' },
+            { score: 0.7, pass: true, text: 'another valid' },
+          ],
+          vars: [],
+        },
+      ],
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      table: mockTable,
+      evalId: 'test-eval',
+      config: { description: 'test config' },
+      setTable: vi.fn(),
+      fetchEvalData: vi.fn(),
+    });
+
+    const { container } = render(<ResultsCharts {...defaultProps} />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('should handle extremely long provider IDs in histogram chart labels and tooltips', () => {
+    const longProviderId =
+      'this-is-an-extremely-long-provider-id-that-should-not-cause-overflow-or-layout-issues';
+    const mockTable = {
+      head: {
+        prompts: [
+          { provider: longProviderId, metrics: { namedScores: {} } },
+          { provider: 'test-provider-2', metrics: { namedScores: {} } },
+        ],
+        vars: [],
+      },
+      body: [
+        {
+          outputs: [
+            { score: 0.8, pass: true, text: 'valid output' },
+            { score: 0.9, pass: true, text: 'valid output' },
+          ],
+          vars: [],
+        },
+        {
+          outputs: [
+            { score: 0.6, pass: true, text: 'another valid' },
+            { score: 0.7, pass: true, text: 'another valid' },
+          ],
+          vars: [],
+        },
+      ],
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      table: mockTable,
+      evalId: 'test-eval',
+      config: { description: 'test config' },
+      setTable: vi.fn(),
+      fetchEvalData: vi.fn(),
+    });
+
+    expect(() => {
+      render(<ResultsCharts {...defaultProps} />);
+    }).not.toThrow();
+  });
+
+  it('handles table data where some prompts are missing the provider property', () => {
+    const mockTable = {
+      head: {
+        prompts: [
+          { provider: 'test-provider-1', metrics: { namedScores: {} } },
+          { metrics: { namedScores: {} } },
+        ],
+        vars: [],
+      },
+      body: [
+        {
+          outputs: [
+            { score: 0.8, pass: true, text: 'valid output' },
+            { score: 0.9, pass: true, text: 'valid output' },
+          ],
+          vars: [],
+        },
+        {
+          outputs: [
+            { score: 0.6, pass: true, text: 'another valid' },
+            { score: 0.7, pass: true, text: 'another valid' },
+          ],
+          vars: [],
+        },
+      ],
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      table: mockTable,
+      evalId: 'test-eval',
+      config: { description: 'test config' },
+      setTable: vi.fn(),
+      fetchEvalData: vi.fn(),
+    });
+
+    const { container } = render(<ResultsCharts {...defaultProps} />);
+
+    const canvasElements = container.querySelectorAll('canvas');
+    expect(canvasElements.length).toBeGreaterThan(0);
+  });
+
   describe('Null Safety and Data Validation', () => {
     it('handles null outputs gracefully', () => {
       const mockTableWithNullOutputs = {

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -105,7 +105,7 @@ function HistogramChart({ table }: ChartProps) {
         (bin) => scores.filter((score) => score >= bin && score < bin + binSize).length,
       );
       return {
-        label: `Column ${promptIdx + 1}`,
+        label: prompt.provider,
         data: counts,
         backgroundColor: COLOR_PALETTE[promptIdx % COLOR_PALETTE.length],
       };
@@ -131,7 +131,7 @@ function HistogramChart({ table }: ChartProps) {
             callbacks: {
               title(context) {
                 const datasetIndex = context[0].datasetIndex;
-                return `Column ${datasetIndex + 1}`;
+                return table.head.prompts[datasetIndex].provider;
               },
               label(context) {
                 const labelIndex = context.dataIndex;

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -145,6 +145,20 @@ function HistogramChart({ table }: ChartProps) {
             },
           },
         },
+        scales: {
+          y: {
+            title: {
+              display: true,
+              text: 'Frequency',
+            },
+          },
+          x: {
+            title: {
+              display: true,
+              text: 'Score',
+            },
+          },
+        },
       },
     });
   }, [table]);

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -28,13 +28,10 @@ import {
 import { ErrorBoundary } from 'react-error-boundary';
 import { usePassRates } from './hooks';
 import { useTableStore } from './store';
-import type { VisibilityState } from '@tanstack/table-core';
 
-import type { EvaluateTable, ResultLightweightWithLabel, UnifiedConfig } from './types';
+import type { EvaluateTable, UnifiedConfig } from './types';
 
 interface ResultsChartsProps {
-  columnVisibility: VisibilityState;
-  recentEvals: ResultLightweightWithLabel[];
   handleHideCharts: () => void;
 }
 
@@ -624,7 +621,7 @@ function PerformanceOverTimeChart({ evalId }: ChartProps) {
   return <canvas ref={lineCanvasRef} style={{ maxHeight: '300px', cursor: 'pointer' }} />;
 }
 
-function ResultsCharts({ columnVisibility, recentEvals, handleHideCharts }: ResultsChartsProps) {
+function ResultsCharts({ handleHideCharts }: ResultsChartsProps) {
   const theme = useTheme();
   Chart.defaults.color = theme.palette.mode === 'dark' ? '#aaa' : '#666';
   const [

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -177,6 +177,12 @@ vi.mock('@app/hooks/useShiftKey', () => {
   };
 });
 
+vi.mock('./ResultsCharts', () => {
+  return {
+    default: vi.fn(() => <div data-testid="results-charts">ResultsCharts Mock</div>),
+  };
+});
+
 declare global {
   interface Window {
     resizeHandler: any;
@@ -240,6 +246,37 @@ describe('ResultsView', () => {
     };
   });
 
+  it('renders ResultsCharts when table, config, and more than one prompt are present and viewport height is at least 1100px', () => {
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 1200,
+    });
+
+    mockTableStoreData = {
+      ...mockTableStoreData,
+      table: {
+        head: {
+          prompts: [{ provider: 'test-provider' }, { provider: 'test-provider-2' }],
+          vars: ['Variable 1'],
+        },
+        body: [
+          {
+            outputs: [{ pass: true, score: 1, text: 'test output' }],
+            test: {},
+            vars: ['test var'],
+          },
+        ],
+      },
+      config: { description: 'Test Config', tags: {} },
+    };
+
+    renderWithProviders(
+      <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
+    );
+
+    expect(screen.getByTestId('results-charts')).toBeInTheDocument();
+  });
   it('renders without crashing', () => {
     renderWithProviders(
       <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
@@ -363,5 +400,115 @@ describe('ResultsView', () => {
     }
 
     expect(container).toBeInTheDocument();
+  });
+
+  it('renders ResultsView without crashing when columnVisibility and recentEvals props are not passed to ResultsCharts', () => {
+    renderWithProviders(
+      <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
+    );
+
+    expect(screen.getByText('Table Settings')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search or select an eval...')).toBeInTheDocument();
+  });
+
+  it('should not render ResultsCharts when all prompts are hidden', () => {
+    mockTableStoreData.table = {
+      head: {
+        prompts: [{ provider: 'test-provider' }, { provider: 'another-provider' }],
+        vars: ['Variable 1'],
+      },
+      body: [
+        {
+          outputs: [{ pass: true, score: 1, text: 'test output' }],
+          test: {},
+          vars: ['test var'],
+        },
+      ],
+    };
+    mockResultsViewSettingsStoreData = {
+      ...mockResultsViewSettingsStoreData,
+      columnStates: {
+        '1': {
+          selectedColumns: ['Variable 1'],
+          columnVisibility: { 'Variable 1': true, 'Prompt 1': false },
+        },
+      },
+    };
+
+    vi.mock('./store', () => ({
+      useTableStore: vi.fn(() => mockTableStoreData),
+      useResultsViewSettingsStore: vi.fn(() => mockResultsViewSettingsStoreData),
+    }));
+
+    renderWithProviders(
+      <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
+    );
+
+    expect(screen.queryByTestId('results-charts')).toBeNull();
+  });
+
+  it('hides ResultsCharts when viewport height is less than 1100px', () => {
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 900,
+    });
+
+    mockTableStoreData.table = {
+      head: {
+        prompts: [{ provider: 'test-provider' }, { provider: 'test-provider' }],
+        vars: ['Variable 1'],
+      },
+      body: [
+        {
+          outputs: [{ pass: true, score: 1, text: 'test output' }],
+          test: {},
+          vars: ['test var'],
+        },
+      ],
+    };
+
+    mockTableStoreData.config = { description: 'Test Config', tags: {} };
+
+    const { container } = renderWithProviders(
+      <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
+    );
+
+    expect(screen.queryByTestId('results-charts')).toBeNull();
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders ResultsCharts with scores outside the normal range', () => {
+    mockTableStoreData.table = {
+      head: {
+        prompts: [{ provider: 'test-provider' }, { provider: 'another-provider' }],
+        vars: ['Variable 1'],
+      },
+      body: [
+        {
+          outputs: [{ pass: true, score: -0.5, text: 'test output' }],
+          test: {},
+          vars: ['test var'],
+        },
+        {
+          outputs: [{ pass: false, score: 1.5, text: 'test output 2' }],
+          test: {},
+          vars: ['test var 2'],
+        },
+      ],
+    };
+    mockTableStoreData.config = { description: 'Test Config', tags: {} };
+
+    mockResultsViewSettingsStoreData = {
+      ...mockResultsViewSettingsStoreData,
+      renderMarkdown: true,
+    };
+
+    renderWithProviders(
+      <ResultsView recentEvals={mockRecentEvals} onRecentEvalSelected={mockOnRecentEvalSelected} />,
+    );
+
+    const showChartsButton = screen.getByText('Show Charts');
+    expect(showChartsButton).toBeInTheDocument();
   });
 });

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -822,11 +822,7 @@ export default function ResultsView({
             </Box>
           </ResponsiveStack>
           {canRenderResultsCharts && renderResultsCharts && (
-            <ResultsCharts
-              columnVisibility={currentColumnState.columnVisibility}
-              recentEvals={recentEvals}
-              handleHideCharts={() => setRenderResultsCharts(false)}
-            />
+            <ResultsCharts handleHideCharts={() => setRenderResultsCharts(false)} />
           )}
         </Box>
         <ResultsTable


### PR DESCRIPTION
**Changes**

- Label bars with provider ids instead of `Column N`.
- Display Frequency and Score on the Y and X axes, respectively, making it clearer this is a histogram.
- Misc: Removes unused props.

**Before**

<img width="572" height="317" alt="image" src="https://github.com/user-attachments/assets/ce79df06-3470-4c11-b310-1b1dc9222975" />

**After**

<img width="570" height="327" alt="image" src="https://github.com/user-attachments/assets/f3ed374e-4d3f-471f-80e3-c87a41059252" />
