### PR TITLE
feat: reuse FilterMode type across backend

### DIFF
--- a/src/app/src/pages/eval/components/CompareEvalMenuItem.tsx
+++ b/src/app/src/pages/eval/components/CompareEvalMenuItem.tsx
@@ -7,8 +7,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import EvalSelectorDialog from './EvalSelectorDialog';
 import { useTableStore } from './store';
-
-import type { ResultLightweightWithLabel } from './types';
+import type { ResultLightweightWithLabel } from '@promptfoo/types';
 
 interface CompareEvalMenuItemProps {
   initialEvals: ResultLightweightWithLabel[];

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type React from 'react';
 
+import { callApi } from '@app/utils/api';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EditIcon from '@mui/icons-material/Edit';
@@ -27,14 +28,12 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { ErrorBoundary } from 'react-error-boundary';
-import { callApi } from '@app/utils/api';
 import { ellipsize } from '../../../../../util/text';
 import TraceView from '../../../components/traces/TraceView';
 import ChatMessages, { type Message } from './ChatMessages';
 import Citations from './Citations';
 import { useTableStore } from './store';
-
-import type { GradingResult } from './types';
+import type { GradingResult } from '@promptfoo/types';
 
 // Common style object for copy buttons
 const copyButtonSx = {

--- a/src/app/src/pages/eval/components/FilterModeSelector.tsx
+++ b/src/app/src/pages/eval/components/FilterModeSelector.tsx
@@ -5,9 +5,10 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
+import type { FilterMode } from './types';
 
 interface FilterModeSelectorProps {
-  filterMode: string;
+  filterMode: FilterMode;
   onChange: (event: SelectChangeEvent) => void;
   showDifferentOption?: boolean;
 }

--- a/src/app/src/pages/eval/components/FilterModeSelector.tsx
+++ b/src/app/src/pages/eval/components/FilterModeSelector.tsx
@@ -5,10 +5,10 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import type { FilterMode } from './types';
+import type { EvalResultsFilterMode } from '@promptfoo/types';
 
 interface FilterModeSelectorProps {
-  filterMode: FilterMode;
+  filterMode: EvalResultsFilterMode;
   onChange: (event: SelectChangeEvent) => void;
   showDifferentOption?: boolean;
 }

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -28,8 +28,7 @@ import {
 import { ErrorBoundary } from 'react-error-boundary';
 import { usePassRates } from './hooks';
 import { useTableStore } from './store';
-
-import type { EvaluateTable, UnifiedConfig } from './types';
+import type { EvaluateTable, UnifiedConfig } from '@promptfoo/types';
 
 interface ResultsChartsProps {
   handleHideCharts: () => void;

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -2,12 +2,6 @@ import React, { useEffect, useRef } from 'react';
 
 import ErrorBoundary from '@app/components/ErrorBoundary';
 import { useToast } from '@app/hooks/useToast';
-import {
-  type EvaluateTable,
-  type EvaluateTableOutput,
-  type EvaluateTableRow,
-  type FilterMode,
-} from '@app/pages/eval/components/types';
 import { callApi } from '@app/utils/api';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -25,6 +19,12 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { FILE_METADATA_KEY } from '@promptfoo/constants';
+import {
+  type EvalResultsFilterMode,
+  type EvaluateTable,
+  type EvaluateTableOutput,
+  type EvaluateTableRow,
+} from '@promptfoo/types';
 import invariant from '@promptfoo/util/invariant';
 import {
   createColumnHelper,
@@ -126,13 +126,13 @@ interface ResultsTableProps {
   maxTextLength: number;
   columnVisibility: VisibilityState;
   wordBreak: 'break-word' | 'break-all';
-  filterMode: FilterMode;
+  filterMode: EvalResultsFilterMode;
   failureFilter: { [key: string]: boolean };
   debouncedSearchText?: string;
   showStats: boolean;
   onFailureFilterToggle: (columnId: string, checked: boolean) => void;
   onSearchTextChange: (text: string) => void;
-  setFilterMode: (mode: FilterMode) => void;
+  setFilterMode: (mode: EvalResultsFilterMode) => void;
   zoom: number;
 }
 

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -50,9 +50,8 @@ import { useResultsViewSettingsStore, useTableStore } from './store';
 import SettingsModal from './TableSettings/TableSettingsModal';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import type { StackProps } from '@mui/material/Stack';
+import type { EvalResultsFilterMode, ResultLightweightWithLabel } from '@promptfoo/types';
 import type { VisibilityState } from '@tanstack/table-core';
-
-import type { FilterMode, ResultLightweightWithLabel } from './types';
 import './ResultsView.css';
 
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -220,10 +219,10 @@ export default function ResultsView({
   invariant(table, 'Table data must be loaded before rendering ResultsView');
   const { head } = table;
 
-  const [filterMode, setFilterMode] = React.useState<FilterMode>('all');
+  const [filterMode, setFilterMode] = React.useState<EvalResultsFilterMode>('all');
 
   const handleFilterModeChange = (event: SelectChangeEvent<unknown>) => {
-    const mode = event.target.value as FilterMode;
+    const mode = event.target.value as EvalResultsFilterMode;
     setFilterMode(mode);
 
     const newFailureFilter: { [key: string]: boolean } = {};

--- a/src/app/src/pages/eval/components/store.test.ts
+++ b/src/app/src/pages/eval/components/store.test.ts
@@ -1,11 +1,10 @@
 import { callApi } from '@app/utils/api';
-import { act } from '@testing-library/react';
 import { Severity } from '@promptfoo/redteam/constants';
+import { act } from '@testing-library/react';
 import { v4 as uuidv4 } from 'uuid';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { type ResultsFilter, useTableStore } from './store';
-
-import type { EvaluateTable, PromptMetrics, ResultsFile } from './types';
+import type { EvaluateTable, PromptMetrics, ResultsFile } from '@promptfoo/types';
 
 vi.mock('uuid', () => ({
   v4: vi.fn(),

--- a/src/app/src/pages/eval/components/store.ts
+++ b/src/app/src/pages/eval/components/store.ts
@@ -5,16 +5,15 @@ import { convertResultsToTable } from '@promptfoo/util/convertEvalResultsToTable
 import { v4 as uuidv4 } from 'uuid';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { VisibilityState } from '@tanstack/table-core';
-
 import type {
+  EvalResultsFilterMode,
   EvalTableDTO,
   EvaluateSummaryV2,
   EvaluateTable,
-  FilterMode,
   ResultsFile,
   UnifiedConfig,
-} from './types';
+} from '@promptfoo/types';
+import type { VisibilityState } from '@tanstack/table-core';
 
 function computeHighlightCount(table: EvaluateTable | null): number {
   if (!table) {
@@ -78,7 +77,7 @@ function computeAvailableSeverities(
 interface FetchEvalOptions {
   pageIndex?: number;
   pageSize?: number;
-  filterMode?: FilterMode;
+  filterMode?: EvalResultsFilterMode;
   searchText?: string;
   skipSettingEvalId?: boolean;
   skipLoadingState?: boolean;

--- a/src/app/src/pages/eval/components/types.ts
+++ b/src/app/src/pages/eval/components/types.ts
@@ -1,3 +1,0 @@
-export type FilterMode = 'all' | 'failures' | 'different' | 'highlights' | 'errors' | 'passes';
-
-export * from '@promptfoo/types';

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -42,6 +42,7 @@ import { getCurrentTimestamp } from '../util/time';
 import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import EvalResult from './evalResult';
 import { getCachedResultsCount, queryTestIndicesOptimized } from './evalPerformance';
+import type { FilterMode } from '../app/src/pages/eval/components/types';
 
 interface FilteredCountRow {
   count: number | null;
@@ -425,14 +426,14 @@ export default class Eval {
   private async queryTestIndices(opts: {
     offset?: number;
     limit?: number;
-    filterMode?: string;
+    filterMode?: FilterMode;
     searchQuery?: string;
     filters?: string[];
   }): Promise<{ testIndices: number[]; filteredCount: number }> {
     const db = getDb();
     const offset = opts.offset ?? 0;
     const limit = opts.limit ?? 50;
-    const mode = opts.filterMode ?? 'all';
+    const mode: FilterMode = opts.filterMode ?? 'all';
 
     // Build filter conditions
     const conditions = [`eval_id = '${this.id}'`];
@@ -583,7 +584,7 @@ export default class Eval {
   async getTablePage(opts: {
     offset?: number;
     limit?: number;
-    filterMode?: string;
+    filterMode?: FilterMode;
     testIndices?: number[];
     searchQuery?: string;
     filters?: string[];

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -40,9 +40,10 @@ import { convertTestResultsToTableRow } from '../util/exportToFile';
 import invariant from '../util/invariant';
 import { getCurrentTimestamp } from '../util/time';
 import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
-import EvalResult from './evalResult';
 import { getCachedResultsCount, queryTestIndicesOptimized } from './evalPerformance';
-import type { FilterMode } from '../app/src/pages/eval/components/types';
+import EvalResult from './evalResult';
+
+import type { EvalResultsFilterMode } from '../types';
 
 interface FilteredCountRow {
   count: number | null;
@@ -426,14 +427,14 @@ export default class Eval {
   private async queryTestIndices(opts: {
     offset?: number;
     limit?: number;
-    filterMode?: FilterMode;
+    filterMode?: EvalResultsFilterMode;
     searchQuery?: string;
     filters?: string[];
   }): Promise<{ testIndices: number[]; filteredCount: number }> {
     const db = getDb();
     const offset = opts.offset ?? 0;
     const limit = opts.limit ?? 50;
-    const mode: FilterMode = opts.filterMode ?? 'all';
+    const mode: EvalResultsFilterMode = opts.filterMode ?? 'all';
 
     // Build filter conditions
     const conditions = [`eval_id = '${this.id}'`];
@@ -584,7 +585,7 @@ export default class Eval {
   async getTablePage(opts: {
     offset?: number;
     limit?: number;
-    filterMode?: FilterMode;
+    filterMode?: EvalResultsFilterMode;
     testIndices?: number[];
     searchQuery?: string;
     filters?: string[];

--- a/src/models/evalPerformance.ts
+++ b/src/models/evalPerformance.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import { getDb } from '../database';
 import { evalResultsTable } from '../database/tables';
 import logger from '../logger';
+import type { FilterMode } from '../app/src/pages/eval/components/types';
 
 interface CountCacheEntry {
   count: number;
@@ -56,7 +57,7 @@ export async function queryTestIndicesOptimized(
   opts: {
     offset?: number;
     limit?: number;
-    filterMode?: string;
+    filterMode?: FilterMode;
     searchQuery?: string;
     filters?: string[];
   },
@@ -64,7 +65,7 @@ export async function queryTestIndicesOptimized(
   const db = getDb();
   const offset = opts.offset ?? 0;
   const limit = opts.limit ?? 50;
-  const mode = opts.filterMode ?? 'all';
+  const mode: FilterMode = opts.filterMode ?? 'all';
 
   // Build base query with efficient filtering
   let baseQuery = sql`eval_id = ${evalId}`;

--- a/src/models/evalPerformance.ts
+++ b/src/models/evalPerformance.ts
@@ -2,7 +2,8 @@ import { sql } from 'drizzle-orm';
 import { getDb } from '../database';
 import { evalResultsTable } from '../database/tables';
 import logger from '../logger';
-import type { FilterMode } from '../app/src/pages/eval/components/types';
+
+import type { EvalResultsFilterMode } from '../types';
 
 interface CountCacheEntry {
   count: number;
@@ -57,7 +58,7 @@ export async function queryTestIndicesOptimized(
   opts: {
     offset?: number;
     limit?: number;
-    filterMode?: FilterMode;
+    filterMode?: EvalResultsFilterMode;
     searchQuery?: string;
     filters?: string[];
   },
@@ -65,7 +66,7 @@ export async function queryTestIndicesOptimized(
   const db = getDb();
   const offset = opts.offset ?? 0;
   const limit = opts.limit ?? 50;
-  const mode: FilterMode = opts.filterMode ?? 'all';
+  const mode: EvalResultsFilterMode = opts.filterMode ?? 'all';
 
   // Build base query with efficient filtering
   let baseQuery = sql`eval_id = ${evalId}`;

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -12,7 +12,6 @@ import { deleteEval, updateResult, writeResultsToDatabase } from '../../util/dat
 import invariant from '../../util/invariant';
 import { ApiSchemas } from '../apiSchemas';
 import type { Request, Response } from 'express';
-import type { FilterMode } from '../../app/src/pages/eval/components/types';
 
 import type {
   EvalTableDTO,
@@ -22,6 +21,7 @@ import type {
   Job,
   ResultsFile,
 } from '../../index';
+import type { EvalResultsFilterMode } from '../../types';
 
 export const evalRouter = Router();
 
@@ -170,7 +170,8 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   const { id } = req.params;
   const limit = Number(req.query.limit) || 50;
   const offset = Number(req.query.offset) || 0;
-  const filterMode: FilterMode = (req.query.filterMode as FilterMode | undefined) ?? 'all';
+  const filterMode: EvalResultsFilterMode =
+    (req.query.filterMode as EvalResultsFilterMode | undefined) ?? 'all';
   const searchText = req.query.search ? String(req.query.search) : '';
   const filters = Array.isArray(req.query.filter)
     ? req.query.filter

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -12,6 +12,7 @@ import { deleteEval, updateResult, writeResultsToDatabase } from '../../util/dat
 import invariant from '../../util/invariant';
 import { ApiSchemas } from '../apiSchemas';
 import type { Request, Response } from 'express';
+import type { FilterMode } from '../../app/src/pages/eval/components/types';
 
 import type {
   EvalTableDTO,
@@ -169,7 +170,7 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   const { id } = req.params;
   const limit = Number(req.query.limit) || 50;
   const offset = Number(req.query.offset) || 0;
-  const filterMode = String(req.query.filterMode || 'all');
+  const filterMode: FilterMode = (req.query.filterMode as FilterMode | undefined) ?? 'all';
   const searchText = req.query.search ? String(req.query.search) : '';
   const filters = Array.isArray(req.query.filter)
     ? req.query.filter

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -8,6 +8,7 @@ import promptfoo from '../../index';
 import logger from '../../logger';
 import Eval from '../../models/eval';
 import EvalResult from '../../models/evalResult';
+import { EvalResultsFilterMode } from '../../types';
 import { deleteEval, updateResult, writeResultsToDatabase } from '../../util/database';
 import invariant from '../../util/invariant';
 import { ApiSchemas } from '../apiSchemas';
@@ -21,7 +22,6 @@ import type {
   Job,
   ResultsFile,
 } from '../../index';
-import type { EvalResultsFilterMode } from '../../types';
 
 export const evalRouter = Router();
 
@@ -170,8 +170,7 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   const { id } = req.params;
   const limit = Number(req.query.limit) || 50;
   const offset = Number(req.query.offset) || 0;
-  const filterMode: EvalResultsFilterMode =
-    (req.query.filterMode as EvalResultsFilterMode | undefined) ?? 'all';
+  const filterMode = EvalResultsFilterMode.parse(req.query.filterMode) ?? 'all';
   const searchText = req.query.search ? String(req.query.search) : '';
   const filters = Array.isArray(req.query.filter)
     ? req.query.filter

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1194,10 +1194,13 @@ export interface LoadApiProviderContext {
   env?: EnvOverrides;
 }
 
-export type EvalResultsFilterMode =
-  | 'all'
-  | 'failures'
-  | 'different'
-  | 'highlights'
-  | 'errors'
-  | 'passes';
+export const EvalResultsFilterMode = z.enum([
+  'all',
+  'failures',
+  'different',
+  'highlights',
+  'errors',
+  'passes',
+]);
+
+export type EvalResultsFilterMode = z.infer<typeof EvalResultsFilterMode>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1193,3 +1193,11 @@ export interface LoadApiProviderContext {
   basePath?: string;
   env?: EnvOverrides;
 }
+
+export type EvalResultsFilterMode =
+  | 'all'
+  | 'failures'
+  | 'different'
+  | 'highlights'
+  | 'errors'
+  | 'passes';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,6 +94,7 @@ describe('index.ts exports', () => {
     'CompletedPromptSchema',
     'CompletionTokenDetailsSchema',
     'DerivedMetricSchema',
+    'EvalResultsFilterMode',
     'NotPrefixedAssertionTypesSchema',
     'OutputConfigSchema',
     'OutputFileExtension',


### PR DESCRIPTION
## Summary
- type ResultsTable selector with shared FilterMode type (we weren't using it)
- apply FilterMode type to eval queries and server route to ensure consistent filtering
- Removes types file which, post-change, solely re-exported `@promptfoo/types`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ca054d588333a427f052cd5349d7