### PR TITLE
chore(webui): remove React.FC type annotations for React 19 compatibility

### DIFF
--- a/src/app/src/components/EnterpriseBanner.tsx
+++ b/src/app/src/components/EnterpriseBanner.tsx
@@ -14,7 +14,7 @@ interface EnterpriseBannerProps {
  * Enterprise Banner component that shows information about community edition
  * Displays only when in redteam mode and when user is not logged into cloud
  */
-const EnterpriseBanner: React.FC<EnterpriseBannerProps> = ({ evalId, sx }) => {
+const EnterpriseBanner = ({ evalId, sx }: EnterpriseBannerProps) => {
   const [isCloudEnabled, setIsCloudEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {

--- a/src/app/src/components/JsonTextField.tsx
+++ b/src/app/src/components/JsonTextField.tsx
@@ -7,7 +7,7 @@ interface JsonTextFieldProps extends Omit<TextFieldProps, 'onChange'> {
   onChange?: (parsed: any) => void;
 }
 
-const JsonTextField: React.FC<JsonTextFieldProps> = ({ onChange, ...props }) => {
+const JsonTextField = ({ onChange, ...props }: JsonTextFieldProps) => {
   const [value, setValue] = React.useState('');
   const [error, setError] = React.useState(false);
 

--- a/src/app/src/components/PostHogProvider.tsx
+++ b/src/app/src/components/PostHogProvider.tsx
@@ -13,7 +13,7 @@ interface PostHogProviderProps {
   children: React.ReactNode;
 }
 
-export const PostHogProvider: React.FC<PostHogProviderProps> = ({ children }) => {
+export const PostHogProvider = ({ children }: PostHogProviderProps) => {
   const [isInitialized, setIsInitialized] = useState(false);
   const { email, userId, fetchEmail, fetchUserId } = useUserStore();
 

--- a/src/app/src/contexts/ShiftKeyContext.tsx
+++ b/src/app/src/contexts/ShiftKeyContext.tsx
@@ -1,8 +1,8 @@
-import React, { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 import { ShiftKeyContext } from './ShiftKeyContextDef';
 
-export const ShiftKeyProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+export const ShiftKeyProvider = ({ children }: { children: ReactNode }) => {
   const [isShiftKeyPressed, setShiftKeyPressed] = useState(false);
 
   useEffect(() => {

--- a/src/app/src/contexts/ToastContext.tsx
+++ b/src/app/src/contexts/ToastContext.tsx
@@ -5,7 +5,7 @@ import Snackbar from '@mui/material/Snackbar';
 import { ToastContext, type ToastProviderProps } from './ToastContextDef';
 import type { AlertColor } from '@mui/material/Alert';
 
-export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
+export const ToastProvider = ({ children }: ToastProviderProps) => {
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<AlertColor>('info');

--- a/src/app/src/pages/eval-creator/components/AddLocalProviderDialog.tsx
+++ b/src/app/src/pages/eval-creator/components/AddLocalProviderDialog.tsx
@@ -16,11 +16,7 @@ interface AddLocalProviderDialogProps {
   onAdd: (provider: ProviderOptions) => void;
 }
 
-const AddLocalProviderDialog: React.FC<AddLocalProviderDialogProps> = ({
-  open,
-  onClose,
-  onAdd,
-}) => {
+const AddLocalProviderDialog = ({ open, onClose, onAdd }: AddLocalProviderDialogProps) => {
   const [path, setPath] = React.useState('');
   const [error, setError] = React.useState('');
 

--- a/src/app/src/pages/eval-creator/components/AssertsForm.tsx
+++ b/src/app/src/pages/eval-creator/components/AssertsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Delete from '@mui/icons-material/Delete';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -70,7 +70,7 @@ const assertTypes: AssertionType[] = [
   'finish-reason',
 ];
 
-const AssertsForm: React.FC<AssertsFormProps> = ({ onAdd, initialValues }) => {
+const AssertsForm = ({ onAdd, initialValues }: AssertsFormProps) => {
   const [asserts, setAsserts] = useState<Assertion[]>(initialValues || []);
 
   const handleAdd = () => {

--- a/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
+++ b/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useStore } from '@app/stores/evalConfig';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -12,7 +12,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
 
-const ConfigureEnvButton: React.FC = () => {
+const ConfigureEnvButton = () => {
   const { config, updateConfig } = useStore();
   const defaultEnv = config.env || {};
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
@@ -37,7 +37,7 @@ function ErrorFallback({
   );
 }
 
-const EvaluateTestSuiteCreator: React.FC = () => {
+const EvaluateTestSuiteCreator = () => {
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
   const { config, updateConfig, reset } = useStore();

--- a/src/app/src/pages/eval-creator/components/PromptDialog.tsx
+++ b/src/app/src/pages/eval-creator/components/PromptDialog.tsx
@@ -15,7 +15,7 @@ interface PromptDialogProps {
   onCancel: () => void;
 }
 
-const PromptDialog: React.FC<PromptDialogProps> = ({ open, prompt, index, onAdd, onCancel }) => {
+const PromptDialog = ({ open, prompt, index, onAdd, onCancel }: PromptDialogProps) => {
   const [editingPrompt, setEditingPrompt] = React.useState(prompt);
   const textFieldRef = React.useRef<HTMLInputElement>(null);
 

--- a/src/app/src/pages/eval-creator/components/PromptsSection.tsx
+++ b/src/app/src/pages/eval-creator/components/PromptsSection.tsx
@@ -23,7 +23,7 @@ import Typography from '@mui/material/Typography';
 import PromptDialog from './PromptDialog';
 import './PromptsSection.css';
 
-const PromptsSection: React.FC = () => {
+const PromptsSection = () => {
   const [promptDialogOpen, setPromptDialogOpen] = useState(false);
   const [editingPromptIndex, setEditingPromptIndex] = useState<number | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/src/app/src/pages/eval-creator/components/ProviderConfigDialog.tsx
+++ b/src/app/src/pages/eval-creator/components/ProviderConfigDialog.tsx
@@ -19,13 +19,13 @@ interface ProviderConfigDialogProps {
   onSave: (providerId: string, config: Record<string, any>) => void;
 }
 
-const ProviderConfigDialog: React.FC<ProviderConfigDialogProps> = ({
+const ProviderConfigDialog = ({
   open,
   providerId,
   config = {},
   onClose,
   onSave,
-}) => {
+}: ProviderConfigDialogProps) => {
   const [localConfig, setLocalConfig] = useState<Record<string, any>>(config);
   const isAzureProvider = providerId.startsWith('azure:');
 

--- a/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
+++ b/src/app/src/pages/eval-creator/components/ProviderSelector.tsx
@@ -644,7 +644,7 @@ interface ProviderSelectorProps {
   onChange: (providers: ProviderOptions[]) => void;
 }
 
-const ProviderSelector: React.FC<ProviderSelectorProps> = ({ providers, onChange }) => {
+const ProviderSelector = ({ providers, onChange }: ProviderSelectorProps) => {
   const { customProviders, addCustomProvider } = useProvidersStore();
   const [selectedProvider, setSelectedProvider] = React.useState<ProviderOptions | null>(null);
   const [isAddLocalDialogOpen, setIsAddLocalDialogOpen] = React.useState(false);

--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useStore } from '@app/stores/evalConfig';
 import { callApi } from '@app/utils/api';
@@ -6,7 +6,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useNavigate } from 'react-router-dom';
 
-const RunTestSuiteButton: React.FC = () => {
+const RunTestSuiteButton = () => {
   const navigate = useNavigate();
   const { config } = useStore();
   const {

--- a/src/app/src/pages/eval-creator/components/TestCaseDialog.tsx
+++ b/src/app/src/pages/eval-creator/components/TestCaseDialog.tsx
@@ -18,13 +18,7 @@ interface TestCaseFormProps {
   onCancel: () => void;
 }
 
-const TestCaseForm: React.FC<TestCaseFormProps> = ({
-  open,
-  onAdd,
-  varsList,
-  initialValues,
-  onCancel,
-}) => {
+const TestCaseForm = ({ open, onAdd, varsList, initialValues, onCancel }: TestCaseFormProps) => {
   const [description, setDescription] = useState(initialValues?.description || '');
   const [vars, setVars] = useState(initialValues?.vars || {});
   const [asserts, setAsserts] = useState(initialValues?.assert || []);

--- a/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
+++ b/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
@@ -54,7 +54,7 @@ function isValidTestCase(obj: any): obj is TestCase {
   return true;
 }
 
-const TestCasesSection: React.FC<TestCasesSectionProps> = ({ varsList }) => {
+const TestCasesSection = ({ varsList }: TestCasesSectionProps) => {
   const { config, updateConfig } = useStore();
   const testCases = (config.tests || []) as TestCase[];
   const setTestCases = (cases: TestCase[]) => updateConfig({ tests: cases });

--- a/src/app/src/pages/eval-creator/components/VarsForm.tsx
+++ b/src/app/src/pages/eval-creator/components/VarsForm.tsx
@@ -11,7 +11,7 @@ interface VarsFormProps {
   initialValues?: Record<string, string>;
 }
 
-const VarsForm: React.FC<VarsFormProps> = ({ onAdd, varsList, initialValues }) => {
+const VarsForm = ({ onAdd, varsList, initialValues }: VarsFormProps) => {
   const [vars, setVars] = React.useState<Record<string, string>>(initialValues || {});
 
   useEffect(() => {

--- a/src/app/src/pages/eval-creator/components/YamlEditor.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.tsx
@@ -54,11 +54,7 @@ const StyledLink = styled(Link)({
   textDecoration: 'none',
 });
 
-const YamlEditorComponent: React.FC<YamlEditorProps> = ({
-  initialConfig,
-  readOnly = false,
-  initialYaml,
-}) => {
+const YamlEditorComponent = ({ initialConfig, readOnly = false, initialYaml }: YamlEditorProps) => {
   const darkMode = useTheme().palette.mode === 'dark';
   const [code, setCode] = React.useState('');
   const [originalCode, setOriginalCode] = React.useState('');

--- a/src/app/src/pages/eval/components/AuthorChip.tsx
+++ b/src/app/src/pages/eval/components/AuthorChip.tsx
@@ -19,12 +19,12 @@ interface AuthorChipProps {
   editable: boolean;
 }
 
-export const AuthorChip: React.FC<AuthorChipProps> = ({
+export const AuthorChip = ({
   author,
   onEditAuthor,
   currentUserEmail,
   editable,
-}) => {
+}: AuthorChipProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [email, setEmail] = useState(author || '');

--- a/src/app/src/pages/eval/components/ColumnSelector.tsx
+++ b/src/app/src/pages/eval/components/ColumnSelector.tsx
@@ -31,11 +31,7 @@ interface ColumnSelectorProps {
   onChange: (event: SelectChangeEvent<string[]>) => void;
 }
 
-export const ColumnSelector: React.FC<ColumnSelectorProps> = ({
-  columnData,
-  selectedColumns,
-  onChange,
-}) => {
+export const ColumnSelector = ({ columnData, selectedColumns, onChange }: ColumnSelectorProps) => {
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = () => setOpen(true);

--- a/src/app/src/pages/eval/components/CustomMetrics.tsx
+++ b/src/app/src/pages/eval/components/CustomMetrics.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import './CustomMetrics.css';
 
 import Box from '@mui/material/Box';
@@ -28,7 +26,7 @@ interface MetricValueProps {
   metricTotals?: Record<string, number>;
 }
 
-const MetricValue: React.FC<MetricValueProps> = ({ metric, score, counts, metricTotals }) => {
+const MetricValue = ({ metric, score, counts, metricTotals }: MetricValueProps) => {
   if (metricTotals && metricTotals[metric]) {
     if (metricTotals[metric] === 0) {
       return <span data-testid={`metric-value-${metric}`}>0%</span>;
@@ -53,7 +51,7 @@ const MetricValue: React.FC<MetricValueProps> = ({ metric, score, counts, metric
   return <span data-testid={`metric-value-${metric}`}>{score?.toFixed(2) ?? '0'}</span>;
 };
 
-const CustomMetrics: React.FC<CustomMetricsProps> = ({
+const CustomMetrics = ({
   lookup,
   counts,
   metricTotals,
@@ -61,7 +59,7 @@ const CustomMetrics: React.FC<CustomMetricsProps> = ({
   onMetricFilter,
   truncationCount = 10,
   onShowMore,
-}) => {
+}: CustomMetricsProps) => {
   if (!lookup || !Object.keys(lookup).length) {
     return null;
   }

--- a/src/app/src/pages/eval/components/CustomMetricsDialog.tsx
+++ b/src/app/src/pages/eval/components/CustomMetricsDialog.tsx
@@ -30,7 +30,7 @@ interface MetricRow {
   [key: string]: any; // For dynamic prompt columns
 }
 
-const MetricsTable: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+const MetricsTable = ({ onClose }: { onClose: () => void }) => {
   const { table, filters, addFilter } = useTableStore();
   const theme = useTheme();
 

--- a/src/app/src/pages/eval/components/EmptyState.tsx
+++ b/src/app/src/pages/eval/components/EmptyState.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-
 import AssessmentIcon from '@mui/icons-material/Assessment';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
-const EmptyState: React.FC = () => {
+const EmptyState = () => {
   return (
     <Box display="flex" justifyContent="center" alignItems="center" minHeight="50vh">
       <Paper

--- a/src/app/src/pages/eval/components/EvalIdChip.tsx
+++ b/src/app/src/pages/eval/components/EvalIdChip.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import FingerprintIcon from '@mui/icons-material/Fingerprint';
 import Box from '@mui/material/Box';
@@ -12,7 +10,7 @@ interface EvalIdChipProps {
   onCopy: () => void;
 }
 
-export const EvalIdChip: React.FC<EvalIdChipProps> = ({ evalId, onCopy }) => {
+export const EvalIdChip = ({ evalId, onCopy }: EvalIdChipProps) => {
   const handleCopy = () => {
     onCopy();
   };

--- a/src/app/src/pages/eval/components/EvalSelectorDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalSelectorDialog.tsx
@@ -17,7 +17,7 @@ type Props = {
   onOpenFocusSearch?: boolean;
 };
 
-const EvalSelectorDialog: React.FC<Props> = ({
+const EvalSelectorDialog = ({
   open,
   onClose,
   onEvalSelected,
@@ -26,7 +26,7 @@ const EvalSelectorDialog: React.FC<Props> = ({
   focusedEvalId,
   filterByDatasetId,
   onOpenFocusSearch = false,
-}) => {
+}: Props) => {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       {title ? <DialogTitle>{title}</DialogTitle> : null}

--- a/src/app/src/pages/eval/components/EvalSelectorKeyboardShortcut.tsx
+++ b/src/app/src/pages/eval/components/EvalSelectorKeyboardShortcut.tsx
@@ -6,7 +6,7 @@ interface EvalSelectorProps {
   onEvalSelected: (evalId: string) => void;
 }
 
-const EvalSelector: React.FC<EvalSelectorProps> = ({ onEvalSelected }) => {
+const EvalSelector = ({ onEvalSelected }: EvalSelectorProps) => {
   const [open, setOpen] = useState(false);
   //const isMac =
   //  typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);

--- a/src/app/src/pages/eval/components/FailReasonCarousel.tsx
+++ b/src/app/src/pages/eval/components/FailReasonCarousel.tsx
@@ -9,7 +9,7 @@ interface FailReasonCarouselProps {
   failReasons: string[];
 }
 
-const FailReasonCarousel: React.FC<FailReasonCarouselProps> = ({ failReasons }) => {
+const FailReasonCarousel = ({ failReasons }: FailReasonCarouselProps) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const handlePrev = () => {

--- a/src/app/src/pages/eval/components/FilterModeSelector.tsx
+++ b/src/app/src/pages/eval/components/FilterModeSelector.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
@@ -22,11 +20,11 @@ const BASE_OPTIONS = [
   { value: 'highlights', label: 'Show highlights only' },
 ];
 
-export const FilterModeSelector: React.FC<FilterModeSelectorProps> = ({
+export const FilterModeSelector = ({
   filterMode,
   onChange,
   showDifferentOption = true,
-}) => {
+}: FilterModeSelectorProps) => {
   const options = showDifferentOption
     ? BASE_OPTIONS
     : BASE_OPTIONS.filter((o) => o.value !== 'different');

--- a/src/app/src/pages/eval/components/MetricFilterSelector.tsx
+++ b/src/app/src/pages/eval/components/MetricFilterSelector.tsx
@@ -8,7 +8,7 @@ import Select from '@mui/material/Select';
 import { useTableStore } from './store';
 import type { SelectChangeEvent } from '@mui/material/Select';
 
-export const MetricFilterSelector: React.FC<{}> = () => {
+export const MetricFilterSelector = () => {
   const { filters, addFilter, resetFilters } = useTableStore();
   const availableMetrics = filters.options.metric;
 

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -49,7 +49,6 @@ import ShareModal from './ShareModal';
 import { useResultsViewSettingsStore, useTableStore } from './store';
 import SettingsModal from './TableSettings/TableSettingsModal';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import type { StackProps } from '@mui/material/Stack';
 import type { EvalResultsFilterMode, ResultLightweightWithLabel } from '@promptfoo/types';
 import type { VisibilityState } from '@tanstack/table-core';
 import './ResultsView.css';
@@ -64,7 +63,7 @@ const ResponsiveStack = styled(Stack)(({ theme }) => ({
   [theme.breakpoints.down('sm')]: {
     flexDirection: 'column',
   },
-})) as React.FC<StackProps>;
+}));
 
 interface ResultsViewProps {
   recentEvals: ResultLightweightWithLabel[];

--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { callApi } from '@app/utils/api';
 import CheckIcon from '@mui/icons-material/Check';
@@ -19,7 +19,7 @@ interface ShareModalProps {
   onShare: (id: string) => Promise<string>;
 }
 
-const ShareModal: React.FC<ShareModalProps> = ({ open, onClose, evalId, onShare }) => {
+const ShareModal = ({ open, onClose, evalId, onShare }: ShareModalProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [copied, setCopied] = useState(false);
   const [showNeedsSignup, setShowNeedsSignup] = useState(false);

--- a/src/app/src/pages/eval/components/TableCommentDialog.tsx
+++ b/src/app/src/pages/eval/components/TableCommentDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -18,14 +16,14 @@ interface CommentDialogProps {
   onChange: (text: string) => void;
 }
 
-const CommentDialog: React.FC<CommentDialogProps> = ({
+const CommentDialog = ({
   open,
   contextText,
   commentText,
   onClose,
   onSave,
   onChange,
-}) => {
+}: CommentDialogProps) => {
   const darkMode = useTheme().palette.mode === 'dark';
 
   return (

--- a/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.tsx
@@ -23,7 +23,7 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-const TableSettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
+const TableSettingsModal = ({ open, onClose }: SettingsModalProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 

--- a/src/app/src/pages/eval/components/TableSettings/components/EnhancedRangeSlider.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/EnhancedRangeSlider.tsx
@@ -27,7 +27,7 @@ interface EnhancedRangeSliderProps {
   icon?: React.ReactNode;
 }
 
-const EnhancedRangeSlider: React.FC<EnhancedRangeSliderProps> = ({
+const EnhancedRangeSlider = ({
   value,
   onChange,
   min,
@@ -39,7 +39,7 @@ const EnhancedRangeSlider: React.FC<EnhancedRangeSliderProps> = ({
   disabled = false,
   tooltipText,
   icon,
-}) => {
+}: EnhancedRangeSliderProps) => {
   // Ensure value is always a valid number
   const safeValue = value === null || value === undefined || Number.isNaN(value) ? min : value;
   const [localValue, setLocalValue] = useState(safeValue);

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingItem.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingItem.tsx
@@ -23,7 +23,7 @@ interface SettingItemProps {
   component?: 'checkbox' | 'switch';
 }
 
-const SettingItem: React.FC<SettingItemProps> = ({
+const SettingItem = ({
   label,
   checked,
   onChange,
@@ -31,7 +31,7 @@ const SettingItem: React.FC<SettingItemProps> = ({
   tooltipText,
   disabled = false,
   component = 'checkbox',
-}) => {
+}: SettingItemProps) => {
   const theme = useTheme();
   const labelId = `setting-${label.replace(/\s+/g, '-').toLowerCase()}`;
 

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -17,7 +17,7 @@ import EnhancedRangeSlider from './EnhancedRangeSlider';
 import SettingItem from './SettingItem';
 import SettingsSection from './SettingsSection';
 
-const SettingsPanel: React.FC = () => {
+const SettingsPanel = () => {
   const {
     stickyHeader,
     setStickyHeader,

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsSection.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsSection.tsx
@@ -14,12 +14,7 @@ interface SettingsSectionProps {
   description?: string;
 }
 
-const SettingsSection: React.FC<SettingsSectionProps> = ({
-  title,
-  children,
-  icon,
-  description,
-}) => {
+const SettingsSection = ({ title, children, icon, description }: SettingsSectionProps) => {
   const theme = useTheme();
   const sectionId = `section-${title.replace(/\s+/g, '-').toLowerCase()}`;
 

--- a/src/app/src/pages/prompts/PromptDialog.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.tsx
@@ -30,12 +30,12 @@ interface PromptDialogProps {
   showDatasetColumn?: boolean;
 }
 
-const PromptDialog: React.FC<PromptDialogProps> = ({
+const PromptDialog = ({
   openDialog,
   handleClose,
   selectedPrompt,
   showDatasetColumn = true,
-}) => {
+}: PromptDialogProps) => {
   const [copySnackbar, setCopySnackbar] = React.useState(false);
 
   const sortedEvals = useMemo(

--- a/src/app/src/pages/redteam/report/components/FrameworkCard.tsx
+++ b/src/app/src/pages/redteam/report/components/FrameworkCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import InfoIcon from '@mui/icons-material/Info';
@@ -43,7 +41,7 @@ interface FrameworkCardProps {
   idx: number;
 }
 
-const FrameworkCard: React.FC<FrameworkCardProps> = ({
+const FrameworkCard = ({
   framework,
   isCompliant,
   frameworkSeverity,
@@ -53,7 +51,7 @@ const FrameworkCard: React.FC<FrameworkCardProps> = ({
   sortedNonCompliantPlugins,
   getPluginPassRate,
   idx,
-}) => {
+}: FrameworkCardProps) => {
   const theme = useTheme();
   const sortedPlugins = sortedNonCompliantPlugins(nonCompliantPlugins);
   const breakInside = idx === 0 ? 'undefined' : 'avoid';

--- a/src/app/src/pages/redteam/report/components/FrameworkCompliance.tsx
+++ b/src/app/src/pages/redteam/report/components/FrameworkCompliance.tsx
@@ -27,10 +27,7 @@ interface FrameworkComplianceProps {
   strategyStats: Record<string, { pass: number; total: number }>;
 }
 
-const FrameworkCompliance: React.FC<FrameworkComplianceProps> = ({
-  categoryStats,
-  strategyStats,
-}) => {
+const FrameworkCompliance = ({ categoryStats, strategyStats }: FrameworkComplianceProps) => {
   const { pluginPassRateThreshold } = useReportStore();
 
   const getNonCompliantPlugins = React.useCallback(

--- a/src/app/src/pages/redteam/report/components/FrameworkCsvExporter.tsx
+++ b/src/app/src/pages/redteam/report/components/FrameworkCsvExporter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import DownloadIcon from '@mui/icons-material/Download';
 import Button from '@mui/material/Button';
 import {
@@ -23,7 +21,7 @@ interface CSVExporterProps {
   pluginPassRateThreshold: number;
 }
 
-const CSVExporter: React.FC<CSVExporterProps> = ({ categoryStats, pluginPassRateThreshold }) => {
+const CSVExporter = ({ categoryStats, pluginPassRateThreshold }: CSVExporterProps) => {
   // Function to export framework compliance data to CSV
   const exportToCSV = () => {
     // Collect data for all frameworks

--- a/src/app/src/pages/redteam/report/components/Overview.tsx
+++ b/src/app/src/pages/redteam/report/components/Overview.tsx
@@ -59,12 +59,12 @@ const DARK_MODE_SECONDARY_TEXT_COLORS = {
   [Severity.Low]: '#00e676',
 };
 
-const Overview: React.FC<OverviewProps> = ({
+const Overview = ({
   categoryStats,
   plugins,
   vulnerabilitiesDataGridRef,
   setVulnerabilitiesDataGridFilterModel,
-}) => {
+}: OverviewProps) => {
   const { pluginPassRateThreshold } = useReportStore();
 
   const severityCounts = Object.values(Severity).reduce(

--- a/src/app/src/pages/redteam/report/components/PluginStrategyFlow.tsx
+++ b/src/app/src/pages/redteam/report/components/PluginStrategyFlow.tsx
@@ -135,11 +135,11 @@ const CustomLink = (props: any) => {
   );
 };
 
-const PluginStrategyFlow: React.FC<PluginStrategyFlowProps> = ({
+const PluginStrategyFlow = ({
   failuresByPlugin,
   passesByPlugin,
   strategyStats,
-}) => {
+}: PluginStrategyFlowProps) => {
   // Extract plugin -> strategy -> outcome mappings from the test records
   const data = useMemo(() => {
     // We'll aggregate counts of tests by (plugin, strategy, outcome)

--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -48,7 +48,7 @@ import ToolsDialog from './ToolsDialog';
 
 import { type GridFilterModel, GridLogicOperator } from '@mui/x-data-grid';
 
-const App: React.FC = () => {
+const App = () => {
   const navigate = useNavigate();
   const [evalId, setEvalId] = React.useState<string | null>(null);
   const [evalData, setEvalData] = React.useState<ResultsFile | null>(null);

--- a/src/app/src/pages/redteam/report/components/ReportDownloadButton.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportDownloadButton.tsx
@@ -15,10 +15,7 @@ interface ReportDownloadButtonProps {
   evalData: ResultsFile;
 }
 
-const ReportDownloadButton: React.FC<ReportDownloadButtonProps> = ({
-  evalDescription,
-  evalData,
-}) => {
+const ReportDownloadButton = ({ evalDescription, evalData }: ReportDownloadButtonProps) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/src/app/src/pages/redteam/report/components/ReportIndex.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportIndex.tsx
@@ -25,7 +25,7 @@ type SortField = 'description' | 'createdAt' | 'evalId';
 
 const ROWS_PER_PAGE = 50;
 
-const ReportIndex: React.FC = () => {
+const ReportIndex = () => {
   const navigate = useNavigate();
   const [recentEvals, setRecentEvals] = React.useState<ResultLightweightWithLabel[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);

--- a/src/app/src/pages/redteam/report/components/ReportSettingsDialogButton.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportSettingsDialogButton.tsx
@@ -12,7 +12,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useReportStore } from './store';
 
-const ReportSettingsDialogButton: React.FC = () => {
+const ReportSettingsDialogButton = () => {
   const {
     showPercentagesOnRiskCards,
     setShowPercentagesOnRiskCards,

--- a/src/app/src/pages/redteam/report/components/RiskCard.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCard.tsx
@@ -23,7 +23,18 @@ import RiskCategoryDrawer from './RiskCategoryDrawer';
 import { useReportStore } from './store';
 import './RiskCard.css';
 
-const RiskCard: React.FC<{
+const RiskCard = ({
+  title,
+  subtitle,
+  progressValue,
+  numTestsPassed,
+  numTestsFailed,
+  testTypes,
+  evalId,
+  failuresByPlugin,
+  passesByPlugin,
+  strategyStats,
+}: {
   title: string;
   subtitle: string;
   progressValue: number;
@@ -40,17 +51,6 @@ const RiskCard: React.FC<{
     { prompt: string; output: string; gradingResult?: GradingResult }[]
   >;
   strategyStats: Record<string, { pass: number; total: number }>;
-}> = ({
-  title,
-  subtitle,
-  progressValue,
-  numTestsPassed,
-  numTestsFailed,
-  testTypes,
-  evalId,
-  failuresByPlugin,
-  passesByPlugin,
-  strategyStats,
 }) => {
   const { showPercentagesOnRiskCards, pluginPassRateThreshold } = useReportStore();
   const [drawerOpen, setDrawerOpen] = React.useState(false);

--- a/src/app/src/pages/redteam/report/components/RiskCategories.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { categoryDescriptions, riskCategories } from '@promptfoo/redteam/constants';
@@ -7,7 +5,13 @@ import RiskCard from './RiskCard';
 import type { TopLevelCategory } from '@promptfoo/redteam/constants';
 import type { GradingResult } from '@promptfoo/types';
 
-const RiskCategories: React.FC<{
+const RiskCategories = ({
+  categoryStats,
+  evalId,
+  failuresByPlugin,
+  passesByPlugin,
+  strategyStats,
+}: {
   categoryStats: Record<string, { pass: number; total: number }>;
   evalId: string;
   failuresByPlugin: Record<
@@ -19,7 +23,7 @@ const RiskCategories: React.FC<{
     { prompt: string; output: string; gradingResult?: GradingResult }[]
   >;
   strategyStats: Record<string, { pass: number; total: number }>;
-}> = ({ categoryStats, evalId, failuresByPlugin, passesByPlugin, strategyStats }) => {
+}) => {
   const categories = Object.keys(riskCategories).map((category) => ({
     name: category,
     passed: riskCategories[category as TopLevelCategory].every(

--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
@@ -113,7 +113,7 @@ function getOutputDisplay(output: string | object) {
   return JSON.stringify(output);
 }
 
-const RiskCategoryDrawer: React.FC<RiskCategoryDrawerProps> = ({
+const RiskCategoryDrawer = ({
   open,
   onClose,
   category,
@@ -123,7 +123,7 @@ const RiskCategoryDrawer: React.FC<RiskCategoryDrawerProps> = ({
   numPassed,
   numFailed,
   strategyStats,
-}) => {
+}: RiskCategoryDrawerProps) => {
   const navigate = useNavigate();
   const categoryName = categoryAliases[category as keyof typeof categoryAliases];
   if (!categoryName) {

--- a/src/app/src/pages/redteam/report/components/StrategyStats.tsx
+++ b/src/app/src/pages/redteam/report/components/StrategyStats.tsx
@@ -65,7 +65,7 @@ const DangerLinearProgress = styled(LinearProgress)(({ theme }) => ({
     backgroundColor:
       theme.palette.mode === 'light' ? theme.palette.error.main : theme.palette.error.light,
   },
-})) as React.FC<React.ComponentProps<typeof LinearProgress>>;
+}));
 
 const StyledCard = styled(Card)(({ theme }) => ({
   transition: 'all 0.3s ease',
@@ -113,11 +113,11 @@ const StyledStrategyDescription = styled(Typography)(({ theme }) => ({
   marginBottom: theme.spacing(2),
 }));
 
-const StrategyStats: React.FC<StrategyStatsProps> = ({
+const StrategyStats = ({
   strategyStats,
   failuresByPlugin = {},
   passesByPlugin = {},
-}) => {
+}: StrategyStatsProps) => {
   const [selectedStrategy, setSelectedStrategy] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState<Error | null>(null);

--- a/src/app/src/pages/redteam/report/components/TestSuites.tsx
+++ b/src/app/src/pages/redteam/report/components/TestSuites.tsx
@@ -73,7 +73,7 @@ const getRiskScoreColor = (riskScore: number, theme: any): string => {
   }
 };
 
-const TestSuites: React.FC<TestSuitesProps> = ({
+const TestSuites = ({
   evalId,
   categoryStats,
   plugins,
@@ -82,7 +82,7 @@ const TestSuites: React.FC<TestSuitesProps> = ({
   vulnerabilitiesDataGridRef,
   vulnerabilitiesDataGridFilterModel,
   setVulnerabilitiesDataGridFilterModel,
-}) => {
+}: TestSuitesProps) => {
   const navigate = useNavigate();
   const theme = useTheme();
   const { recordEvent } = useTelemetry();

--- a/src/app/src/pages/redteam/report/components/ToolsDialog.tsx
+++ b/src/app/src/pages/redteam/report/components/ToolsDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -29,7 +27,7 @@ interface ToolsDialogProps {
   tools: Tool[];
 }
 
-const ToolsDialog: React.FC<ToolsDialogProps> = ({ open, onClose, tools }) => {
+const ToolsDialog = ({ open, onClose, tools }: ToolsDialogProps) => {
   if (!tools || tools.length === 0) {
     return null;
   }

--- a/src/app/src/pages/redteam/setup/components/RunOptions.tsx
+++ b/src/app/src/pages/redteam/setup/components/RunOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FormControlLabel, Switch } from '@mui/material';
@@ -31,13 +31,13 @@ interface RunOptionsProps {
   useGuardrailAssertion?: boolean;
 }
 
-export const RunOptionsContent: React.FC<RunOptionsProps> = ({
+export const RunOptionsContent = ({
   numTests,
   runOptions,
   updateConfig,
   updateRunOption,
   useGuardrailAssertion,
-}) => {
+}: RunOptionsProps) => {
   // These two settings are mutually exclusive
   const canSetDelay = Boolean(!runOptions?.maxConcurrency || runOptions?.maxConcurrency === 1);
 
@@ -239,7 +239,7 @@ export const RunOptionsContent: React.FC<RunOptionsProps> = ({
   );
 };
 
-export const RunOptions: React.FC<RunOptionsProps> = (props) => {
+export const RunOptions = (props: RunOptionsProps) => {
   const [expanded, setExpanded] = useState(true);
 
   const normalizedProps: RunOptionsProps = {

--- a/src/app/src/pages/redteam/setup/components/Targets/BrowserAutomationConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/BrowserAutomationConfiguration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Box from '@mui/material/Box';
@@ -20,10 +18,10 @@ interface BrowserAutomationConfigurationProps {
   updateCustomTarget: (field: string, value: any) => void;
 }
 
-const BrowserAutomationConfiguration: React.FC<BrowserAutomationConfigurationProps> = ({
+const BrowserAutomationConfiguration = ({
   selectedTarget,
   updateCustomTarget,
-}) => {
+}: BrowserAutomationConfigurationProps) => {
   return (
     <Box mt={2}>
       <Typography variant="h6" gutterBottom>

--- a/src/app/src/pages/redteam/setup/components/Targets/CommonConfigurationOptions.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CommonConfigurationOptions.tsx
@@ -19,13 +19,13 @@ interface CommonConfigurationOptionsProps {
   onExtensionsChange?: (extensions: string[]) => void;
 }
 
-const CommonConfigurationOptions: React.FC<CommonConfigurationOptionsProps> = ({
+const CommonConfigurationOptions = ({
   selectedTarget,
   updateCustomTarget,
   onValidationChange,
   extensions = [],
   onExtensionsChange,
-}) => {
+}: CommonConfigurationOptionsProps) => {
   const handleExtensionsChange = React.useCallback(
     (newExtensions: string[]) => {
       onExtensionsChange?.(newExtensions);

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
@@ -16,13 +16,13 @@ interface CustomTargetConfigurationProps {
   bodyError: string | null;
 }
 
-const CustomTargetConfiguration: React.FC<CustomTargetConfigurationProps> = ({
+const CustomTargetConfiguration = ({
   selectedTarget,
   updateCustomTarget,
   rawConfigJson,
   setRawConfigJson,
   bodyError,
-}) => {
+}: CustomTargetConfigurationProps) => {
   const [targetId, setTargetId] = useState(selectedTarget.id || '');
 
   useEffect(() => {

--- a/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
@@ -17,11 +17,11 @@ interface FoundationModelConfigurationProps {
   providerType: string;
 }
 
-const FoundationModelConfiguration: React.FC<FoundationModelConfigurationProps> = ({
+const FoundationModelConfiguration = ({
   selectedTarget,
   updateCustomTarget,
   providerType,
-}) => {
+}: FoundationModelConfigurationProps) => {
   const [modelId, setModelId] = useState(selectedTarget.id || '');
 
   useEffect(() => {

--- a/src/app/src/pages/redteam/setup/components/Targets/HttpAdvancedConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/HttpAdvancedConfiguration.tsx
@@ -61,11 +61,11 @@ const highlightJS = (code: string): string => {
   }
 };
 
-const HttpAdvancedConfiguration: React.FC<HttpAdvancedConfigurationProps> = ({
+const HttpAdvancedConfiguration = ({
   selectedTarget,
   defaultRequestTransform,
   updateCustomTarget,
-}) => {
+}: HttpAdvancedConfigurationProps) => {
   const theme = useTheme();
   const { showToast } = useToast();
   const darkMode = theme.palette.mode === 'dark';

--- a/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/HttpEndpointConfiguration.tsx
@@ -1,6 +1,6 @@
 import './syntax-highlighting.css';
 
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { callApi } from '@app/utils/api';
 import AddIcon from '@mui/icons-material/Add';
@@ -56,7 +56,7 @@ interface GeneratedConfig {
   };
 }
 
-const HttpEndpointConfiguration: React.FC<HttpEndpointConfigurationProps> = ({
+const HttpEndpointConfiguration = ({
   selectedTarget,
   updateCustomTarget,
   bodyError,
@@ -64,7 +64,7 @@ const HttpEndpointConfiguration: React.FC<HttpEndpointConfigurationProps> = ({
   urlError,
   setUrlError,
   updateFullTarget,
-}): JSX.Element => {
+}: HttpEndpointConfigurationProps): JSX.Element => {
   const theme = useTheme();
   const darkMode = theme.palette.mode === 'dark';
 

--- a/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestTargetConfiguration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoIcon from '@mui/icons-material/Info';
 import Accordion from '@mui/material/Accordion';
@@ -28,12 +26,12 @@ interface TestTargetConfigurationProps {
   testResult: any;
 }
 
-const TestTargetConfiguration: React.FC<TestTargetConfigurationProps> = ({
+const TestTargetConfiguration = ({
   testingTarget,
   handleTestTarget,
   selectedTarget,
   testResult,
-}) => {
+}: TestTargetConfigurationProps) => {
   const theme = useTheme();
 
   const getTestButtonTooltip = () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -12,11 +10,11 @@ interface WebSocketEndpointConfigurationProps {
   urlError: string | null;
 }
 
-const WebSocketEndpointConfiguration: React.FC<WebSocketEndpointConfigurationProps> = ({
+const WebSocketEndpointConfiguration = ({
   selectedTarget,
   updateWebSocketTarget,
   urlError,
-}) => {
+}: WebSocketEndpointConfigurationProps) => {
   return (
     <Box mt={2}>
       <Typography variant="h6" gutterBottom>


### PR DESCRIPTION
## Summary

Remove React.FC type annotations from all React components in the web UI to prepare for React 19 upgrade and improve TypeScript inference.

## Changes Made

- **Replaced React.FC with direct prop typing**: Changed `React.FC<Props>` to `({ ...props }: Props)` pattern across 55+ components
- **Cleaned up unused imports**: Removed unused React imports that were no longer needed after removing React.FC
- **Maintained functionality**: All component logic, prop destructuring, and behavior preserved exactly as before
- **Improved type safety**: Better TypeScript inference without React.FC wrapper

## Why This Change?

React 19 deprecates `React.FC` in favor of direct prop typing for several reasons:

1. **Better TypeScript inference**: Direct prop typing provides more accurate type checking
2. **Simplified component signatures**: Cleaner, more readable component declarations  
3. **Future compatibility**: Aligns with React 19's recommended patterns
4. **Reduced boilerplate**: Eliminates the need for the React.FC wrapper

## Files Affected

62 files across:
- Context providers (ToastProvider, PostHogProvider, etc.)
- Page components (eval, redteam, prompts)
- UI components (modals, forms, charts)
- Configuration components (targets, settings)

## Testing

- ✅ TypeScript compilation passes without errors
- ✅ Linting passes with no issues  
- ✅ All component functionality preserved
- ✅ No breaking changes to component APIs