### PR TITLE
chore(webui): replace emoji icons with Material-UI IconButton components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- chore(webui): replace emoji icons with Material-UI IconButton components in evaluation results page — action icons now display circular hover effects, color-coded active states (green for pass, red for fail), always-visible icons for better discoverability, and full accessibility support with aria-pressed and aria-label attributes
 - chore(lint): enforce explicit /index imports in directory paths to prepare for ESM migration (#6263)
 - chore(webui): improve UI treatment for domain-specific risks in red team setup (#6269)
 - chore(deps): re-generate lock file (#6249)

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -122,7 +122,7 @@ describe('EvalOutputCell', () => {
 
   it('passes metadata correctly to the dialog', async () => {
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
-    await userEvent.click(screen.getByText('🔎'));
+    await userEvent.click(screen.getByRole('button', { name: /view output and test details/i }));
 
     const dialogComponent = screen.getByTestId('dialog-component');
     expect(dialogComponent).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('EvalOutputCell', () => {
 
   it('handles enter key press to open dialog', async () => {
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
-    const promptButton = screen.getByText('🔎');
+    const promptButton = screen.getByRole('button', { name: /view output and test details/i });
     expect(promptButton).toBeInTheDocument();
     promptButton.focus();
     await userEvent.keyboard('{enter}');
@@ -149,17 +149,17 @@ describe('EvalOutputCell', () => {
 
   it('handles keyboard navigation between buttons', async () => {
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
-    const promptButton = screen.getByText('🔎');
+    const promptButton = screen.getByRole('button', { name: /view output and test details/i });
     expect(promptButton).toBeInTheDocument();
     promptButton.focus();
     await userEvent.tab();
-    expect(document.activeElement).toHaveTextContent('👍');
+    expect(document.activeElement).toHaveAttribute('aria-label', 'Mark test passed');
     await userEvent.tab();
-    expect(document.activeElement).toHaveTextContent('👎');
+    expect(document.activeElement).toHaveAttribute('aria-label', 'Mark test failed');
     await userEvent.tab();
-    expect(document.activeElement).toHaveTextContent('🔢');
+    expect(screen.getByRole('button', { name: /set test score/i })).toHaveFocus();
     await userEvent.tab();
-    expect(document.activeElement).toHaveTextContent('✏️');
+    expect(screen.getByRole('button', { name: /edit comment/i })).toHaveFocus();
   });
 
   it('preserves existing metadata citations', async () => {
@@ -175,7 +175,7 @@ describe('EvalOutputCell', () => {
     };
 
     renderWithProviders(<EvalOutputCell {...propsWithMetadataCitations} />);
-    await userEvent.click(screen.getByText('🔎'));
+    await userEvent.click(screen.getByRole('button', { name: /view output and test details/i }));
 
     const dialogComponent = screen.getByTestId('dialog-component');
     const passedMetadata = JSON.parse(dialogComponent.getAttribute('data-metadata') || '{}');
@@ -202,7 +202,7 @@ describe('EvalOutputCell', () => {
   it('combines assertion contexts in comment dialog', async () => {
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-    await userEvent.click(screen.getByText('✏️'));
+    await userEvent.click(screen.getByRole('button', { name: /edit comment/i }));
 
     const dialogContent = screen.getByTestId('context-text');
     expect(dialogContent).toHaveTextContent('Assertion 1 (accuracy): expected value');
@@ -236,7 +236,7 @@ describe('EvalOutputCell', () => {
 
     renderWithProviders(<EvalOutputCell {...propsWithoutMetrics} />);
 
-    await userEvent.click(screen.getByText('✏️'));
+    await userEvent.click(screen.getByRole('button', { name: /edit comment/i }));
 
     const dialogContent = screen.getByTestId('context-text');
     expect(dialogContent).toHaveTextContent('Assertion 1 (contains): expected value');
@@ -245,7 +245,7 @@ describe('EvalOutputCell', () => {
   it('handles comment updates', async () => {
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-    await userEvent.click(screen.getByText('✏️'));
+    await userEvent.click(screen.getByRole('button', { name: /edit comment/i }));
 
     const commentInput = screen.getByRole('textbox');
     await userEvent.clear(commentInput);
@@ -291,7 +291,7 @@ describe('EvalOutputCell', () => {
 
     renderWithProviders(<EvalOutputCell {...propsWithoutResults} />);
 
-    await userEvent.click(screen.getByText('✏️'));
+    await userEvent.click(screen.getByRole('button', { name: /edit comment/i }));
 
     const dialogContent = screen.getByTestId('context-text');
     expect(dialogContent).toHaveTextContent('Test output text');
@@ -429,10 +429,10 @@ describe('EvalOutputCell', () => {
 
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-    const shareButtonWrapper = screen.getByText('🔗').closest('.action');
-    expect(shareButtonWrapper).toBeInTheDocument();
+    const shareButton = screen.getByRole('button', { name: /share output/i });
+    expect(shareButton).toBeInTheDocument();
 
-    await userEvent.click(shareButtonWrapper!);
+    await userEvent.click(shareButton);
 
     expect(mockClipboard.writeText).toHaveBeenCalled();
 
@@ -1364,7 +1364,7 @@ describe('EvalOutputCell thumbs up/down toggle functionality', () => {
     const props = createPropsForToggleTest();
     renderWithProviders(<EvalOutputCell {...props} />);
 
-    const thumbsUpButton = screen.getByLabelText('Mark test passed (score 1.0)');
+    const thumbsUpButton = screen.getByLabelText('Mark test passed');
     expect(thumbsUpButton).toBeInTheDocument();
 
     // First click - set rating to true
@@ -1385,7 +1385,7 @@ describe('EvalOutputCell thumbs up/down toggle functionality', () => {
     const props = createPropsForToggleTest();
     renderWithProviders(<EvalOutputCell {...props} />);
 
-    const thumbsDownButton = screen.getByLabelText('Mark test failed (score 0.0)');
+    const thumbsDownButton = screen.getByLabelText('Mark test failed');
     expect(thumbsDownButton).toBeInTheDocument();
 
     // First click - set rating to false
@@ -1403,8 +1403,8 @@ describe('EvalOutputCell thumbs up/down toggle functionality', () => {
     const props = createPropsForToggleTest();
     renderWithProviders(<EvalOutputCell {...props} />);
 
-    const thumbsUpButton = screen.getByLabelText('Mark test passed (score 1.0)');
-    const thumbsDownButton = screen.getByLabelText('Mark test failed (score 0.0)');
+    const thumbsUpButton = screen.getByLabelText('Mark test passed');
+    const thumbsDownButton = screen.getByLabelText('Mark test failed');
 
     // Click thumbs up first
     await userEvent.click(thumbsUpButton);
@@ -1431,7 +1431,7 @@ describe('EvalOutputCell thumbs up/down toggle functionality', () => {
     };
     renderWithProviders(<EvalOutputCell {...props} />);
 
-    const thumbsUpButton = screen.getByLabelText('Mark test passed (score 1.0)');
+    const thumbsUpButton = screen.getByLabelText('Mark test passed');
     await userEvent.click(thumbsUpButton);
 
     // Verify comment is passed to onRating

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -3,6 +3,18 @@ import React, { useMemo } from 'react';
 import { useShiftKey } from '@app/hooks/useShiftKey';
 import { useEvalOperations } from '@app/hooks/useEvalOperations';
 import useCloudConfig from '@app/hooks/useCloudConfig';
+import {
+  Check,
+  ContentCopy,
+  Edit,
+  Link,
+  Numbers,
+  Search,
+  Star,
+  ThumbDown,
+  ThumbUp,
+} from '@mui/icons-material';
+import IconButton from '@mui/material/IconButton';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import { type EvaluateTableOutput, ResultFailureReason } from '@promptfoo/types';
 import { diffJson, diffSentences, diffWords } from 'diff';
@@ -586,36 +598,43 @@ function EvalOutputCell({
       {shiftKeyPressed && (
         <>
           <Tooltip title={'Copy output to clipboard'} slotProps={tooltipSlotProps}>
-            <button className="action" onClick={handleCopy} onMouseDown={(e) => e.preventDefault()}>
-              {copied ? '✅' : '📋'}
-            </button>
+            <IconButton
+              className="action"
+              size="small"
+              onClick={handleCopy}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
+            </IconButton>
           </Tooltip>
           <Tooltip title={'Toggle test highlight'} slotProps={tooltipSlotProps}>
-            <button
+            <IconButton
               className="action"
+              size="small"
               onClick={handleToggleHighlight}
               onMouseDown={(e) => e.preventDefault()}
             >
-              🌟
-            </button>
+              <Star fontSize="small" />
+            </IconButton>
           </Tooltip>
           <Tooltip title={'Share output'} slotProps={tooltipSlotProps}>
-            <button
+            <IconButton
               className="action"
+              size="small"
               onClick={handleRowShareLink}
               onMouseDown={(e) => e.preventDefault()}
             >
-              {linked ? '✅' : '🔗'}
-            </button>
+              {linked ? <Check fontSize="small" /> : <Link fontSize="small" />}
+            </IconButton>
           </Tooltip>
         </>
       )}
       {output.prompt && (
         <>
           <Tooltip title={'View output and test details'} slotProps={tooltipSlotProps}>
-            <button className="action" onClick={handlePromptOpen}>
-              🔎
-            </button>
+            <IconButton className="action" size="small" onClick={handlePromptOpen}>
+              <Search fontSize="small" />
+            </IconButton>
           </Tooltip>
           {openPrompt && (
             <EvalOutputPromptDialog
@@ -641,30 +660,38 @@ function EvalOutputCell({
         </>
       )}
       <Tooltip title={'Mark test passed (score 1.0)'} slotProps={tooltipSlotProps}>
-        <button
+        <IconButton
           className={`action ${activeRating === true ? 'active' : ''}`}
+          size="small"
           onClick={() => handleRating(true)}
+          color={activeRating === true ? 'success' : 'default'}
+          aria-pressed={activeRating === true}
+          aria-label="Mark test passed"
         >
-          👍
-        </button>
+          <ThumbUp fontSize="small" />
+        </IconButton>
       </Tooltip>
       <Tooltip title={'Mark test failed (score 0.0)'} slotProps={tooltipSlotProps}>
-        <button
+        <IconButton
           className={`action ${activeRating === false ? 'active' : ''}`}
+          size="small"
           onClick={() => handleRating(false)}
+          color={activeRating === false ? 'error' : 'default'}
+          aria-pressed={activeRating === false}
+          aria-label="Mark test failed"
         >
-          👎
-        </button>
+          <ThumbDown fontSize="small" />
+        </IconButton>
       </Tooltip>
       <Tooltip title={'Set test score'} slotProps={tooltipSlotProps}>
-        <button className="action" onClick={handleSetScore}>
-          🔢
-        </button>
+        <IconButton className="action" size="small" onClick={handleSetScore}>
+          <Numbers fontSize="small" />
+        </IconButton>
       </Tooltip>
       <Tooltip title={'Edit comment'} slotProps={tooltipSlotProps}>
-        <button className="action" onClick={handleCommentOpen}>
-          ✏️
-        </button>
+        <IconButton className="action" size="small" onClick={handleCommentOpen}>
+          <Edit fontSize="small" />
+        </IconButton>
       </Tooltip>
     </div>
   );

--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -131,12 +131,6 @@ table.results-table,
   cursor: zoom-in;
 }
 
-.results-table tr .variable > *,
-.compact.results-table tr .cell > * {
-  /* Header and vars always inline, cells are inline in compact mode. */
-  /*display: inline;*/
-}
-
 .results-table tr .cell .prompt {
   background-color: var(--variable-background-color);
   border: 1px solid var(--border-color);
@@ -172,21 +166,7 @@ table.results-table,
 }
 
 .results-table tr .cell-actions .action {
-  /* using opacity instead of visibility to maintain focus order */
-  opacity: 0;
   line-height: normal;
-}
-
-/* Show all actions on hover */
-.results-table td:hover .cell-actions .action,
-.results-table td:focus-visible .cell-actions .action,
-.results-table td:focus-within .cell-actions .action {
-  opacity: 1;
-}
-
-/* Always show active thumbs */
-.results-table tr .cell-actions .action.active {
-  opacity: 1;
 }
 
 .results-table tr .cell-detail {
@@ -205,8 +185,8 @@ table.results-table,
   color: #888;
 }
 
-/* Allows button to be styled as a span*/
-.results-table tr button.action {
+/* Remove default button styling - but not for MUI IconButton */
+.results-table tr button.action:not(.MuiIconButton-root) {
   background: none;
   color: inherit;
   border: none;
@@ -214,10 +194,6 @@ table.results-table,
   font: inherit;
   appearance: none;
   cursor: pointer;
-}
-
-.results-table tr .cell-actions .action.active {
-  filter: saturate(1.5);
 }
 
 /* Table-within-a-cell, used for markdown tables */


### PR DESCRIPTION

<img width="1728" height="841" alt="image" src="https://github.com/user-attachments/assets/f0c43b87-823f-4484-838b-151d9602563b" />


## Summary

Improves the evaluation results page by replacing emoji icons with Material-UI IconButton components, providing better visual feedback, accessibility, and consistency with the rest of the application.

This change mirrors the improvements made in promptfoo-cloud PR #2490.

## Visual Improvements

- **MUI IconButton components** - Replaced all emoji icons (👍👎📋🌟🔗🔎🔢✏️) with proper Material-UI icons
- **Circular hover effect** - Icons now display the same circular background hover state used throughout the app
- **Color-coded active states** - Thumbs up shows subtle green when active (pass), thumbs down shows subtle red when active (fail)
- **Always visible icons** - Action icons are now always visible, no longer require hovering over cells for better discoverability

## Accessibility Improvements

- **`aria-pressed` attribute** - Toggle buttons announce their pressed/unpressed state to screen readers
- **`aria-label` attribute** - Each button has a descriptive label ("Mark test passed", "Mark test failed")
- **Multiple indicators** - Users can rely on color, icon shape, or screen reader announcements
- **WCAG compliant** - Meets accessibility standards for toggle buttons

## Technical Changes

- Updated `EvalOutputCell.tsx` to use IconButton components with size="small"
- Added proper color props: `color="success"` for active thumbs up, `color="error"` for active thumbs down
- Modified CSS to preserve MUI IconButton styles while maintaining existing functionality
- Updated tests to query buttons by accessible role instead of emoji text content

## Test Plan

- [x] All 50 EvalOutputCell tests pass
- [x] Lint and format checks pass
- [x] Icons display with circular hover effect
- [x] Active states show correct colors (green/red)
- [x] Screen readers announce button states correctly
- [x] Icons are visible without hovering
- [x] All button interactions work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)