### PR TITLE
fix: Target type selector for custom targets

### DIFF
--- a/src/app/src/pages/redteam/setup/cloud-ProviderEditor.tsx
+++ b/src/app/src/pages/redteam/setup/cloud-ProviderEditor.tsx
@@ -1,0 +1,218 @@
+import React, { useRef, useState } from 'react';
+
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import { useTheme } from '@mui/material/styles';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ProviderConfigEditor from './ProviderConfigEditor';
+import ProviderTypeSelector from './ProviderTypeSelector';
+import type { ProviderOptions } from '@promptfoo/types';
+
+import type { ProviderConfigEditorRef } from './ProviderConfigEditor';
+
+export function defaultHttpTarget(): ProviderOptions {
+  return {
+    id: 'http',
+    config: {
+      url: '',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: '{{prompt}}',
+      }),
+    },
+  };
+}
+
+interface ProviderProps {
+  onActionButtonClick?: () => void;
+  onBack?: () => void;
+  provider: ProviderOptions | undefined;
+  setProvider: (provider: ProviderOptions) => void;
+  extensions?: string[];
+  onExtensionsChange?: (extensions: string[]) => void;
+  opts?: {
+    availableProviderIds?: string[];
+    description?: React.ReactNode;
+    disableNameField?: boolean;
+    disableTitle?: boolean;
+    actionButtonText?: string;
+    defaultRequestTransform?: string;
+    hideErrors?: boolean;
+    disableModelSelection?: boolean;
+  };
+  setError?: (error: string | null) => void;
+  validateAll?: boolean; // Flag to force validation of all fields
+}
+
+export default function ProviderEditor({
+  onActionButtonClick,
+  onBack,
+  provider,
+  setProvider,
+  extensions,
+  onExtensionsChange,
+  opts = {},
+  setError,
+  validateAll = false,
+}: ProviderProps) {
+  const theme = useTheme();
+  const {
+    disableNameField = false,
+    description,
+    disableTitle = false,
+    actionButtonText,
+    availableProviderIds,
+    defaultRequestTransform,
+    disableModelSelection = false,
+    hideErrors = false,
+  } = opts;
+
+  const configEditorRef = useRef<ProviderConfigEditorRef>(null);
+  const [validationErrors, setValidationErrors] = useState<string | null>(null);
+  const [shouldValidate, setShouldValidate] = useState<boolean>(false);
+  const providerType = provider?.config?.id?.split(':')[0] ?? availableProviderIds?.[0] ?? 'custom';
+
+  // Handle errors from child components
+  const handleError = (error: string | null) => {
+    setValidationErrors(error);
+    setError?.(error);
+  };
+
+  if (!provider) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" spacing={3}>
+      {!disableTitle && (
+        <Typography variant="h4" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+          Select Red Team Provider
+        </Typography>
+      )}
+
+      <Typography variant="body1">
+        {description ||
+          'A target is the specific LLM or endpoint you want to evaluate in your red teaming process.'}{' '}
+        For more information on available targets and how to configure them, please visit our{' '}
+        <Link href="https://www.promptfoo.dev/docs/providers/" target="_blank" rel="noopener">
+          documentation
+        </Link>
+        .
+      </Typography>
+
+      {!disableNameField && (
+        <TextField
+          fullWidth
+          sx={{ mb: 2 }}
+          label="Provider Name"
+          value={provider?.label ?? ''}
+          placeholder="e.g. 'customer-service-agent'"
+          onChange={(e) => {
+            if (provider) {
+              setProvider({ ...provider, label: e.target.value });
+            }
+          }}
+          margin="normal"
+          required
+          autoFocus
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+      )}
+
+      {/* Provider Type Selection Section */}
+      <ProviderTypeSelector
+        provider={provider}
+        setProvider={setProvider}
+        availableProviderIds={availableProviderIds}
+        disableModelSelection={disableModelSelection}
+      />
+
+      {/* Provider Configuration Section */}
+      <ProviderConfigEditor
+        ref={configEditorRef}
+        provider={provider}
+        setProvider={setProvider}
+        extensions={extensions}
+        onExtensionsChange={onExtensionsChange}
+        opts={{
+          defaultRequestTransform,
+          hideErrors,
+          disableModelSelection,
+        }}
+        setError={handleError}
+        validateAll={validateAll || shouldValidate}
+        onValidate={(isValid) => {
+          // Validation errors will be displayed through the handleError function
+        }}
+        providerType={providerType}
+      />
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: validationErrors ? 'space-between' : 'flex-end',
+          mt: 4,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 2,
+            ...(validationErrors && {
+              width: '100%',
+              justifyContent: 'space-between',
+            }),
+          }}
+        >
+          {onBack && (
+            <Button
+              variant="outlined"
+              startIcon={<KeyboardArrowLeftIcon />}
+              onClick={onBack}
+              sx={{ px: 4, py: 1 }}
+            >
+              Back
+            </Button>
+          )}
+          {onActionButtonClick && (
+            <Button
+              variant="contained"
+              onClick={() => {
+                // Enable validation when button is clicked
+                setShouldValidate(true);
+
+                // Use the ref to validate
+                const isValid = configEditorRef.current?.validate() ?? false;
+
+                // Only proceed if there are no errors
+                if (isValid && !validationErrors) {
+                  onActionButtonClick();
+                }
+              }}
+              endIcon={<KeyboardArrowRightIcon />}
+              sx={{
+                backgroundColor: theme.palette.primary.main,
+                '&:hover': { backgroundColor: theme.palette.primary.dark },
+                '&:disabled': { backgroundColor: theme.palette.action.disabledBackground },
+                px: 4,
+                py: 1,
+              }}
+            >
+              {actionButtonText || 'Next'}
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </Stack>
+  );
+}

