### PR TITLE
chore: Make provider options less strict

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -38,6 +38,9 @@
                     "type": "string"
                   },
                   {
+                    "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/1"
+                  },
+                  {
                     "type": "object",
                     "additionalProperties": {
                       "type": "object",
@@ -383,10 +386,7 @@
                     }
                   },
                   {
-                    "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties"
-                  },
-                  {
-                    "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/1"
+                    "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/2/additionalProperties"
                   }
                 ]
               }
@@ -505,7 +505,7 @@
                             "type": "string"
                           },
                           {
-                            "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties"
+                            "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/2/additionalProperties"
                           },
                           {
                             "type": "object",
@@ -1016,7 +1016,7 @@
         "env": {
           "anyOf": [
             {
-              "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties/properties/env"
+              "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/2/additionalProperties/properties/env"
             },
             {
               "type": "object",
@@ -1093,10 +1093,10 @@
                   "type": "string"
                 },
                 {
-                  "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/1/additionalProperties"
+                  "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/provider/anyOf/2"
                 },
                 {
-                  "$ref": "#/definitions/PromptfooConfigSchema/properties/tests/anyOf/1/items/anyOf/1/properties/provider/anyOf/2"
+                  "$ref": "#/definitions/PromptfooConfigSchema/properties/providers/anyOf/2/items/anyOf/2/additionalProperties"
                 }
               ],
               "description": "Provider used for generating adversarial inputs"

--- a/src/validators/providers.ts
+++ b/src/validators/providers.ts
@@ -104,11 +104,11 @@ export const ProvidersSchema = z.union([
   z.array(
     z.union([
       z.string(),
+      CallApiFunctionSchema,
       z.record(z.string(), ProviderOptionsSchema),
       ProviderOptionsSchema,
-      CallApiFunctionSchema,
     ]),
   ),
 ]);
 
-export const ProviderSchema = z.union([z.string(), ProviderOptionsSchema, ApiProviderSchema]);
+export const ProviderSchema = z.union([z.string(), ApiProviderSchema, ProviderOptionsSchema]);

--- a/test/server/routes/providers.test.ts
+++ b/test/server/routes/providers.test.ts
@@ -248,25 +248,6 @@ describe('Providers Routes', () => {
       expect(response.status).toBe(500);
     });
 
-    it('should return 400 for malformed body with extra fields', async () => {
-      const response = await request(app)
-        .post('/api/providers/test')
-        .send({
-          providerOptions: {
-            id: 'test-provider',
-            unexpectedField: 'should cause validation error',
-          },
-          prompt: 'Test',
-        });
-
-      expect(response.status).toBe(400);
-      expect(response.body).toEqual(
-        expect.objectContaining({
-          error: expect.stringContaining('Unrecognized key'),
-        }),
-      );
-    });
-
     it('should handle provider loading failure', async () => {
       const providerOptions: ProviderOptions = {
         id: 'invalid-provider',

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1769,31 +1769,6 @@ describe('readConfig', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith('config.yaml', 'utf-8');
   });
 
-  it('should throw validation error for invalid dereferenced config', async () => {
-    const mockConfig = {
-      description: 'invalid_config',
-      providers: [{ $ref: 'defaultParams.yaml#/invalidKey' }],
-    };
-
-    const dereferencedConfig = {
-      description: 'invalid_config',
-      providers: [{ invalid: true }],
-    };
-
-    jest.mocked(fs.readFileSync).mockReturnValueOnce(yaml.dump(mockConfig));
-    jest.spyOn($RefParser.prototype, 'dereference').mockResolvedValueOnce(dereferencedConfig);
-    jest.mocked(fs.existsSync).mockReturnValueOnce(true);
-
-    await readConfig('config.yaml');
-
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Invalid configuration file config.yaml:\nValidation error: Unrecognized key(s) in object: \'invalid\' at "providers[0]"',
-    );
-    const calls = jest.mocked(logger.warn).mock.calls;
-    expect(calls[0][0]).toContain('Invalid configuration file');
-  });
-
   it('should handle empty YAML file by defaulting to empty object', async () => {
     jest.spyOn(fs, 'readFileSync').mockReturnValue('');
     jest.spyOn(path, 'parse').mockReturnValue({ ext: '.yaml' } as any);

--- a/test/validators/providers.test.ts
+++ b/test/validators/providers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProviderOptionsSchema, ProviderSchema } from '../../src/validators/providers';
+
+describe('ProviderOptionsSchema', () => {
+  it('should filter unknown keys without erroring', () => {
+    const input = {
+      id: 'test-provider',
+      label: 'Test Provider',
+      unknownField: 'this should be filtered',
+      anotherUnknown: 123,
+    };
+
+    const result = ProviderOptionsSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('id', 'test-provider');
+    expect(result.data).toHaveProperty('label', 'Test Provider');
+    expect(result.data).not.toHaveProperty('unknownField');
+    expect(result.data).not.toHaveProperty('anotherUnknown');
+  });
+
+  it('should accept valid provider options', () => {
+    const input = {
+      id: 'test-provider',
+      label: 'Test Provider',
+      config: { temperature: 0.7 },
+      prompts: ['prompt1', 'prompt2'],
+      transform: 'output.toLowerCase()',
+      delay: 1000,
+    };
+
+    const result = ProviderOptionsSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(input);
+  });
+
+  it('should accept empty object', () => {
+    const result = ProviderOptionsSchema.safeParse({});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({});
+  });
+});
+
+describe('ProviderSchema union', () => {
+  it('should match ApiProviderSchema before ProviderOptionsSchema when callApi is present', () => {
+    const mockCallApi = vi.fn();
+    const input = {
+      id: () => 'custom-provider',
+      callApi: mockCallApi,
+      label: 'Custom Provider',
+    };
+
+    const result = ProviderSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    // callApi should be preserved because ApiProviderSchema matches first
+    expect(result.data).toHaveProperty('callApi');
+    expect(result.data).toHaveProperty('id');
+    expect(result.data).toHaveProperty('label', 'Custom Provider');
+  });
+
+  it('should match ProviderOptionsSchema when no callApi function', () => {
+    const input = {
+      id: 'test-provider',
+      label: 'Test Provider',
+      unknownField: 'should be filtered',
+    };
+
+    const result = ProviderSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('id', 'test-provider');
+    expect(result.data).toHaveProperty('label', 'Test Provider');
+    // unknownField should be filtered by ProviderOptionsSchema
+    expect(result.data).not.toHaveProperty('unknownField');
+  });
+
+  it('should accept string provider', () => {
+    const result = ProviderSchema.safeParse('openai:gpt-4');
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe('openai:gpt-4');
+  });
+});


### PR DESCRIPTION
Had a bug in cloud such that a key that wasn't strictly adherent to this schema was saved- Not sure how many bad targets were created, but this schema check makes cloud targets error out if an extraneous key is pulled, which IMO is not a big deal. Making it `strict` and every key `optional` also doesn't make much sense IMO, so I'm just going to remove that constraint. 