### PR TITLE
fix(internals): Database migration script

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,24 +1,27 @@
 import * as path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { getDb } from './database';
-import logger from './logger';
+
+//@ts-expect-error
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 /**
  * Run migrations on the database, skipping the ones already applied. Also creates the sqlite db if it doesn't exist.
  */
-export async function runDbMigrations() {
+export function runDbMigrations() {
   try {
     const db = getDb();
     const migrationsFolder = path.join(__dirname, '..', 'drizzle');
-    logger.debug(`[DB Migrate] Running migrations from ${migrationsFolder}...`);
-    await migrate(db, { migrationsFolder });
-    logger.debug('[DB Migrate] Migrations completed');
+    console.log(`[DB Migrate] Running migrations from ${migrationsFolder}...`);
+    migrate(db, { migrationsFolder });
+    console.log('[DB Migrate] Migrations completed');
   } catch (error) {
-    logger.error(`Error running database migrations: ${error}`);
+    console.error(`Error running database migrations: ${error}`);
   }
 }
 
-if (require.main === module) {
-  runDbMigrations();
-}
+runDbMigrations();


### PR DESCRIPTION
- `npm run db:migrate` is broken
- Log statements also don't print to terminal