### PR TITLE
chore: Exclude node modules and build/dist from biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,11 @@
       "**/*.mjs",
       "**/*.cjs",
       "!drizzle/**/*",
-      "!src/app/src/polyfills/**/*"
+      "!src/app/src/polyfills/**/*",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/build/**",
+      "!**/public/**"
     ]
   },
   "formatter": {


### PR DESCRIPTION
This has stopped biome from taking up 10gb of memory on my machine.