### PR TITLE
fix: throw error instead of failing when trace data is unavailable

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -695,6 +695,8 @@ The `trace-span-count` assertion counts the number of spans in a trace that matc
 
 :::note
 Trace assertions require tracing to be enabled in your evaluation. See the [tracing documentation](/docs/tracing/) for setup instructions.
+
+If trace data is not available, the assertion will throw an error rather than failing, indicating that the assertion could not be evaluated.
 :::
 
 Example:
@@ -737,6 +739,10 @@ Common patterns:
 
 The `trace-span-duration` assertion checks if span durations in a trace are within acceptable limits. It can check individual spans or percentiles across all matching spans.
 
+:::note
+This assertion requires trace data to be available. If tracing is not enabled or trace data is missing, the assertion will throw an error.
+:::
+
 Example:
 
 ```yaml
@@ -771,6 +777,10 @@ The assertion will show the slowest spans when a threshold is exceeded, making i
 ### Trace-Error-Spans
 
 The `trace-error-spans` assertion detects error spans in a trace and ensures the error rate is within acceptable limits. It automatically detects errors through status codes, error attributes, and status messages.
+
+:::note
+This assertion requires trace data to be available. If tracing is not enabled or trace data is missing, the assertion will throw an error.
+:::
 
 Example:
 

--- a/src/assertions/traceErrorSpans.ts
+++ b/src/assertions/traceErrorSpans.ts
@@ -65,12 +65,7 @@ function isErrorSpan(span: TraceSpan): boolean {
 
 export const handleTraceErrorSpans = ({ assertion, context }: AssertionParams): GradingResult => {
   if (!context.trace || !context.trace.spans) {
-    return {
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-error-spans assertion',
-      assertion,
-    };
+    throw new Error('No trace data available for trace-error-spans assertion');
   }
 
   const value = assertion.value;

--- a/src/assertions/traceSpanCount.ts
+++ b/src/assertions/traceSpanCount.ts
@@ -20,12 +20,7 @@ function matchesPattern(spanName: string, pattern: string): boolean {
 
 export const handleTraceSpanCount = ({ assertion, context }: AssertionParams): GradingResult => {
   if (!context.trace || !context.trace.spans) {
-    return {
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-span-count assertion',
-      assertion,
-    };
+    throw new Error('No trace data available for trace-span-count assertion');
   }
 
   const value = assertion.value as TraceSpanCountValue;

--- a/src/assertions/traceSpanDuration.ts
+++ b/src/assertions/traceSpanDuration.ts
@@ -30,12 +30,7 @@ function calculatePercentile(durations: number[], percentile: number): number {
 
 export const handleTraceSpanDuration = ({ assertion, context }: AssertionParams): GradingResult => {
   if (!context.trace || !context.trace.spans) {
-    return {
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-span-duration assertion',
-      assertion,
-    };
+    throw new Error('No trace data available for trace-span-duration assertion');
   }
 
   const value = assertion.value as TraceSpanDurationValue;

--- a/test/assertions/traceErrorSpans.test.ts
+++ b/test/assertions/traceErrorSpans.test.ts
@@ -351,13 +351,9 @@ describe('handleTraceErrorSpans', () => {
       renderedValue: { max_count: 0 },
     };
 
-    const result = handleTraceErrorSpans(params);
-    expect(result).toEqual({
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-error-spans assertion',
-      assertion: params.assertion,
-    });
+    expect(() => handleTraceErrorSpans(params)).toThrow(
+      'No trace data available for trace-error-spans assertion',
+    );
   });
 
   it('should handle empty trace spans', () => {

--- a/test/assertions/traceSpanCount.test.ts
+++ b/test/assertions/traceSpanCount.test.ts
@@ -240,13 +240,9 @@ describe('handleTraceSpanCount', () => {
       renderedValue: { pattern: '*', min: 1 },
     };
 
-    const result = handleTraceSpanCount(params);
-    expect(result).toEqual({
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-span-count assertion',
-      assertion: params.assertion,
-    });
+    expect(() => handleTraceSpanCount(params)).toThrow(
+      'No trace data available for trace-span-count assertion',
+    );
   });
 
   it('should handle empty trace spans', () => {

--- a/test/assertions/traceSpanDuration.test.ts
+++ b/test/assertions/traceSpanDuration.test.ts
@@ -250,13 +250,9 @@ describe('handleTraceSpanDuration', () => {
       renderedValue: { max: 1000 },
     };
 
-    const result = handleTraceSpanDuration(params);
-    expect(result).toEqual({
-      pass: false,
-      score: 0,
-      reason: 'No trace data available for trace-span-duration assertion',
-      assertion: params.assertion,
-    });
+    expect(() => handleTraceSpanDuration(params)).toThrow(
+      'No trace data available for trace-span-duration assertion',
+    );
   });
 
   it('should show top 3 slowest spans when limit exceeded', () => {


### PR DESCRIPTION
## Summary
- Fixed trace assertions to throw errors instead of returning failures when trace data is unavailable
- Updated `trace-error-spans`, `trace-span-count`, and `trace-span-duration` assertions
- Updated documentation to clarify the error behavior

## Problem
User reported that when trace data is not available, trace assertions were returning failures (test failed) rather than errors (test could not be evaluated). This was confusing because it suggested the test ran and failed, when actually it couldn't run at all.

## Solution
Changed all three trace assertions to throw an error with a descriptive message when `context.trace` or `context.trace.spans` is missing. This aligns with the behavior of other assertions like `perplexity` and `cost` that throw errors when required data is unavailable.

## Changes
- Modified assertion handlers to throw errors instead of returning failure results
- Updated unit tests to expect thrown errors
- Added documentation notes explaining the error behavior

## Test plan
- [x] All existing unit tests pass
- [x] Tests updated to verify error is thrown when trace data is missing
- [x] Documentation updated with clear notes about error behavior