### PR TITLE
chore: add /index to directory imports for ESM compatibility

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,7 +6,7 @@ import { getEnvBool, getEnvInt, getEnvString } from './envars';
 import logger from './logger';
 import { REQUEST_TIMEOUT_MS } from './providers/shared';
 import { getConfigDirectoryPath } from './util/config/manage';
-import { fetchWithRetries } from './util/fetch';
+import { fetchWithRetries } from './util/fetch/index';
 import type { Cache } from 'cache-manager';
 
 let cacheInstance: Cache | undefined;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,7 +9,7 @@ import { VERSION } from '../constants';
 import logger from '../logger';
 import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
-import { fetchWithProxy } from '../util/fetch';
+import { fetchWithProxy } from '../util/fetch/index';
 import { promptfooCommand } from '../util/promptfooCommand';
 import type { Command } from 'commander';
 

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import dedent from 'dedent';
 import { getUserEmail } from './globalConfig/accounts';
 import logger from './logger';
-import { fetchWithProxy } from './util/fetch';
+import { fetchWithProxy } from './util/fetch/index';
 import { promptUser } from './util/readline';
 
 /**

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -1,7 +1,7 @@
 import logger from './logger';
 
 import type { CsvRow } from './types/index';
-import { fetchWithProxy } from './util/fetch';
+import { fetchWithProxy } from './util/fetch/index';
 
 export async function checkGoogleSheetAccess(url: string) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { evaluate as doEvaluate } from './evaluator';
 import guardrails from './guardrails';
 import { runDbMigrations } from './migrate';
 import Eval from './models/eval';
-import { processPrompts, readProviderPromptMap } from './prompts';
+import { processPrompts, readProviderPromptMap } from './prompts/index';
 import { loadApiProvider, loadApiProviders, resolveProvider } from './providers/index';
 import { doGenerateRedteam } from './redteam/commands/generate';
 import { extractEntities } from './redteam/extraction/entities';

--- a/src/integrations/helicone.ts
+++ b/src/integrations/helicone.ts
@@ -1,5 +1,5 @@
 import { getEnvString } from '../envars';
-import { fetchWithProxy } from '../util/fetch';
+import { fetchWithProxy } from '../util/fetch/index';
 
 const heliconeApiKey = getEnvString('HELICONE_API_KEY');
 

--- a/src/integrations/portkey.ts
+++ b/src/integrations/portkey.ts
@@ -1,5 +1,5 @@
 import { getEnvString } from '../envars';
-import { fetchWithProxy } from '../util/fetch';
+import { fetchWithProxy } from '../util/fetch/index';
 import invariant from '../util/invariant';
 
 interface PortkeyResponse {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -18,7 +18,7 @@ import {
   OPENAI_CLOSED_QA_PROMPT,
   PROMPTFOO_FACTUALITY_PROMPT,
   SELECT_BEST_PROMPT,
-} from './prompts';
+} from './prompts/index';
 import { loadApiProvider } from './providers/index';
 import { getDefaultProviders } from './providers/defaults';
 import { LLAMA_GUARD_REPLICATE_PROVIDER } from './redteam/constants';

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
-import { getDb } from './database';
+import { getDb } from './database/index';
 import logger from './logger';
 
 /**

--- a/src/providers/azure/moderation.ts
+++ b/src/providers/azure/moderation.ts
@@ -1,7 +1,7 @@
 import { getCache, isCacheEnabled } from '../../cache';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import { REQUEST_TIMEOUT_MS } from '../shared';
 import { AzureGenericProvider } from './generic';
 

--- a/src/providers/promptfooModel.ts
+++ b/src/providers/promptfooModel.ts
@@ -1,6 +1,6 @@
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
-import { fetchWithProxy } from '../util/fetch';
+import { fetchWithProxy } from '../util/fetch/index';
 
 import type {
   ApiProvider,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -58,7 +58,7 @@ import {
   LocalAiEmbeddingProvider,
 } from './localai';
 import { ManualInputProvider } from './manualInput';
-import { MCPProvider } from './mcp';
+import { MCPProvider } from './mcp/index';
 import { MistralChatCompletionProvider, MistralEmbeddingProvider } from './mistral';
 import { OllamaChatProvider, OllamaCompletionProvider, OllamaEmbeddingProvider } from './ollama';
 import { OpenAiAssistantProvider } from './openai/assistant';

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -6,7 +6,7 @@ import yaml from 'js-yaml';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import telemetry from '../../telemetry';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import { setupEnv } from '../../util/index';
 import { getRemoteGenerationUrl } from '../remoteGeneration';
 import type { Command } from 'commander';

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -25,11 +25,11 @@ import {
 } from './constants';
 import { extractEntities } from './extraction/entities';
 import { extractSystemPurpose } from './extraction/purpose';
-import { Plugins } from './plugins';
+import { Plugins } from './plugins/index';
 import { CustomPlugin } from './plugins/custom';
 import { redteamProviderManager } from './providers/shared';
 import { getRemoteHealthUrl, shouldGenerateRemote } from './remoteGeneration';
-import { loadStrategy, Strategies, validateStrategies } from './strategies';
+import { loadStrategy, Strategies, validateStrategies } from './strategies/index';
 import { DEFAULT_LANGUAGES } from './strategies/multilingual';
 import { extractGoalFromPrompt, getShortPluginId } from './util';
 

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -5,7 +5,7 @@ import { VERSION } from '../../constants';
 import { renderPrompt } from '../../evaluatorHelpers';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -4,7 +4,7 @@ import { VERSION } from '../../constants';
 import { renderPrompt } from '../../evaluatorHelpers';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { safeJsonStringify } from '../../util/json';
 import { getNunjucksEngine } from '../../util/templates';

--- a/src/redteam/strategies/index.ts
+++ b/src/redteam/strategies/index.ts
@@ -23,7 +23,7 @@ import { addMathPrompt } from './mathPrompt';
 import { addMischievousUser } from './mischievousUser';
 import { addMultilingual } from './multilingual';
 import { addOtherEncodings, EncodingType } from './otherEncodings';
-import { addInjections } from './promptInjections';
+import { addInjections } from './promptInjections/index';
 import { addRetryTestCases } from './retry';
 import { addRot13 } from './rot13';
 import { addAudioToBase64 } from './simpleAudio';

--- a/src/server/routes/providers.ts
+++ b/src/server/routes/providers.ts
@@ -11,7 +11,7 @@ import {
   type TargetPurposeDiscoveryResult,
 } from '../../redteam/commands/discover';
 import { neverGenerateRemote } from '../../redteam/remoteGeneration';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { ProviderOptionsSchema } from '../../validators/providers';
 import type { Request, Response } from 'express';

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -7,7 +7,7 @@ import { Plugins } from '../../redteam/plugins/index';
 import { redteamProviderManager } from '../../redteam/providers/shared';
 import { getRemoteGenerationUrl } from '../../redteam/remoteGeneration';
 import { doRedteamRun } from '../../redteam/shared';
-import { fetchWithProxy } from '../../util/fetch';
+import { fetchWithProxy } from '../../util/fetch/index';
 import { evalJobs } from './eval';
 import type { Request, Response } from 'express';
 

--- a/src/share.ts
+++ b/src/share.ts
@@ -9,7 +9,7 @@ import { getUserEmail, setUserEmail } from './globalConfig/accounts';
 import { cloudConfig } from './globalConfig/cloud';
 import logger, { isDebugEnabled } from './logger';
 import { checkCloudPermissions, makeRequest as makeCloudRequest } from './util/cloud';
-import { fetchWithProxy } from './util/fetch';
+import { fetchWithProxy } from './util/fetch/index';
 
 import type Eval from './models/eval';
 import type EvalResult from './models/evalResult';

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,4 +1,4 @@
-import { SUGGEST_PROMPTS_SYSTEM_MESSAGE } from './prompts';
+import { SUGGEST_PROMPTS_SYSTEM_MESSAGE } from './prompts/index';
 import { DefaultSuggestionsProvider } from './providers/openai/defaults';
 
 import type { TokenUsage } from './types/index';

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,7 +5,7 @@ import { POSTHOG_KEY } from './constants/build';
 import { getEnvBool, getEnvString, isCI } from './envars';
 import { getUserEmail, getUserId, isLoggedIntoCloud } from './globalConfig/accounts';
 import logger from './logger';
-import { fetchWithProxy, fetchWithTimeout } from './util/fetch';
+import { fetchWithProxy, fetchWithTimeout } from './util/fetch/index';
 
 export const TelemetryEventSchema = z.object({
   event: z.enum([

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -5,7 +5,7 @@ import semverGt from 'semver/functions/gt';
 import { TERMINAL_MAX_WIDTH, VERSION } from './constants';
 import { getEnvBool } from './envars';
 import logger from './logger';
-import { fetchWithTimeout } from './util/fetch';
+import { fetchWithTimeout } from './util/fetch/index';
 
 const execAsync = promisify(exec);
 

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { Command } from 'commander';
 import { importCommand } from '../../src/commands/import';
-import { getDb } from '../../src/database';
+import { getDb } from '../../src/database/index';
 import logger from '../../src/logger';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';

--- a/test/database/index.test.ts
+++ b/test/database/index.test.ts
@@ -7,7 +7,7 @@ import {
   getDbPath,
   getDbSignalPath,
   isDbOpen,
-} from '../../src/database';
+} from '../../src/database/index';
 import { getEnvBool } from '../../src/envars';
 import logger from '../../src/logger';
 import { getConfigDirectoryPath } from '../../src/util/config/manage';

--- a/test/factories/evalFactory.ts
+++ b/test/factories/evalFactory.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 
 import { ResultFailureReason } from '../../src';
-import { getDb } from '../../src/database';
+import { getDb } from '../../src/database/index';
 import { evalsTable } from '../../src/database/tables';
 import Eval from '../../src/models/eval';
 import { oldStyleEval } from './data/eval/database_records';

--- a/test/matchers/answer-relevance.test.ts
+++ b/test/matchers/answer-relevance.test.ts
@@ -1,5 +1,5 @@
 import { matchesAnswerRelevance } from '../../src/matchers';
-import { ANSWER_RELEVANCY_GENERATE } from '../../src/prompts';
+import { ANSWER_RELEVANCY_GENERATE } from '../../src/prompts/index';
 import {
   DefaultEmbeddingProvider,
   DefaultGradingProvider,

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1,4 +1,4 @@
-import { getDb } from '../../src/database';
+import { getDb } from '../../src/database/index';
 import { getUserEmail } from '../../src/globalConfig/accounts';
 import { runDbMigrations } from '../../src/migrate';
 import Eval, { EvalQueries, getEvalSummaries } from '../../src/models/eval';

--- a/test/models/evalHighlights.test.ts
+++ b/test/models/evalHighlights.test.ts
@@ -1,4 +1,4 @@
-import { getDb } from '../../src/database';
+import { getDb } from '../../src/database/index';
 import { ResultFailureReason } from '../../src/types';
 import { runDbMigrations } from '../../src/migrate';
 import { queryTestIndicesOptimized } from '../../src/models/evalPerformance';

--- a/test/prompts/index.test.ts
+++ b/test/prompts/index.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import dedent from 'dedent';
 import { globSync } from 'glob';
 import { importModule } from '../../src/esm';
-import { processPrompts, readPrompts, readProviderPromptMap } from '../../src/prompts';
+import { processPrompts, readPrompts, readProviderPromptMap } from '../../src/prompts/index';
 import { maybeFilePath } from '../../src/prompts/utils';
 
 import type { ApiProvider, Prompt, ProviderResponse, UnifiedConfig } from '../../src/types/index';

--- a/test/prompts/wildcard.test.ts
+++ b/test/prompts/wildcard.test.ts
@@ -1,4 +1,4 @@
-import { processPrompts } from '../../src/prompts';
+import { processPrompts } from '../../src/prompts/index';
 
 // Mock the python execution
 jest.mock('../../src/python/pythonUtils', () => ({

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import dotenv from 'dotenv';
 import { globSync } from 'glob';
-import { getDb } from '../../src/database';
+import { getDb } from '../../src/database/index';
 import * as googleSheets from '../../src/googleSheets';
 import Eval from '../../src/models/eval';
 import {


### PR DESCRIPTION
## Summary
Add explicit `/index` suffix to imports from directories that contain index.ts files. This is a preparatory step for ESM migration (PR 3a/3b from the ESM migration strategy).

## Changes
- `./util/fetch` → `./util/fetch/index`
- `./prompts` → `./prompts/index` (for src/prompts directory)
- `./database` → `./database/index`
- `./plugins` → `./plugins/index` (for src/redteam/plugins directory)
- `./strategies` → `./strategies/index` (for src/redteam/strategies directory)
- `./promptInjections` → `./promptInjections/index`
- `./mcp` → `./mcp/index`

## Why
This change improves module resolution clarity and prepares the codebase for future ESM support. While CommonJS tolerates directory imports without the `/index` suffix, making this explicit now:
1. Makes imports more explicit and easier to understand
2. Prepares for ESM where this distinction may matter more
3. Is backwards compatible with current CommonJS build

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] All imports resolve correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)