### PR TITLE
fix(providers): Validate that OpenAI response reasoning outputs have summary items

### DIFF
--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -382,7 +382,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
           }
         } else if (item.type === 'tool_result') {
           result = JSON.stringify(item);
-        } else if (item.type === 'reasoning') {
+        } else if (item.type === 'reasoning' && item.summary && item.summary.length > 0) {
           // Handle reasoning output from deep research models
           if (result) {
             result += '\n';


### PR DESCRIPTION
Currently, when an [output](https://platform.openai.com/docs/api-reference/responses/object#responses/object-output) is of type Reasoning and its `summary` property is an empty array, the output is prepended with `Reasoning: []`. 