### PR TITLE
fix: handle dynamic imports without eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:app": "npm run build --prefix src/app",
     "build:clean": "shx rm -rf dist",
     "build:watch": "tsc --watch",
-    "build": "npm run generate-constants && tsc && shx cp src/*.html dist/src && shx cp src/python/wrapper.py dist/src/python && shx mkdir -p dist/src/golang && shx cp src/golang/wrapper.go dist/src/golang && shx rm -rf dist/drizzle && shx cp -r drizzle dist/drizzle && npm run build:app && shx chmod +x dist/src/main.js",
+    "build": "npm run generate-constants && tsc && shx cp src/*.html dist/src && shx cp src/python/wrapper.py dist/src/python && shx mkdir -p dist/src/golang && shx cp src/golang/wrapper.go dist/src/golang && shx cp src/dynamic-import.cjs dist/src && shx rm -rf dist/drizzle && shx cp -r drizzle dist/drizzle && npm run build:app && shx chmod +x dist/src/main.js",
     "citation:generate": "ts-node scripts/generateCitation.ts",
     "db:generate": "npx drizzle-kit generate",
     "db:migrate": "node --require tsx/cjs src/migrate.ts",

--- a/src/dynamic-import.cjs
+++ b/src/dynamic-import.cjs
@@ -1,0 +1,7 @@
+async function dynamicImport(specifier) {
+  return import(specifier);
+}
+
+module.exports = {
+  dynamicImport,
+};

--- a/src/dynamic-import.d.ts
+++ b/src/dynamic-import.d.ts
@@ -1,0 +1,1 @@
+export declare function dynamicImport<T = unknown>(specifier: string): Promise<T>;


### PR DESCRIPTION
This prevents SAST flags.  Tested: js, mjs, and ts custom providers