### PR TITLE
fix: hide non-critical hasModelAuditBeenShared error logging

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -492,7 +492,7 @@ export async function hasModelAuditBeenShared(audit: ModelAudit): Promise<boolea
         );
     }
   } catch (e) {
-    logger.error(`[hasModelAuditBeenShared]: error checking if model audit has been shared: ${e}`);
+    logger.debug(`[hasModelAuditBeenShared]: error checking if model audit has been shared: ${e}`);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Changed error logging to debug logging in hasModelAuditBeenShared function
- This check is non-critical (used only for confirmation dialog when re-sharing)
- Reduces noise during model audit sharing when network connectivity has issues

## Test plan
- [x] Build passes
- [x] Model audit sharing works end-to-end
- [x] Error no longer appears in normal output (only in debug mode)

## How to test
1. Create a test model file:
   ```python
   import pickle
   class TestModel:
       def __init__(self):
           self.weights = [1, 2, 3]
   model = TestModel()
   with open('test.pkl', 'wb') as f:
       pickle.dump(model, f)
   ```

2. Scan the model:
   ```bash
   promptfoo scan-model test.pkl --name "Test Scan"
   ```

3. Share the scan (note the scan ID from step 2):
   ```bash
   promptfoo share <scan-id>
   ```

4. Verify clean output with no error messages about "hasModelAuditBeenShared"

## Context
When sharing model audits, the system checks if the audit has already been shared to show a confirmation dialog. Network errors from this check were being logged as errors even though the operation continues successfully regardless of this check's outcome.