### PR TITLE
feat(redteam): add -t/--target option to redteam generate command

### DIFF
--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -109,6 +109,7 @@ type CommonOptions = {
 export interface RedteamCliGenerateOptions extends CommonOptions {
   cache: boolean;
   config?: string;
+  target?: string;
   defaultConfig: Record<string, unknown>;
   defaultConfigPath?: string;
   envFile?: string;
@@ -121,6 +122,8 @@ export interface RedteamCliGenerateOptions extends CommonOptions {
   abortSignal?: AbortSignal;
   burpEscapeJson?: boolean;
   progressBar?: boolean;
+  liveRedteamConfig?: any;
+  loadedFromCloud?: boolean;
 }
 
 export interface RedteamFileConfig extends CommonOptions {

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -148,6 +148,7 @@ export const RedteamGenerateOptionsSchema = z.object({
     .describe('Additional strategies to include'),
   cache: z.boolean().describe('Whether to use caching'),
   config: z.string().optional().describe('Path to the configuration file'),
+  target: z.string().optional().describe('Cloud provider target ID to run the scan on'),
   defaultConfig: z.record(z.unknown()).describe('Default configuration object'),
   defaultConfigPath: z.string().optional().describe('Path to the default configuration file'),
   delay: z
@@ -175,6 +176,8 @@ export const RedteamGenerateOptionsSchema = z.object({
   write: z.boolean().describe('Whether to write the output'),
   burpEscapeJson: z.boolean().describe('Whether to escape quotes in Burp payloads').optional(),
   progressBar: z.boolean().describe('Whether to show a progress bar').optional(),
+  liveRedteamConfig: z.any().optional().describe('Live redteam configuration from cloud'),
+  loadedFromCloud: z.boolean().optional().describe('Whether the config was loaded from cloud'),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add support for the `-t, --target <id>` option to the `promptfoo redteam generate` command
- This allows users to specify a cloud provider target ID when generating red team tests
- The implementation mirrors the existing `redteam run` command's handling of cloud targets

## Changes
- Added `target`, `liveRedteamConfig`, and `loadedFromCloud` fields to `RedteamCliGenerateOptions` interface
- Updated validation schema to include the new fields
- Added command-line option `-t, --target <id>` to both `promptfoo redteam generate` and `promptfoo generate redteam` commands
- Implemented cloud config fetching logic in the command handler
- Added handling for `liveRedteamConfig` in `doGenerateRedteam` to write cloud configs to temp files

## Usage
```bash
promptfoo redteam generate -c <cloud-config-uuid> -t <target-uuid>
```

## Test plan
- [x] TypeScript compilation passes
- [x] Linting and formatting checks pass
- [x] Option appears correctly in help text for both command variants
- [ ] Manual testing with cloud config and target IDs
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)