### PR TITLE
fix: improve OpenAI embedding provider error handling

### DIFF
--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -27,7 +27,10 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       model: this.modelName,
     };
 
-    let data, status, statusText;
+    let data: any;
+    let status: number | undefined;
+    let statusText: string | undefined;
+    let deleteFromCache: (() => Promise<void>) | undefined;
     let cached = false;
     try {
       const response = await fetchWithCache(
@@ -47,7 +50,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
         false,
         this.config.maxRetries,
       );
-      ({ data, cached, status, statusText } = response as any);
+      ({ data, cached, status, statusText, deleteFromCache } = response as any);
 
       // Check HTTP status like chat provider
       if (status < 200 || status >= 300) {
@@ -57,7 +60,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       }
     } catch (err) {
       logger.error(`API call error: ${String(err)}`);
-      await data?.deleteFromCache?.();
+      await deleteFromCache?.();
       return {
         error: `API call error: ${String(err)}`,
       };
@@ -76,7 +79,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       };
     } catch (err) {
       logger.error(`Response parsing error: ${String(err)}`);
-      await data?.deleteFromCache?.();
+      await deleteFromCache?.();
       return {
         error: `API error: ${String(err)}: ${JSON.stringify(data)}`,
       };

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -53,9 +53,9 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
       ({ data, cached, status, statusText, deleteFromCache } = response as any);
 
       // Check HTTP status like chat provider
-      if (status < 200 || status >= 300) {
+      if (status && (status < 200 || status >= 300)) {
         return {
-          error: `API error: ${status} ${statusText}\n${typeof data === 'string' ? data : JSON.stringify(data)}`,
+          error: `API error: ${status} ${statusText || 'Unknown error'}\n${typeof data === 'string' ? data : JSON.stringify(data)}`,
         };
       }
     } catch (err) {

--- a/test/providers/openai/embedding.test.ts
+++ b/test/providers/openai/embedding.test.ts
@@ -86,19 +86,23 @@ describe('OpenAI Provider', () => {
       const originalEnv = process.env.OPENAI_API_KEY;
       delete process.env.OPENAI_API_KEY;
 
-      const providerNoKey = new OpenAiEmbeddingProvider('text-embedding-3-large', {
-        config: {},
-      });
+      try {
+        const providerNoKey = new OpenAiEmbeddingProvider('text-embedding-3-large', {
+          config: {},
+        });
 
-      const result = await providerNoKey.callEmbeddingApi('test text');
-      expect(result.error).toBe(
-        'API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
-      );
-      expect(result.embedding).toBeUndefined();
-
-      // Restore original environment
-      if (originalEnv) {
-        process.env.OPENAI_API_KEY = originalEnv;
+        const result = await providerNoKey.callEmbeddingApi('test text');
+        expect(result.error).toBe(
+          'API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
+        );
+        expect(result.embedding).toBeUndefined();
+      } finally {
+        // Always restore original environment state
+        if (originalEnv !== undefined) {
+          process.env.OPENAI_API_KEY = originalEnv;
+        } else {
+          delete process.env.OPENAI_API_KEY;
+        }
       }
     });
   });

--- a/test/providers/openai/embedding.test.ts
+++ b/test/providers/openai/embedding.test.ts
@@ -53,7 +53,53 @@ describe('OpenAI Provider', () => {
     it('should handle API errors', async () => {
       jest.mocked(fetchWithCache).mockRejectedValue(new Error('API error'));
 
-      await expect(provider.callEmbeddingApi('test text')).rejects.toThrow('API error');
+      const result = await provider.callEmbeddingApi('test text');
+      expect(result.error).toBe('API call error: Error: API error');
+      expect(result.embedding).toBeUndefined();
+    });
+
+    it('should validate input type', async () => {
+      const result = await provider.callEmbeddingApi({ message: 'test' } as any);
+      expect(result.error).toBe(
+        'Invalid input type for embedding API. Expected string, got object. Input: {"message":"test"}',
+      );
+      expect(result.embedding).toBeUndefined();
+    });
+
+    it('should handle HTTP error status', async () => {
+      jest.mocked(fetchWithCache).mockResolvedValue({
+        data: { error: { message: 'Unauthorized' } },
+        cached: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const result = await provider.callEmbeddingApi('test text');
+      expect(result.error).toBe(
+        'API error: 401 Unauthorized\n{"error":{"message":"Unauthorized"}}',
+      );
+      expect(result.embedding).toBeUndefined();
+    });
+
+    it('should validate API key', async () => {
+      // Clear any environment variables that might provide an API key
+      const originalEnv = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+
+      const providerNoKey = new OpenAiEmbeddingProvider('text-embedding-3-large', {
+        config: {},
+      });
+
+      const result = await providerNoKey.callEmbeddingApi('test text');
+      expect(result.error).toBe(
+        'API key is not set. Set the OPENAI_API_KEY environment variable or add `apiKey` to the provider config.',
+      );
+      expect(result.embedding).toBeUndefined();
+
+      // Restore original environment
+      if (originalEnv) {
+        process.env.OPENAI_API_KEY = originalEnv;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add input type validation to catch objects early with clear error messages
- Add API key validation before making requests
- Add HTTP status code checking (200-299 range)
- Change from throwing exceptions to returning error objects
- Follow same error handling patterns as chat provider
- Add proper cache cleanup on errors

## Test plan
- [x] All existing tests pass
- [x] New comprehensive tests added for all error scenarios
- [x] Tests pass in random order confirming no interdependencies
- [x] Manual testing confirms fast failure with clear error messages
- [x] Build and linting checks pass

Resolves issues where invalid API keys or malformed inputs would result in unhelpful "Request failed after 4 retries: undefined" error messages. Now returns immediate, actionable error messages.