### PR TITLE
fix(deps): update node-forge to 1.3.2 to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,7 @@
         "@ibm-cloud/watsonx-ai": "^1.7.4",
         "@ibm-generative-ai/node-sdk": "^3.2.4",
         "@jest/globals": "^30.2.0",
+        "@smithy/types": "^4.9.0",
         "@swc/core": "^1.15.3",
         "@swc/jest": "^0.2.39",
         "@types/async": "^3.2.25",
@@ -31871,9 +31872,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"


### PR DESCRIPTION
## Summary

- Updates `node-forge` from 1.3.1 to 1.3.2 to address a security vulnerability
- Adds `@smithy/types` to devDependencies to resolve transitive dependency warnings

## Test plan

- [x] Ran `npm audit` - shows 0 vulnerabilities