### PR TITLE
chore: silence dotenv commercial logging messages

### DIFF
--- a/examples/redteam-mcp-agent/src/openai-agent-provider.js
+++ b/examples/redteam-mcp-agent/src/openai-agent-provider.js
@@ -1,6 +1,6 @@
 const MCPClient = require('./mcp-client');
 const ReactAgent = require('./react-agent');
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 
 class OpenAIAgentProvider {
   constructor(options = {}) {

--- a/examples/redteam-medical-agent/src/llm.js
+++ b/examples/redteam-medical-agent/src/llm.js
@@ -5,7 +5,7 @@
 const OpenAI = require('openai');
 const dotenv = require('dotenv');
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 // Initialize OpenAI client
 const openai = new OpenAI({

--- a/examples/redteam-medical-agent/src/test-agent.js
+++ b/examples/redteam-medical-agent/src/test-agent.js
@@ -2,7 +2,7 @@
  * Test script to verify the agentic functionality of the medical agent
  */
 
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 const { handleMessage, resetSession } = require('./agent');
 
 // A series of test messages to verify different agentic functionalities

--- a/scripts/generate-blog-image.js
+++ b/scripts/generate-blog-image.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 // Load environment variables from .env file
-require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+require('dotenv').config({ path: path.join(__dirname, '..', '.env'), quiet: true });
 // Get OpenAI API key from environment
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 if (!OPENAI_API_KEY) {

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ quiet: true });
 
 import cliState from './cliState';
 import type { EnvOverrides } from './types/env';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,6 +1,7 @@
 import compression from 'compression';
 import cors from 'cors';
-import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ quiet: true });
 
 import http from 'node:http';
 import path from 'node:path';

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -323,9 +323,9 @@ export function printBorder() {
 export function setupEnv(envPath: string | undefined) {
   if (envPath) {
     logger.info(`Loading environment variables from ${envPath}`);
-    dotenv.config({ path: envPath, override: true });
+    dotenv.config({ path: envPath, override: true, quiet: true });
   } else {
-    dotenv.config();
+    dotenv.config({ quiet: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `quiet: true` to all dotenv.config() calls to suppress promotional logging
- Clean test output without commercial messages about dotenvx/radar