### PR TITLE
perf(webui): Reduces eval results load-time when filters are applied via search param

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -475,31 +475,6 @@ export default function ResultsView({
     [handleSearchTextChange],
   );
 
-  /**
-   * Apply filters from URL params.
-   */
-  React.useEffect(() => {
-    const pluginParam = searchParams.get('plugin');
-
-    if (pluginParam) {
-      const { addFilter, resetFilters } = useTableStore.getState();
-
-      resetFilters();
-
-      addFilter({
-        type: 'plugin',
-        operator: 'equals',
-        value: pluginParam,
-      });
-
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        newParams.delete('plugin');
-        return newParams;
-      });
-    }
-  }, [searchParams, setSearchParams]);
-
   // Render the charts if a) they can be rendered, and b) the viewport, at mount-time, is tall enough.
   const canRenderResultsCharts = table && config && table.head.prompts.length > 1;
   const [renderResultsCharts, setRenderResultsCharts] = React.useState(window.innerHeight >= 1100);


### PR DESCRIPTION
When a filter is applied via search param (e.g. when navigating to eval results from the vuln. report), unnecessary HTTP requests – which do not contain the filter – are made prior to the filter request. This PR ensures the filter is applied on the initial request.