### PR TITLE
fix: require bug

### DIFF
--- a/src/util/config/manage.ts
+++ b/src/util/config/manage.ts
@@ -1,5 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
+import fs from 'fs';
 
 import { getEnvString } from '../../envars';
 
@@ -11,7 +12,6 @@ const isNodeEnvironment =
 
 export function getConfigDirectoryPath(createIfNotExists: boolean = false): string {
   const p = configDirectoryPath || path.join(os.homedir(), '.promptfoo');
-  const fs = require('fs');
 
   // Only perform filesystem operations in Node.js environment
   if (createIfNotExists && isNodeEnvironment) {


### PR DESCRIPTION
Seeing this issue:
```
npm run local -- eval -c examples/python-provider/promptfooconfig.yaml --no-cache

> promptfoo@0.119.14 local
> tsx src/main.ts eval -c examples/python-provider/promptfooconfig.yaml --no-cache

/Users/faizan/workspace/promptfoo/src/util/config/manage.ts:14
  const fs = require('fs');
             ^


ReferenceError: require is not defined in ES module scope, you can use import instead
    at getConfigDirectoryPath (/Users/faizan/workspace/promptfoo/src/util/config/manage.ts:14:14)
    at readGlobalConfig (/Users/faizan/workspace/promptfoo/src/globalConfig/globalConfig.ts:22:21)
    at new CloudConfig (/Users/faizan/workspace/promptfoo/src/globalConfig/cloud.ts:58:25)
    at <anonymous> (/Users/faizan/workspace/promptfoo/src/globalConfig/cloud.ts:233:28)
    at ModuleJob.run (node:internal/modules/esm/module_job:370:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:99:5)

Node.js v24.4.1
```

Think it's a result of me not merging this change from my last PR (https://github.com/promptfoo/promptfoo/pull/6465#discussion_r2582461560)