### PR TITLE
fix(webui): prevent empty state flash when loading large evals

### DIFF
--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -196,10 +196,10 @@ export default function Eval({ fetchId }: EvalOptions) {
       const run = async () => {
         const success = await loadEvalById(fetchId);
         if (success) {
-          setLoaded(true);
           setDefaultEvalId(fetchId);
           // Load other recent eval runs
           fetchRecentFileEvals();
+          // Note: setLoaded(true) is handled by the useEffect that watches for table updates
         }
       };
       run();
@@ -271,8 +271,8 @@ export default function Eval({ fetchId }: EvalOptions) {
           const defaultEvalId = evals[0].evalId;
           const success = await loadEvalById(defaultEvalId);
           if (success) {
-            setLoaded(true);
             setDefaultEvalId(defaultEvalId);
+            // Note: setLoaded(true) is handled by the useEffect that watches for table updates
           }
         } else {
           // No evals exist - clear stale state and show empty state


### PR DESCRIPTION
## Summary
- Fixes race condition causing empty state to briefly flash before large eval results load
- Removes premature `setLoaded(true)` calls that occurred before table construction completed
- Relies on existing useEffect (line 318) to properly set loaded state only after table is ready

## Problem
In commit aeac4d3c45c1093a82583f6888b4227b81135fee, the loading behavior was updated to show an improved empty state. However, this introduced a race condition:

1. When loading a large eval, `loadEvalById()` would return successfully and set `loaded = true`
2. But the table construction (an expensive operation) might still be in progress, so `table = null`
3. The render logic would pass the `!loaded` check, then hit `!table` and show EmptyState
4. Shortly after, table construction completes and the eval finally renders
5. Result: brief flash of the empty state screen

## Solution
The code already has a useEffect at line 318-322 that watches for table updates and sets `loaded = true` when the table is constructed. This fix removes the duplicate/premature `setLoaded(true)` calls, ensuring loaded state is only set when data is actually ready to display.

## Test plan
- [x] Existing tests pass
- [x] Lint and format checks pass  
- [x] Build succeeds
- Manual testing: Load a large eval and verify no empty state flash occurs