### PR TITLE
feat: add session-hooks-lifecycle example [draft]

### DIFF
--- a/examples/session-hooks-lifecycle/README.md
+++ b/examples/session-hooks-lifecycle/README.md
@@ -1,0 +1,447 @@
+# session-hooks-lifecycle (Session Management with Hooks)
+
+This example demonstrates how to manage stateful sessions using promptfoo's `beforeAll` and `afterAll` extension hooks with custom providers. It shows an alternative pattern to provider-level session management where the session lifecycle is controlled through hooks rather than within the provider itself.
+
+## Quick Start
+
+```bash
+npx promptfoo@latest init --example session-hooks-lifecycle
+```
+
+## What This Example Demonstrates
+
+- **Session Lifecycle Management**: Create sessions before tests run and clean them up afterward
+- **Shared State Pattern**: Share session information between hooks and custom providers
+- **Mock Service Implementation**: Simulate a stateful service that requires session management
+- **Cross-Language Support**: Both JavaScript and Python implementations following the same pattern
+- **Error Handling**: Graceful handling of session creation and cleanup failures
+
+## When to Use This Pattern
+
+### Use Session Hooks When:
+
+- **Shared Sessions**: Multiple providers need to share the same session
+- **Centralized Management**: Session lifecycle should be independent of provider logic
+- **Test Suite Scope**: Session should span the entire test suite, not individual tests
+- **External Dependencies**: Managing external services like database connections or API clients
+- **Complex Setup**: Session creation involves multiple steps or dependencies
+
+### Use Provider-Level Sessions When:
+
+- **Provider-Specific**: Each provider needs its own isolated session
+- **Tight Coupling**: Session logic is inherently part of the provider's functionality
+- **Per-Request Scope**: New sessions needed for each request or test
+- **Native Patterns**: Following a provider's built-in session management
+
+## Architecture
+
+The example follows a clean separation of concerns:
+
+```
+┌─────────────────┐
+│   beforeAll     │ ─── Creates Session ──→ ┌──────────────┐
+│      Hook       │                          │   Shared     │
+└─────────────────┘                          │    State     │
+                                            │ (sessionId)  │
+┌─────────────────┐                          └──────────────┘
+│ Custom Provider │ ←── Reads Session ────────┘      │
+│                 │                                   │
+│                 │ ─── Makes Requests ──→ ┌─────────▼────┐
+└─────────────────┘                        │   Session    │
+                                           │   Service    │
+┌─────────────────┐                        └─────────▲────┘
+│    afterAll     │ ←── Closes Session ──────────────┘
+│      Hook       │
+└─────────────────┘
+```
+
+## How It Works
+
+### 1. Session Service Initialization
+
+The `beforeAll` hook runs before any tests:
+- Initializes the mock session service
+- Creates a new session for the test user
+- Stores the session ID in shared state
+
+### 2. Provider Uses Session
+
+Each test runs with the custom provider:
+- Provider checks for active session in shared state
+- Makes requests using the session context
+- Session maintains conversation history
+
+### 3. Session Cleanup
+
+The `afterAll` hook runs after all tests:
+- Retrieves session statistics
+- Closes the active session
+- Cleans up shared state
+
+## Running the Examples
+
+### JavaScript Version
+
+```bash
+cd examples/session-hooks-lifecycle
+npm run local -- eval -c promptfooconfig.yaml
+```
+
+Expected output:
+```
+=== Session Lifecycle Hook: Setting up ===
+SessionService initialized
+Session created for user test-user-123: a1b2c3d4...
+✓ Session created successfully: a1b2c3d4...
+✓ User ID: test-user-123
+===========================================
+
+[Test execution...]
+
+=== Session Lifecycle Hook: Cleaning up ===
+✓ Session stats: {"active_sessions":1,"total_requests":3}
+Closing session a1b2c3d4... for user test-user-123
+  Total requests: 3
+  Duration: 523ms
+✓ Session closed: a1b2c3d4...
+============================================
+```
+
+### Python Version
+
+```bash
+npm run local -- eval -c promptfooconfig-python.yaml
+```
+
+The Python version provides identical functionality with Python-idiomatic implementation.
+
+### Setting a Custom User ID
+
+```bash
+TEST_USER_ID=production-user npm run local -- eval -c promptfooconfig.yaml
+```
+
+## Code Structure
+
+### JavaScript Implementation
+
+**sessionService.js**: Mock service simulating a stateful API
+```javascript
+class SessionService {
+  createSession(userId) { /* Creates session */ }
+  makeRequest(sessionId, prompt) { /* Processes requests */ }
+  closeSession(sessionId) { /* Cleanup */ }
+}
+```
+
+**sessionProvider.js**: Custom provider using shared state
+```javascript
+const sharedState = { sessionId: null };
+
+class SessionProvider {
+  async callApi(prompt, context) {
+    if (!sharedState.sessionId) {
+      throw new Error('No active session');
+    }
+    // Use session for request
+  }
+}
+```
+
+**sessionHooks.js**: Lifecycle management
+```javascript
+async function sessionHook(hookName, context) {
+  if (hookName === 'beforeAll') {
+    // Create session, store in sharedState
+  } else if (hookName === 'afterAll') {
+    // Clean up session
+  }
+}
+```
+
+### Python Implementation
+
+The Python version follows the same pattern with Python-specific adaptations:
+- Uses `asyncio` for async operations
+- Type hints for better IDE support
+- File-based persistence for cross-process communication
+- Session data stored as JSON files in temp directory
+
+**Important:** Since Python providers run in separate processes, the Python implementation uses:
+- File-based session storage (`/tmp/promptfoo_sessions/`)
+- Persistent session state file (`/tmp/promptfoo_session_state.json`)
+- This ensures session data is accessible across process boundaries
+
+## Extending This Example
+
+### Real-World Use Cases
+
+#### 1. Database Connection Pool
+
+Replace the mock service with actual database connection:
+
+```javascript
+// sessionService.js
+const { Pool } = require('pg');
+
+class DatabaseSessionService {
+  async createSession(userId) {
+    this.pool = new Pool({ /* config */ });
+    await this.pool.connect();
+    return this.pool;
+  }
+
+  async closeSession() {
+    await this.pool.end();
+  }
+}
+```
+
+#### 2. OAuth Session Management
+
+Manage OAuth tokens across tests:
+
+```javascript
+class OAuthSessionService {
+  async createSession(userId) {
+    const token = await this.authenticate(userId);
+    this.tokens.set(sessionId, token);
+    return sessionId;
+  }
+
+  async makeRequest(sessionId, endpoint) {
+    const token = this.tokens.get(sessionId);
+    return fetch(endpoint, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+  }
+}
+```
+
+#### 3. Browser Automation Session
+
+Control a browser instance for testing:
+
+```javascript
+const puppeteer = require('puppeteer');
+
+class BrowserSessionService {
+  async createSession() {
+    this.browser = await puppeteer.launch();
+    this.page = await this.browser.newPage();
+    return this.page;
+  }
+
+  async closeSession() {
+    await this.browser.close();
+  }
+}
+```
+
+#### 4. WebSocket Connection
+
+Maintain WebSocket connections:
+
+```javascript
+class WebSocketSessionService {
+  createSession(url) {
+    this.ws = new WebSocket(url);
+    return new Promise(resolve => {
+      this.ws.on('open', () => resolve(this.ws));
+    });
+  }
+
+  closeSession() {
+    this.ws.close();
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### "No active session found" Error
+
+**Problem**: Provider can't find the session
+```
+Error: No active session found. Make sure beforeAll hook ran successfully.
+```
+
+**Solutions**:
+1. Ensure extensions are configured in `promptfooconfig.yaml`
+2. Check that the hook file exports the correct function
+3. Verify shared state is properly imported in both files
+
+#### Session Not Cleaned Up
+
+**Problem**: Sessions remain open after tests
+
+**Solutions**:
+1. Check for errors in test execution that might skip `afterAll`
+2. Add error handling in the cleanup hook
+3. Consider using process exit handlers for critical cleanup
+
+#### Python Import Errors
+
+**Problem**: "ModuleNotFoundError: No module named 'session_service'"
+
+**Solutions**:
+1. Ensure all Python files are in the same directory
+2. Check that file names match import statements
+3. Verify Python path includes the current directory
+
+#### Session State Not Persisting
+
+**Problem**: Each test seems to get a new session
+
+**Solutions**:
+1. Verify you're using `beforeAll` not `beforeEach`
+2. Check that shared state is properly exported/imported
+3. Ensure provider reads from shared state, not creating new sessions
+
+### Debug Tips
+
+1. **Enable Verbose Logging**: Add console.log statements to track session flow
+2. **Check Shared State**: Log `sharedState` at the start of each provider call
+3. **Monitor Hook Execution**: Verify hooks run in expected order
+4. **Test Isolation**: Run a single test to isolate issues
+
+## Comparison with Provider-Level Sessions
+
+### Session Hooks (This Example)
+
+**Advantages:**
+- Centralized session management
+- Share sessions across multiple providers
+- Clear separation of concerns
+- Easier to test session logic independently
+
+**Best For:**
+- Multi-provider test suites
+- Complex session setup/teardown
+- Shared test fixtures
+- External service management
+
+### Provider-Level Sessions (PR #5866)
+
+**Advantages:**
+- Self-contained provider logic
+- Each provider manages its own lifecycle
+- No shared state complexity
+- Provider-specific session configurations
+
+**Best For:**
+- Single provider scenarios
+- Provider-specific session requirements
+- Stateless test execution
+- Following provider's native patterns
+
+## Implementation Notes
+
+### Shared State Pattern
+
+The example uses a module-level shared object pattern:
+
+**JavaScript**: Exported object from provider module
+```javascript
+// Provider module exports shared state
+module.exports.sharedState = sharedState;
+
+// Hooks import and modify
+const { sharedState } = require('./sessionProvider');
+```
+
+**Python**: Module-level global with accessor functions
+```python
+# Global state in provider module
+_shared_state = {"session_id": None}
+
+def get_shared_state():
+    return _shared_state
+```
+
+### Error Handling Strategy
+
+- **Setup Failures**: Log errors but don't throw (lets tests fail with clear messages)
+- **Runtime Errors**: Return error in provider response format
+- **Cleanup Failures**: Log warnings but don't block test completion
+
+### Concurrency Limitations
+
+This pattern creates one session per test suite run. It's suitable for:
+- Sequential test execution
+- Concurrent tests within a suite (sharing the session)
+
+Not suitable for:
+- Parallel test suite execution (would need unique session IDs)
+- Per-test isolation requirements
+
+## Advanced Patterns
+
+### Multiple Sessions
+
+For providers needing different sessions:
+
+```javascript
+const sharedState = {
+  dbSession: null,
+  apiSession: null,
+  cacheSession: null
+};
+
+// Create multiple sessions in beforeAll
+// Each provider uses its specific session
+```
+
+### Session Pooling
+
+For better resource utilization:
+
+```javascript
+class SessionPool {
+  constructor(maxSessions = 5) {
+    this.available = [];
+    this.inUse = new Map();
+  }
+
+  acquire(userId) {
+    // Get session from pool or create new
+  }
+
+  release(sessionId) {
+    // Return session to pool
+  }
+}
+```
+
+### Hierarchical Sessions
+
+For nested test scenarios:
+
+```javascript
+const sessionStack = [];
+
+// beforeAll: Create parent session
+// beforeEach: Create child session
+// afterEach: Close child session
+// afterAll: Close parent session
+```
+
+## Learn More
+
+- [Extension Hooks Documentation](https://promptfoo.dev/docs/configuration/hooks)
+- [Custom Providers Guide](https://promptfoo.dev/docs/providers/custom)
+- [Testing Best Practices](https://promptfoo.dev/docs/guides/testing)
+
+## Summary
+
+This example demonstrates a powerful pattern for managing stateful sessions in promptfoo tests. By leveraging extension hooks and shared state, you can:
+
+- Manage complex session lifecycles
+- Share resources across multiple providers
+- Implement proper setup and teardown
+- Handle errors gracefully
+- Support multiple implementation languages
+
+Whether you're testing APIs, managing database connections, or controlling browser sessions, this pattern provides a clean and maintainable approach to session management in your LLM evaluation workflows.

--- a/examples/session-hooks-lifecycle/javascript/sessionHooks.js
+++ b/examples/session-hooks-lifecycle/javascript/sessionHooks.js
@@ -1,0 +1,71 @@
+const sessionService = require('./sessionService');
+const { sharedState } = require('./sessionProvider');
+
+/**
+ * Extension hook for managing session lifecycle.
+ * This hook creates a session before all tests and cleans it up after.
+ *
+ * @param {string} hookName - The name of the hook being called
+ * @param {Object} context - Hook context object
+ * @returns {Promise<Object|undefined>} Modified context or undefined
+ */
+async function sessionHook(hookName, context) {
+  if (hookName === 'beforeAll') {
+    console.log('\n=== Session Lifecycle Hook: Setting up ===');
+
+    try {
+      // Initialize the session service
+      await sessionService.initialize();
+
+      // Get user ID from environment or use default
+      const userId = process.env.TEST_USER_ID || 'test-user-123';
+
+      // Create a new session
+      const sessionId = sessionService.createSession(userId);
+
+      // Store session ID in shared state for provider access
+      sharedState.sessionId = sessionId;
+
+      console.log(`✓ Session created successfully: ${sessionId}`);
+      console.log(`✓ User ID: ${userId}`);
+      console.log('===========================================\n');
+
+      // Return the context (required for beforeAll/beforeEach)
+      return context;
+    } catch (error) {
+      console.error('✗ Failed to create session:', error.message);
+      console.log('===========================================\n');
+      // Don't throw - let tests fail gracefully with clear error messages
+      return context;
+    }
+  }
+
+  else if (hookName === 'afterAll') {
+    console.log('\n=== Session Lifecycle Hook: Cleaning up ===');
+
+    if (sharedState.sessionId) {
+      try {
+        // Get final stats before closing
+        const stats = sessionService.getStats();
+        console.log(`✓ Session stats: ${JSON.stringify(stats)}`);
+
+        // Close the session
+        sessionService.closeSession(sharedState.sessionId);
+        console.log(`✓ Session closed: ${sharedState.sessionId}`);
+
+        // Clear the shared state
+        sharedState.sessionId = null;
+      } catch (error) {
+        console.warn(`⚠ Warning during cleanup: ${error.message}`);
+      }
+    } else {
+      console.log('ℹ No session to clean up');
+    }
+
+    console.log('============================================\n');
+    // Don't return anything from afterAll/afterEach
+  }
+}
+
+// Export the hook function
+module.exports = sessionHook;

--- a/examples/session-hooks-lifecycle/javascript/sessionProvider.js
+++ b/examples/session-hooks-lifecycle/javascript/sessionProvider.js
@@ -1,0 +1,79 @@
+const sessionService = require('./sessionService');
+
+/**
+ * Shared state object for session management.
+ * This is accessed by both the provider and the hooks.
+ */
+const sharedState = {
+  sessionId: null,
+};
+
+/**
+ * Custom provider that uses a managed session.
+ * The session is created in the beforeAll hook and cleaned up in afterAll.
+ */
+class SessionProvider {
+  constructor(options = {}) {
+    this.providerId = options.id || 'session-provider';
+    this.config = options.config || {};
+  }
+
+  /**
+   * Get the provider ID
+   * @returns {string} Provider identifier
+   */
+  id() {
+    return this.providerId;
+  }
+
+  /**
+   * Call the API using the session context
+   * @param {string} prompt - The prompt to send
+   * @param {Object} context - Provider context
+   * @returns {Promise<Object>} Provider response
+   */
+  async callApi(prompt, context) {
+    // Check if session is available
+    if (!sharedState.sessionId) {
+      throw new Error(
+        'No active session found. Make sure beforeAll hook ran successfully. ' +
+        'The session should be created before any provider calls.'
+      );
+    }
+
+    try {
+      // Make request using the session
+      const response = await sessionService.makeRequest(
+        sharedState.sessionId,
+        prompt
+      );
+
+      // Return in ProviderResponse format
+      return {
+        output: response.text,
+        metadata: {
+          sessionId: sharedState.sessionId,
+          requestCount: response.requestCount,
+          contextUsed: response.contextUsed,
+          provider: this.providerId,
+        },
+      };
+    } catch (error) {
+      // Handle errors gracefully
+      return {
+        error: `Session provider error: ${error.message}`,
+        metadata: {
+          sessionId: sharedState.sessionId,
+          provider: this.providerId,
+          errorType: error.constructor.name,
+        },
+      };
+    }
+  }
+}
+
+// Export the provider class
+module.exports = SessionProvider;
+
+// Also export the shared state so hooks can access it
+module.exports.sharedState = sharedState;

--- a/examples/session-hooks-lifecycle/javascript/sessionService.js
+++ b/examples/session-hooks-lifecycle/javascript/sessionService.js
@@ -1,0 +1,136 @@
+const crypto = require('crypto');
+
+/**
+ * Mock session service that simulates a stateful API or database connection
+ * that requires session management.
+ */
+class SessionService {
+  constructor() {
+    this.sessions = new Map();
+    this.isInitialized = false;
+  }
+
+  /**
+   * Initialize the service (simulated async operation)
+   */
+  async initialize() {
+    if (!this.isInitialized) {
+      // Simulate service startup delay
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      this.isInitialized = true;
+      console.log('SessionService initialized');
+    }
+  }
+
+  /**
+   * Create a new session for a user
+   * @param {string} userId - The user ID to create a session for
+   * @returns {string} The created session ID
+   */
+  createSession(userId) {
+    if (!this.isInitialized) {
+      throw new Error('SessionService not initialized. Call initialize() first.');
+    }
+
+    const sessionId = crypto.randomBytes(16).toString('hex');
+    const session = {
+      id: sessionId,
+      userId,
+      createdAt: Date.now(),
+      conversationHistory: [],
+      metadata: {
+        requestCount: 0,
+        lastActivity: Date.now(),
+      },
+    };
+
+    this.sessions.set(sessionId, session);
+    console.log(`Session created for user ${userId}: ${sessionId}`);
+    return sessionId;
+  }
+
+  /**
+   * Get a session by ID
+   * @param {string} sessionId - The session ID to retrieve
+   * @returns {Object|null} The session object or null if not found
+   */
+  getSession(sessionId) {
+    return this.sessions.get(sessionId) || null;
+  }
+
+  /**
+   * Make a request within a session context
+   * @param {string} sessionId - The session ID
+   * @param {string} prompt - The prompt/request to process
+   * @returns {Object} The response object
+   */
+  async makeRequest(sessionId, prompt) {
+    const session = this.getSession(sessionId);
+    if (!session) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    // Update activity timestamp
+    session.metadata.lastActivity = Date.now();
+    session.metadata.requestCount++;
+
+    // Build context from conversation history (last 3 exchanges)
+    const contextHistory = session.conversationHistory
+      .slice(-3)
+      .map((entry) => `User: ${entry.prompt}\nAssistant: ${entry.response}`)
+      .join('\n\n');
+
+    // Simulate an API call with session context
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Generate a mock response that shows session awareness
+    const response = `Response to: "${prompt}"\n` +
+      `(Session has ${session.conversationHistory.length} prior exchanges, ` +
+      `request #${session.metadata.requestCount} for user ${session.userId})`;
+
+    // Store in conversation history
+    session.conversationHistory.push({
+      prompt,
+      response,
+      timestamp: Date.now(),
+    });
+
+    return {
+      text: response,
+      requestCount: session.metadata.requestCount,
+      sessionId,
+      contextUsed: contextHistory.length > 0,
+    };
+  }
+
+  /**
+   * Close a session and clean up resources
+   * @param {string} sessionId - The session ID to close
+   */
+  closeSession(sessionId) {
+    const session = this.getSession(sessionId);
+    if (session) {
+      console.log(`Closing session ${sessionId} for user ${session.userId}`);
+      console.log(`  Total requests: ${session.metadata.requestCount}`);
+      console.log(`  Duration: ${Date.now() - session.createdAt}ms`);
+      this.sessions.delete(sessionId);
+    }
+  }
+
+  /**
+   * Get statistics about active sessions
+   * @returns {Object} Session statistics
+   */
+  getStats() {
+    return {
+      activeSessions: this.sessions.size,
+      totalRequests: Array.from(this.sessions.values()).reduce(
+        (sum, session) => sum + session.metadata.requestCount,
+        0
+      ),
+    };
+  }
+}
+
+// Export singleton instance
+module.exports = new SessionService();

