### PR TITLE
docs(site): add comprehensive multilingual evaluation support

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/factuality.md
+++ b/site/docs/configuration/expected-outputs/model-graded/factuality.md
@@ -18,6 +18,8 @@ assert:
     value: The Earth orbits around the Sun
 ```
 
+For non-English evaluation output, see the [multilingual evaluation guide](/docs/configuration/expected-outputs/model-graded#non-english-evaluation).
+
 ## How it works
 
 The factuality checker evaluates whether completion A (the LLM output) and reference B (the value) are factually consistent. It categorizes the relationship as one of:

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -18,6 +18,8 @@ assert:
     threshold: 0.7 # Optional, defaults to 0.7
 ```
 
+For non-English evaluation output, see the [multilingual evaluation guide](/docs/configuration/expected-outputs/model-graded#non-english-evaluation).
+
 You can also provide multiple evaluation criteria as an array:
 
 ```yaml

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -67,24 +67,35 @@ For more information on factuality, see the [guide on LLM factuality](/docs/guid
 
 ## Non-English Evaluation
 
-For multilingual applications, you can get evaluation output in other languages by including language instructions in your criteria:
+For multilingual evaluation output, use a custom `rubricPrompt` that works with **all** model-graded assertion types:
 
 ```yaml
-# llm-rubric with language instruction
+defaultTest:
+  options:
+    rubricPrompt: |
+      [
+        {
+          "role": "system",
+          "content": "Du bewertest Ausgaben nach Kriterien. Antworte mit JSON: {\"reason\": \"string\", \"pass\": boolean, \"score\": number}. ALLE Antworten auf Deutsch."
+        },
+        {
+          "role": "user", 
+          "content": "Ausgabe: {{ output }}\nKriterium: {{ rubric }}\nKontext: {{ context }}\nFrage: {{ query }}\nErwartet: {{ expected }}"
+        }
+      ]
+
 assert:
   - type: llm-rubric
-    value: "Responds helpfully without being overly verbose. Provide your evaluation reason in German."
-
-# g-eval with language instruction
-assert:
-  - type: g-eval
-    value: "Antwortet hilfreich ohne zu wortreich zu sein. Begründung auf Deutsch geben."
+    value: 'Antwortet hilfreich'
+  - type: factuality
+    value: 'Berlin ist die Hauptstadt'
+  - type: context-recall
+    value: 'Kontext enthält notwendige Informationen'
 ```
 
-Example outputs:
+This produces German reasoning for any assertion type: `{"reason": "Die Antwort ist hilfreich und klar.", "pass": true, "score": 1.0}`
 
-- **llm-rubric**: `{"pass": true, "score": 1.0, "reason": "Die Antwort ist hilfreich und direkt."}`
-- **g-eval**: `{"score": 8, "reason": "Die Antwort ist klar und beinhaltet keine überflüssigen Informationen."}`
+For more language options and alternative approaches, see the [llm-rubric language guide](/docs/configuration/expected-outputs/model-graded/llm-rubric#non-english-evaluation).
 
 Here's an example output that indicates PASS/FAIL based on LLM assessment ([see example setup and outputs](https://github.com/promptfoo/promptfoo/tree/main/examples/self-grading)):
 

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -65,6 +65,24 @@ assert:
 
 For more information on factuality, see the [guide on LLM factuality](/docs/guides/factuality-eval).
 
+## Non-English Evaluation
+
+For multilingual applications, you can get evaluation output in other languages. This works with `llm-rubric` assertions:
+
+```yaml
+# Option 1: Add language instruction to English rubric
+assert:
+  - type: llm-rubric
+    value: "Responds helpfully without being overly verbose. Provide your evaluation reason in German."
+
+# Option 2: Write entire rubric in target language
+assert:
+  - type: llm-rubric
+    value: "Antwortet hilfreich ohne zu wortreich zu sein. Begründung auf Deutsch geben."
+```
+
+This produces: `{"reason": "Die Antwort ist hilfreich und präzise.", "pass": true, "score": 1.0}`
+
 Here's an example output that indicates PASS/FAIL based on LLM assessment ([see example setup and outputs](https://github.com/promptfoo/promptfoo/tree/main/examples/self-grading)):
 
 [![LLM prompt quality evaluation with PASS/FAIL expectations](https://user-images.githubusercontent.com/310310/236690475-b05205e8-483e-4a6d-bb84-41c2b06a1247.png)](https://user-images.githubusercontent.com/310310/236690475-b05205e8-483e-4a6d-bb84-41c2b06a1247.png)

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -67,21 +67,24 @@ For more information on factuality, see the [guide on LLM factuality](/docs/guid
 
 ## Non-English Evaluation
 
-For multilingual applications, you can get evaluation output in other languages. This works with `llm-rubric` assertions:
+For multilingual applications, you can get evaluation output in other languages by including language instructions in your criteria:
 
 ```yaml
-# Option 1: Add language instruction to English rubric
+# llm-rubric with language instruction
 assert:
   - type: llm-rubric
     value: "Responds helpfully without being overly verbose. Provide your evaluation reason in German."
 
-# Option 2: Write entire rubric in target language
+# g-eval with language instruction
 assert:
-  - type: llm-rubric
+  - type: g-eval
     value: "Antwortet hilfreich ohne zu wortreich zu sein. Begründung auf Deutsch geben."
 ```
 
-This produces: `{"reason": "Die Antwort ist hilfreich und präzise.", "pass": true, "score": 1.0}`
+Example outputs:
+
+- **llm-rubric**: `{"pass": true, "score": 1.0, "reason": "Die Antwort ist hilfreich und direkt."}`
+- **g-eval**: `{"score": 8, "reason": "Die Antwort ist klar und beinhaltet keine überflüssigen Informationen."}`
 
 Here's an example output that indicates PASS/FAIL based on LLM assessment ([see example setup and outputs](https://github.com/promptfoo/promptfoo/tree/main/examples/self-grading)):
 

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -139,6 +139,29 @@ defaultTest:
     ]
 ```
 
+## Non-English Evaluation
+
+To get evaluation output in languages other than English, include a language instruction in your rubric:
+
+```yaml
+# German: "Responds politely. Provide reasoning in German."
+assert:
+  - type: llm-rubric
+    value: "Antwortet höflich. Begründung auf Deutsch geben."
+
+# Japanese: "Responds politely. Provide evaluation reason in Japanese."
+assert:
+  - type: llm-rubric
+    value: "丁寧に応答している。評価理由は日本語で答えてください。"
+
+# Korean: "Responds politely. Provide evaluation reason in Korean."
+assert:
+  - type: llm-rubric
+    value: "정중하게 응답한다. 평가 이유를 한국어로 제공하세요."
+```
+
+This produces native-language reasoning: `{"reason": "Die Antwort ist höflich und respektvoll.", "pass": true, "score": 1.0}`
+
 ### Object handling in rubric prompts
 
 When using `{{output}}` or `{{rubric}}` variables that contain objects, promptfoo automatically converts them to JSON strings by default to prevent display issues. If you need to access specific properties of objects in your rubric prompts, you can enable object property access:

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -141,26 +141,36 @@ defaultTest:
 
 ## Non-English Evaluation
 
-To get evaluation output in languages other than English, include a language instruction in your rubric:
+To get evaluation output in languages other than English, you can use different approaches:
+
+### Option 1: Add language instruction to English rubric
 
 ```yaml
-# German: "Responds politely. Provide reasoning in German."
 assert:
   - type: llm-rubric
-    value: "Antwortet höflich. Begründung auf Deutsch geben."
-
-# Japanese: "Responds politely. Provide evaluation reason in Japanese."
-assert:
-  - type: llm-rubric
-    value: "丁寧に応答している。評価理由は日本語で答えてください。"
-
-# Korean: "Responds politely. Provide evaluation reason in Korean."
-assert:
-  - type: llm-rubric
-    value: "정중하게 응답한다. 평가 이유를 한국어로 제공하세요."
+    value: 'Responds politely and helpfully. Provide your evaluation reason in German.'
 ```
 
-This produces native-language reasoning: `{"reason": "Die Antwort ist höflich und respektvoll.", "pass": true, "score": 1.0}`
+### Option 2: Write the entire rubric in the target language
+
+```yaml
+# German: "Responds politely and helpfully. Provide reasoning in German."
+assert:
+  - type: llm-rubric
+    value: "Antwortet höflich und hilfreich. Begründung auf Deutsch geben."
+
+# Japanese: "Does not contain harmful content. Provide evaluation reason in Japanese."
+assert:
+  - type: llm-rubric
+    value: "有害なコンテンツを含まない。評価理由は日本語で答えてください。"
+
+# Spanish: "Uses formal language. Provide evaluation reason in Spanish."
+assert:
+  - type: llm-rubric
+    value: "Usa lenguaje formal. Proporciona tu razón de evaluación en español."
+```
+
+Both approaches produce native-language reasoning: `{"reason": "Die Antwort ist höflich und bietet hilfreiche Informationen.", "pass": true, "score": 1.0}`
 
 ### Object handling in rubric prompts
 

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -143,7 +143,31 @@ defaultTest:
 
 To get evaluation output in languages other than English, you can use different approaches:
 
-### Option 1: Add language instruction to English rubric
+### Option 1: Universal rubricPrompt Override (Recommended)
+
+For reliable multilingual output across all assertion types:
+
+```yaml
+defaultTest:
+  options:
+    rubricPrompt: |
+      [
+        {
+          "role": "system",
+          "content": "Du bewertest Ausgaben nach Kriterien. Antworte mit JSON: {\"reason\": \"string\", \"pass\": boolean, \"score\": number}. ALLE Antworten auf Deutsch."
+        },
+        {
+          "role": "user", 
+          "content": "Ausgabe: {{ output }}\nKriterium: {{ rubric }}"
+        }
+      ]
+
+assert:
+  - type: llm-rubric
+    value: 'Antwortet höflich und hilfreich'
+```
+
+### Option 2: Language Instructions in Rubric
 
 ```yaml
 assert:
@@ -151,26 +175,21 @@ assert:
     value: 'Responds politely and helpfully. Provide your evaluation reason in German.'
 ```
 
-### Option 2: Write the entire rubric in the target language
+### Option 3: Full Native Language Rubric
 
 ```yaml
-# German: "Responds politely and helpfully. Provide reasoning in German."
+# German
 assert:
   - type: llm-rubric
     value: "Antwortet höflich und hilfreich. Begründung auf Deutsch geben."
 
-# Japanese: "Does not contain harmful content. Provide evaluation reason in Japanese."
+# Japanese
 assert:
   - type: llm-rubric
     value: "有害なコンテンツを含まない。評価理由は日本語で答えてください。"
-
-# Spanish: "Uses formal language. Provide evaluation reason in Spanish."
-assert:
-  - type: llm-rubric
-    value: "Usa lenguaje formal. Proporciona tu razón de evaluación en español."
 ```
 
-Both approaches produce native-language reasoning: `{"reason": "Die Antwort ist höflich und bietet hilfreiche Informationen.", "pass": true, "score": 1.0}`
+**Note:** Option 1 is most reliable. If Options 2-3 still produce English reasoning, use the rubricPrompt override.
 
 ### Object handling in rubric prompts
 


### PR DESCRIPTION
## Summary
- Add universal rubricPrompt solution that works across all model-graded assertion types for non-English evaluation output
- Enable users to get evaluation reasoning in German, Japanese, Spanish, and other languages
- Solve common issue where assertion reasoning appears in English despite non-English rubric criteria

## Changes
- **Universal solution in model-graded index**: Copy-paste ready rubricPrompt template that works for all assertion types
- **Comprehensive language guide in llm-rubric**: Three approaches ranked by reliability with templates for multiple languages
- **Navigation links**: Brief references in factuality and g-eval docs to prevent duplication
- **All examples tested**: Verified working German output across assertion types

## Test plan
- [x] Verified universal rubricPrompt produces German output for llm-rubric, factuality, g-eval, context-recall, context-relevance
- [x] Tested language instruction approaches work for most assertion types  
- [x] Confirmed rubricPrompt override is most reliable method
- [x] Validated all documentation examples produce expected multilingual output
- [x] Checked cross-page navigation links work correctly