### PR TITLE
docs: add SARIF output format documentation for ModelAudit

### DIFF
--- a/site/docs/model-audit/index.md
+++ b/site/docs/model-audit/index.md
@@ -131,6 +131,9 @@ promptfoo scan-model model.pkl model2.h5 models_directory
 # Export results to JSON
 promptfoo scan-model model.pkl --format json --output results.json
 
+# Export results to SARIF for security tool integration
+promptfoo scan-model model.pkl --format sarif --output results.sarif
+
 # Add custom blacklist patterns
 promptfoo scan-model model.pkl --blacklist "unsafe_model" --blacklist "malicious_net"
 

--- a/site/docs/model-audit/usage.md
+++ b/site/docs/model-audit/usage.md
@@ -169,21 +169,21 @@ jobs:
           pip install modelaudit[all]
 
       - name: Scan models
-        run: promptfoo scan-model models/ --format json --output scan-results.json
+        run: promptfoo scan-model models/ --format sarif --output model-scan.sarif
 
-      - name: Check for critical issues
-        run: |
-          if grep -q '"severity":"critical"' scan-results.json; then
-            echo "Critical security issues found in models!"
-            exit 1
-          fi
+      - name: Upload SARIF to GitHub Advanced Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: model-scan.sarif
+          category: model-security
 
-      - name: Upload scan results
+      - name: Upload scan results as artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: model-scan-results
-          path: scan-results.json
+          path: model-scan.sarif
 ```
 
 ### GitLab CI
@@ -303,6 +303,135 @@ When using `--format json`, ModelAudit outputs structured results:
   ]
 }
 ```
+
+## SARIF Output Format
+
+ModelAudit supports SARIF (Static Analysis Results Interchange Format) 2.1.0 output for seamless integration with security tools and CI/CD pipelines:
+
+```bash
+# Output SARIF to stdout
+promptfoo scan-model model.pkl --format sarif
+
+# Save SARIF to file
+promptfoo scan-model model.pkl --format sarif --output results.sarif
+
+# Scan multiple models with SARIF output
+promptfoo scan-model models/ --format sarif --output scan-results.sarif
+```
+
+### SARIF Structure
+
+The SARIF output includes:
+
+- **Rules**: Unique security patterns detected (e.g., pickle issues, dangerous imports)
+- **Results**: Individual findings with severity levels, locations, and fingerprints
+- **Artifacts**: Information about scanned files including hashes
+- **Tool Information**: ModelAudit version and capabilities
+- **Invocation Details**: Command-line arguments and scan statistics
+
+Example SARIF output structure:
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ModelAudit",
+          "version": "0.2.3",
+          "rules": [
+            {
+              "id": "MA-PICKLE-ISSUE",
+              "name": "Pickle Security Issue",
+              "defaultConfiguration": {
+                "level": "error",
+                "rank": 90.0
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "MA-PICKLE-ISSUE",
+          "level": "error",
+          "message": {
+            "text": "Suspicious module reference found: os.system"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "model.pkl"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Severity Mapping
+
+ModelAudit severities are mapped to SARIF levels:
+- `CRITICAL` → `error`
+- `WARNING` → `warning`
+- `INFO` → `note`
+- `DEBUG` → `none`
+
+### Integration with Security Tools
+
+SARIF output enables integration with:
+
+#### GitHub Advanced Security
+```yaml
+# .github/workflows/security.yml
+- name: Scan models
+  run: promptfoo scan-model models/ --format sarif --output model-scan.sarif
+
+- name: Upload SARIF to GitHub
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: model-scan.sarif
+    category: model-security
+```
+
+#### Azure DevOps
+```yaml
+# azure-pipelines.yml
+- script: |
+    promptfoo scan-model models/ --format sarif --output $(Build.ArtifactStagingDirectory)/model-scan.sarif
+  displayName: 'Scan models'
+
+- task: PublishSecurityAnalysisLogs@3
+  inputs:
+    ArtifactName: 'CodeAnalysisLogs'
+    ArtifactType: 'Container'
+    AllTools: false
+    ToolLogsNotFoundAction: 'Standard'
+```
+
+#### VS Code SARIF Viewer
+```bash
+# Generate SARIF for local viewing
+promptfoo scan-model . --format sarif --output scan.sarif
+
+# Open in VS Code with SARIF Viewer extension
+code scan.sarif
+```
+
+#### Static Analysis Platforms
+SARIF output is compatible with:
+- SonarQube/SonarCloud (via import)
+- Fortify
+- Checkmarx
+- CodeQL
+- Snyk
+- And many other SARIF-compatible tools
 
 ## Software Bill of Materials (SBOM)
 


### PR DESCRIPTION
## Summary
Add comprehensive documentation for the new SARIF output format feature introduced in ModelAudit.

## Changes
- Added SARIF format examples to basic usage in `index.md`
- Created detailed SARIF format section in `usage.md` with:
  - Command examples for SARIF output
  - SARIF structure explanation
  - Severity level mapping
  - Integration guides for security tools
- Updated CI/CD examples to demonstrate SARIF usage with GitHub Advanced Security

## Related
- ModelAudit PR: https://github.com/promptfoo/modelaudit/pull/349

## Documentation Sections Added
1. **SARIF Output Format** - Complete reference for SARIF 2.1.0 output
2. **Severity Mapping** - How ModelAudit severities map to SARIF levels
3. **Tool Integration** - Examples for GitHub, Azure DevOps, VS Code, etc.
4. **CI/CD Updates** - GitHub Actions example now uses SARIF format

🤖 Generated with [Claude Code](https://claude.ai/code)