### PR TITLE
fix: Update util.ts to reflect correct Anthropic Haiku 3.5 pricing

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -58,8 +58,8 @@ export const ANTHROPIC_MODELS = [
   ...['claude-3-5-haiku-20241022', 'claude-3-5-haiku-latest'].map((model) => ({
     id: model,
     cost: {
-      input: 1 / 1e6,
-      output: 5 / 1e6,
+      input: 0.80 / 1e6,
+      output: 4 / 1e6,
     },
   })),
   ...[


### PR DESCRIPTION
The current pricing page has haiku 3.5 inputs priced at $0.80 / 1MTok, and $4/M outputs

https://www.anthropic.com/pricing#api