### PR TITLE
fix(webui): unify page layout styles and eliminate layout shift

### DIFF
--- a/src/app/src/components/PageShell.tsx
+++ b/src/app/src/components/PageShell.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import Navigation from '@app/components/Navigation';
 import { PostHogProvider } from '@app/components/PostHogProvider';
 import UpdateBanner from '@app/components/UpdateBanner';
+import Box from '@mui/material/Box';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Outlet } from 'react-router-dom';
@@ -235,7 +236,7 @@ const lightTheme = createAppTheme(false);
 const darkTheme = createAppTheme(true);
 
 function Layout({ children }: { children: React.ReactNode }) {
-  return <div>{children}</div>;
+  return <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>{children}</Box>;
 }
 
 export default function PageShell() {
@@ -279,7 +280,9 @@ export default function PageShell() {
         <Layout>
           <Navigation darkMode={darkMode} onToggleDarkMode={toggleDarkMode} />
           <UpdateBanner />
-          <Outlet />
+          <Box sx={{ flex: 1, overflow: 'auto', position: 'relative' }}>
+            <Outlet />
+          </Box>
           <PostHogPageViewTracker />
         </Layout>
       </PostHogProvider>

--- a/src/app/src/pages/datasets/Datasets.tsx
+++ b/src/app/src/pages/datasets/Datasets.tsx
@@ -4,6 +4,7 @@ import { formatDataGridDate } from '@app/utils/date';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import { alpha, useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -213,18 +214,13 @@ export default function Datasets({ data, isLoading, error }: DatasetsProps) {
   }
 
   return (
-    <Box
+    <Container
+      maxWidth="xl"
       sx={{
-        position: 'absolute',
-        top: 64,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        bgcolor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.common.black, 0.2)
-            : alpha(theme.palette.grey[50], 0.5),
-        p: 3,
+        height: '100%',
+        py: 2,
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
       <Paper
@@ -341,6 +337,6 @@ export default function Datasets({ data, isLoading, error }: DatasetsProps) {
           testCase={data[dialogState.selectedIndex]}
         />
       )}
-    </Box>
+    </Container>
   );
 }

--- a/src/app/src/pages/evals/page.tsx
+++ b/src/app/src/pages/evals/page.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useState } from 'react';
-
 import { usePageMeta } from '@app/hooks/usePageMeta';
 import Container from '@mui/material/Container';
 import { useNavigate } from 'react-router-dom';
@@ -7,27 +5,18 @@ import EvalsDataGrid from './components/EvalsDataGrid';
 
 export default function EvalsIndexPage() {
   const navigate = useNavigate();
-  const [offsetTop, setOffsetTop] = useState(0);
 
   usePageMeta({ title: 'Evals', description: 'Browse evaluation runs' });
-
-  /**
-   * Calculate the offset top of the container once it's mounted.
-   */
-  const containerRef = useCallback((node: HTMLDivElement) => {
-    if (node) {
-      setOffsetTop(node.offsetTop);
-    }
-  }, []);
 
   return (
     <Container
       maxWidth="xl"
-      style={{
-        height: offsetTop > 0 ? `calc(100vh - ${offsetTop}px)` : '100%',
+      sx={{
+        height: '100%',
+        py: 2,
+        display: 'flex',
+        flexDirection: 'column',
       }}
-      sx={{ py: 2 }}
-      ref={containerRef}
     >
       <EvalsDataGrid
         onEvalSelected={(evalId) => navigate(`/eval/${evalId}`)}

--- a/src/app/src/pages/history/History.tsx
+++ b/src/app/src/pages/history/History.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import Container from '@mui/material/Container';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import { alpha, useTheme } from '@mui/material/styles';
@@ -218,17 +219,13 @@ export default function History({
   );
 
   return (
-    <Box
+    <Container
+      maxWidth="xl"
       sx={{
-        top: 64,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        bgcolor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.common.black, 0.2)
-            : alpha(theme.palette.grey[50], 0.5),
-        p: 3,
+        height: '100%',
+        py: 2,
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
       <Paper
@@ -331,6 +328,6 @@ export default function History({
           }}
         />
       </Paper>
-    </Box>
+    </Container>
   );
 }

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { formatDataGridDate } from '@app/utils/date';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import { alpha, useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -160,18 +161,13 @@ export default function Prompts({
   };
 
   return (
-    <Box
+    <Container
+      maxWidth="xl"
       sx={{
-        position: 'absolute',
-        top: 64,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        bgcolor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.common.black, 0.2)
-            : alpha(theme.palette.grey[50], 0.5),
-        p: 3,
+        height: '100%',
+        py: 2,
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
       <Paper
@@ -291,6 +287,6 @@ export default function Prompts({
             showDatasetColumn={showDatasetColumn}
           />
         )}
-    </Box>
+    </Container>
   );
 }


### PR DESCRIPTION
## Summary

Fixes layout shift issues between main pages by implementing a consistent flexbox-based layout pattern.

## Changes

- **PageShell**: Implement flexbox layout with proper content area sizing
- **All main pages** (/prompts, /history, /datasets, /evals): Unified to use consistent Container pattern
- **Layout approach**: Replace absolute positioning and hardcoded heights with dynamic flexbox
- **Responsive design**: Improved mobile and tablet experience

## Technical Details

- Removed dynamic height calculation with  measurement
- Implemented  pattern across all pages
- Added proper flexbox structure for automatic height management
- Eliminates layout shift when navigating between pages
- Better handles dynamic components like UpdateBanner

## Testing

- [x] Layout consistency across all main pages
- [x] No layout shift during navigation
- [x] Responsive behavior on different screen sizes
- [x] Dynamic banner appearance/dismissal
- [x] Linting and formatting checks passed