### PR TITLE
fix(webui): add max height with scroll to custom policies container

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -627,7 +627,8 @@ export default function Review({
                         sx={{
                           position: 'absolute',
                           right: 4,
-                          top: 4,
+                          top: '50%',
+                          transform: 'translateY(-50%)',
                           padding: '2px',
                         }}
                       >


### PR DESCRIPTION
## Before

<img width="1728" height="962" alt="image" src="https://github.com/user-attachments/assets/84399b04-08ef-4458-a78f-df2ef568494f" />

## After

<img width="853" height="567" alt="image" src="https://github.com/user-attachments/assets/e62d172d-1a59-4b0a-b4ac-1b98d3d480af" />