### PR TITLE
fix: preserve all file:// references in vars context for runtime loading

### DIFF
--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -79,10 +79,12 @@ export function maybeLoadFromExternalFile(
     return renderedFilePath;
   }
 
-  // In vars contexts, preserve file:// glob patterns for test case expansion
-  // This prevents premature glob expansion that should be handled by generateVarCombinations
-  if (context === 'vars' && hasMagic(renderedFilePath)) {
-    logger.debug(`Preserving glob pattern in vars context: ${renderedFilePath}`);
+  // In vars contexts, preserve all file:// references for test case expansion
+  // This prevents premature file loading - JS/Python files should be executed at runtime
+  // by renderPrompt in evaluatorHelpers.ts, and glob patterns should be expanded by
+  // generateVarCombinations in evaluator.ts
+  if (context === 'vars') {
+    logger.debug(`Preserving file reference in vars context: ${renderedFilePath}`);
     return renderedFilePath;
   }
 

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -923,16 +923,39 @@ describe('file utilities', () => {
         expect(fs.readFileSync).not.toHaveBeenCalled();
       });
 
-      it('should still resolve non-glob file references in vars when they do not contain wildcards', () => {
-        (fs.readFileSync as jest.Mock).mockReturnValue('test data');
+      it('should preserve non-glob file references in vars for runtime loading by renderPrompt', () => {
         const config = {
           vars: {
-            content: 'file://content.txt', // No glob pattern
+            content: 'file://content.txt', // No glob pattern - still preserved
           },
         };
         const result = maybeLoadConfigFromExternalFile(config);
-        expect(result.vars.content).toBe('test data');
-        expect(fs.readFileSync).toHaveBeenCalled();
+        // File references in vars should be preserved for runtime loading
+        // JS/Python files will be executed by renderPrompt in evaluatorHelpers.ts
+        expect(result.vars.content).toBe('file://content.txt');
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+      });
+
+      it('should preserve JS file references in vars for runtime execution', () => {
+        const config = {
+          vars: {
+            dynamicContent: 'file://generateContent.js',
+          },
+        };
+        const result = maybeLoadConfigFromExternalFile(config);
+        expect(result.vars.dynamicContent).toBe('file://generateContent.js');
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+      });
+
+      it('should preserve Python file references in vars for runtime execution', () => {
+        const config = {
+          vars: {
+            dynamicContent: 'file://generateContent.py',
+          },
+        };
+        const result = maybeLoadConfigFromExternalFile(config);
+        expect(result.vars.dynamicContent).toBe('file://generateContent.py');
+        expect(fs.readFileSync).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fix: preserve all `file://` references in vars context, not just glob patterns
- This enables JS/Python files to be executed at runtime by `renderPrompt` instead of being read as text

## Problem

When using `file://` references to JS/Python files in `vars`, they were being read as plain text during config loading instead of being preserved for runtime execution.

```yaml
# This didn't work - JS was read as text instead of executed
vars:
  author: author_name
  style_sample: file://generateStyleSamples.js
```

The issue was in `maybeLoadFromExternalFile` which only preserved `file://` references with glob patterns (`*`, `?`, etc.) in vars context.

## Solution

Changed the condition in `maybeLoadFromExternalFile` to preserve ALL `file://` references in vars context, allowing:
- JS files to be imported and executed (expecting `{ output: string }` return format)
- Python files to be executed via `runPython`
- Glob patterns to be expanded by `generateVarCombinations`

## Use Case

This enables dynamic variable generation using JS/Python files:

```javascript
// generateStyleSamples.js
module.exports = async function(varName, prompt, vars, provider) {
  const author = vars.author;
  // Read and concatenate files dynamically
  const content = /* ... */;
  return { output: content };
};
```

## Test plan
- [x] Updated existing test that expected different behavior
- [x] Added new tests for JS and Python file references in vars

