### PR TITLE
fix(site): add metadata key to the provider response class

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -231,6 +231,7 @@ class ProviderResponse:
     cost: Optional[float]
     cached: Optional[bool]
     logProbs: Optional[List[float]]
+    metadata: Optional[Dict[str, Any]]
 
 class ProviderEmbeddingResponse:
     embedding: List[float]


### PR DESCRIPTION
The metadata field (Dict[str, Any]) is now documented in the Python provider ProviderResponse type definition. This field allows providers to return arbitrary metadata that will be displayed in the Metadata tab of the evaluation output dialog drawer in the web UI.

The metadata is rendered in a key-value table format via the MetadataPanel component, making it easy for users to inspect additional provider-specific information such as HTTP headers, request details, or custom debugging data.