### PR TITLE
fix: lower sharing chunk size

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -178,7 +178,7 @@ async function sendChunkedResults(evalRecord: Eval, url: string): Promise<string
   logger.debug(`Largest result size from sample: ${largestSize} bytes`);
 
   // Determine how many results per chunk
-  const TARGET_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB in bytes
+  const TARGET_CHUNK_SIZE = 0.9 * 1024 * 1024; // 900KB in bytes
   const estimatedResultsPerChunk =
     getEnvInt('PROMPTFOO_SHARE_CHUNK_SIZE') ??
     Math.max(1, Math.floor(TARGET_CHUNK_SIZE / largestSize));


### PR DESCRIPTION
A lot of users have been hitting ngnix max request size errors. The default max request size of ngnix is 1mb, so setting this just below that.