### PR TITLE
refactor(webui): remove delimiter stripping logic from EvalOutputCell

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -151,18 +151,10 @@ function EvalOutputCell({
       .filter((reason) => reason); // Filter out empty/undefined reasons
   }
 
-  // Handle failure messages by splitting the text at '---' if present
-  if (text && text.includes('---')) {
-    text = text.split('---').slice(1).join('---');
-  }
 
   if (showDiffs && firstOutput) {
     let firstOutputText =
       typeof firstOutput.text === 'string' ? firstOutput.text : JSON.stringify(firstOutput.text);
-
-    if (firstOutputText.includes('---')) {
-      firstOutputText = firstOutputText.split('---').slice(1).join('---');
-    }
 
     let diffResult;
     try {


### PR DESCRIPTION
Remove the '---' delimiter stripping logic from the web UI component since fail reasons are already extracted directly from componentResults array and displayed via FailReasonCarousel. This logic was redundant in the web UI and is only needed for CLI display formatting.