### PR TITLE
fix(webui): prevent infinite loop in StrategyConfigDialog useEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(webui): prevent infinite loop in StrategyConfigDialog useEffect - fixes vitest tests hanging by using stable empty array references for default parameters (#6203)
 - fix(webui): require configuration for layer strategy before allowing navigation in red team setup - layer strategy now shows red border and blocks Next button until steps array is configured, similar to plugins requiring configuration
 - fix(webui): filter hidden metadata keys from metadata filter dropdown - ensures consistent filtering of 'citations' and '\_promptfooFileMetadata' keys across MetadataPanel, EvalOutputPromptDialog, and metadata filter dropdown (#6177)
 - fix(cli): format object and array variables with pretty-printed JSON in console table and HTML outputs for improved readability (#6175)

--- a/src/app/src/pages/redteam/setup/components/StrategyConfigDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/StrategyConfigDialog.tsx
@@ -53,6 +53,10 @@ const getStepId = (step: StepType): string => {
   return typeof step === 'string' ? step : step.id;
 };
 
+// Stable empty arrays to avoid infinite loops in useEffect dependencies
+const EMPTY_PLUGINS_ARRAY: string[] = [];
+const EMPTY_STRATEGIES_ARRAY: Array<string | { id: string; config?: Record<string, any> }> = [];
+
 interface StrategyConfigDialogProps {
   open: boolean;
   strategy: string | null;
@@ -71,8 +75,8 @@ export default function StrategyConfigDialog({
   onClose,
   onSave,
   strategyData,
-  selectedPlugins = [],
-  allStrategies = [],
+  selectedPlugins = EMPTY_PLUGINS_ARRAY,
+  allStrategies = EMPTY_STRATEGIES_ARRAY,
 }: StrategyConfigDialogProps) {
   const [localConfig, setLocalConfig] = React.useState<Record<string, any>>(config || {});
   const [enabled, setEnabled] = React.useState<boolean>(


### PR DESCRIPTION
## Summary

Fixes vitest tests hanging indefinitely in `StrategyConfigDialog.test.tsx` by preventing an infinite render loop.

## Problem

PR #6180 introduced an infinite loop in the `StrategyConfigDialog` component that caused vitest to hang at the "RUN" phase. The issue was caused by default parameter values creating new array instances on every render:

```typescript
export default function StrategyConfigDialog({
  selectedPlugins = [],      // ❌ New array on every render
  allStrategies = [],        // ❌ New array on every render
}: StrategyConfigDialogProps) {
```

Since `selectedPlugins` is in the `useEffect` dependency array and the effect calls `setState`, this created an infinite loop:
1. Render with new `selectedPlugins = []`
2. `useEffect` triggers (dependency changed)
3. `setState` called → re-render
4. Repeat forever

## Solution

Created stable constant arrays outside the component to use as default values:

```typescript
const EMPTY_PLUGINS_ARRAY: string[] = [];
const EMPTY_STRATEGIES_ARRAY: Array<string | { id: string; config?: Record<string, any> }> = [];

export default function StrategyConfigDialog({
  selectedPlugins = EMPTY_PLUGINS_ARRAY,    // ✅ Stable reference
  allStrategies = EMPTY_STRATEGIES_ARRAY,    // ✅ Stable reference
}: StrategyConfigDialogProps) {
```

## Test Results

- ✅ All 26 tests in `StrategyConfigDialog.test.tsx` now pass (was hanging before)
- ✅ All 154 test files pass (1943 tests total)
- ✅ Test duration: ~1 second (was infinite before)

## Related

Fixes the CI failures introduced in PR #6180