### PR TITLE
feat: map content filter response to guardrails output

### DIFF
--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -5,23 +5,22 @@ import cliState from '../../cliState';
 import { getEnvFloat, getEnvInt, getEnvString } from '../../envars';
 import { importModule } from '../../esm';
 import logger from '../../logger';
-import { maybeLoadToolsFromExternalFile, renderVarsInObject } from '../../util/index';
-import { maybeLoadFromExternalFile } from '../../util/file';
-import { isJavascriptFile } from '../../util/fileExtensions';
-import { normalizeFinishReason } from '../../util/finishReason';
-import { MCPClient } from '../mcp/client';
-import { transformMCPToolsToOpenAi } from '../mcp/transform';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS } from '../shared';
-import { OpenAiGenericProvider } from '.';
-import { calculateOpenAICost, getTokenUsage, OPENAI_CHAT_MODELS } from './util';
-
+import type { EnvOverrides } from '../../types/env';
 import type {
   CallApiContextParams,
   CallApiOptionsParams,
   ProviderResponse,
 } from '../../types/index';
-import type { EnvOverrides } from '../../types/env';
+import { maybeLoadFromExternalFile } from '../../util/file';
+import { isJavascriptFile } from '../../util/fileExtensions';
+import { FINISH_REASON_MAP, normalizeFinishReason } from '../../util/finishReason';
+import { maybeLoadToolsFromExternalFile, renderVarsInObject } from '../../util/index';
+import { MCPClient } from '../mcp/client';
+import { transformMCPToolsToOpenAi } from '../mcp/transform';
+import { parseChatPrompt, REQUEST_TIMEOUT_MS } from '../shared';
+import { OpenAiGenericProvider } from './';
 import type { OpenAiCompletionOptions, ReasoningEffort } from './types';
+import { calculateOpenAICost, getTokenUsage, OPENAI_CHAT_MODELS } from './util';
 
 export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
   static OPENAI_CHAT_MODELS = OPENAI_CHAT_MODELS;
@@ -361,6 +360,10 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
             output: errorMessage,
             tokenUsage: data?.usage ? getTokenUsage(data, cached) : undefined,
             isRefusal: true,
+            guardrails: {
+              flagged: true,
+              flaggedInput: true, // This error specifically indicates input was rejected
+            },
           };
         }
 
@@ -380,14 +383,32 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       const message = data.choices[0].message;
       const finishReason = normalizeFinishReason(data.choices[0].finish_reason);
 
+      // Track content filtering for guardrails
+      const contentFiltered = finishReason === FINISH_REASON_MAP.content_filter;
+
       if (message.refusal) {
         return {
           output: message.refusal,
           tokenUsage: getTokenUsage(data, cached),
           isRefusal: true,
           ...(finishReason && { finishReason }),
+          guardrails: contentFiltered ? { flagged: true } : undefined,
         };
       }
+
+      // Check if content was filtered
+      if (contentFiltered) {
+        return {
+          output: message.content || 'Content filtered by provider',
+          tokenUsage: getTokenUsage(data, cached),
+          isRefusal: true,
+          finishReason: FINISH_REASON_MAP.content_filter,
+          guardrails: {
+            flagged: true,
+          },
+        };
+      }
+
       let output = '';
       if (message.reasoning) {
         output = message.reasoning;
@@ -522,6 +543,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
               data.usage?.audio_prompt_tokens,
               data.usage?.audio_completion_tokens,
             ),
+            ...(contentFiltered ? { guardrails: { flagged: true } } : {}),
           };
         }
       }
@@ -557,6 +579,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
             data.usage?.audio_prompt_tokens,
             data.usage?.audio_completion_tokens,
           ),
+          ...(contentFiltered ? { guardrails: { flagged: true } } : {}),
         };
       }
 
@@ -574,6 +597,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           data.usage?.audio_prompt_tokens,
           data.usage?.audio_completion_tokens,
         ),
+        ...(contentFiltered ? { guardrails: { flagged: true } } : {}),
       };
     } catch (err) {
       await data?.deleteFromCache?.();


### PR DESCRIPTION
## Add content_filter handling to OpenAI chat provider

OpenAI's chat completions API returns `finish_reason: "content_filter"` when content is filtered, but we weren't detecting it. This caused filtered responses to not be flagged as refusals in evals.

### Changes

- Detect `finish_reason: "content_filter"` and set `isRefusal: true` + `guardrails.flagged: true`
- Match Azure provider behavior for consistency
- Conservative approach: only set `flaggedInput` when certain (e.g., `invalid_prompt` error)

### Why

Client reported their Mistral endpoint returns `content_filter` finish_reason but promptfoo wasn't flagging it. This affects any OpenAI-compatible provider that implements content filtering per OpenAI spec.

### Testing

Added test case for `content_filter` detection. Updated existing `invalid_prompt` test to verify guardrails field.

Fixes redteam evaluations missing filtered responses on OpenAI-compatible providers.