### PR TITLE
fix: Show response headers in test target results

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TestSection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TestSection.tsx
@@ -36,6 +36,8 @@ const TestSection: React.FC<TestSectionProps> = ({
   handleTestTarget,
   disabled,
 }) => {
+  const responseHeaders = testResult?.providerResponse?.metadata?.http?.headers;
+
   return (
     <Paper elevation={1} sx={{ mt: 3, p: 3, backgroundColor: 'background.default' }}>
       <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 'bold' }}>
@@ -276,29 +278,24 @@ const TestSection: React.FC<TestSectionProps> = ({
                   {testResult.providerResponse && testResult.providerResponse.raw !== undefined ? (
                     <>
                       {/* Response Headers */}
-                      {testResult.providerResponse?.metadata?.headers &&
-                        Object.keys(testResult.providerResponse.metadata.headers).length > 0 && (
-                          <>
-                            <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-                              Response Headers:
-                            </Typography>
-                            <Box sx={{ mb: 2, maxHeight: '200px', overflow: 'auto' }}>
-                              <pre
-                                style={{
-                                  margin: '4px 0',
-                                  fontSize: '12px',
-                                  overflowWrap: 'anywhere',
-                                }}
-                              >
-                                {JSON.stringify(
-                                  testResult.providerResponse.metadata.headers,
-                                  null,
-                                  2,
-                                )}
-                              </pre>
-                            </Box>
-                          </>
-                        )}
+                      {responseHeaders && Object.keys(responseHeaders).length > 0 && (
+                        <>
+                          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+                            Response Headers:
+                          </Typography>
+                          <Box sx={{ mb: 2, maxHeight: '200px', overflow: 'auto' }}>
+                            <pre
+                              style={{
+                                margin: '4px 0',
+                                fontSize: '12px',
+                                overflowWrap: 'anywhere',
+                              }}
+                            >
+                              {JSON.stringify(responseHeaders, null, 2)}
+                            </pre>
+                          </Box>
+                        </>
+                      )}
 
                       <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
                         Raw Response:


### PR DESCRIPTION
Unfortunately, this was looking at the wrong path. 

<img width="1248" height="727" alt="Screenshot 2025-10-07 at 8 48 42 AM" src="https://github.com/user-attachments/assets/0a18a78f-662b-498b-a312-07eb240ba9a2" />
