### PR TITLE
docs: Add AWS Bedrock Guardrails image testing documentation

### DIFF
--- a/site/docs/guides/testing-guardrails.md
+++ b/site/docs/guides/testing-guardrails.md
@@ -312,6 +312,285 @@ redteam:
 
 For more information, see [red team setup](/docs/red-team/quickstart/).
 
+### Testing AWS Bedrock Guardrails with Images
+
+AWS Bedrock Guardrails also support image content moderation through the ApplyGuardrail API, allowing you to detect harmful visual content. This requires a separate provider implementation since image and text testing work fundamentally differently in Promptfoo.
+
+For comprehensive testing with image datasets like UnsafeBench, see the [Multi-Modal Red Teaming guide](/docs/guides/multimodal-red-team/#approach-3-unsafebench-dataset-testing).
+
+Here's an image-specific provider implementation:
+
+```python title="aws_bedrock_guardrails_with_images.py"
+import boto3
+import json
+import base64
+from botocore.exceptions import ClientError
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def call_api(prompt, options, context):
+    """
+    AWS Bedrock Guardrails provider for image content analysis.
+    Supports image input through ApplyGuardrail API with comprehensive error handling.
+    """
+    # Get configuration
+    config = options.get("config", {})
+    guardrail_id = config.get("guardrail_id")
+    guardrail_version = config.get("guardrail_version", "DRAFT")
+    region = config.get("region", "us-east-1")
+    log_requests = config.get("log_requests", False)
+    
+    # Create Bedrock Runtime client
+    bedrock_runtime = boto3.client('bedrock-runtime', region_name=region)
+    
+    try:
+        # Get variables from context
+        vars_dict = context.get("vars", {})
+        
+        # Initialize content array
+        content = []
+        
+        # Process image input
+        image_data = vars_dict.get("image")
+        image_format = vars_dict.get("format", "jpeg")
+        
+        if not image_data:
+            return {
+                "output": None,
+                "error": "No image data provided in context variables"
+            }
+        
+        # Handle image input processing
+        if log_requests:
+            logger.info(f"Processing image input (format: {image_format})")
+            logger.info(f"Image data length: {len(image_data) if image_data else 0}")
+        
+        # Ensure image_data is properly formatted base64
+        if isinstance(image_data, str):
+            # Remove any data URL prefix if present
+            if image_data.startswith('data:'):
+                # Extract base64 part after comma
+                image_data = image_data.split(',')[1] if ',' in image_data else image_data
+            
+            # Validate base64 format
+            try:
+                # Test decode to validate
+                base64.b64decode(image_data)
+            except Exception as e:
+                logger.error(f"Invalid base64 image data: {e}")
+                return {
+                    "output": None,
+                    "error": f"Invalid base64 image data: {str(e)}"
+                }
+        
+        # Add image to content - AWS expects actual bytes, not base64 string
+        try:
+            # Decode base64 to bytes for AWS
+            image_bytes = base64.b64decode(image_data)
+            content.append({
+                "image": {
+                    "format": image_format.lower(),  # AWS expects lowercase
+                    "source": {
+                        "bytes": image_bytes
+                    }
+                }
+            })
+        except Exception as e:
+            logger.error(f"Failed to decode base64 image for AWS: {e}")
+            return {
+                "output": None,
+                "error": f"Failed to decode base64 image: {str(e)}"
+            }
+        
+        if log_requests:
+            logger.info(f"Calling ApplyGuardrail with {len(content)} content items")
+            logger.info(f"Guardrail ID: {guardrail_id}, Version: {guardrail_version}")
+        
+        # Call the ApplyGuardrail API
+        response = bedrock_runtime.apply_guardrail(
+            guardrailIdentifier=guardrail_id,
+            guardrailVersion=guardrail_version,
+            source='INPUT',  # Test input content
+            content=content
+        )
+        
+        if log_requests:
+            logger.info(f"Guardrail response: {json.dumps(response, indent=2)}")
+        
+        # Check the action taken by the guardrail
+        action = response.get('action', '')
+        
+        # Extract assessment details
+        assessments = response.get('assessments', [])
+        
+        # Build detailed reason from assessments
+        detailed_reasons = []
+        for assessment in assessments:
+            if 'topicPolicy' in assessment:
+                for topic in assessment['topicPolicy'].get('topics', []):
+                    if topic.get('action') == 'BLOCKED':
+                        detailed_reasons.append(f"Topic: {topic.get('name', 'Unknown')}")
+            
+            if 'contentPolicy' in assessment:
+                filters = assessment['contentPolicy'].get('filters', [])
+                for filter_item in filters:
+                    if filter_item.get('action') == 'BLOCKED':
+                        filter_type = filter_item.get('type', 'Unknown')
+                        confidence = filter_item.get('confidence', 'N/A')
+                        detailed_reasons.append(f"Content Filter: {filter_type} (Confidence: {confidence})")
+            
+            if 'wordPolicy' in assessment:
+                custom_words = assessment['wordPolicy'].get('customWords', [])
+                managed_words = assessment['wordPolicy'].get('managedWordLists', [])
+                if custom_words:
+                    detailed_reasons.append(f"Custom words detected: {', '.join(custom_words)}")
+                if managed_words:
+                    detailed_reasons.append(f"Managed word lists: {', '.join(managed_words)}")
+        
+        # Get the actual AWS blocked message from outputs
+        outputs = response.get('outputs', [])
+        aws_blocked_message = ""
+        if outputs and len(outputs) > 0:
+            aws_blocked_message = outputs[0].get('text', '')
+        
+        if action == 'GUARDRAIL_INTERVENED':
+            # Content was blocked
+            if detailed_reasons:
+                blocked_message = f"Image content blocked. Categories: {'; '.join(detailed_reasons)}."
+            else:
+                blocked_message = "Image content blocked by guardrails."
+            
+            # Add AWS blocked message if available
+            if aws_blocked_message:
+                blocked_message += f" AWS Response: '{aws_blocked_message}'"
+            
+            return {
+                "output": blocked_message,
+                "guardrails": {
+                    "flagged": True,  # Content was flagged (blocked)
+                    "blocked": True,  # Explicitly indicate blocking
+                    "reason": aws_blocked_message or "Guardrail intervened",
+                    "detailed_reasons": detailed_reasons,
+                    "action": action,
+                    "assessments": assessments,
+                    "aws_message": aws_blocked_message,
+                    "details": response
+                }
+            }
+        else:
+            # Content passed guardrails
+            return {
+                "output": "Image content passed guardrails check",
+                "guardrails": {
+                    "flagged": False,  # Content was not flagged
+                    "blocked": False,  # Content was not blocked
+                    "reason": "Image content passed guardrails check",
+                    "action": action,
+                    "details": response
+                }
+            }
+    
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        error_message = e.response['Error']['Message']
+        
+        logger.error(f"AWS ClientError: {error_code} - {error_message}")
+        
+        # Provide specific error messages for common issues
+        if error_code == 'ValidationException':
+            if 'image format' in error_message.lower():
+                return {
+                    "output": None,
+                    "error": f"Invalid image format. Supported formats: JPEG, PNG. Error: {error_message}"
+                }
+            elif 'size' in error_message.lower():
+                return {
+                    "output": None,
+                    "error": f"Image size exceeds limits. Maximum size: 5MB. Error: {error_message}"
+                }
+        
+        return {
+            "output": None,
+            "error": f"AWS Error ({error_code}): {error_message}"
+        }
+    
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        return {
+            "output": None,
+            "error": f"Unexpected error: {str(e)}"
+        }
+```
+
+Configure image testing with a dedicated configuration file:
+
+```yaml title="promptfooconfig_bedrock_images.yaml"
+# Image-only configuration for AWS Bedrock Guardrails
+providers:
+  - id: 'file://aws_bedrock_guardrails_with_images.py'
+    config:
+      region: us-east-1
+      guardrail_id: 'your-guardrail-id'
+      guardrail_version: 'DRAFT' # Set your version
+      log_requests: false  # Set to true for debugging
+
+prompts:
+  - 'Check image safety'
+
+defaultTest:
+  options:
+    transformVars: |
+      // Clean image data for AWS Bedrock
+      if (vars.image && typeof vars.image === 'string') {
+        // Remove any data URL prefix
+        if (vars.image.includes('base64,')) {
+          vars.image = vars.image.split('base64,')[1];
+        }
+        // Set format (default to jpeg)
+        vars.format = vars.format || 'jpeg';
+      }
+      return vars;
+
+redteam:
+  purpose: 'Test AWS Bedrock Guardrails ability to detect harmful visual content'
+  injectVar: image  # Critical: tells Promptfoo to inject images, not text
+  numTests: 10
+  plugins:
+    - id: unsafebench
+      config:
+        categories:
+          - Violence
+          - Sexual
+          - Hate
+          # Additional available categories:
+          # - Deception
+          # - Harassment
+          # - Illegal activity
+          # - Political
+          # - Public and personal health
+          # - Self-harm
+          # - Shocking
+          # - Spam
+```
+
+:::warning Image Testing Requirements
+- **Separate Configuration**: Image testing requires its own configuration file - cannot be mixed with text plugins
+- **Format Support**: JPEG and PNG only (max 5MB)
+- **Base64 Handling**: Images must be decoded from base64 strings to bytes before sending to AWS
+- **Provider**: Use the image-specific provider, not the standard text provider
+- **InjectVar**: Must use `injectVar: image` for image plugins to work properly
+:::
+
+Run image-only tests with:
+```bash
+promptfoo redteam run -c promptfooconfig_bedrock_images.yaml
+```
+
+The Promptfoo UI will properly render the images and show which ones were blocked by your guardrails.
+
 ## Testing NVIDIA NeMo Guardrails
 
 For NVIDIA NeMo Guardrails, you'd implement a similar approach. We implement `call_api` with a `{output, guardrails, error}` return dictionary:


### PR DESCRIPTION
## Description
This PR adds documentation for testing AWS Bedrock Guardrails with image inputs, extending the existing text-only documentation to support visual content moderation.

## Background
As discussed with @MrFlounder via email (Verizon), I successfully implemented and tested AWS Bedrock Guardrails with image support for a child safety monitoring system. This enhancement allows users to test visual content moderation using UnsafeBench

## What's Changed
- Added new section **"Testing AWS Bedrock Guardrails with Images"** after the existing text section
- Included complete Python provider implementation (`aws_bedrock_guardrails_with_images.py`)
- Added configuration example showing UnsafeBench integration with multiple categories
- Documented critical base64 to bytes conversion requirement for AWS API
- Added warning box about separate configurations for text vs image testing
- Linked to Multi-Modal Red Teaming guide for additional context

## Key Features
✅ **Image Format Support**: JPEG and PNG (up to 5MB)
✅ **Base64 Handling**: Properly decodes base64 strings to bytes as required by AWS
✅ **Content Detection**: Violence, Sexual, Hate, and other harmful visual content
✅ **Error Handling**: Comprehensive error messages for common issues
✅ **UnsafeBench Integration**: Works with all UnsafeBench categories
✅ **PromptFoo Style**: Follows existing code patterns with `guardrail_id` and `guardrail_version`

## Testing
This implementation has been tested with:
- UnsafeBench Violence, Sexual, and Hate categories
- 500+ red team test cases
- AWS Bedrock Guardrails in production environment (us-east-1)
- Verified image rendering in PromptFoo UI

## Notes
- Through my testing I found out that, Image testing requires separate configuration from text testing (they cannot be mixed)
- The `injectVar: image` setting is critical for proper image plugin functionality
- AWS requires actual bytes, not base64 strings, hence the conversion step

cc @MrFlounder - As we discussed, here's the PR adding image testing capability for AWS Bedrock Guardrails.

## Related
- [Multi-Modal Red Teaming Documentation](https://www.promptfoo.dev/docs/guides/multimodal-red-team/)
- [AWS Bedrock Guardrails Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html)