### PR TITLE
fix(deps): resolve Express CVE-2024-51999 vulnerability

### DIFF
--- a/examples/claude-agent-sdk/working-dir/sample-project/package.json
+++ b/examples/claude-agent-sdk/working-dir/sample-project/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "express": "^5.2.1"
   }
 }

--- a/examples/redteam-tracing-example/package.json
+++ b/examples/redteam-tracing-example/package.json
@@ -9,6 +9,6 @@
     "eval": "cd ../.. && npm run local -- eval -c examples/redteam-tracing-example/promptfooconfig.yaml"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "express": "^5.2.1"
   }
 }

--- a/examples/stateful-session-management/package.json
+++ b/examples/stateful-session-management/package.json
@@ -7,7 +7,7 @@
     "server": "node server.js"
   },
   "dependencies": {
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "uuid": "^9.0.1",
     "openai": "^4.104.0"
   }

--- a/examples/stateful-session-management/server.js
+++ b/examples/stateful-session-management/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
-const OpenAI = require('openai/index.mjs');
+const OpenAI = require('openai');
 
 const app = express();
 const port = 8080;

--- a/examples/websockets-streaming/server/package.json
+++ b/examples/websockets-streaming/server/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "openai": "^4.104.0",
     "ws": "^8.18.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.44.7",
         "execa": "^9.6.0",
-        "express": "^5.1.0",
+        "express": "^5.2.1",
         "fast-deep-equal": "^3.1.3",
         "fast-safe-stringify": "^2.1.1",
         "fast-xml-parser": "^5.3.2",
@@ -103,7 +103,7 @@
         "@adaline/together-ai": "1.6.0",
         "@adaline/types": "1.9.1",
         "@adaline/vertex": "1.9.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.1.55",
+        "@anthropic-ai/claude-agent-sdk": "^0.1.56",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.942.0",
         "@aws-sdk/client-bedrock-runtime": "^3.941.0",
         "@aws-sdk/client-sagemaker-runtime": "^3.940.0",
@@ -22269,9 +22269,9 @@
       }
     },
     "node_modules/express": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.0.tgz",
-      "integrity": "sha512-XdpJDLxfztVY59X0zPI6sibRiGcxhTPXRD3IhJmjKf2jwMvkRGV1j7loB8U+heeamoU3XvihAaGRTR4aXXUN3A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -40652,16 +40652,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/webpack-dev-server/node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -40687,40 +40677,40 @@
       "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -40731,6 +40721,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/express/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/webpack-dev-server/node_modules/finalhandler": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
     "https-proxy-agent": "^7.0.0",
     "mongoose": {
       "gcp-metadata": "^8.1.2"
+    },
+    "webpack-dev-server": {
+      "express": "^4.22.0"
     }
   },
   "devDependencies": {
@@ -258,7 +261,7 @@
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.44.7",
     "execa": "^9.6.0",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "fast-deep-equal": "^3.1.3",
     "fast-safe-stringify": "^2.1.1",
     "fast-xml-parser": "^5.3.2",


### PR DESCRIPTION
## Summary

- Update 4 examples from Express 4.21.2 to Express 5.1.0 to resolve CVE-2024-51999
- Add npm override to force webpack-dev-server (transitive dependency) to use Express 4.22.0+
- Fix broken OpenAI import in stateful-session-management example

## Test plan

- [x] All 4 example servers tested and working with Express 5
- [x] `npm audit` shows 0 vulnerabilities  
- [x] Project build passes

Fixes https://github.com/promptfoo/promptfoo/security/dependabot/205

🤖 Generated with [Claude Code](https://claude.com/claude-code)