### PR TITLE
feat: Improved error handling in CLI and error logging

### DIFF
--- a/src/cliState.ts
+++ b/src/cliState.ts
@@ -12,6 +12,12 @@ interface CliState {
 
   // Indicates an evaluation is running in resume mode
   resume?: boolean;
+
+  // Path to the debug log file
+  debugLogPath?: string;
+
+  // Path to the error log file
+  errorLogPath?: string;
 }
 
 const state: CliState = {};

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -12,7 +12,7 @@ import { getEnvBool, getEnvFloat, getEnvInt } from '../envars';
 import { DEFAULT_MAX_CONCURRENCY, evaluate } from '../evaluator';
 import { checkEmailStatusOrExit, promptForEmailUnverified } from '../globalConfig/accounts';
 import { cloudConfig } from '../globalConfig/cloud';
-import logger, { debugLogPath, errorLogPath, getLogLevel } from '../logger';
+import logger, { getLogLevel } from '../logger';
 import { runDbMigrations } from '../migrate';
 import Eval from '../models/eval';
 import { loadApiProvider } from '../providers/index';
@@ -775,7 +775,7 @@ export async function doEval(
       logger.info(
         '\n' +
           chalk.red.bold(
-            `See ${chalk.greenBright.bold(errorLogPath)} for detailed error logs or ${chalk.greenBright.bold(debugLogPath)} for verbose logs`,
+            `See ${chalk.greenBright.bold(cliState.errorLogPath)} for detailed error logs or ${chalk.greenBright.bold(cliState.debugLogPath)} for verbose logs`,
           ),
       );
     printBorder();

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -194,6 +194,7 @@ class ProgressBarManager {
    * Stop the progress bar
    */
   stop(): void {
+    enableConsoleLogging();
     if (this.progressBar) {
       this.progressBar.stop();
     }
@@ -1421,7 +1422,7 @@ class Evaluator {
         // CI progress reporter update
         ciProgressReporter.update(numComplete);
       } else {
-        logger.info(`Eval #${index + 1} complete (${numComplete} of ${runEvalOptions.length})`);
+        logger.debug(`Eval #${index + 1} complete (${numComplete} of ${runEvalOptions.length})`);
       }
     };
 

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -7,12 +7,7 @@ import Table from 'cli-table3';
 import yaml from 'js-yaml';
 import cliState from '../cliState';
 import { getEnvString } from '../envars';
-import logger, {
-  disableConsoleLogging,
-  enableConsoleLogging,
-  errorLogPath,
-  getLogLevel,
-} from '../logger';
+import logger, { disableConsoleLogging, enableConsoleLogging, getLogLevel } from '../logger';
 import { checkRemoteHealth } from '../util/apiHealth';
 import invariant from '../util/invariant';
 import { extractVariablesFromTemplates } from '../util/templates';
@@ -996,7 +991,7 @@ export async function synthesize({
   ) {
     logger.info(
       chalk.red.bold(
-        `See ${chalk.greenBright.bold(errorLogPath)} for more details on failed generations`,
+        `See ${chalk.greenBright.bold(cliState.errorLogPath)} for more details on failed generations`,
       ),
     );
   }

--- a/src/util/dateTime.ts
+++ b/src/util/dateTime.ts
@@ -1,4 +1,0 @@
-export function getDateTimeForFilename(): string {
-  const isoWithoutMs = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-  return isoWithoutMs.replace(/[:]/g, '').replace('T', '_').replace('Z', '');
-}

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -3,3 +3,12 @@ export function getCurrentTimestamp() {
 }
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ *
+ * @returns The current date and time as a string in the format of YYYYMMDD_HHMMSS
+ */
+export function getDateTimeForFilename(): string {
+  const isoWithoutMs = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  return isoWithoutMs.replace(/[:]/g, '').replace('T', '_').replace('Z', '');
+}


### PR DESCRIPTION
Changes:
- Disable console logging while there is a progress bar to improve the UI
- Add verbose and error logs for each command initialization that go into `LOG_DIR` or the default config directory + logs eg: `~/.promptfoo/logs`


### During test generation show the number of failed plugins and error log information
<img width="1367" height="904" alt="image" src="https://github.com/user-attachments/assets/8edb5eab-f002-4b7b-94f5-ab80b9465939" />


### Eval runs - show errors in progress bar text and error log information
<img width="1825" height="404" alt="image" src="https://github.com/user-attachments/assets/7dff528a-adbe-477a-a1b1-e4484078e9ed" />
