### PR TITLE
fix(provider): merge config and prompt systemInstruction instead of throwing error in gemini

### DIFF
--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -752,7 +752,10 @@ export function geminiFormatAndSystemInstructions(
 
   let systemInstruction: Content | undefined = parsedSystemInstruction;
 
-  const parsedConfigInstruction = parseConfigSystemInstruction(configSystemInstruction, contextVars);
+  const parsedConfigInstruction = parseConfigSystemInstruction(
+    configSystemInstruction,
+    contextVars,
+  );
   if (parsedConfigInstruction) {
     systemInstruction = systemInstruction
       ? { parts: [...parsedConfigInstruction.parts, ...systemInstruction.parts] }

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -1034,7 +1034,7 @@ describe('util', () => {
     it('should merge system messages from both prompt and config with string config', () => {
       const prompt = [
         { role: 'system', content: 'prompt system instruction' },
-        { role: 'user', content: 'user message' }
+        { role: 'user', content: 'user message' },
       ];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
@@ -1043,17 +1043,14 @@ describe('util', () => {
       );
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
       expect(systemInstruction).toEqual({
-        parts: [
-          { text: 'config system instruction' },
-          { text: 'prompt system instruction' }
-        ]
+        parts: [{ text: 'config system instruction' }, { text: 'prompt system instruction' }],
       });
     });
 
     it('should merge system messages from both prompt and config with object config', () => {
       const prompt = [
         { role: 'system', content: 'prompt system instruction' },
-        { role: 'user', content: 'user message' }
+        { role: 'user', content: 'user message' },
       ];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
@@ -1062,26 +1059,20 @@ describe('util', () => {
       );
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
       expect(systemInstruction).toEqual({
-        parts: [
-          { text: 'config system instruction' },
-          { text: 'prompt system instruction' }
-        ]
+        parts: [{ text: 'config system instruction' }, { text: 'prompt system instruction' }],
       });
     });
 
     it('should merge multiple parts from config systemInstruction', () => {
       const prompt = [
         { role: 'system', content: 'prompt system instruction' },
-        { role: 'user', content: 'user message' }
+        { role: 'user', content: 'user message' },
       ];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
         {},
         {
-          parts: [
-            { text: 'config system instruction 1' },
-            { text: 'config system instruction 2' }
-          ]
+          parts: [{ text: 'config system instruction 1' }, { text: 'config system instruction 2' }],
         },
       );
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
@@ -1089,8 +1080,8 @@ describe('util', () => {
         parts: [
           { text: 'config system instruction 1' },
           { text: 'config system instruction 2' },
-          { text: 'prompt system instruction' }
-        ]
+          { text: 'prompt system instruction' },
+        ],
       });
     });
 
@@ -1098,7 +1089,7 @@ describe('util', () => {
       const prompt = [
         { role: 'system', content: 'prompt system instruction 1' },
         { role: 'system', content: 'prompt system instruction 2' },
-        { role: 'user', content: 'user message' }
+        { role: 'user', content: 'user message' },
       ];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
@@ -1110,15 +1101,13 @@ describe('util', () => {
         parts: [
           { text: 'config system instruction' },
           { text: 'prompt system instruction 1' },
-          { text: 'prompt system instruction 2' }
-        ]
+          { text: 'prompt system instruction 2' },
+        ],
       });
     });
 
     it('should render Nunjucks templates in config systemInstruction', () => {
-      const prompt = [
-        { role: 'user', content: 'user message' }
-      ];
+      const prompt = [{ role: 'user', content: 'user message' }];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
         { role: 'a helpful assistant', language: 'Japanese' },
@@ -1126,16 +1115,14 @@ describe('util', () => {
       );
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
       expect(systemInstruction).toEqual({
-        parts: [
-          { text: 'You are a helpful assistant. Respond in Japanese.' }
-        ]
+        parts: [{ text: 'You are a helpful assistant. Respond in Japanese.' }],
       });
     });
 
     it('should skip empty string config systemInstruction', () => {
       const prompt = [
         { role: 'system', content: 'prompt system instruction' },
-        { role: 'user', content: 'user message' }
+        { role: 'user', content: 'user message' },
       ];
       const { contents, systemInstruction } = geminiFormatAndSystemInstructions(
         JSON.stringify(prompt),
@@ -1145,9 +1132,7 @@ describe('util', () => {
       expect(contents).toEqual([{ parts: [{ text: 'user message' }], role: 'user' }]);
       // Empty string is falsy, so config systemInstruction is not processed
       expect(systemInstruction).toEqual({
-        parts: [
-          { text: 'prompt system instruction' }
-        ]
+        parts: [{ text: 'prompt system instruction' }],
       });
     });
 


### PR DESCRIPTION
resolves #5822 

Previously, when both config.systemInstruction and prompt system role existed, the Gemini provider would throw an error. This changes the behavior to merge both instructions with config parts first, followed by prompt parts.

Changes:
- Extract parseConfigSystemInstruction() helper function for cleaner code
- Merge systemInstruction parts instead of rejecting the combination

---

And it works with this repro.

```yaml
# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json

prompts:
- What is 2+2?

providers:
- vertex:gemini-2.5-flash

defaultTest:
  options:
    provider:
      id: vertex:gemini-2.5-flash
      config:
        systemInstruction: |
          You are a pirate.
          You MUST respond to EVERY question using pirate language with 'Arrr', 'matey', 'ye', etc.
          Never use normal English.

tests:
- assert:
  - type: llm-rubric
    value: |
      Evaluate the output
      Score of 0.0: Response does not answer the math question
      Score of 0.5: Response answers the math question
      Score of 1.0: Response answers the math question correctly (the answer is 4)
    threshold: 1.0
```

<img width="1900" height="583" alt="image" src="https://github.com/user-attachments/assets/187e03e9-0154-4625-89b6-48c4e7755e5d" />
