### PR TITLE
fix: Fix cache init

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { createCache } from 'cache-manager';
 import { Keyv } from 'keyv';
-import KeyvFile from 'keyv-file';
+import { KeyvFile } from 'keyv-file';
 import { getEnvBool, getEnvInt, getEnvString } from './envars';
 import logger from './logger';
 import { REQUEST_TIMEOUT_MS } from './providers/shared';

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -89,6 +89,7 @@ vi.mock('keyv', () => {
 vi.mock('keyv-file', () => {
   return {
     __esModule: true,
+    KeyvFile: class MockKeyvFile {},
     default: class MockKeyvFile {},
   };
 });


### PR DESCRIPTION
Fixes the dreaded cache init failure I've been seeing:

```
Running 12 test cases (up to 4 at a time)...
Evaluating [░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 0% | 0/12 |   [Cache] Failed to initialize disk 
cache: KeyvFile is not a constructor. Using memory cache instead.
Evaluating [████████████████████████████████████████] 100% | 12/12 | file://provider.py:call_api "Write a 
ve" topic=turt
Sharing | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | 0% | 0/3 results 
```