### PR TITLE
docs(site): fix buttons unclickable when animations disabled

### DIFF
--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -31,6 +31,9 @@ html {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+    /* Ensure elements are visible and interactive when animations are disabled */
+    opacity: 1 !important;
+    transform: none !important;
   }
 
   /* Disable specific animations that might be problematic */


### PR DESCRIPTION
When users have animations disabled on mobile devices (prefers-reduced-motion), homepage buttons, links, and tabs were visible but not clickable due to transform properties from animation keyframes causing hit detection issues.

This fix ensures all elements are interactive by setting transform: none when
animations are reduced, while also ensuring consistent visibility with opacity: 1.