### PR TITLE
fix: remove duplicate 'Successfully logged in' message in auth login

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -54,6 +54,12 @@ export function authCommand(program: Command) {
           // Set current organization context
           cloudConfig.setCurrentOrganization(organization.id);
 
+          // Display login success with user/org info
+          logger.info(chalk.green.bold('Successfully logged in'));
+          logger.info(`User: ${chalk.cyan(user.email)}`);
+          logger.info(`Organization: ${chalk.cyan(organization.name)}`);
+          logger.info(`App: ${chalk.cyan(cloudConfig.getAppUrl())}`);
+
           // Set up default team (only if no team is already selected for this org)
           try {
             const allTeams = await getUserTeams();
@@ -64,13 +70,11 @@ export function authCommand(program: Command) {
               // Team already selected, keep it
               try {
                 const currentTeam = await getTeamById(existingTeamId);
-                logger.info(chalk.green('Successfully logged in'));
                 logger.info(`Team: ${chalk.cyan(currentTeam.name)}`);
               } catch (_error) {
                 // Stored team no longer valid, fall back to default
                 const defaultTeam = await getDefaultTeam();
                 cloudConfig.setCurrentTeamId(defaultTeam.id, organization.id);
-                logger.info(chalk.green('Successfully logged in'));
                 logger.info(`Team: ${chalk.cyan(defaultTeam.name)} ${chalk.dim('(default)')}`);
               }
             } else {
@@ -78,7 +82,6 @@ export function authCommand(program: Command) {
               const defaultTeam = await getDefaultTeam();
               cloudConfig.setCurrentTeamId(defaultTeam.id, organization.id);
 
-              logger.info(chalk.green('Successfully logged in'));
               logger.info(`Team: ${chalk.cyan(defaultTeam.name)} ${chalk.dim('(default)')}`);
               if (allTeams.length > 1) {
                 logger.info(chalk.dim(`Use 'promptfoo auth teams list' to see all teams`));
@@ -89,7 +92,6 @@ export function authCommand(program: Command) {
             logger.warn(
               `Could not set up team context: ${teamError instanceof Error ? teamError.message : String(teamError)}`,
             );
-            logger.info(chalk.green('Successfully logged in'));
           }
           return;
         } else {

--- a/src/globalConfig/cloud.ts
+++ b/src/globalConfig/cloud.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { readGlobalConfig, writeGlobalConfigPartial } from './globalConfig';
@@ -143,12 +142,6 @@ export class CloudConfig {
       this.setApiKey(token);
       this.setApiHost(apiHost);
       this.setAppUrl(app.url);
-
-      logger.info(chalk.green.bold('Successfully logged in'));
-      logger.info(chalk.dim('Logged in as:'));
-      logger.info(`User: ${chalk.cyan(user.email)}`);
-      logger.info(`Organization: ${chalk.cyan(organization.name)}`);
-      logger.info(`Access the app at ${chalk.cyan(app.url)}`);
 
       return {
         user,

--- a/test/globalConfig/cloud.test.ts
+++ b/test/globalConfig/cloud.test.ts
@@ -1,6 +1,5 @@
 import { API_HOST, CloudConfig, cloudConfig } from '../../src/globalConfig/cloud';
 import { readGlobalConfig, writeGlobalConfigPartial } from '../../src/globalConfig/globalConfig';
-import logger from '../../src/logger';
 import { fetchWithProxy } from '../../src/util/fetch/index';
 
 jest.mock('../../src/util/fetch/index.ts');
@@ -133,7 +132,6 @@ describe('CloudConfig', () => {
           appUrl: 'https://test.app',
         }),
       });
-      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully logged in'));
     });
 
     it('should throw error on failed validation', async () => {


### PR DESCRIPTION
## Summary

Fixes duplicate "Successfully logged in" message that was displayed twice during `promptfoo auth login`.

## Changes

- Removed login success logging from `CloudConfig.validateAndSetApiToken()` 
- Consolidated all authentication output in the `auth login` command handler
- Updated test expectations to match new behavior

## Before

```
Successfully logged in
Logged in as:
User: michael@promptfoo.dev
Organization: Promptfoo
Access the app at https://www.promptfoo.app
Successfully logged in
Team: Promptfoo (default)
```

## After

```
Successfully logged in
User: michael@promptfoo.dev
Organization: Promptfoo
App: https://www.promptfoo.app
Team: Promptfoo (default)
```

## Testing

- ✅ All auth-related tests pass
- ✅ End-to-end test confirms single message
- ✅ Lint and format checks pass