### PR TITLE
docs: add warning against using commit --amend and force push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,8 @@ Always follow this workflow:
 
    NEVER blindly `git add` everything - there might be other unrelated files lying around.
 
+   **NEVER use `git commit --amend` or `git push --force` unless explicitly asked by the user.**
+
 3. **Push and create PR**:
 
    ```bash


### PR DESCRIPTION
Add explicit warning in Git Workflow section to never use `git commit --amend` or `git push --force` unless explicitly requested by the user.

This helps prevent accidental force pushes and history rewrites without user consent.