### PR TITLE
chore(examples): fix claude-vs-gpt-image example

### DIFF
--- a/examples/claude-vs-gpt-image/README.md
+++ b/examples/claude-vs-gpt-image/README.md
@@ -9,8 +9,8 @@ npx promptfoo@latest init --example claude-vs-gpt-image
 This example compares an image analysis task using:
 
 - gpt-4.1 via OpenAI
-- claude-sonnet-4 via Amazon Bedrock
-- claude-3.5 via Anthropic
+- claude-sonnet-4-5 via Amazon Bedrock
+- claude-sonnet-4-5 via Anthropic
 
 GPT-4.1 and Claude have different prompt formats. We use custom provider functions in Python and JavaScript to dynamically format the prompt based on context about the provider. The responses are scored using `llm-rubric` with a vision-capable OpenAI model.
 

--- a/examples/claude-vs-gpt-image/prompt.js
+++ b/examples/claude-vs-gpt-image/prompt.js
@@ -3,13 +3,7 @@
  *
  * This example demonstrates how to format prompts for different AI providers
  * when performing image analysis tasks.
- *
- * Note: For simplicity and to avoid dependencies, this example uses the built-in
- * 'https' module. In a production environment, use more robust libraries like
- * axios for better error handling and features.
  */
-
-const https = require('https');
 
 // The system prompt that instructs the AI model
 const systemPrompt = 'Describe the image in a few words';
@@ -19,25 +13,19 @@ const systemPrompt = 'Describe the image in a few words';
  * This is required for many providers like Anthropic and llava (via ollama, llama.cpp, etc.)
  *
  * @param {string} imageUrl - The URL of the image to fetch
- * @returns {Promise<string>} A promise that resolves with the base64-encoded image data
+ * @returns {Promise<{base64: string, mediaType: string}>} A promise that resolves with the base64-encoded image data and media type
  */
-function getImageBase64(imageUrl) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(imageUrl, (response) => {
-        const data = [];
-        response.on('data', (chunk) => {
-          data.push(chunk);
-        });
-        response.on('end', () => {
-          const buffer = Buffer.concat(data);
-          resolve(buffer.toString('base64'));
-        });
-      })
-      .on('error', (err) => {
-        reject(err);
-      });
-  });
+async function getImageBase64(imageUrl) {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`);
+  }
+  const contentType = response.headers.get('content-type') || 'image/jpeg';
+  const buffer = await response.arrayBuffer();
+  return {
+    base64: Buffer.from(buffer).toString('base64'),
+    mediaType: contentType.split(';')[0], // Remove charset if present
+  };
 }
 
 /**
@@ -56,8 +44,10 @@ async function formatImagePrompt(context) {
   // The ID always exists
   if (
     context.provider.id.startsWith('bedrock:anthropic') ||
-    context.provider.id === 'anthropic:claude-3-5-sonnet-20241022'
+    context.provider.id.startsWith('bedrock:us.anthropic') ||
+    context.provider.id.startsWith('anthropic:')
   ) {
+    const image = await getImageBase64(context.vars.image_url);
     return [
       { role: 'system', content: systemPrompt },
       {
@@ -67,8 +57,8 @@ async function formatImagePrompt(context) {
             type: 'image',
             source: {
               type: 'base64',
-              media_type: 'image/jpeg',
-              data: await getImageBase64(context.vars.image_url),
+              media_type: image.mediaType,
+              data: image.base64,
             },
           },
         ],

--- a/examples/claude-vs-gpt-image/prompt.py
+++ b/examples/claude-vs-gpt-image/prompt.py
@@ -1,7 +1,6 @@
 import base64
 import typing
-
-import requests
+from urllib.request import urlopen
 
 
 # Type definitions for improved code readability
@@ -11,7 +10,7 @@ class Vars(typing.TypedDict):
 
 class Provider(typing.TypedDict):
     id: str
-    label: str | None
+    label: typing.Optional[str]
 
 
 class PromptFunctionContext(typing.TypedDict):
@@ -19,7 +18,7 @@ class PromptFunctionContext(typing.TypedDict):
     provider: Provider
 
 
-def get_image_base64(image_url: str) -> str:
+def get_image_base64(image_url: str) -> tuple[str, str]:
     """
     Fetch an image from a URL and convert it to a base64-encoded string.
 
@@ -27,10 +26,11 @@ def get_image_base64(image_url: str) -> str:
         image_url (str): The URL of the image to fetch.
 
     Returns:
-        str: The base64-encoded image data.
+        tuple[str, str]: The base64-encoded image data and media type.
     """
-    response = requests.get(image_url)
-    return base64.b64encode(response.content).decode("utf-8")
+    with urlopen(image_url) as response:
+        media_type = response.headers.get("Content-Type", "image/jpeg").split(";")[0]
+        return base64.b64encode(response.read()).decode("utf-8"), media_type
 
 
 # System prompt for image description task
@@ -53,10 +53,13 @@ def format_image_prompt(context: PromptFunctionContext) -> list[dict[str, typing
     Raises:
         ValueError: If an unsupported provider is specified.
     """
+    provider_id = context["provider"]["id"]
     if (
-        context["provider"]["id"].startswith("bedrock:anthropic")
-        or context["provider"]["id"] == "anthropic:claude-3-5-sonnet-20241022"
+        provider_id.startswith("bedrock:anthropic")
+        or provider_id.startswith("bedrock:us.anthropic")
+        or provider_id.startswith("anthropic:")
     ):
+        image_data, media_type = get_image_base64(context["vars"]["image_url"])
         return [
             {"role": "system", "content": system_prompt},
             {
@@ -66,8 +69,8 @@ def format_image_prompt(context: PromptFunctionContext) -> list[dict[str, typing
                         "type": "image",
                         "source": {
                             "type": "base64",
-                            "media_type": "image/jpeg",
-                            "data": get_image_base64(context["vars"]["image_url"]),
+                            "media_type": media_type,
+                            "data": image_data,
                         },
                     }
                 ],

--- a/examples/claude-vs-gpt-image/promptfooconfig.yaml
+++ b/examples/claude-vs-gpt-image/promptfooconfig.yaml
@@ -6,14 +6,14 @@ prompts:
   - file://prompt.js:formatImagePrompt
 
 providers:
-  - id: bedrock:anthropic.claude-sonnet-4-20250514-v1:0
-  - id: anthropic:claude-3-5-sonnet-20241022
+  - id: bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  - id: anthropic:claude-sonnet-4-5-20250929
   - id: openai:gpt-4.1
     label: custom label for gpt-4.1
 
 tests:
   - vars:
-      image_url: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Great_Wave_off_Kanagawa2.jpg/640px-Great_Wave_off_Kanagawa2.jpg
+      image_url: https://images.metmuseum.org/CRDImages/as/original/DP130155.jpg
       label: Great Wave off Kanagawa
 
 defaultTest:


### PR DESCRIPTION
## Summary
- Update model IDs to latest versions (claude-sonnet-4-5-20250929)
- Use inference profile format for Bedrock (us.anthropic prefix)
- Switch image URL from Wikipedia to Met Museum (OpenAI can't fetch Wikipedia URLs)
- Replace `requests` with `urllib` in Python (zero external dependencies)
- Fix provider ID matching for new model formats
- Auto-detect image media type from Content-Type header

## Test plan
- [x] Run `npm run local -- eval -c examples/claude-vs-gpt-image/promptfooconfig.yaml`
- [x] Verify all 6 test cases pass (both Python and JS prompts across 3 providers)
- [x] Confirm 100% pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)