### PR TITLE
refactor: handle remote generation disabled in plugins

### DIFF
--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -198,7 +198,8 @@ const pluginFactories: PluginFactory[] = [
     key: category,
     action: async (params: PluginActionParams) => {
       if (neverGenerateRemote()) {
-        throw new Error(`${category} plugin requires remote generation to be enabled`);
+        logger.error(`${category} plugin requires remote generation to be enabled`);
+        return [];
       }
 
       const testCases = await getHarmfulTests(params, category);
@@ -248,7 +249,8 @@ const biasPlugins: PluginFactory[] = BIAS_PLUGINS.map((category: string) => ({
   key: category,
   action: async (params: PluginActionParams) => {
     if (neverGenerateRemote()) {
-      throw new Error(`${category} plugin requires remote generation to be enabled`);
+      logger.error(`${category} plugin requires remote generation to be enabled`);
+      return [];
     }
 
     const testCases = await fetchRemoteTestCases(
@@ -277,7 +279,8 @@ function createRemotePlugin<T extends PluginConfig>(
     validate: validate as ((config: PluginConfig) => void) | undefined,
     action: async ({ purpose, injectVar, n, config }: PluginActionParams) => {
       if (neverGenerateRemote()) {
-        throw new Error(`${key} plugin requires remote generation to be enabled`);
+        logger.error(`${key} plugin requires remote generation to be enabled`);
+        return [];
       }
       const testCases: TestCase[] = await fetchRemoteTestCases(
         key,

--- a/test/redteam/plugins/bias.test.ts
+++ b/test/redteam/plugins/bias.test.ts
@@ -30,48 +30,44 @@ describe('Bias Plugin', () => {
   });
 
   describe('remote-only behavior', () => {
-    it('should throw error when remote generation is disabled for age bias', async () => {
+    it('should return empty array when remote generation is disabled for age bias', async () => {
       jest.mocked(neverGenerateRemote).mockReturnValue(true);
 
       const agebiasPlugin = Plugins.find((p) => p.key === 'bias:age');
       expect(agebiasPlugin).toBeDefined();
 
-      await expect(agebiasPlugin!.action(mockPluginParams)).rejects.toThrow(
-        'bias:age plugin requires remote generation to be enabled',
-      );
+      const result = await agebiasPlugin!.action(mockPluginParams);
+      expect(result).toEqual([]);
     });
 
-    it('should throw error when remote generation is disabled for disability bias', async () => {
+    it('should return empty array when remote generation is disabled for disability bias', async () => {
       jest.mocked(neverGenerateRemote).mockReturnValue(true);
 
       const disabilityBiasPlugin = Plugins.find((p) => p.key === 'bias:disability');
       expect(disabilityBiasPlugin).toBeDefined();
 
-      await expect(disabilityBiasPlugin!.action(mockPluginParams)).rejects.toThrow(
-        'bias:disability plugin requires remote generation to be enabled',
-      );
+      const result = await disabilityBiasPlugin!.action(mockPluginParams);
+      expect(result).toEqual([]);
     });
 
-    it('should throw error when remote generation is disabled for gender bias', async () => {
+    it('should return empty array when remote generation is disabled for gender bias', async () => {
       jest.mocked(neverGenerateRemote).mockReturnValue(true);
 
       const genderBiasPlugin = Plugins.find((p) => p.key === 'bias:gender');
       expect(genderBiasPlugin).toBeDefined();
 
-      await expect(genderBiasPlugin!.action(mockPluginParams)).rejects.toThrow(
-        'bias:gender plugin requires remote generation to be enabled',
-      );
+      const result = await genderBiasPlugin!.action(mockPluginParams);
+      expect(result).toEqual([]);
     });
 
-    it('should throw error when remote generation is disabled for race bias', async () => {
+    it('should return empty array when remote generation is disabled for race bias', async () => {
       jest.mocked(neverGenerateRemote).mockReturnValue(true);
 
       const raceBiasPlugin = Plugins.find((p) => p.key === 'bias:race');
       expect(raceBiasPlugin).toBeDefined();
 
-      await expect(raceBiasPlugin!.action(mockPluginParams)).rejects.toThrow(
-        'bias:race plugin requires remote generation to be enabled',
-      );
+      const result = await raceBiasPlugin!.action(mockPluginParams);
+      expect(result).toEqual([]);
     });
   });
 

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -291,15 +291,14 @@ describe('Plugins', () => {
       const unalignedPlugin = Plugins.find(
         (p) => p.key === Object.keys(UNALIGNED_PROVIDER_HARM_PLUGINS)[0],
       );
-      await expect(
-        unalignedPlugin?.action({
-          provider: mockProvider,
-          purpose: 'test',
-          injectVar: 'testVar',
-          n: 1,
-          delayMs: 0,
-        }),
-      ).rejects.toThrow('requires remote generation to be enabled');
+      const result = await unalignedPlugin?.action({
+        provider: mockProvider,
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        delayMs: 0,
+      });
+      expect(result).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- log errors and return empty arrays when remote generation is disabled instead of throwing
- adjust bias and plugin tests for new behavior

## Testing
- `npm test test/redteam/plugins/index.test.ts test/redteam/plugins/bias.test.ts`
- `npx @biomejs/biome lint src/redteam/plugins/index.ts test/redteam/plugins/index.test.ts test/redteam/plugins/bias.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1c45827388333b2d2c2104cbe92ce