### PR TITLE
chore(webui): fix z-index on version update banner

### DIFF
--- a/src/app/src/components/UpdateBanner.tsx
+++ b/src/app/src/components/UpdateBanner.tsx
@@ -16,6 +16,8 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
   borderRadius: 0,
   padding: theme.spacing(0.75, 2),
   alignItems: 'center',
+  position: 'relative',
+  zIndex: theme.zIndex.appBar + 1,
   '& .MuiAlert-message': {
     width: '100%',
     padding: theme.spacing(0.5, 0),


### PR DESCRIPTION
## Summary
• Fix z-index issue where the version update banner was rendering behind table content
• Add proper positioning and z-index to ensure banner appears above other elements

## Changes
• Added `position: relative` and `zIndex: theme.zIndex.appBar + 1` to StyledAlert component
• Ensures version update banner is visible when displayed on pages with tables

## Test plan
- [ ] Start dev environment
- [ ] Trigger update banner display (by temporarily downgrading version)
- [ ] Navigate to datasets page and verify banner appears above table content
- [ ] Verify banner can be dismissed and interacted with properly