### PR TITLE
fix: mcp eval example

### DIFF
--- a/examples/simple-mcp/README.md
+++ b/examples/simple-mcp/README.md
@@ -1,15 +1,6 @@
 # Simple MCP (Model Context Protocol) Provider Example
 
-This example demonstrates how to use the MCP provider for security testing and red-teaming MCP servers. The MCP provider is designed for direct tool calling evaluation rather than text generation, making it ideal for testing tool behavior, security vulnerabilities, and edge cases.
-
-## What is MCP?
-
-Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to LLMs. With promptfoo's MCP provider, you can:
-
-- **Security Test MCP Tools**: Test for path traversal, command injection, SSRF, and other vulnerabilities
-- **Validate Tool Behavior**: Ensure tools handle invalid inputs gracefully
-- **Red-team MCP Servers**: Systematically test security boundaries and restrictions
-- **Evaluate Multiple Servers**: Test tools across different MCP implementations
+This example demonstrates how to use the MCP provider for evaluating MCP servers. The MCP provider is designed for direct tool calling evaluation rather than text generation, making it ideal for testing tool behavior, security vulnerabilities, and edge cases.
 
 ## Quick Start
 
@@ -18,12 +9,6 @@ You can run this example with:
 ```bash
 npx promptfoo@latest init --example simple-mcp
 ```
-
-## Prerequisites
-
-- Node.js (v16+)
-- An MCP server running locally or accessible via HTTP
-- Properly configured MCP server with tools that can handle text generation
 
 ## Getting Started
 
@@ -62,18 +47,14 @@ providers:
 tests:
   # Test path traversal prevention
   - vars:
-      tool: 'read_file'
-      args:
-        path: '../../../etc/passwd'
+      prompt: '{"tool": "read_file", "args": {"path": "../../../etc/passwd"}}'
     assert:
       - type: contains
         value: 'Path traversal not allowed'
 
   # Test command injection prevention
   - vars:
-      tool: 'execute_command'
-      args:
-        command: 'rm -rf /'
+      prompt: '{"tool": "execute_command", "args": {"command": "rm -rf /"}}'
     assert:
       - type: contains
         value: 'Dangerous command blocked'
@@ -87,106 +68,25 @@ Test various security scenarios and edge cases:
 tests:
   # SSRF prevention
   - vars:
-      tool: 'fetch_url'
-      args:
-        url: 'http://localhost:8080/admin'
+      prompt: '{"tool": "fetch_url", "args": {"url": "http://localhost:8080/admin"}}'
     assert:
       - type: contains
         value: 'Internal network access blocked'
 
   # SQL injection prevention
   - vars:
-      tool: 'query_database'
-      args:
-        query: 'SELECT * FROM users; DROP TABLE users;'
+      prompt: '{"tool": "query_database", "args": {"query": "SELECT * FROM users; DROP TABLE users;"}}'
     assert:
       - type: contains
         value: 'dangerous SQL query blocked'
 
   # XSS sanitization
   - vars:
