### PR TITLE
fix: Adjust padding on docs sidebar to prevent overlap

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -71,7 +71,7 @@ code p {
 }
 
 .theme-doc-sidebar-container > div > div {
-  padding-top: 1rem !important;
+  padding-top: calc(1rem + 45px) !important;
 }
 
 .navbar__brand {


### PR DESCRIPTION
### Before
<img width="1129" height="536" alt="Screenshot 2025-07-29 at 8 48 45 AM" src="https://github.com/user-attachments/assets/43f2a624-8859-486d-a72d-d6b864ffa139" />

### After
<img width="1278" height="794" alt="Screenshot 2025-07-29 at 8 47 39 AM" src="https://github.com/user-attachments/assets/f0c44ffe-5a17-4f1d-bf74-c16b6e3201b5" />
