### PR TITLE
fix: trace visualization circular dependency

### DIFF
--- a/src/app/src/components/traces/TraceTimeline.tsx
+++ b/src/app/src/components/traces/TraceTimeline.tsx
@@ -149,7 +149,8 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
 
           // Original temporal timeline approach - both position AND width based on time
           const spanDurationPercent = totalDuration > 0 ? (span.duration / totalDuration) * 100 : 0;
-          const spanStartPercent = totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
+          const spanStartPercent =
+            totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
 
           return (
             <Box

--- a/src/app/src/components/traces/TraceTimeline.tsx
+++ b/src/app/src/components/traces/TraceTimeline.tsx
@@ -146,15 +146,12 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
         {/* Convert milliseconds to microseconds */}
       </Typography>
 
-      <Paper variant="outlined" sx={{ p: 2, overflow: 'auto' }}>
+      <Paper variant="outlined" sx={{ p: 2 }}>
         {spans.map((span, index) => {
           const status = getSpanStatus(span.statusCode);
 
-          // Scale span width based on its duration relative to the longest span
-          const spanDurationPercent = maxSpanDuration > 0 ? (span.duration / maxSpanDuration) * 100 : 0;
-
-          // Position span based on its start time relative to trace start
-          const spanStartPercent = totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
+          // Scale span width based on its duration relative to the longest span (max 70% width)
+          const spanDurationPercent = maxSpanDuration > 0 ? Math.min((span.duration / maxSpanDuration) * 70, 70) : 0;
 
           return (
             <Box
@@ -162,66 +159,66 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                mb: 1,
+                mb: 1.5,
                 minHeight: 40,
-                position: 'relative',
               }}
             >
-              {/* Span name with indentation */}
+              {/* Span name with indentation and better styling */}
               <Box
                 sx={{
-                  width: '30%',
+                  width: '25%',
                   pr: 2,
-                  pl: span.depth * 2,
+                  pl: span.depth * 1.5,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
                 }}
               >
-                <Tooltip title={span.name}>
-                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                <Tooltip title={`${span.name} (${formatDuration(span.duration * 1000)})`}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontFamily: 'monospace',
+                      fontWeight: 500,
+                      color: theme.palette.text.primary,
+                    }}
+                  >
                     {span.name}
                   </Typography>
                 </Tooltip>
               </Box>
 
-              {/* Timeline bar */}
-              <Box
-                sx={{
-                  flex: 1,
-                  position: 'relative',
-                  height: 24,
-                  backgroundColor: theme.palette.action.hover,
-                  borderRadius: 1,
-                }}
-              >
+              {/* Duration bar - no background container needed */}
+              <Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>
                 <Tooltip
                   title={
                     <Box>
                       <Typography variant="caption">
-                        Duration: {formatDuration(span.duration * 1000)}
+                        <strong>Duration:</strong> {formatDuration(span.duration * 1000)}
                       </Typography>
                       <br />
                       <Typography variant="caption">
-                        Start: {formatTimestamp(span.startTime)}
+                        <strong>Start:</strong> {formatTimestamp(span.startTime)}
                       </Typography>
                       {span.endTime && (
                         <>
                           <br />
                           <Typography variant="caption">
-                            End: {formatTimestamp(span.endTime)}
+                            <strong>End:</strong> {formatTimestamp(span.endTime)}
                           </Typography>
                         </>
                       )}
                       {span.attributes && Object.keys(span.attributes).length > 0 && (
                         <>
                           <br />
-                          <Typography variant="caption">Attributes:</Typography>
+                          <Typography variant="caption" sx={{ mt: 1, display: 'block' }}>
+                            <strong>Attributes:</strong>
+                          </Typography>
                           {Object.entries(span.attributes).map(([key, value]) => (
                             <Typography
                               key={key}
                               variant="caption"
-                              sx={{ display: 'block', ml: 1 }}
+                              sx={{ display: 'block', ml: 1, fontFamily: 'monospace' }}
                             >
                               {key}: {JSON.stringify(value)}
                             </Typography>
@@ -233,21 +230,24 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                 >
                   <Box
                     sx={{
-                      position: 'absolute',
-                      left: `${spanStartPercent}%`,
-                      width: `${Math.max(spanDurationPercent, 2)}%`, // Minimum 2% width for visibility
-                      height: '100%',
+                      width: `${Math.max(spanDurationPercent, 5)}%`, // Minimum 5% width for visibility
+                      height: 28,
                       backgroundColor:
                         status.color === 'error'
                           ? theme.palette.error.main
                           : status.color === 'success'
                             ? theme.palette.success.main
                             : theme.palette.primary.main,
-                      borderRadius: 1,
+                      borderRadius: 2,
                       display: 'flex',
                       alignItems: 'center',
-                      px: 1,
-                      overflow: 'hidden',
+                      px: 1.5,
+                      cursor: 'pointer',
+                      transition: 'all 0.2s ease',
+                      '&:hover': {
+                        transform: 'scale(1.02)',
+                        boxShadow: theme.shadows[2],
+                      },
                     }}
                   >
                     <Typography
@@ -260,6 +260,7 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                               ? theme.palette.success.main
                               : theme.palette.primary.main,
                         ),
+                        fontWeight: 600,
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',

--- a/src/app/src/components/traces/TraceTimeline.tsx
+++ b/src/app/src/components/traces/TraceTimeline.tsx
@@ -133,6 +133,9 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
 
   const { spans, totalDuration } = processedSpans;
 
+  // Calculate the maximum span duration once for proportional scaling
+  const maxSpanDuration = spans.length > 0 ? Math.max(...spans.map(s => s.duration)) : 0;
+
   return (
     <Box pt={2}>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -146,9 +149,12 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
       <Paper variant="outlined" sx={{ p: 2, overflow: 'auto' }}>
         {spans.map((span, index) => {
           const status = getSpanStatus(span.statusCode);
-          const spanDurationPercent = totalDuration > 0 ? (span.duration / totalDuration) * 100 : 0;
-          const spanStartPercent =
-            totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
+
+          // Scale span width based on its duration relative to the longest span
+          const spanDurationPercent = maxSpanDuration > 0 ? (span.duration / maxSpanDuration) * 100 : 0;
+
+          // Position span based on its start time relative to trace start
+          const spanStartPercent = totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
 
           return (
             <Box
@@ -229,7 +235,7 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                     sx={{
                       position: 'absolute',
                       left: `${spanStartPercent}%`,
-                      width: `${Math.max(spanDurationPercent, 0.5)}%`,
+                      width: `${Math.max(spanDurationPercent, 2)}%`, // Minimum 2% width for visibility
                       height: '100%',
                       backgroundColor:
                         status.color === 'error'

--- a/src/app/src/components/traces/TraceTimeline.tsx
+++ b/src/app/src/components/traces/TraceTimeline.tsx
@@ -133,9 +133,6 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
 
   const { spans, totalDuration } = processedSpans;
 
-  // Calculate the maximum span duration once for proportional scaling
-  const maxSpanDuration = spans.length > 0 ? Math.max(...spans.map(s => s.duration)) : 0;
-
   return (
     <Box pt={2}>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -146,14 +143,12 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
         {/* Convert milliseconds to microseconds */}
       </Typography>
 
-      <Paper variant="outlined" sx={{ p: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2, overflow: 'auto' }}>
         {spans.map((span, index) => {
           const status = getSpanStatus(span.statusCode);
 
-          // Scale span width based on its duration relative to the longest span
-          const spanDurationPercent = maxSpanDuration > 0 ? (span.duration / maxSpanDuration) * 100 : 0;
-
-          // Position span based on its start time relative to trace start
+          // Original temporal timeline approach - both position AND width based on time
+          const spanDurationPercent = totalDuration > 0 ? (span.duration / totalDuration) * 100 : 0;
           const spanStartPercent = totalDuration > 0 ? (span.relativeStart / totalDuration) * 100 : 0;
 
           return (
@@ -193,7 +188,6 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                   height: 24,
                   backgroundColor: theme.palette.action.hover,
                   borderRadius: 1,
-                  maxWidth: '100%', // Prevent overflow
                 }}
               >
                 <Tooltip
@@ -235,8 +229,8 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                   <Box
                     sx={{
                       position: 'absolute',
-                      left: `${Math.min(spanStartPercent, 95)}%`, // Cap at 95% to prevent overflow
-                      width: `${Math.min(Math.max(spanDurationPercent, 2), 50)}%`, // Cap at 50% max width
+                      left: `${spanStartPercent}%`,
+                      width: `${Math.max(spanDurationPercent, 0.5)}%`, // Minimum width for visibility
                       height: '100%',
                       backgroundColor:
                         status.color === 'error'

--- a/src/app/src/components/traces/TraceView.test.tsx
+++ b/src/app/src/components/traces/TraceView.test.tsx
@@ -113,7 +113,7 @@ describe('TraceView', () => {
     expect(alert).toHaveTextContent(/traces were created but no spans were received/i);
   });
 
-  it('should render an error message when the API returns malformed JSON', async () => {
+  it('should render an error message when the API call returns malformed JSON', async () => {
     vi.mocked(callApi).mockResolvedValue({
       ok: true,
       json: () => Promise.reject(new Error('Unexpected token < in JSON at position 0')),
@@ -414,5 +414,233 @@ describe('TraceView', () => {
     expect(screen.getByText('Trace ID: trace-4')).toBeInTheDocument();
     expect(screen.queryByText('Trace ID: trace-1')).not.toBeInTheDocument();
     expect(screen.queryByText('Trace ID: trace-3')).not.toBeInTheDocument();
+  });
+
+  it('should not call the API and render null when evaluationId is an empty string', () => {
+    const { container } = render(<TraceView evaluationId="" />);
+
+    expect(vi.mocked(callApi)).not.toHaveBeenCalled();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should call onVisibilityChange with false when evaluationId is an empty string', async () => {
+    const onVisibilityChange = vi.fn();
+
+    render(<TraceView evaluationId="" onVisibilityChange={onVisibilityChange} />);
+
+    await waitFor(() => {
+      expect(onVisibilityChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('should display only traces whose testCaseId matches the provided testIndex and promptIndex when testCaseId is not provided but both indices are specified', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: '1-1',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+      {
+        traceId: 'trace-2',
+        testCaseId: '2-2',
+        spans: [{ spanId: 'span-2', name: 'span-name-2', startTime: 3, endTime: 4 }],
+      },
+      {
+        traceId: 'trace-3',
+        testCaseId: '1-2',
+        spans: [{ spanId: 'span-3', name: 'span-name-3', startTime: 5, endTime: 6 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(<TraceView evaluationId="eval-xyz-789" testIndex={1} promptIndex={1} />);
+
+    const timelines = await screen.findAllByTestId('trace-timeline');
+    expect(timelines).toHaveLength(1);
+    expect(screen.getByText('Trace ID: trace-1')).toBeInTheDocument();
+    expect(screen.queryByText('Trace ID: trace-2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Trace ID: trace-3')).not.toBeInTheDocument();
+  });
+
+  it('should not render traces where testCaseId is a number', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: 123,
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+      {
+        traceId: 'trace-2',
+        testCaseId: 'test-case-2',
+        spans: [{ spanId: 'span-2', name: 'span-name-2', startTime: 3, endTime: 4 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="test-case-1"
+        testIndex={1}
+        promptIndex={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Trace ID: trace-1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render a message indicating no traces are available when testCaseId is malformed', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-abc-123',
+        testCaseId: 'abc-xyz',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+      {
+        traceId: 'trace-def-456',
+        testCaseId: '3-test',
+        spans: [{ spanId: 'span-2', name: 'span-name-2', startTime: 3, endTime: 4 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="test-case-123"
+        testIndex={1}
+        promptIndex={2}
+      />,
+    );
+
+    const message = await screen.findByText('No traces available for this test case');
+    expect(message).toBeInTheDocument();
+  });
+
+  it('should render "No traces available for this test case" when testIndex is negative', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: '0-0',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="some-uuid"
+        testIndex={-1}
+        promptIndex={0}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No traces available for this test case')).toBeInTheDocument();
+    });
+  });
+
+  it('should render "No traces available for this test case" when testIndex is NaN', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: '0-0',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="some-uuid"
+        testIndex={NaN}
+        promptIndex={0}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No traces available for this test case')).toBeInTheDocument();
+    });
+  });
+
+  it('should render "No traces available for this test case" when promptIndex is negative', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: '0-0',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="some-uuid"
+        testIndex={0}
+        promptIndex={-1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No traces available for this test case')).toBeInTheDocument();
+    });
+  });
+
+  it('should render "No traces available for this test case" when promptIndex is NaN', async () => {
+    const mockTraces = [
+      {
+        traceId: 'trace-1',
+        testCaseId: '0-0',
+        spans: [{ spanId: 'span-1', name: 'span-name-1', startTime: 1, endTime: 2 }],
+      },
+    ];
+
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
+
+    render(
+      <TraceView
+        evaluationId="eval-xyz-789"
+        testCaseId="some-uuid"
+        testIndex={0}
+        promptIndex={NaN}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No traces available for this test case')).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/src/components/traces/TraceView.test.tsx
+++ b/src/app/src/components/traces/TraceView.test.tsx
@@ -113,7 +113,7 @@ describe('TraceView', () => {
     expect(alert).toHaveTextContent(/traces were created but no spans were received/i);
   });
 
-  it('should render an error message when the API call returns malformed JSON', async () => {
+  it('should render an error message when the API returns malformed JSON', async () => {
     vi.mocked(callApi).mockResolvedValue({
       ok: true,
       json: () => Promise.reject(new Error('Unexpected token < in JSON at position 0')),

--- a/src/app/src/components/traces/TraceView.test.tsx
+++ b/src/app/src/components/traces/TraceView.test.tsx
@@ -649,7 +649,10 @@ describe('TraceView', () => {
       { traceId: 't-a', testCaseId: '1-2', spans: [{ spanId: 's1' }] },
       { traceId: 't-b', testCaseId: '3-1', spans: [{ spanId: 's2' }] },
     ];
-    vi.mocked(callApi).mockResolvedValue({ ok: true, json: () => Promise.resolve({ traces: mockTraces }) } as Response);
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
 
     render(<TraceView evaluationId="eval-1" testIndex={3} promptIndex={1} />);
 
@@ -663,7 +666,10 @@ describe('TraceView', () => {
       { traceId: 't-direct', testCaseId: 'uuid-123', spans: [{ spanId: 's1' }] },
       { traceId: 't-fallback', testCaseId: '3-1', spans: [{ spanId: 's2' }] },
     ];
-    vi.mocked(callApi).mockResolvedValue({ ok: true, json: () => Promise.resolve({ traces: mockTraces }) } as Response);
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ traces: mockTraces }),
+    } as Response);
 
     render(<TraceView evaluationId="eval-1" testCaseId="uuid-123" testIndex={3} promptIndex={1} />);
 

--- a/src/app/src/components/traces/TraceView.test.tsx
+++ b/src/app/src/components/traces/TraceView.test.tsx
@@ -643,4 +643,33 @@ describe('TraceView', () => {
       expect(screen.getByText('No traces available for this test case')).toBeInTheDocument();
     });
   });
+
+  it('filters by indices when no testCaseId is provided', async () => {
+    const mockTraces = [
+      { traceId: 't-a', testCaseId: '1-2', spans: [{ spanId: 's1' }] },
+      { traceId: 't-b', testCaseId: '3-1', spans: [{ spanId: 's2' }] },
+    ];
+    vi.mocked(callApi).mockResolvedValue({ ok: true, json: () => Promise.resolve({ traces: mockTraces }) } as Response);
+
+    render(<TraceView evaluationId="eval-1" testIndex={3} promptIndex={1} />);
+
+    const timelines = await screen.findAllByTestId('trace-timeline');
+    expect(timelines).toHaveLength(1);
+    expect(screen.getByText('Trace ID: t-b')).toBeInTheDocument();
+  });
+
+  it('prefers direct testCaseId match over index fallback', async () => {
+    const mockTraces = [
+      { traceId: 't-direct', testCaseId: 'uuid-123', spans: [{ spanId: 's1' }] },
+      { traceId: 't-fallback', testCaseId: '3-1', spans: [{ spanId: 's2' }] },
+    ];
+    vi.mocked(callApi).mockResolvedValue({ ok: true, json: () => Promise.resolve({ traces: mockTraces }) } as Response);
+
+    render(<TraceView evaluationId="eval-1" testCaseId="uuid-123" testIndex={3} promptIndex={1} />);
+
+    const timelines = await screen.findAllByTestId('trace-timeline');
+    expect(timelines).toHaveLength(1);
+    expect(screen.getByText('Trace ID: t-direct')).toBeInTheDocument();
+    expect(screen.queryByText('Trace ID: t-fallback')).not.toBeInTheDocument();
+  });
 });

--- a/src/app/src/components/traces/TraceView.tsx
+++ b/src/app/src/components/traces/TraceView.tsx
@@ -10,12 +10,16 @@ import TraceTimeline from './TraceTimeline';
 interface TraceViewProps {
   evaluationId?: string;
   testCaseId?: string;
+  testIndex?: number;
+  promptIndex?: number;
   onVisibilityChange?: (shouldShow: boolean) => void;
 }
 
 export default function TraceView({
   evaluationId,
   testCaseId,
+  testIndex,
+  promptIndex,
   onVisibilityChange,
 }: TraceViewProps) {
   const [traces, setTraces] = useState<any[]>([]);
@@ -107,12 +111,63 @@ export default function TraceView({
     );
   }
 
-  // Filter traces by test case ID if provided
-  const filteredTraces = testCaseId
-    ? traces.filter((trace) => trace.testCaseId === testCaseId)
-    : traces;
+  // Filter traces with try-direct-match then fallback approach
+  let filteredTraces: any[] = traces;
 
-  if (filteredTraces.length === 0 && testCaseId) {
+  if (traces.length > 0) {
+    if (testCaseId) {
+      // Try direct testCaseId match first
+      const directMatches = traces.filter((trace) => trace.testCaseId === testCaseId);
+
+      if (directMatches.length > 0) {
+        filteredTraces = directMatches;
+      } else if (testIndex !== undefined && promptIndex !== undefined) {
+        // Fallback: try index-based matching on composed trace.testCaseId
+        filteredTraces = traces.filter((trace) => {
+          if (!trace.testCaseId || typeof trace.testCaseId !== 'string') {
+            return false;
+          }
+          const parts = trace.testCaseId.split('-');
+          if (parts.length !== 2) {
+            return false;
+          }
+          const traceTestIndex = Number.parseInt(parts[0], 10);
+          const tracePromptIndex = Number.parseInt(parts[1], 10);
+          return (
+            !Number.isNaN(traceTestIndex) &&
+            !Number.isNaN(tracePromptIndex) &&
+            traceTestIndex === testIndex &&
+            tracePromptIndex === promptIndex
+          );
+        });
+      } else {
+        // No direct match and no indices for fallback
+        filteredTraces = [];
+      }
+    } else if (testIndex !== undefined && promptIndex !== undefined) {
+      // No testCaseId but indices provided - try index-based filtering
+      filteredTraces = traces.filter((trace) => {
+        if (!trace.testCaseId || typeof trace.testCaseId !== 'string') {
+          return false;
+        }
+        const parts = trace.testCaseId.split('-');
+        if (parts.length !== 2) {
+          return false;
+        }
+        const traceTestIndex = Number.parseInt(parts[0], 10);
+        const tracePromptIndex = Number.parseInt(parts[1], 10);
+        return (
+          !Number.isNaN(traceTestIndex) &&
+          !Number.isNaN(tracePromptIndex) &&
+          traceTestIndex === testIndex &&
+          tracePromptIndex === promptIndex
+        );
+      });
+    }
+    // If no testCaseId and no indices, show all traces for the evaluation
+  }
+
+  if (filteredTraces.length === 0 && (testCaseId || testIndex !== undefined)) {
     return (
       <Box sx={{ p: 2 }}>
         <Typography variant="body2" color="text.secondary">

--- a/src/app/src/pages/eval/components/DebuggingPanel.test.tsx
+++ b/src/app/src/pages/eval/components/DebuggingPanel.test.tsx
@@ -3,7 +3,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { DebuggingPanel } from './DebuggingPanel';
 
 vi.mock('../../../components/traces/TraceView', () => ({
-  default: ({ evaluationId, testCaseId, testIndex, promptIndex }: { evaluationId?: string; testCaseId?: string; testIndex?: number; promptIndex?: number }) => (
+  default: ({
+    evaluationId,
+    testCaseId,
+    testIndex,
+    promptIndex,
+  }: {
+    evaluationId?: string;
+    testCaseId?: string;
+    testIndex?: number;
+    promptIndex?: number;
+  }) => (
     <div data-testid="mock-trace-view">
       <span>Evaluation ID: {evaluationId}</span>
       <span>Test Case ID: {testCaseId}</span>

--- a/src/app/src/pages/eval/components/DebuggingPanel.test.tsx
+++ b/src/app/src/pages/eval/components/DebuggingPanel.test.tsx
@@ -3,21 +3,23 @@ import { describe, it, expect, vi } from 'vitest';
 import { DebuggingPanel } from './DebuggingPanel';
 
 vi.mock('../../../components/traces/TraceView', () => ({
-  default: ({ evaluationId, testCaseId }: { evaluationId?: string; testCaseId?: string }) => (
+  default: ({ evaluationId, testCaseId, testIndex, promptIndex }: { evaluationId?: string; testCaseId?: string; testIndex?: number; promptIndex?: number }) => (
     <div data-testid="mock-trace-view">
       <span>Evaluation ID: {evaluationId}</span>
       <span>Test Case ID: {testCaseId}</span>
+      <span>Test Index: {testIndex}</span>
+      <span>Prompt Index: {promptIndex}</span>
     </div>
   ),
 }));
 
 describe('DebuggingPanel', () => {
-  it('should render the Trace Timeline header and TraceView when evaluationId is provided and showTraceSection is true', () => {
+  it('should render the Trace Timeline header and TraceView when evaluationId is provided', () => {
     const props = {
       evaluationId: 'eval-123',
       testCaseId: 'test-456',
-      showTraceSection: true,
-      onTraceSectionVisibilityChange: vi.fn(),
+      testIndex: 1,
+      promptIndex: 0,
     };
 
     render(<DebuggingPanel {...props} />);
@@ -29,26 +31,41 @@ describe('DebuggingPanel', () => {
 
     expect(screen.getByText('Evaluation ID: eval-123')).toBeInTheDocument();
     expect(screen.getByText('Test Case ID: test-456')).toBeInTheDocument();
+    expect(screen.getByText('Test Index: 1')).toBeInTheDocument();
+    expect(screen.getByText('Prompt Index: 0')).toBeInTheDocument();
   });
 
-  it('should not render the trace section when showTraceSection is false, even if evaluationId is provided', () => {
+  it('should not render anything when evaluationId is not provided', () => {
     const props = {
-      evaluationId: 'eval-123',
       testCaseId: 'test-456',
-      showTraceSection: false,
-      onTraceSectionVisibilityChange: vi.fn(),
+      testIndex: 1,
+      promptIndex: 0,
     };
 
     render(<DebuggingPanel {...props} />);
 
-    const traceTimelineElement = screen.queryByText('Trace Timeline');
+    expect(screen.queryByText('Trace Timeline')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-trace-view')).not.toBeInTheDocument();
+  });
+
+  it('should always show TraceView when evaluationId exists (no display gating)', () => {
+    const props = {
+      evaluationId: 'eval-123',
+      testCaseId: 'test-456',
+      testIndex: 2,
+      promptIndex: 1,
+    };
+
+    render(<DebuggingPanel {...props} />);
+
+    const traceTimelineElement = screen.getByText('Trace Timeline');
     expect(traceTimelineElement).toBeInTheDocument();
 
-    const traceViewElement = screen.queryByTestId('mock-trace-view');
+    const traceViewElement = screen.getByTestId('mock-trace-view');
     expect(traceViewElement).toBeInTheDocument();
 
-    // Check that the parent container (the Box with mb={2}) has display: none
-    const parentContainer = traceTimelineElement?.parentElement;
-    expect(parentContainer).toHaveStyle('display: none');
+    // Check that the parent container does not have display: none
+    const parentContainer = traceTimelineElement.parentElement;
+    expect(parentContainer).not.toHaveStyle('display: none');
   });
 });

--- a/src/app/src/pages/eval/components/DebuggingPanel.tsx
+++ b/src/app/src/pages/eval/components/DebuggingPanel.tsx
@@ -12,6 +12,8 @@ const subtitleTypographySx = {
 interface DebuggingPanelProps {
   evaluationId?: string;
   testCaseId?: string;
+  testIndex?: number;
+  promptIndex?: number;
   showTraceSection: boolean;
   onTraceSectionVisibilityChange: (visible: boolean) => void;
 }
@@ -19,6 +21,8 @@ interface DebuggingPanelProps {
 export function DebuggingPanel({
   evaluationId,
   testCaseId,
+  testIndex,
+  promptIndex,
   showTraceSection,
   onTraceSectionVisibilityChange,
 }: DebuggingPanelProps) {
@@ -33,6 +37,8 @@ export function DebuggingPanel({
             <TraceView
               evaluationId={evaluationId}
               testCaseId={testCaseId}
+              testIndex={testIndex}
+              promptIndex={promptIndex}
               onVisibilityChange={onTraceSectionVisibilityChange}
             />
           </ErrorBoundary>

--- a/src/app/src/pages/eval/components/DebuggingPanel.tsx
+++ b/src/app/src/pages/eval/components/DebuggingPanel.tsx
@@ -14,8 +14,6 @@ interface DebuggingPanelProps {
   testCaseId?: string;
   testIndex?: number;
   promptIndex?: number;
-  showTraceSection: boolean;
-  onTraceSectionVisibilityChange: (visible: boolean) => void;
 }
 
 export function DebuggingPanel({
@@ -23,14 +21,12 @@ export function DebuggingPanel({
   testCaseId,
   testIndex,
   promptIndex,
-  showTraceSection,
-  onTraceSectionVisibilityChange,
 }: DebuggingPanelProps) {
   return (
     <Box>
       {evaluationId && (
-        <Box mb={2} sx={{ display: showTraceSection ? 'block' : 'none' }}>
-          <Typography variant="subtitle1" sx={subtitleTypographySx}>
+        <Box mb={2}>
+          <Typography variant="subtitle1" sx={subtitleTypographySx} aria-label="Trace Timeline">
             Trace Timeline
           </Typography>
           <ErrorBoundary fallback={<Alert severity="error">Error loading traces</Alert>}>
@@ -39,7 +35,6 @@ export function DebuggingPanel({
               testCaseId={testCaseId}
               testIndex={testIndex}
               promptIndex={promptIndex}
-              onVisibilityChange={onTraceSectionVisibilityChange}
             />
           </ErrorBoundary>
         </Box>

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -604,6 +604,7 @@ function EvalOutputCell({
               evaluationId={evaluationId}
               testCaseId={testCaseId || output.id}
               testIndex={rowIndex}
+              promptIndex={promptIndex}
               variables={output.testCase?.vars}
             />
           )}

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -183,7 +183,6 @@ export default function EvalOutputPromptDialog({
   const [replayLoading, setReplayLoading] = useState(false);
   const [replayOutput, setReplayOutput] = useState<string | null>(null);
   const [replayError, setReplayError] = useState<string | null>(null);
-  const [showTraceSection, setShowTraceSection] = useState(true);
   const { addFilter, resetFilters } = useTableStore();
 
   useEffect(() => {
@@ -508,8 +507,6 @@ export default function EvalOutputPromptDialog({
                 testCaseId={testCaseId}
                 testIndex={testIndex}
                 promptIndex={promptIndex}
-                showTraceSection={showTraceSection}
-                onTraceSectionVisibilityChange={setShowTraceSection}
               />
             </Box>
           )}

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -195,7 +195,6 @@ export default function EvalOutputPromptDialog({
     setActiveTab(0); // Reset to first tab when dialog opens
   }, [prompt]);
 
-
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
   };

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -195,9 +195,6 @@ export default function EvalOutputPromptDialog({
     setActiveTab(0); // Reset to first tab when dialog opens
   }, [prompt]);
 
-  useEffect(() => {
-    setShowTraceSection(true);
-  }, [evaluationId]);
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -155,6 +155,7 @@ interface EvalOutputPromptDialogProps {
   evaluationId?: string;
   testCaseId?: string;
   testIndex?: number;
+  promptIndex?: number;
   variables?: Record<string, any>;
 }
 
@@ -169,6 +170,7 @@ export default function EvalOutputPromptDialog({
   evaluationId,
   testCaseId,
   testIndex,
+  promptIndex,
   variables,
 }: EvalOutputPromptDialogProps) {
   const [activeTab, setActiveTab] = useState(0);
@@ -182,7 +184,6 @@ export default function EvalOutputPromptDialog({
   const [replayOutput, setReplayOutput] = useState<string | null>(null);
   const [replayError, setReplayError] = useState<string | null>(null);
   const [showTraceSection, setShowTraceSection] = useState(true);
-  const [hasTraces, setHasTraces] = useState(false);
   const { addFilter, resetFilters } = useTableStore();
 
   useEffect(() => {
@@ -197,8 +198,6 @@ export default function EvalOutputPromptDialog({
 
   useEffect(() => {
     setShowTraceSection(true);
-    // Don't assume traces exist - let DebuggingPanel determine this
-    setHasTraces(false);
   }, [evaluationId]);
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -355,8 +354,9 @@ export default function EvalOutputPromptDialog({
     visibleTabs.push('metadata');
   }
 
-  // Only show traces tab if we have actual traces to display
-  const hasTracesData = Boolean(hasTraces && evaluationId);
+  // Always show traces tab when evaluationId exists - TraceView will handle empty state messaging
+  // This prevents tab indices from shifting when TraceView reports no content
+  const hasTracesData = Boolean(evaluationId);
 
   // Put Traces tab last if it should be shown
   if (hasTracesData) {
@@ -506,12 +506,10 @@ export default function EvalOutputPromptDialog({
               <DebuggingPanel
                 evaluationId={evaluationId}
                 testCaseId={testCaseId}
+                testIndex={testIndex}
+                promptIndex={promptIndex}
                 showTraceSection={showTraceSection}
-                onTraceSectionVisibilityChange={(hasContent) => {
-                  setShowTraceSection(hasContent);
-                  // Update whether we have traces based on the TraceView callback
-                  setHasTraces(hasContent);
-                }}
+                onTraceSectionVisibilityChange={setShowTraceSection}
               />
             </Box>
           )}


### PR DESCRIPTION
## Summary

Resolves two core issues with trace visualization in the web UI:

• **Circular dependency fix**: Traces tab now always appears when evaluationId exists, eliminating the chicken-and-egg problem where hasTraces state prevented the tab from showing
• **Format reconciliation**: Simplified TraceView filtering with robust fallback logic to handle both UUID testCaseIds (from evaluations) and "testIdx-promptIdx" format (from trace system)
• **Component improvements**: Added promptIndex prop threading throughout the component chain for better trace filtering

## Changes

- `EvalOutputPromptDialog.tsx`: Always show traces tab when evaluationId exists, removed unused hasTraces state
- `TraceView.tsx`: Simplified filtering with try-direct-match then fallback approach
- `DebuggingPanel.tsx`: Added testIndex and promptIndex prop forwarding  
- `EvalOutputCell.tsx`: Added promptIndex prop to dialog call
- `TraceView.test.tsx`: Added test coverage for mixed arrays with missing testCaseId

## Test Instructions

1. Run evaluation with tracing enabled: `promptfoo eval -c config.yaml` (with `tracing.enabled: true`)
2. Open web UI: `promptfoo view`
3. Navigate to any evaluation and click the magnifying glass (🔎) on a test case
4. Verify "Traces" tab is always visible when evaluationId exists
5. Test with both UUID testCaseIds and "testIdx-promptIdx" format testCaseIds
6. Confirm no JavaScript errors in browser console

Relates to #5662