### PR TITLE
docs(site): add October 2025 release highlights

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -22,7 +22,7 @@ This month we shipped **jailbreak:meta and Simba red team strategies**, **remedi
 
 - **[OpenAI Agents SDK](/docs/providers/openai/)** - Agents, tools, handoffs, and OTLP tracing
 - **[Claude Agent SDK](/docs/providers/anthropic/)** - Anthropic agent framework
-- **[Azure AI Foundry Agents](/docs/providers/azure-ai-foundry/)** - Azure AI agent framework
+- **[Azure AI Foundry Agents](/docs/providers/azure/#azure-ai-foundry-agents)** - Azure AI agent framework
 - **[Ruby](/docs/providers/ruby/)** - Execute Ruby scripts as providers
 - **[Snowflake Cortex](/docs/providers/snowflake/)** - Snowflake LLM provider
 - **[Slack](/docs/providers/slack/)** - Test Slack bots
@@ -109,11 +109,11 @@ Plugin-specific grading rules:
 
 - **[Wordplay](/docs/red-team/plugins/wordplay/)** - Tests if systems can be tricked into generating profanity through wordplay like riddles and rhyming games
 - **[COPPA](/docs/red-team/plugins/coppa/)** - Tests if AI systems collect personal information from children without parental consent or age verification
-- **[GDPR preset](/docs/red-team/plugins/gdpr/)** - GDPR and data privacy compliance testing
+- **[GDPR preset](/docs/red-team/gdpr/)** - GDPR and data privacy compliance testing
 
 #### Other Strategies
 
-- **[Authoritative Markup Injection](/docs/red-team/strategies/authoritative-markup/)** - Tests vulnerability to malicious instructions embedded in markup
+- **[Authoritative Markup Injection](/docs/red-team/strategies/authoritative-markup-injection/)** - Tests vulnerability to malicious instructions embedded in markup
 
 ---
 


### PR DESCRIPTION
## Summary

Adds October 2025 release highlights to the documentation site.

## October Highlights

### Red Team Strategies
- **jailbreak:meta** - Multi-agent attack strategy, up to 50% more effective than some multi-turn attacks
- **Simba** - Multi-turn attack strategy with reconnaissance phase for agent systems

### Remediation Reports
- Executive summary, prioritized action items, system prompt suggestions, and guardrail recommendations

### Providers
- New providers: OpenAI Agents SDK, Claude Agent SDK, Azure AI Foundry Agents, Ruby, Snowflake Cortex, Slack
- New model: Claude Haiku 4.5
- Python provider persistence for 10-100x performance improvement

### HTTP Target Configuration
- Postman/cURL import
- Connection testing
- Request transform parity

### Other Features
- SARIF export for vulnerability reports
- Metric filtering with operators (eq, neq, gt, gte, lt, lte, is_defined)
- Grading guidance for plugin-specific rules
- Model Audit revision tracking and deduplication
- MCP server configuration
- Chat Playground redesign
- Keyboard navigation
- File-based logging

### Plugins
- COPPA, GDPR preset, Wordplay
- Authoritative Markup Injection strategy

## Checklist

- [x] Content verified against open-source and enterprise CHANGELOGs
- [x] Format matches previous months
- [x] No LLM-isms or marketing language
- [x] All major features included