--- a/src/app/src/pages/redteam/setup/cloud-ProviderTypeSelector.tsx
+++ b/src/app/src/pages/redteam/setup/cloud-ProviderTypeSelector.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from 'react';
+
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import Paper from '@mui/material/Paper';
+import Radio from '@mui/material/Radio';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import { getProviderType } from './helpers';
+import type { ProviderOptions } from '@promptfoo/types';
+
+// Provider options grouped by category
+const providerOptions = [
+  {
+    category: 'endpoint',
+    title: 'API Endpoints',
+    description: 'Connect to existing AI applications via HTTP or WebSocket',
+    options: [
+      {
+        value: 'http',
+        label: 'HTTP/HTTPS Endpoint',
+        description: 'Connect to REST APIs and HTTP endpoints',
+      },
+      {
+        value: 'websocket',
+        label: 'WebSocket Endpoint',
+        description: 'Real-time communication with WebSocket APIs',
+      },
+    ],
+  },
+  {
+    category: 'model',
+    title: 'Foundation Models',
+    description: 'Test models directly without application context',
+    options: [
+      {
+        value: 'openrouter',
+        label: 'OpenRouter',
+        description: 'Access hundreds of top AI models through a single API',
+      },
+      {
+        value: 'azure',
+        label: 'Azure OpenAI',
+        description: 'Access Azure OpenAI models',
+      },
+    ],
+  },
+  {
+    category: 'custom',
+    title: 'Custom Providers',
+    description: 'Use custom code or specialized integrations',
+    options: [
+      {
+        value: 'javascript',
+        label: 'JavaScript Provider',
+        description: 'Custom JS provider for specialized integrations',
+      },
+      {
+        value: 'python',
+        label: 'Python Provider',
+        description: 'Custom Python provider for specialized integrations',
+      },
+      {
+        value: 'custom',
+        label: 'Custom Provider',
+        description: 'Other custom providers and implementations',
+      },
+      {
+        value: 'mcp',
+        label: 'MCP Server',
+        description: 'Connect to Model Context Protocol (MCP) servers for direct tool red teaming',
+      },
+    ],
+  },
+];
+
+interface ProviderTypeSelectorProps {
+  provider: ProviderOptions | undefined;
+  setProvider: (provider: ProviderOptions) => void;
+  availableProviderIds?: string[];
+  disableModelSelection?: boolean;
+  providerType?: string;
+}
+
+export default function ProviderTypeSelector({
+  provider,
+  providerType,
+  setProvider,
+  availableProviderIds,
+}: ProviderTypeSelectorProps) {
+  const theme = useTheme();
+
+  const [selectedProviderType, setSelectedProviderType] = useState<string | undefined>(
+    providerType ?? getProviderType(provider?.id),
+  );
+
+  useEffect(() => {
+    if (!provider?.id) {
+      setSelectedProviderType('http');
+      setProvider({
+        id: 'http',
+        config: {
+          url: '',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: '{{prompt}}',
+          }),
+        },
+      });
+    }
+  }, []);
+
+  // Handle provider type selection
+  const handleProviderTypeSelect = (value: string) => {
+    setSelectedProviderType(value);
+
+    const currentLabel = provider?.label;
+
+    if (value === 'custom') {
+      setProvider({
+        id: '',
+        label: currentLabel,
+        config: {},
+      });
+    } else if (value === 'javascript') {
+      setProvider({
+        id: 'file:///path/to/custom_provider.js',
+        config: {},
+        label: currentLabel,
+      });
+    } else if (value === 'python') {
+      setProvider({
+        id: 'file:///path/to/custom_provider.py',
+        config: {},
+        label: currentLabel,
+      });
+    } else if (value === 'http') {
+      setProvider({
+        id: 'http',
+        label: currentLabel,
+        config: {
+          url: '',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: '{{prompt}}',
+          }),
+        },
+      });
+    } else if (value === 'websocket') {
+      setProvider({
+        id: 'websocket',
+        label: currentLabel,
+        config: {
+          type: 'websocket',
+          url: 'wss://example.com/ws',
+          messageTemplate: '{"message": "{{prompt}}"}',
+          transformResponse: 'response.message',
+          timeoutMs: 30000,
+        },
+      });
+    } else if (value === 'mcp') {
+      setProvider({
+        id: 'mcp',
+        label: currentLabel,
+        config: {
+          enabled: true,
+          verbose: false,
+        },
+      });
+    } else if (value === 'browser') {
+      setProvider({
+        id: 'browser',
+        label: currentLabel,
+        config: {
+          steps: [
+            {
+              action: 'navigate',
+              args: { url: 'https://example.com' },
+            },
+          ],
+        },
+      });
+    } else if (value === 'openrouter') {
+      setProvider({
+        id: 'openrouter:openai/gpt-4o',
+        config: {},
+        label: currentLabel,
+      });
+    } else if (value === 'azure') {
+      setProvider({
+        id: 'azure:chat:',
+        config: {},
+        label: currentLabel,
+      });
+    } else {
+      setProvider({
+        id: value,
+        config: {},
+        label: currentLabel,
+      });
+    }
+  };
+
+  // Filter available options if availableProviderIds is provided
+  const filteredProviderOptions = providerOptions
+    .map((group) => ({
+      ...group,
+      options: group.options.filter(
+        (option) => !availableProviderIds || availableProviderIds.includes(option.value),
+      ),
+    }))
+    .filter((group) => group.options.length > 0);
+
+  return (
+    <Box>
+      <FormControl component="fieldset" sx={{ width: '100%' }}>
+        {filteredProviderOptions.map((group) => (
+          <Box key={group.category} sx={{ mb: 3 }}>
+            <Typography
+              variant="subtitle1"
+              sx={{
+                mb: 1.5,
+                fontWeight: 600,
+                color: 'text.primary',
+                fontSize: '1rem',
+              }}
+            >
+              {group.title}
+            </Typography>
+
+            <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+              {group.description}
+            </Typography>
+
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                gap: 2,
+                height: '105px',
+              }}
+            >
+              {group.options.map((option) => (
+                <Paper
+                  key={option.value}
+                  variant="outlined"
+                  onClick={() => handleProviderTypeSelect(option.value)}
+                  sx={{
+                    border: '1px solid',
+                    borderColor: selectedProviderType === option.value ? 'primary.main' : 'divider',
+                    borderWidth: selectedProviderType === option.value ? 2 : 1,
+                    borderRadius: 2,
+                    bgcolor:
+                      selectedProviderType === option.value
+                        ? 'rgba(25, 118, 210, 0.04)'
+                        : 'transparent',
+                    '&:hover': {
+                      bgcolor: 'rgba(0, 0, 0, 0.04)',
+                      cursor: 'pointer',
+                      borderColor:
+                        selectedProviderType === option.value
+                          ? 'primary.main'
+                          : theme.palette.action.hover,
+                    },
+                    p: selectedProviderType === option.value ? '15px' : 2,
+                    transition: 'background-color 0.2s',
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Radio
+                      checked={selectedProviderType === option.value}
+                      onChange={() => handleProviderTypeSelect(option.value)}
+                      value={option.value}
+                      name="provider-type-radio"
+                      sx={{ mr: 1, p: 0 }}
+                      size="small"
+                    />
+                    <Typography
+                      variant="subtitle1"
+                      sx={{
+                        fontWeight: selectedProviderType === option.value ? 600 : 500,
+                        color:
+                          selectedProviderType === option.value ? 'primary.main' : 'text.primary',
+                        flex: 1,
+                      }}
+                    >
+                      {option.label}
+                    </Typography>
+                    {selectedProviderType === option.value && (
+                      <CheckCircleIcon color="primary" fontSize="small" />
+                    )}
+                  </Box>
+
+                  <Typography variant="body2" sx={{ color: 'text.secondary', ml: '28px' }}>
+                    {option.description}
+                  </Typography>
+                </Paper>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/app/src/pages/redteam/setup/cloud-edit.tsx
+++ b/src/app/src/pages/redteam/setup/cloud-edit.tsx
@@ -1,0 +1,978 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import ErrorFallback from '@cloud-ui/components/ErrorFallback';
+import { getProviderType } from '@cloud-ui/components/providers/helpers';
+import ProviderConfigEditor from '@cloud-ui/components/providers/ProviderConfigEditor';
+import ProviderTypeSelector from '@cloud-ui/components/providers/ProviderTypeSelector';
+import { ROUTES } from '@cloud-ui/constants';
+import { useCan } from '@cloud-ui/contexts/RbacContext';
+import { useNavigateOnTeamChange } from '@cloud-ui/contexts/TeamsContext';
+import { useMutateProvider, useProvider } from '@cloud-ui/hooks/useProvider';
+import { KeyboardArrowLeft as KeyboardArrowLeftIcon } from '@mui/icons-material';
+import DescriptionIcon from '@mui/icons-material/Description';
+import TargetIcon from '@mui/icons-material/GpsFixed';
+import InfoIcon from '@mui/icons-material/Info';
+import ReviewIcon from '@mui/icons-material/RateReview';
+import SettingsIcon from '@mui/icons-material/Settings';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  Alert as MuiAlert,
+  Radio,
+  RadioGroup,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { Actions, Subjects } from '@shared/dto/rbac';
+import { useQueryClient } from '@tanstack/react-query';
+import { cloneDeep, isEqual } from 'lodash';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import DisplayTargetConfig from '../components/plugins/DisplayTargetConfig';
+import { makeProviderPurposeDiscoveryQueryKey } from '../hooks/providers';
+import ApplicationDescriptionForm from './components/ApplicationDescription';
+import ReviewPanel from './components/ReviewPanel';
+import type { ProviderConfigEditorRef } from '@cloud-ui/components/providers/ProviderConfigEditor';
+import type { ProviderOptions } from '@promptfoo/types';
+import type { UpdateProviderRequest } from '@shared/dto/providers';
+
+const DEFAULT_PROVIDER_CONFIG: UpdateProviderRequest = {
+  stateful: true,
+};
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+  '& .MuiTabs-indicator': {
+    left: 0,
+    right: 'auto',
+  },
+  width: '100%',
+  backgroundColor: theme.palette.background.paper,
+  '& .MuiTab-root': {
+    minHeight: '48px',
+  },
+  '& .MuiTabs-scrollButtons': {
+    display: 'none',
+  },
+}));
+
+const StyledTab = styled(Tab)(({ theme }) => ({
+  alignItems: 'center',
+  textAlign: 'left',
+  justifyContent: 'flex-start',
+  '&.Mui-selected': {
+    backgroundColor: theme.palette.action.selected,
+    borderLeft: `3px solid ${theme.palette.primary.main}`,
+  },
+  maxWidth: 'none',
+  width: '100%',
+  minHeight: '48px',
+  padding: theme.spacing(1, 2),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  '& .MuiSvgIcon-root': {
+    marginRight: theme.spacing(1),
+    fontSize: '18px',
+  },
+  textTransform: 'none',
+  fontSize: '0.875rem',
+}));
+
+const Root = styled(Box)(({ theme }) => ({
+  position: 'fixed',
+  top: 64,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: theme.palette.mode === 'dark' ? '#1e1e1e' : '#fff',
+  overflow: 'hidden',
+}));
+
+const PageHeader = styled(Box)(({ theme }) => ({
+  borderTop: `1px solid ${theme.palette.divider}`,
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  backgroundColor: theme.palette.background.paper,
+  '.headerContent': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(1, 2),
+    minHeight: 56,
+  },
+  '.leftSection': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  '.backButton': {
+    marginRight: theme.spacing(0.5),
+  },
+}));
+
+const MainContent = styled(Box)({
+  display: 'flex',
+  flex: 1,
+  overflow: 'hidden',
+});
+
+const OuterSidebarContainer = styled(Box)(({ theme }) => ({
+  width: '280px',
+  borderRight: `1px solid ${theme.palette.divider}`,
+  backgroundColor: theme.palette.background.paper,
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+const InnerSidebarContainer = styled(Box)({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+});
+
+const Content = styled(Box)({
+  flex: 1,
+  overflow: 'auto',
+  padding: '24px',
+});
+
+const TabContent = styled(Box)({
+  height: '100%',
+});
+
+const TabsContainer = styled(Box)({
+  flex: 1,
+  overflow: 'auto',
+});
+
+const Alert = styled(MuiAlert)(({ theme }) => ({
+  margin: theme.spacing(2),
+  backgroundColor: '#FFF1F1',
+  border: 'none',
+  '& .MuiAlert-icon': {
+    color: theme.palette.error.main,
+  },
+  '& ul': {
+    margin: '8px 0 0 0',
+    paddingLeft: '1.25rem',
+    listStyleType: 'none',
+  },
+  '& li': {
+    marginBottom: '4px',
+    '&::before': {
+      content: '"•"',
+      color: theme.palette.error.main,
+      display: 'inline-block',
+      width: '1em',
+      marginLeft: '-1em',
+    },
+  },
+}));
+
+export enum TabIndex {
+  TargetSelection = 0,
+  Configuration = 1,
+  ApplicationDetails = 2,
+  Context = 3,
+  Review = 4,
+}
+
+function TabPanel(props: { children?: React.ReactNode; index: number; value: number }) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <Box
+      role="tabpanel"
+      hidden={value !== index}
+      id={`tabpanel-${index}`}
+      aria-labelledby={`tab-${index}`}
+      sx={{ height: '100%' }}
+      {...other}
+    >
+      {value === index && <Box sx={{ height: '100%' }}>{children}</Box>}
+    </Box>
+  );
+}
+
+export default function EditTargetPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isNew = id === 'new';
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [descriptionError, setDescriptionError] = useState<string | null>(null);
+  const [configTabHasError, setConfigTabHasError] = useState<boolean>(isNew);
+  const [descriptionTabHasError, setDescriptionTabHasError] = useState<boolean>(isNew);
+  const [hasVisitedDescriptionTab, setHasVisitedDescriptionTab] = useState<boolean>(!isNew);
+  const [hasVisitedApplicationDetailsTab, setHasVisitedApplicationDetailsTab] = useState<boolean>(
+    !isNew,
+  );
+  const [validateAllFields, setValidateAllFields] = useState<boolean>(false);
+  const queryClient = useQueryClient();
+
+  // Define available tabs based on provider type
+  const tabs = useMemo<TabIndex[]>(() => {
+    // Initial tabs setup
+    return [
+      TabIndex.TargetSelection,
+      TabIndex.Configuration,
+      TabIndex.ApplicationDetails,
+      TabIndex.Context,
+      TabIndex.Review,
+    ];
+  }, []);
+
+  // References for validation
+  const configEditorRef = useRef<ProviderConfigEditorRef>(null);
+
+  // State for updates and target
+  const [updates, setUpdates] = useState<UpdateProviderRequest | undefined>(
+    isNew ? DEFAULT_PROVIDER_CONFIG : undefined,
+  );
+
+  const {
+    data: target,
+    isLoading,
+    error: fetchProviderError,
+    refetch: refetchTarget,
+  } = useProvider(id, !isNew);
+
+  const currentConfig = useMemo(() => {
+    if (!updates?.type || updates.type === target?.type) {
+      return { ...cloneDeep(target?.config), ...cloneDeep(updates?.config) };
+    }
+    return updates?.config ?? {};
+  }, [updates, target]);
+
+  const canEdit = useCan(Actions.UPDATE, Subjects.PROVIDER);
+
+  const [activeTab, setActiveTab] = useState<TabIndex>(() => {
+    const hash = location.hash.replace('#', '');
+    if (!isNew && !hash) {
+      return TabIndex.Review;
+    }
+    const parsedIndex = hash ? Number.parseInt(hash, 10) : 0;
+    // Map numeric index to TabIndex enum
+    switch (parsedIndex) {
+      case 0:
+        return TabIndex.TargetSelection;
+      case 1:
+        return TabIndex.Configuration;
+      case 2:
+        return TabIndex.ApplicationDetails;
+      case 3:
+        return TabIndex.Context;
+      case 4:
+        return TabIndex.Review;
+      default:
+        return TabIndex.TargetSelection;
+    }
+  });
+
+  useNavigateOnTeamChange(isNew, ROUTES.redteam.targets);
+
+  const providerType = updates?.type ?? target?.type ?? getProviderType(currentConfig?.id);
+
+  const handleUpdate = (key: keyof UpdateProviderRequest, value: any) => {
+    setUpdates((updates) => {
+      const newUpdates = { ...(updates ?? {}) };
+      newUpdates[key] = value;
+
+      // Check if value and value.config exist before using 'in' operator
+      if (
+        key === 'config' &&
+        value &&
+        value.config &&
+        typeof value.config === 'object' &&
+        'sessionSource' in value.config
+      ) {
+        newUpdates.sessionSource = value.config.sessionSource;
+      }
+      return newUpdates;
+    });
+  };
+
+  const saveMutation = useMutateProvider(id, isNew, async (savedProvider) => {
+    setUpdates(undefined);
+
+    if (!isNew) {
+      refetchTarget();
+    }
+    if (isNew) {
+      navigate(`${ROUTES.redteam.targets}/${savedProvider.id}#${activeTab}`);
+    }
+
+    // Reset the purpose discovery query: this allows the user to re-run discover e.g. if it errored because
+    // of a provider misconfiguration.
+    await queryClient.resetQueries({
+      queryKey: makeProviderPurposeDiscoveryQueryKey(savedProvider.id),
+      exact: true,
+    });
+  });
+
+  const isDirty = useMemo(() => {
+    return (
+      (updates?.name && updates?.name !== target?.name) ||
+      (updates?.config && !isEqual(updates?.config, target?.config)) ||
+      (updates?.applicationDescription &&
+        !isEqual(updates?.applicationDescription, target?.applicationDescription)) ||
+      (updates?.stateful !== undefined && updates?.stateful !== target?.stateful) ||
+      (updates?.type !== undefined && updates?.type !== target?.type) ||
+      (updates?.extensions !== undefined && !isEqual(updates?.extensions, target?.extensions))
+    );
+  }, [updates, currentConfig, target]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (updates) {
+        e.preventDefault();
+        e.returnValue = '';
+        return '';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [updates]);
+
+  useEffect(() => {
+    if (location.hash !== `#${activeTab}`) {
+      setActiveTab(Number(location.hash.replace('#', '')));
+    }
+  }, [location.hash]);
+
+  const updateHash = (newValue: TabIndex) => {
+    if (location.hash !== `#${newValue}`) {
+      navigate(`#${newValue}`);
+    }
+  };
+
+  // Convert logical tab index to actual tab index
+  const getActualTabIndex = (logicalIndex: TabIndex): number => {
+    return tabs.findIndex((tab) => tab === logicalIndex);
+  };
+
+  // Find next tab based on current tab and available tabs
+  const getNextTab = (currentTab: TabIndex): TabIndex => {
+    return tabs[currentTab + 1];
+  };
+
+  // Find previous tab based on current tab and available tabs
+  const getPreviousTab = (currentTab: TabIndex): TabIndex => {
+    const currentTabIndex = tabs.findIndex((tab) => tab === currentTab);
+    if (currentTabIndex > 0) {
+      return tabs[currentTabIndex - 1];
+    }
+    return currentTab;
+  };
+
+  const handleNext = () => {
+    const currentTab = tabs.includes(activeTab) ? activeTab : TabIndex.TargetSelection;
+
+    const nextTab = getNextTab(currentTab);
+    updateHash(nextTab);
+    setActiveTab(nextTab);
+  };
+
+  const handleBack = () => {
+    const currentTab = tabs.includes(activeTab) ? activeTab : TabIndex.Review;
+
+    const prevTab = getPreviousTab(currentTab);
+    updateHash(prevTab);
+    setActiveTab(prevTab);
+  };
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    // Find the actual tab from the tab array
+    // newValue is the index in the visible tabs array
+    const selectedTab = tabs[newValue];
+
+    if (selectedTab === TabIndex.Context) {
+      setHasVisitedDescriptionTab(true);
+    }
+
+    if (selectedTab === TabIndex.ApplicationDetails) {
+      setHasVisitedApplicationDetailsTab(true);
+    }
+
+    updateHash(selectedTab);
+    setActiveTab(selectedTab);
+  };
+
+  const handleConfigSetError = useCallback((errorMessage: string | null) => {
+    setConfigError(errorMessage);
+    setConfigTabHasError(!!errorMessage);
+  }, []);
+
+  const handleDescriptionSetError = (errorMessage: string | null) => {
+    setDescriptionError(errorMessage);
+    setDescriptionTabHasError(!!errorMessage);
+  };
+
+  // Handle provider selection/update from the ProviderTypeSelector
+  const handleProviderSelect = (providerOptions: ProviderOptions) => {
+    // Update the provider config
+    setUpdates((oldUpdates) => {
+      return {
+        ...oldUpdates,
+        name: oldUpdates?.name ?? '',
+      };
+    });
+    handleUpdate('type', getProviderType(providerOptions.id));
+    handleUpdate('config', providerOptions);
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (fetchProviderError) {
+    return <ErrorFallback error={new Error(`Failed to fetch target: ${fetchProviderError}`)} />;
+  }
+
+  const canSave = Boolean(
+    !saveMutation.isPending &&
+      isDirty &&
+      (currentConfig.name || updates?.name?.trim() || target?.name?.trim()),
+  );
+
+  const handleSave = () => {
+    setValidateAllFields(true);
+    saveMutation.mutate(updates ?? {});
+  };
+
+  const canProceedToNext = (currentTab: number): boolean => {
+    if (currentTab === TabIndex.TargetSelection) {
+      const hasName = Boolean(updates?.name && updates.name.length > 0) || Boolean(target?.name);
+      // Check for either an existing selection in updates or target
+      const hasTargetSelection = Boolean(providerType);
+
+      return hasName && hasTargetSelection;
+    }
+    if (currentTab === TabIndex.Configuration) {
+      return !configTabHasError && !configError;
+    }
+    if (currentTab === TabIndex.ApplicationDetails) {
+      return !descriptionTabHasError && !descriptionError;
+    }
+    if (currentTab === TabIndex.Context) {
+      return !descriptionTabHasError && !descriptionError;
+    }
+    return true;
+  };
+
+  // Function to get tab index based on actual visible tabs in the UI
+  const getTabId = (tabIndex: TabIndex): number => {
+    return tabs.findIndex((tab) => tab === tabIndex);
+  };
+
+  return (
+    <Root>
+      <PageHeader>
+        <div className="headerContent">
+          <div className="leftSection">
+            <IconButton
+              className="backButton"
+              onClick={() => navigate(ROUTES.redteam.targets)}
+              aria-label="back to targets list"
+            >
+              <KeyboardArrowLeftIcon />
+            </IconButton>
+            <Typography variant="h6">{updates?.name || target?.name || 'New Target'}</Typography>
+            {isDirty && canEdit && (
+              <Typography
+                variant="body2"
+                color="warning.main"
+                sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+              >
+                <span>●</span> Unsaved changes
+              </Typography>
+            )}
+          </div>
+          <div className="rightSection">
+            {canEdit && (
+              <Button variant="contained" onClick={handleSave} disabled={!canSave}>
+                {saveMutation.isPending ? 'Saving...' : 'Save Target'}
+              </Button>
+            )}
+          </div>
+        </div>
+      </PageHeader>
+
+      <MainContent>
+        <OuterSidebarContainer>
+          <InnerSidebarContainer>
+            <TabsContainer>
+              <StyledTabs
+                orientation="vertical"
+                variant="scrollable"
+                value={getActualTabIndex(activeTab)}
+                onChange={handleTabChange}
+              >
+                <StyledTab
+                  icon={<TargetIcon />}
+                  iconPosition="start"
+                  label="Target Selection"
+                  id={`tab-${getTabId(TabIndex.TargetSelection)}`}
+                  aria-controls={`tabpanel-${getTabId(TabIndex.TargetSelection)}`}
+                />
+                <StyledTab
+                  icon={<SettingsIcon />}
+                  iconPosition="start"
+                  label={
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      Configuration
+                      {configTabHasError && (
+                        <Box
+                          component="span"
+                          sx={{
+                            ml: 1,
+                            color: 'warning.main',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            fontSize: '1rem',
+                          }}
+                        >
+                          ⚠️
+                        </Box>
+                      )}
+                    </Box>
+                  }
+                  id={`tab-${getTabId(TabIndex.Configuration)}`}
+                  aria-controls={`tabpanel-${getTabId(TabIndex.Configuration)}`}
+                />
+                {tabs.includes(TabIndex.ApplicationDetails) && (
+                  <StyledTab
+                    icon={<InfoIcon />}
+                    iconPosition="start"
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        Application Details
+                        {!hasVisitedApplicationDetailsTab && (
+                          <Box
+                            component="span"
+                            sx={{
+                              ml: 1,
+                              color: 'primary.main',
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              fontSize: '0.75rem',
+                              width: '8px',
+                              height: '8px',
+                              borderRadius: '50%',
+                              backgroundColor: 'primary.main',
+                            }}
+                          />
+                        )}
+                        {hasVisitedApplicationDetailsTab && descriptionTabHasError && (
+                          <Box
+                            component="span"
+                            sx={{
+                              ml: 1,
+                              color: 'warning.main',
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                            }}
+                          >
+                            ⚠️
+                          </Box>
+                        )}
+                      </Box>
+                    }
+                    id={`tab-${getTabId(TabIndex.ApplicationDetails)}`}
+                    aria-controls={`tabpanel-${getTabId(TabIndex.ApplicationDetails)}`}
+                  />
+                )}
+                {tabs.includes(TabIndex.Context) && (
+                  <StyledTab
+                    icon={<DescriptionIcon />}
+                    iconPosition="start"
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        Context
+                        {!hasVisitedDescriptionTab && (
+                          <Box
+                            component="span"
+                            sx={{
+                              ml: 1,
+                              color: 'primary.main',
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              fontSize: '0.75rem',
+                              width: '8px',
+                              height: '8px',
+                              borderRadius: '50%',
+                              backgroundColor: 'primary.main',
+                            }}
+                          />
+                        )}
+                        {hasVisitedDescriptionTab && descriptionTabHasError && (
+                          <Box
+                            component="span"
+                            sx={{
+                              ml: 1,
+                              color: 'warning.main',
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                            }}
+                          >
+                            ⚠️
+                          </Box>
+                        )}
+                      </Box>
+                    }
+                    id={`tab-${getTabId(TabIndex.Context)}`}
+                    aria-controls={`tabpanel-${getTabId(TabIndex.Context)}`}
+                  />
+                )}
+                <StyledTab
+                  icon={<ReviewIcon />}
+                  iconPosition="start"
+                  label="Review"
+                  id={`tab-${getTabId(TabIndex.Review)}`}
+                  aria-controls={`tabpanel-${getTabId(TabIndex.Review)}`}
+                />
+              </StyledTabs>
+            </TabsContainer>
+          </InnerSidebarContainer>
+        </OuterSidebarContainer>
+
+        <Content>
+          <TabContent>
+            <TabPanel value={activeTab} index={TabIndex.TargetSelection}>
+              <Box
+                sx={{
+                  maxWidth: 'max(85%, 1200px)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <TextField
+                  sx={{ mb: 3, width: '375px' }}
+                  label="Target Name"
+                  value={updates?.name ?? target?.name ?? ''}
+                  placeholder="e.g. customer-service-agent"
+                  onChange={(e) => handleUpdate('name', e.target.value)}
+                  margin="normal"
+                  required
+                  autoFocus
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                  error={Boolean(updates?.name === '')}
+                  helperText={updates?.name === '' && 'This field is required'}
+                  disabled={!canEdit}
+                />
+
+                <ProviderTypeSelector
+                  provider={currentConfig}
+                  setProvider={handleProviderSelect}
+                  disableModelSelection={false}
+                  providerType={providerType}
+                />
+              </Box>
+
+              <Box
+                sx={{
+                  maxWidth: 'max(85%, 1200px)',
+                  my: 4,
+
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Box>
+                  {!((updates?.name && updates.name.length > 0) || Boolean(target?.name)) && (
+                    <Typography variant="caption" color="error" sx={{ mr: 2 }}>
+                      Target name is required
+                    </Typography>
+                  )}
+                  {!providerType && (
+                    <Typography variant="caption" color="error">
+                      Target type selection is required
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  variant="contained"
+                  onClick={handleNext}
+                  disabled={!canProceedToNext(TabIndex.TargetSelection)}
+                >
+                  Next
+                </Button>
+              </Box>
+            </TabPanel>
+
+            <TabPanel value={activeTab} index={TabIndex.Configuration}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  maxWidth: 'max(85%, 1200px)',
+                  flexDirection: 'column',
+                  gap: 2,
+                }}
+              >
+                {configTabHasError && configError && (
+                  <Alert severity="error" sx={{ mb: 2 }}>
+                    {configError}
+                  </Alert>
+                )}
+                {canEdit ? (
+                  <ProviderConfigEditor
+                    ref={configEditorRef}
+                    providerType={providerType}
+                    provider={currentConfig}
+                    setProvider={(value) => handleUpdate('config', value)}
+                    extensions={updates?.extensions ?? target?.extensions ?? []}
+                    onExtensionsChange={(value) => handleUpdate('extensions', value)}
+                    opts={{
+                      hideErrors: false,
+                      disableModelSelection: false,
+                    }}
+                    setError={handleConfigSetError}
+                    validateAll={validateAllFields}
+                    onValidate={(isValid) => {
+                      // We can use this to track validation state
+                      setConfigTabHasError(!isValid);
+                    }}
+                  />
+                ) : (
+                  <DisplayTargetConfig config={target?.config} />
+                )}
+                <Box sx={{ pb: 8, display: 'flex', justifyContent: 'space-between' }}>
+                  <Button variant="outlined" onClick={handleBack}>
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={handleNext}
+                    disabled={!canProceedToNext(TabIndex.Configuration)}
+                  >
+                    Next
+                  </Button>
+                </Box>
+              </Box>
+            </TabPanel>
+
+            {tabs.includes(TabIndex.ApplicationDetails) && (
+              <TabPanel value={activeTab} index={TabIndex.ApplicationDetails}>
+                <Box
+                  sx={{ maxWidth: 'max(85%, 1200px)', display: 'flex', flexDirection: 'column' }}
+                >
+                  <Typography variant="h6" sx={{ mb: 3, fontWeight: 'medium' }}>
+                    Application Details
+                  </Typography>
+                  <ApplicationDescriptionForm
+                    data={updates?.applicationDescription ?? target?.applicationDescription ?? {}}
+                    onUpdate={(value) => handleUpdate('applicationDescription', value)}
+                    setError={handleDescriptionSetError}
+                    canEdit={canEdit}
+                    currentConfig={currentConfig}
+                    providerId={target?.id ?? null}
+                  />
+                </Box>
+                <Box
+                  sx={{
+                    my: 4,
+                    pb: 8,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    maxWidth: 'max(85%, 1200px)',
+                  }}
+                >
+                  <Button variant="outlined" onClick={handleBack}>
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={handleNext}
+                    disabled={!canProceedToNext(TabIndex.ApplicationDetails)}
+                  >
+                    Next
+                  </Button>
+                </Box>
+              </TabPanel>
+            )}
+
+            {tabs.includes(TabIndex.Context) && (
+              <TabPanel value={activeTab} index={TabIndex.Context}>
+                <Box
+                  sx={{ maxWidth: 'max(85%, 1200px)', display: 'flex', flexDirection: 'column' }}
+                >
+                  <Typography variant="h6" sx={{ mb: 3, fontWeight: 'medium' }}>
+                    Application Context
+                  </Typography>
+                  <FormControl sx={{ mb: 4 }} component="fieldset">
+                    <Typography variant="subtitle1" sx={{ mb: 2 }}>
+                      Conversation History
+                    </Typography>
+                    <RadioGroup
+                      value={String(
+                        updates && 'stateful' in updates
+                          ? updates.stateful
+                          : (target?.stateful ?? false),
+                      )}
+                      onChange={(e) => handleUpdate('stateful', e.target.value === 'true')}
+                    >
+                      <FormControlLabel
+                        value="true"
+                        control={<Radio />}
+                        label="System maintains conversation history"
+                        disabled={!canEdit}
+                      />
+                      <FormControlLabel
+                        value="false"
+                        control={<Radio />}
+                        label="The whole conversation gets sent on every request or there is no conversation history"
+                        disabled={!canEdit}
+                      />
+                    </RadioGroup>
+                  </FormControl>
+                  <Box sx={{ mb: 4 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'medium', mb: 1 }}>
+                      Who is the red team user?
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      Define the persona attempting to attack your system. This helps create
+                      realistic attack scenarios for social engineering attacks targeting PII,
+                      hijacking attempts, prompt extraction, system prompt override, and role-based
+                      security vulnerabilities.
+                    </Typography>
+                    <TextField
+                      fullWidth
+                      value={
+                        updates?.applicationDescription?.redteamUser ??
+                        target?.applicationDescription?.redteamUser ??
+                        ''
+                      }
+                      onChange={(e) =>
+                        handleUpdate('applicationDescription', {
+                          ...(updates?.applicationDescription ??
+                            target?.applicationDescription ??
+                            {}),
+                          redteamUser: e.target.value,
+                        })
+                      }
+                      placeholder="e.g. A patient seeking medical assistance, a customer service representative, an external researcher..."
+                      disabled={!canEdit}
+                      multiline
+                      minRows={2}
+                      variant="outlined"
+                      sx={{
+                        '& .MuiInputBase-inputMultiline': {
+                          resize: 'vertical',
+                          minHeight: '56px',
+                        },
+                      }}
+                    />
+                  </Box>
+                  <Box sx={{ mb: 4 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 'medium', mb: 1 }}>
+                      Test Generation Instructions
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      Provide specific instructions for how tests should be generated for this
+                      target. This helps customize the red teaming approach based on your
+                      application's specific requirements and constraints.
+                    </Typography>
+                    <TextField
+                      fullWidth
+                      value={
+                        updates?.applicationDescription?.testGenerationInstructions ??
+                        target?.applicationDescription?.testGenerationInstructions ??
+                        ''
+                      }
+                      onChange={(e) =>
+                        handleUpdate('applicationDescription', {
+                          ...(updates?.applicationDescription ??
+                            target?.applicationDescription ??
+                            {}),
+                          testGenerationInstructions: e.target.value,
+                        })
+                      }
+                      placeholder="e.g. Every test should begin by asking about a health plan, and then ask about a specific health plan"
+                      disabled={!canEdit}
+                      multiline
+                      minRows={3}
+                      variant="outlined"
+                      sx={{
+                        '& .MuiInputBase-inputMultiline': {
+                          resize: 'vertical',
+                          minHeight: '72px',
+                        },
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <Box
+                  sx={{
+                    maxWidth: 'max(85%, 1200px)',
+                    my: 4,
+                    pb: 8,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <Button variant="outlined" onClick={handleBack}>
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={handleNext}
+                    disabled={!canProceedToNext(TabIndex.Context)}
+                  >
+                    Next
+                  </Button>
+                </Box>
+              </TabPanel>
+            )}
+
+            <TabPanel value={activeTab} index={TabIndex.Review}>
+              <ReviewPanel target={target} updates={updates} canEdit={canEdit} isNew={isNew} />
+              <Box sx={{ mt: 4, pb: 4, display: 'flex', justifyContent: 'space-between' }}>
+                <Button variant="outlined" onClick={handleBack}>
+                  Back
+                </Button>
+                {isNew || isDirty ? (
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleSave}
+                    disabled={!canSave}
+                  >
+                    {saveMutation.isPending ? 'Saving...' : 'Save Target'}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={() =>
+                      navigate(
+                        ROUTES.redteam.target.dashboard.replace(
+                          ':targetId',
+                          encodeURIComponent(target?.id ?? ''),
+                        ),
+                      )
+                    }
+                  >
+                    Go to Target Overview
+                  </Button>
+                )}
+              </Box>
+            </TabPanel>
+          </TabContent>
+        </Content>
+      </MainContent>
+    </Root>
+  );
+}

--- a/src/app/src/pages/redteam/setup/components/Targets/index.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/index.test.tsx
@@ -1,14 +1,270 @@
 import React from 'react';
 
+import { useTelemetry } from '@app/hooks/useTelemetry';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import CustomTargetConfiguration from './CustomTargetConfiguration';
+import Targets from './index';
+
+// Mock dependencies
+vi.mock('../../hooks/useRedTeamConfig');
+vi.mock('@app/hooks/useTelemetry');
+vi.mock('@app/utils/api');
+
+const mockUseTelemetry = vi.mocked(useTelemetry);
+const mockUseRedTeamConfig = vi.mocked(useRedTeamConfig);
 
 const renderWithTheme = (ui: React.ReactElement) => {
   const theme = createTheme({ palette: { mode: 'light' } });
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 };
+
+describe('Targets Component', () => {
+  let mockUpdateConfig: ReturnType<typeof vi.fn>;
+  let mockRecordEvent: ReturnType<typeof vi.fn>;
+  let mockOnNext: ReturnType<typeof vi.fn>;
+  let mockOnBack: ReturnType<typeof vi.fn>;
+
+  const defaultConfig = {
+    target: {
+      id: 'http',
+      label: 'Test Target',
+      config: { url: 'https://example.com' },
+    },
+  };
+
+  beforeEach(() => {
+    mockUpdateConfig = vi.fn();
+    mockRecordEvent = vi.fn();
+    mockOnNext = vi.fn();
+    mockOnBack = vi.fn();
+
+    mockUseRedTeamConfig.mockReturnValue({
+      config: defaultConfig,
+      updateConfig: mockUpdateConfig,
+    });
+
+    mockUseTelemetry.mockReturnValue({
+      recordEvent: mockRecordEvent,
+      identifyUser: vi.fn(),
+      isInitialized: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render with default HTTP target selected', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    expect(screen.getByDisplayValue('HTTP/HTTPS Endpoint')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Test Target')).toBeInTheDocument();
+  });
+
+  it('should initialize selectedTargetType correctly for HTTP target', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    expect(select).toHaveValue('http');
+  });
+
+  it('should initialize selectedTargetType as custom for unknown target ids', () => {
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        target: {
+          id: 'unknown-provider',
+          label: 'Unknown Target',
+          config: {},
+        },
+      },
+      updateConfig: mockUpdateConfig,
+    });
+
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    expect(select).toHaveValue('custom');
+  });
+
+  it('should handle target type change to custom', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const customOption = await screen.findByText('Custom Target');
+    fireEvent.click(customOption);
+
+    expect(mockRecordEvent).toHaveBeenCalledWith('feature_used', {
+      feature: 'redteam_config_target_changed',
+      target: 'custom',
+    });
+
+    // Should show custom target configuration
+    await waitFor(() => {
+      expect(screen.getByLabelText('Target ID')).toBeInTheDocument();
+    });
+  });
+
+  it('should handle target type change to websocket', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const websocketOption = await screen.findByText('WebSocket Endpoint');
+    fireEvent.click(websocketOption);
+
+    expect(mockRecordEvent).toHaveBeenCalledWith('feature_used', {
+      feature: 'redteam_config_target_changed',
+      target: 'websocket',
+    });
+
+    // Should show websocket configuration
+    await waitFor(() => {
+      expect(screen.getByLabelText('WebSocket URL')).toBeInTheDocument();
+    });
+  });
+
+  it('should handle target type change to javascript custom provider', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const jsOption = await screen.findByText('JavaScript (Custom)');
+    fireEvent.click(jsOption);
+
+    // Should show custom target input for JavaScript
+    await waitFor(() => {
+      expect(screen.getByLabelText('Custom Target')).toBeInTheDocument();
+    });
+  });
+
+  it('should update target label', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const labelInput = screen.getByLabelText('Target Name');
+    fireEvent.change(labelInput, { target: { value: 'New Target Name' } });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith(
+      'target',
+      expect.objectContaining({
+        label: 'New Target Name',
+      }),
+    );
+  });
+
+  it('should show missing fields validation', () => {
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        target: {
+          id: 'http',
+          label: '', // Empty label should trigger validation
+          config: { url: '' }, // Empty URL should trigger validation
+        },
+      },
+      updateConfig: mockUpdateConfig,
+    });
+
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    expect(screen.getByText(/Missing required fields: Target Name, URL/)).toBeInTheDocument();
+
+    const nextButton = screen.getByRole('button', { name: /Next/ });
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('should enable next button when all required fields are filled', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const nextButton = screen.getByRole('button', { name: /Next/ });
+    expect(nextButton).not.toBeDisabled();
+  });
+
+  it('should call onNext when next button is clicked', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const nextButton = screen.getByRole('button', { name: /Next/ });
+    fireEvent.click(nextButton);
+
+    expect(mockOnNext).toHaveBeenCalled();
+  });
+
+  it('should call onBack when back button is clicked', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const backButton = screen.getByRole('button', { name: /Back/ });
+    fireEvent.click(backButton);
+
+    expect(mockOnBack).toHaveBeenCalled();
+  });
+
+  it('should show HTTP configuration when HTTP target is selected', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    // Should show HTTP-specific fields
+    expect(screen.getByLabelText('URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Method')).toBeInTheDocument();
+  });
+
+  it('should enable testing for HTTP targets', () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    expect(screen.getByRole('button', { name: /Test Target/ })).toBeInTheDocument();
+  });
+
+  it('should not show testing option for non-HTTP targets', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const customOption = await screen.findByText('Custom Target');
+    fireEvent.click(customOption);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Test Target/ })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show prompts section for targets that require prompts', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const gptOption = await screen.findByText('OpenAI GPT-4o');
+    fireEvent.click(gptOption);
+
+    await waitFor(() => {
+      expect(screen.getByText('Prompts')).toBeInTheDocument();
+    });
+  });
+
+  it('should preserve select display when custom target id is edited', async () => {
+    renderWithTheme(<Targets onNext={mockOnNext} onBack={mockOnBack} setupModalOpen={false} />);
+
+    // Switch to custom target
+    const select = screen.getByLabelText('Target Type');
+    fireEvent.mouseDown(select);
+
+    const customOption = await screen.findByText('Custom Target');
+    fireEvent.click(customOption);
+
+    // Edit the target ID
+    await waitFor(async () => {
+      const targetIdInput = screen.getByLabelText('Target ID');
+      fireEvent.change(targetIdInput, { target: { value: 'my-custom-provider' } });
+
+      // Select should still show "Custom Target"
+      expect(select).toHaveValue('custom');
+    });
+  });
+});
 
 describe('CustomTargetConfiguration - Config Field Handling', () => {
   let mockUpdateCustomTarget: ReturnType<typeof vi.fn>;
@@ -143,5 +399,31 @@ describe('updateCustomTarget function behavior', () => {
 
     expect(result.config).toEqual(newConfig);
     expect(result.config).not.toHaveProperty('config'); // No nesting
+  });
+
+  it('should handle delay field correctly', () => {
+    const mockSelectedTarget: any = {
+      id: 'custom',
+      config: { temperature: 0.5 },
+      label: 'Custom Target',
+    };
+
+    const updateCustomTarget = (field: string, value: any) => {
+      const updatedTarget = { ...mockSelectedTarget };
+
+      if (field === 'delay') {
+        updatedTarget.delay = value;
+      } else if (field === 'config') {
+        updatedTarget.config = value;
+      } else {
+        (updatedTarget.config as any)[field] = value;
+      }
+
+      return updatedTarget;
+    };
+
+    const result = updateCustomTarget('delay', 1000);
+    expect(result).toHaveProperty('delay', 1000);
+    expect(result.config).not.toHaveProperty('delay');
   });
 });


### PR DESCRIPTION
this fixes an issue where when selecting `Custom Target`, the type select would be empty, because it's predicated on the target's `id`, for which custom is blank- the user will add that. This change de-couples the display from the configuration by adding a target type state.


### Before
<img width="981" height="671" alt="Screenshot 2025-07-28 at 8 43 07 AM" src="https://github.com/user-attachments/assets/ab7eabb8-75d6-4ead-b096-c68421f5a2a6" />



### After
<img width="1088" height="701" alt="Screenshot 2025-07-28 at 8 42 34 AM" src="https://github.com/user-attachments/assets/2795241c-6c35-4f49-9b39-d539710cf1c1" />
