### PR TITLE
feat: add update check for modelaudit package

### DIFF
--- a/src/commands/modelScan.ts
+++ b/src/commands/modelScan.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 
 import chalk from 'chalk';
 import logger from '../logger';
+import { checkModelAuditUpdates } from '../updates';
 import type { Command } from 'commander';
 
 const execAsync = promisify(exec);
@@ -54,6 +55,9 @@ export function modelScanCommand(program: Command): void {
         logger.info('For more information, visit: https://www.promptfoo.dev/docs/model-audit/');
         process.exit(1);
       }
+
+      // Check for modelaudit updates
+      await checkModelAuditUpdates();
 
       const args = ['scan', ...paths];
 

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,9 +1,13 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import chalk from 'chalk';
 import semverGt from 'semver/functions/gt';
 import { TERMINAL_MAX_WIDTH, VERSION } from './constants';
 import { getEnvBool } from './envars';
 import { fetchWithTimeout } from './fetch';
 import logger from './logger';
+
+const execAsync = promisify(exec);
 
 export async function getLatestVersion() {
   const response = await fetchWithTimeout(`https://api.promptfoo.dev/api/latestVersion`, {}, 1000);
@@ -36,6 +40,59 @@ ${chalk.yellow('⚠️')} The current version of promptfoo ${chalk.yellow(
 Please run ${chalk.green('npx promptfoo@latest')} or ${chalk.green(
         'npm install -g promptfoo@latest',
       )} to update.
+${border}\n`,
+    );
+    return true;
+  }
+  return false;
+}
+
+export async function getModelAuditLatestVersion(): Promise<string | null> {
+  try {
+    const response = await fetchWithTimeout('https://pypi.org/pypi/modelaudit/json', {}, 1000);
+    if (!response.ok) {
+      throw new Error('Failed to fetch package information for modelaudit');
+    }
+    const data = (await response.json()) as { info: { version: string } };
+    return data.info.version;
+  } catch {
+    return null;
+  }
+}
+
+export async function getModelAuditCurrentVersion(): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync('pip show modelaudit');
+    const versionMatch = stdout.match(/Version:\s*(\S+)/);
+    return versionMatch ? versionMatch[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkModelAuditUpdates(): Promise<boolean> {
+  if (getEnvBool('PROMPTFOO_DISABLE_UPDATE')) {
+    return false;
+  }
+
+  const [currentVersion, latestVersion] = await Promise.all([
+    getModelAuditCurrentVersion(),
+    getModelAuditLatestVersion(),
+  ]);
+
+  if (!currentVersion || !latestVersion) {
+    return false;
+  }
+
+  if (semverGt(latestVersion, currentVersion)) {
+    const border = '='.repeat(TERMINAL_MAX_WIDTH);
+    logger.info(
+      `\n${border}
+${chalk.yellow('⚠️')} The current version of modelaudit ${chalk.yellow(
+        currentVersion,
+      )} is lower than the latest available version ${chalk.green(latestVersion)}.
+
+Please run ${chalk.green('pip install --upgrade modelaudit')} to update.
 ${border}\n`,
     );
     return true;

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -1,6 +1,20 @@
-import packageJson from '../package.json';
-import { fetchWithTimeout } from '../src/fetch';
-import { checkForUpdates, getLatestVersion } from '../src/updates';
+let mockExecAsync: jest.Mock;
+
+jest.mock('util', () => ({
+  ...jest.requireActual('util'),
+  promisify: jest.fn((fn) => {
+    if (fn.name === 'exec') {
+      // Return a function that will use mockExecAsync when called
+      return (...args: any[]) => {
+        if (!mockExecAsync) {
+          mockExecAsync = jest.fn();
+        }
+        return mockExecAsync(...args);
+      };
+    }
+    return jest.requireActual('util').promisify(fn);
+  }),
+}));
 
 jest.mock('../src/fetch', () => ({
   fetchWithTimeout: jest.fn(),
@@ -9,6 +23,20 @@ jest.mock('../src/fetch', () => ({
 jest.mock('../package.json', () => ({
   version: '0.11.0',
 }));
+
+import packageJson from '../package.json';
+import { fetchWithTimeout } from '../src/fetch';
+import {
+  checkForUpdates,
+  checkModelAuditUpdates,
+  getLatestVersion,
+  getModelAuditCurrentVersion,
+  getModelAuditLatestVersion,
+} from '../src/updates';
+
+beforeEach(() => {
+  mockExecAsync = jest.fn();
+});
 
 describe('getLatestVersion', () => {
   it('should return the latest version of the package', async () => {
@@ -68,6 +96,157 @@ describe('checkForUpdates', () => {
     } as never);
 
     const result = await checkForUpdates();
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('getModelAuditLatestVersion', () => {
+  it('should return the latest version from PyPI', async () => {
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ info: { version: '0.1.7' } }),
+    } as never);
+
+    const version = await getModelAuditLatestVersion();
+    expect(version).toBe('0.1.7');
+    expect(fetchWithTimeout).toHaveBeenCalledWith(
+      'https://pypi.org/pypi/modelaudit/json',
+      {},
+      1000,
+    );
+  });
+
+  it('should return null if PyPI request fails', async () => {
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: false,
+    } as never);
+
+    const version = await getModelAuditLatestVersion();
+    expect(version).toBeNull();
+  });
+
+  it('should return null if fetch throws', async () => {
+    jest.mocked(fetchWithTimeout).mockRejectedValueOnce(new Error('Network error'));
+
+    const version = await getModelAuditLatestVersion();
+    expect(version).toBeNull();
+  });
+});
+
+describe('getModelAuditCurrentVersion', () => {
+  it('should return the current version from pip show', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nVersion: 0.1.5\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    const version = await getModelAuditCurrentVersion();
+    expect(version).toBe('0.1.5');
+  });
+
+  it('should return null if pip show fails', async () => {
+    mockExecAsync.mockRejectedValueOnce(new Error('Command failed'));
+
+    const version = await getModelAuditCurrentVersion();
+    expect(version).toBeNull();
+  });
+
+  it('should return null if version pattern not found', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    const version = await getModelAuditCurrentVersion();
+    expect(version).toBeNull();
+  });
+});
+
+describe('checkModelAuditUpdates', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    delete process.env.PROMPTFOO_DISABLE_UPDATE;
+  });
+
+  afterEach(() => {
+    jest.mocked(console.log).mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('should return true and log message when update is available', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nVersion: 0.1.5\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ info: { version: '0.1.7' } }),
+    } as never);
+
+    const result = await checkModelAuditUpdates();
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false when versions are equal', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nVersion: 0.1.7\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ info: { version: '0.1.7' } }),
+    } as never);
+
+    const result = await checkModelAuditUpdates();
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false when current version is newer', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nVersion: 0.2.0\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ info: { version: '0.1.7' } }),
+    } as never);
+
+    const result = await checkModelAuditUpdates();
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false when PROMPTFOO_DISABLE_UPDATE is set', async () => {
+    process.env.PROMPTFOO_DISABLE_UPDATE = 'true';
+
+    const result = await checkModelAuditUpdates();
+    expect(result).toBeFalsy();
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should return false when current version cannot be determined', async () => {
+    mockExecAsync.mockRejectedValueOnce(new Error('Command failed'));
+
+    jest.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ info: { version: '0.1.7' } }),
+    } as never);
+
+    const result = await checkModelAuditUpdates();
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false when latest version cannot be determined', async () => {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: 'Name: modelaudit\nVersion: 0.1.5\nSummary: Model audit tool',
+      stderr: '',
+    });
+
+    jest.mocked(fetchWithTimeout).mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await checkModelAuditUpdates();
     expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- Adds automatic update checking for the modelaudit PyPI package when running `scan-model` command
- Displays a user-friendly update message similar to promptfoo's own update notifications
- Respects the PROMPTFOO_DISABLE_UPDATE environment variable to allow users to opt out

## Changes
- Added `checkModelAuditUpdates()`, `getModelAuditLatestVersion()`, and `getModelAuditCurrentVersion()` functions to `src/updates.ts`
- Integrated update check into the `scan-model` command workflow in `src/commands/modelScan.ts`
- Added comprehensive test coverage for all new functionality

## Implementation Details
The update check:
1. Fetches the latest version from PyPI's JSON API
2. Gets the current installed version via `pip show modelaudit`
3. Compares versions using semver
4. Shows an update message if a newer version is available

## Test Plan
- [x] All existing tests pass
- [x] New tests added for modelaudit update checking functions
- [x] Tests verify correct behavior with different version scenarios
- [x] Tests verify PROMPTFOO_DISABLE_UPDATE is respected
- [x] Manual testing confirms update check works as expected