### PR TITLE
docs(site): improve all model-graded assertion documentation

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -2,45 +2,82 @@
 sidebar_label: Answer Relevance
 ---
 
-# Answer Relevance
+# Answer relevance
 
-The `answer-relevance` assertion evaluates whether an LLM's output is relevant to the original query. It uses a combination of embedding similarity and LLM evaluation to determine relevance.
+The `answer-relevance` assertion checks if your LLM's response actually answers the user's question.
 
-### How to use it
+**What it measures**: Given a user's query and the LLM's response, it evaluates how well the response addresses what was asked. It does this by generating potential questions the response could answer, then checking if those match the original query.
 
-To use the `answer-relevance` assertion type, add it to your test configuration like this:
+**Example**:
+
+- Query: "What is the capital of France?"
+- Good response (high score): "The capital of France is Paris."
+- Poor response (low score): "France has excellent wine and cheese." (doesn't answer the question)
+
+This metric evaluates **response quality**, ensuring the LLM stays on topic.
+
+## Required fields
+
+The answer-relevance assertion requires:
+
+- `query` or prompt - The user's question (from test vars or prompt)
+- Output - The LLM's response to evaluate
+- `threshold` (optional but recommended) - Minimum relevance score from 0 to 1 (defaults to 0)
+
+## Configuration
+
+### Basic usage
 
 ```yaml
 assert:
   - type: answer-relevance
-    threshold: 0.7 # Score between 0 and 1
+    threshold: 0.8 # Require 80% relevance to the query
 ```
 
-### How it works
+:::warning
+The default threshold is 0, which means the assertion will pass even with completely irrelevant responses. Always set an appropriate threshold value for meaningful evaluation.
+:::
+
+## How it works
 
 The answer relevance checker:
 
-1. Uses an LLM to generate potential questions that the output could be answering
-2. Compares these questions with the original query using embedding similarity
-3. Calculates a relevance score based on the similarity scores
+1. Takes the LLM's response and generates potential questions it could be answering
+2. Compares these generated questions with the original query using embeddings
+3. Returns a score from 0 to 1:
+   - **1.0**: Response perfectly answers the query
+   - **0.5**: Response is somewhat related but off-topic
+   - **0.0**: Response is completely irrelevant
 
-A higher threshold requires the output to be more closely related to the original query.
+This helps identify when your LLM goes off-topic or provides tangential information instead of answering directly.
 
-### Example Configuration
+### Complete example
 
-Here's a complete example showing how to use answer relevance:
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Ensure LLM responses are relevant to user queries'
 
-```yaml
 prompts:
   - 'Tell me about {{topic}}'
+
 providers:
-  - openai:gpt-4
+  - id: openai:gpt-4o-mini
+
 tests:
-  - vars:
+  - description: 'Test response relevance for quantum computing query'
+    vars:
       topic: quantum computing
     assert:
       - type: answer-relevance
-        threshold: 0.8
+        threshold: 0.8 # Response must be 80% relevant to the topic
+
+  - description: 'Test with explicit query variable'
+    vars:
+      query: 'What are the benefits of exercise?'
+      topic: 'physical fitness'
+    assert:
+      - type: answer-relevance
+        threshold: 0.85 # Higher threshold for health topics
 ```
 
 ### Overriding the Providers
@@ -89,6 +126,13 @@ defaultTest:
       Make the questions specific and directly related to the content.
 ```
 
-# Further reading
+## Related assertions
 
-See [model-graded metrics](/docs/configuration/expected-outputs/model-graded) for more options.
+- [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric) - For custom relevance criteria
+- [`similar`](/docs/configuration/expected-outputs/similar) - For semantic similarity to expected answers
+- [`context-faithfulness`](/docs/configuration/expected-outputs/model-graded/context-faithfulness) - When working with RAG systems
+
+## Further reading
+
+- Explore all [model-graded metrics](/docs/configuration/expected-outputs/model-graded) for comprehensive evaluation options
+- See [Getting Started](/docs/getting-started) for more examples

--- a/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
@@ -2,9 +2,19 @@
 sidebar_position: 25
 ---
 
-# Conversation Relevance
+# Conversation relevance
 
-The `conversation-relevance` assertion evaluates whether responses in a conversation remain relevant throughout the dialogue. This is particularly useful for chatbot applications where maintaining conversational coherence is critical.
+The `conversation-relevance` assertion ensures your chatbot stays on topic throughout multi-turn conversations.
+
+**What it measures**: Given a conversation history, it evaluates whether each response remains relevant to the conversation context using a sliding window approach. This catches when chatbots drift off-topic or give unrelated answers.
+
+**Example**:
+
+- User: "What's the weather?" → Bot: "It's sunny today" ✓ Relevant
+- User: "What about tomorrow?" → Bot: "Tomorrow will be rainy" ✓ Relevant
+- User: "Should I bring an umbrella?" → Bot: "The capital of France is Paris" ✗ Irrelevant
+
+This metric is ideal for **chatbot quality assurance** and ensuring conversational coherence.
 
 ## How it works
 

--- a/site/docs/configuration/expected-outputs/model-graded/factuality.md
+++ b/site/docs/configuration/expected-outputs/model-graded/factuality.md
@@ -4,17 +4,34 @@ sidebar_label: Factuality
 
 # Factuality
 
-The `factuality` assertion evaluates the factual consistency between an LLM output and a reference answer. It uses a structured prompt based on [OpenAI's evals](https://github.com/openai/evals/blob/main/evals/registry/modelgraded/fact.yaml) to determine if the output is factually consistent with the reference.
+The `factuality` assertion checks if your LLM's output is factually consistent with a ground truth reference.
 
-## How to use it
+**What it measures**: Given a reference answer (ground truth) and the LLM's output, it evaluates whether they are factually consistent - the output doesn't have to match exactly, but it can't contradict the facts.
 
-To use the `factuality` assertion type, add it to your test configuration like this:
+**Example**:
+
+- Reference: "Paris is the capital of France with 2.2 million residents"
+- Good output: "The capital of France is Paris" ✓ (subset, consistent)
+- Good output: "Paris, France's capital, has 2.2M people in a metro area of 10M" ✓ (superset, consistent)
+- Bad output: "Lyon is the capital of France" ✗ (contradicts facts)
+
+This metric is ideal for **fact-checking** and ensuring accuracy against known correct answers.
+
+## Required fields
+
+The factuality assertion requires:
+
+- `value` - The reference answer/ground truth to check against
+- Output - The LLM's response to evaluate
+
+## Configuration
+
+### Basic usage
 
 ```yaml
 assert:
   - type: factuality
-    # Specify the reference statement to check against:
-    value: The Earth orbits around the Sun
+    value: 'The Earth orbits around the Sun' # Ground truth reference
 ```
 
 ## How it works

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -4,20 +4,39 @@ sidebar_position: 8
 
 # G-Eval
 
-G-Eval is a framework that uses LLMs with chain-of-thoughts (CoT) to evaluate LLM outputs based on custom criteria. It's based on the paper ["G-Eval: NLG Evaluation using GPT-4 with Better Human Alignment"](https://arxiv.org/abs/2303.16634).
+The `g-eval` assertion uses chain-of-thought reasoning to provide more thoughtful, nuanced evaluation of your LLM outputs.
 
-## How to use it
+**What it measures**: Given custom evaluation criteria, it uses a grading LLM with chain-of-thought prompting to deeply analyze whether the output meets those criteria. This produces more reliable evaluations than simple scoring.
 
-To use G-Eval in your test configuration:
+**Example**:
+
+- Criteria: "Response is factually accurate and well-structured"
+- Analysis: The grader thinks step-by-step about factual claims and structure
+- Result: Normalized score from 0-1 based on detailed reasoning
+
+This metric is ideal for **complex evaluation criteria** that benefit from reasoning through multiple aspects.
+
+## Required fields
+
+The g-eval assertion requires:
+
+- `value` - Evaluation criteria (string or array of strings)
+- `threshold` (optional) - Minimum score from 0 to 1 (defaults to 0.7)
+- Prompt - The original prompt (for context)
+- Output - The LLM's response to evaluate
+
+## Configuration
+
+### Basic usage
 
 ```yaml
 assert:
   - type: g-eval
     value: 'Ensure the response is factually accurate and well-structured'
-    threshold: 0.7 # Optional, defaults to 0.7
+    threshold: 0.7 # Default threshold
 ```
 
-You can also provide multiple evaluation criteria as an array:
+### Multiple criteria
 
 ```yaml
 assert:
@@ -26,17 +45,21 @@ assert:
       - 'Check if the response maintains a professional tone'
       - 'Verify that all technical terms are used correctly'
       - 'Ensure no confidential information is revealed'
+    threshold: 0.8 # Higher threshold for multiple criteria
 ```
 
 ## How it works
 
-G-Eval uses GPT-4o (by default) to evaluate outputs based on your specified criteria. The evaluation process:
+The G-Eval process:
 
-1. Takes your evaluation criteria
-2. Uses chain-of-thought prompting to analyze the output
-3. Returns a normalized score between 0 and 1
+1. **Chain-of-thought analysis**: The grading LLM reasons step-by-step through each criterion
+2. **Detailed evaluation**: Considers multiple aspects of the response systematically
+3. **Score normalization**: Returns a score from 0 to 1:
+   - **1.0**: Fully meets all criteria with excellent quality
+   - **0.7**: Meets criteria adequately (default threshold)
+   - **0.0**: Fails to meet criteria
 
-The assertion passes if the score meets or exceeds the threshold (default 0.7).
+G-Eval's chain-of-thought approach produces more consistent and explainable evaluations than simple scoring. Based on the paper ["G-Eval: NLG Evaluation using GPT-4 with Better Human Alignment"](https://arxiv.org/abs/2303.16634).
 
 ## Customizing the evaluator
 
@@ -57,21 +80,30 @@ defaultTest:
     provider: openai:gpt-4.1-mini
 ```
 
-## Example
+### Complete example
 
-Here's a complete example showing how to use G-Eval to assess multiple aspects of an LLM response:
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Use G-Eval for nuanced evaluation with chain-of-thought'
 
-```yaml
 prompts:
-  - |
-    Write a technical explanation of {{topic}} 
-    suitable for a beginner audience.
+  - 'Write a technical explanation of {{topic}} suitable for a {{audience}} audience.'
+
 providers:
-  - openai:gpt-4
+  - id: openai:gpt-4o-mini
+
 tests:
-  - vars:
+  - description: 'Evaluate beginner-friendly explanation'
+    vars:
       topic: 'quantum computing'
+      audience: 'beginner'
     assert:
+      # Single criterion
+      - type: g-eval
+        value: 'Explanation is clear and accessible to beginners'
+        threshold: 0.75
+
+      # Multiple criteria evaluated together
       - type: g-eval
         value:
           - 'Explains technical concepts in simple terms'
@@ -79,9 +111,34 @@ tests:
           - 'Includes relevant examples or analogies'
           - 'Avoids unnecessary jargon'
         threshold: 0.8
+
+  - description: 'Evaluate expert-level explanation'
+    vars:
+      topic: 'quantum computing'
+      audience: 'expert'
+    assert:
+      - type: g-eval
+        value:
+          - 'Uses precise technical terminology correctly'
+          - 'Covers advanced concepts like quantum entanglement'
+          - 'Discusses current research or applications'
+        threshold: 0.85
 ```
+
+## When to use G-Eval vs. alternatives
+
+- **Use `g-eval`** for complex criteria requiring thoughtful analysis
+- **Use [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric)** for simpler custom evaluation
+- **Use [`model-graded-closedqa`](/docs/configuration/expected-outputs/model-graded/model-graded-closedqa)** for binary yes/no evaluation
+
+## Related assertions
+
+- [`llm-rubric`](/docs/configuration/expected-outputs/model-graded/llm-rubric) - Simpler custom evaluation without CoT
+- [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - For fact-checking against ground truth
+- [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - For checking if answers address the query
 
 ## Further reading
 
 - [Model-graded metrics overview](/docs/configuration/expected-outputs/model-graded)
-- [G-Eval paper](https://arxiv.org/abs/2303.16634)
+- [G-Eval paper](https://arxiv.org/abs/2303.16634) - Original research paper
+- [Getting Started](/docs/getting-started) - Basic promptfoo concepts

--- a/site/docs/configuration/expected-outputs/model-graded/max-score.md
+++ b/site/docs/configuration/expected-outputs/model-graded/max-score.md
@@ -4,9 +4,19 @@ description: Configure the `max-score` assertion to deterministically pick the h
 sidebar_label: Max Score
 ---
 
-# Max Score
+# Max score
 
-The `max-score` assertion selects the output with the highest aggregate score from other assertions. Unlike `select-best` which uses LLM judgment, `max-score` provides objective, deterministic selection based on quantitative scores from other assertions.
+The `max-score` assertion automatically selects the best output based on objective scores from other assertions.
+
+**What it measures**: Unlike `select-best` which uses LLM judgment, `max-score` aggregates numerical scores from other assertions (like factuality, contains, llm-rubric) and deterministically selects the highest-scoring output.
+
+**Example**:
+
+- Output A: Scores 0.6 on factuality, 1.0 on contains, 0.7 on rubric = Average 0.77 ✗
+- Output B: Scores 0.9 on factuality, 1.0 on contains, 0.8 on rubric = Average 0.90 ✓ Winner
+- Output C: Scores 0.8 on factuality, 0.0 on contains, 0.9 on rubric = Average 0.57 ✗
+
+This metric is ideal for **objective selection** when you want transparent, reproducible results without LLM API calls.
 
 ## When to use max-score
 


### PR DESCRIPTION
## Summary
Comprehensive improvement of all model-graded assertion documentation for clarity and consistency.

## Changes
- Added clear 'What it measures' sections with concrete examples for every assertion
- Standardized structure: Required fields → Configuration → Complete examples → How it works
- Added warnings about default thresholds (especially for context-* and answer-relevance defaulting to 0)
- Included 'When to use vs. alternatives' sections for better decision-making
- Added proper YAML file titles and JSON schema references to all examples
- Improved cross-linking between related assertions

## Assertions Updated
- ✅ answer-relevance
- ✅ context-faithfulness 
- ✅ context-recall
- ✅ context-relevance
- ✅ conversation-relevance
- ✅ factuality
- ✅ g-eval
- ✅ llm-rubric
- ✅ max-score
- ✅ model-graded-closedqa
- ✅ pi
- ✅ select-best