### PR TITLE
fix: suppress verbose error logging for update check timeouts

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -10,7 +10,13 @@ import { fetchWithTimeout } from './util/fetch';
 const execAsync = promisify(exec);
 
 export async function getLatestVersion() {
-  const response = await fetchWithTimeout(`https://api.promptfoo.dev/api/latestVersion`, {}, 10000);
+  const response = await fetchWithTimeout(
+    `https://api.promptfoo.dev/api/latestVersion`,
+    {
+      headers: { 'x-promptfoo-silent': 'true' },
+    },
+    10000,
+  );
   if (!response.ok) {
     throw new Error(`Failed to fetch package information for promptfoo`);
   }
@@ -49,7 +55,13 @@ ${border}\n`,
 
 export async function getModelAuditLatestVersion(): Promise<string | null> {
   try {
-    const response = await fetchWithTimeout('https://pypi.org/pypi/modelaudit/json', {}, 10000);
+    const response = await fetchWithTimeout(
+      'https://pypi.org/pypi/modelaudit/json',
+      {
+        headers: { 'x-promptfoo-silent': 'true' },
+      },
+      10000,
+    );
     if (!response.ok) {
       return null;
     }

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -111,7 +111,7 @@ describe('getModelAuditLatestVersion', () => {
     expect(version).toBe('0.1.7');
     expect(fetchWithTimeout).toHaveBeenCalledWith(
       'https://pypi.org/pypi/modelaudit/json',
-      {},
+      { headers: { 'x-promptfoo-silent': 'true' } },
       10000,
     );
   });


### PR DESCRIPTION
## Summary
- Add `x-promptfoo-silent` header to update check API requests to suppress ugly error logging
- Fixes verbose stack traces appearing when version check APIs timeout 
- Update corresponding test expectations

## Test plan
- [x] Manually tested timeout scenario - no more ugly errors
- [x] All existing update tests pass
- [x] Linting and formatting checks pass

## Before
```
Error in fetch: {
  "stack": "AbortError: This operation was aborted\n    at node:internal/deps/undici/undici:13502:13..."
} AbortError: This operation was aborted
```

## After  
Clean output with no error logging when update checks timeout (as intended).