### PR TITLE
fix: Handle Qwen tool call responses in openrouter provider

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -118,7 +118,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
 
     // Prioritize content over reasoning
     let output = '';
-    if (message.content) {
+    if (message.content && message.content.trim()) {
       output = message.content;
       // Add reasoning as thinking content if present and showThinking is enabled
       if (message.reasoning && (this.config.showThinking ?? true)) {


### PR DESCRIPTION
Relates to https://github.com/promptfoo/promptfoo/issues/5262

For some reason, when qwen does a tool call, `message.content` is set to "\n\n", so it would output two newlines rather than the tool call. 