### PR TITLE
feat: move config name to modal from review page

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -7,9 +7,7 @@ import { useToast } from '@app/hooks/useToast';
 import YamlEditor from '@app/pages/eval-creator/components/YamlEditor';
 import { callApi } from '@app/utils/api';
 import AssessmentIcon from '@mui/icons-material/Assessment';
-import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
-import EditIcon from '@mui/icons-material/Edit';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
@@ -101,8 +99,6 @@ export default function Review({
   const [isPurposeExpanded, setIsPurposeExpanded] = useState(false);
   const [isTestInstructionsExpanded, setIsTestInstructionsExpanded] = useState(false);
   const [isRunOptionsExpanded, setIsRunOptionsExpanded] = useState(true);
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [tempDescription, setTempDescription] = useState(config.description || '');
 
   // Auto-expand advanced config if there are existing test variables
   const hasTestVariables =
@@ -177,31 +173,13 @@ export default function Review({
     });
   };
 
-  const handleStartEditingDescription = () => {
-    setTempDescription(config.description || '');
-    setIsEditingDescription(true);
-  };
-
-  const handleSaveDescription = () => {
-    updateConfig('description', tempDescription);
-    setIsEditingDescription(false);
-  };
-
-  const handleCancelEditingDescription = () => {
-    setTempDescription(config.description || '');
-    setIsEditingDescription(false);
+  const handleDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateConfig('description', event.target.value);
   };
 
   useEffect(() => {
     recordEvent('webui_page_view', { page: 'redteam_config_review' });
   }, []);
-
-  // Update tempDescription when config.description changes
-  useEffect(() => {
-    if (!isEditingDescription) {
-      setTempDescription(config.description || '');
-    }
-  }, [config.description, isEditingDescription]);
 
   // Sync local maxConcurrency state with config
   useEffect(() => {
@@ -474,50 +452,15 @@ export default function Review({
   return (
     <PageWrapper title="Review & Run" onBack={onBack}>
       <Box>
-        {isEditingDescription ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 4 }}>
-            <TextField
-              fullWidth
-              label="Configuration Name"
-              placeholder="My Red Team Configuration"
-              value={tempDescription}
-              onChange={(e) => setTempDescription(e.target.value)}
-              variant="outlined"
-              autoFocus
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleSaveDescription();
-                } else if (e.key === 'Escape') {
-                  handleCancelEditingDescription();
-                }
-              }}
-            />
-            <IconButton
-              onClick={handleSaveDescription}
-              color="primary"
-              size="small"
-              disabled={!tempDescription.trim()}
-            >
-              <CheckIcon />
-            </IconButton>
-            <IconButton onClick={handleCancelEditingDescription} color="default" size="small">
-              <CloseIcon />
-            </IconButton>
-          </Box>
-        ) : (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 4 }}>
-            <Typography variant="h6" sx={{ py: 1 }}>
-              Configuration: {config.description || 'Untitled Configuration'}
-            </Typography>
-            <IconButton
-              onClick={handleStartEditingDescription}
-              size="small"
-              sx={{ color: 'text.secondary', ml: 0.5 }}
-            >
-              <EditIcon />
-            </IconButton>
-          </Box>
-        )}
+        <TextField
+          fullWidth
+          label="Description"
+          placeholder="My Red Team Configuration"
+          value={config.description || ''}
+          onChange={handleDescriptionChange}
+          variant="outlined"
+          sx={{ mb: 4 }}
+        />
 
         <Typography variant="h5" gutterBottom sx={{ mb: 3 }}>
           Configuration Summary

--- a/src/app/src/pages/redteam/setup/components/Setup.tsx
+++ b/src/app/src/pages/redteam/setup/components/Setup.tsx
@@ -10,13 +10,13 @@ import Link from '@mui/material/Link';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
-
 interface SetupProps {
   open: boolean;
   onClose: () => void;
   highlightConfigName?: boolean;
   setHighlightConfigName?: (highlight: boolean) => void;
+  configName: string;
+  setConfigName: (name: string) => void;
 }
 
 export default function Setup({
@@ -24,9 +24,10 @@ export default function Setup({
   onClose,
   highlightConfigName,
   setHighlightConfigName,
+  configName,
+  setConfigName,
 }: SetupProps) {
   const theme = useTheme();
-  const { config, updateConfig } = useRedTeamConfig();
 
   return (
     <Dialog
@@ -58,13 +59,11 @@ export default function Setup({
           fullWidth
           label="Configuration Name"
           placeholder="My Red Team Configuration"
-          value={config.description || ''}
-          onChange={(e) => updateConfig('description', e.target.value)}
+          value={configName}
+          onChange={(e) => setConfigName(e.target.value)}
           autoFocus
-          error={Boolean(highlightConfigName && !config.description)}
-          helperText={
-            highlightConfigName && !config.description ? 'Configuration name is required' : ''
-          }
+          error={Boolean(highlightConfigName && !configName)}
+          helperText={highlightConfigName && !configName ? 'Configuration name is required' : ''}
           onFocus={() => setHighlightConfigName?.(false)}
         />
         <Box
@@ -87,7 +86,7 @@ export default function Setup({
             variant="contained"
             endIcon={<KeyboardArrowRightIcon />}
             onClick={() => {
-              if (!config.description) {
+              if (!configName) {
                 setHighlightConfigName?.(true);
                 return;
               }
@@ -99,7 +98,7 @@ export default function Setup({
               px: 4,
               py: 1,
             }}
-            disabled={!config.description}
+            disabled={!configName}
           >
             Continue
           </Button>

--- a/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
+++ b/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
@@ -55,7 +55,7 @@ export const DEFAULT_HTTP_TARGET: ProviderOptions = {
 };
 
 const defaultConfig: Config = {
-  description: '',
+  description: 'My Red Team Configuration',
   prompts: ['{{prompt}}'],
   target: DEFAULT_HTTP_TARGET,
   plugins: [],


### PR DESCRIPTION
## Summary
Move “Configuration Name” input from the Review step to a modal that shows up when initially creating a red team configuration.