### PR TITLE
fix(redteam): clean up multilingual strategy logging and fix chunk numbering

### DIFF
--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -177,7 +177,7 @@ async function generateMultilingual(
       progressBar.start(chunks.length, 0);
     }
 
-    await async.forEachOfLimit(chunks, maxConcurrency, async (chunkObj, index) => {
+    await async.forEachOfLimit(chunks, maxConcurrency, async (chunkObj, _index) => {
       const chunk = chunkObj.data;
       const chunkNum = chunkObj.chunkNum;
       try {


### PR DESCRIPTION
## Summary

Fixes three issues with the multilingual remote generation strategy:

### 1. Fixed chunk numbering
- Chunks now display sequential numbers (1, 2, 3...) regardless of concurrent execution order
- Previously showed array indices which appeared out of order (17, 19, 18...)

### 2. Reduced logging noise
- Moved all error/warn logs to debug level
- Removed confusing "24/8 test cases" ratio warnings (24=outputs, 8=inputs)
- Removed verbose retry attempt messages
- All failures now logged at debug level since automatic retries handle them

### 3. Added timeout diagnostics
- Tracks timeout rate across chunks
- Logs summary if significant (≥3 chunks or >20% timeout rate)
- Suggests tuning remoteChunkSize or maxConcurrency

### 4. Made chunk size configurable
- Users can now set `remoteChunkSize` in config
- Allows tuning performance vs reliability tradeoff

## Result
Progress bar now shows cleanly without spam. Only debug logs visible with `--verbose`.

## Testing
- All 38 existing multilingual tests pass
- Build succeeds