### PR TITLE
test: fix vitest timeout error in EvalOutputPromptDialog tests

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -18,9 +18,9 @@ vi.mock('./Citations', () => ({
 vi.mock('./DebuggingPanel', () => {
   const MockDebuggingPanel = vi.fn((props) => {
     if (props.onTraceSectionVisibilityChange) {
-      setTimeout(() => {
+      queueMicrotask(() => {
         props.onTraceSectionVisibilityChange(false);
-      }, 0);
+      });
     }
     return (
       <div data-testid="mock-debugging-panel" data-prompt-index={props.promptIndex}>


### PR DESCRIPTION
## Summary
- Fixed `ReferenceError: window is not defined` error in EvalOutputPromptDialog tests
- Replaced `setTimeout` with `queueMicrotask` in DebuggingPanel mock

## Test plan
- [x] All 30 tests in EvalOutputPromptDialog.test.tsx pass
- [x] No unhandled errors after test teardown