### PR TITLE
docs(site): add missing jailbreak:hydra strategy to StrategyTable

### DIFF
--- a/site/docs/_shared/data/strategies.ts
+++ b/site/docs/_shared/data/strategies.ts
@@ -171,6 +171,17 @@ export const strategies: Strategy[] = [
   },
   {
     category: 'Multi-turn',
+    strategy: 'jailbreak:hydra',
+    displayName: 'Hydra Multi-turn',
+    description: 'Adaptive multi-turn branching',
+    longDescription:
+      'Adaptive multi-turn jailbreak agent that pivots across branches with persistent scan-wide memory to uncover hidden vulnerabilities',
+    cost: 'High',
+    asrIncrease: '70-90%',
+    link: '/docs/red-team/strategies/hydra/',
+  },
+  {
+    category: 'Multi-turn',
     strategy: 'mischievous-user',
     displayName: 'Mischievous User',
     description: 'Mischievous user conversations',


### PR DESCRIPTION
## Summary

- Add missing `jailbreak:hydra` strategy to the StrategyTable component

## Details

The `jailbreak:hydra` strategy was fully implemented in the codebase and documented at `/docs/red-team/strategies/hydra/`, but was missing from the `site/docs/_shared/data/strategies.ts` file that populates the StrategyTable component.

This resulted in the Hydra Multi-turn strategy not appearing in the strategy overview table on the red team strategies page.

## Changes

- Added `jailbreak:hydra` entry to the Multi-turn category in `strategies.ts`
- Positioned alphabetically between GOAT and Mischievous User
- Used consistent formatting with other multi-turn strategies (High cost, 70-90% ASR increase)