### PR TITLE
fix: Don't test session management if target is not stateful

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -128,13 +128,18 @@ async function testHttpProvider(provider: ApiProvider): Promise<void> {
   const connectivityResult = await testHTTPProviderConnectivity(provider);
   displayTestResult(connectivityResult, 'Connectivity test');
 
-  // Test 2: Session management (only if connectivity test passed)
+  // Test 2: Session management (only if connectivity test passed and target is stateful)
   if (connectivityResult.success) {
-    logger.info('\nTesting session management...');
-    const sessionResult = await testProviderSession(provider, undefined, {
-      skipConfigValidation: true,
-    });
-    displayTestResult(sessionResult, 'Session test');
+    // Check if the provider is explicitly configured as non-stateful
+    if (provider.config?.stateful === false) {
+      logger.info(chalk.dim('\nSkipping session management test (target is not stateful)'));
+    } else {
+      logger.info('\nTesting session management...');
+      const sessionResult = await testProviderSession(provider, undefined, {
+        skipConfigValidation: true,
+      });
+      displayTestResult(sessionResult, 'Session test');
+    }
   } else {
     logger.info(chalk.dim('\nSkipping session management test (connectivity test failed)'));
   }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -758,6 +758,8 @@ export const HttpProviderConfigSchema = z.object({
     .optional()
     .describe('Use HTTPS for the request. This only works with the raw request option'),
   sessionParser: z.union([z.string(), z.function()]).optional(),
+  sessionSource: z.enum(['client', 'server']).optional(),
+  stateful: z.boolean().optional(),
   transformRequest: z.union([z.string(), z.function()]).optional(),
   transformResponse: z.union([z.string(), z.function()]).optional(),
   url: z.string().optional(),

--- a/test/commands/validate-provider-tests.test.ts
+++ b/test/commands/validate-provider-tests.test.ts
@@ -125,6 +125,31 @@ describe('Validate Command Provider Tests', () => {
       );
     });
 
+    it('should skip session test when target is not stateful (stateful=false)', async () => {
+      const mockNonStatefulHttpProvider: ApiProvider = {
+        id: () => 'http://example.com',
+        callApi: jest.fn(),
+        config: { stateful: false },
+        constructor: { name: 'HttpProvider' },
+      } as any;
+
+      jest.mocked(loadApiProvider).mockResolvedValue(mockNonStatefulHttpProvider);
+      jest.mocked(testHTTPProviderConnectivity).mockResolvedValue({
+        success: true,
+        message: 'Connectivity test passed',
+        providerResponse: { output: 'test' },
+        transformedRequest: {},
+      });
+
+      await doValidateTarget({ target: 'http://example.com' }, defaultConfig);
+
+      expect(testHTTPProviderConnectivity).toHaveBeenCalledWith(mockNonStatefulHttpProvider);
+      expect(testProviderSession).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping session management test (target is not stateful)'),
+      );
+    });
+
     it('should test non-HTTP provider with basic connectivity only when -t flag is provided', async () => {
       jest.mocked(loadApiProvider).mockResolvedValue(mockEchoProvider);
 


### PR DESCRIPTION
### Summary
- If the http target has `config.stateful` set to false, then it'll skip the session management test.

**Possibly controversial:** Previously, `sessionSource` and `stateful` were considered UI only config values are would be removed from unified config. Not anymore. 

### Example output
```
$ npm run local -- validate target -t bc0a1770-bf4e-4e22-8a3d-0b0330aafbaf    

> promptfoo@0.118.17 local
> ts-node --cwdMode --transpileOnly src/main.ts validate target -t bc0a1770-bf4e-4e22-8a3d-0b0330aafbaf

Testing provider...

Running provider tests...

Testing HTTP provider: https://customer-service-chatbot-example.promptfoo.app
Testing basic connectivity...
Starting evaluation eval-utw-2025-10-21T17:38:46
Running 1 test cases (up to 1 at a time)...
✓ Connectivity test passed
  Test successfully completed. We've verified that the provider is working correctly.
  Session ID: 69c20470-9c9e-45dd-b6d8-c5c47648a362

Skipping session management test (target is not stateful)
```