### PR TITLE
fix: web ui email verification

### DIFF
--- a/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/EmailVerificationDialog.tsx
@@ -66,19 +66,19 @@ export function EmailVerificationDialog({
       const statusResult = await checkEmailStatus({ validate: true });
 
       if (statusResult.error) {
-        saveEmail("");
+        saveEmail('');
         setEmailError(statusResult.error);
         return;
       }
 
       if (result.error) {
-        saveEmail("");
+        saveEmail('');
         setEmailError(result.error || 'Failed to verify email');
         return;
       }
 
       if (!statusResult.canProceed) {
-        saveEmail("");
+        saveEmail('');
         setEmailError('Email validation failed. Please use a different email.');
         return;
       }


### PR DESCRIPTION
Issue was caused by validating before saving the email (which sounds like it would make sense), but caused validation to fail since the email was null when validated. New approach is to save, then validate, then clear if validation fails.