### PR TITLE
docs(site): add cross-links between multimodal strategy documentation

### DIFF
--- a/site/docs/guides/multimodal-red-team.md
+++ b/site/docs/guides/multimodal-red-team.md
@@ -61,7 +61,11 @@ This approach uses a fixed image while generating various potentially problemati
 
 This approach converts potentially harmful text into images and then sends those images to the model. It tests whether harmful content embedded in images can bypass safety filters that would catch the same content in plain text. For more details, see [Image Jailbreaking](/docs/red-team/strategies/image).
 
-#### 3. UnsafeBench Dataset Testing
+#### 3. Text-to-Video Conversion (Video Strategy)
+
+This approach converts potentially harmful text into videos with text overlay and then sends those videos to the model. It tests whether harmful content embedded in videos can bypass safety filters that would catch the same content in plain text. For more details, see [Video Jailbreaking](/docs/red-team/strategies/video).
+
+#### 4. UnsafeBench Dataset Testing
 
 This approach uses real unsafe images from the [UnsafeBench](https://huggingface.co/datasets/yiting/UnsafeBench) dataset to test how models respond to potentially harmful visual content across various categories. It evaluates whether models can properly detect and refuse to engage with unsafe imagery.
 
@@ -493,5 +497,6 @@ npx promptfoo@latest redteam run -c promptfooconfig.yaml
 - [Red Team Strategies](/docs/red-team/strategies/)
 - [Image Inputs Strategy](/docs/red-team/strategies/image)
 - [Audio Inputs Strategy](/docs/red-team/strategies/audio)
+- [Video Inputs Strategy](/docs/red-team/strategies/video)
 - [LLM Red Teaming Guide](/docs/red-team/)
 - [Testing Guardrails](/docs/guides/testing-guardrails)

--- a/site/docs/red-team/strategies/audio.md
+++ b/site/docs/red-team/strategies/audio.md
@@ -66,7 +66,8 @@ This strategy is worth implementing because:
 
 ## Related Concepts
 
-- [Image Jailbreaking](/docs/red-team/strategies/image.md) - Similar approach using images instead of audio
+- [Image Jailbreaking](/docs/red-team/strategies/image) - Similar approach using images instead of audio
+- [Video Jailbreaking](/docs/red-team/strategies/video) - Similar approach using video instead of audio
+- [Multi-Modal Red Teaming Guide](/docs/guides/multimodal-red-team) - Comprehensive guide for testing multi-modal models
 - [Types of LLM Vulnerabilities](/docs/red-team/llm-vulnerability-types) - Comprehensive overview of vulnerabilities
 - [Red Teaming Strategies](/docs/red-team/strategies) - Other red teaming approaches
-- [Multi-Modal Red Teaming Guide](/docs/guides/multimodal-red-team)

--- a/site/docs/red-team/strategies/image.md
+++ b/site/docs/red-team/strategies/image.md
@@ -107,7 +107,9 @@ npm i sharp
 ## Related Concepts
 
 - [Audio Jailbreaking](audio.md) - Similar approach using speech audio instead of images
+- [Video Jailbreaking](video.md) - Similar approach using video instead of images
 - [Base64 Encoding](base64.md) - Similar encoding technique using text-to-base64 conversion
+- [Multi-Modal Red Teaming Guide](/docs/guides/multimodal-red-team) - Comprehensive guide for testing multi-modal models
 - [Types of LLM Vulnerabilities](/docs/red-team/llm-vulnerability-types) - Comprehensive overview of vulnerabilities
 
 For a comprehensive overview of LLM vulnerabilities and red teaming strategies, visit our [Types of LLM Vulnerabilities](/docs/red-team/llm-vulnerability-types) page.

--- a/site/docs/red-team/strategies/video.md
+++ b/site/docs/red-team/strategies/video.md
@@ -146,5 +146,7 @@ This strategy is worth implementing because:
 
 - [Audio Jailbreaking](/docs/red-team/strategies/audio) - Similar approach using speech audio
 - [Image Jailbreaking](/docs/red-team/strategies/image) - Similar approach using images
+- [Multi-Modal Red Teaming Guide](/docs/guides/multimodal-red-team) - Comprehensive guide for testing multi-modal models
+- [Types of LLM Vulnerabilities](/docs/red-team/llm-vulnerability-types) - Comprehensive overview of vulnerabilities
 
 For a comprehensive overview of LLM vulnerabilities and red teaming strategies, visit our [Types of LLM Vulnerabilities](/docs/red-team/llm-vulnerability-types) page.


### PR DESCRIPTION
## Summary
- Add cross-references between image, audio, and video strategy documentation
- Link strategy docs to the comprehensive multimodal red team guide  
- Add video strategy section to the multimodal guide

## Changes
- Updated `site/docs/red-team/strategies/image.md` - added links to video strategy and multimodal guide
- Updated `site/docs/red-team/strategies/audio.md` - added links to video strategy and multimodal guide
- Updated `site/docs/red-team/strategies/video.md` - added link to multimodal guide
- Updated `site/docs/guides/multimodal-red-team.md` - added video strategy section and link

## Test plan
- [x] Verify all links are correctly formatted
- [x] Confirm documentation builds without errors
- [x] Check that cross-references improve navigation between related docs