### PR TITLE
test: add mock cleanup to Python provider tests

### DIFF
--- a/test/providers/pythonCompletion.fileRef.test.ts
+++ b/test/providers/pythonCompletion.fileRef.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import logger from '../../src/logger';
 import { PythonProvider } from '../../src/providers/pythonCompletion';
+import * as pythonUtils from '../../src/python/pythonUtils';
 import { runPython } from '../../src/python/pythonUtils';
 import { parsePathOrGlob } from '../../src/util/index';
 import { processConfigFileReferences } from '../../src/util/fileReference';
@@ -24,6 +25,9 @@ jest.mock('../../src/util/fileReference', () => ({
 describe('PythonProvider with file references', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    // Reset Python state to avoid test interference
+    pythonUtils.state.cachedPythonPath = null;
+    pythonUtils.state.validationPromise = null;
 
     jest.mocked(logger.debug).mockImplementation(
       () =>

--- a/test/providers/pythonCompletion.test.ts
+++ b/test/providers/pythonCompletion.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { getCache, isCacheEnabled } from '../../src/cache';
 import { PythonProvider } from '../../src/providers/pythonCompletion';
+import * as pythonUtils from '../../src/python/pythonUtils';
 import { runPython } from '../../src/python/pythonUtils';
 
 jest.mock('../../src/python/pythonUtils');
@@ -41,6 +42,11 @@ describe('PythonProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mocked implementations to avoid test interference
+    mockRunPython.mockReset();
+    // Reset Python state to avoid test interference
+    pythonUtils.state.cachedPythonPath = null;
+    pythonUtils.state.validationPromise = null;
     mockGetCache.mockResolvedValue({
       get: jest.fn(),
       set: jest.fn(),

--- a/test/providers/pythonCompletion.unicode.test.ts
+++ b/test/providers/pythonCompletion.unicode.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from '@jest/globals';
 import { PythonProvider } from '../../src/providers/pythonCompletion';
 import type { CallApiContextParams } from '../../src/types/index';
+import * as pythonUtils from '../../src/python/pythonUtils';
 import { runPython } from '../../src/python/pythonUtils';
 
 // Mock the expensive Python execution for fast, reliable tests
@@ -20,6 +21,11 @@ describe('PythonProvider Unicode handling', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mocked implementations to avoid test interference
+    mockRunPython.mockReset();
+    // Reset Python state to avoid test interference
+    pythonUtils.state.cachedPythonPath = null;
+    pythonUtils.state.validationPromise = null;
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-unicode-test-'));
   });
 


### PR DESCRIPTION
## Summary

Apply the same mock reset and state cleanup pattern from PR #5824 to all Python provider and wrapper tests to prevent test interference and timeouts on Windows.

## Context

After fixing the flaky Python assertion tests in #5824, discovered that the Python provider tests (`pythonCompletion.*.test.ts`) also needed the same mock cleanup pattern to prevent intermittent timeouts. Additionally, the `wrapper.test.ts` race condition tests were timing out on Windows Node 22.x.

## Changes

**Python Provider Tests:**
- Added `mockReset()` for `runPython` mock in `beforeEach` hooks
- Reset `pythonUtils.state` (`cachedPythonPath`, `validationPromise`) between tests
- Applied to:
  - `pythonCompletion.test.ts`
  - `pythonCompletion.unicode.test.ts`  
  - `pythonCompletion.fileRef.test.ts`

**Wrapper Race Condition Tests:**
- Mock `tryPath` and `getSysExecutable` at module level to prevent actual Python detection
- Prevents hanging on Windows when tests try to find Python on the system
- Tests now use mocked implementations instead of actual system calls

## Why This Helps

Mock implementations set with `mockResolvedValue()` persist across tests unless explicitly reset. The `pythonUtils.state` cache also persists. This can cause:
- Test interference when running with `--randomize`
- Timeouts on Windows due to actual Python detection hanging
- Inconsistent behavior depending on test execution order

## Test Results

✅ All Python tests pass consistently on all platforms (Node 20, 22, 24 on Windows, macOS, Ubuntu)
✅ No more race condition test timeouts on Windows Node 22.x

## Related

- #5824 - Original Python test flakiness fix