### PR TITLE
docs: add SKIP_OG_GENERATION environment variable for faster docs builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,13 @@ SKIP_OG_GENERATION=true npm run build
 The OG image generation process can take several minutes and may cause CI timeouts. For documentation-only changes, skipping it is safe and recommended.
 
 **When to use `SKIP_OG_GENERATION=true`:**
+
 - Testing documentation changes locally
 - CI builds timing out due to OG image generation
 - Documentation-only PRs where OG images aren't critical
 
 **When NOT to skip OG generation:**
+
 - Final production builds
 - When OG image changes are specifically needed
 - When testing social media sharing functionality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,27 @@ npm run local -- eval -c path/to/config.yaml
 
 This ensures you're testing with your current changes instead of the installed version.
 
+## Documentation Testing
+
+When testing documentation changes that require building the site, you can speed up the process by skipping OG (Open Graph) image generation:
+
+```bash
+cd site
+SKIP_OG_GENERATION=true npm run build
+```
+
+The OG image generation process can take several minutes and may cause CI timeouts. For documentation-only changes, skipping it is safe and recommended.
+
+**When to use `SKIP_OG_GENERATION=true`:**
+- Testing documentation changes locally
+- CI builds timing out due to OG image generation
+- Documentation-only PRs where OG images aren't critical
+
+**When NOT to skip OG generation:**
+- Final production builds
+- When OG image changes are specifically needed
+- When testing social media sharing functionality
+
 ## Code Style Guidelines
 
 - Use TypeScript with strict type checking

--- a/site/src/plugins/docusaurus-plugin-og-image/index.js
+++ b/site/src/plugins/docusaurus-plugin-og-image/index.js
@@ -565,6 +565,12 @@ module.exports = function (context, options) {
     },
 
     async postBuild({ siteConfig, routesPaths, outDir, plugins, content, routes }) {
+      // Skip OG image generation if disabled via environment variable
+      if (process.env.SKIP_OG_GENERATION === 'true') {
+        console.log('⏭️  Skipping OG image generation (SKIP_OG_GENERATION=true)');
+        return;
+      }
+
       console.log('Generating OG images for documentation pages...');
 
       const generatedImages = new Map();


### PR DESCRIPTION
## Problem

The documentation build process often times out in CI due to OG (Open Graph) image generation taking too long. This blocks PRs with documentation changes and creates friction for contributors.

## Solution

Added  environment variable to bypass OG image generation when set to 'true':

- **Fast builds**: Reduces docs build time from ~5+ minutes to under 20 seconds
- **CI reliability**: Prevents timeout failures for documentation-only changes  
- **Selective usage**: Can be enabled only when OG images aren't needed

## Usage


> promptfoo-docs@0.0.1 build
> docusaurus build

[INFO] [en] Creating an optimized production build...
[webpackbar] ℹ Compiling Client
[webpackbar] ℹ Compiling Server
[webpackbar] ✔ Server: Compiled successfully in 6.10s
[webpackbar] ✔ Client: Compiled successfully in 6.64s
⏭️  Skipping OG image generation (SKIP_OG_GENERATION=true)
Successfully created llms.txt and llms-full.txt files.
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.

## Documentation

Updated  with clear guidelines on when to use this feature:
- ✅ Testing documentation changes locally
- ✅ CI builds timing out due to OG image generation
- ✅ Documentation-only PRs where OG images aren't critical
- ❌ Final production builds
- ❌ When OG image changes are specifically needed

## Testing

- [x] Verified build completes successfully with env var set
- [x] Confirmed OG generation is properly skipped with clear logging
- [x] Ensured all other build processes remain intact