### PR TITLE
chore: Add link to documentation in plugin sample modal

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -1410,6 +1410,36 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
                     </Box>
                   </Box>
                 ) : null}
+
+                {/* Documentation link */}
+                {generatingPlugin && hasSpecificPluginDocumentation(generatingPlugin) && (
+                  <Box sx={{ mt: 3, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+                    <Link
+                      href={getPluginDocumentationUrl(generatingPlugin)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        fontSize: '0.875rem',
+                        textDecoration: 'none',
+                        '&:hover': {
+                          textDecoration: 'underline',
+                        },
+                      }}
+                    >
+                      Learn more about the{' '}
+                      {displayNameOverrides[generatingPlugin] ||
+                        categoryAliases[generatingPlugin] ||
+                        generatingPlugin}{' '}
+                      plugin
+                      <Box component="span" sx={{ fontSize: '0.75rem' }}>
+                        ↗
+                      </Box>
+                    </Link>
+                  </Box>
+                )}
               </DialogContent>
               <DialogActions>
                 <Button


### PR DESCRIPTION
<img width="951" height="468" alt="Screenshot 2025-08-06 at 1 12 52 PM" src="https://github.com/user-attachments/assets/181e8ccc-7593-45bc-a8d5-e5d252275445" />
