### PR TITLE
chore(webui): Clearer vulnerability report primary cta

### DIFF
--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -570,54 +570,6 @@ const App = () => {
     setSearchQuery('');
   };
 
-  const ActionButtons = () => (
-    <>
-      <Tooltip title="View all logs" placement="top">
-        <IconButton
-          sx={{ position: 'relative' }}
-          aria-label="view all logs"
-          onClick={(event) => {
-            const url = `/eval/${evalId}`;
-            if (event.ctrlKey || event.metaKey) {
-              window.open(url, '_blank');
-            } else if (evalId) {
-              navigate(url);
-            }
-          }}
-        >
-          <ListAltIcon />
-        </IconButton>
-      </Tooltip>
-      <ReportDownloadButton
-        evalDescription={evalData.config.description || evalId}
-        evalData={evalData}
-      />
-      <Tooltip
-        title="Print this page (Ctrl+P) and select 'Save as PDF' for best results"
-        placement="top"
-      >
-        <IconButton
-          sx={{ position: 'relative' }}
-          aria-label="print page"
-          onClick={() => window.print()}
-        >
-          <PrintIcon />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Filter results" placement="top">
-        <IconButton
-          sx={{ position: 'relative' }}
-          aria-label="filter results"
-          onClick={() => setIsFiltersVisible(!isFiltersVisible)}
-          color={hasActiveFilters ? 'primary' : 'default'}
-        >
-          <FilterListIcon />
-        </IconButton>
-      </Tooltip>
-      <ReportSettingsDialogButton />
-    </>
-  );
-
   return (
     <>
       <Box
@@ -661,7 +613,14 @@ const App = () => {
               {evalData.config.description && `: ${evalData.config.description}`}
             </Typography>
             <Box sx={{ display: 'flex', flexShrink: 0 }}>
-              <ActionButtons />
+              <Button
+                variant="contained"
+                color="primary"
+                href={`/eval/${evalId}`}
+                startIcon={<ListAltIcon />}
+              >
+                View Probes
+              </Button>
             </Box>
           </Box>
         </Container>
@@ -674,7 +633,14 @@ const App = () => {
               sx={{ position: 'absolute', top: 8, right: 8, display: 'flex' }}
               className="print-hide"
             >
-              <ActionButtons />
+              <Button
+                variant="contained"
+                color="primary"
+                href={`/eval/${evalId}`}
+                startIcon={<ListAltIcon />}
+              >
+                View Probes
+              </Button>
             </Box>
             <Typography variant="h4">
               <strong>LLM Risk Assessment</strong>
@@ -744,6 +710,37 @@ const App = () => {
                   style={{ cursor: 'pointer' }}
                 />
               )}
+            </Box>
+            <Box sx={{ mt: 2 }}>
+              <Stack direction="row" spacing={0.25}>
+                <ReportDownloadButton
+                  evalDescription={evalData.config.description || evalId}
+                  evalData={evalData}
+                />
+                <Tooltip
+                  title="Print this page (Ctrl+P) and select 'Save as PDF' for best results"
+                  placement="top"
+                >
+                  <IconButton
+                    sx={{ position: 'relative' }}
+                    aria-label="print page"
+                    onClick={() => window.print()}
+                  >
+                    <PrintIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Filter results" placement="top">
+                  <IconButton
+                    sx={{ position: 'relative' }}
+                    aria-label="filter results"
+                    onClick={() => setIsFiltersVisible(!isFiltersVisible)}
+                    color={hasActiveFilters ? 'primary' : 'default'}
+                  >
+                    <FilterListIcon />
+                  </IconButton>
+                </Tooltip>
+                <ReportSettingsDialogButton />
+              </Stack>
             </Box>
           </Card>
           {isFiltersVisible && (


### PR DESCRIPTION
Received feedback from Lily that that primary CTA – viewing probe logs – was non-obvious (she was unable to find it). This PR distinguishes the primary CTA from the other CTAs in content, style, and layout.

**Before**

<img width="1507" height="182" alt="image" src="https://github.com/user-attachments/assets/e1af2c54-d984-4c47-aa15-bb9ac168a27b" />

**After**

<img width="1503" height="233" alt="image" src="https://github.com/user-attachments/assets/492e091f-8255-4884-8fa6-f24b78f168dc" />
