### PR TITLE
chore(modelAudit): defer auth to modelaudit via environment variable

### DIFF
--- a/src/commands/modelScan.ts
+++ b/src/commands/modelScan.ts
@@ -94,7 +94,13 @@ export function modelScanCommand(program: Command): void {
 
       logger.info(`Running model scan on: ${paths.join(', ')}`);
 
-      const modelAudit = spawn('modelaudit', args, { stdio: 'inherit' });
+      // Set up environment for delegation
+      const delegationEnv = {
+        ...process.env,
+        PROMPTFOO_DELEGATED: 'true', // Signal to modelaudit that it's being delegated
+      };
+
+      const modelAudit = spawn('modelaudit', args, { stdio: 'inherit', env: delegationEnv });
 
       modelAudit.on('error', (error) => {
         logger.error(`Failed to start modelaudit: ${error.message}`);


### PR DESCRIPTION
## Summary
- Add PROMPTFOO_DELEGATED environment variable to signal delegation of authentication handling to modelaudit

## Changes
- Set `PROMPTFOO_DELEGATED: 'true'` in spawn environment when running modelaudit
- This allows modelaudit to handle authentication delegation properly

## Test plan
- [ ] Verify modelaudit still runs with the new environment variable
- [ ] Confirm delegation behavior works as expected