### PR TITLE
docs: clarify file extension requirements for custom providers

### DIFF
--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -20,7 +20,8 @@ promptfoo supports multiple JavaScript module formats. Complete working examples
 
 At minimum, a custom provider must implement an `id` method and a `callApi` method.
 
-```javascript title="echoProvider.js"
+```javascript title="echoProvider.mjs"
+// Save as echoProvider.mjs for ES6 syntax, or echoProvider.js for CommonJS
 export default class EchoProvider {
   id = () => 'echo';
 
@@ -275,13 +276,14 @@ const { data, cached } = await promptfoo.cache.fetchWithCache(
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: file://./myProvider.js
+  - id: file://./myProvider.mjs # ES6 modules
     label: 'My Custom API' # Display name in UI
     config:
       model: 'gpt-4.1'
       temperature: 0.7
       max_tokens: 2000
       custom_parameter: 'custom value'
+  # - id: file://./myProvider.js   # CommonJS modules
 ```
 
 ### Multiple Instances


### PR DESCRIPTION
Update custom API provider documentation to clarify when to use .mjs vs .js extensions:

- Change basic example from echoProvider.js to echoProvider.mjs with explanatory comment
- Update configuration examples to show .mjs extension for ES6 modules
- Add commented alternative showing .js option for CommonJS modules

This helps users avoid common "Unexpected token 'export'" errors when using ES6 export default syntax in CommonJS projects.