### PR TITLE
fix: make database migrations non-blocking and fix error handling

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -6,19 +6,33 @@ import logger from './logger';
 
 /**
  * Run migrations on the database, skipping the ones already applied. Also creates the sqlite db if it doesn't exist.
+ *
+ * Note: While the underlying drizzle-orm migrate() function is synchronous, we wrap it in a Promise
+ * with setImmediate to avoid blocking the event loop during startup. This allows other async
+ * operations to proceed while migrations run.
  */
-export async function runDbMigrations() {
-  try {
-    const db = getDb();
-    const migrationsFolder = path.join(__dirname, '..', 'drizzle');
-    logger.debug(`[DB Migrate] Running migrations from ${migrationsFolder}...`);
-    await migrate(db, { migrationsFolder });
-    logger.debug('[DB Migrate] Migrations completed');
-  } catch (error) {
-    logger.error(`Error running database migrations: ${error}`);
-  }
+export async function runDbMigrations(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Run the synchronous migration in the next tick to avoid blocking
+    setImmediate(() => {
+      try {
+        const db = getDb();
+        const migrationsFolder = path.join(__dirname, '..', 'drizzle');
+        logger.debug(`Running database migrations...`);
+        migrate(db, { migrationsFolder });
+        logger.debug('Database migrations completed');
+        resolve();
+      } catch (error) {
+        logger.error(`Database migration failed: ${error}`);
+        reject(error);
+      }
+    });
+  });
 }
 
 if (require.main === module) {
-  runDbMigrations();
+  // Run migrations and exit with appropriate code
+  runDbMigrations()
+    .then(() => process.exit(0))
+    .catch(() => process.exit(1));
 }

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../src/logger', () => ({
 }));
 
 jest.mock('../../../src/migrate', () => ({
-  runDbMigrations: jest.fn(),
+  runDbMigrations: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../src/telemetry', () => ({

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -33,7 +33,7 @@ jest.mock('../../../src/evaluator', () => ({
 
 // Mock other dependencies to prevent actual execution
 jest.mock('../../../src/migrate', () => ({
-  runDbMigrations: jest.fn().mockResolvedValue({}),
+  runDbMigrations: jest.fn().mockResolvedValue(undefined),
 }));
 
 // Mock the table generation


### PR DESCRIPTION
## Summary
- Wrap synchronous SQLite migrations in `setImmediate()` to prevent blocking the event loop during startup
- Fix error handling so migrations properly propagate failures instead of silently continuing
- Add proper exit codes when running `npm run db:migrate` directly

## Problem
The current migration implementation has several issues:
1. Synchronous SQLite operations block the Node.js event loop during CLI/server startup
2. Errors are logged but not propagated, leading to silent failures
3. No exit codes when run directly, breaking CI/CD pipelines
4. Unnecessarily verbose logging

## Solution  
- Use `setImmediate()` to defer migrations to the next tick, allowing other async operations to proceed
- Properly reject the promise on errors so callers can handle failures
- Exit with code 0 on success, 1 on failure when run directly
- Simplify logging: silent on success, clear error messages only when needed

## Test plan
- [x] Run `npm run db:migrate` - should be silent on success
- [x] Run `pnpm run db:migrate` - should work correctly  
- [x] Test error case by renaming migrations folder - should show error and exit with code 1
- [x] All tests pass (`npm test`)
- [x] Debug logging still works with `LOG_LEVEL=debug npm run db:migrate`