### PR TITLE
chore: replace direct process.env calls with environment helpers

### DIFF
--- a/src/constants/build.ts
+++ b/src/constants/build.ts
@@ -2,6 +2,8 @@
 // In production builds, these values come from src/generated/constants.ts
 // In development, they fall back to environment variables
 
+import { getEnvString } from '../envars';
+
 let POSTHOG_KEY: string;
 
 try {
@@ -10,7 +12,7 @@ try {
   POSTHOG_KEY = generated.POSTHOG_KEY;
 } catch {
   // Fallback to environment variables for development
-  POSTHOG_KEY = process.env.PROMPTFOO_POSTHOG_KEY || '';
+  POSTHOG_KEY = getEnvString('PROMPTFOO_POSTHOG_KEY', '');
 }
 
 export { POSTHOG_KEY };

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -53,6 +53,7 @@ type EnvVars = {
   PROMPTFOO_STRIP_RESPONSE_OUTPUT?: boolean;
   PROMPTFOO_STRIP_TEST_VARS?: boolean;
   PROMPTFOO_TELEMETRY_DEBUG?: boolean;
+  PROMPTFOO_TRACING_ENABLED?: boolean;
   PROMPTFOO_DISABLE_UNBLOCKING?: boolean;
 
   //=========================================================================

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -1,5 +1,6 @@
 import Clone from 'rfdc';
 import { z } from 'zod';
+import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import { renderVarsInObject } from '../../util';
 import { maybeLoadFromExternalFile } from '../../util/file';
@@ -347,8 +348,8 @@ export async function resolveProjectId(
     config.projectId ||
     env?.VERTEX_PROJECT_ID ||
     env?.GOOGLE_PROJECT_ID ||
-    process.env.VERTEX_PROJECT_ID ||
-    process.env.GOOGLE_PROJECT_ID ||
+    getEnvString('VERTEX_PROJECT_ID') ||
+    getEnvString('GOOGLE_PROJECT_ID') ||
     ''
   );
 }

--- a/src/providers/helicone.ts
+++ b/src/providers/helicone.ts
@@ -1,4 +1,5 @@
 import { OpenAiChatCompletionProvider } from './openai/chat';
+import { getEnvString } from '../envars';
 
 import type { ProviderOptions } from '../types';
 import type { OpenAiCompletionOptions } from './openai/types';
@@ -45,7 +46,7 @@ export class HeliconeGatewayProvider extends OpenAiChatCompletionProvider {
       ...config,
       apiBaseUrl,
       // Use placeholder API key since Helicone Gateway handles authentication
-      apiKey: config.apiKey || process.env.HELICONE_API_KEY || 'placeholder-api-key',
+      apiKey: config.apiKey || getEnvString('HELICONE_API_KEY') || 'placeholder-api-key',
     };
 
     // Call parent constructor with the model and modified config

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import { PostHog } from 'posthog-node';
 import { z } from 'zod';
 import { VERSION } from './constants';
-import { getEnvBool, isCI } from './envars';
+import { getEnvBool, getEnvString, isCI } from './envars';
 import { fetchWithTimeout } from './fetch';
 import { POSTHOG_KEY } from './constants/build';
 import { getUserEmail, getUserId, isLoggedIntoCloud } from './globalConfig/accounts';
@@ -176,7 +176,7 @@ export class Telemetry {
       },
       body: JSON.stringify({
         event: eventName,
-        environment: process.env.NODE_ENV ?? 'development',
+        environment: getEnvString('NODE_ENV', 'development'),
         email: this.email,
         meta: {
           user_id: this.id,

--- a/src/tracing/evaluatorTracing.ts
+++ b/src/tracing/evaluatorTracing.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto';
 
+import { getEnvBool } from '../envars';
 import logger from '../logger';
 import telemetry from '../telemetry';
 
@@ -109,7 +110,7 @@ export async function stopOtlpReceiverIfNeeded(): Promise<void> {
  * Check if tracing is enabled for a test case
  */
 export function isTracingEnabled(test: TestCase, testSuite?: TestSuite): boolean {
-  return test.metadata?.tracingEnabled === true || process.env.PROMPTFOO_TRACING_ENABLED === 'true';
+  return test.metadata?.tracingEnabled === true || getEnvBool('PROMPTFOO_TRACING_ENABLED', false);
 }
 
 /**


### PR DESCRIPTION
## Summary
Replaces direct `process.env` calls with centralized environment variable helpers for consistency and better type safety.

## Changes
- Replace `process.env.NODE_ENV` with `getEnvString()` in telemetry.ts
- Replace `process.env.PROMPTFOO_POSTHOG_KEY` with `getEnvString()` in constants/build.ts  
- Replace `process.env.VERTEX_PROJECT_ID` and `process.env.GOOGLE_PROJECT_ID` with `getEnvString()` in providers/google/util.ts
- Replace `process.env.PROMPTFOO_TRACING_ENABLED` with `getEnvBool()` in tracing/evaluatorTracing.ts
- Add `PROMPTFOO_TRACING_ENABLED` to EnvVars type definition

## Test plan
- [x] Format and lint checks pass
- [x] All relevant tests pass  
- [x] Build succeeds
- [x] Environment variable resolution follows established patterns

This ensures consistent environment variable handling throughout the codebase and leverages the centralized environment variable resolution system with proper CLI state integration.