### PR TITLE
docs: add YAML schema directives to example configs

### DIFF
--- a/examples/bedrock-agentcore/promptfooconfig.multi-agent.yaml
+++ b/examples/bedrock-agentcore/promptfooconfig.multi-agent.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 # Multi-Agent System Example with AWS Bedrock AgentCore
 # This example demonstrates testing multiple specialized agents working together
 

--- a/examples/bedrock-agentcore/promptfooconfig.yaml
+++ b/examples/bedrock-agentcore/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 # AWS Bedrock AgentCore Provider Example Configuration
 # This example demonstrates how to use AWS Bedrock AgentCore with promptfoo
 

--- a/examples/conversation-relevance/promptfooconfig.yaml
+++ b/examples/conversation-relevance/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 # Example configuration for testing conversation relevance
 # This metric evaluates whether chatbot responses remain relevant throughout a conversation
 

--- a/examples/google-vertex/promptfooconfig.response-schema.yaml
+++ b/examples/google-vertex/promptfooconfig.response-schema.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: 'Test Vertex AI responseSchema with file:// protocol'
 
 prompts:

--- a/examples/opentelemetry-tracing/promptfooconfig.yaml
+++ b/examples/opentelemetry-tracing/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: Test trace UI visualization
 
 providers:

--- a/examples/redteam-mcp-agent/promptfooconfig.yaml
+++ b/examples/redteam-mcp-agent/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: file://./src/openai-agent-provider.js
     config:


### PR DESCRIPTION
Add yaml-language-server schema directive to 6 promptfooconfig.yaml files in examples/ that were missing it. This enables proper schema validation and IntelliSense support in editors.