### PR TITLE
feat: Allow remote Turso as a data provider

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,37 @@
 import { defineConfig } from 'drizzle-kit';
 import { getDbPath } from './src/database';
 
+// Determine database URL based on environment variables
+const getDatabaseUrl = () => {
+  const tursoUrl = process.env.TURSO_DATABASE_URL || process.env.DATABASE_URL;
+  const useTurso = process.env.PROMPTFOO_USE_TURSO === 'true';
+  
+  if (useTurso && tursoUrl) {
+    return tursoUrl;
+  }
+  
+  return `file:${getDbPath()}`;
+};
+
+const getDatabaseCredentials = () => {
+  const tursoUrl = process.env.TURSO_DATABASE_URL || process.env.DATABASE_URL;
+  const useTurso = process.env.PROMPTFOO_USE_TURSO === 'true';
+  
+  if (useTurso && tursoUrl) {
+    return {
+      url: tursoUrl,
+      authToken: process.env.TURSO_AUTH_TOKEN,
+    };
+  }
+  
+  return {
+    url: `file:${getDbPath()}`,
+  };
+};
+
 export default defineConfig({
   dialect: 'turso',
   schema: './src/database/tables.ts',
   out: './drizzle',
-  dbCredentials: {
-    url: `file:${getDbPath()}`,
-  },
+  dbCredentials: getDatabaseCredentials(),
 });

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -94,6 +94,14 @@ type EnvVars = {
   PROMPTFOO_JKS_ALIAS?: string;
 
   //=========================================================================
+  // Database configuration
+  //=========================================================================
+  DATABASE_URL?: string;
+  TURSO_DATABASE_URL?: string;
+  TURSO_AUTH_TOKEN?: string;
+  PROMPTFOO_USE_TURSO?: boolean;
+
+  //=========================================================================
   // HTTP proxy settings
   //=========================================================================
   ALL_PROXY?: string;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1403,10 +1403,10 @@ class Evaluator {
       }
 
       const compareAssertion = resultsToCompare[0].testCase.assert?.find(
-        (a) => a.type === 'select-best',
+        (a: any) => a.type === 'select-best',
       ) as Assertion;
       if (compareAssertion) {
-        const outputs = resultsToCompare.map((r) => r.response?.output || '');
+        const outputs = resultsToCompare.map((r: any) => r.response?.output || '');
         const gradingResults = await runCompareAssertion(
           resultsToCompare[0].testCase,
           compareAssertion,
@@ -1494,11 +1494,11 @@ class Evaluator {
         }
 
         const maxScoreAssertion = resultsToCompare[0].testCase.assert?.find(
-          (a) => a.type === 'max-score',
+          (a: any) => a.type === 'max-score',
         ) as Assertion;
 
         if (maxScoreAssertion) {
-          const outputs = resultsToCompare.map((r) => r.response?.output || '');
+          const outputs = resultsToCompare.map((r: any) => r.response?.output || '');
 
           // Pass the results with their grading results to selectMaxScore
           const maxScoreGradingResults = await selectMaxScore(

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -116,7 +116,7 @@ export default class EvalResult {
   static async createManyFromEvaluateResult(results: EvaluateResult[], evalId: string) {
     const db = getDb();
     const returnResults: EvalResult[] = [];
-    await db.transaction(async (tx) => {
+    await db.transaction(async (tx: any) => {
       for (const result of results) {
         const dbResult = await tx
           .insert(evalResultsTable)
@@ -145,7 +145,7 @@ export default class EvalResult {
           opts?.testIdx == null ? undefined : eq(evalResultsTable.testIdx, opts.testIdx),
         ),
       );
-    return results.map((result) => new EvalResult({ ...result, persisted: true }));
+    return results.map((result: any) => new EvalResult({ ...result, persisted: true }));
   }
 
   static async findManyByEvalIdAndTestIndices(evalId: string, testIndices: number[]) {
@@ -166,7 +166,7 @@ export default class EvalResult {
         ),
       );
 
-    return results.map((result) => new EvalResult({ ...result, persisted: true }));
+    return results.map((result: any) => new EvalResult({ ...result, persisted: true }));
   }
 
   // This is a generator that yields batches of results from the database
@@ -198,7 +198,7 @@ export default class EvalResult {
         break;
       }
 
-      yield results.map((result) => new EvalResult({ ...result, persisted: true }));
+      yield results.map((result: any) => new EvalResult({ ...result, persisted: true }));
       offset += batchSize;
     }
   }

--- a/src/redteam/strategies/retry.ts
+++ b/src/redteam/strategies/retry.ts
@@ -57,7 +57,7 @@ async function getFailedTestCases(pluginId: string, targetLabel: string): Promis
       .limit(100);
 
     const testCases = results
-      .map((r) => {
+      .map((r: any) => {
         try {
           const testCase: TestCase =
             typeof r.testCase === 'string' ? JSON.parse(r.testCase) : r.testCase;
@@ -83,7 +83,7 @@ async function getFailedTestCases(pluginId: string, targetLabel: string): Promis
           return null;
         }
       })
-      .filter((tc): tc is NonNullable<typeof tc> => tc !== null);
+      .filter((tc: any): tc is NonNullable<typeof tc> => tc !== null);
 
     const unique = deduplicateTests(testCases);
     logger.debug(

--- a/src/tracing/store.ts
+++ b/src/tracing/store.ts
@@ -126,7 +126,7 @@ export class TraceStore {
 
       // Get spans for each trace
       const tracesWithSpans = await Promise.all(
-        traces.map(async (trace) => {
+        traces.map(async (trace: any) => {
           logger.debug(`[TraceStore] Fetching spans for trace ${trace.traceId}`);
           const spans = await db
             .select()

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -502,7 +502,7 @@ export async function getStandaloneEvals({
   }
 
   const db = getDb();
-  const results = db
+  const results = await db
     .select({
       evalId: evalsTable.id,
       description: evalsTable.description,
@@ -532,7 +532,7 @@ export async function getStandaloneEvals({
   // TODO(Performance): Load all necessary data in one go rather than re-requesting each eval!
   const standaloneEvals = (
     await Promise.all(
-      results.map(async (result) => {
+      results.map(async (result: any) => {
         const {
           description,
           createdAt,


### PR DESCRIPTION
Maintaining this in line with promptfoo's main branch is going to get annoying. I don't think we can get this merged into their main - the async / sync types result in a lot of weird `any` returns and that feels icky in typescript.

I've got another iteration going that tries to unify on drizzle as the single ORM layer, which might be a better approach to get something merged to promptfoo - but this is a start.