### PR TITLE
fix(tests): correct TypeScript errors in test files

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -142,9 +142,10 @@ vi.mock('./EvalSelectorKeyboardShortcut', () => ({
 
 const mockRecentEvals: ResultLightweightWithLabel[] = [
   {
-    id: 'eval-1',
+    evalId: 'eval-1',
+    datasetId: null,
     label: 'Evaluation 1',
-    createdAt: '2023-01-01T00:00:00Z',
+    createdAt: new Date('2023-01-01T00:00:00Z').getTime(),
     description: 'Test evaluation 1',
     numTests: 5,
   },

--- a/src/app/src/pages/eval/components/ShareModal.test.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.test.tsx
@@ -33,14 +33,15 @@ describe('ShareModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Mock successful domain check by default
-    mockCallApi.mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
+    mockCallApi.mockResolvedValue(
+      new Response(
+        JSON.stringify({
           domain: 'localhost:3000',
           isCloudEnabled: false,
         }),
-    });
+        { status: 200, statusText: 'OK' },
+      ),
+    );
   });
 
   it('does not render when closed', () => {
@@ -58,14 +59,15 @@ describe('ShareModal', () => {
   });
 
   it('displays signup prompt when cloud is not enabled', async () => {
-    mockCallApi.mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
+    mockCallApi.mockResolvedValue(
+      new Response(
+        JSON.stringify({
           domain: 'promptfoo.app',
           isCloudEnabled: false,
         }),
-    });
+        { status: 200, statusText: 'OK' },
+      ),
+    );
 
     render(<ShareModal {...defaultProps} />);
 
@@ -108,13 +110,14 @@ describe('ShareModal', () => {
   });
 
   it('displays error when domain check fails', async () => {
-    mockCallApi.mockResolvedValue({
-      ok: false,
-      json: () =>
-        Promise.resolve({
+    mockCallApi.mockResolvedValue(
+      new Response(
+        JSON.stringify({
           error: 'Domain check failed',
         }),
-    });
+        { status: 500, statusText: 'Internal Server Error' },
+      ),
+    );
 
     render(<ShareModal {...defaultProps} />);
 
@@ -152,14 +155,15 @@ describe('ShareModal', () => {
   });
 
   it('opens external link when "Take me there" is clicked', async () => {
-    mockCallApi.mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
+    mockCallApi.mockResolvedValue(
+      new Response(
+        JSON.stringify({
           domain: 'promptfoo.app',
           isCloudEnabled: false,
         }),
-    });
+        { status: 200, statusText: 'OK' },
+      ),
+    );
 
     // Mock window.open
     const mockOpen = vi.fn();


### PR DESCRIPTION
## Summary
Fix TypeScript compilation errors that were exposed after upgrading Vite from v6 to v7 in commit 16ff8409b.

## Root Cause
The recent Vite upgrade to v7 (PR #5681) exposed existing TypeScript errors in test files that were previously not caught by the build process. The upgrade brought stricter compilation checking that revealed:

1. **ResultsView.test.tsx**: Mock object structure didn't match the `ResultLightweightWithLabel` interface
   - `createdAt` field expected `number` (timestamp) but was receiving `string` 
   - Missing required `evalId` and `datasetId` fields from the interface

2. **ShareModal.test.tsx**: Mock `callApi` responses used plain objects instead of proper `Response` objects
   - Tests were mocking with `{ ok: true, json: () => Promise.resolve(...) }` 
   - But `callApi` returns `Promise<Response>` which requires full Response interface

## Changes Made
- ✅ Fixed `ResultsView.test.tsx` by updating mock to match `ResultLightweightWithLabel` interface structure
- ✅ Fixed `ShareModal.test.tsx` by using proper `Response` constructor for mocks instead of plain objects
- ✅ All tests now pass and TypeScript compilation succeeds

## Test Plan
- [x] Build passes locally (`npm run build`)
- [x] Tests pass locally (14/14 tests passing)
- [x] Linting and formatting applied (`npm run l && npm run f`)

This resolves the CI failures that have been blocking main since the Vite upgrade.