### PR TITLE
chore(ci): fix CHANGELOG.md formatting and auto-format after release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,30 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Format CHANGELOG.md after release-please creates/updates the PR
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        with:
+          fetch-depth: 0
+      # This fixes the asterisk bullet markers that release-please generates
+      - name: Format CHANGELOG.md
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          echo "Formatting CHANGELOG.md on branch: $PR_BRANCH"
+          git fetch origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+          npx prettier --write CHANGELOG.md
+          if git diff --quiet CHANGELOG.md; then
+            echo "No formatting changes needed"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "chore: format CHANGELOG.md with prettier"
+            git push origin "$PR_BRANCH"
+          fi
+
   build:
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.119.13](https://github.com/promptfoo/promptfoo/compare/promptfoo-v0.119.12...promptfoo-v0.119.13) (2025-11-25)
 
-
 ### Features
 
-* ecommerce plugin pack ([#6168](https://github.com/promptfoo/promptfoo/issues/6168)) ([152b1ff](https://github.com/promptfoo/promptfoo/commit/152b1ff3f3fdb6ca43a0a5718d463757f63a1814))
-
+- ecommerce plugin pack ([#6168](https://github.com/promptfoo/promptfoo/issues/6168)) ([152b1ff](https://github.com/promptfoo/promptfoo/commit/152b1ff3f3fdb6ca43a0a5718d463757f63a1814))
 
 ### Bug Fixes
 
-* **deps:** bump posthog-node from 5.13.2 to 5.14.0 for sha1-hulud mitigation ([6a44eda](https://github.com/promptfoo/promptfoo/commit/6a44eda819f48273230853cc8692b821f8db14a0))
+- **deps:** bump posthog-node from 5.13.2 to 5.14.0 for sha1-hulud mitigation ([6a44eda](https://github.com/promptfoo/promptfoo/commit/6a44eda819f48273230853cc8692b821f8db14a0))
 
 ## [0.119.12](https://github.com/promptfoo/promptfoo/compare/promptfoo-v0.119.11...promptfoo-v0.119.12) (2025-11-24)
 


### PR DESCRIPTION
## Summary

- Fix CHANGELOG.md formatting to pass style check
- Remove extra blank lines after section headers (release-please artifact)
- Normalize list markers from `*` to `-` for Prettier consistency
- **Add automation** to auto-format CHANGELOG.md after release-please creates/updates PRs

## Root Cause

Release-please generates changelog entries with:
1. `*` list markers (Prettier prefers `-`)
2. Extra blank lines after section headers

This causes the Style Check CI to fail on all PRs.

## Solution

1. **Immediate fix**: Format the existing CHANGELOG.md with Prettier
2. **Preventive fix**: Add a post-processing step to the release-please workflow that runs Prettier on CHANGELOG.md after release-please creates/updates a PR

## Test plan

- [x] `npm run format:check` passes locally
- [ ] CI passes on this PR
- [ ] Next release-please PR should have properly formatted CHANGELOG.md