### PR TITLE
fix(webui): prioritize JSON prettify over Markdown rendering when both enabled

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -242,30 +242,40 @@ function EvalOutputCell({
         )}
       </div>
     );
-  } else if (renderMarkdown && !showDiffs) {
-    node = (
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          img: ({ src, alt }) => (
-            <img
-              loading="lazy"
-              src={src}
-              alt={alt}
-              onClick={() => toggleLightbox(src)}
-              style={{ cursor: 'pointer' }}
-            />
-          ),
-        }}
-      >
-        {text}
-      </ReactMarkdown>
-    );
-  } else if (prettifyJson) {
-    try {
-      node = <pre>{JSON.stringify(JSON.parse(text), null, 2)}</pre>;
-    } catch {
-      // Ignore because it's probably not JSON.
+  } else if ((prettifyJson || renderMarkdown) && !showDiffs) {
+    // When both prettifyJson and renderMarkdown are enabled,
+    // display as JSON if it's a valid object/array, otherwise render as Markdown
+    let isJsonHandled = false;
+    if (prettifyJson) {
+      try {
+        const parsed = JSON.parse(text);
+        if (typeof parsed === 'object' && parsed !== null) {
+          node = <pre>{JSON.stringify(parsed, null, 2)}</pre>;
+          isJsonHandled = true;
+        }
+      } catch {
+        // Not valid JSON, continue to Markdown if enabled
+      }
+    }
+    if (!isJsonHandled && renderMarkdown) {
+      node = (
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            img: ({ src, alt }) => (
+              <img
+                loading="lazy"
+                src={src}
+                alt={alt}
+                onClick={() => toggleLightbox(src)}
+                style={{ cursor: 'pointer' }}
+              />
+            ),
+          }}
+        >
+          {text}
+        </ReactMarkdown>
+      );
     }
   }
 


### PR DESCRIPTION
resolves #5704 

This is necessary for use cases where we need to evaluate outputs that include both Markdown text for users and multiple structured data from an Agent.


Markdown rendering (top) and JSON output (bottom)

<img width="1210" height="684" alt="image" src="https://github.com/user-attachments/assets/b78fc3ce-a211-4197-a97e-62b08848fb89" />

https://gist.github.com/pokutuna/8fc497e03a2e81259cd95d75cba50927