### PR TITLE
fix(providers): handle system-only prompt in Gemini

### DIFF
--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -252,7 +252,7 @@ export function maybeCoerceToGeminiFormat(
     return { contents: contents as GeminiFormat, coerced: false, systemInstruction: undefined };
   }
 
-  const systemPromptParts: { text: string }[] = [];
+  let systemPromptParts: { text: string }[] = [];
   coercedContents = coercedContents.filter((message) => {
     if (message.role === ('system' as any) && message.parts.length > 0) {
       systemPromptParts.push(
@@ -264,6 +264,17 @@ export function maybeCoerceToGeminiFormat(
     }
     return true;
   });
+
+  // Convert system-only prompts to user messages
+  // Gemini does not support execution with systemInstruction only
+  if (coercedContents.length === 0 && systemPromptParts.length > 0) {
+    coercedContents = [{
+      role: 'user',
+      parts: systemPromptParts,
+    }];
+    coerced = true;
+    systemPromptParts = [];
+  }
 
   return {
     contents: coercedContents,

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -268,10 +268,12 @@ export function maybeCoerceToGeminiFormat(
   // Convert system-only prompts to user messages
   // Gemini does not support execution with systemInstruction only
   if (coercedContents.length === 0 && systemPromptParts.length > 0) {
-    coercedContents = [{
-      role: 'user',
-      parts: systemPromptParts,
-    }];
+    coercedContents = [
+      {
+        role: 'user',
+        parts: systemPromptParts,
+      },
+    ];
     coerced = true;
     systemPromptParts = [];
   }

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -580,6 +580,32 @@ describe('util', () => {
       });
     });
 
+    it('should convert system-only prompts to user messages', () => {
+      const input = [{ role: 'system', content: 'You are a helpful assistant.' }];
+      const result = maybeCoerceToGeminiFormat(input);
+      expect(result).toEqual({
+        contents: [{ role: 'user', parts: [{ text: 'You are a helpful assistant.' }] }],
+        coerced: true,
+        systemInstruction: undefined,
+      });
+    });
+
+    it('should convert multiple system-only messages to single user message', () => {
+      const input = [
+        { role: 'system', content: 'First instruction.' },
+        { role: 'system', content: 'Second instruction.' },
+      ];
+      const result = maybeCoerceToGeminiFormat(input);
+      expect(result).toEqual({
+        contents: [{
+          role: 'user',
+          parts: [{ text: 'First instruction.' }, { text: 'Second instruction.' }]
+        }],
+        coerced: true,
+        systemInstruction: undefined,
+      });
+    });
+
     it('should log a warning and return the input for unknown formats', () => {
       const loggerSpy = jest.spyOn(logger, 'warn');
       const input = { unknownFormat: 'test' };

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -597,10 +597,12 @@ describe('util', () => {
       ];
       const result = maybeCoerceToGeminiFormat(input);
       expect(result).toEqual({
-        contents: [{
-          role: 'user',
-          parts: [{ text: 'First instruction.' }, { text: 'Second instruction.' }]
-        }],
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'First instruction.' }, { text: 'Second instruction.' }],
+          },
+        ],
         coerced: true,
         systemInstruction: undefined,
       });


### PR DESCRIPTION
resolves: #5501

I confirmed that the following config, which previously did not work, now works with this fix.
https://gist.github.com/pokutuna/071b4812933e79022a058d1af5de6320

- `$ GEMINI_API_KEY=*** npm run local -- eval -c ./gemini-systemonly-reproduce-google.yaml`
- `$ npm run local -- eval -c ./gemini-systemonly-reproduce-vertex.yaml` (with gcloud credentials)