### PR TITLE
docs(site): fix missing front matter in lethal-trifecta blog post

### DIFF
--- a/site/blog/lethal-trifecta-testing.md
+++ b/site/blog/lethal-trifecta-testing.md
@@ -2,6 +2,22 @@
 title: 'Testing AI’s “Lethal Trifecta” with Promptfoo'
 description: Learn what the lethal trifecta is and how to use promptfoo red teaming to detect prompt injection and data exfiltration risks in AI agents.
 image: /img/blog/lethal-trifecta/lethal-trifecta-venn.png
+keywords:
+  [
+    lethal trifecta,
+    AI security,
+    prompt injection,
+    data exfiltration,
+    AI agents,
+    red teaming,
+    LLM security,
+    untrusted content,
+    private data,
+    AI vulnerabilities,
+  ]
+date: 2025-09-28
+authors: [ian]
+tags: [security-vulnerability, best-practices, agents, red-teaming]
 ---
 
 # Testing AI’s "Lethal Trifecta" with Promptfoo


### PR DESCRIPTION
## Summary

Added missing Docusaurus front matter fields to the lethal-trifecta blog post to match the standard format used by other blog posts.

## Changes

- **keywords**: Added SEO keywords array for search optimization
- **date**: 2025-09-28 (matching the original commit date)
- **authors**: [ian]
- **tags**: [security-vulnerability, best-practices, agents, red-teaming]

## Verification

- Site builds successfully
- Front matter matches format from other recent blog posts (agent-security.md, 2025-summer-new-redteam-agent.md)