### PR TITLE
refactor(redteam): remove dead code and optimize page meta handling

### DIFF
--- a/src/app/src/pages/redteam/report/components/ReportIndex.test.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportIndex.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EvalSummary } from '@promptfoo/types';
+
+import { callApi } from '@app/utils/api';
+import { formatDataGridDate } from '@app/utils/date';
+import ReportIndex from './ReportIndex';
+
+vi.mock('@app/utils/api');
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+const mockData: EvalSummary[] = [
+  {
+    evalId: 'eval-1',
+    datasetId: 'dataset-1',
+    description: 'My First Redteam Report',
+    providers: [{ id: 'openai:gpt-4', label: 'GPT-4' }],
+    createdAt: new Date('2023-10-26T10:00:00.000Z').getTime(),
+    passRate: 75.123,
+    numTests: 100,
+    label: 'My First Redteam Report',
+    isRedteam: true,
+  },
+  {
+    evalId: 'eval-2',
+    datasetId: 'dataset-2',
+    description: 'Another Security Scan',
+    providers: [{ id: 'anthropic:claude-2', label: null }],
+    createdAt: new Date('2023-10-27T12:30:00.000Z').getTime(),
+    passRate: 100,
+    numTests: 50,
+    label: 'Another Security Scan',
+    isRedteam: true,
+  },
+];
+
+describe('ReportIndex', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ReportsDataGrid rendering', () => {
+    it('should render all rows and columns with correct values and formatting for a given EvalSummary[] data and isLoading=false', async () => {
+      vi.mocked(callApi).mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockData }),
+      } as Response);
+
+      render(
+        <MemoryRouter>
+          <ReportIndex />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'My First Redteam Report' })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('GPT-4')).toBeInTheDocument();
+      expect(screen.getByText(formatDataGridDate(mockData[0].createdAt))).toBeInTheDocument();
+      expect(screen.getByText('75.12%')).toBeInTheDocument();
+      const numTestsCell1 = screen.getAllByRole('gridcell', { name: '100' });
+      expect(numTestsCell1.length).toBeGreaterThan(0);
+      expect(screen.getByText('eval-1')).toBeInTheDocument();
+
+      expect(screen.getByRole('link', { name: 'Another Security Scan' })).toBeInTheDocument();
+      expect(screen.getByText('anthropic:claude-2')).toBeInTheDocument();
+      expect(screen.getByText(formatDataGridDate(mockData[1].createdAt))).toBeInTheDocument();
+      expect(screen.getByText('100.00%')).toBeInTheDocument();
+      const numTestsCell2 = screen.getAllByRole('gridcell', { name: '50' });
+      expect(numTestsCell2.length).toBeGreaterThan(0);
+      expect(screen.getByText('eval-2')).toBeInTheDocument();
+    });
+
+    it('should render the CustomToolbar in the DataGrid toolbar slot', async () => {
+      vi.mocked(callApi).mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockData }),
+      } as Response);
+
+      render(
+        <MemoryRouter>
+          <ReportIndex />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Select columns' })).toBeInTheDocument();
+      });
+    });
+
+    it('should render "No target" when providers array is empty', async () => {
+      const mockData: EvalSummary[] = [
+        {
+          evalId: 'eval-1',
+          datasetId: 'dataset-1',
+          description: 'Report with no providers',
+          providers: [],
+          createdAt: new Date('2023-10-26T10:00:00.000Z').getTime(),
+          passRate: 75,
+          numTests: 100,
+          label: 'Report with no providers',
+          isRedteam: true,
+        },
+      ];
+
+      vi.mocked(callApi).mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockData }),
+      } as Response);
+
+      render(
+        <MemoryRouter>
+          <ReportIndex />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('No target')).toBeInTheDocument();
+      });
+    });
+
+    it('should display "Untitled Evaluation" in the description column when description is missing', async () => {
+      const mockData: EvalSummary[] = [
+        {
+          evalId: 'eval-3',
+          datasetId: 'dataset-3',
+          providers: [{ id: 'openai:gpt-3.5-turbo', label: 'GPT-3.5-Turbo' }],
+          createdAt: new Date('2023-11-15T15:00:00.000Z').getTime(),
+          passRate: 60,
+          numTests: 80,
+          label: 'Missing Description Report',
+          isRedteam: true,
+          description: '',
+        },
+      ];
+      vi.mocked(callApi).mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockData }),
+      } as Response);
+
+      render(
+        <MemoryRouter>
+          <ReportIndex />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'Untitled Evaluation' })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('ReportsDataGrid navigation', () => {
+    it('should navigate to /reports?evalId={evalId} when a cell in a row is clicked and that row has a valid evalId', async () => {
+      vi.mocked(callApi).mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: mockData }),
+      } as Response);
+
+      const navigate = vi.fn();
+      vi.mocked(useNavigate).mockReturnValue(navigate);
+
+      render(
+        <MemoryRouter>
+          <ReportIndex />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'My First Redteam Report' })).toBeInTheDocument();
+      });
+
+      const linkElement = screen.getByRole('link', { name: 'My First Redteam Report' });
+      fireEvent.click(linkElement);
+
+      expect(navigate).toHaveBeenCalledWith('/reports?evalId=eval-1');
+    });
+  });
+});

