### PR TITLE
fix: double sharing red teams

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -21,19 +21,19 @@ import { generateTable } from '../table';
 import telemetry from '../telemetry';
 import { CommandLineOptionsSchema, OutputFileExtension, TestSuiteSchema } from '../types/index';
 import { isApiProvider } from '../types/providers';
-import { printBorder, setupEnv, writeMultipleOutputs } from '../util/index';
-import { promptfooCommand } from '../util/promptfooCommand';
 import { checkCloudPermissions } from '../util/cloud';
 import { clearConfigCache, loadDefaultConfig } from '../util/config/default';
 import { resolveConfigs } from '../util/config/load';
 import { maybeLoadFromExternalFile } from '../util/file';
 import { formatDuration } from '../util/formatDuration';
+import { printBorder, setupEnv, writeMultipleOutputs } from '../util/index';
 import invariant from '../util/invariant';
+import { promptfooCommand } from '../util/promptfooCommand';
 import { TokenUsageTracker } from '../util/tokenUsage';
 import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { filterProviders } from './eval/filterProviders';
 import { filterTests } from './eval/filterTests';
-import { getErrorResultIds, deleteErrorResults, recalculatePromptMetrics } from './retry';
+import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './share';
 import type { Command } from 'commander';
 
@@ -538,7 +538,9 @@ export async function doEval(
 
     const shareableUrl =
       wantsToShare && isSharingEnabled(evalRecord) ? await createShareableUrl(evalRecord) : null;
-
+    if (shareableUrl) {
+      evalRecord.shared = true;
+    }
     let successes = 0;
     let failures = 0;
     let errors = 0;

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -177,6 +177,7 @@ export default class Eval {
   vars: string[];
   _resultsLoaded: boolean = false;
   runtimeOptions?: Partial<import('../types').EvaluateOptions>;
+  _shared: boolean = false;
 
   static async latest() {
     const db = getDb();
@@ -901,6 +902,14 @@ export default class Eval {
       db.delete(evalResultsTable).where(eq(evalResultsTable.evalId, this.id)).run();
       db.delete(evalsTable).where(eq(evalsTable.id, this.id)).run();
     });
+  }
+
+  get shared() {
+    return this._shared;
+  }
+
+  set shared(shared: boolean) {
+    this._shared = shared;
   }
 }
 

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -6,10 +6,9 @@ import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { doEval } from '../commands/eval';
 import logger, { setLogCallback, setLogLevel } from '../logger';
-import { createShareableUrl } from '../share';
-import { promptfooCommand } from '../util/promptfooCommand';
 import { checkRemoteHealth } from '../util/apiHealth';
 import { loadDefaultConfig } from '../util/config/default';
+import { promptfooCommand } from '../util/promptfooCommand';
 import { doGenerateRedteam } from './commands/generate';
 import { getRemoteHealthUrl } from './remoteGeneration';
 
@@ -113,10 +112,7 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
   );
 
   logger.info(chalk.green('\nRed team scan complete!'));
-  if (options.loadedFromCloud) {
-    const url = await createShareableUrl(evalResult, false);
-    logger.info(`View results: ${chalk.greenBright.bold(url)}`);
-  } else {
+  if (!evalResult?.shared) {
     if (options.liveRedteamConfig) {
       logger.info(
         chalk.blue(


### PR DESCRIPTION
Red teams were being shared twice, once in the eval flow and once in the red team run command code. This removes that second share and relies on the eval code to share it properly.