### PR TITLE
fix(providers): correct WebP image detection in Google provider

### DIFF
--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -417,7 +417,7 @@ function isValidBase64Image(data: string): boolean {
       data.startsWith('/9j/') || // JPEG
       data.startsWith('iVBORw0KGgo') || // PNG
       data.startsWith('R0lGODlh') || // GIF
-      data.startsWith('UklGRg') // WebP
+      data.startsWith('UklGR') // WebP
     );
   } catch {
     return false;
@@ -431,7 +431,7 @@ function getMimeTypeFromBase64(base64Data: string): string {
     return 'image/png';
   } else if (base64Data.startsWith('R0lGODlh')) {
     return 'image/gif';
-  } else if (base64Data.startsWith('UklGRg')) {
+  } else if (base64Data.startsWith('UklGR')) {
     return 'image/webp';
   }
   // Default to jpeg for unknown formats


### PR DESCRIPTION
## Summary
Fixes WebP image detection in the Google provider by correcting the base64 signature check from "UklGRg" to "UklGR".

## Problem
The Google provider was checking for WebP files starting with the Base64-encoded string "UklGRg", but it should be "UklGR" (without the trailing "g"). This was causing WebP images to not be properly recognized when using the Google Gemini provider.

## Root Cause
WebP files start with the ASCII characters "RIFF" followed by the file size as a uint32. When encoding "RIFF" (32 bits) in Base64 (which uses 6-bit groupings), it results in "UklGR" (5 characters × 6 bits = 30 bits), with 2 bits left over that carry into the next Base64 grouping. Since the next bytes are the file size (which is variable), the next character after "UklGR" is variable.

## Changes
- Fixed WebP detection in `isValidBase64Image()` function
- Fixed WebP detection in `getMimeTypeFromBase64()` function
- Added comprehensive test cases for WebP image detection with various file sizes

## Test plan
- [x] All existing tests pass
- [x] Added new tests specifically for WebP image detection
- [x] Tests verify WebP images with different file sizes are correctly detected
- [x] Code has been linted and formatted

Relates to #5169