### PR TITLE
feat: add azure:responses provider alias for Azure Responses API

### DIFF
--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -68,8 +68,235 @@ providers:
 - `azure:chat:<deployment name>` - For chat endpoints (e.g., gpt-4o, gpt-4o-mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano)
 - `azure:completion:<deployment name>` - For completion endpoints (e.g., gpt-35-turbo-instruct)
 - `azure:embedding:<deployment name>` - For embedding models (e.g., text-embedding-3-small, text-embedding-3-large)
+- `azure:responses:<deployment name>` - For the Responses API (e.g., gpt-4.1, gpt-5, o3-mini)
 
 Vision-capable models (GPT-4o, GPT-4.1) use the standard `azure:chat:` provider type.
+
+## Azure Responses API
+
+The Azure OpenAI Responses API is a stateful API that brings together the best capabilities from chat completions and assistants API in one unified experience. It provides advanced features like MCP servers, code interpreter, and background tasks.
+
+### Using the Responses API
+
+To use the Azure Responses API with promptfoo, use the `azure:responses` provider type:
+
+```yaml
+providers:
+  # Using the azure:responses alias (recommended)
+  - id: azure:responses:gpt-4.1-deployment
+    config:
+      temperature: 0.7
+      instructions: 'You are a helpful assistant.'
+      response_format: file://./response-schema.json
+
+  # Or using openai:responses with Azure configuration (legacy method)
+  - id: openai:responses:gpt-4.1
+    config:
+      apiHost: 'your-resource.openai.azure.com'
+      apiKey: '${AZURE_API_KEY}'
+      temperature: 0.7
+      instructions: 'You are a helpful assistant.'
+```
+
+### Supported Responses Models
+
+The Responses API supports all Azure OpenAI models:
+
+- **GPT-5 Series**: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`
+- **GPT-4 Series**: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
+- **Reasoning Models**: `o1`, `o1-mini`, `o1-pro`, `o3`, `o3-mini`, `o3-pro`, `o4-mini`
+- **Specialized Models**: `computer-use-preview`, `gpt-image-1`, `codex-mini-latest`
+- **Deep Research Models**: `o3-deep-research`, `o4-mini-deep-research`
+
+### Responses API Features
+
+#### Response Format with External Files
+
+Load complex JSON schemas from external files for better organization:
+
+```yaml
+providers:
+  - id: openai:responses:gpt-4.1
+    config:
+      apiHost: 'your-resource.openai.azure.com'
+      response_format: file://./schemas/response-schema.json
+```
+
+Example `response-schema.json`:
+
+```json
+{
+  "type": "json_schema",
+  "name": "structured_output",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "result": { "type": "string" },
+      "confidence": { "type": "number" }
+    },
+    "required": ["result", "confidence"],
+    "additionalProperties": false
+  }
+}
+```
+
+#### Advanced Configuration
+
+**Instructions**: Provide system-level instructions to guide model behavior:
+
+```yaml
+config:
+  instructions: 'You are a helpful assistant specializing in technical documentation.'
+```
+
+**Background Tasks**: Enable asynchronous processing for long-running tasks:
+
+```yaml
+config:
+  background: true
+  store: true
+```
+
+**Chaining Responses**: Chain multiple responses together for multi-turn conversations:
+
+```yaml
+config:
+  previous_response_id: '{{previous_id}}'
+```
+
+**MCP Servers**: Connect to remote MCP servers for extended tool capabilities:
+
+```yaml
+config:
+  tools:
+    - type: mcp
+      server_label: github
+      server_url: https://example.com/mcp-server
+      require_approval: never
+      headers:
+        Authorization: 'Bearer ${MCP_API_KEY}'
+```
+
+**Code Interpreter**: Enable code execution capabilities:
+
+```yaml
+config:
+  tools:
+    - type: code_interpreter
+      container:
+        type: auto
+```
+
+**Web Search**: Enable web search capabilities:
+
+```yaml
+config:
+  tools:
+    - type: web_search_preview
+```
+
+**Image Generation**: Use image generation with supported models:
+
+```yaml
+config:
+  tools:
+    - type: image_generation
+      partial_images: 2 # For streaming partial images
+```
+
+### Complete Responses API Example
+
+Here's a comprehensive example using multiple Azure Responses API features:
+
+```yaml
+# promptfooconfig.yaml
+description: Azure Responses API evaluation
+
+providers:
+  # Using the new azure:responses alias (recommended)
+  - id: azure:responses:gpt-4.1-deployment
+    label: azure-gpt-4.1
+    config:
+      temperature: 0.7
+      max_output_tokens: 2000
+      instructions: 'You are a helpful AI assistant.'
+      response_format: file://./response-format.json
+      tools:
+        - type: code_interpreter
+          container:
+            type: auto
+        - type: web_search_preview
+      metadata:
+        session: 'eval-001'
+        user: 'test-user'
+      store: true
+
+  # Reasoning model example
+  - id: azure:responses:o3-mini-deployment
+    label: azure-reasoning
+    config:
+      reasoning_effort: medium
+      max_completion_tokens: 4000
+
+prompts:
+  - 'Analyze this data and provide insights: {{data}}'
+  - 'Write a Python function to solve: {{problem}}'
+
+tests:
+  - vars:
+      data: 'Sales increased by 25% in Q3 compared to Q2'
+    assert:
+      - type: contains
+        value: 'growth'
+      - type: contains
+        value: '25%'
+
+  - vars:
+      problem: 'Calculate fibonacci sequence up to n terms'
+    assert:
+      - type: javascript
+        value: 'output.includes("def fibonacci") || output.includes("function fibonacci")'
+      - type: contains
+        value: 'recursive'
+```
+
+### Additional Responses API Configuration
+
+**Streaming**: Enable streaming for real-time output:
+
+```yaml
+config:
+  stream: true
+```
+
+**Parallel Tool Calls**: Allow multiple tool calls in parallel:
+
+```yaml
+config:
+  parallel_tool_calls: true
+  max_tool_calls: 5
+```
+
+**Truncation**: Configure how input is truncated when it exceeds limits:
+
+```yaml
+config:
+  truncation: auto # or 'disabled'
+```
+
+**Webhook URL**: Set a webhook for async notifications:
+
+```yaml
+config:
+  webhook_url: 'https://your-webhook.com/callback'
+```
+
+### Responses API Limitations
+
+- Web search tool support is still in development
+- PDF file upload with `purpose: user_data` requires workaround (use `purpose: assistants`)
+- Background mode requires `store: true`
+- Some features may have region-specific availability
 
 ## Environment Variables
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -1312,6 +1312,23 @@ providers:
       tool_choice: 'auto'
 ```
 
