### PR TITLE
fix: Ensure that `-filter-failing` correctly filters failing tests when re-running an eval

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -18,11 +18,11 @@ import { collectFileMetadata, renderPrompt, runExtensionHook } from './evaluator
 import logger from './logger';
 import { selectMaxScore } from './matchers';
 import { generateIdFromPrompt } from './models/prompt';
+import { CIProgressReporter } from './progress/ciProgressReporter';
 import { maybeEmitAzureOpenAiWarning } from './providers/azure/warnings';
 import { isPromptfooSampleTarget } from './providers/shared';
 import { generatePrompts } from './suggestions';
 import telemetry from './telemetry';
-import { CIProgressReporter } from './progress/ciProgressReporter';
 import {
   generateTraceContextIfNeeded,
   isOtlpReceiverStarted,

--- a/test/commands/eval/filterFailingBug.test.ts
+++ b/test/commands/eval/filterFailingBug.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Test for the --filter-failing bug where test.vars gets mutated
+ * during evaluation, causing mismatches when trying to filter failing tests.
+ *
+ * Bug: When evaluation adds runtime vars like _conversation to test.vars,
+ * it mutates the original test object. This mutated test is stored in results.
+ * On subsequent runs with --filter-failing, freshly loaded tests don't have
+ * these runtime vars, so deepEqual comparison fails.
+ */
+
+import { filterTests } from '../../../src/commands/eval/filterTests';
+import Eval from '../../../src/models/eval';
+import { ResultFailureReason } from '../../../src/types';
+
+import type { TestSuite } from '../../../src/types';
+
+jest.mock('../../../src/models/eval', () => ({
+  findById: jest.fn(),
+}));
+
+describe('filterTests - vars mutation bug', () => {
+  it('should match tests even when stored results have additional runtime vars', async () => {
+    // Simulate a test suite as it would be loaded from config
+    const mockTestSuite: TestSuite = {
+      prompts: [],
+      providers: [],
+      tests: [
+        {
+          description: 'test1',
+          vars: { input: 'hello', language: 'en' },
+          assert: [],
+        },
+        {
+          description: 'test2',
+          vars: { input: 'goodbye', language: 'en' },
+          assert: [],
+        },
+        {
+          description: 'test3',
+          vars: { input: 'thanks', language: 'en' },
+          assert: [],
+        },
+      ],
+    };
+
+    // Simulate stored results where test.vars was mutated with _conversation
+    // This is what happens in the bug - the runtime adds _conversation to vars
+    const mockEval = {
+      id: 'eval-123',
+      createdAt: new Date().getTime(),
+      config: {},
+      results: [],
+      resultsCount: 0,
+      prompts: [],
+      persisted: true,
+      toEvaluateSummary: jest.fn().mockResolvedValue({
+        version: 2,
+        timestamp: new Date().toISOString(),
+        results: [
+          {
+            // This test failed and has the original vars
+            vars: { input: 'hello', language: 'en' },
+            success: false,
+            failureReason: ResultFailureReason.ASSERT,
+            testCase: {
+              description: 'test1',
+              // Bug: stored testCase.vars has _conversation added
+              vars: { input: 'hello', language: 'en', _conversation: [] },
+              assert: [],
+            },
+          },
+          {
+            // This test also failed
+            vars: { input: 'thanks', language: 'en' },
+            success: false,
+            failureReason: ResultFailureReason.ERROR,
+            testCase: {
+              description: 'test3',
+              // Bug: stored testCase.vars has _conversation added
+              vars: { input: 'thanks', language: 'en', _conversation: [] },
+              assert: [],
+            },
+          },
+        ],
+        table: { head: { prompts: [], vars: [] }, body: [] },
+        stats: {
+          successes: 0,
+          failures: 0,
+          errors: 0,
+          tokenUsage: {
+            total: 0,
+            prompt: 0,
+            completion: 0,
+            cached: 0,
+            numRequests: 0,
+            completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+          },
+        },
+      }),
+    };
+
+    jest.mocked(Eval.findById).mockResolvedValue(mockEval as any);
+
+    // When filtering failing tests, it should match based on the original vars
+    // not fail because of the extra _conversation property
+    const result = await filterTests(mockTestSuite, { failing: 'eval-123' });
+
+    // Should find both failing tests
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.description)).toEqual(['test1', 'test3']);
+  });
+});


### PR DESCRIPTION
## Summary

Relates to https://github.com/promptfoo/promptfoo/issues/5755

## Description

Minimal reproduction here:
 <details>

<summary>promptfooconfig.yaml</summary>

```yaml
description: 'Bug reproduction: --filter-failing not matching tests correctly'

prompts:
  - 'Translate "{{input}}" to {{language}}: {{_conversation}}'

providers:
  - python:provider.py

tests:
  - description: 'Test 1 - Should pass'
    vars:
      input: 'Hello'
      language: 'French'
    assert:
      - type: contains
        value: 'Bonjour'

  - description: 'Test 2 - Should fail (expects wrong translation)'
    vars:
      input: 'Goodbye'
      language: 'French'
    assert:
      - type: contains
        value: 'Salut' # Wrong - will fail since output is "Bonjour"

  - description: 'Test 3 - Should pass'
    vars:
      input: 'Thank you'
      language: 'French'
    assert:
      - type: contains
        value: 'Bonjour'

  - description: 'Test 4 - Should fail (expects wrong output)'
    vars:
      input: 'Good morning'
      language: 'French'
    assert:
      - type: contains
        value: 'Au revoir' # Wrong - will fail

  - description: 'Test 5 - Should fail (expects wrong output)'
    vars:
      input: 'Good night'
      language: 'Spanish'
    assert:
      - type: equals
        value: 'Hola' # Wrong - will fail
```

</details>

<details><summary>provider.py</summary>

```python
"""Simple mock provider that returns a fixed response."""


def call_api(prompt, options=None, context=None):
    """Always return Bonjour as the translation."""
    return {"output": "Bonjour"}

```

</details>

When evaluation runs, it adds runtime variables (like `_conversation`) to `test.vars`, mutating the original test object. This mutated test is saved in the results. On subsequent runs with `--filter-failing`, freshly loaded tests don't have these runtime vars, so the deep equality comparison fails and tests don't match. This fixes the check by filtering out meta vars.