### PR TITLE
chore(webui): demo mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29315,91 +29315,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
@@ -29453,29 +29368,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mongoose/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -41463,6 +41355,7 @@
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.6.0",
         "diff": "^8.0.2",
+        "dotenv": "17.2.2",
         "fuzzysearch": "^1.0.3",
         "idb-keyval": "^6.2.2",
         "js-yaml": "^4.1.0",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -40,6 +40,7 @@
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.6.0",
     "diff": "^8.0.2",
+    "dotenv": "17.2.2",
     "fuzzysearch": "^1.0.3",
     "idb-keyval": "^6.2.2",
     "js-yaml": "^4.1.0",

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router-dom';
 import PageShell from './components/PageShell';
 import { ToastProvider } from './contexts/ToastContext';
+import useDemoMode from './hooks/useDemoMode';
 import { useTelemetry } from './hooks/useTelemetry';
 import DatasetsPage from './pages/datasets/page';
 import EvalPage from './pages/eval/page';
@@ -83,6 +84,9 @@ const router = createBrowserRouter(
 );
 
 function App() {
+  const { isDemoMode } = useDemoMode();
+  console.debug('Demo Mode:', isDemoMode);
+
   return (
     <ToastProvider>
       <RouterProvider router={router} />

--- a/src/app/src/hooks/useDemoMode.test.ts
+++ b/src/app/src/hooks/useDemoMode.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import useDemoMode from './useDemoMode';
+
+describe('useDemoMode', () => {
+  const originalEnv = import.meta.env;
+
+  beforeEach(() => {
+    // Reset import.meta.env to a fresh object for each test
+    vi.stubGlobal('import.meta', {
+      env: { ...originalEnv },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should return isDemoMode as true when VITE_PUBLIC_PROMPTFOO_DEMO_MODE is "true"', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = 'true';
+
+    const { result } = renderHook(() => useDemoMode());
+
+    expect(result.current.isDemoMode).toBe(true);
+  });
+
+  it('should return isDemoMode as false when VITE_PUBLIC_PROMPTFOO_DEMO_MODE is "false"', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = 'false';
+
+    const { result } = renderHook(() => useDemoMode());
+
+    expect(result.current.isDemoMode).toBe(false);
+  });
+
+  it('should return isDemoMode as false when VITE_PUBLIC_PROMPTFOO_DEMO_MODE is undefined', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    delete import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE;
+
+    const { result } = renderHook(() => useDemoMode());
+
+    expect(result.current.isDemoMode).toBe(false);
+  });
+
+  it('should return isDemoMode as false when VITE_PUBLIC_PROMPTFOO_DEMO_MODE is an empty string', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = '';
+
+    const { result } = renderHook(() => useDemoMode());
+
+    expect(result.current.isDemoMode).toBe(false);
+  });
+
+  it('should return isDemoMode as false when VITE_PUBLIC_PROMPTFOO_DEMO_MODE has any value other than "true"', () => {
+    const testValues = ['True', 'TRUE', '1', 'yes', 'on', 'random-value'];
+
+    testValues.forEach((value) => {
+      // @ts-ignore - we're mocking import.meta.env
+      import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = value;
+
+      const { result } = renderHook(() => useDemoMode());
+
+      expect(result.current.isDemoMode).toBe(false);
+    });
+  });
+
+  it('should return a consistent object structure', () => {
+    const { result } = renderHook(() => useDemoMode());
+
+    expect(result.current).toHaveProperty('isDemoMode');
+    expect(typeof result.current.isDemoMode).toBe('boolean');
+  });
+
+  it('should be a pure function that returns the same value for the same environment', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = 'true';
+
+    const { result: result1 } = renderHook(() => useDemoMode());
+    const { result: result2 } = renderHook(() => useDemoMode());
+
+    expect(result1.current.isDemoMode).toBe(result2.current.isDemoMode);
+    expect(result1.current.isDemoMode).toBe(true);
+  });
+
+  it('should not rerender when called multiple times with the same environment', () => {
+    // @ts-ignore - we're mocking import.meta.env
+    import.meta.env.VITE_PUBLIC_PROMPTFOO_DEMO_MODE = 'true';
+
+    let renderCount = 0;
+    const { result, rerender } = renderHook(() => {
+      renderCount++;
+      return useDemoMode();
+    });
+
+    expect(renderCount).toBe(1);
+    expect(result.current.isDemoMode).toBe(true);
+
+    // Rerender without changing the environment
+    rerender();
+
+    expect(renderCount).toBe(2);
+    expect(result.current.isDemoMode).toBe(true);
+  });
+});

