### PR TITLE
fix: replace broken Ashby iframe with link to careers page

### DIFF
--- a/site/blog/hacker-summer-camp.md
+++ b/site/blog/hacker-summer-camp.md
@@ -86,14 +86,7 @@ We're throwing an open bar [party](https://promptfoo.dev/events/defcon-2025) at 
 
 We're also expanding the team! If you're looking for a new role as an AI red teamer, deployment engineer, or software engineer, we would love to talk with you.
 
-<iframe
-  src="https://jobs.ashbyhq.com/promptfoo/embed"
-  width="100%"
-  height="525"
-  frameBorder="0"
-  aria-hidden="false"
-  tabIndex="0"
-/>
+[View open positions on our careers page →](https://promptfoo.dev/careers)
 
 ## See You There
 


### PR DESCRIPTION
The Ashby iframe in the hacker summer camp blog post was trying to load a JS file as an iframe source. Replaced with a link to the careers page where the proper Ashby integration is implemented.