### PR TITLE
docs(echo): add examples for evaluating logged production outputs

### DIFF
--- a/site/docs/providers/echo.md
+++ b/site/docs/providers/echo.md
@@ -68,3 +68,65 @@ The Echo Provider is useful for:
 - **Testing Transformations**: Test how transformations affect the output without the variability of an LLM response.
 
 - **Mocking in Test Environments**: Use as a drop-in replacement for other providers in test environments when you don't want to make actual API calls.
+
+### Evaluating Logged Production Outputs
+
+A common pattern is evaluating LLM outputs that were already generated in production. This allows you to run assertions against real production data without making new API calls.
+
+Use your logged output directly as the prompt:
+
+```yaml
+prompts:
+  - '{{logged_output}}'
+
+providers:
+  - echo
+
+tests:
+  - vars:
+      logged_output: 'Paris is the capital of France.'
+    assert:
+      - type: llm-rubric
+        value: 'Answer is factually correct'
+      - type: contains
+        value: 'Paris'
+```
+
+The echo provider returns the prompt as-is, so your logged output flows directly to assertions without any API calls.
+
+For JSON-formatted production logs, use a default transform to extract specific fields:
+
+```yaml
+prompts:
+  - '{{logged_output}}'
+
+providers:
+  - echo
+
+defaultTest:
+  options:
+    # Extract just the response field from all logged outputs
+    transform: 'JSON.parse(output).response'
+
+tests:
+  - vars:
+      # Production logs often contain JSON strings
+      logged_output: '{"response": "Paris is the capital of France.", "confidence": 0.95, "model": "gpt-5"}'
+    assert:
+      - type: llm-rubric
+        value: 'Answer is factually correct'
+  - vars:
+      logged_output: '{"response": "London is in England.", "confidence": 0.98, "model": "gpt-5"}'
+    assert:
+      - type: contains
+        value: 'London'
+```
+
+This pattern is particularly useful for:
+
+- Post-deployment evaluation of production prompts
+- Regression testing against known outputs
+- A/B testing assertion strategies on historical data
+- Validating system behavior without API costs
+
+For loading large volumes of logged outputs, test cases can be generated dynamically from [CSV files, Python scripts, JavaScript functions, or JSON](/docs/configuration/test-cases).


### PR DESCRIPTION
Adds documentation to the echo provider showing how to evaluate LLM outputs that were already generated in production (\"online evaluation\").

## Changes

- Added \"Evaluating Logged Production Outputs\" subsection to echo provider docs
- Includes two examples:
  1. Simple example: using logged output directly as a prompt variable
  2. Advanced example: using `defaultTest` transform to extract fields from JSON-formatted logs
- Added link to test cases documentation for loading large volumes of logged outputs
- Both examples tested and verified working

## Use Case

This addresses a common pattern requested in Discord where users want to:
- Evaluate production prompts post-deployment
- Run regression tests against known outputs
- A/B test assertion strategies on historical data
- Validate system behavior without API costs

Reference: Discord conversation where user discovered this pattern as a workaround and we're now documenting it as the recommended approach.