### PR TITLE
feat: add google vertex credentials in config

### DIFF
--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -770,7 +770,6 @@ For more details, see the [Google documentation on Grounding with Google Search]
 ## See Also
 
 - [Google AI Studio Provider](/docs/providers/google) - For direct Google AI Studio integration
-- [Google Vertex Credentials Example](https://github.com/promptfoo/promptfoo/tree/main/examples/google-vertex-credentials) - Working example of using service account credentials
 - [Vertex AI Examples](https://github.com/promptfoo/promptfoo/tree/main/examples) - Browse working examples for Vertex AI
 - [Google Cloud Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs) - Official Vertex AI documentation
 - [Model Garden](https://console.cloud.google.com/vertex-ai/publishers) - Access and enable additional models

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -187,7 +187,37 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
 export VERTEX_PROJECT_ID="your-project-id"
 ```
 
-#### Option 3: Direct API Key (Quick Testing)
+#### Option 3: Service Account via Config (Alternative)
+
+You can also provide service account credentials directly in your configuration:
+
+```yaml
+providers:
+  - id: vertex:gemini-2.5-pro
+    config:
+      # Load credentials from file
+      credentials: 'file://service-account.json'
+      projectId: 'your-project-id'
+```
+
+Or with inline credentials (not recommended for production):
+
+```yaml
+providers:
+  - id: vertex:gemini-2.5-pro
+    config:
+      credentials: '{"type":"service_account","project_id":"..."}'
+      projectId: 'your-project-id'
+```
+
+This approach:
+
+- Allows per-provider authentication
+- Enables using different service accounts for different models
+- Simplifies credential management in complex setups
+- Avoids the need for environment variables
+
+#### Option 4: Direct API Key (Quick Testing)
 
 For quick testing, you can use a temporary access token:
 
@@ -201,7 +231,7 @@ export VERTEX_PROJECT_ID="your-project-id"
 
 **Note:** Access tokens expire after 1 hour. For long-running evaluations, use Application Default Credentials or Service Account authentication.
 
-#### 4. Environment Variables
+#### 5. Environment Variables
 
 Promptfoo automatically loads environment variables from your shell or a `.env` file. Create a `.env` file in your project root:
 
@@ -355,8 +385,11 @@ jobs:
 providers:
   - id: vertex:gemini-2.5-pro
     config:
+      # Authentication options
+      credentials: 'file://service-account.json' # Optional: Use specific service account
       projectId: ${VERTEX_PROJECT_ID}
       region: ${VERTEX_REGION:-us-central1}
+
       generationConfig:
         temperature: 0.2
         maxOutputTokens: 2048
@@ -475,7 +508,8 @@ defaultTest:
 | `apiKey`                           | GCloud API token                                 | None                                 |
 | `apiHost`                          | API host override                                | `{region}-aiplatform.googleapis.com` |
 | `apiVersion`                       | API version                                      | `v1`                                 |
-| `projectId`                        | GCloud project ID                                | None                                 |
+| `credentials`                      | Service account credentials (JSON or file path)  | None                                 |
+| `projectId`                        | GCloud project ID                                | `VERTEX_PROJECT_ID` env var          |
 | `region`                           | GCloud region                                    | `us-central1`                        |
 | `publisher`                        | Model publisher                                  | `google`                             |
 | `context`                          | Model context                                    | None                                 |
@@ -736,6 +770,7 @@ For more details, see the [Google documentation on Grounding with Google Search]
 ## See Also
 
 - [Google AI Studio Provider](/docs/providers/google) - For direct Google AI Studio integration
+- [Google Vertex Credentials Example](https://github.com/promptfoo/promptfoo/tree/main/examples/google-vertex-credentials) - Working example of using service account credentials
 - [Vertex AI Examples](https://github.com/promptfoo/promptfoo/tree/main/examples) - Browse working examples for Vertex AI
 - [Google Cloud Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs) - Official Vertex AI documentation
 - [Model Garden](https://console.cloud.google.com/vertex-ai/publishers) - Access and enable additional models

--- a/src/providers/adaline.gateway.ts
+++ b/src/providers/adaline.gateway.ts
@@ -210,7 +210,10 @@ export class AdalineGatewayEmbeddingProvider extends AdalineGatewayGenericProvid
         });
       } else if (this.providerName === 'vertex') {
         const provider = new GatewayVertex();
-        const parentClass = new VertexEmbeddingProvider(this.modelName, this.config, this.env);
+        const parentClass = new VertexEmbeddingProvider(this.modelName, {
+          config: this.config,
+          env: this.env,
+        });
         const client = await parentClass.getClientWithCredentials();
         const projectId = await parentClass.getProjectId();
         const token = await client.getAccessToken();

--- a/src/providers/adaline.gateway.ts
+++ b/src/providers/adaline.gateway.ts
@@ -18,7 +18,6 @@ import { AzureChatCompletionProvider } from './azure/chat';
 import { AzureEmbeddingProvider } from './azure/embedding';
 import { calculateAzureCost } from './azure/util';
 import { AIStudioChatProvider } from './google/ai.studio';
-import { getGoogleClient } from './google/util';
 import { VertexChatProvider, VertexEmbeddingProvider } from './google/vertex';
 import { GroqProvider } from './groq';
 import { OpenAiChatCompletionProvider } from './openai/chat';
@@ -211,8 +210,9 @@ export class AdalineGatewayEmbeddingProvider extends AdalineGatewayGenericProvid
         });
       } else if (this.providerName === 'vertex') {
         const provider = new GatewayVertex();
-        const parentClass = new VertexEmbeddingProvider(this.modelName, this.providerOptions);
-        const { client, projectId } = await getGoogleClient();
+        const parentClass = new VertexEmbeddingProvider(this.modelName, this.config, this.env);
+        const client = await parentClass.getClientWithCredentials();
+        const projectId = await parentClass.getProjectId();
         const token = await client.getAccessToken();
         gatewayEmbeddingModel = provider.embeddingModel({
           modelName: this.modelName,
@@ -448,8 +448,12 @@ export class AdalineGatewayChatProvider extends AdalineGatewayGenericProvider {
           gatewayConfig.presencePenalty ?? getEnvFloat('OPENAI_PRESENCE_PENALTY', 0);
       } else if (this.providerName === 'vertex') {
         const provider = new GatewayVertex();
-        const parentClass = new VertexChatProvider(this.modelName, this.providerOptions);
-        const { client, projectId } = await getGoogleClient();
+        const parentClass = new VertexChatProvider(this.modelName, {
+          config: this.config as any,
+          env: this.env,
+        });
+        const client = await parentClass.getClientWithCredentials();
+        const projectId = await parentClass.getProjectId();
         const token = await client.getAccessToken();
         if (token === null) {
           throw new Error('Vertex API token is not set. Please configure the Google Cloud SDK');

--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -97,6 +97,7 @@ export interface CompletionOptions {
   apiVersion?: string; // For Live API: 'v1alpha' or 'v1' (default: v1alpha)
   anthropicVersion?: string;
   anthropic_version?: string; // Alternative format
+  credentials?: string; // Google service account credentials JSON string or file:// path
 
   // https://ai.google.dev/api/rest/v1beta/models/streamGenerateContent#request-body
   context?: string;

--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -97,7 +97,14 @@ export interface CompletionOptions {
   apiVersion?: string; // For Live API: 'v1alpha' or 'v1' (default: v1alpha)
   anthropicVersion?: string;
   anthropic_version?: string; // Alternative format
-  credentials?: string; // Google service account credentials JSON string or file:// path
+  /**
+   * Google service account credentials.
+   * Can be:
+   * 1. JSON string containing service account key
+   * 2. File path prefixed with 'file://' to load from external file
+   * 3. Undefined to use default authentication (Application Default Credentials)
+   */
+  credentials?: string;
 
   // https://ai.google.dev/api/rest/v1beta/models/streamGenerateContent#request-body
   context?: string;

--- a/test/providers/google/image.test.ts
+++ b/test/providers/google/image.test.ts
@@ -7,18 +7,26 @@ jest.mock('../../../src/cache', () => ({
 
 jest.mock('../../../src/providers/google/util', () => ({
   getGoogleClient: jest.fn(),
+  loadCredentials: jest.fn(),
+  resolveProjectId: jest.fn(),
 }));
 
 describe('GoogleImageProvider', () => {
   const mockFetchWithCache = fetchWithCache as jest.Mock;
-  const mockGetGoogleClient = require('../../../src/providers/google/util')
-    .getGoogleClient as jest.Mock;
+  const utilMocks = require('../../../src/providers/google/util');
+  const mockGetGoogleClient = utilMocks.getGoogleClient as jest.Mock;
+  const mockLoadCredentials = utilMocks.loadCredentials as jest.Mock;
+  const mockResolveProjectId = utilMocks.resolveProjectId as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.GOOGLE_API_KEY = 'test-api-key';
     delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     delete process.env.GEMINI_API_KEY;
+    
+    // Set up default mock behaviors
+    mockLoadCredentials.mockImplementation((creds) => creds);
+    mockResolveProjectId.mockResolvedValue('test-project');
   });
 
   afterEach(() => {

--- a/test/providers/google/image.test.ts
+++ b/test/providers/google/image.test.ts
@@ -1,5 +1,5 @@
-import { GoogleImageProvider } from '../../../src/providers/google/image';
 import { fetchWithCache } from '../../../src/cache';
+import { GoogleImageProvider } from '../../../src/providers/google/image';
 
 jest.mock('../../../src/cache', () => ({
   fetchWithCache: jest.fn(),
@@ -23,7 +23,7 @@ describe('GoogleImageProvider', () => {
     process.env.GOOGLE_API_KEY = 'test-api-key';
     delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     delete process.env.GEMINI_API_KEY;
-    
+
     // Set up default mock behaviors
     mockLoadCredentials.mockImplementation((creds) => creds);
     mockResolveProjectId.mockResolvedValue('test-project');

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -120,7 +120,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -285,7 +285,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -379,7 +379,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -448,7 +448,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1074,7 +1074,7 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1147,7 +1147,7 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1235,7 +1235,7 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1313,7 +1313,7 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1363,7 +1363,7 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
@@ -1416,7 +1416,7 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
-    
+
     jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
     jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -59,7 +59,6 @@ jest.mock('../../../src/providers/google/util', () => ({
   getGoogleClient: jest.fn(),
 }));
 
-jest.mock('../../../src/providers/google/util');
 jest.mock('../../../src/esm', () => ({
   importModule: jest.fn(),
 }));
@@ -133,7 +132,7 @@ describe('VertexChatProvider.callGeminiApi', () => {
       metadata: {},
     });
 
-    expect(vertexUtil.getGoogleClient).toHaveBeenCalledWith();
+    expect(vertexUtil.getGoogleClient).toHaveBeenCalledWith({ credentials: undefined });
     expect(mockRequest).toHaveBeenCalledWith({
       url: expect.any(String),
       method: 'POST',

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -57,6 +57,8 @@ jest.mock('../../../src/cache', () => ({
 jest.mock('../../../src/providers/google/util', () => ({
   ...jest.requireActual('../../../src/providers/google/util'),
   getGoogleClient: jest.fn(),
+  loadCredentials: jest.fn(),
+  resolveProjectId: jest.fn(),
 }));
 
 jest.mock('../../../src/esm', () => ({
@@ -118,6 +120,9 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     const response = await provider.callGeminiApi('test prompt');
 
@@ -280,6 +285,9 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     const response = await provider.callGeminiApi('What is the weather in San Francisco?');
 
@@ -371,6 +379,9 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     const response = await provider.callGeminiApi('test prompt', {
       vars: { location: 'San Francisco' },
@@ -437,6 +448,9 @@ describe('VertexChatProvider.callGeminiApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     provider = new VertexChatProvider('gemini-2.0-flash-001');
     await provider.callGeminiApi('test prompt');
@@ -1060,6 +1074,9 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     const response = await provider.callLlamaApi('test prompt');
 
@@ -1130,6 +1147,9 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     await provider.callLlamaApi('test prompt');
 
@@ -1215,6 +1235,9 @@ describe('VertexChatProvider.callLlamaApi', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     await provider.callGeminiApi('test prompt');
 
@@ -1290,6 +1313,9 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     await provider.callClaudeApi('test prompt');
 
@@ -1337,6 +1363,9 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     await provider.callClaudeApi('test prompt');
 
@@ -1387,6 +1416,9 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       } as unknown as JSONClient,
       projectId: 'test-project-id',
     });
+    
+    jest.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) => creds);
+    jest.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
     await provider.callClaudeApi('test prompt');
 


### PR DESCRIPTION
This is to handle a new config field, `credentials`, which allows the user to specify credentials in their config, rather than an env var.