### PR TITLE
fix: do not truncate image responses in eval

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
-import EvalOutputCell from './EvalOutputCell';
+import EvalOutputCell, { isImageProvider } from './EvalOutputCell';
 
 import type { EvalOutputCellProps } from './EvalOutputCell';
 
@@ -1307,6 +1307,40 @@ describe('EvalOutputCell cell highlighting styling', () => {
     expect(statusElement?.contains(statusRowElement)).toBe(true);
     expect(statusRowElement?.contains(pillElement)).toBe(true);
     expect(cellElement?.contains(statusElement)).toBe(true);
+  });
+});
+
+describe('isImageProvider helper function', () => {
+  it('should return true for DALL-E 3 provider', () => {
+    expect(isImageProvider('openai:image:dall-e-3')).toBe(true);
+  });
+
+  it('should return true for DALL-E 2 provider', () => {
+    expect(isImageProvider('openai:image:dall-e-2')).toBe(true);
+  });
+
+  it('should return true for any provider with :image: in the name', () => {
+    expect(isImageProvider('some-provider:image:model')).toBe(true);
+  });
+
+  it('should return false for text completion providers', () => {
+    expect(isImageProvider('openai:gpt-4')).toBe(false);
+  });
+
+  it('should return false for chat providers', () => {
+    expect(isImageProvider('openai:chat:gpt-4')).toBe(false);
+  });
+
+  it('should return false for anthropic providers', () => {
+    expect(isImageProvider('anthropic:claude-3-opus')).toBe(false);
+  });
+
+  it('should return false for undefined provider', () => {
+    expect(isImageProvider(undefined)).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isImageProvider('')).toBe(false);
   });
 });
 

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -39,6 +39,15 @@ function scoreToString(score: number | null) {
   return `(${score.toFixed(2)})`;
 }
 
+/**
+ * Detects if the provider is an image generation provider.
+ * Image providers follow the pattern like 'openai:image:dall-e-3'.
+ * Used to skip truncation for image content since truncating `![alt](url)` breaks rendering.
+ */
+export function isImageProvider(provider: string | undefined): boolean {
+  return provider?.includes(':image:') ?? false;
+}
+
 const tooltipSlotProps: TooltipProps['slotProps'] = {
   popper: { disablePortal: true },
 };
@@ -722,7 +731,10 @@ function EvalOutputCell({
         </div>
       )}
       <div style={contentStyle}>
-        <TruncatedText text={node || text} maxLength={maxTextLength} />
+        <TruncatedText
+          text={node || text}
+          maxLength={renderMarkdown && isImageProvider(output.provider) ? 0 : maxTextLength}
+        />
       </div>
       {comment}
       {detail}


### PR DESCRIPTION
While playing with image generation, I noticed that we render markdown for image generation, and it's frequently truncated.  By expanding the text, it shows more of the markdown, which lets it render the image.  This is janky.  So instead, I'm trying to detect if it's a image response, and skip truncating,  