-      tool: 'process_data'
-      args:
-        data: '<script>alert("xss")</script>Hello'
-        operation: 'sanitize'
+      prompt: '{"tool": "process_data", "args": {"data": "<script>alert(\"xss\")</script>Hello", "operation": "sanitize"}}'
     assert:
       - type: contains
         value: '[SCRIPT_REMOVED]'
 ```
-
-### Multiple MCP Servers
-
-```yaml
-providers:
-  - id: mcp
-    config:
-      enabled: true
-      servers:
-        - name: tools-server
-          url: http://localhost:3000/mcp
-        - name: data-server
-          path: ./data-server.py
-        - name: npm-server
-          command: npx
-          args: [some-mcp-package]
-      tools:
-        - generate_text
-        - analyze_data
-      exclude_tools:
-        - dangerous_tool
-      verbose: true
-      debug: true
-```
-
-## Provider Formats
-
-The MCP provider supports several formats:
-
-- `mcp` - Basic MCP provider for tool calling
-- `mcp:server_name` - Target specific server (when using multiple servers)
-
-## Test Case Format
-
-Each test case specifies the tool to call and its arguments:
-
-```yaml
-tests:
-  - vars:
-      tool: 'tool_name' # Required: name of the MCP tool to call
-      args: # Optional: arguments to pass to the tool
-        param1: 'value1'
-        param2: 'value2'
-      # Alternative argument formats:
-      # arguments: { ... }         # Can use 'arguments' instead of 'args'
-      # params: { ... }            # Can use 'params' instead of 'args'
-    assert:
-      - type: contains
-        value: 'expected output'
-```
-
-## Security Testing Scenarios
-
-The example includes test cases for:
-
-1. **Path Traversal**: Test file operations with `../` patterns to ensure proper path validation
-2. **Command Injection**: Test command execution tools with dangerous commands like `rm -rf /`
-3. **SSRF Prevention**: Test URL fetching tools with internal network addresses
-4. **SQL Injection**: Test database tools with malicious SQL patterns
-5. **XSS Prevention**: Test data processing tools with script injection attempts
-6. **Access Control**: Test file operations on restricted system files like `/etc/passwd`
-7. **Input Validation**: Test tools with malformed JSON and edge cases
-
-## Troubleshooting
-
-### Common Issues
-
-1. **"No tool specified"**: Each test case must specify which tool to call in the `vars.tool` field.
-
-2. **"Tool Not Found"**: Verify that the tool name exists in your MCP server and is not excluded by the `exclude_tools` configuration.
-
-3. **Connection Failed**: Check that your MCP server is running and accessible at the specified URL or path.
-
-4. **Invalid Arguments**: Ensure the arguments match what the MCP tool expects. Check the tool's input schema.
 
 ### Debug Mode
 

--- a/examples/simple-mcp/example-server.js
+++ b/examples/simple-mcp/example-server.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+
+import { exec } from 'child_process';
+import fs from 'fs';
+import { promisify } from 'util';
+
 /**
  * Simple MCP Server Example
  *
@@ -9,198 +14,17 @@
  *   node example-server.js
  *
  * Dependencies:
- *   npm install @modelcontextprotocol/sdk
+ *   npm install @modelcontextprotocol/sdk zod
  */
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { exec } from 'child_process';
-import fs from 'fs';
-import { promisify } from 'util';
+import { z } from 'zod';
 
 // Create MCP server
-const server = new Server(
-  {
-    name: 'example-text-server',
-    version: '1.0.0',
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
-
-// Define available tools
-const tools = [
-  {
-    name: 'read_file',
-    description: 'Read contents of a file from the local filesystem',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string',
-          description: 'File path to read',
-        },
-        encoding: {
-          type: 'string',
-          description: 'File encoding',
-          enum: ['utf8', 'base64', 'binary'],
-          default: 'utf8',
-        },
-      },
-      required: ['path'],
-    },
-  },
-  {
-    name: 'write_file',
-    description: 'Write content to a file on the local filesystem',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string',
-          description: 'File path to write to',
-        },
-        content: {
-          type: 'string',
-          description: 'Content to write to the file',
-        },
-        mode: {
-          type: 'string',
-          description: 'Write mode',
-          enum: ['write', 'append'],
-          default: 'write',
-        },
-      },
-      required: ['path', 'content'],
-    },
-  },
-  {
-    name: 'execute_command',
-    description: 'Execute a system command',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        command: {
-          type: 'string',
-          description: 'Command to execute',
-        },
-        args: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Command arguments',
-          default: [],
-        },
-        timeout: {
-          type: 'number',
-          description: 'Timeout in milliseconds',
-          default: 5000,
-        },
-      },
-      required: ['command'],
-    },
-  },
-  {
-    name: 'fetch_url',
-    description: 'Fetch content from a URL',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        url: {
-          type: 'string',
-          description: 'URL to fetch',
-        },
-        method: {
-          type: 'string',
-          description: 'HTTP method',
-          enum: ['GET', 'POST', 'PUT', 'DELETE'],
-          default: 'GET',
-        },
-        headers: {
-          type: 'object',
-          description: 'HTTP headers',
-          default: {},
-        },
-        body: {
-          type: 'string',
-          description: 'Request body for POST/PUT requests',
-        },
-      },
-      required: ['url'],
-    },
-  },
-  {
-    name: 'query_database',
-    description: 'Execute a database query',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: {
-          type: 'string',
-          description: 'SQL query to execute',
-        },
-        database: {
-          type: 'string',
-          description: 'Database name',
-          default: 'default',
-        },
-        params: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Query parameters',
-          default: [],
-        },
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'process_data',
-    description: 'Process and transform data',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        data: {
-          type: 'string',
-          description: 'Data to process (JSON string or plain text)',
-        },
-        operation: {
-          type: 'string',
-          description: 'Operation to perform',
-          enum: ['validate', 'transform', 'extract'],
-        },
-        format: {
-          type: 'string',
-          description: 'Expected data format',
-          enum: ['json', 'xml', 'csv', 'text'],
-          default: 'text',
-        },
-      },
-      required: ['data', 'operation'],
-    },
-  },
-  {
-    name: 'get_system_info',
-    description: 'Get system information',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        info_type: {
-          type: 'string',
-          description: 'Type of system information',
-          enum: ['cpu', 'memory', 'disk', 'network', 'processes', 'environment'],
-        },
-        detailed: {
-          type: 'boolean',
-          description: 'Return detailed information',
-          default: false,
-        },
-      },
-      required: ['info_type'],
-    },
-  },
-];
+const server = new McpServer({
+  name: 'example-text-server',
+  version: '1.0.0',
+});
 
 const execAsync = promisify(exec);
 
@@ -330,71 +154,262 @@ function getSystemInfo(infoType, detailed = false) {
   return info[infoType] || 'Unknown system information type';
 }
 
-// Handle tool listing
-server.setRequestHandler('tools/list', async () => {
-  return { tools };
-});
-
-// Handle tool calls
-server.setRequestHandler('tools/call', async (request) => {
-  const { name, arguments: args } = request.params;
-
-  try {
-    let result;
-
-    switch (name) {
-      case 'read_file':
-        result = readFile(args.path, args.encoding);
-        break;
-
-      case 'write_file':
-        result = writeFile(args.path, args.content, args.mode);
-        break;
-
-      case 'execute_command':
-        result = await executeCommand(args.command, args.args, args.timeout);
-        break;
-
-      case 'fetch_url':
-        result = await fetchUrl(args.url, args.method, args.headers, args.body);
-        break;
-
-      case 'query_database':
-        result = queryDatabase(args.query, args.database, args.params);
-        break;
-
-      case 'process_data':
-        result = processData(args.data, args.operation, args.format);
-        break;
-
-      case 'get_system_info':
-        result = getSystemInfo(args.info_type, args.detailed);
-        break;
-
-      default:
-        throw new Error(`Unknown tool: ${name}`);
+// Register tools with the MCP server
+server.registerTool(
+  'read_file',
+  {
+    title: 'Read File',
+    description: 'Read contents of a file from the local filesystem',
+    inputSchema: {
+      path: z.string().describe('File path to read'),
+      encoding: z.enum(['utf8', 'base64', 'binary']).default('utf8').describe('File encoding'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = readFile(args.path, args.encoding);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: String(result),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
     }
+  },
+);
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: String(result),
-        },
-      ],
-    };
-  } catch (error) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error: ${error.message}`,
-        },
-      ],
-      isError: true,
-    };
-  }
-});
+server.registerTool(
+  'write_file',
+  {
+    title: 'Write File',
+    description: 'Write content to a file on the local filesystem',
+    inputSchema: {
+      path: z.string().describe('File path to write to'),
+      content: z.string().describe('Content to write to the file'),
+      mode: z.enum(['write', 'append']).default('write').describe('Write mode'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = writeFile(args.path, args.content, args.mode);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'execute_command',
+  {
+    title: 'Execute Command',
+    description: 'Execute a system command',
+    inputSchema: {
+      command: z.string().describe('Command to execute'),
+      args: z.array(z.string()).default([]).describe('Command arguments'),
+      timeout: z.number().default(5000).describe('Timeout in milliseconds'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = await executeCommand(args.command, args.args, args.timeout);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: String(result),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'fetch_url',
+  {
+    title: 'Fetch URL',
+    description: 'Fetch content from a URL',
+    inputSchema: {
+      url: z.string().describe('URL to fetch'),
+      method: z.enum(['GET', 'POST', 'PUT', 'DELETE']).default('GET').describe('HTTP method'),
+      headers: z.record(z.string()).default({}).describe('HTTP headers'),
+      body: z.string().optional().describe('Request body for POST/PUT requests'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = await fetchUrl(args.url, args.method, args.headers, args.body);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'query_database',
+  {
+    title: 'Query Database',
+    description: 'Execute a database query',
+    inputSchema: {
+      query: z.string().describe('SQL query to execute'),
+      database: z.string().default('default').describe('Database name'),
+      params: z.array(z.string()).default([]).describe('Query parameters'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = queryDatabase(args.query, args.database, args.params);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'process_data',
+  {
+    title: 'Process Data',
+    description: 'Process and transform data',
+    inputSchema: {
+      data: z.string().describe('Data to process (JSON string or plain text)'),
+      operation: z.enum(['validate', 'transform', 'extract']).describe('Operation to perform'),
+      format: z
+        .enum(['json', 'xml', 'csv', 'text'])
+        .default('text')
+        .describe('Expected data format'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = processData(args.data, args.operation, args.format);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'get_system_info',
+  {
+    title: 'Get System Info',
+    description: 'Get system information',
+    inputSchema: {
+      info_type: z
+        .enum(['cpu', 'memory', 'disk', 'network', 'processes', 'environment'])
+        .describe('Type of system information'),
+      detailed: z.boolean().default(false).describe('Return detailed information'),
+    },
+  },
+  async (args) => {
+    try {
+      const result = getSystemInfo(args.info_type, args.detailed);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
 
 // Start the server
 async function main() {

--- a/examples/simple-mcp/package.json
+++ b/examples/simple-mcp/package.json
@@ -9,7 +9,8 @@
     "test": "promptfoo eval"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.4"
+    "@modelcontextprotocol/sdk": "^1.17.4",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "promptfoo": "*"

--- a/examples/simple-mcp/promptfooconfig.yaml
+++ b/examples/simple-mcp/promptfooconfig.yaml
@@ -1,8 +1,12 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: 'MCP tool evaluation and security testing'
 
+# Note: The MCP provider expects JSON-formatted tool calls in the 'prompt' variable.
+# Format: {"tool": "tool_name", "args": {"param1": "value1", "param2": "value2"}}
+# Alternative field names are also supported (see README.md for details)
+
 prompts:
-  - 'MCP Tool Call Test'
+  - '{{prompt}}'
 
 providers:
   - id: mcp
@@ -18,85 +22,65 @@ providers:
 tests:
   # Test basic file reading
   - vars:
-      tool: 'read_file'
-      args:
-        path: 'package.json'
+      prompt: '{"tool": "read_file", "args": {"path": "package.json"}}'
     assert:
-      - type: not-empty
+      - type: javascript
+        value: 'output && output.trim().length > 0'
       - type: contains
         value: 'simple-mcp-example'
 
   # Test path traversal prevention
   - vars:
-      tool: 'read_file'
-      args:
-        path: '../../../etc/passwd'
+      prompt: '{"tool": "read_file", "args": {"path": "../../../etc/passwd"}}'
     assert:
       - type: contains
         value: 'Path traversal not allowed'
 
   # Test restricted file access
   - vars:
-      tool: 'read_file'
-      args:
-        path: '/etc/passwd'
+      prompt: '{"tool": "read_file", "args": {"path": "/etc/passwd"}}'
     assert:
       - type: contains
         value: 'Permission denied'
 
   # Test command execution blocking
   - vars:
-      tool: 'execute_command'
-      args:
-        command: 'rm -rf /'
+      prompt: '{"tool": "execute_command", "args": {"command": "rm -rf /"}}'
     assert:
       - type: contains
         value: 'Dangerous command blocked'
 
   # Test safe command execution
   - vars:
-      tool: 'execute_command'
-      args:
-        command: 'echo'
-        args: ['Hello World']
+      prompt: '{"tool": "execute_command", "args": {"command": "echo", "args": ["Hello World"]}}'
     assert:
       - type: contains
         value: 'Hello World'
 
   # Test SSRF prevention
   - vars:
-      tool: 'fetch_url'
-      args:
-        url: 'http://localhost:8080/admin'
+      prompt: '{"tool": "fetch_url", "args": {"url": "http://localhost:8080/admin"}}'
     assert:
       - type: contains
         value: 'Internal network access blocked'
 
   # Test SQL injection prevention
   - vars:
-      tool: 'query_database'
-      args:
-        query: 'SELECT * FROM users; DROP TABLE users;'
+      prompt: '{"tool": "query_database", "args": {"query": "SELECT * FROM users; DROP TABLE users;"}}'
     assert:
       - type: contains
         value: 'dangerous SQL query blocked'
 
   # Test safe database query
   - vars:
-      tool: 'query_database'
-      args:
-        query: 'SELECT name FROM products WHERE category = ?'
-        params: ['electronics']
+      prompt: '{"tool": "query_database", "args": {"query": "SELECT name FROM products WHERE category = ?", "params": ["electronics"]}}'
     assert:
       - type: contains
         value: 'Mock query result'
 
   # Test data sanitization
   - vars:
-      tool: 'process_data'
-      args:
-        data: '<script>alert("xss")</script>Hello World'
-        operation: 'sanitize'
+      prompt: '{"tool": "process_data", "args": {"data": "<script>alert(\"xss\")</script>Hello World", "operation": "sanitize"}}'
     assert:
       - type: contains
         value: '[SCRIPT_REMOVED]'
@@ -105,53 +89,38 @@ tests:
 
   # Test JSON validation
   - vars:
-      tool: 'process_data'
-      args:
-        data: '{"valid": "json"}'
-        operation: 'validate'
-        format: 'json'
+      prompt: '{"tool": "process_data", "args": {"data": "{\"valid\": \"json\"}", "operation": "validate", "format": "json"}}'
     assert:
       - type: contains
         value: 'Valid JSON data'
 
   # Test system information access
   - vars:
-      tool: 'get_system_info'
-      args:
-        info_type: 'cpu'
-        detailed: true
+      prompt: '{"tool": "get_system_info", "args": {"info_type": "cpu", "detailed": true}}'
     assert:
       - type: contains
         value: 'Intel i7'
 
   # Test invalid tool name
   - vars:
-      tool: 'hack_system'
-      args:
-        target: 'everything'
+      prompt: '{"tool": "hack_system", "args": {"target": "everything"}}'
     assert:
       - type: contains
         value: 'Unknown tool'
 
   # Test file write restrictions
   - vars:
-      tool: 'write_file'
-      args:
-        path: '/etc/shadow'
-        content: 'malicious content'
+      prompt: '{"tool": "write_file", "args": {"path": "/etc/shadow", "content": "malicious content"}}'
     assert:
       - type: contains
         value: 'Permission denied'
 
-  # Test JSON string arguments
+  # Test with alternative field names (using "function" instead of "tool")
   - vars:
-      tool: 'get_system_info'
-      args: '{"info_type": "memory", "detailed": false}'
+      prompt: '{"function": "get_system_info", "arguments": {"info_type": "memory", "detailed": false}}'
     assert:
       - type: contains
         value: 'Memory'
-
-outputPath: './output'
 
 evaluateOptions:
   maxConcurrency: 1 # MCP connections may need to be sequential


### PR DESCRIPTION
This fixes the mcp eval example `examples/simple-mcp`, which had the wrong test schema. Also updates the simple mcp server to use the latest api for mcp, and updates the documentation. 