### PR TITLE
fix: suppress noisy health check logs during dev startup

### DIFF
--- a/src/app/src/pages/launcher/page.tsx
+++ b/src/app/src/pages/launcher/page.tsx
@@ -135,10 +135,21 @@ export default function LauncherPage() {
   }, [darkMode]);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    // Simple delay to allow server startup, then start health checks
+    let interval: NodeJS.Timeout;
+    const timeout = setTimeout(() => {
       checkHealth();
-    }, 2000);
-    return () => clearInterval(interval);
+      interval = setInterval(() => {
+        checkHealth();
+      }, 2000);
+    }, 3000);
+
+    return () => {
+      clearTimeout(timeout);
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
   }, [checkHealth]);
 
   useEffect(() => {

--- a/src/util/fetch/monkeyPatchFetch.ts
+++ b/src/util/fetch/monkeyPatchFetch.ts
@@ -20,7 +20,9 @@ export async function monkeyPatchFetch(
   options?: RequestInit,
 ): Promise<Response> {
   const NO_LOG_URLS = [R_ENDPOINT, CONSENT_ENDPOINT, EVENTS_ENDPOINT];
-  const logEnabled = !NO_LOG_URLS.some((logUrl) => url.toString().startsWith(logUrl));
+  const headers = options?.headers as Record<string, string> || {};
+  const isSilent = headers['x-promptfoo-silent'] === 'true';
+  const logEnabled = !NO_LOG_URLS.some((logUrl) => url.toString().startsWith(logUrl)) && !isSilent;
 
   const opts = {
     ...options,

--- a/src/util/server.ts
+++ b/src/util/server.ts
@@ -89,7 +89,11 @@ export async function checkServerFeatureSupport(
 export async function checkServerRunning(port = getDefaultPort()): Promise<boolean> {
   logger.debug(`Checking for existing server on port ${port}...`);
   try {
-    const response = await fetchWithProxy(`http://localhost:${port}/health`);
+    const response = await fetchWithProxy(`http://localhost:${port}/health`, {
+      headers: {
+        'x-promptfoo-silent': 'true'
+      }
+    });
     const data = await response.json();
     return data.status === 'OK' && data.version === VERSION;
   } catch (err) {


### PR DESCRIPTION
## Summary
Eliminates connection error logs that appear during normal development startup when frontend tries to connect before server is fully ready.

## Changes
- Add silent header mechanism (`x-promptfoo-silent`) to suppress internal health check logging
- Delay frontend health checks by 3 seconds to allow server startup  
- Keep all existing functionality while removing startup noise

## Before
```
[0] API request:
[0] URL: http://localhost:15500/health
[0] Method: GET
[0] Request Body: undefined
[0] Connection error, please check your network connectivity to the host: http://localhost:15500/health
[0] Server running at http://localhost:15500 and monitoring for new evals.
```

## After
```
[0] Server running at http://localhost:15500 and monitoring for new evals.
```

## Test plan
- [x] Verify clean startup with `npm run dev`
- [x] Confirm health checks still work after delay
- [x] Ensure no regression in existing functionality
- [x] Test server detection still works for duplicate instances

Fixes the race condition between frontend and backend startup without adding complexity or new failure modes.