### PR TITLE
ci: revert temporarily disable redteam multi-lingual strategy in integration tests

### DIFF
--- a/test/redteam/integration/promptfooconfig.yaml
+++ b/test/redteam/integration/promptfooconfig.yaml
@@ -32,10 +32,7 @@ redteam:
     - id: jailbreak:composite # Finds novel jailbreak prompts by chaining together individual techniques
       config:
         numTests: 1
-
-    # FIXME(mldangelo) temporarily disabled on 2025-09-18 due to intermittent generation failures
-    # It normally adds ~12 test cases but is currently failing in CI
-    # - id: multilingual
-    #   config:
-    #     languages:
-    #       - es-ES
+    - id: multilingual
+      config:
+        languages:
+          - es-ES

--- a/test/redteam/integration/test.sh
+++ b/test/redteam/integration/test.sh
@@ -15,11 +15,11 @@ else
   echo "Confirmed: No promptfoo-errors.log file exists"
 fi
 
-# Check for expected output patterns (reduced count due to disabled multilingual strategy)
-if echo "$output" | grep -q "Wrote 12 test cases to redteam.yaml"; then
-  echo "Expected line (Wrote 12 test cases to redteam.yaml) found for promptfoo redteam generate"
+# Check for expected output patterns
+if echo "$output" | grep -q "Wrote 2[34] test cases to redteam.yaml"; then
+  echo "Expected line (Wrote 2[34] test cases to redteam.yaml) found for promptfoo redteam generate"
 else
-  echo "ERROR: Expected line (Wrote 12 test cases to redteam.yaml) not found in output."
+  echo "ERROR: Expected line (Wrote 2[34] test cases to redteam.yaml) not found in output."
   echo "$output"
   exit 1
 fi


### PR DESCRIPTION
Reverts promptfoo/promptfoo#5639