### PR TITLE
fix: ensure python and js providers have appropriate path prefix

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CustomTargetConfiguration from './CustomTargetConfiguration';
+
+import type { ProviderOptions } from '../../types';
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  const theme = createTheme({ palette: { mode: 'light' } });
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+describe('CustomTargetConfiguration', () => {
+  describe('file:// prefix handling', () => {
+    it('should add file:// prefix to Python file paths', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: '/path/to/script.py' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'file:///path/to/script.py');
+    });
+
+    it('should add file:// prefix to JavaScript file paths', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: '/path/to/provider.js' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'file:///path/to/provider.js');
+    });
+
+    it('should not add file:// prefix if already present', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: 'file:///path/to/script.py' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'file:///path/to/script.py');
+    });
+
+    it('should not modify non-Python/JavaScript provider IDs', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: 'openai:gpt-4' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'openai:gpt-4');
+    });
+
+    it('should handle relative Python paths', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: './provider.py' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'file://./provider.py');
+    });
+
+    it('should strip file:// prefix for display', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: 'file:///path/to/script.py',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i) as HTMLInputElement;
+      expect(input.value).toBe('/path/to/script.py');
+    });
+
+    it('should handle HTTP provider IDs without modification', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: 'http://example.com/api' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'http://example.com/api');
+    });
+  });
+});

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.test.tsx
@@ -180,5 +180,56 @@ describe('CustomTargetConfiguration', () => {
 
       expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'http://example.com/api');
     });
+
+    it('should add file:// prefix to Python paths with custom function names', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: '/path/to/script.py:custom_func' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith(
+        'id',
+        'file:///path/to/script.py:custom_func',
+      );
+    });
+
+    it('should add file:// prefix to JavaScript paths with custom function names', () => {
+      const mockUpdateCustomTarget = vi.fn();
+      const mockSetRawConfigJson = vi.fn();
+      const selectedTarget: ProviderOptions = {
+        id: '',
+        config: {},
+      };
+
+      renderWithTheme(
+        <CustomTargetConfiguration
+          selectedTarget={selectedTarget}
+          updateCustomTarget={mockUpdateCustomTarget}
+          rawConfigJson="{}"
+          setRawConfigJson={mockSetRawConfigJson}
+          bodyError={null}
+        />,
+      );
+
+      const input = screen.getByLabelText(/Target ID/i);
+      fireEvent.change(input, { target: { value: './provider.js:myFunc' } });
+
+      expect(mockUpdateCustomTarget).toHaveBeenCalledWith('id', 'file://./provider.js:myFunc');
+    });
   });
 });

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
@@ -23,16 +23,23 @@ const CustomTargetConfiguration = ({
   setRawConfigJson,
   bodyError,
 }: CustomTargetConfigurationProps) => {
-  const [targetId, setTargetId] = useState(selectedTarget.id || '');
+  const [targetId, setTargetId] = useState(selectedTarget.id?.replace('file://', '') || '');
 
   useEffect(() => {
-    setTargetId(selectedTarget.id || '');
+    setTargetId(selectedTarget.id?.replace('file://', '') || '');
   }, [selectedTarget.id]);
 
   const handleTargetIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newId = e.target.value;
-    setTargetId(newId);
-    updateCustomTarget('id', newId);
+    const value = e.target.value;
+    setTargetId(value);
+
+    let idToSave = value;
+    if (value && (value.endsWith('.py') || value.endsWith('.js'))) {
+      if (!value.startsWith('file://')) {
+        idToSave = `file://${value}`;
+      }
+    }
+    updateCustomTarget('id', idToSave);
   };
 
   return (

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomTargetConfiguration.tsx
@@ -34,10 +34,14 @@ const CustomTargetConfiguration = ({
     setTargetId(value);
 
     let idToSave = value;
-    if (value && (value.endsWith('.py') || value.endsWith('.js'))) {
-      if (!value.startsWith('file://')) {
-        idToSave = `file://${value}`;
-      }
+    if (
+      value &&
+      !value.startsWith('file://') &&
+      !value.startsWith('http://') &&
+      !value.startsWith('https://') &&
+      (value.includes('.py') || value.includes('.js'))
+    ) {
+      idToSave = `file://${value}`;
     }
     updateCustomTarget('id', idToSave);
   };


### PR DESCRIPTION
## Summary
Fixes an issue where Python and JavaScript provider file paths created through the UI would lose their `file://` prefix, causing "Could not identify provider" errors when running `npx promptfoo redteam run` from the CLI.

## Changes
  - **CustomTargetConfiguration.tsx**: Auto-add `file://` prefix for `.py` and `.js` paths, strip for display
  - **CustomTargetConfiguration.test.tsx**: Added comprehensive test coverage (7 tests)

  ## Tests
  - ✅ All new tests passing (7/7)
  - ✅ Existing tests passing
  - ✅ Lint and format checks passing