--- a/examples/session-hooks-lifecycle/promptfooconfig-python.yaml
+++ b/examples/session-hooks-lifecycle/promptfooconfig-python.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Python session management
+
+prompts:
+  - file://prompts.txt
+
+providers:
+  - id: file://python/session_provider.py:call_api
+    label: Python Session Provider
+
+extensions:
+  - file://python/session_hooks.py:session_hook
+
+tests:
+  - vars:
+      query: "What is the capital of France?"
+    assert:
+      - type: contains
+        value: "Session has"
+      - type: contains
+        value: "request #1"
+
+  - vars:
+      query: "Tell me an interesting fact about Paris"
+    assert:
+      - type: contains
+        value: "Session has 1 prior exchanges"
+      - type: contains
+        value: "request #2"
+
+  - vars:
+      query: "What did we just discuss?"
+    assert:
+      - type: contains-any
+        value:
+          - "Session has 2 prior exchanges"
+          - "request #3"

--- a/examples/session-hooks-lifecycle/promptfooconfig.yaml
+++ b/examples/session-hooks-lifecycle/promptfooconfig.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Session management with hooks
+
+prompts:
+  - file://prompts.txt
+
+providers:
+  - id: file://javascript/sessionProvider.js
+    label: Session-based Provider
+
+extensions:
+  - file://javascript/sessionHooks.js
+
+tests:
+  - vars:
+      query: "What is the capital of France?"
+    assert:
+      - type: contains
+        value: "Session has"
+      - type: contains
+        value: "request #1"
+
+  - vars:
+      query: "Tell me an interesting fact about Paris"
+    assert:
+      - type: contains
+        value: "Session has 1 prior exchanges"
+      - type: contains
+        value: "request #2"
+
+  - vars:
+      query: "What did we just discuss?"
+    assert:
+      - type: contains-any
+        value:
+          - "Session has 2 prior exchanges"
+          - "request #3"

