### PR TITLE
chore(webui): add 404 page with telemetry tracking

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -20,6 +20,7 @@ import HistoryPage from './pages/history/page';
 import LauncherPage from './pages/launcher/page';
 import LoginPage from './pages/login';
 import ModelAuditPage from './pages/model-audit/page';
+import NotFoundPage from './pages/NotFoundPage';
 import PromptsPage from './pages/prompts/page';
 import ReportPage from './pages/redteam/report/page';
 import RedteamSetupPage from './pages/redteam/setup/page';
@@ -73,6 +74,7 @@ const router = createBrowserRouter(
           <Route path="/reports" element={<ReportPage />} />
           <Route path="/setup" element={<EvalCreatorPage />} />
           <Route path="/login" element={<LoginPage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Route>
     </>,

--- a/src/app/src/pages/NotFoundPage.tsx
+++ b/src/app/src/pages/NotFoundPage.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect } from 'react';
+
+import { usePageMeta } from '@app/hooks/usePageMeta';
+import { useTelemetry } from '@app/hooks/useTelemetry';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import HomeIcon from '@mui/icons-material/Home';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { recordEvent } = useTelemetry();
+
+  usePageMeta({
+    title: 'Page Not Found',
+    description: 'The page you are looking for could not be found'
+  });
+
+  useEffect(() => {
+    recordEvent('webui_404_page_view', {
+      path: location.pathname,
+      search: location.search,
+      referrer: document.referrer
+    });
+  }, [location.pathname, location.search, recordEvent]);
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Paper elevation={3} sx={{ padding: 4, width: '100%', textAlign: 'center' }}>
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: '4rem',
+              fontWeight: 700,
+              color: 'primary.main',
+              mb: 2
+            }}
+          >
+            404
+          </Typography>
+
+          <Typography component="h1" variant="h4" gutterBottom>
+            Page Not Found
+          </Typography>
+
+          <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+            The page you're looking for doesn't exist or has been moved.
+          </Typography>
+
+          <Button
+            variant="contained"
+            startIcon={<HomeIcon />}
+            onClick={() => {
+              recordEvent('webui_404_go_home_click', {
+                from_path: location.pathname
+              });
+              navigate('/');
+            }}
+            size="large"
+          >
+            Go Home
+          </Button>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Add NotFoundPage component with clean Material-UI styling
- Include telemetry tracking for 404 page views and navigation clicks
- Add catch-all route (`path="*"`) to handle invalid URLs
- Simple, focused design with single "Go Home" button

## Test plan
- [x] Navigate to invalid URL (e.g., `/nonexistent-page`) to see 404 page
- [x] Verify "Go Home" button navigates back to root
- [x] Check that page follows existing design system (dark/light theme support)
- [x] Confirm no TypeScript or linting errors