### PR TITLE
chore: rename azure ai foundry assistant to ai foundry agent

### DIFF
--- a/examples/azure-foundry-agent/README.md
+++ b/examples/azure-foundry-agent/README.md
@@ -1,11 +1,11 @@
-# azure-foundry-assistant (Azure AI Foundry Assistant)
+# azure-foundry-agent (Azure AI Foundry Agent)
 
-This example demonstrates how to use the Azure Foundry Assistant provider with promptfoo. This provider uses the `@azure/ai-projects` SDK instead of direct HTTP calls to the OpenAI-compatible API.
+This example demonstrates how to use the Azure Foundry Agent provider with promptfoo. This provider uses the `@azure/ai-projects` SDK instead of direct HTTP calls to the OpenAI-compatible API.
 
 You can run this example with:
 
 ```bash
-npx promptfoo@latest init --example azure-foundry-assistant
+npx promptfoo@latest init --example azure-foundry-agent
 ```
 
 ## Setup
@@ -30,11 +30,11 @@ export AZURE_AI_PROJECT_URL="https://your-project.services.ai.azure.com/api/proj
 
 ## Configuration
 
-The provider uses the `azure:foundry-assistant:assistant-id` format.
+The provider uses the `azure:foundry-agent:agent-id` format.
 
 ```yaml
 providers:
-  - azure:foundry-assistant:asst_uRGMedGFDehLkjJJaq51J9GY:
+  - azure:foundry-agent:asst_uRGMedGFDehLkjJJaq51J9GY:
       projectUrl: 'https://faiza-m92xlckl-swedencentral.services.ai.azure.com/api/projects/faiza-m92xlckl-swedence-project'
       config:
         temperature: 0.7
@@ -58,7 +58,7 @@ All the same configuration options from the regular Azure Assistant provider are
 - `tools`: Function tools configuration
 - `tool_choice`: Tool selection strategy
 - `tool_resources`: Resource configuration (file search, etc.)
-- `instructions`: System instructions for the assistant
+- `instructions`: System instructions for the agent
 - `functionToolCallbacks`: Custom function callbacks
 - `timeoutMs`: Request timeout in milliseconds
 - `maxPollTimeMs`: Maximum time to poll for completion
@@ -70,7 +70,7 @@ You can provide custom function callbacks just like with the regular Azure Assis
 
 ```yaml
 providers:
-  - azure:foundry-assistant:asst_uRGMedGFDehLkjJJaq51J9GY:
+  - azure:foundry-agent:asst_uRGMedGFDehLkjJJaq51J9GY:
       projectUrl: 'https://your-project.services.ai.azure.com/api/projects/your-project-id'
       config:
         functionToolCallbacks:
@@ -88,7 +88,7 @@ The main differences are:
 1. **SDK Usage**: Uses `@azure/ai-projects` SDK instead of direct HTTP calls
 2. **Authentication**: Uses `DefaultAzureCredential` for Azure authentication
 3. **Project URL**: Requires an Azure AI Project URL instead of Azure OpenAI endpoint
-4. **Provider Format**: Uses `azure:foundry-assistant:assistant-id` instead of `azure:assistant:assistant-id`
+4. **Provider Format**: Uses `azure:foundry-agent:agent-id` instead of `azure:assistant:assistant-id`
 
 ## Environment Variables
 

--- a/examples/azure-foundry-agent/promptfooconfig.yaml
+++ b/examples/azure-foundry-agent/promptfooconfig.yaml
@@ -1,7 +1,7 @@
-description: 'Azure AI Foundry Assistant evaluation'
+description: 'Azure AI Foundry Agent evaluation'
 
 providers:
-  - id: azure:foundry-assistant:asst_...
+  - id: azure:foundry-agent:asst_...
     config:
       projectUrl: 'project.services.ai.azure.com/api/projects/project-id'
       temperature: 0.7

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -70,7 +70,7 @@ providers:
 - `azure:embedding:<deployment name>` - For embedding models (e.g., text-embedding-3-small, text-embedding-3-large)
 - `azure:responses:<deployment name>` - For the Responses API (e.g., gpt-4.1, gpt-5, o3-mini)
 - `azure:assistant:<assistant id>` - For Azure OpenAI Assistants (using Azure OpenAI API)
