### PR TITLE
chore: make openai max retries configurable

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -88,6 +88,7 @@ Supported parameters include:
 | `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                                                                                                                              |
 | `headers`               | Additional headers to include in the request.                                                                                                                                                                                                                                                     |
 | `max_tokens`            | Controls the maximum length of the output in tokens. Not valid for reasoning models (o1, o3, o3-pro, o3-mini, o4-mini).                                                                                                                                                                           |
+| `maxRetries`            | Maximum number of retry attempts for failed API requests. Defaults to 4. Set to 0 to disable retries.                                                                                                                                                                                             |
 | `metadata`              | Key-value pairs for request tagging and organization.                                                                                                                                                                                                                                             |
 | `organization`          | Your OpenAI organization key.                                                                                                                                                                                                                                                                     |
 | `passthrough`           | A flexible object that allows passing arbitrary parameters directly to the OpenAI API request body. Useful for experimental, new, or provider-specific parameters not yet explicitly supported in promptfoo. This parameter is merged into the final API request and can override other settings. |
@@ -145,6 +146,7 @@ interface OpenAiConfig {
   apiBaseUrl?: string;
   organization?: string;
   headers?: { [key: string]: string };
+  maxRetries?: number;
 }
 ```
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1739,15 +1739,12 @@ class Evaluator {
         (r) => r.failureReason === ResultFailureReason.ERROR && r.error?.includes('timed out'),
       );
 
-    // Calculate number of probes (total API requests made)
-    // This matches how Report.tsx calculates probes: selectedPrompt?.metrics?.tokenUsage?.numRequests
-    const numProbes = this.stats.tokenUsage.numRequests || this.evalRecord.results.length;
-
     telemetry.record('eval_ran', {
       // Basic metrics
       numPrompts: prompts.length,
       numTests: this.stats.successes + this.stats.failures + this.stats.errors,
-      numProbes,
+      numRequests: this.stats.tokenUsage.numRequests || 0,
+      numResults: this.evalRecord.results.length,
       numVars: varNames.size,
       numProviders: testSuite.providers.length,
       numRepeat: options.repeat || 1,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1739,10 +1739,15 @@ class Evaluator {
         (r) => r.failureReason === ResultFailureReason.ERROR && r.error?.includes('timed out'),
       );
 
+    // Calculate number of probes (total API requests made)
+    // This matches how Report.tsx calculates probes: selectedPrompt?.metrics?.tokenUsage?.numRequests
+    const numProbes = this.stats.tokenUsage.numRequests || this.evalRecord.results.length;
+
     telemetry.record('eval_ran', {
       // Basic metrics
       numPrompts: prompts.length,
       numTests: this.stats.successes + this.stats.failures + this.stats.errors,
+      numProbes,
       numVars: varNames.size,
       numProviders: testSuite.providers.length,
       numRepeat: options.repeat || 1,
@@ -1765,6 +1770,8 @@ class Evaluator {
 
       // Token and cost metrics
       totalTokens,
+      promptTokens: this.stats.tokenUsage.prompt,
+      completionTokens: this.stats.tokenUsage.completion,
       cachedTokens,
       totalCost,
       totalRequests,

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -345,6 +345,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         REQUEST_TIMEOUT_MS,
         'json',
         context?.bustCache ?? context?.debug,
+        this.config.maxRetries,
       ));
 
       if (status < 200 || status >= 300) {

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -88,6 +88,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
         REQUEST_TIMEOUT_MS,
         'json',
         context?.bustCache ?? context?.debug,
+        this.config.maxRetries,
       )) as unknown as any);
     } catch (err) {
       logger.error(`API call error: ${String(err)}`);

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -32,6 +32,9 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           body: JSON.stringify(body),
         },
         REQUEST_TIMEOUT_MS,
+        'json',
+        false,
+        this.config.maxRetries,
       )) as unknown as any);
     } catch (err) {
       logger.error(`API call error: ${err}`);

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -286,6 +286,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
         timeout,
         'json',
         context?.bustCache ?? context?.debug,
+        this.config.maxRetries,
       ));
 
       if (status < 200 || status >= 300) {

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -35,6 +35,7 @@ export interface OpenAiSharedOptions {
   organization?: string;
   cost?: number;
   headers?: { [key: string]: string };
+  maxRetries?: number;
 }
 
 export type ReasoningEffort = 'low' | 'medium' | 'high' | null;


### PR DESCRIPTION
- **chore: add probes and token metrics to eval event**
- **split it up**
- **chore: make openai max retries configurable**
