### PR TITLE
test: add snowflake provider tests and environment variables

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -318,6 +318,10 @@ type EnvVars = {
   // Slack
   SLACK_BOT_TOKEN?: string;
 
+  // Snowflake
+  SNOWFLAKE_ACCOUNT_IDENTIFIER?: string;
+  SNOWFLAKE_API_KEY?: string;
+
   // Together AI
   TOGETHER_API_KEY?: string;
 

--- a/test/providers/snowflake.test.ts
+++ b/test/providers/snowflake.test.ts
@@ -1,0 +1,231 @@
+import { clearCache } from '../../src/cache';
+import { SnowflakeCortexProvider } from '../../src/providers/snowflake';
+
+jest.mock('../../src/cache', () => ({
+  fetchWithCache: jest.fn(),
+  clearCache: jest.fn(),
+  enableCache: jest.fn(),
+  disableCache: jest.fn(),
+  isCacheEnabled: jest.fn(),
+}));
+
+const mockFetchWithCache = jest.mocked(
+  require('../../src/cache').fetchWithCache,
+) as jest.MockedFunction<typeof import('../../src/cache').fetchWithCache>;
+
+describe('Snowflake Cortex Provider', () => {
+  afterEach(async () => {
+    await clearCache();
+    jest.clearAllMocks();
+    delete process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER;
+    delete process.env.SNOWFLAKE_API_KEY;
+  });
+
+  describe('initialization', () => {
+    it('should initialize with accountIdentifier from config', () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      expect(provider.modelName).toBe('mistral-large2');
+      expect(provider.id()).toBe('snowflake:mistral-large2');
+      expect(provider.toString()).toBe('[Snowflake Cortex Provider mistral-large2]');
+    });
+
+    it('should initialize with accountIdentifier from environment', () => {
+      process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER = 'myorg-myaccount';
+
+      const provider = new SnowflakeCortexProvider('claude-3-5-sonnet', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      expect(provider.modelName).toBe('claude-3-5-sonnet');
+    });
+
+    it('should throw error when accountIdentifier is not provided', () => {
+      expect(() => {
+        new SnowflakeCortexProvider('mistral-large2', {
+          config: {
+            apiKey: 'test-key',
+          },
+        });
+      }).toThrow('Snowflake provider requires an account identifier');
+    });
+
+    it('should use apiBaseUrl when provided instead of constructing from accountIdentifier', () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          apiBaseUrl: 'https://custom.snowflakecomputing.com',
+          apiKey: 'test-key',
+        },
+      });
+
+      expect(provider['getApiUrl']()).toBe('https://custom.snowflakecomputing.com');
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should serialize to JSON correctly', () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'secret-key',
+          temperature: 0.7,
+        },
+      });
+
+      const json = provider.toJSON();
+      expect(json).toEqual({
+        provider: 'snowflake',
+        model: 'mistral-large2',
+        config: expect.objectContaining({
+          temperature: 0.7,
+          apiKey: undefined,
+        }),
+      });
+    });
+  });
+
+  describe('callApi', () => {
+    beforeEach(() => {
+      process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER = 'myorg-myaccount';
+      process.env.SNOWFLAKE_API_KEY = 'test-key';
+    });
+
+    it('should call Snowflake Cortex API with correct endpoint', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      const mockResponse = {
+        choices: [
+          {
+            message: { content: 'Test response' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+      };
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: mockResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(mockFetchWithCache).toHaveBeenCalledWith(
+        'https://myorg-myaccount.snowflakecomputing.com/api/v2/cortex/inference:complete',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-key',
+          }),
+        }),
+        expect.any(Number),
+        'json',
+        undefined,
+      );
+
+      expect(result).toEqual({
+        output: 'Test response',
+        tokenUsage: {
+          total: 10,
+          prompt: 5,
+          completion: 5,
+        },
+        cached: false,
+        cost: undefined,
+        finishReason: 'stop',
+      });
+    });
+
+    it('should handle API errors', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: 'API error',
+        cached: false,
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.error).toContain('400 Bad Request');
+    });
+
+    it('should handle network errors', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      mockFetchWithCache.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.error).toContain('Network error');
+    });
+
+    it('should handle tool calls', async () => {
+      const provider = new SnowflakeCortexProvider('claude-3-5-sonnet', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_123',
+                  type: 'function',
+                  function: { name: 'test_function', arguments: '{"arg": "value"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+      };
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: mockResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.output).toEqual([
+        {
+          id: 'call_123',
+          type: 'function',
+          function: { name: 'test_function', arguments: '{"arg": "value"}' },
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Completes the Snowflake Cortex provider implementation from #5882 by adding missing tests and environment variable registration.

## Changes

- Add `SNOWFLAKE_ACCOUNT_IDENTIFIER` and `SNOWFLAKE_API_KEY` to `src/envars.ts`
- Add comprehensive unit tests for `SnowflakeCortexProvider` in `test/providers/snowflake.test.ts`
  - Initialization with config and environment variables
  - API endpoint construction
  - Error handling
  - Tool calls support

## Testing

All 9 tests pass with coverage and randomization:
```
npx jest test/providers/snowflake.test.ts --coverage --randomize
```