-- `azure:foundry-assistant:<assistant id>` - For Azure AI Foundry Assistants (using Azure AI Projects SDK)
+- `azure:foundry-agent:<assistant id>` - For Azure AI Foundry Agents (using Azure AI Projects SDK)
 
 Vision-capable models (GPT-4o, GPT-4.1) use the standard `azure:chat:` provider type.
 
@@ -880,18 +880,18 @@ For complete working examples of Azure OpenAI Assistants with various tool confi
 
 See the guide on [How to evaluate OpenAI assistants](/docs/guides/evaluate-openai-assistants/) for more information on how to compare different models, instructions, and more.
 
-## Azure AI Foundry Assistants
+## Azure AI Foundry Agents
 
-Azure AI Foundry Assistants provide an alternative way to use Azure OpenAI Assistants through the Azure AI Projects SDK (`@azure/ai-projects`). This provider uses native Azure SDK authentication and is designed for use with Azure AI Foundry projects.
+Azure AI Foundry Agents provide an alternative way to use Azure OpenAI Assistants through the Azure AI Projects SDK (`@azure/ai-projects`). This provider uses native Azure SDK authentication and is designed for use with Azure AI Foundry projects.
 
 ### Key Differences from Standard Azure Assistants
 
-| Feature             | Azure Assistant                              | Azure Foundry Assistant                                                       |
+| Feature             | Azure Assistant                              | Azure Foundry Agent                                                           |
 | ------------------- | -------------------------------------------- | ----------------------------------------------------------------------------- |
 | **API Type**        | Direct HTTP calls to Azure OpenAI API        | Azure AI Projects SDK (`@azure/ai-projects`)                                  |
 | **Authentication**  | API key or Azure credentials                 | `DefaultAzureCredential` (Azure CLI, environment variables, managed identity) |
 | **Endpoint**        | Azure OpenAI endpoint (`*.openai.azure.com`) | Azure AI Project URL (`*.services.ai.azure.com/api/projects/*`)               |
-| **Provider Format** | `azure:assistant:<assistant_id>`             | `azure:foundry-assistant:<assistant_id>`                                      |
+| **Provider Format** | `azure:assistant:<assistant_id>`             | `azure:foundry-agent:<assistant_id>`                                          |
 
 ### Setup
 
@@ -917,11 +917,11 @@ Alternatively, you can provide the `projectUrl` in your configuration file.
 
 ### Basic Configuration
 
-The provider uses the `azure:foundry-assistant:<assistant_id>` format:
+The provider uses the `azure:foundry-agent:<assistant_id>` format:
 
 ```yaml
 providers:
-  - id: azure:foundry-assistant:asst_E4GyOBYKlnAzMi19SZF2Sn8I
+  - id: azure:foundry-agent:asst_E4GyOBYKlnAzMi19SZF2Sn8I
     config:
       projectUrl: 'https://your-project.services.ai.azure.com/api/projects/your-project-id'
       temperature: 0.7
@@ -931,7 +931,7 @@ providers:
 
 ### Configuration Options
 
-The Azure Foundry Assistant provider supports all the same configuration options as the standard Azure Assistant provider:
+The Azure Foundry Agent provider supports all the same configuration options as the standard Azure Assistant provider:
 
 | Parameter               | Description                                                                  |
 | ----------------------- | ---------------------------------------------------------------------------- |
@@ -948,13 +948,13 @@ The Azure Foundry Assistant provider supports all the same configuration options
 | `maxPollTimeMs`         | Maximum time to poll for completion (default: 300000ms / 5 minutes)          |
 | `response_format`       | Response format specification                                                |
 
-### Function Tools with Azure Foundry Assistants
+### Function Tools with Azure Foundry Agents
 
 Function tools work the same way as with standard Azure Assistants. You can define functions and provide callback implementations:
 
 ```yaml
 providers:
