### PR TITLE
chore: Unify all date formats across tables

### DIFF
--- a/src/app/src/pages/datasets/Datasets.tsx
+++ b/src/app/src/pages/datasets/Datasets.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { formatDataGridDate } from '@app/utils/date';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -146,15 +147,11 @@ export default function Datasets({ data, isLoading, error }: DatasetsProps) {
         description: 'The date of the most recent eval for this set of test cases',
         flex: 1.5,
         minWidth: 150,
-        renderCell: (params: GridRenderCellParams<DatasetRow>) => {
-          if (!params.value) {
-            return (
-              <Typography variant="body2" color="text.secondary">
-                Unknown
-              </Typography>
-            );
+        valueFormatter: (value: string | number | Date | null | undefined) => {
+          if (!value) {
+            return 'Unknown';
           }
-          return params.value;
+          return formatDataGridDate(value);
         },
       },
       {

--- a/src/app/src/pages/evals/components/EvalsDataGrid.tsx
+++ b/src/app/src/pages/evals/components/EvalsDataGrid.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 
 import { callApi } from '@app/utils/api';
+import { formatDataGridDate } from '@app/utils/date';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -239,7 +240,7 @@ export default function EvalsDataGrid({
           valueGetter: (value: Eval['createdAt'], row: Eval) => {
             return new Date(value);
           },
-          valueFormatter: (value: Eval['createdAt']) => new Date(value).toLocaleString(),
+          valueFormatter: (value: Eval['createdAt']) => formatDataGridDate(value),
         },
         // Only show the redteam column if there are redteam evals.
         ...(hasRedteamEvals

--- a/src/app/src/pages/model-audit/components/HistoryTab.test.tsx
+++ b/src/app/src/pages/model-audit/components/HistoryTab.test.tsx
@@ -1,10 +1,9 @@
+import { formatDataGridDate } from '@app/utils/date';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { ThemeProvider, createTheme } from '@mui/material/styles';
-
-import HistoryTab from './HistoryTab';
 import { useModelAuditStore } from '../store';
+import HistoryTab from './HistoryTab';
 
 vi.mock('../store');
 
@@ -110,7 +109,7 @@ describe('HistoryTab', () => {
     const row1 = rows[0];
     expect(within(row1).getByText(mockHistoricalScans[0].id)).toBeInTheDocument();
     expect(
-      within(row1).getByText(new Date(mockHistoricalScans[0].createdAt).toLocaleString()),
+      within(row1).getByText(formatDataGridDate(mockHistoricalScans[0].createdAt)),
     ).toBeInTheDocument();
     expect(within(row1).getByText('Scan with multiple issues')).toBeInTheDocument();
     expect(within(row1).getByText('/path/to/model1.gguf')).toBeInTheDocument();
@@ -127,7 +126,7 @@ describe('HistoryTab', () => {
     const row2 = rows[1];
     expect(within(row2).getByText(mockHistoricalScans[1].id)).toBeInTheDocument();
     expect(
-      within(row2).getByText(new Date(mockHistoricalScans[1].createdAt).toLocaleString()),
+      within(row2).getByText(formatDataGridDate(mockHistoricalScans[1].createdAt)),
     ).toBeInTheDocument();
     expect(within(row2).getByText('Unnamed scan')).toBeInTheDocument();
     expect(within(row2).getByText('/path/to/model2.safetensors')).toBeInTheDocument();

--- a/src/app/src/pages/model-audit/components/HistoryTab.tsx
+++ b/src/app/src/pages/model-audit/components/HistoryTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { formatDataGridDate } from '@app/utils/date';
 import {
   CheckCircle as CheckCircleIcon,
   Delete as DeleteIcon,
@@ -73,7 +74,7 @@ export default function HistoryTab() {
   };
 
   const formatDate = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDataGridDate(timestamp);
   };
 
   const getSeverityColor = (hasErrors: boolean) => {

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { formatDataGridDate } from '@app/utils/date';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
@@ -135,7 +136,7 @@ export default function Prompts({
                   '&:hover': { textDecoration: 'underline' },
                 }}
               >
-                {params.value}
+                {formatDataGridDate(params.value)}
               </Typography>
             </Link>
           );

--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -4,6 +4,7 @@ import EnterpriseBanner from '@app/components/EnterpriseBanner';
 import { usePageMeta } from '@app/hooks/usePageMeta';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import { callApi } from '@app/utils/api';
+import { formatDataGridDate } from '@app/utils/date';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import PrintIcon from '@mui/icons-material/Print';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -35,6 +36,9 @@ import { convertResultsToTable } from '@promptfoo/util/convertEvalResultsToTable
 import { useNavigate } from 'react-router-dom';
 import FrameworkCompliance from './FrameworkCompliance';
 import Overview from './Overview';
+import './Report.css';
+
+import { type GridFilterModel, GridLogicOperator } from '@mui/x-data-grid';
 import ReportDownloadButton from './ReportDownloadButton';
 import ReportSettingsDialogButton from './ReportSettingsDialogButton';
 import RiskCategories from './RiskCategories';
@@ -42,9 +46,6 @@ import StrategyStats from './StrategyStats';
 import { getPluginIdFromResult, getStrategyIdFromTest } from './shared';
 import TestSuites from './TestSuites';
 import ToolsDialog from './ToolsDialog';
-import './Report.css';
-
-import { type GridFilterModel, GridLogicOperator } from '@mui/x-data-grid';
 
 const App: React.FC = () => {
   const navigate = useNavigate();
@@ -390,11 +391,7 @@ const App: React.FC = () => {
             {evalData.config.description && `: ${evalData.config.description}`}
           </Typography>
           <Typography variant="subtitle1" mb={2}>
-            {new Date(evalData.createdAt).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            {formatDataGridDate(evalData.createdAt)}
           </Typography>
           <Box className="report-details">
             {selectedPrompt && (

--- a/src/app/src/pages/redteam/report/components/ReportIndex.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportIndex.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { callApi } from '@app/utils/api';
+import { formatDataGridDate } from '@app/utils/date';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -16,9 +17,9 @@ import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import type { ResultLightweightWithLabel } from '@promptfoo/types';
 import fuzzysearch from 'fuzzysearch';
 import { useNavigate } from 'react-router-dom';
-import type { ResultLightweightWithLabel } from '@promptfoo/types';
 
 type SortField = 'description' | 'createdAt' | 'evalId';
 
@@ -192,15 +193,7 @@ const ReportIndex: React.FC = () => {
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2">
-                    {new Date(eval_.createdAt).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                  </Typography>
+                  <Typography variant="body2">{formatDataGridDate(eval_.createdAt)}</Typography>
                 </TableCell>
                 <TableCell>
                   <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import PylonChat from '@app/components/PylonChat';
 import ErrorBoundary from '@app/components/ErrorBoundary';
+import PylonChat from '@app/components/PylonChat';
 import { UserProvider } from '@app/contexts/UserContext';
 import { usePageMeta } from '@app/hooks/usePageMeta';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import { useToast } from '@app/hooks/useToast';
 import { callApi } from '@app/utils/api';
+import { formatDataGridDate } from '@app/utils/date';
 import AppIcon from '@mui/icons-material/Apps';
 import DownloadIcon from '@mui/icons-material/Download';
 import PluginIcon from '@mui/icons-material/Extension';
@@ -32,6 +33,7 @@ import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { REDTEAM_DEFAULTS } from '@promptfoo/redteam/constants';
+import type { RedteamStrategy } from '@promptfoo/types';
 import { ProviderOptionsSchema } from '@promptfoo/validators/providers';
 import yaml from 'js-yaml';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -46,10 +48,9 @@ import TargetTypeSelection from './components/Targets/TargetTypeSelection';
 import { DEFAULT_HTTP_TARGET, useRedTeamConfig } from './hooks/useRedTeamConfig';
 import { useSetupState } from './hooks/useSetupState';
 import { generateOrderedYaml } from './utils/yamlHelpers';
-import type { RedteamStrategy } from '@promptfoo/types';
 
-import type { Config, RedteamUITarget } from './types';
 import './page.css';
+import type { Config, RedteamUITarget } from './types';
 
 export const SIDEBAR_WIDTH = 240;
 
@@ -621,7 +622,7 @@ export default function RedTeamSetupPage() {
                 ) : (
                   configDate && (
                     <Typography className="dateText" color="text.secondary" variant="body2">
-                      {new Date(configDate).toLocaleString()}
+                      {formatDataGridDate(configDate)}
                     </Typography>
                   )
                 )}
@@ -840,7 +841,7 @@ export default function RedTeamSetupPage() {
                     >
                       <ListItemText
                         primary={config.name}
-                        secondary={new Date(config.updatedAt).toLocaleString()}
+                        secondary={formatDataGridDate(config.updatedAt)}
                       />
                     </ListItemButton>
                   ))}

--- a/src/app/src/utils/date.ts
+++ b/src/app/src/utils/date.ts
@@ -1,0 +1,32 @@
+/**
+ * Utility functions for date formatting
+ */
+
+/**
+ * Format a date value for display in DataGrid columns.
+ * Uses locale string with short timezone name.
+ *
+ * @param value - The date value to format (string, number, or Date)
+ * @returns Formatted date string with timezone, or empty string if value is invalid
+ */
+export function formatDataGridDate(value: string | number | Date | null | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    const date = new Date(value);
+    if (isNaN(date.getTime())) {
+      return '';
+    }
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Verified that sorting and such are still working for all the table columns.

<img width="1715" height="270" alt="Screenshot 2025-09-11 at 2 52 05 PM" src="https://github.com/user-attachments/assets/d575fc12-67bd-4a53-84ed-f16bcd4d453c" />
<img width="1267" height="455" alt="Screenshot 2025-09-11 at 2 51 58 PM" src="https://github.com/user-attachments/assets/e93b3632-bf4c-48ec-b28d-24d6b18785b8" />
<img width="949" height="476" alt="Screenshot 2025-09-11 at 2 51 53 PM" src="https://github.com/user-attachments/assets/9edb4259-a1fe-46c6-a6b7-d61ad797c607" />
<img width="1546" height="434" alt="Screenshot 2025-09-11 at 2 51 39 PM" src="https://github.com/user-attachments/assets/fd1a6767-c63a-4791-b5ae-94b5872e0068" />

