### PR TITLE
fix: Fix json-output example

### DIFF
--- a/examples/json-output/promptfooconfig.yaml
+++ b/examples/json-output/promptfooconfig.yaml
@@ -5,7 +5,10 @@ prompts:
   - 'Output a JSON object that contains the keys `color` and `countries`, describing the following object: {{item}}'
 
 providers:
-  - openai:chat:gpt-4.1-mini
+  - id: openai:chat:gpt-4.1-mini
+    config:
+      response_format:
+        type: json_object
 
 tests:
   - vars:


### PR DESCRIPTION
GPT 4.1-mini was responding with json in markdown instead of a json object. Setting the response format to `json_object` is the reliable way of getting a json object.