### PR TITLE
docs(site): add linkedTargetId documentation for custom provider linking

### DIFF
--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -275,3 +275,33 @@ providers:
 ```
 
 For detailed MCP documentation and advanced configurations, see the [MCP Integration Guide](../integrations/mcp.md).
+
+## Advanced Usage
+
+### Linking Custom Providers to Existing Targets (Promptfoo Cloud)
+
+:::info Promptfoo Cloud Feature
+This feature is available in [Promptfoo Cloud](/docs/enterprise) deployments.
+:::
+
+Use `linkedTargetId` to link custom providers to existing cloud targets. Results from the custom provider appear under the linked target instead of creating duplicate entries.
+
+```yaml
+providers:
+  - id: 'custom-wrapper'
+    config:
+      linkedTargetId: 'promptfoo://provider/12345-abcd-uuid'
+      # other custom provider config...
+```
+
+#### Supported target types
+
+- **Cloud provider IDs**: Format `promptfoo://provider/<uuid>` - points to existing cloud providers
+- **CLI target IDs**: Plain strings - points to CLI targets
+
+## Next Steps
+
+- [Configuration guide](/docs/configuration/guide) - Learn about test cases and assertions
+- [Expected outputs](/docs/configuration/expected-outputs) - Set up automatic evaluation
+- [Custom providers](/docs/providers/custom-api) - Build your own provider integrations
+- [Provider examples](https://github.com/promptfoo/promptfoo/tree/main/examples) - See real configuration examples


### PR DESCRIPTION
Add documentation for the `linkedTargetId` feature in the Advanced Usage section of the providers documentation.

This feature allows custom providers to link their evaluation results to existing cloud targets, preventing duplicate target entries and maintaining proper result attribution.

## Changes
- Added new Advanced Usage section to `site/docs/providers/index.md`
- Documents `linkedTargetId` configuration option
- Explains supported target types (cloud provider IDs and CLI targets)
- Includes YAML configuration example

## Feature Details
- Available in Promptfoo Cloud deployments
- Supports both `promptfoo://provider/<uuid>` format for cloud providers
- Supports plain strings for CLI targets
- Results from custom providers appear under the linked target