### PR TITLE
feat: add AI auto-fill for HTTP target configuration

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
@@ -2,10 +2,8 @@ import './syntax-highlighting.css';
 
 import React, { useCallback, useState } from 'react';
 
-import yaml from 'js-yaml';
-import Editor from 'react-simple-code-editor';
-
 import AddIcon from '@mui/icons-material/Add';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -23,13 +21,15 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
-import { useTheme } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
+import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import yaml from 'js-yaml';
+import Editor from 'react-simple-code-editor';
+import HttpAdvancedConfiguration from './HttpAdvancedConfiguration';
 
 import type { ProviderOptions } from '../../types';
-import HttpAdvancedConfiguration from './HttpAdvancedConfiguration';
 
 interface HttpEndpointConfigurationProps {
   selectedTarget: ProviderOptions;
@@ -259,7 +259,7 @@ ${exampleRequest}`;
     setGenerating(true);
     setError('');
     try {
-      const res = await fetch('https://api.promptfoo.app/api/http-provider-generator', {
+      const res = await fetch('https://api.promptfoo.app/api/v1/http-provider-generator', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -332,21 +332,37 @@ ${exampleRequest}`;
 
   return (
     <Box>
-      <FormControlLabel
-        control={
-          <Switch
-            checked={Boolean(selectedTarget.config.request)}
-            onChange={(e) => {
-              resetState(e.target.checked);
-              if (e.target.checked) {
-                updateCustomTarget('request', exampleRequest);
-              }
-            }}
-          />
-        }
-        label="Use Raw HTTP Request"
-        sx={{ mb: 2, display: 'block' }}
-      />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={Boolean(selectedTarget.config.request)}
+              onChange={(e) => {
+                resetState(e.target.checked);
+                if (e.target.checked) {
+                  updateCustomTarget('request', exampleRequest);
+                }
+              }}
+            />
+          }
+          label="Use Raw HTTP Request"
+        />
+        <Button
+          variant="outlined"
+          startIcon={<AutoFixHighIcon />}
+          onClick={() => setConfigDialogOpen(true)}
+          sx={{
+            borderColor: 'primary.main',
+            color: 'primary.main',
+            '&:hover': {
+              borderColor: 'primary.dark',
+              backgroundColor: 'action.hover',
+            },
+          }}
+        >
+          AI Auto-fill from Example
+        </Button>
+      </Box>
       {selectedTarget.config.request ? (
         <Box
           mt={2}
@@ -502,12 +518,16 @@ ${exampleRequest}`;
         maxWidth="lg"
         fullWidth
       >
-        <DialogTitle>Generate HTTP Configuration</DialogTitle>
+        <DialogTitle>AI Auto-fill HTTP Configuration</DialogTitle>
         <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Paste an example HTTP request and optionally a response. AI will automatically generate
+            the configuration for you.
+          </Typography>
           <Grid container spacing={3} sx={{ mt: 1 }}>
             <Grid item xs={12} md={6}>
               <Typography variant="h6" gutterBottom>
-                Example Request
+                Example Request (paste your HTTP request here)
               </Typography>
               <Paper elevation={3} sx={{ height: '300px', overflow: 'auto' }}>
                 <Editor
@@ -526,7 +546,7 @@ ${exampleRequest}`;
             </Grid>
             <Grid item xs={12} md={6}>
               <Typography variant="h6" gutterBottom>
-                Example Response
+                Example Response (optional, improves accuracy)
               </Typography>
               <Paper elevation={3} sx={{ height: '300px', overflow: 'auto' }}>
                 <Editor


### PR DESCRIPTION
## Summary
- Add prominent "AI Auto-fill from Example" button to HTTP configuration UI
- Improve dialog with better descriptions and labels for user guidance
- Users can paste HTTP request/response examples to auto-generate configuration



https://github.com/user-attachments/assets/d71df3fa-fc44-4486-8b6b-dd9aceb989ff

