### PR TITLE
docs(site): document transform and contextTransform for model-graded assertions

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -467,6 +467,70 @@ tests:
         threshold: 0.9
 ```
 
+## Transforming outputs for context assertions
+
+### Transform: Extract answer before context grading
+
+```yaml
+providers:
+  - echo
+
+tests:
+  - vars:
+      prompt: '{"answer": "Paris is the capital of France", "confidence": 0.95}'
+      context: 'France is a country in Europe. Its capital city is Paris, which has over 2 million residents.'
+    assert:
+      - type: context-faithfulness
+        transform: 'JSON.parse(output).answer' # Grade only the answer field
+        threshold: 0.9
+
+      - type: context-recall
+        transform: 'JSON.parse(output).answer' # Check if answer appears in context
+        value: 'Paris is the capital of France'
+        threshold: 0.8
+```
+
+### Context transform: Extract context from provider response
+
+```yaml
+providers:
+  - echo
+
+tests:
+  - vars:
+      prompt: '{"answer": "Returns accepted within 30 days", "sources": ["Returns are accepted for 30 days from purchase", "30-day money-back guarantee"]}'
+      query: 'What is the return policy?'
+    assert:
+      - type: context-faithfulness
+        transform: 'JSON.parse(output).answer'
+        contextTransform: 'JSON.parse(output).sources.join(". ")' # Extract sources as context
+        threshold: 0.9
+
+      - type: context-relevance
+        contextTransform: 'JSON.parse(output).sources.join(". ")' # Check if context is relevant to query
+        threshold: 0.8
+```
+
+### Transform response: Normalize RAG system output
+
+```yaml
+providers:
+  - id: http://rag-api.example.com/search
+    config:
+      transformResponse: 'json.data' # Extract data field from API response
+
+tests:
+  - vars:
+      query: 'What are the office hours?'
+    assert:
+      - type: context-faithfulness
+        transform: 'output.answer' # After transformResponse, extract answer
+        contextTransform: 'output.documents.map(d => d.text).join(" ")' # Extract documents as context
+        threshold: 0.85
+```
+
+**Processing order:** API call → `transformResponse` → `transform` → `contextTransform` → context assertion
+
 ## Other assertion types
 
 For more info on assertions, see [Test assertions](/docs/configuration/expected-outputs).


### PR DESCRIPTION
## Summary
- Add documentation for `transform`, `contextTransform`, and `transformResponse` in model-graded assertions
- Focus on context-based assertions (context-faithfulness, context-recall, context-relevance)
- Use concise examples with the echo provider to demonstrate concepts

## Changes
- Document how `transform` extracts fields before context grading
- Explain `contextTransform` for extracting context from provider responses
- Show `transformResponse` for normalizing RAG system outputs
- Include processing order diagram

## Test plan
- [x] Documentation builds without errors
- [x] Examples are syntactically correct
- [x] Formatting passes linting checks