### PR TITLE
fix: Add gpt-oss to openai reasoning model list

### DIFF
--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -171,6 +171,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       this.modelName.startsWith('o1') ||
       this.modelName.startsWith('o3') ||
       this.modelName.startsWith('o4') ||
+      this.modelName.startsWith('gpt-oss') ||
       this.modelName.startsWith('gpt-5')
     );
   }


### PR DESCRIPTION
gpt-oss is a reasoning model, so when testing with a provider like groq, we can't parse or hide reasoning from the output for evaluation. 

This fixes that.