### PR TITLE
fix: restore correct cache matching behavior for test results

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -423,7 +423,8 @@ export function resultIsForTestCase(result: EvaluateResult, testCase: TestCase):
 
   // Filter out runtime variables like _conversation when matching
   // These are added during evaluation but shouldn't affect test matching
-  const resultVars = filterRuntimeVars(result.testCase?.vars ?? result.vars);
+  // Use result.vars (not result.testCase.vars) as it contains the actual vars used during evaluation
+  const resultVars = filterRuntimeVars(result.vars);
   const testVars = filterRuntimeVars(testCase.vars);
   return varsMatch(testVars, resultVars) && providersMatch;
 }

--- a/test/util/index.test.ts
+++ b/test/util/index.test.ts
@@ -475,6 +475,60 @@ describe('util', () => {
 
       expect(resultIsForTestCase(absolutePathResult, noPathTestCase)).toBe(true);
     });
+
+    it('matches when result.vars has runtime variables like _conversation', () => {
+      // This tests the fix for issue #5849 - cache behavior regression
+      // result.vars contains runtime variables that should be filtered out
+      const testCase: TestCase = {
+        provider: 'provider',
+        vars: {
+          input: 'hello',
+          language: 'en',
+        },
+      };
+
+      const result = {
+        provider: 'provider',
+        vars: {
+          input: 'hello',
+          language: 'en',
+          _conversation: [], // Runtime variable added during evaluation
+        },
+        testCase: {
+          vars: {
+            input: 'hello',
+            language: 'en',
+          },
+        },
+      } as any as EvaluateResult;
+
+      // Should match because _conversation is filtered out
+      expect(resultIsForTestCase(result, testCase)).toBe(true);
+    });
+
+    it('matches when result.vars has runtime variables and testCase also has them', () => {
+      // Edge case: both have runtime vars (shouldn't happen in practice but should still work)
+      const testCase: TestCase = {
+        provider: 'provider',
+        vars: {
+          input: 'hello',
+          language: 'en',
+          _conversation: [],
+        },
+      };
+
+      const result = {
+        provider: 'provider',
+        vars: {
+          input: 'hello',
+          language: 'en',
+          _conversation: [],
+        },
+      } as any as EvaluateResult;
+
+      // Should match because both have same vars after filtering
+      expect(resultIsForTestCase(result, testCase)).toBe(true);
+    });
   });
 
   describe('parsePathOrGlob', () => {


### PR DESCRIPTION
## Summary

Fixes a cache behavior regression introduced in PR #5770 where test results would not properly match cached entries, causing all tests to re-run instead of only failed/error tests.

## Root Cause

PR #5770 changed the `resultIsForTestCase()` function to use `result.testCase?.vars ?? result.vars` instead of `result.vars`. While this was intended to handle runtime variables, it introduced inconsistencies because `result.testCase.vars` is not always the source of truth for the actual variables used during evaluation.

## Changes

- **src/util/index.ts**: Changed line 427 to use `result.vars` (the actual vars from evaluation) instead of `result.testCase?.vars`
- **test/util/index.test.ts**: Added regression tests for runtime variable handling scenarios

## Why This Works

1. `result.vars` always contains the actual variables used during evaluation (source of truth)
2. `filterRuntimeVars()` already handles filtering out runtime-only variables like `_conversation`
3. This approach correctly handles both the original #5770 scenario and the #5849 regression

## Testing

- ✅ All existing tests pass (84/84 in util test suite)
- ✅ Original #5770 test still passes
- ✅ New regression tests added for issue #5849
- ✅ No breaking changes detected

## Verification

The fix ensures that:
- Successful tests are properly cached and not re-run
- Failed/error tests are correctly identified and re-executed
- Runtime variables don't interfere with cache matching

Fixes #5849
Related to #5770