--- a/src/app/src/hooks/useDemoMode.ts
+++ b/src/app/src/hooks/useDemoMode.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 /**
  * Hook to determine if the app is running in demo mode.
  * Reads from the VITE_PROMPTFOO_DEMO_MODE environment variable.
@@ -5,9 +7,22 @@
  */
 export default function useDemoMode(): {
   isDemoMode: boolean;
+  setEmailAddress: (email: string) => void;
+  emailAddressSet: boolean;
 } {
+  const [emailAddress, setEmailAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (emailAddress) {
+      console.log('Email address set:', emailAddress);
+    }
+  }, [emailAddress]);
+
   const envFlag = import.meta.env.VITE_PROMPTFOO_DEMO_MODE;
+
   return {
     isDemoMode: envFlag ? envFlag === 'true' : false,
+    setEmailAddress,
+    emailAddressSet: emailAddress !== null,
   };
 }

--- a/src/app/src/hooks/useDemoMode.ts
+++ b/src/app/src/hooks/useDemoMode.ts
@@ -1,0 +1,13 @@
+/**
+ * Hook to determine if the app is running in demo mode.
+ * Reads from the VITE_PROMPTFOO_DEMO_MODE environment variable.
+ * @returns
+ */
+export default function useDemoMode(): {
+  isDemoMode: boolean;
+} {
+  const envFlag = import.meta.env.VITE_PROMPTFOO_DEMO_MODE;
+  return {
+    isDemoMode: envFlag ? envFlag === 'true' : false,
+  };
+}

--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -15,7 +15,7 @@ import Typography from '@mui/material/Typography';
 interface EmailVerificationDialogProps {
   open: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (email: string) => Promise<void>;
   message?: string;
 }
 
