### PR TITLE
fix: Infinite re-render on redteam review page

### DIFF
--- a/src/app/src/pages/redteam/setup/components/DefaultTestVariables.tsx
+++ b/src/app/src/pages/redteam/setup/components/DefaultTestVariables.tsx
@@ -49,7 +49,7 @@ export default function DefaultTestVariables() {
     });
     isUpdatingFromLocal.current = true; // Mark that we're updating from local state
     updateConfig('defaultTest', { ...config.defaultTest, vars });
-  }, [variables, config.defaultTest, updateConfig]);
+  }, [variables, updateConfig]);
 
   // Validate variable names for duplicates
   const validateVariableNames = useCallback((updatedVariables: Variable[]) => {


### PR DESCRIPTION
The review page was infinitely re-rendering due to this deps array =(