### PR TITLE
docs(site): add multi-lingual RAG evaluation guidance

### DIFF
--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -459,7 +459,7 @@ These metrics fail when languages don't match:
 
 This metric attempts to verify that the context contains specific expected information by matching text. When your expected answer is "The capital is Paris" but your context says "La capital es París," the metric fails to recognize the match. **Use `llm-rubric` instead** to check for concept coverage.
 
-#### [String-based metrics (Levenshtein, ROUGE, BLEU)](../configuration/expected-outputs/deterministic.md#deterministic-metrics)
+#### [String-based metrics (Levenshtein, ROUGE, BLEU)](../configuration/expected-outputs/deterministic.md)
 
 These traditional NLP metrics measure surface-level text similarity - comparing characters, words, or n-grams. They have no understanding that "dog" and "perro" mean the same thing. They'll report near-zero similarity for semantically identical content in different languages.
 


### PR DESCRIPTION
## Summary
- Add comprehensive section on evaluating RAG systems across different languages
- Document which metrics work effectively for cross-lingual scenarios (context-relevance, context-faithfulness, answer-relevance) 
- Explain why traditional text-matching metrics fail with language differences
- Provide practical configuration examples for cross-lingual evaluation
- Include performance thresholds and recommendations for metric selection

## Changes
- Added new "Multi-lingual RAG Evaluation" section to evaluate-rag.md guide
- Documented cross-lingual challenges and solutions for RAG evaluation
- Provided metric recommendations with accuracy ranges for cross-lingual use cases

This addresses a common pain point for users building global RAG applications where documents and queries may be in different languages.