### PR TITLE
fix: update act import for React 19 compatibility

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';


### PR DESCRIPTION
## Summary

- Updates deprecated `import { act } from 'react-dom/test-utils'` to `import { act } from 'react'`
- Prepares codebase for React 19 migration where `react-dom/test-utils` is removed
- Maintains backward compatibility with React 18.3+

## Changes

- **src/app/src/pages/eval/components/ResultsTable.test.tsx**: Updated act import

## Testing

- ✅ All tests pass (27/27 in ResultsTable test suite)
- ✅ App builds successfully
- ✅ No breaking changes introduced

## Background

React 19 removes `act` from `react-dom/test-utils` in favor of importing directly from `react`. This change ensures our tests will continue working when we upgrade to React 19 while maintaining compatibility with our current React 18.3.1.