### PR TITLE
docs(site): Adds custom strategy to the strategies reference table

### DIFF
--- a/site/docs/_shared/data/strategies.ts
+++ b/site/docs/_shared/data/strategies.ts
@@ -24,6 +24,17 @@ export const strategies: Strategy[] = [
     link: '/docs/red-team/strategies/custom/',
   },
   {
+    category: 'Custom',
+    strategy: 'custom-strategy',
+    displayName: 'Custom Strategy',
+    description: 'Custom prompt-based multi-turn strategy',
+    longDescription:
+      'Write natural language instructions to create powerful multi-turn red team strategies. No coding required.',
+    cost: 'Variable',
+    asrIncrease: 'Variable',
+    link: '/docs/red-team/strategies/custom-strategy/',
+  },
+  {
     category: 'Dynamic (Single-Turn)',
     strategy: 'best-of-n',
     displayName: 'Best-of-N',


### PR DESCRIPTION
Custom Strategy is presently missing from the [Strategies Reference Table](https://www.promptfoo.dev/docs/red-team/strategies/#available-strategies).