### PR TITLE
fix: Validate target test fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - chore: Add visiblity button for PFX passphrase (#6258)
 - feat(app): Red Team Strategy Test Generation (#6005)
 
+### Fixed
+
+- fix(cli): add missing Authorization header in `validate target` command to fix 403 Forbidden error when calling agent helper endpoint (#6274)
+
 ## [0.119.8] - 2025-11-18
 
 ### Added

--- a/src/validators/testProvider.ts
+++ b/src/validators/testProvider.ts
@@ -118,6 +118,7 @@ export async function testProviderConnectivity(
 
     // Call the agent helper endpoint to evaluate the results (even if there's an error)
     const HOST = cloudConfig.getApiHost();
+    const apiKey = cloudConfig.getApiKey();
 
     try {
       logger.debug('[testProviderConnectivity] Calling agent helper', {
@@ -128,6 +129,7 @@ export async function testProviderConnectivity(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
           config: provider.config,

--- a/test/providers/testProvider.test.ts
+++ b/test/providers/testProvider.test.ts
@@ -17,6 +17,13 @@ jest.mock('../../src/models/eval');
 jest.mock('../../src/redteam/remoteGeneration');
 jest.mock('../../src/remoteGrading');
 jest.mock('../../src/util/fetch');
+jest.mock('../../src/globalConfig/cloud', () => ({
+  cloudConfig: {
+    getApiHost: jest.fn(() => 'https://api.promptfoo.app'),
+    getApiKey: jest.fn(() => 'test-api-key'),
+    isEnabled: jest.fn(() => true),
+  },
+}));
 jest.mock('uuid', () => ({
   v4: jest.fn(() => 'test-uuid-1234'),
 }));
@@ -168,6 +175,7 @@ describe('Provider Test Functions', () => {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
+              Authorization: 'Bearer test-api-key',
             },
             body: JSON.stringify({
               config: mockProvider.config,


### PR DESCRIPTION
At some point this endpoint started to require the api key in the headers. Adding it fixed the `forbidden` issues. 