### PR TITLE
chore(watsonx): update default granite model to granite-3-3-8b-instruct

### DIFF
--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -81,7 +81,7 @@ providers:
 | [Web Browser](./browser.md)                         | Custom - Automate web browser interactions                   | `browser`                                                                 |
 | [Sequence](./sequence.md)                           | Custom - Multi-prompt sequencing                             | `sequence` with config.inputs array                                       |
 | [Simulated User](./simulated-user.md)               | Custom - Conversation simulator                              | `promptfoo:simulated-user`                                                |
-| [WatsonX](./watsonx.md)                             | IBM's WatsonX                                                | `watsonx:ibm/granite-13b-chat-v2`                                         |
+| [WatsonX](./watsonx.md)                             | IBM's WatsonX                                                | `watsonx:ibm/granite-3-3-8b-instruct`                                     |
 | [X.AI](./xai.md)                                    | X.AI's models                                                | `xai:grok-3-beta`                                                         |
 
 ## Provider Syntax

--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -97,7 +97,7 @@ To install the WatsonX provider, use the following steps:
 
    ```yaml
    providers:
-     - id: watsonx:ibm/granite-13b-chat-v2
+     - id: watsonx:ibm/granite-3-3-8b-instruct
        config:
          # Option 1: IAM Authentication
          apiKey: your-ibm-cloud-api-key
@@ -115,7 +115,7 @@ Once configured, you can use the WatsonX provider to generate text responses bas
 
 ```yaml
 providers:
-  - watsonx:ibm/granite-13b-chat-v2 # for Meta models, use watsonx:meta-llama/llama-3-2-1b-instruct
+  - watsonx:ibm/granite-3-3-8b-instruct # for Meta models, use watsonx:meta-llama/llama-3-2-1b-instruct
 
 prompts:
   - "Answer the following question: '{{question}}'"

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
@@ -760,7 +760,7 @@ export default function ProviderTypeSelector({
     } else if (value === 'watsonx') {
       setProvider(
         {
-          id: 'watsonx:ibm/granite-13b-chat-v2',
+          id: 'watsonx:ibm/granite-3-3-8b-instruct',
           config: {},
           label: currentLabel,
         },

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -481,7 +481,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
         name: '[WatsonX] Llama, IBM Granite, ...',
         value: [
           'watsonx:meta-llama/llama-3-2-11b-vision-instruct',
-          'watsonx:ibm/granite-13b-chat-v2',
+          'watsonx:ibm/granite-3-3-8b-instruct',
         ],
       },
     ];


### PR DESCRIPTION
# Summary

granite-13b-chat-v2 has been withdrawn from watsonx as of February, the recommended replacement is granite-3-8b-instruct. I am suggesting we bump to granite 3.3 8b as it is newer

https://www.ibm.com/docs/en/watsonx/saas?topic=model-foundation-lifecycle

## Notes

there are some references to the old model in the bam provider but I'm not familiar with this provider. Might be worth tagging the contributor for the bam provider

Thank you!