### PR TITLE
fix: ctrl+c not working to exit process

### DIFF
--- a/test/providers/providerRegistryHandlers.test.ts
+++ b/test/providers/providerRegistryHandlers.test.ts
@@ -1,0 +1,116 @@
+import { ProviderRegistry } from '../../src/providers/providerRegistry';
+
+type ProcessEvent = NodeJS.Signals | 'beforeExit';
+
+type DeferredPromise = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+function createDeferred(): DeferredPromise {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createProcessMock() {
+  const handlers = new Map<ProcessEvent, (...args: any[]) => void>();
+  const exitMock = jest.fn();
+  let mockProcess: any;
+
+  const once = jest.fn((event: ProcessEvent, handler: (...args: any[]) => void) => {
+    handlers.set(event, handler);
+    return mockProcess;
+  });
+
+  mockProcess = {
+    once,
+    exit: ((code?: number) => {
+      exitMock(code);
+      return undefined as never;
+    }) as (code?: number) => never,
+    emit(event: ProcessEvent, ...args: any[]) {
+      const handler = handlers.get(event);
+      if (!handler) {
+        return;
+      }
+      handlers.delete(event);
+      handler(...args);
+    },
+    getHandler(event: ProcessEvent) {
+      return handlers.get(event);
+    },
+    exitMock,
+  };
+
+  return mockProcess as {
+    once: jest.MockedFunction<typeof once>;
+    exit: (code?: number) => never;
+    emit(event: ProcessEvent, ...args: any[]): void;
+    getHandler(event: ProcessEvent): ((...args: any[]) => void) | undefined;
+    exitMock: jest.Mock;
+  };
+}
+
+describe('ProviderRegistry shutdown handlers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('waits for provider shutdown before exiting on SIGINT', async () => {
+    const processMock = createProcessMock();
+    const registry = new ProviderRegistry(processMock);
+
+    const deferred = createDeferred();
+    const provider = {
+      shutdown: jest.fn(() => deferred.promise),
+    };
+
+    registry.register(provider);
+
+    expect(processMock.once).toHaveBeenCalledTimes(3);
+
+    processMock.emit('SIGINT');
+    expect(provider.shutdown).toHaveBeenCalledTimes(1);
+    expect(processMock.exitMock).not.toHaveBeenCalled();
+
+    deferred.resolve();
+    await flushAsyncWork();
+
+    expect(processMock.exitMock).toHaveBeenCalledWith(130);
+  });
+
+  it('exits with signal-specific exit code on SIGTERM', async () => {
+    const processMock = createProcessMock();
+    const registry = new ProviderRegistry(processMock);
+
+    registry.register({
+      shutdown: jest.fn(() => Promise.resolve()),
+    });
+
+    processMock.emit('SIGTERM');
+    await flushAsyncWork();
+
+    expect(processMock.exitMock).toHaveBeenCalledWith(143);
+  });
+
+  it('does not force exit during beforeExit cleanup', () => {
+    const processMock = createProcessMock();
+    const registry = new ProviderRegistry(processMock);
+
+    registry.register({
+      shutdown: jest.fn(() => Promise.resolve()),
+    });
+
+    processMock.emit('beforeExit');
+
+    expect(processMock.exitMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
  ## Summary

  Fixes an issue where pressing Ctrl+C would not properly exit the process after Python provider cleanup completed.
  The process would perform cleanup but then hang instead of exiting.

  ## Problem

  The `ProviderRegistry` registered async shutdown handlers for `SIGINT` and `SIGTERM` signals to clean up Python
  providers, but these handlers never called `process.exit()` after the async cleanup completed. This meant that:

  1. User presses Ctrl+C (SIGINT)
  2. Cleanup runs successfully
  3. Process hangs instead of exiting
  4. User has to force-kill the process

  ## Solution

  - Modified shutdown handlers to call `process.exit()` with proper exit codes after cleanup completes
  - Used conventional Unix exit codes: 130 for SIGINT, 143 for SIGTERM
  - Made `ProviderRegistry` testable by injecting the process dependency
  - Added `beforeExit` handler to continue allowing graceful shutdown without forced exit
  - Exported `ProviderRegistry` class to enable testing

  ## Changes

  - `src/providers/providerRegistry.ts`: Added process dependency injection, exit codes, and forced exit after
  cleanup
  - `test/providers/providerRegistryHandlers.test.ts`: Added comprehensive tests verifying shutdown behavior

  ## Test Plan

  - [x] Added unit tests verifying SIGINT exits with code 130 after cleanup
  - [x] Added unit tests verifying SIGTERM exits with code 143 after cleanup
  - [x] Added unit tests verifying beforeExit doesn't force exit
  - [x] Verified Ctrl+C properly exits the process in development
  - [x] Tests pass: `npm test`
  - [x] Lint passes: `npm run lint`
