### PR TITLE
perf: remove unnecessary await from synchronous database operations

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -119,7 +119,7 @@ FROM eval_results where eval_id IN (${evals.map((e) => `'${e.id}'`).join(',')}))
   static async setVars(evalId: string, vars: string[]) {
     const db = getDb();
     try {
-      await db.update(evalsTable).set({ vars }).where(eq(evalsTable.id, evalId)).run();
+      db.update(evalsTable).set({ vars }).where(eq(evalsTable.id, evalId)).run();
     } catch (e) {
       logger.error(`Error setting vars: ${vars} for eval ${evalId}: ${e}`);
     }
@@ -446,7 +446,7 @@ export default class Eval {
       invariant(this.oldResults, 'Old results not found');
       updateObj.results = this.oldResults;
     }
-    await db.update(evalsTable).set(updateObj).where(eq(evalsTable.id, this.id)).run();
+    db.update(evalsTable).set(updateObj).where(eq(evalsTable.id, this.id)).run();
     this.persisted = true;
   }
 
@@ -830,7 +830,7 @@ export default class Eval {
     this.prompts = prompts;
     if (this.persisted) {
       const db = getDb();
-      await db.update(evalsTable).set({ prompts }).where(eq(evalsTable.id, this.id)).run();
+      db.update(evalsTable).set({ prompts }).where(eq(evalsTable.id, this.id)).run();
     }
   }
 

--- a/src/models/evalPerformance.ts
+++ b/src/models/evalPerformance.ts
@@ -27,7 +27,7 @@ export async function getCachedResultsCount(evalId: string): Promise<number> {
   const start = Date.now();
 
   // Use COUNT(*) with the composite index on (eval_id, test_idx)
-  const result = await db
+  const result = db
     .select({ count: sql<number>`COUNT(DISTINCT test_idx)` })
     .from(evalResultsTable)
     .where(sql`eval_id = ${evalId}`)
@@ -101,7 +101,7 @@ export async function queryTestIndicesOptimized(
     WHERE ${whereClause}
   `;
 
-  const countResult = await db.all<{ count: number }>(countQuery);
+  const countResult = db.all<{ count: number }>(countQuery);
   const filteredCount = Number(countResult[0]?.count ?? 0);
   logger.debug(`Optimized count query took ${Date.now() - countStart}ms`);
 
@@ -116,7 +116,7 @@ export async function queryTestIndicesOptimized(
     OFFSET ${offset}
   `;
 
-  const rows = await db.all<{ test_idx: number }>(idxQuery);
+  const rows = db.all<{ test_idx: number }>(idxQuery);
   const testIndices = rows.map((row) => row.test_idx);
   logger.debug(`Optimized index query took ${Date.now() - idxStart}ms`);
 

--- a/src/models/modelAudit.ts
+++ b/src/models/modelAudit.ts
@@ -156,7 +156,7 @@ export default class ModelAudit {
       scannerVersion: params.scannerVersion || null,
     };
     const db = getDb();
-    await db.insert(modelAuditsTable).values(data).run();
+    db.insert(modelAuditsTable).values(data).run();
 
     logger.debug(`Created model audit ${id} for ${params.modelPath}`);
 
@@ -353,7 +353,7 @@ export default class ModelAudit {
     }
 
     const db = getDb();
-    await db.delete(modelAuditsTable).where(eq(modelAuditsTable.id, this.id)).run();
+    db.delete(modelAuditsTable).where(eq(modelAuditsTable.id, this.id)).run();
 
     this.persisted = false;
   }


### PR DESCRIPTION
Remove unnecessary `await` keywords from synchronous better-sqlite3 operations.

The codebase uses `better-sqlite3` which is synchronous - methods like `.run()` and `.all()` return results immediately without Promises. Some queries were incorrectly using `await` on these synchronous operations, creating unnecessary overhead.

**Changes:**
- Remove `await` from `.run()` calls in eval.ts and modelAudit.ts
- Remove `await` from `.all()` calls in evalPerformance.ts

All tests pass (7,874 tests).