### PR TITLE
chore: update DeepSeek provider to V3.2-Exp

### DIFF
--- a/site/docs/providers/deepseek.md
+++ b/site/docs/providers/deepseek.md
@@ -41,23 +41,25 @@ providers:
 
 :::note
 
-The API model names are aliases that automatically point to the latest versions: `deepseek-chat` points to DeepSeek-V3-0324 and `deepseek-reasoner` points to DeepSeek-R1-0528.
+As of September 29, 2025, both `deepseek-chat` and `deepseek-reasoner` have been upgraded to use **DeepSeek-V3.2-Exp**, featuring significant cost reductions (50% lower pricing) and improved efficiency through DeepSeek Sparse Attention (DSA) technology.
 
 :::
 
-### deepseek-chat (DeepSeek-V3)
+### deepseek-chat (DeepSeek-V3.2-Exp)
 
+- Non-thinking mode of DeepSeek-V3.2-Exp
 - General purpose model for conversations and content
 - 64K context window, 8K output tokens
-- Input: $0.07/1M (cache), $0.27/1M (no cache)
-- Output: $1.10/1M
+- Input: $0.028/1M (cache hit), $0.28/1M (cache miss)
+- Output: $0.42/1M
 
-### deepseek-reasoner (DeepSeek-R1)
+### deepseek-reasoner (DeepSeek-V3.2-Exp)
 
+- Thinking mode of DeepSeek-V3.2-Exp
 - Specialized for reasoning and problem-solving
 - 64K context, 32K reasoning tokens, 8K output tokens
-- Input: $0.14/1M (cache), $0.55/1M (no cache)
-- Output: $2.19/1M
+- Input: $0.028/1M (cache hit), $0.28/1M (cache miss)
+- Output: $0.42/1M
 - Supports showing or hiding reasoning content through the `showThinking` parameter
 
 :::warning

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -463,6 +463,7 @@ export const providerMap: ProviderFactory[] = [
       context: LoadApiProviderContext,
     ) => {
       const splits = providerPath.split(':');
+      // As of Sept 2025, deepseek-chat and deepseek-reasoner are upgraded to DeepSeek-V3.2-Exp
       const modelName = splits.slice(1).join(':') || 'deepseek-chat';
       return new OpenAiChatCompletionProvider(modelName, {
         ...providerOptions,


### PR DESCRIPTION
Update documentation and code comments to reflect DeepSeek V3.2-Exp release:
- deepseek-chat and deepseek-reasoner now use V3.2-Exp models
- Updated pricing reflecting 50% cost reduction
- Input: $0.028/1M (cache hit), $0.28/1M (cache miss)
- Output: $0.42/1M
- Added clarification about thinking vs non-thinking modes
- Noted DeepSeek Sparse Attention (DSA) technology
