### PR TITLE
chore: Change mcp log from error to debug

### DIFF
--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -95,7 +95,9 @@ export class MCPClient {
           await client.connect(transport);
           logger.debug('Connected using Streamable HTTP transport');
         } catch (error) {
-          logger.error(`Failed to connect to MCP server ${serverKey}: ${error}`);
+          logger.debug(
+            `Failed to connect to MCP server with Streamable HTTP transport ${serverKey}: ${error}`,
+          );
           const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
           transport = new SSEClientTransport(new URL(server.url), options);
           await client.connect(transport);


### PR DESCRIPTION
this would probably be fixed by specifying http vs sse transport, but currently the promptfoo mcp client just tries both types, and if one fails, it emits an error log, which makes it seem like the client didn't connect properly. This changes that log to a debug log, which is more appropriate.