### PR TITLE
chore: remove outdated license notice

### DIFF
--- a/src/app/src/pages/redteam/README.md
+++ b/src/app/src/pages/redteam/README.md
@@ -1,1 +1,0 @@
-Code in this directory is subject to a commercial license. See LICENSE.md.


### PR DESCRIPTION
Removes outdated license notice from redteam UI directory. The entire project is MIT licensed.