### PR TITLE
ci: increase test timeout from 8 to 10 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}
-    timeout-minutes: 8
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Increases the test timeout from 8 to 10 minutes for all Node.js test matrix jobs to address occasional timeouts in CI.

## Changes

- Updated  from 8 to 10 in the test job matrix
- Affects all Node.js versions (20.x, 22.x, 24.x) across all OS platforms (Ubuntu, Windows, macOS)

## Motivation

Recent CI runs have occasionally hit the 8-minute timeout limit, causing flaky test failures. This change provides additional buffer time while maintaining reasonable CI performance.