### PR TITLE
chore(providers): add support for gpt-5-codex model

### DIFF
--- a/examples/openai-responses/promptfooconfig.codex.yaml
+++ b/examples/openai-responses/promptfooconfig.codex.yaml
@@ -6,8 +6,8 @@ prompts:
     Please write a function in Python that {{func_purpose}} and is named {{func_name}}.
 
 providers:
-  - id: openai:responses:codex-mini-latest
-    label: codex-mini-latest
+  - id: openai:responses:gpt-5-codex
+    label: gpt-5-codex
     config:
       max_output_tokens: 1000
       reasoning_effort: 'medium'

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -961,6 +961,7 @@ The Responses API supports a wide range of models, including:
 - `o3-mini` - Smaller, more affordable reasoning model
 - `o4-mini` - Latest fast, cost-effective reasoning model
 - `codex-mini-latest` - Fast reasoning model optimized for the Codex CLI
+- `gpt-5-codex` - GPT-5 based coding model optimized for code generation
 
 ### Using the Responses API
 

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -68,6 +68,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'o3-mini-2025-01-31',
     // GPT-4.5 models deprecated as of 2025-07-14, removed from API
     'codex-mini-latest',
+    'gpt-5-codex',
     // Deep research models
     'o3-deep-research',
     'o3-deep-research-2025-06-26',

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -300,6 +300,13 @@ export const OPENAI_CHAT_MODELS = [
       output: 6.0 / 1e6,
     },
   })),
+  ...['gpt-5-codex'].map((model) => ({
+    id: model,
+    cost: {
+      input: 1.25 / 1e6,
+      output: 10 / 1e6,
+    },
+  })),
 ];
 
 // Deep research models for Responses API


### PR DESCRIPTION
## Summary
Adds support for the new `gpt-5-codex` model introduced in the latest OpenAI SDK update.

## Changes
- Added `gpt-5-codex` to OpenAI Responses provider model list
- Added `gpt-5-codex` to OpenAI Chat provider with appropriate pricing ($1.25/1M input, $10/1M output)
- Updated OpenAI documentation to include `gpt-5-codex` in supported models list
- Updated codex example configuration to demonstrate usage

## Test Plan
- [x] Provider loading tests pass
- [x] Model name recognition works correctly
- [x] Configuration validation succeeds
- [x] All existing OpenAI tests continue to pass