### PR TITLE
feat: Compress data when sharing an eval

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -102,6 +102,8 @@ async function sendEvalRecord(
   headers: Record<string, string>,
 ): Promise<string> {
   const evalDataWithoutResults = { ...evalRecord, results: [] };
+  const jsonData = JSON.stringify(evalDataWithoutResults);
+
   logger.debug(
     `Sending initial eval data to ${url} - eval ${evalRecord.id} with ${evalRecord.prompts.length} prompts`,
   );
@@ -109,7 +111,8 @@ async function sendEvalRecord(
   const response = await fetchWithProxy(url, {
     method: 'POST',
     headers,
-    body: JSON.stringify(evalDataWithoutResults),
+    body: jsonData,
+    compress: true,
   });
 
   if (!response.ok) {
@@ -117,6 +120,18 @@ async function sendEvalRecord(
     // Ensure full error is visible by formatting it properly
     const errorMessage = `Failed to send initial eval data to ${url}: ${response.statusText}`;
     const bodyMessage = responseBody ? `\nResponse body: ${responseBody}` : '';
+    const debugInfo = {
+      url,
+      statusCode: response.status,
+      statusText: response.statusText,
+      headers: Object.keys(headers),
+      evalId: evalRecord.id,
+      errorMessage,
+      bodyMessage,
+    };
+    logger.error(
+      `Sharing your eval data to ${url} failed. Debug info: ${JSON.stringify(debugInfo, null, 2)}`,
+    );
     throw new Error(`${errorMessage}${bodyMessage}`);
   }
 
@@ -141,12 +156,12 @@ async function sendChunkOfResults(
   const chunkSizeBytes = Buffer.byteLength(stringifiedChunk, 'utf8');
 
   logger.debug(`Sending chunk of ${chunk.length} results to ${targetUrl}`);
-  logger.debug(`Chunk size: ${(chunkSizeBytes / 1024 / 1024).toFixed(2)} MB`);
 
   const response = await fetchWithProxy(targetUrl, {
     method: 'POST',
     headers,
     body: stringifiedChunk,
+    compress: true,
   });
 
   if (!response.ok) {
@@ -579,7 +594,7 @@ export async function createShareableModelAuditUrl(
  * @returns The shareable URL for the model audit.
  */
 export function getShareableModelAuditUrl(
-  audit: ModelAudit,
+  _audit: ModelAudit,
   remoteAuditId: string,
   showAuth: boolean = false,
 ): string {

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -13,6 +13,7 @@ import invariant from '../../util/invariant';
 import { sleep } from '../../util/time';
 import { sanitizeUrl } from '../sanitizer';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
+import type { FetchOptions } from './types';
 
 /**
  * Options for configuring TLS in proxy connections
@@ -122,7 +123,7 @@ function getOrCreateAgent(url: string): Agent | ProxyAgent {
 
 export async function fetchWithProxy(
   url: RequestInfo,
-  options: RequestInit = {},
+  options: FetchOptions = {},
 ): Promise<Response> {
   let finalUrl = url;
   let finalUrlString: string | undefined = undefined;
@@ -140,7 +141,7 @@ export async function fetchWithProxy(
   }
 
   // This is overridden globally but Node v20 is still complaining so we need to add it here too
-  const finalOptions: RequestInit & { dispatcher?: any } = {
+  const finalOptions: FetchOptions & { dispatcher?: any } = {
     ...options,
     headers: {
       ...(options.headers as Record<string, string>),
@@ -185,7 +186,7 @@ export async function fetchWithProxy(
 
 export function fetchWithTimeout(
   url: RequestInfo,
-  options: RequestInit = {},
+  options: FetchOptions = {},
   timeout: number,
 ): Promise<Response> {
   return new Promise((resolve, reject) => {
@@ -258,9 +259,11 @@ export async function handleRateLimit(response: Response): Promise<void> {
 /**
  * Fetch with automatic retries and rate limit handling
  */
+export type { FetchOptions } from './types';
+
 export async function fetchWithRetries(
   url: RequestInfo,
-  options: RequestInit = {},
+  options: FetchOptions = {},
   timeout: number,
   maxRetries?: number,
 ): Promise<Response> {

--- a/src/util/fetch/monkeyPatchFetch.ts
+++ b/src/util/fetch/monkeyPatchFetch.ts
@@ -55,7 +55,7 @@ export async function monkeyPatchFetch(
   ) {
     const token = cloudConfig.getApiKey();
     opts.headers = {
-      ...(options?.headers || {}),
+      ...(opts.headers || {}),
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
   }

--- a/src/util/fetch/monkeyPatchFetch.ts
+++ b/src/util/fetch/monkeyPatchFetch.ts
@@ -1,6 +1,11 @@
+import { gzip } from 'zlib';
+import { promisify } from 'util';
 import { CONSENT_ENDPOINT, EVENTS_ENDPOINT, R_ENDPOINT } from '../../constants';
 import { CLOUD_API_HOST, cloudConfig } from '../../globalConfig/cloud';
 import logger, { logRequestResponse } from '../../logger';
+import type { FetchOptions } from './types';
+
+const gzipAsync = promisify(gzip);
 
 function isConnectionError(error: Error) {
   return (
@@ -12,21 +17,37 @@ function isConnectionError(error: Error) {
 }
 
 /**
- * Enhanced fetch wrapper that adds logging, authentication, and error handling
+ * Enhanced fetch wrapper that adds logging, authentication, error handling, and optional compression
  */
 
 export async function monkeyPatchFetch(
   url: string | URL | Request,
-  options?: RequestInit,
+  options?: FetchOptions,
 ): Promise<Response> {
   const NO_LOG_URLS = [R_ENDPOINT, CONSENT_ENDPOINT, EVENTS_ENDPOINT];
   const headers = (options?.headers as Record<string, string>) || {};
   const isSilent = headers['x-promptfoo-silent'] === 'true';
   const logEnabled = !NO_LOG_URLS.some((logUrl) => url.toString().startsWith(logUrl)) && !isSilent;
 
-  const opts = {
+  const opts: RequestInit = {
     ...options,
   };
+
+  const originalBody = opts.body;
+
+  // Handle compression if requested
+  if (options?.compress && opts.body && typeof opts.body === 'string') {
+    try {
+      const compressed = await gzipAsync(opts.body);
+      opts.body = compressed as BodyInit;
+      opts.headers = {
+        ...(opts.headers || {}),
+        'Content-Encoding': 'gzip',
+      };
+    } catch (e) {
+      logger.warn(`Failed to compress request body: ${e}`);
+    }
+  }
 
   if (
     (typeof url === 'string' && url.startsWith(CLOUD_API_HOST)) ||
@@ -45,7 +66,7 @@ export async function monkeyPatchFetch(
     if (logEnabled) {
       logRequestResponse({
         url: url.toString(),
-        requestBody: opts.body,
+        requestBody: originalBody,
         requestMethod: opts.method || 'GET',
         response,
       });

--- a/src/util/fetch/types.ts
+++ b/src/util/fetch/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Extended RequestInit options with additional features
+ */
+export interface FetchOptions extends RequestInit {
+  /**
+   * Whether to compress the request body using gzip
+   */
+  compress?: boolean;
+}

--- a/test/commands/export.test.ts
+++ b/test/commands/export.test.ts
@@ -43,6 +43,7 @@ jest.mock('fs', () => ({
 
 jest.mock('zlib', () => ({
   createGzip: jest.fn(),
+  gzip: jest.fn(),
 }));
 
 jest.mock('../../src/database', () => ({


### PR DESCRIPTION
We're running into some massive evals where the config is > 50mb with 30k tests. This makes for a massive http request. Using gzip compresses that down to 8mb which is much more manageable.  This is not an ideal solution but that would require a major re-work of our data model which is not in the cards right now.


Added it as an option in our fetch so it can be re-used other places in the future if needed.