+### Using with Azure
+
+The Responses API can also be used with Azure OpenAI endpoints by configuring the `apiHost`:
+
+```yaml
+providers:
+  - id: openai:responses:gpt-4.1
+    config:
+      apiHost: 'your-resource.openai.azure.com'
+      apiKey: '${AZURE_API_KEY}'
+      temperature: 0.7
+      instructions: 'You are a helpful assistant.'
+      response_format: file://./response-schema.json
+```
+
+For comprehensive Azure Responses API documentation, see the [Azure provider documentation](/docs/providers/azure#azure-responses-api).
+
 ### Complete Example
 
 For a complete working example, see the [OpenAI Responses API example](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-responses) or initialize it with:

--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -1,0 +1,83 @@
+import { getEnvString } from '../../envars';
+import { FunctionCallbackHandler } from '../functionCallbackUtils';
+import { OpenAiResponsesProvider } from '../openai/responses';
+import { AzureGenericProvider } from './generic';
+
+import type { CallApiContextParams, CallApiOptionsParams, ProviderResponse } from '../../types';
+import type { OpenAiCompletionOptions } from '../openai/types';
+
+export class AzureResponsesProvider extends AzureGenericProvider {
+  private functionCallbackHandler = new FunctionCallbackHandler();
+  private openAiResponsesProvider: OpenAiResponsesProvider;
+
+  constructor(...args: ConstructorParameters<typeof AzureGenericProvider>) {
+    super(...args);
+
+    // Create an OpenAiResponsesProvider instance with Azure configuration
+    this.openAiResponsesProvider = new OpenAiResponsesProvider(this.deploymentName, {
+      config: {
+        ...this.config,
+        apiHost: this.apiHost,
+        apiBaseUrl: this.apiBaseUrl,
+        // Azure providers handle auth headers separately, so we'll override them in callApi
+      } as OpenAiCompletionOptions,
+      env: this.env,
+    });
+  }
+
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    callApiOptions?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    // Ensure Azure authentication is initialized
+    await this.ensureInitialized();
+
+    // Temporarily set the auth headers on the OpenAiResponsesProvider
+    // This is a bit of a hack, but it allows us to reuse the OpenAiResponsesProvider logic
+    // while using Azure authentication
+    const originalGetApiKey = this.openAiResponsesProvider.getApiKey;
+    const originalGetApiUrl = this.openAiResponsesProvider.getApiUrl;
+
+    // Override the getApiKey to return Azure API key if available
+    this.openAiResponsesProvider.getApiKey = () => {
+      if (this.authHeaders?.['api-key']) {
+        return this.authHeaders['api-key'];
+      }
+      return this.config.apiKey || this.env?.AZURE_API_KEY || getEnvString('AZURE_API_KEY');
+    };
+
+    // Override the getApiUrl to use Azure endpoint format
+    this.openAiResponsesProvider.getApiUrl = () => {
+      const baseUrl = this.getApiBaseUrl();
+      if (!baseUrl) {
+        throw new Error('Azure API host must be set.');
+      }
+      // Azure Responses API uses the same URL format as OpenAI but with Azure base URL
+      return baseUrl;
+    };
+
+    // Set headers including Azure auth headers
+    this.openAiResponsesProvider.config.headers = {
+      ...this.config.headers,
+      ...this.authHeaders,
+    };
+
+    try {
+      // Delegate to OpenAiResponsesProvider for the actual API call
+      const result = await this.openAiResponsesProvider.callApi(prompt, context, callApiOptions);
+
+      // Restore original methods
+      this.openAiResponsesProvider.getApiKey = originalGetApiKey;
+      this.openAiResponsesProvider.getApiUrl = originalGetApiUrl;
+
+      return result;
+    } catch (error) {
+      // Restore original methods even on error
+      this.openAiResponsesProvider.getApiKey = originalGetApiKey;
+      this.openAiResponsesProvider.getApiUrl = originalGetApiUrl;
+
+      throw error;
+    }
+  }
+}

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -20,6 +20,9 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'gpt-4o-2024-08-06',
     'gpt-4o-2024-11-20',
     'gpt-4o-2024-05-13',