--- a/src/app/src/pages/redteam/report/components/ReportIndex.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportIndex.tsx
@@ -140,7 +140,7 @@ function ReportsDataGrid({ data, isLoading }: { data: EvalSummary[]; isLoading: 
         cellClassName: 'dg-cursor-pointer',
       },
     ],
-    [data],
+    [],
   );
 
   return (

--- a/src/app/src/pages/redteam/report/page.test.tsx
+++ b/src/app/src/pages/redteam/report/page.test.tsx
@@ -60,7 +60,7 @@ describe('ReportPage', () => {
     });
   });
 
-  it("should set page metadata to 'Red team report' when evalId is present", () => {
+  it("should set page metadata to 'Red Team Vulnerability Reports' when evalId is present", () => {
     const url = 'http://localhost/reports?evalId=test-eval-123';
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -75,7 +75,7 @@ describe('ReportPage', () => {
 
     expect(mockedUsePageMeta).toHaveBeenCalledTimes(1);
     expect(mockedUsePageMeta).toHaveBeenCalledWith({
-      title: 'Red team report',
+      title: 'Red Team Vulnerability Reports',
       description: 'View or browse red team results',
     });
 
@@ -225,7 +225,7 @@ describe('ReportPage', () => {
 
     expect(mockedUsePageMeta).toHaveBeenCalledTimes(1);
     expect(mockedUsePageMeta).toHaveBeenCalledWith({
-      title: 'Red team report',
+      title: 'Red Team Vulnerability Reports',
       description: 'View or browse red team results',
     });
     expect(screen.getByText('Report Component')).toBeInTheDocument();

--- a/src/app/src/pages/redteam/report/page.test.tsx
+++ b/src/app/src/pages/redteam/report/page.test.tsx
@@ -117,6 +117,23 @@ describe('ReportPage', () => {
     expect(screen.queryByText('Report Component')).not.toBeInTheDocument();
   });
 
+  it('should render ReportIndex component when evalId is an empty string in URL search parameters', () => {
+    const url = 'http://localhost/reports?evalId=';
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: new URL(url),
+    });
+
+    render(
+      <MemoryRouter>
+        <ReportPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('ReportIndex Component')).toBeInTheDocument();
+    expect(screen.queryByText('Report Component')).not.toBeInTheDocument();
+  });
+
   it('should redirect to the login page when the user is not logged in and email is null', () => {
     const navigate = vi.fn();
     mockedUseNavigate.mockReturnValue(navigate);

--- a/src/app/src/pages/redteam/report/page.tsx
+++ b/src/app/src/pages/redteam/report/page.tsx
@@ -16,7 +16,7 @@ export default function ReportPage() {
   const searchParams = new URLSearchParams(window.location.search);
   const evalId = searchParams.get('evalId');
   usePageMeta({
-    title: evalId ? 'Red team report' : 'Red Team Vulnerability Reports',
+    title: 'Red Team Vulnerability Reports',
     description: 'View or browse red team results',
   });
 


### PR DESCRIPTION
- Remove unnecessary conditional title logic in page.tsx since Report component sets its own title
- Remove unnecessary data dependency in ReportIndex useMemo to prevent unnecessary re-renders

Relates to https://github.com/promptfoo/promptfoo/pull/5637#discussion_r2363258791