### PR TITLE
ci: temporarily disable macOS Node 24.x tests due to flaky failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         node: ['20.x', '22.x', '24.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        # Temporarily exclude macOS with Node 24.x due to flaky test failures
+        exclude:
+          - node: '24.x'
+            os: macOS-latest
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
- Temporarily excludes macOS Node 24.x test combination from CI matrix due to frequent flaky failures
- Keeps all other Node/OS combinations intact to maintain test coverage
- Adds clear comment in workflow explaining the temporary nature of this change

## Test plan
- [x] Verify CI workflow syntax is valid
- [x] Confirm other test combinations still run (ubuntu/windows with all Node versions, macOS with Node 20.x/22.x)
- [x] Check that this reduces CI flakiness without compromising essential test coverage

This is a temporary measure to improve CI stability while the underlying flakiness is investigated.