### PR TITLE
feat: ability to pause/resume evals

### DIFF
--- a/drizzle/0020_skinny_maverick.sql
+++ b/drizzle/0020_skinny_maverick.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `evals` ADD `runtime_options` text;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1232 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "13809a10-f429-465a-aa78-ea982c3e93fc",
+  "prevId": "f1b657dd-569a-4284-8822-8b2676a46613",
+  "tables": {
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "configs_created_at_idx": {
+          "name": "configs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "configs_type_idx": {
+          "name": "configs_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "datasets": {
+      "name": "datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tests": {
+          "name": "tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "datasets_created_at_idx": {
+          "name": "datasets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case": {
+          "name": "test_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grading_result": {
+          "name": "grading_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "named_scores": {
+          "name": "named_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_result_eval_id_idx": {
+          "name": "eval_result_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_idx": {
+          "name": "eval_result_test_idx",
+          "columns": [
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_idx": {
+          "name": "eval_result_eval_test_idx",
+          "columns": [
+            "eval_id",
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_success_idx": {
+          "name": "eval_result_eval_success_idx",
+          "columns": [
+            "eval_id",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_failure_idx": {
+          "name": "eval_result_eval_failure_idx",
+          "columns": [
+            "eval_id",
+            "failure_reason"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_success_idx": {
+          "name": "eval_result_eval_test_success_idx",
+          "columns": [
+            "eval_id",
+            "test_idx",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_response_idx": {
+          "name": "eval_result_response_idx",
+          "columns": [
+            "response"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_reason_idx": {
+          "name": "eval_result_grading_result_reason_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.reason')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_comment_idx": {
+          "name": "eval_result_grading_result_comment_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.comment')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_vars_idx": {
+          "name": "eval_result_test_case_vars_idx",
+          "columns": [
+            "json_extract(\"test_case\", '$.vars')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_metadata_idx": {
+          "name": "eval_result_test_case_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_named_scores_idx": {
+          "name": "eval_result_named_scores_idx",
+          "columns": [
+            "json_extract(\"named_scores\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_idx": {
+          "name": "eval_result_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_plugin_id_idx": {
+          "name": "eval_result_metadata_plugin_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.pluginId')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_strategy_id_idx": {
+          "name": "eval_result_metadata_strategy_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.strategyId')"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_eval_id_evals_id_fk": {
+          "name": "eval_results_eval_id_evals_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eval_results_prompt_id_prompts_id_fk": {
+          "name": "eval_results_prompt_id_prompts_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals": {
+      "name": "evals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_options": {
+          "name": "runtime_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_redteam": {
+          "name": "is_redteam",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "evals_created_at_idx": {
+          "name": "evals_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "evals_author_idx": {
+          "name": "evals_author_idx",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        },
+        "evals_is_redteam_idx": {
+          "name": "evals_is_redteam_idx",
+          "columns": [
+            "is_redteam"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_datasets": {
+      "name": "evals_to_datasets",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_datasets_eval_id_idx": {
+          "name": "evals_to_datasets_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_datasets_dataset_id_idx": {
+          "name": "evals_to_datasets_dataset_id_idx",
+          "columns": [
+            "dataset_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_datasets_eval_id_evals_id_fk": {
+          "name": "evals_to_datasets_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_datasets_dataset_id_datasets_id_fk": {
+          "name": "evals_to_datasets_dataset_id_datasets_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_datasets_eval_id_dataset_id_pk": {
+          "columns": [
+            "eval_id",
+            "dataset_id"
+          ],
+          "name": "evals_to_datasets_eval_id_dataset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_prompts": {
+      "name": "evals_to_prompts",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_prompts_eval_id_idx": {
+          "name": "evals_to_prompts_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_prompts_prompt_id_idx": {
+          "name": "evals_to_prompts_prompt_id_idx",
+          "columns": [
+            "prompt_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_prompts_eval_id_evals_id_fk": {
+          "name": "evals_to_prompts_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evals_to_prompts_prompt_id_prompts_id_fk": {
+          "name": "evals_to_prompts_prompt_id_prompts_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_prompts_eval_id_prompt_id_pk": {
+          "columns": [
+            "eval_id",
+            "prompt_id"
+          ],
+          "name": "evals_to_prompts_eval_id_prompt_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_tags": {
+      "name": "evals_to_tags",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_tags_eval_id_idx": {
+          "name": "evals_to_tags_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_tags_tag_id_idx": {
+          "name": "evals_to_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_tags_eval_id_evals_id_fk": {
+          "name": "evals_to_tags_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_tags_tag_id_tags_id_fk": {
+          "name": "evals_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_tags_eval_id_tag_id_pk": {
+          "columns": [
+            "eval_id",
+            "tag_id"
+          ],
+          "name": "evals_to_tags_eval_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_audits": {
+      "name": "model_audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_path": {
+          "name": "model_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checks": {
+          "name": "checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_errors": {
+          "name": "has_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_checks": {
+          "name": "total_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passed_checks": {
+          "name": "passed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_checks": {
+          "name": "failed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_audits_created_at_idx": {
+          "name": "model_audits_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_path_idx": {
+          "name": "model_audits_model_path_idx",
+          "columns": [
+            "model_path"
+          ],
+          "isUnique": false
+        },
+        "model_audits_has_errors_idx": {
+          "name": "model_audits_has_errors_idx",
+          "columns": [
+            "has_errors"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_type_idx": {
+          "name": "model_audits_model_type_idx",
+          "columns": [
+            "model_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_created_at_idx": {
+          "name": "prompts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        },
+        "spans_span_id_idx": {
+          "name": "spans_span_id_idx",
+          "columns": [
+            "span_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "spans_trace_id_traces_trace_id_fk": {
+          "name": "spans_trace_id_traces_trace_id_fk",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "trace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "tags_name_value_unique": {
+          "name": "tags_name_value_unique",
+          "columns": [
+            "name",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "traces_trace_id_unique": {
+          "name": "traces_trace_id_unique",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": true
+        },
+        "traces_evaluation_idx": {
+          "name": "traces_evaluation_idx",
+          "columns": [
+            "evaluation_id"
+          ],
+          "isUnique": false
+        },
+        "traces_trace_id_idx": {
+          "name": "traces_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "traces_evaluation_id_evals_id_fk": {
+          "name": "traces_evaluation_id_evals_id_fk",
+          "tableFrom": "traces",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "eval_result_grading_result_reason_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.reason')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_grading_result_comment_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.comment')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_vars_idx": {
+        "columns": {
+          "json_extract(\"test_case\", '$.vars')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_named_scores_idx": {
+        "columns": {
+          "json_extract(\"named_scores\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_plugin_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.pluginId')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_strategy_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.strategyId')": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1757026874299,
       "tag": "0019_new_clint_barton",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1757650210456,
+      "tag": "0020_skinny_maverick",
+      "breakpoints": true
     }
   ]
 }

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -63,43 +63,44 @@ Most commands support the following common options:
 
 By default the `eval` command will read the `promptfooconfig.yaml` configuration file in your current directory. But, if you're looking to override certain parameters you can supply optional arguments:
 
-| Option                              | Description                                                                 |
-| ----------------------------------- | --------------------------------------------------------------------------- |
-| `-a, --assertions <path>`           | Path to assertions file                                                     |
-| `-c, --config <paths...>`           | Path to configuration file(s). Automatically loads promptfooconfig.yaml     |
-| `--delay <number>`                  | Delay between each test (in milliseconds)                                   |
-| `--description <description>`       | Description of the eval run                                                 |
-| `--filter-failing <path or id>`     | Filter tests that failed in a previous evaluation (by file path or eval ID) |
-| `--filter-errors-only <path or id>` | Filter tests that resulted in errors in a previous evaluation               |
-| `-n, --filter-first-n <number>`     | Only run the first N tests                                                  |
-| `--filter-sample <number>`          | Only run a random sample of N tests                                         |
-| `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                    |
-| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern                  |
-| `--filter-providers <providers>`    | Only run tests with these providers (regex match)                           |
-| `--filter-targets <targets>`        | Only run tests with these targets (alias for --filter-providers)            |
-| `--grader <provider>`               | Model that will grade outputs                                               |
-| `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                      |
-| `--model-outputs <path>`            | Path to JSON containing list of LLM output strings                          |
-| `--no-cache`                        | Do not read or write results to disk cache                                  |
-| `--no-progress-bar`                 | Do not show progress bar                                                    |
-| `--no-table`                        | Do not output table in CLI                                                  |
-| `--no-write`                        | Do not write results to promptfoo directory                                 |
-| `-o, --output <paths...>`           | Path(s) to output file (csv, txt, json, jsonl, yaml, yml, html, xml)        |
-| `-p, --prompts <paths...>`          | Paths to prompt files (.txt)                                                |
-| `--prompt-prefix <path>`            | Prefix prepended to every prompt                                            |
-| `--prompt-suffix <path>`            | Suffix appended to every prompt                                             |
-| `-r, --providers <name or path...>` | Provider names or paths to custom API caller modules                        |
-| `--remote`                          | Force remote inference wherever possible (used for red teams)               |
-| `--repeat <number>`                 | Number of times to run each test                                            |
-| `--share`                           | Create a shareable URL                                                      |
-| `--no-share`                        | Do not create a shareable URL, this overrides the config file               |
-| `--suggest-prompts <number>`        | Generate N new prompts and append them to the prompt list                   |
-| `--table`                           | Output table in CLI                                                         |
-| `--table-cell-max-length <number>`  | Truncate console table cells to this length                                 |
-| `-t, --tests <path>`                | Path to CSV with test cases                                                 |
-| `--var <key=value>`                 | Set a variable in key=value format                                          |
-| `-v, --vars <path>`                 | Path to CSV with test cases (alias for --tests)                             |
-| `-w, --watch`                       | Watch for changes in config and re-run                                      |
+| Option                              | Description                                                                   |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| `-a, --assertions <path>`           | Path to assertions file                                                       |
+| `-c, --config <paths...>`           | Path to configuration file(s). Automatically loads promptfooconfig.yaml       |
+| `--delay <number>`                  | Delay between each test (in milliseconds)                                     |
+| `--description <description>`       | Description of the eval run                                                   |
+| `--filter-failing <path or id>`     | Filter tests that failed in a previous evaluation (by file path or eval ID)   |
+| `--filter-errors-only <path or id>` | Filter tests that resulted in errors in a previous evaluation                 |
+| `-n, --filter-first-n <number>`     | Only run the first N tests                                                    |
+| `--filter-sample <number>`          | Only run a random sample of N tests                                           |
+| `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                      |
+| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern                    |
+| `--filter-providers <providers>`    | Only run tests with these providers (regex match)                             |
+| `--filter-targets <targets>`        | Only run tests with these targets (alias for --filter-providers)              |
+| `--grader <provider>`               | Model that will grade outputs                                                 |
+| `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                        |
+| `--model-outputs <path>`            | Path to JSON containing list of LLM output strings                            |
+| `--no-cache`                        | Do not read or write results to disk cache                                    |
+| `--no-progress-bar`                 | Do not show progress bar                                                      |
+| `--no-table`                        | Do not output table in CLI                                                    |
+| `--no-write`                        | Do not write results to promptfoo directory                                   |
+| `--resume [evalId]`                 | Resume a paused/incomplete evaluation. If `evalId` is omitted, resumes latest |
+| `-o, --output <paths...>`           | Path(s) to output file (csv, txt, json, jsonl, yaml, yml, html, xml)          |
+| `-p, --prompts <paths...>`          | Paths to prompt files (.txt)                                                  |
+| `--prompt-prefix <path>`            | Prefix prepended to every prompt                                              |
+| `--prompt-suffix <path>`            | Suffix appended to every prompt                                               |
+| `-r, --providers <name or path...>` | Provider names or paths to custom API caller modules                          |
+| `--remote`                          | Force remote inference wherever possible (used for red teams)                 |
+| `--repeat <number>`                 | Number of times to run each test                                              |
+| `--share`                           | Create a shareable URL                                                        |
+| `--no-share`                        | Do not create a shareable URL, this overrides the config file                 |
+| `--suggest-prompts <number>`        | Generate N new prompts and append them to the prompt list                     |
+| `--table`                           | Output table in CLI                                                           |
+| `--table-cell-max-length <number>`  | Truncate console table cells to this length                                   |
+| `-t, --tests <path>`                | Path to CSV with test cases                                                   |
+| `--var <key=value>`                 | Set a variable in key=value format                                            |
+| `-v, --vars <path>`                 | Path to CSV with test cases (alias for --tests)                               |
+| `-w, --watch`                       | Watch for changes in config and re-run                                        |
 
 The `eval` command will return exit code `100` when there is at least 1 test case failure or when the pass rate is below the threshold set by `PROMPTFOO_PASS_RATE_THRESHOLD`. It will return exit code `1` for any other error. The exit code for failed tests can be overridden with environment variable `PROMPTFOO_FAILED_TEST_EXIT_CODE`.
 
@@ -126,6 +127,19 @@ If you've used `PROMPTFOO_CONFIG_DIR` to override the promptfoo output directory
 ## `promptfoo share [evalId]`
 
 Create a URL that can be shared online.
+
+### Pause and Resume
+
+- Press Ctrl+C once during an evaluation to pause it gracefully. In-flight requests are aborted and completed results remain saved.
+- Resume later with:
+
+  ```sh
+  promptfoo eval --resume            # resumes the latest evaluation
+  promptfoo eval --resume <evalId>   # resumes a specific evaluation
+  ```
+
+- When resuming, promptfoo reuses the effective runtime options from the original run (e.g., `--delay`, `--no-cache`, `--max-concurrency`, `--repeat`).
+- Completed test/prompt pairs are skipped; only missing work runs. To ensure correctness, some CLI overrides that change test ordering (filters, provider selection) are ignored during resume so test indices match the original run.
 
 | Option        | Description                                     |
 | ------------- | ----------------------------------------------- |

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -104,6 +104,15 @@ By default the `eval` command will read the `promptfooconfig.yaml` configuration
 
 The `eval` command will return exit code `100` when there is at least 1 test case failure or when the pass rate is below the threshold set by `PROMPTFOO_PASS_RATE_THRESHOLD`. It will return exit code `1` for any other error. The exit code for failed tests can be overridden with environment variable `PROMPTFOO_FAILED_TEST_EXIT_CODE`.
 
+### Pause and Resume
+
+```sh
+promptfoo eval --resume            # resumes the latest evaluation
+promptfoo eval --resume <evalId>   # resumes a specific evaluation
+```
+
+- On resume, promptfoo reuses the original run's effective runtime options (e.g., `--delay`, `--no-cache`, `--max-concurrency`, `--repeat`), skips completed test/prompt pairs, ignores CLI flags that change test ordering to keep indices aligned, and disables watch mode.
+
 ## `promptfoo init [directory]`
 
 Initialize a new project with dummy files.
@@ -127,19 +136,6 @@ If you've used `PROMPTFOO_CONFIG_DIR` to override the promptfoo output directory
 ## `promptfoo share [evalId]`
 
 Create a URL that can be shared online.
-
-### Pause and Resume
-
-- Press Ctrl+C once during an evaluation to pause it gracefully. In-flight requests are aborted and completed results remain saved.
-- Resume later with:
-
-  ```sh
-  promptfoo eval --resume            # resumes the latest evaluation
-  promptfoo eval --resume <evalId>   # resumes a specific evaluation
-  ```
-
-- When resuming, promptfoo reuses the effective runtime options from the original run (e.g., `--delay`, `--no-cache`, `--max-concurrency`, `--repeat`).
-- Completed test/prompt pairs are skipped; only missing work runs. To ensure correctness, some CLI overrides that change test ordering (filters, provider selection) are ignored during resume so test indices match the original run.
 
 | Option        | Description                                     |
 | ------------- | ----------------------------------------------- |

--- a/src/cliState.ts
+++ b/src/cliState.ts
@@ -9,6 +9,9 @@ interface CliState {
 
   // Indicates we're running in web UI mode
   webUI?: boolean;
+
+  // Indicates an evaluation is running in resume mode
+  resume?: boolean;
 }
 
 const state: CliState = {};

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -252,7 +252,7 @@ export async function doEval(
         Number.isSafeInteger(persisted.repeat || 0) && (persisted.repeat as number) > 0
           ? (persisted.repeat as number)
           : 1;
-      cache = persisted.cache;
+      cache = persisted.cache ?? true;
       maxConcurrency = (persisted.maxConcurrency as number | undefined) ?? DEFAULT_MAX_CONCURRENCY;
       delay = (persisted.delay as number | undefined) ?? 0;
     } else {
@@ -260,13 +260,13 @@ export async function doEval(
       // CLI values explicitly provided by user should override config, but defaults should not
       const iterations = cmdObj.repeat ?? evaluateOptions.repeat ?? Number.NaN;
       repeat = Number.isSafeInteger(iterations) && iterations > 0 ? iterations : 1;
-      cache = cmdObj.cache ?? evaluateOptions.cache;
+      cache = cmdObj.cache ?? evaluateOptions.cache ?? true;
       maxConcurrency =
         cmdObj.maxConcurrency ?? evaluateOptions.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
       delay = cmdObj.delay ?? evaluateOptions.delay ?? 0;
     }
 
-    if (!cache || repeat > 1) {
+    if (cache === false || repeat > 1) {
       logger.info('Cache is disabled.');
       disableCache();
     }

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -183,8 +183,8 @@ export async function doEval(
             }) as any,
         );
       }
-      // Mark resume mode so evaluator can skip completed work
-      process.env.PROMPTFOO_RESUME = 'true';
+      // Mark resume mode in CLI state so evaluator can skip completed work
+      cliState.resume = true;
     } else {
       ({
         config,
@@ -411,6 +411,8 @@ export async function doEval(
     if (sigintHandler) {
       process.removeListener('SIGINT', sigintHandler);
     }
+    // Clear resume flag after run completes
+    cliState.resume = false;
 
     // If paused, print minimal guidance and skip the rest of the reporting
     if (paused) {

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -64,6 +64,9 @@ export const evalsTable = sqliteTable(
     config: text('config', { mode: 'json' }).$type<Partial<UnifiedConfig>>().notNull(),
     prompts: text('prompts', { mode: 'json' }).$type<CompletedPrompt[]>(),
     vars: text('vars', { mode: 'json' }).$type<string[]>(),
+    runtimeOptions: text('runtime_options', { mode: 'json' }).$type<
+      Partial<import('../types').EvaluateOptions>
+    >(),
     isRedteam: integer('is_redteam', { mode: 'boolean' }).notNull().default(false),
   },
   (table) => ({

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1054,8 +1054,8 @@ class Evaluator {
       }
     }
 
-    // Resume support: if PROMPTFOO_RESUME is set, skip already-completed (testIdx,promptIdx) pairs
-    if (process.env.PROMPTFOO_RESUME === 'true' && this.evalRecord.persisted) {
+    // Resume support: if CLI is in resume mode, skip already-completed (testIdx,promptIdx) pairs
+    if (cliState.resume && this.evalRecord.persisted) {
       try {
         const { default: EvalResult } = await import('./models/evalResult');
         const completedPairs = await EvalResult.getCompletedIndexPairs(this.evalRecord.id);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1456,7 +1456,7 @@ class Evaluator {
         if (evalTimedOut) {
           logger.warn(`Evaluation stopped after reaching max duration (${maxEvalTimeMs}ms)`);
         } else {
-          logger.info('Evaluation interrupted by user; saving progress...');
+          logger.info('Evaluation interrupted, saving progress...');
         }
       } else {
         if (ciProgressReporter) {

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -111,6 +111,7 @@ export default class Eval {
   persisted: boolean;
   vars: string[];
   _resultsLoaded: boolean = false;
+  runtimeOptions?: Partial<import('../types').EvaluateOptions>;
 
   static async latest() {
     const db = getDb();
@@ -159,6 +160,7 @@ export default class Eval {
       datasetId,
       persisted: true,
       vars: eval_.vars || [],
+      runtimeOptions: (eval_ as any).runtimeOptions,
     });
     if (eval_.results && 'table' in eval_.results) {
       evalInstance.oldResults = eval_.results as EvaluateSummaryV2;
@@ -205,6 +207,7 @@ export default class Eval {
       // Be wary, this is EvalResult[] and not EvaluateResult[]
       results?: EvalResult[];
       vars?: string[];
+      runtimeOptions?: Partial<import('../types').EvaluateOptions>;
     },
   ): Promise<Eval> {
     const createdAt = opts?.createdAt || new Date();
@@ -224,6 +227,7 @@ export default class Eval {
           config,
           results: {},
           vars: opts?.vars || [],
+          runtimeOptions: opts?.runtimeOptions,
         })
         .run();
 
@@ -302,7 +306,13 @@ export default class Eval {
       }
     });
 
-    return new Eval(config, { id: evalId, author: opts?.author, createdAt, persisted: true });
+    return new Eval(config, {
+      id: evalId,
+      author: opts?.author,
+      createdAt,
+      persisted: true,
+      runtimeOptions: opts?.runtimeOptions,
+    });
   }
 
   constructor(
@@ -316,6 +326,7 @@ export default class Eval {
       datasetId?: string;
       persisted?: boolean;
       vars?: string[];
+      runtimeOptions?: Partial<import('../types').EvaluateOptions>;
     },
   ) {
     const createdAt = opts?.createdAt || new Date();
@@ -329,6 +340,7 @@ export default class Eval {
     this.persisted = opts?.persisted || false;
     this._resultsLoaded = false;
     this.vars = opts?.vars || [];
+    this.runtimeOptions = opts?.runtimeOptions;
   }
 
   version() {
@@ -358,6 +370,7 @@ export default class Eval {
       author: this.author,
       updatedAt: getCurrentTimestamp(),
       vars: Array.from(this.vars),
+      runtimeOptions: this.runtimeOptions,
     };
 
     if (this.useOldResults()) {

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -169,6 +169,23 @@ export default class EvalResult {
     return results.map((result) => new EvalResult({ ...result, persisted: true }));
   }
 
+  /**
+   * Returns a set of completed (testIdx,promptIdx) pairs for a given eval.
+   * Key format: `${testIdx}:${promptIdx}`
+   */
+  static async getCompletedIndexPairs(evalId: string): Promise<Set<string>> {
+    const db = getDb();
+    const rows = await db
+      .select({ testIdx: evalResultsTable.testIdx, promptIdx: evalResultsTable.promptIdx })
+      .from(evalResultsTable)
+      .where(eq(evalResultsTable.evalId, evalId));
+    const ret = new Set<string>();
+    for (const r of rows) {
+      ret.add(`${r.testIdx}:${r.promptIdx}`);
+    }
+    return ret;
+  }
+
   // This is a generator that yields batches of results from the database
   // These are batched by test Id, not just results to ensure we get all results for a given test
   static async *findManyByEvalIdBatched(


### PR DESCRIPTION
Ability to pause evals (Ctrl+C) and resume them with `promptfoo eval --resume`