### PR TITLE
fix(ci): restore original tag format for GitHub releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "bootstrap-sha": "779729198d01eacd9d00b0796d62cc5a16f0ccac",
+  "include-component-in-tag": false,
+  "include-v-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Fixes #6401 - GitHub `/releases/latest` API endpoint returns 404 since v0.119.12.

### Root Cause

When release-please was introduced in #6315, the default tag format changed from `0.119.11` to `promptfoo-v0.119.13`. GitHub's `/releases/latest` endpoint relies on semantic versioning detection to identify the most recent release, and the new prefixed format breaks this detection.

### Fix

Add two options to `release-please-config.json`:
- `"include-component-in-tag": false` - Removes the `promptfoo-` prefix
- `"include-v-in-tag": false` - Removes the `v` prefix

This restores the original tag format (`0.119.14`) that was used before the release-please migration.

### Research

- [googleapis/release-please-action#951](https://github.com/googleapis/release-please-action/issues/951) - Documents the `include-component-in-tag` option behavior
- [Release Please v4 Configuration](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) - Manifest configuration options

### Follow-up

After merging, we should create matching tags for the two affected releases:
- `0.119.12` → points to same commit as `promptfoo-v0.119.12`
- `0.119.13` → points to same commit as `promptfoo-v0.119.13`

## Test Plan

- [ ] Verify next release creates tag in format `0.119.x` (no prefix)
- [ ] Verify `/releases/latest` API returns 200 after new release