--- a/examples/session-hooks-lifecycle/prompts.txt
+++ b/examples/session-hooks-lifecycle/prompts.txt
@@ -1,0 +1,1 @@
+Process this query using the session context: {{query}}

--- a/examples/session-hooks-lifecycle/python/session_hooks.py
+++ b/examples/session-hooks-lifecycle/python/session_hooks.py
@@ -1,0 +1,81 @@
+import os
+import asyncio
+import json
+from typing import Optional, Dict, Any
+from session_service import get_session_service
+from session_state import save_session_id, load_session_id, clear_session_id
+
+
+async def session_hook(hook_name: str, context: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Extension hook for managing session lifecycle.
+    This hook creates a session before all tests and cleans it up after.
+
+    Args:
+        hook_name: The name of the hook being called
+        context: Hook context object
+
+    Returns:
+        Modified context for beforeAll/beforeEach, None for afterAll/afterEach
+    """
+    service = get_session_service()
+
+    if hook_name == "beforeAll":
+        print("\n=== Session Lifecycle Hook: Setting up ===")
+
+        try:
+            # Initialize the session service
+            await service.initialize()
+
+            # Get user ID from environment or use default
+            user_id = os.getenv("TEST_USER_ID", "test-user-123")
+
+            # Create a new session
+            session_id = service.create_session(user_id)
+
+            # Store session ID in persistent storage (works across Python processes)
+            save_session_id(session_id)
+
+            print(f"✓ Session created successfully: {session_id}")
+            print(f"✓ User ID: {user_id}")
+            print("===========================================\n")
+
+            # Return the context (required for beforeAll/beforeEach)
+            return context
+
+        except Exception as error:
+            print(f"✗ Failed to create session: {str(error)}")
+            print("===========================================\n")
+            # Don't throw - let tests fail gracefully with clear error messages
+            return context
+
+    elif hook_name == "afterAll":
+        print("\n=== Session Lifecycle Hook: Cleaning up ===")
+
+        # Load session ID from persistent storage
+        session_id = load_session_id()
+
+        if session_id:
+            try:
+                # Get final stats before closing
+                stats = service.get_stats()
+                print(f"✓ Session stats: {json.dumps(stats)}")
+
+                # Close the session
+                service.close_session(session_id)
+                print(f"✓ Session closed: {session_id}")
+
+                # Clear the persistent state
+                clear_session_id()
+
+            except Exception as error:
+                print(f"⚠ Warning during cleanup: {str(error)}")
+        else:
+            print("ℹ No session to clean up")
+
+        print("============================================\n")
+        # Don't return anything from afterAll/afterEach
+        return None
+
+    # For other hooks, just pass through
+    return None

--- a/examples/session-hooks-lifecycle/python/session_provider.py
+++ b/examples/session-hooks-lifecycle/python/session_provider.py
@@ -1,0 +1,56 @@
+import asyncio
+from typing import Dict, Any
+from session_service import get_session_service
+from session_state import load_session_id
+
+
+async def call_api(
+    prompt: str, options: Dict[str, Any], context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Custom provider that uses a managed session.
+    The session is created in the beforeAll hook and cleaned up in afterAll.
+
+    Args:
+        prompt: The prompt to send
+        options: Provider options
+        context: Provider context
+
+    Returns:
+        Provider response dict
+    """
+    # Load session ID from persistent storage (works across Python processes)
+    session_id = load_session_id()
+    if not session_id:
+        raise RuntimeError(
+            "No active session found. Make sure beforeAll hook ran successfully. "
+            "The session should be created before any provider calls."
+        )
+
+    try:
+        # Get the session service
+        service = get_session_service()
+
+        # Make request using the session
+        response = await service.make_request(session_id, prompt)
+
+        # Return in ProviderResponse format
+        return {
+            "output": response["text"],
+            "metadata": {
+                "sessionId": session_id,
+                "requestCount": response["request_count"],
+                "contextUsed": response["context_used"],
+                "provider": "python-session-provider",
+            },
+        }
+    except Exception as error:
+        # Handle errors gracefully
+        return {
+            "error": f"Session provider error: {str(error)}",
+            "metadata": {
+                "sessionId": session_id,
+                "provider": "python-session-provider",
+                "errorType": type(error).__name__,
+            },
+        }

--- a/examples/session-hooks-lifecycle/python/session_service.py
+++ b/examples/session-hooks-lifecycle/python/session_service.py
@@ -1,0 +1,216 @@
+import json
+import uuid
+import time
+from datetime import datetime
+from typing import Dict, Any, Optional, List
+from pathlib import Path
+import tempfile
+
+
+class SessionService:
+    """
+    Mock session service that simulates a stateful API or database connection
+    that requires session management. Uses file-based storage to persist
+    sessions across Python process invocations.
+    """
+
+    def __init__(self):
+        # Use a temp directory for session storage
+        self.storage_dir = Path(tempfile.gettempdir()) / "promptfoo_sessions"
+        self.storage_dir.mkdir(exist_ok=True)
+        self.is_initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize the service (simulated async operation)"""
+        if not self.is_initialized:
+            # Simulate service startup delay
+            time.sleep(0.1)
+            self.is_initialized = True
+            print("SessionService initialized")
+
+    def _get_session_file(self, session_id: str) -> Path:
+        """Get the file path for a session."""
+        return self.storage_dir / f"{session_id}.json"
+
+    def _save_session(self, session: Dict[str, Any]) -> None:
+        """Save session to file."""
+        session_file = self._get_session_file(session["id"])
+        with open(session_file, 'w') as f:
+            json.dump(session, f, indent=2)
+
+    def _load_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Load session from file."""
+        session_file = self._get_session_file(session_id)
+        if not session_file.exists():
+            return None
+        try:
+            with open(session_file, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return None
+
+    def create_session(self, user_id: str) -> str:
+        """
+        Create a new session for a user.
+
+        Args:
+            user_id: The user ID to create a session for
+
+        Returns:
+            The created session ID
+
+        Raises:
+            RuntimeError: If service is not initialized
+        """
+        if not self.is_initialized:
+            raise RuntimeError("SessionService not initialized. Call initialize() first.")
+
+        session_id = str(uuid.uuid4())
+        session = {
+            "id": session_id,
+            "user_id": user_id,
+            "created_at": datetime.now().isoformat(),
+            "conversation_history": [],
+            "metadata": {
+                "request_count": 0,
+                "last_activity": datetime.now().isoformat(),
+            },
+        }
+
+        self._save_session(session)
+        print(f"Session created for user {user_id}: {session_id}")
+        return session_id
+
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get a session by ID.
+
+        Args:
+            session_id: The session ID to retrieve
+
+        Returns:
+            The session dict or None if not found
+        """
+        return self._load_session(session_id)
+
+    async def make_request(self, session_id: str, prompt: str) -> Dict[str, Any]:
+        """
+        Make a request within a session context.
+
+        Args:
+            session_id: The session ID
+            prompt: The prompt/request to process
+
+        Returns:
+            The response object
+
+        Raises:
+            ValueError: If session is not found
+        """
+        session = self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        # Update activity timestamp
+        session["metadata"]["last_activity"] = datetime.now().isoformat()
+        session["metadata"]["request_count"] += 1
+
+        # Build context from conversation history (last 3 exchanges)
+        context_history = self._build_context(session["conversation_history"][-3:])
+
+        # Simulate an API call with session context
+        time.sleep(0.05)
+
+        # Generate a mock response that shows session awareness
+        response_text = (
+            f'Response to: "{prompt}"\n'
+            f'(Session has {len(session["conversation_history"])} prior exchanges, '
+            f'request #{session["metadata"]["request_count"]} for user {session["user_id"]})'
+        )
+
+        # Store in conversation history
+        session["conversation_history"].append(
+            {
+                "prompt": prompt,
+                "response": response_text,
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+
+        # Save updated session to file
+        self._save_session(session)
+
+        return {
+            "text": response_text,
+            "request_count": session["metadata"]["request_count"],
+            "session_id": session_id,
+            "context_used": len(context_history) > 0,
+        }
+
+    def _build_context(self, history: List[Dict[str, Any]]) -> str:
+        """Build context string from conversation history."""
+        if not history:
+            return ""
+
+        context_parts = []
+        for entry in history:
+            context_parts.append(f"User: {entry['prompt']}\nAssistant: {entry['response']}")
+
+        return "\n\n".join(context_parts)
+
+    def close_session(self, session_id: str) -> None:
+        """
+        Close a session and clean up resources.
+
+        Args:
+            session_id: The session ID to close
+        """
+        session = self.get_session(session_id)
+        if session:
+            created_at = datetime.fromisoformat(session["created_at"])
+            duration = (datetime.now() - created_at).total_seconds() * 1000
+
+            print(f"Closing session {session_id} for user {session['user_id']}")
+            print(f"  Total requests: {session['metadata']['request_count']}")
+            print(f"  Duration: {duration:.0f}ms")
+
+            # Delete the session file
+            session_file = self._get_session_file(session_id)
+            if session_file.exists():
+                session_file.unlink()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get statistics about active sessions.
+
+        Returns:
+            Session statistics dict
+        """
+        # Count active sessions by counting JSON files
+        session_files = list(self.storage_dir.glob("*.json"))
+        total_requests = 0
+
+        for session_file in session_files:
+            try:
+                with open(session_file, 'r') as f:
+                    session = json.load(f)
+                    total_requests += session["metadata"]["request_count"]
+            except (json.JSONDecodeError, IOError, KeyError):
+                continue
+
+        return {
+            "active_sessions": len(session_files),
+            "total_requests": total_requests,
+        }
+
+
+# Singleton instance
+_service_instance: Optional[SessionService] = None
+
+
+def get_session_service() -> SessionService:
+    """Get the singleton SessionService instance."""
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = SessionService()
+    return _service_instance

--- a/examples/session-hooks-lifecycle/python/session_state.py
+++ b/examples/session-hooks-lifecycle/python/session_state.py
@@ -1,0 +1,53 @@
+"""
+Session state management using file-based persistence.
+This approach works across different Python process invocations.
+"""
+
+import json
+import os
+import tempfile
+from typing import Optional, Dict, Any
+from pathlib import Path
+
+
+# Use a consistent temp file for session state
+STATE_FILE = Path(tempfile.gettempdir()) / "promptfoo_session_state.json"
+
+
+def save_session_id(session_id: str) -> None:
+    """
+    Save session ID to persistent storage.
+
+    Args:
+        session_id: The session ID to save
+    """
+    state = {"session_id": session_id}
+    with open(STATE_FILE, 'w') as f:
+        json.dump(state, f)
+
+
+def load_session_id() -> Optional[str]:
+    """
+    Load session ID from persistent storage.
+
+    Returns:
+        The session ID or None if not found
+    """
+    if not STATE_FILE.exists():
+        return None
+
+    try:
+        with open(STATE_FILE, 'r') as f:
+            state = json.load(f)
+            return state.get("session_id")
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def clear_session_id() -> None:
+    """Clear the stored session ID."""
+    if STATE_FILE.exists():
+        try:
+            STATE_FILE.unlink()
+        except IOError:
+            pass

--- a/test/examples/session-hooks-lifecycle/sessionHooks.test.js
+++ b/test/examples/session-hooks-lifecycle/sessionHooks.test.js
@@ -1,0 +1,378 @@
+const sessionHook = require('../../../examples/session-hooks-lifecycle/javascript/sessionHooks');
+const sessionService = require('../../../examples/session-hooks-lifecycle/javascript/sessionService');
+const { sharedState } = require('../../../examples/session-hooks-lifecycle/javascript/sessionProvider');
+
+describe('SessionHooks', () => {
+  let originalSharedState;
+  let originalEnv;
+  let consoleSpy;
+
+  beforeEach(() => {
+    // Save original state
+    originalSharedState = { ...sharedState };
+    originalEnv = process.env.TEST_USER_ID;
+
+    // Reset shared state
+    sharedState.sessionId = null;
+
+    // Reset session service
+    sessionService.sessions.clear();
+    sessionService.isInitialized = false;
+
+    // Spy on console methods
+    consoleSpy = {
+      log: jest.spyOn(console, 'log').mockImplementation(),
+      error: jest.spyOn(console, 'error').mockImplementation(),
+      warn: jest.spyOn(console, 'warn').mockImplementation(),
+    };
+  });
+
+  afterEach(() => {
+    // Restore original state
+    Object.assign(sharedState, originalSharedState);
+    process.env.TEST_USER_ID = originalEnv;
+
+    // Restore console
+    consoleSpy.log.mockRestore();
+    consoleSpy.error.mockRestore();
+    consoleSpy.warn.mockRestore();
+  });
+
+  describe('beforeAll Hook', () => {
+    it('should initialize service and create session', async () => {
+      const context = { testContext: 'value' };
+
+      const result = await sessionHook('beforeAll', context);
+
+      // Should return the context
+      expect(result).toBe(context);
+
+      // Should have initialized the service
+      expect(sessionService.isInitialized).toBe(true);
+
+      // Should have created a session
+      expect(sharedState.sessionId).toBeDefined();
+      expect(typeof sharedState.sessionId).toBe('string');
+
+      // Should log success messages
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining('Session Lifecycle Hook: Setting up')
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining(`✓ Session created successfully: ${sharedState.sessionId}`)
+      );
+    });
+
+    it('should use TEST_USER_ID from environment', async () => {
+      process.env.TEST_USER_ID = 'custom-test-user';
+
+      await sessionHook('beforeAll', {});
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining('✓ User ID: custom-test-user')
+      );
+
+      // Verify the session was created with correct user ID
+      const session = sessionService.getSession(sharedState.sessionId);
+      expect(session.userId).toBe('custom-test-user');
+    });
+
+    it('should use default user ID when env var not set', async () => {
+      delete process.env.TEST_USER_ID;
+
+      await sessionHook('beforeAll', {});
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining('✓ User ID: test-user-123')
+      );
+
+      const session = sessionService.getSession(sharedState.sessionId);
+      expect(session.userId).toBe('test-user-123');
+    });
+
+    it('should handle initialization errors gracefully', async () => {
+      // Mock initialize to throw error
+      const originalInitialize = sessionService.initialize;
+      sessionService.initialize = jest.fn().mockRejectedValue(
+        new Error('Initialization failed')
+      );
+
+      const context = { test: 'context' };
+      const result = await sessionHook('beforeAll', context);
+
+      // Should still return context
+      expect(result).toBe(context);
+
+      // Should log error
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '✗ Failed to create session:',
+        'Initialization failed'
+      );
+
+      // Should not set session ID
+      expect(sharedState.sessionId).toBeNull();
+
+      // Restore original method
+      sessionService.initialize = originalInitialize;
+    });
+
+    it('should handle session creation errors gracefully', async () => {
+      // Mock createSession to throw error after initialization
+      const originalCreateSession = sessionService.createSession;
+      await sessionService.initialize();
+      sessionService.createSession = jest.fn().mockImplementation(() => {
+        throw new Error('Session creation failed');
+      });
+
+      const context = { test: 'context' };
+      const result = await sessionHook('beforeAll', context);
+
+      // Should still return context
+      expect(result).toBe(context);
+
+      // Should log error
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '✗ Failed to create session:',
+        'Session creation failed'
+      );
+
+      // Should not set session ID
+      expect(sharedState.sessionId).toBeNull();
+
+      // Restore original method
+      sessionService.createSession = originalCreateSession;
+    });
+
+    it('should not modify context object', async () => {
+      const originalContext = {
+        key: 'value',
+        nested: { prop: 'data' },
+      };
+      const contextCopy = JSON.parse(JSON.stringify(originalContext));
+
+      const result = await sessionHook('beforeAll', originalContext);
+
+      expect(result).toBe(originalContext);
+      expect(originalContext).toEqual(contextCopy);
+    });
+  });
+
+  describe('afterAll Hook', () => {
+    beforeEach(async () => {
+      // Initialize service for afterAll tests
+      await sessionService.initialize();
+    });
+
+    it('should close session and clear shared state', async () => {
+      // Create a session first
+      const sessionId = sessionService.createSession('cleanup-user');
+      sharedState.sessionId = sessionId;
+
+      // Make some requests to generate stats
+      await sessionService.makeRequest(sessionId, 'Request 1');
+      await sessionService.makeRequest(sessionId, 'Request 2');
+
+      // Call afterAll hook
+      await sessionHook('afterAll', {});
+
+      // Should log cleanup messages
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining('Session Lifecycle Hook: Cleaning up')
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining('✓ Session stats:')
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining(`✓ Session closed: ${sessionId}`)
+      );
+
+      // Should clear shared state
+      expect(sharedState.sessionId).toBeNull();
+
+      // Session should be closed
+      expect(sessionService.getSession(sessionId)).toBeNull();
+    });
+
+    it('should log statistics before closing', async () => {
+      const sessionId = sessionService.createSession('stats-user');
+      sharedState.sessionId = sessionId;
+
+      // Make requests
+      await sessionService.makeRequest(sessionId, 'Request 1');
+      await sessionService.makeRequest(sessionId, 'Request 2');
+      await sessionService.makeRequest(sessionId, 'Request 3');
+
+      await sessionHook('afterAll', {});
+
+      // Should log stats with correct values
+      const statsCall = consoleSpy.log.mock.calls.find(
+        call => call[0] && call[0].includes('Session stats:')
+      );
+      expect(statsCall).toBeDefined();
+      expect(statsCall[0]).toContain('"activeSessions":1');
+      expect(statsCall[0]).toContain('"totalRequests":3');
+    });
+
+    it('should handle missing session gracefully', async () => {
+      // No session in shared state
+      sharedState.sessionId = null;
+
+      await sessionHook('afterAll', {});
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        'ℹ No session to clean up'
+      );
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+    });
+
+    it('should handle cleanup errors gracefully', async () => {
+      const sessionId = sessionService.createSession('error-user');
+      sharedState.sessionId = sessionId;
+
+      // Mock closeSession to throw error
+      const originalCloseSession = sessionService.closeSession;
+      sessionService.closeSession = jest.fn().mockImplementation(() => {
+        throw new Error('Cleanup error');
+      });
+
+      await sessionHook('afterAll', {});
+
+      // Should warn about error
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠ Warning during cleanup: Cleanup error')
+      );
+
+      // Shared state won't be cleared if there's an error in the try block
+      expect(sharedState.sessionId).toBe(sessionId);
+
+      // Restore original method
+      sessionService.closeSession = originalCloseSession;
+    });
+
+    it('should not return anything from afterAll', async () => {
+      const sessionId = sessionService.createSession('return-test-user');
+      sharedState.sessionId = sessionId;
+
+      const result = await sessionHook('afterAll', { context: 'value' });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle invalid session ID in shared state', async () => {
+      // Set an invalid session ID
+      sharedState.sessionId = 'non-existent-session';
+
+      await sessionHook('afterAll', {});
+
+      // Should successfully clear state even with invalid session
+      // (closeSession handles non-existent sessions gracefully)
+      expect(sharedState.sessionId).toBeNull();
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Other Hooks', () => {
+    it('should ignore beforeEach hook', async () => {
+      const context = { test: 'value' };
+      const result = await sessionHook('beforeEach', context);
+
+      expect(result).toBeUndefined();
+      expect(sharedState.sessionId).toBeNull();
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+
+    it('should ignore afterEach hook', async () => {
+      const context = { test: 'value' };
+      const result = await sessionHook('afterEach', context);
+
+      expect(result).toBeUndefined();
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+
+    it('should ignore unknown hooks', async () => {
+      const result = await sessionHook('unknownHook', {});
+
+      expect(result).toBeUndefined();
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Hook Lifecycle Integration', () => {
+    it('should complete full lifecycle successfully', async () => {
+      // Ensure service is initialized for this integration test
+      await sessionService.initialize();
+
+      // Simulate full test lifecycle
+      const context = { testRun: 'integration' };
+
+      // beforeAll - setup
+      const beforeResult = await sessionHook('beforeAll', context);
+      expect(beforeResult).toBe(context);
+      expect(sharedState.sessionId).toBeDefined();
+
+      const sessionId = sharedState.sessionId;
+
+      // Simulate test execution
+      await sessionService.makeRequest(sessionId, 'Test request 1');
+      await sessionService.makeRequest(sessionId, 'Test request 2');
+
+      // afterAll - cleanup
+      const afterResult = await sessionHook('afterAll', context);
+      expect(afterResult).toBeUndefined();
+      expect(sharedState.sessionId).toBeNull();
+      expect(sessionService.getSession(sessionId)).toBeNull();
+    });
+
+    it('should handle multiple lifecycle calls idempotently', async () => {
+      // Ensure service is initialized
+      await sessionService.initialize();
+
+      // Call beforeAll multiple times
+      await sessionHook('beforeAll', {});
+      const firstSessionId = sharedState.sessionId;
+
+      await sessionHook('beforeAll', {});
+      const secondSessionId = sharedState.sessionId;
+
+      // Should create new session each time
+      expect(firstSessionId).not.toBe(secondSessionId);
+
+      // Call afterAll multiple times
+      await sessionHook('afterAll', {});
+      expect(sharedState.sessionId).toBeNull();
+
+      await sessionHook('afterAll', {});
+      expect(consoleSpy.log).toHaveBeenCalledWith('ℹ No session to clean up');
+    });
+  });
+
+  describe('Console Output', () => {
+    it('should format setup output correctly', async () => {
+      await sessionHook('beforeAll', {});
+
+      const logCalls = consoleSpy.log.mock.calls.map(call => call[0]);
+
+      expect(logCalls).toContain('\n=== Session Lifecycle Hook: Setting up ===');
+      expect(logCalls).toContain('===========================================\n');
+      expect(logCalls.some(msg => msg.includes('✓ Session created successfully:'))).toBe(true);
+      expect(logCalls.some(msg => msg.includes('✓ User ID:'))).toBe(true);
+    });
+
+    it('should format cleanup output correctly', async () => {
+      // Ensure service is initialized
+      await sessionService.initialize();
+
+      const sessionId = sessionService.createSession('format-user');
+      sharedState.sessionId = sessionId;
+
+      await sessionHook('afterAll', {});
+
+      const logCalls = consoleSpy.log.mock.calls.map(call => call[0]);
+
+      expect(logCalls).toContain('\n=== Session Lifecycle Hook: Cleaning up ===');
+      expect(logCalls).toContain('============================================\n');
+      expect(logCalls.some(msg => msg.includes('✓ Session stats:'))).toBe(true);
+      expect(logCalls.some(msg => msg.includes('✓ Session closed:'))).toBe(true);
+    });
+  });
+});

--- a/test/examples/session-hooks-lifecycle/sessionProvider.test.js
+++ b/test/examples/session-hooks-lifecycle/sessionProvider.test.js
@@ -1,0 +1,295 @@
+const SessionProvider = require('../../../examples/session-hooks-lifecycle/javascript/sessionProvider');
+const { sharedState } = require('../../../examples/session-hooks-lifecycle/javascript/sessionProvider');
+const sessionService = require('../../../examples/session-hooks-lifecycle/javascript/sessionService');
+
+describe('SessionProvider', () => {
+  let provider;
+  let originalSharedState;
+
+  beforeEach(async () => {
+    // Initialize service
+    await sessionService.initialize();
+
+    // Save original shared state
+    originalSharedState = { ...sharedState };
+
+    // Clear shared state
+    sharedState.sessionId = null;
+
+    // Create provider instance
+    provider = new SessionProvider({
+      id: 'test-provider',
+      config: { testOption: 'value' },
+    });
+  });
+
+  afterEach(() => {
+    // Restore shared state
+    Object.assign(sharedState, originalSharedState);
+
+    // Clean up any sessions created during tests
+    if (sharedState.sessionId) {
+      sessionService.closeSession(sharedState.sessionId);
+    }
+  });
+
+  describe('Provider Identity', () => {
+    it('should return correct provider ID', () => {
+      expect(provider.id()).toBe('test-provider');
+    });
+
+    it('should use default ID when none provided', () => {
+      const defaultProvider = new SessionProvider();
+      expect(defaultProvider.id()).toBe('session-provider');
+    });
+
+    it('should store config options', () => {
+      expect(provider.config).toEqual({ testOption: 'value' });
+    });
+  });
+
+  describe('API Calls with Active Session', () => {
+    beforeEach(() => {
+      // Create a session and set it in shared state
+      const sessionId = sessionService.createSession('test-user');
+      sharedState.sessionId = sessionId;
+    });
+
+    it('should successfully call API with active session', async () => {
+      const prompt = 'Test prompt';
+      const context = { vars: { someVar: 'value' } };
+
+      const response = await provider.callApi(prompt, context);
+
+      expect(response).toMatchObject({
+        output: expect.stringContaining(`Response to: "${prompt}"`),
+        metadata: {
+          sessionId: sharedState.sessionId,
+          requestCount: 1,
+          contextUsed: false,
+          provider: 'test-provider',
+        },
+      });
+    });
+
+    it('should increment request count across multiple calls', async () => {
+      const response1 = await provider.callApi('First prompt', {});
+      const response2 = await provider.callApi('Second prompt', {});
+      const response3 = await provider.callApi('Third prompt', {});
+
+      expect(response1.metadata.requestCount).toBe(1);
+      expect(response2.metadata.requestCount).toBe(2);
+      expect(response3.metadata.requestCount).toBe(3);
+    });
+
+    it('should use context from previous exchanges', async () => {
+      // Make several calls to build history
+      await provider.callApi('First message', {});
+      await provider.callApi('Second message', {});
+      await provider.callApi('Third message', {});
+
+      const response = await provider.callApi('Fourth message', {});
+
+      expect(response.metadata.contextUsed).toBe(true);
+      expect(response.output).toContain('Session has 3 prior exchanges');
+    });
+
+    it('should maintain session ID in metadata', async () => {
+      const expectedSessionId = sharedState.sessionId;
+
+      const response1 = await provider.callApi('Test 1', {});
+      const response2 = await provider.callApi('Test 2', {});
+
+      expect(response1.metadata.sessionId).toBe(expectedSessionId);
+      expect(response2.metadata.sessionId).toBe(expectedSessionId);
+    });
+
+    it('should handle empty prompts', async () => {
+      const response = await provider.callApi('', {});
+
+      expect(response.output).toContain('Response to: ""');
+      expect(response.metadata.requestCount).toBe(1);
+    });
+  });
+
+  describe('API Calls without Session', () => {
+    it('should throw error when no session is available', async () => {
+      // Ensure no session in shared state
+      sharedState.sessionId = null;
+
+      await expect(provider.callApi('Test prompt', {})).rejects.toThrow(
+        'No active session found'
+      );
+    });
+
+    it('should include helpful error message', async () => {
+      sharedState.sessionId = null;
+
+      await expect(provider.callApi('Test', {})).rejects.toThrow(
+        /Make sure beforeAll hook ran successfully.*The session should be created before any provider calls/
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid session ID gracefully', async () => {
+      // Set an invalid session ID that doesn't exist
+      sharedState.sessionId = 'invalid-session-id';
+
+      const response = await provider.callApi('Test prompt', {});
+
+      expect(response).toMatchObject({
+        error: expect.stringContaining('Session provider error'),
+        metadata: {
+          sessionId: 'invalid-session-id',
+          provider: 'test-provider',
+          errorType: expect.any(String),
+        },
+      });
+    });
+
+    it('should preserve session ID in error metadata', async () => {
+      const invalidId = 'non-existent-session';
+      sharedState.sessionId = invalidId;
+
+      const response = await provider.callApi('Test', {});
+
+      expect(response.metadata.sessionId).toBe(invalidId);
+    });
+
+    it('should handle service errors gracefully', async () => {
+      // Create a valid session
+      const sessionId = sessionService.createSession('test-user');
+      sharedState.sessionId = sessionId;
+
+      // Mock makeRequest to throw an error
+      const originalMakeRequest = sessionService.makeRequest;
+      sessionService.makeRequest = jest.fn().mockRejectedValue(
+        new TypeError('Simulated service error')
+      );
+
+      const response = await provider.callApi('Test prompt', {});
+
+      expect(response).toMatchObject({
+        error: 'Session provider error: Simulated service error',
+        metadata: {
+          errorType: 'TypeError',
+        },
+      });
+
+      // Restore original method
+      sessionService.makeRequest = originalMakeRequest;
+    });
+  });
+
+  describe('Shared State Integration', () => {
+    it('should use the same shared state across multiple provider instances', async () => {
+      const provider1 = new SessionProvider({ id: 'provider-1' });
+      const provider2 = new SessionProvider({ id: 'provider-2' });
+
+      // Create session and set in shared state
+      const sessionId = sessionService.createSession('shared-user');
+      sharedState.sessionId = sessionId;
+
+      const response1 = await provider1.callApi('From provider 1', {});
+      const response2 = await provider2.callApi('From provider 2', {});
+
+      // Both should use the same session
+      expect(response1.metadata.sessionId).toBe(sessionId);
+      expect(response2.metadata.sessionId).toBe(sessionId);
+
+      // Request counts should increment across providers
+      expect(response1.metadata.requestCount).toBe(1);
+      expect(response2.metadata.requestCount).toBe(2);
+    });
+
+    it('should reflect changes in shared state immediately', async () => {
+      // Initially no session
+      sharedState.sessionId = null;
+
+      await expect(provider.callApi('Before session', {})).rejects.toThrow(
+        'No active session found'
+      );
+
+      // Create session
+      sharedState.sessionId = sessionService.createSession('dynamic-user');
+
+      const response2 = await provider.callApi('After session', {});
+      expect(response2.output).toBeDefined();
+      expect(response2.error).toBeUndefined();
+    });
+  });
+
+  describe('Provider Configuration', () => {
+    it('should handle provider with no options', () => {
+      const bareProvider = new SessionProvider();
+
+      expect(bareProvider.id()).toBe('session-provider');
+      expect(bareProvider.config).toEqual({});
+    });
+
+    it('should handle provider with partial options', () => {
+      const partialProvider = new SessionProvider({ id: 'custom-id' });
+
+      expect(partialProvider.id()).toBe('custom-id');
+      expect(partialProvider.config).toEqual({});
+    });
+
+    it('should preserve config throughout lifecycle', async () => {
+      const configProvider = new SessionProvider({
+        id: 'config-test',
+        config: {
+          option1: 'value1',
+          option2: 123,
+          nested: { key: 'value' },
+        },
+      });
+
+      // Create session for testing
+      sharedState.sessionId = sessionService.createSession('config-user');
+
+      await configProvider.callApi('Test', {});
+
+      // Config should remain unchanged
+      expect(configProvider.config).toEqual({
+        option1: 'value1',
+        option2: 123,
+        nested: { key: 'value' },
+      });
+    });
+  });
+
+  describe('Context Handling', () => {
+    beforeEach(() => {
+      sharedState.sessionId = sessionService.createSession('context-user');
+    });
+
+    it('should handle various context structures', async () => {
+      const contexts = [
+        {},
+        { vars: {} },
+        { vars: { key: 'value' } },
+        { options: { setting: true } },
+        null,
+        undefined,
+      ];
+
+      for (const context of contexts) {
+        const response = await provider.callApi('Test', context);
+        expect(response.output).toBeDefined();
+      }
+    });
+
+    it('should not modify the original context', async () => {
+      const originalContext = {
+        vars: { key: 'value' },
+        options: { setting: true },
+      };
+      const contextCopy = JSON.parse(JSON.stringify(originalContext));
+
+      await provider.callApi('Test', originalContext);
+
+      expect(originalContext).toEqual(contextCopy);
+    });
+  });
+});

--- a/test/examples/session-hooks-lifecycle/sessionService.test.js
+++ b/test/examples/session-hooks-lifecycle/sessionService.test.js
@@ -1,0 +1,338 @@
+const sessionService = require('../../../examples/session-hooks-lifecycle/javascript/sessionService');
+
+describe('SessionService', () => {
+  // Store original state to restore between tests
+  let originalSessions;
+  let originalIsInitialized;
+
+  beforeEach(() => {
+    // Save original state
+    originalSessions = new Map(sessionService.sessions);
+    originalIsInitialized = sessionService.isInitialized;
+
+    // Reset service state for each test
+    sessionService.sessions.clear();
+    sessionService.isInitialized = false;
+  });
+
+  afterEach(() => {
+    // Restore original state to prevent test pollution
+    sessionService.sessions = originalSessions;
+    sessionService.isInitialized = originalIsInitialized;
+  });
+
+  describe('Service Initialization', () => {
+    it('should initialize the service successfully', async () => {
+      expect(sessionService.isInitialized).toBe(false);
+
+      await sessionService.initialize();
+
+      expect(sessionService.isInitialized).toBe(true);
+    });
+
+    it('should initialize only once', async () => {
+      await sessionService.initialize();
+      const firstInitTime = Date.now();
+
+      // Try to initialize again
+      await sessionService.initialize();
+      const secondInitTime = Date.now();
+
+      // Should be very fast since it doesn't actually initialize again
+      expect(secondInitTime - firstInitTime).toBeLessThan(10);
+      expect(sessionService.isInitialized).toBe(true);
+    });
+
+    it('should throw error when creating session before initialization', () => {
+      expect(() => sessionService.createSession('user123')).toThrow(
+        'SessionService not initialized. Call initialize() first.'
+      );
+    });
+  });
+
+  describe('Session Creation', () => {
+    beforeEach(async () => {
+      await sessionService.initialize();
+    });
+
+    it('should create a new session with unique ID', () => {
+      const userId = 'test-user-456';
+      const sessionId = sessionService.createSession(userId);
+
+      expect(sessionId).toBeDefined();
+      expect(typeof sessionId).toBe('string');
+      expect(sessionId.length).toBe(32); // hex string of 16 bytes
+    });
+
+    it('should create different session IDs for multiple sessions', () => {
+      const sessionId1 = sessionService.createSession('user1');
+      const sessionId2 = sessionService.createSession('user2');
+
+      expect(sessionId1).not.toBe(sessionId2);
+    });
+
+    it('should store session with correct structure', () => {
+      const userId = 'test-user-789';
+      const sessionId = sessionService.createSession(userId);
+      const session = sessionService.getSession(sessionId);
+
+      expect(session).toMatchObject({
+        id: sessionId,
+        userId: userId,
+        conversationHistory: [],
+        metadata: {
+          requestCount: 0,
+          lastActivity: expect.any(Number),
+        },
+      });
+      expect(session.createdAt).toBeDefined();
+      expect(typeof session.createdAt).toBe('number');
+    });
+  });
+
+  describe('Session Retrieval', () => {
+    beforeEach(async () => {
+      await sessionService.initialize();
+    });
+
+    it('should retrieve an existing session', () => {
+      const userId = 'retrieve-test-user';
+      const sessionId = sessionService.createSession(userId);
+
+      const retrievedSession = sessionService.getSession(sessionId);
+
+      expect(retrievedSession).toBeDefined();
+      expect(retrievedSession.id).toBe(sessionId);
+      expect(retrievedSession.userId).toBe(userId);
+    });
+
+    it('should return null for non-existent session', () => {
+      const nonExistentSession = sessionService.getSession('non-existent-id');
+
+      expect(nonExistentSession).toBeNull();
+    });
+  });
+
+  describe('Request Handling', () => {
+    let sessionId;
+
+    beforeEach(async () => {
+      await sessionService.initialize();
+      sessionId = sessionService.createSession('request-test-user');
+    });
+
+    it('should process a request successfully', async () => {
+      const prompt = 'What is the weather today?';
+      const response = await sessionService.makeRequest(sessionId, prompt);
+
+      expect(response).toMatchObject({
+        text: expect.stringContaining(`Response to: "${prompt}"`),
+        requestCount: 1,
+        sessionId: sessionId,
+        contextUsed: false,
+      });
+    });
+
+    it('should increment request counter', async () => {
+      await sessionService.makeRequest(sessionId, 'First request');
+      const response2 = await sessionService.makeRequest(sessionId, 'Second request');
+      const response3 = await sessionService.makeRequest(sessionId, 'Third request');
+
+      expect(response2.requestCount).toBe(2);
+      expect(response3.requestCount).toBe(3);
+    });
+
+    it('should update conversation history', async () => {
+      const prompt1 = 'Hello';
+      const prompt2 = 'How are you?';
+
+      await sessionService.makeRequest(sessionId, prompt1);
+      await sessionService.makeRequest(sessionId, prompt2);
+
+      const session = sessionService.getSession(sessionId);
+      expect(session.conversationHistory).toHaveLength(2);
+      expect(session.conversationHistory[0].prompt).toBe(prompt1);
+      expect(session.conversationHistory[1].prompt).toBe(prompt2);
+    });
+
+    it('should build context from previous exchanges', async () => {
+      // Make several requests to build history
+      await sessionService.makeRequest(sessionId, 'First');
+      await sessionService.makeRequest(sessionId, 'Second');
+      await sessionService.makeRequest(sessionId, 'Third');
+
+      const response = await sessionService.makeRequest(sessionId, 'Fourth');
+
+      // Should indicate context was used (3 prior exchanges)
+      expect(response.contextUsed).toBe(true);
+      expect(response.text).toContain('Session has 3 prior exchanges');
+    });
+
+    it('should limit context to last 3 exchanges', async () => {
+      // Make 5 requests to exceed context limit
+      for (let i = 1; i <= 5; i++) {
+        await sessionService.makeRequest(sessionId, `Request ${i}`);
+      }
+
+      const response = await sessionService.makeRequest(sessionId, 'Final request');
+
+      // Should still have context from last 3 exchanges
+      expect(response.contextUsed).toBe(true);
+      expect(response.text).toContain('Session has 5 prior exchanges');
+      expect(response.text).toContain('request #6');
+    });
+
+    it('should update last activity timestamp', async () => {
+      const session1 = sessionService.getSession(sessionId);
+      const initialActivity = session1.metadata.lastActivity;
+
+      // Wait a bit to ensure timestamp changes
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      await sessionService.makeRequest(sessionId, 'New request');
+      const session2 = sessionService.getSession(sessionId);
+
+      expect(session2.metadata.lastActivity).toBeGreaterThan(initialActivity);
+    });
+
+    it('should throw error for non-existent session', async () => {
+      await expect(
+        sessionService.makeRequest('invalid-session-id', 'Test prompt')
+      ).rejects.toThrow('Session invalid-session-id not found');
+    });
+  });
+
+  describe('Session Closure', () => {
+    beforeEach(async () => {
+      await sessionService.initialize();
+    });
+
+    it('should close an existing session', () => {
+      const sessionId = sessionService.createSession('close-test-user');
+
+      expect(sessionService.getSession(sessionId)).toBeDefined();
+
+      sessionService.closeSession(sessionId);
+
+      expect(sessionService.getSession(sessionId)).toBeNull();
+    });
+
+    it('should handle closing non-existent session gracefully', () => {
+      // Should not throw
+      expect(() => {
+        sessionService.closeSession('non-existent-session');
+      }).not.toThrow();
+    });
+
+    it('should log statistics when closing session', async () => {
+      const sessionId = sessionService.createSession('stats-test-user');
+
+      // Make some requests
+      await sessionService.makeRequest(sessionId, 'Request 1');
+      await sessionService.makeRequest(sessionId, 'Request 2');
+
+      // Spy on console.log to verify statistics are logged
+      const consoleSpy = jest.spyOn(console, 'log');
+
+      sessionService.closeSession(sessionId);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Total requests: 2')
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Statistics', () => {
+    beforeEach(async () => {
+      await sessionService.initialize();
+    });
+
+    it('should return correct statistics for active sessions', async () => {
+      // Create multiple sessions
+      const session1 = sessionService.createSession('user1');
+      const session2 = sessionService.createSession('user2');
+      const session3 = sessionService.createSession('user3');
+
+      // Make different numbers of requests
+      await sessionService.makeRequest(session1, 'Request 1');
+      await sessionService.makeRequest(session1, 'Request 2');
+      await sessionService.makeRequest(session2, 'Request 1');
+
+      const stats = sessionService.getStats();
+
+      expect(stats).toEqual({
+        activeSessions: 3,
+        totalRequests: 3,
+      });
+    });
+
+    it('should update statistics after closing sessions', async () => {
+      const session1 = sessionService.createSession('user1');
+      const session2 = sessionService.createSession('user2');
+
+      await sessionService.makeRequest(session1, 'Request');
+      await sessionService.makeRequest(session2, 'Request');
+
+      // Close one session
+      sessionService.closeSession(session1);
+
+      const stats = sessionService.getStats();
+
+      expect(stats).toEqual({
+        activeSessions: 1,
+        totalRequests: 1, // Only counting remaining session
+      });
+    });
+
+    it('should return zero statistics when no sessions exist', () => {
+      const stats = sessionService.getStats();
+
+      expect(stats).toEqual({
+        activeSessions: 0,
+        totalRequests: 0,
+      });
+    });
+  });
+
+  describe('Error Handling and Edge Cases', () => {
+    beforeEach(async () => {
+      await sessionService.initialize();
+    });
+
+    it('should handle empty prompt gracefully', async () => {
+      const sessionId = sessionService.createSession('edge-test-user');
+
+      const response = await sessionService.makeRequest(sessionId, '');
+
+      expect(response.text).toContain('Response to: ""');
+      expect(response.requestCount).toBe(1);
+    });
+
+    it('should handle very long prompts', async () => {
+      const sessionId = sessionService.createSession('long-prompt-user');
+      const longPrompt = 'x'.repeat(10000);
+
+      const response = await sessionService.makeRequest(sessionId, longPrompt);
+
+      expect(response).toBeDefined();
+      expect(response.requestCount).toBe(1);
+    });
+
+    it('should maintain session isolation', async () => {
+      const session1 = sessionService.createSession('user1');
+      const session2 = sessionService.createSession('user2');
+
+      await sessionService.makeRequest(session1, 'Session 1 request');
+      await sessionService.makeRequest(session2, 'Session 2 request');
+
+      const response1 = await sessionService.makeRequest(session1, 'Another request');
+      const response2 = await sessionService.makeRequest(session2, 'Another request');
+
+      expect(response1.requestCount).toBe(2);
+      expect(response2.requestCount).toBe(2);
+      expect(response1.sessionId).not.toBe(response2.sessionId);
+    });
+  });
+});


### PR DESCRIPTION
Adds a comprehensive example demonstrating how to manage sessions using `beforeAll` and `afterAll` extension hooks with custom providers in both JavaScript and Python.

This example provides an alternative pattern to the provider-level session interface introduced in PR #5866, showing users how to achieve session management when the lifecycle should be independent of provider logic or shared across multiple providers.