-  - id: azure:foundry-assistant:your_assistant_id
+  - id: azure:foundry-agent:your_assistant_id
     config:
       projectUrl: 'https://your-project.services.ai.azure.com/api/projects/your-project-id'
       # Load function tool definitions
@@ -990,13 +990,13 @@ The function callbacks receive two parameters:
 - `args`: String containing JSON-encoded function arguments
 - `context`: Object with `{ threadId, runId, assistantId, provider }` for advanced use cases
 
-### Using Vector Stores with Azure Foundry Assistants
+### Using Vector Stores with Azure Foundry Agents
 
 Vector stores work the same way as with standard Azure Assistants:
 
 ```yaml
 providers:
-  - id: azure:foundry-assistant:your_assistant_id
+  - id: azure:foundry-agent:your_assistant_id
     config:
       projectUrl: 'https://your-project.services.ai.azure.com/api/projects/your-project-id'
       # Add tools for file search
@@ -1026,10 +1026,10 @@ providers:
 Here's a complete example configuration:
 
 ```yaml
-description: 'Azure Foundry Assistant evaluation'
+description: 'Azure Foundry Agent evaluation'
 
 providers:
-  - id: azure:foundry-assistant:asst_uRGMedGFDehLkjJJaq51J9GY
+  - id: azure:foundry-agent:asst_uRGMedGFDehLkjJJaq51J9GY
     config:
       projectUrl: 'https://my-project.services.ai.azure.com/api/projects/my-project-id'
       temperature: 0.7
@@ -1057,7 +1057,7 @@ tests:
 
 ### Error Handling
 
-The Azure Foundry Assistant provider includes comprehensive error handling:
+The Azure Foundry Agent provider includes comprehensive error handling:
 
 - **Content Filter Detection**: Automatically detects and reports content filtering events with guardrails metadata
 - **Rate Limit Handling**: Identifies rate limit errors for proper retry handling
@@ -1078,14 +1078,14 @@ Enable caching globally in your configuration:
 cache: true
 
 providers:
