### PR TITLE
feat(providers): add Claude Agent SDK plugin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(providers): add Claude Agent SDK plugin support - enables loading local plugins via `plugins` config
 - feat(providers): add Claude Opus 4.5 support across Anthropic (claude-opus-4-5-20251101, claude-opus-4-5-latest), Google Vertex AI (claude-opus-4-5@20251101), and AWS Bedrock (anthropic.claude-opus-4-5-20251101-v1:0 for all regions) with $5/MTok input and $25/MTok output pricing; includes comprehensive documentation updates, advanced coding example demonstrating bug diagnosis and tradeoff analysis, updated provider examples, and cost calculation tests
 - feat(util): add support for loading tool definitions from Python/JavaScript files - providers now support dynamic tool generation using `file://tools.py:get_tools` and `file://tools.js:get_tools` syntax, enabling runtime tool definitions based on environment, config, or external APIs (#6272)
 - feat(server): add server-side provider list customization via ui-providers.yaml - enables organizations to define custom provider lists that appear in eval creator and redteam setup UIs; when ui-providers.yaml exists, replaces default ~600 providers with organization-specific options for simplified workflow and security control (#6124)

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -137,6 +137,12 @@ export interface ClaudeCodeOptions {
    * if not supplied, it won't look for any settings, CLAUDE.md, or slash commands
    */
   setting_sources?: SettingSource[];
+
+  /**
+   * 'plugins' allows loading Claude Code plugins from local file system paths
+   * Each plugin must be a directory containing .claude-plugin/plugin.json manifest
+   */
+  plugins?: Array<{ type: 'local'; path: string }>;
 }
 
 export class ClaudeCodeSDKProvider implements ApiProvider {
@@ -290,6 +296,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       maxThinkingTokens: config.max_thinking_tokens,
       allowedTools,
       disallowedTools,
+      plugins: config.plugins,
       env,
     };
 

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -721,6 +721,30 @@ describe('ClaudeCodeSDKProvider', () => {
           });
         });
 
+        it('with plugins configuration', async () => {
+          mockQuery.mockReturnValue(createMockResponse('Response'));
+
+          const plugins = [
+            { type: 'local' as const, path: './my-plugin' },
+            { type: 'local' as const, path: '/absolute/path/to/plugin' },
+          ];
+
+          const provider = new ClaudeCodeSDKProvider({
+            config: {
+              plugins,
+            },
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          await provider.callApi('Test prompt');
+
+          expect(mockQuery).toHaveBeenCalledWith({
+            prompt: 'Test prompt',
+            options: expect.objectContaining({
+              plugins,
+            }),
+          });
+        });
+
         it('with append system prompt', async () => {
           mockQuery.mockReturnValue(createMockResponse('Response'));
 


### PR DESCRIPTION
# Summary:
- Add support for local claude plugins in the claude sdk provider
- Rename claude sdk test so that it runs in CI (it wasn't running AFAICT)