### PR TITLE
docs: expose sidebar on pages that aren't in the sidebar

### DIFF
--- a/site/docs/configuration/huggingface-datasets.md
+++ b/site/docs/configuration/huggingface-datasets.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+displayed_sidebar: promptfoo
 sidebar_label: HuggingFace Datasets
 title: Loading Test Cases from HuggingFace Datasets
 description: Load HuggingFace datasets directly for LLM evaluation with automatic splits, filtering, and format conversion capabilities
@@ -14,7 +14,7 @@ keywords:
     existing datasets,
   ]
 pagination_prev: configuration/datasets
-pagination_next: configuration/outputs
+pagination_next: configuration/scenarios
 ---
 
 # HuggingFace Datasets

--- a/site/docs/configuration/modular-configs.md
+++ b/site/docs/configuration/modular-configs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 999
+displayed_sidebar: promptfoo
 sidebar_label: Managing Large Configs
 title: Managing Large Promptfoo Configurations
 description: Organize complex promptfoo configurations using modular YAML structures, file imports, and environment-specific settings

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+displayed_sidebar: promptfoo
 sidebar_label: Overview
 title: Configuration Overview - Prompts, Tests, and Outputs
 description: Quick overview of promptfoo's core configuration concepts including prompts, test cases, outputs, and common patterns for LLM evaluation.


### PR DESCRIPTION
Figure it's better to show the sidebar and not have a highlighted path, than to have no sidebar:
<img width="1479" height="990" alt="Screenshot 2025-08-26 at 11 37 36 AM" src="https://github.com/user-attachments/assets/458b894f-9e13-4b4d-aed8-4a1cbc13e4a1" />
