### PR TITLE
fix(site): add truncation marker to blog post

### DIFF
--- a/site/blog/will-agents-hack-everything.md
+++ b/site/blog/will-agents-hack-everything.md
@@ -26,6 +26,8 @@ tags: [security-vulnerability, ai-security, agents]
 
 _A Promptfoo engineer uses Claude Code to run agent-based attacks against a CTF—a system made deliberately vulnerable for security training._
 
+<!-- truncate -->
+
 ## The first big attack
 
 Yesterday, Anthropic [published a report](https://www.anthropic.com/news/disrupting-AI-espionage) on the first documented state-level cyberattack carried out largely autonomously by AI agents.


### PR DESCRIPTION
## Summary
- Add missing `<!-- truncate -->` marker to the "Will agents hack everything?" blog post
- Fixes Docusaurus warning about blog posts without truncation markers

## Test plan
- [x] Verify `npm start` in `site/` no longer shows the truncation warning