@@ -67,7 +67,7 @@ export function EmailVerificationDialog({
         return;
       }
       showToast('Email saved successfully, starting redteam.');
-      onSuccess();
+      return onSuccess(email);
     } catch (error) {
       console.error('Error submitting email:', error);
       setEmailError(
@@ -78,9 +78,9 @@ export function EmailVerificationDialog({
     }
   };
 
-  const handleKeyPress = (event: React.KeyboardEvent) => {
+  const handleKeyPress = async (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && !isSubmitting) {
-      handleSubmit();
+      return handleSubmit();
     }
   };
 

--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -391,9 +391,7 @@ export default function Review({
   const handleRun = async () => {
     // Always prompt for email in demo mode
     if (isDemoMode) {
-      setEmailVerificationMessage(
-        'Redteam evals require email verification. Please enter your work email:',
-      );
+      setEmailVerificationMessage('Please enter your work email:');
       setIsEmailDialogOpen(true);
       return;
     }

--- a/src/app/src/pages/redteam/setup/components/RunOptions.tsx
+++ b/src/app/src/pages/redteam/setup/components/RunOptions.tsx
@@ -1,18 +1,19 @@
 import { useState } from 'react';
 
+import useDemoMode from '@app/hooks/useDemoMode';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FormControlLabel, Switch } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Box from '@mui/material/Box';
+import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import InputAdornment from '@mui/material/InputAdornment';
-import type { RedteamRunOptions } from '@promptfoo/types';
 import { Config } from '../types';
+import type { RedteamRunOptions } from '@promptfoo/types';
 
 const LabelWithTooltip = ({ label, tooltip }: { label: string; tooltip: string }) => {
   return (
@@ -38,6 +39,7 @@ export const RunOptionsContent = ({
   updateRunOption,
   useGuardrailAssertion,
 }: RunOptionsProps) => {
+  const { isDemoMode } = useDemoMode();
   // These two settings are mutually exclusive
   const canSetDelay = Boolean(!runOptions?.maxConcurrency || runOptions?.maxConcurrency === 1);
 
@@ -93,6 +95,7 @@ export const RunOptionsContent = ({
           const n = Number(numTestsInput);
           return Number.isNaN(n) || n < 1;
         })()}
+        disabled={isDemoMode}
       />
       {/**
        * Delay between API calls (ms)
@@ -115,7 +118,7 @@ export const RunOptionsContent = ({
           )
         }
         value={delayInput}
-        disabled={!canSetDelay}
+        disabled={!canSetDelay || isDemoMode}
         onChange={(e) => {
           const raw = e.target.value;
           const digitsOnly = raw.replace(/\D/g, '');
@@ -177,7 +180,7 @@ export const RunOptionsContent = ({
           )
         }
         value={maxConcurrencyInput}
-        disabled={!canSetMaxConcurrency}
+        disabled={!canSetMaxConcurrency || isDemoMode}
         onChange={(e) => {
           const raw = e.target.value;
           const digitsOnly = raw.replace(/\D/g, '');
@@ -221,6 +224,7 @@ export const RunOptionsContent = ({
           <Switch
             checked={runOptions?.verbose}
             onChange={(e) => updateRunOption('verbose', e.target.checked)}
+            disabled={isDemoMode}
           />
         }
         label={

--- a/src/app/src/vite-env.d.ts
+++ b/src/app/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_PUBLIC_PROMPTFOO_SHARE_API_URL: string;
   readonly VITE_PUBLIC_PROMPTFOO_APP_SHARE_URL: string;
   readonly VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL: string;
+  readonly VITE_PROMPTFOO_DEMO_MODE?: string;
   readonly VITE_PROMPTFOO_VERSION: string;
   readonly VITE_PUBLIC_BASENAME: string;
   readonly VITE_PROMPTFOO_DISABLE_TELEMETRY: string;

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -3,9 +3,17 @@
 import path from 'path';
 
 import react from '@vitejs/plugin-react';
+import { config as dotenvConfig } from 'dotenv';
 import { defineConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import packageJson from '../../package.json';
+
+// Vite does not automatically load the root `.env` file, so we need to do it manually:
+dotenvConfig({
+  // Load the root `.env` file
+  path: '../../.env',
+  quiet: true,
+});
 
 const API_PORT = process.env.API_PORT || '15500';
 
@@ -89,6 +97,9 @@ export default defineConfig({
     'import.meta.env.VITE_PROMPTFOO_VERSION': JSON.stringify(packageJson.version),
     'import.meta.env.VITE_PROMPTFOO_DISABLE_TELEMETRY': JSON.stringify(
       process.env.PROMPTFOO_DISABLE_TELEMETRY || 'false',
+    ),
+    'import.meta.env.VITE_PROMPTFOO_DEMO_MODE': JSON.stringify(
+      process.env.PROMPTFOO_DEMO_MODE || 'false',
     ),
     'import.meta.env.VITE_POSTHOG_KEY': JSON.stringify(process.env.PROMPTFOO_POSTHOG_KEY || ''),
     'import.meta.env.VITE_POSTHOG_HOST': JSON.stringify(


### PR DESCRIPTION
- [x] Adds dotenv [to read the root `.env`](https://github.com/promptfoo/promptfoo/pull/4983#issuecomment-3091450443).
- [x] Adds a new flag, `PROMPTFOO_DEMO_MODE`, to activate demo mode
- [ ] Reduces the default red team runtime by slimming down the config
- [x] Requires an email address be provided each time the "run now" button is clicked
- [ ] Fixes a bug where refreshing the page while running a scan does not auto-abort the scan [see stash]