### PR TITLE
revert: defer identify() until first event (#6094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - fix(python): use REQUEST_TIMEOUT_MS for consistent timeout behavior across providers (300s default, previously 120s) (#6098)
-- chore(telemetry): defer PostHog identify() to first telemetry event to keep module initialization synchronous (#6094)
 - refactor(redteam): Prevent early (evaluator-based) exits in Jailbreak, Crescendo, and Custom Strategies (#6047)
 - chore(webui): expand language options to 486 ISO 639-2 languages with support for all 687 ISO codes (639-1, 639-2/T, 639-2/B) in red team run settings (#6069)
 - chore(app): larger eval selector dialog (#6063)

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -56,26 +56,15 @@ const TELEMETRY_TIMEOUT_MS = 1000;
 
 export class Telemetry {
   private telemetryDisabledRecorded = false;
-  private identified = false;
   private id: string;
   private email: string | null;
 
   constructor() {
     this.id = getUserId();
     this.email = getUserEmail();
-  }
-
-  /**
-   * Ensures user identification before recording telemetry events.
-   * Deferred from constructor to keep module initialization synchronous.
-   */
-  private ensureIdentified(): void {
-    if (!this.identified && !this.disabled) {
-      this.identified = true;
-      this.identify().catch(() => {
-        // Silently ignore identification errors
-      });
-    }
+    this.identify().then(() => {
+      // pass
+    });
   }
 
   async identify() {
@@ -115,8 +104,6 @@ export class Telemetry {
   }
 
   record(eventName: TelemetryEventTypes, properties: EventProperties): void {
-    this.ensureIdentified();
-
     if (this.disabled) {
       this.recordTelemetryDisabled();
     } else {


### PR DESCRIPTION
This reverts PR #6094 which deferred PostHog identify() to the first telemetry event.

**Reason for revert:**
[Add reason here]

Reverts commit e0226f6d6.