+    'gpt-4o-2024-07-18',
+    'gpt-4o-mini',
+    'gpt-4o-mini-2024-07-18',
     'gpt-4.1',
     'gpt-4.1-2025-04-14',
     'gpt-4.1-mini',
@@ -29,11 +32,18 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     // GPT-5 models
     'gpt-5',
     'gpt-5-2025-08-07',
+    'gpt-5-chat',
     'gpt-5-chat-latest',
     'gpt-5-nano',
     'gpt-5-nano-2025-08-07',
     'gpt-5-mini',
     'gpt-5-mini-2025-08-07',
+    // Computer use model
+    'computer-use-preview',
+    // Image generation model
+    'gpt-image-1',
+    'gpt-image-1-2025-04-15',
+    // Reasoning models
     'o1',
     'o1-2024-12-17',
     'o1-preview',

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -24,6 +24,7 @@ import { AzureChatCompletionProvider } from './azure/chat';
 import { AzureCompletionProvider } from './azure/completion';
 import { AzureEmbeddingProvider } from './azure/embedding';
 import { AzureModerationProvider } from './azure/moderation';
+import { AzureResponsesProvider } from './azure/responses';
 import { BAMProvider } from './bam';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './bedrock/index';
 import { BrowserProvider } from './browser';
@@ -250,8 +251,11 @@ export const providerMap: ProviderFactory[] = [
       if (modelType === 'completion') {
         return new AzureCompletionProvider(deploymentName, providerOptions);
       }
+      if (modelType === 'responses') {
+        return new AzureResponsesProvider(deploymentName || 'gpt-4.1-2025-04-14', providerOptions);
+      }
       throw new Error(
-        `Unknown Azure model type: ${modelType}. Use one of the following providers: azure:chat:<model name>, azure:assistant:<assistant id>, azure:completion:<model name>, azure:moderation:<model name>`,
+        `Unknown Azure model type: ${modelType}. Use one of the following providers: azure:chat:<model name>, azure:assistant:<assistant id>, azure:completion:<model name>, azure:moderation:<model name>, azure:responses:<model name>`,
       );
     },
   },


### PR DESCRIPTION
## Summary

This PR adds support for the `azure:responses:` provider alias, making it more intuitive for users to use the Azure OpenAI Responses API with promptfoo.

## Problem

Daniel Furman reported in issue PF-566 that users need to use `openai:responses` with Azure configuration, which is not intuitive. The Azure Responses API documentation shows it's a fully supported Azure service.

## Solution

- Created `AzureResponsesProvider` that extends `AzureGenericProvider` and delegates to `OpenAiResponsesProvider`
- Added `azure:responses:` provider type registration in the registry
- Updated documentation to show both methods (new `azure:responses` alias and legacy `openai:responses` with Azure config)
- Ensures proper Azure authentication support (API keys and Azure AD)

## Usage

Users can now use the more intuitive Azure-specific alias:

```yaml
providers:
  # New recommended method
  - id: azure:responses:gpt-4.1-deployment
    config:
      temperature: 0.7
      instructions: 'You are a helpful assistant.'
      response_format: file://./schema.json
      
  # Legacy method still supported
  - id: openai:responses:gpt-4.1
    config:
      apiHost: 'instance.openai.azure.com'
      apiKey: '${AZURE_API_KEY}'
```

## Testing

- Verified the provider is recognized and attempts API calls
- External file loading for `response_format` works correctly
- All Azure Responses API models are supported

Fixes PF-566