### PR TITLE
docs: Adds note to context transform docs regarding `transformResponse`

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -328,7 +328,7 @@ The `contextTransform` property accepts a stringified Javascript expression whic
 type ContextTransform = (output: Output, context: Context) => string;
 
 /**
- * The provider's response output.
+ * The provider's response output OR, if defined, the return value of a `transformResponse` function.
  */
 type Output = string | object;
 
@@ -379,6 +379,10 @@ assert:
     contextTransform: 'context.metadata.retrieved_docs.map(d => d.content).join("\n")'
     threshold: 0.7
 ```
+
+:::note
+When a `transformResponse` function is defined on your provider, it will run before the `contextTransform` function and `output` will be its return value.
+:::
 
 If your expression should return `undefined` or `null`, for example because no context is available, add a fallback:
 


### PR DESCRIPTION
It's not clear from the current documentation that `transformResponse`, if defined on the provider, will run prior to `contextTransform` and the return value of the former will be the input value of the `output` argument in the latter.