-  - id: azure:foundry-assistant:your_assistant_id
+  - id: azure:foundry-agent:your_assistant_id
     config:
       projectUrl: 'https://your-project.services.ai.azure.com/api/projects/your-project-id'
 ```
 
-### When to Use Azure Foundry Assistants
+### When to Use Azure Foundry Agents
 
-Use Azure Foundry Assistants when:
+Use Azure Foundry Agents when:
 
 - You're working within Azure AI Foundry projects
 - You prefer native Azure SDK authentication (`DefaultAzureCredential`)
@@ -1100,7 +1100,7 @@ Use standard Azure Assistants when:
 
 ### Example Repository
 
-For complete working examples, check out the [azure-foundry-assistant example directory](https://github.com/promptfoo/promptfoo/tree/main/examples/azure-foundry-assistant).
+For complete working examples, check out the [azure-foundry-agent example directory](https://github.com/promptfoo/promptfoo/tree/main/examples/azure-foundry-agent).
 
 ## See Also
 

--- a/src/providers/azure/foundry-agent.ts
+++ b/src/providers/azure/foundry-agent.ts
@@ -81,7 +81,7 @@ interface ToolOutput {
   output: string;
 }
 
-export class AzureFoundryAssistantProvider extends AzureGenericProvider {
+export class AzureFoundryAgentProvider extends AzureGenericProvider {
   assistantConfig: AzureAssistantOptions;
   private loadedFunctionCallbacks: Record<string, Function> = {};
   private projectClient: AIProjectClient | null = null;
@@ -288,7 +288,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
     _callApiOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
     // Create a simple cache key based on the input and configuration
-    const cacheKey = `azure_foundry_assistant:${this.deploymentName}:${JSON.stringify({
+    const cacheKey = `azure_foundry_agent:${this.deploymentName}:${JSON.stringify({
       frequency_penalty: this.assistantConfig.frequency_penalty,
       instructions: this.assistantConfig.instructions,
       max_completion_tokens: this.assistantConfig.max_completion_tokens,
@@ -315,7 +315,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
         const cachedResult = await cache.get<ProviderResponse>(cacheKey);
 
         if (cachedResult) {
-          logger.debug(`Cache hit for assistant prompt: ${prompt.substring(0, 50)}...`);
+          logger.debug(`Cache hit for agent prompt: ${prompt.substring(0, 50)}...`);
           return { ...cachedResult, cached: true };
         }
       } catch (err) {
@@ -454,7 +454,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
         try {
           const cache = await getCache();
           await cache.set(cacheKey, result);
-          logger.debug(`Cached assistant response for prompt: ${prompt.substring(0, 50)}...`);
+          logger.debug(`Cached agent response for prompt: ${prompt.substring(0, 50)}...`);
         } catch (err) {
           logger.warn(`Error caching result: ${err}`);
           // Continue even if caching fails
@@ -463,7 +463,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
 
       return result;
     } catch (err: any) {
-      logger.error(`Error in Azure Foundry Assistant API call: ${err}`);
+      logger.error(`Error in Azure Foundry Agent API call: ${err}`);
       return this.formatError(err);
     }
   }
@@ -498,7 +498,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
       errorMessage.includes("Can't add messages to thread") &&
       errorMessage.includes('while a run')
     ) {
-      return { error: `Error in Azure Foundry Assistant API call: ${errorMessage}` };
+      return { error: `Error in Azure Foundry Agent API call: ${errorMessage}` };
     }
     if (this.isRateLimitError(errorMessage)) {
       return { error: `Rate limit exceeded: ${errorMessage}` };
@@ -507,7 +507,7 @@ export class AzureFoundryAssistantProvider extends AzureGenericProvider {
       return { error: `Service error: ${errorMessage}` };
     }
 
-    return { error: `Error in Azure Foundry Assistant API call: ${errorMessage}` };
+    return { error: `Error in Azure Foundry Agent API call: ${errorMessage}` };
   }
 
   /**

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -150,5 +150,5 @@ export interface AzureAssistantProviderOptions {
   config?: AzureAssistantOptions & { projectUrl?: string };
   id?: string;
   env?: EnvOverrides;
-  /** Azure AI Project URL for Foundry assistant provider */
+  /** Azure AI Project URL for Foundry agent provider */
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -22,7 +22,7 @@ import { AzureAssistantProvider } from './azure/assistant';
 import { AzureChatCompletionProvider } from './azure/chat';
 import { AzureCompletionProvider } from './azure/completion';
 import { AzureEmbeddingProvider } from './azure/embedding';
-import { AzureFoundryAssistantProvider } from './azure/foundry-assistant';
+import { AzureFoundryAgentProvider } from './azure/foundry-agent';
 import { AzureModerationProvider } from './azure/moderation';
 import { AzureResponsesProvider } from './azure/responses';
 import { AwsBedrockCompletionProvider, AwsBedrockEmbeddingProvider } from './bedrock/index';
@@ -78,12 +78,12 @@ import { createPerplexityProvider } from './perplexity';
 import { PortkeyChatCompletionProvider } from './portkey';
 import { PromptfooModelProvider } from './promptfooModel';
 import { PythonProvider } from './pythonCompletion';
-import { RubyProvider } from './rubyCompletion';
 import {
   ReplicateImageProvider,
   ReplicateModerationProvider,
   ReplicateProvider,
 } from './replicate';
+import { RubyProvider } from './rubyCompletion';
 import { createScriptBasedProviderFactory } from './scriptBasedProvider';
 import { ScriptCompletionProvider } from './scriptCompletion';
 import { SequenceProvider } from './sequence';
@@ -263,8 +263,8 @@ export const providerMap: ProviderFactory[] = [
       if (modelType === 'assistant') {
         return new AzureAssistantProvider(deploymentName, providerOptions);
       }
-      if (modelType === 'foundry-assistant') {
-        return new AzureFoundryAssistantProvider(deploymentName, providerOptions);
+      if (modelType === 'foundry-agent') {
+        return new AzureFoundryAgentProvider(deploymentName, providerOptions);
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {
         return new AzureEmbeddingProvider(

--- a/test/providers/azure/foundry-agent.test.ts
+++ b/test/providers/azure/foundry-agent.test.ts
@@ -1,4 +1,4 @@
-import { AzureFoundryAssistantProvider } from '../../../src/providers/azure/foundry-assistant';
+import { AzureFoundryAgentProvider } from '../../../src/providers/azure/foundry-agent';
 
 jest.mock('../../../src/cache', () => ({
   getCache: jest.fn(),
@@ -59,26 +59,26 @@ jest.mock('@azure/identity', () => ({
   DefaultAzureCredential: jest.fn(),
 }));
 
-describe('Azure Foundry Assistant Provider', () => {
+describe('Azure Foundry Agent Provider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('instantiation', () => {
     it('should create provider with minimal config', () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
         },
       });
 
       expect(provider).toBeDefined();
-      expect(provider.deploymentName).toBe('test-assistant');
+      expect(provider.deploymentName).toBe('test-agent');
     });
 
     it('should throw error if projectUrl is not provided', () => {
       expect(() => {
-        new AzureFoundryAssistantProvider('test-assistant', {
+        new AzureFoundryAgentProvider('test-agent', {
           config: {},
         });
       }).toThrow('Azure AI Project URL must be provided');
@@ -87,7 +87,7 @@ describe('Azure Foundry Assistant Provider', () => {
     it('should accept projectUrl from environment variable', () => {
       process.env.AZURE_AI_PROJECT_URL = 'https://env.services.ai.azure.com/api/projects/test';
 
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {},
       });
 
@@ -98,7 +98,7 @@ describe('Azure Foundry Assistant Provider', () => {
 
   describe('run options parameters', () => {
     it('should pass max_tokens to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           max_tokens: 150,
@@ -117,7 +117,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass max_completion_tokens to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           max_completion_tokens: 200,
@@ -136,7 +136,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass both max_tokens and max_completion_tokens when both are provided', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           max_tokens: 100,
@@ -157,7 +157,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass frequency_penalty to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           frequency_penalty: 0.5,
@@ -176,7 +176,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass presence_penalty to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           presence_penalty: 0.3,
@@ -195,7 +195,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass response_format to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           response_format: { type: 'json_object' },
@@ -214,7 +214,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass stop sequences to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           stop: ['END', 'STOP'],
@@ -233,7 +233,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass seed to run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           seed: 12345,
@@ -252,7 +252,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should pass all parameters together when configured', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           temperature: 0.7,
@@ -287,7 +287,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should not include undefined parameters in run options', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
           temperature: 0.5,
@@ -312,7 +312,7 @@ describe('Azure Foundry Assistant Provider', () => {
 
   describe('basic functionality', () => {
     it('should create thread, message, and run', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
         },
@@ -320,7 +320,7 @@ describe('Azure Foundry Assistant Provider', () => {
 
       await provider.callApi('test prompt');
 
-      expect(mockClient.agents.getAgent).toHaveBeenCalledWith('test-assistant');
+      expect(mockClient.agents.getAgent).toHaveBeenCalledWith('test-agent');
       expect(mockClient.agents.threads.create).toHaveBeenCalled();
       expect(mockClient.agents.messages.create).toHaveBeenCalledWith(
         mockThread.id,
@@ -335,7 +335,7 @@ describe('Azure Foundry Assistant Provider', () => {
     });
 
     it('should return formatted output', async () => {
-      const provider = new AzureFoundryAssistantProvider('test-assistant', {
+      const provider = new AzureFoundryAgentProvider('test-agent', {
         config: {
           projectUrl: 'https://test.services.ai.azure.com/api/projects/test-project',
         },


### PR DESCRIPTION
Turns out it's AI Foundry Agents, not assistants, despite the ids starting with `asst_...`