### PR TITLE
docs: add missing providers and troubleshooting pages to index

### DIFF
--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -32,6 +32,7 @@ providers:
 | [Shell Command](./custom-script.md)                 | Custom - script-based providers                              | `exec: python chain.py`                                                   |
 | [AI21 Labs](./ai21.md)                              | Jurassic and Jamba models                                    | `ai21:jamba-1.5-mini`                                                     |
 | [AI/ML API](./aimlapi.md)                           | Tap into 300+ cutting-edge AI models with a single API       | `aimlapi:chat:deepseek-r1`                                                |
+| [Alibaba Cloud (Qwen)](./alibaba.md)                | Alibaba Cloud's Qwen models                                  | `alibaba:qwen-max` or `qwen-plus`                                         |
 | [AWS Bedrock](./aws-bedrock.md)                     | AWS-hosted models from various providers                     | `bedrock:us.anthropic.claude-sonnet-4-20250514-v1:0`                      |
 | [AWS Bedrock Agents](./bedrock-agents.md)           | Amazon Bedrock Agents for orchestrating AI workflows         | `bedrock-agent:YOUR_AGENT_ID`                                             |
 | [Amazon SageMaker](./sagemaker.md)                  | Models deployed on SageMaker endpoints                       | `sagemaker:my-endpoint-name`                                              |
@@ -45,6 +46,7 @@ providers:
 | [Databricks](./databricks.md)                       | Databricks Foundation Model APIs                             | `databricks:databricks-meta-llama-3-3-70b-instruct`                       |
 | [DeepSeek](./deepseek.md)                           | DeepSeek's language models                                   | `deepseek:deepseek-r1`                                                    |
 | [Docker Model Runner](./docker.md)                  | Evaluate with local models                                   | `docker:ai/llama3.2:3B-Q4_K_M`                                            |
+| [Envoy AI Gateway](./envoy.md)                      | OpenAI-compatible AI Gateway proxy                           | `envoy:my-model`                                                          |
 | [F5](./f5.md)                                       | OpenAI-compatible AI Gateway interface                       | `f5:path-name`                                                            |
 | [fal.ai](./fal.md)                                  | Image Generation Provider                                    | `fal:image:fal-ai/fast-sdxl`                                              |
 | [Fireworks AI](./fireworks.md)                      | Various hosted models                                        | `fireworks:accounts/fireworks/models/qwen-v2p5-7b`                        |
@@ -65,6 +67,7 @@ providers:
 | [Perplexity AI](./perplexity.md)                    | Search-augmented chat with citations                         | `perplexity:sonar-pro`                                                    |
 | [Replicate](./replicate.md)                         | Various hosted models                                        | `replicate:stability-ai/sdxl`                                             |
 | [Slack](./slack.md)                                 | Human feedback via Slack channels/DMs                        | `slack:C0123ABCDEF` or `slack:channel:C0123ABCDEF`                        |
+| [Snowflake Cortex](./snowflake.md)                  | Snowflake's AI platform with Claude, GPT, and Llama models   | `snowflake:mistral-large2`                                                |
 | [Together AI](./togetherai.md)                      | Various hosted models                                        | Compatible with OpenAI syntax                                             |
 | [Voyage AI](./voyage.md)                            | Specialized embedding models                                 | `voyage:voyage-3`                                                         |
 | [vLLM](./vllm.md)                                   | Local                                                        | Compatible with OpenAI syntax                                             |

--- a/site/docs/red-team/troubleshooting/overview.md
+++ b/site/docs/red-team/troubleshooting/overview.md
@@ -13,11 +13,13 @@ Common issues encountered when red teaming LLM applications with promptfoo.
 | [Attack Generation](/docs/red-team/troubleshooting/attack-generation)             | Configuration errors in system scope, permissions, or available actions can prevent effective attack generation.            |
 | [Connection Problems](/docs/red-team/troubleshooting/connecting-to-targets)       | Authentication failures, rate limiting issues, and incorrect endpoint configuration can prevent successful API connections. |
 | [False Positives](/docs/red-team/troubleshooting/grading-results)                 | Insufficient system context or misconfigured grader settings can lead to incorrect vulnerability assessments.               |
+| [Inference Limits](/docs/red-team/troubleshooting/inference-limit)                | Usage limits on cloud-based inference services can restrict test case generation, attack execution, and evaluation.         |
 | [Multi-Turn Sessions](/docs/red-team/troubleshooting/multi-turn-sessions)         | Session management issues can disrupt conversation context in both client and server-side implementations.                  |
 | [Multiple Response Types](/docs/red-team/troubleshooting/multiple-response-types) | Response parsing errors occur when handling non-standard formats, guardrails, or error states.                              |
 | [Remote Generation](/docs/red-team/troubleshooting/remote-generation)             | Corporate firewalls may block access to remote generation endpoints due to security policies around adversarial content.    |
 
 ## Related Documentation
 
+- [Best Practices for Configuring AI Red Teaming](/docs/red-team/troubleshooting/best-practices)
 - [Red Team Quickstart](/docs/red-team/quickstart/)
 - [Configuration Guide](/docs/configuration/guide/)


### PR DESCRIPTION
added alibaba, envoy, snowflake to providers index and inference limits + best practices to troubleshooting overveiw