### PR TITLE
chore(deps): remove unused dependencies from app workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14826,13 +14826,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/fuzzysearch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fuzzysearch/-/fuzzysearch-1.0.2.tgz",
-      "integrity": "sha512-G2M0M7acg75BzTtUv1qmPFMe7nTwX1K2AEKNeBO8zW0o+H2oTmyir7IJ2v0UW8pZkY4nHgHALvgpWQpB9WXPpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -23196,13 +23189,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/fuzzysearch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fuzzysearch/-/fuzzysearch-1.0.3.tgz",
-      "integrity": "sha512-s+kNWQuI3mo9OALw0HJ6YGmMbLqEufCh2nX/zzV5CrICQ/y4AwPxM+6TIiF9ItFCHXFCyM/BfCCmN57NTIJuPg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/gaxios": {
       "version": "7.1.3",
@@ -34737,34 +34723,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/redent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^5.0.0",
-        "strip-indent": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/redent/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/redis": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
@@ -35256,6 +35214,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -36374,6 +36333,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -37899,18 +37859,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
-      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -41907,11 +41855,6 @@
     },
     "src/app": {
       "version": "0.0.0",
-      "dependencies": {
-        "redent": "^4.0.0",
-        "reselect": "^5.1.1",
-        "set-cookie-parser": "^2.7.2"
-      },
       "devDependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -41928,7 +41871,6 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@types/fuzzysearch": "^1.0.2",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.10.1",
         "@types/prismjs": "^1.26.5",
@@ -41941,7 +41883,6 @@
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.6.0",
         "diff": "^8.0.2",
-        "fuzzysearch": "^1.0.3",
         "idb-keyval": "^6.2.2",
         "js-yaml": "^4.1.1",
         "jsdom": "^26.1.0",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -29,7 +29,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/fuzzysearch": "^1.0.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
     "@types/prismjs": "^1.26.5",
@@ -42,7 +41,6 @@
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.6.0",
     "diff": "^8.0.2",
-    "fuzzysearch": "^1.0.3",
     "idb-keyval": "^6.2.2",
     "js-yaml": "^4.1.1",
     "jsdom": "^26.1.0",
@@ -63,10 +61,5 @@
     "vite-plugin-node-polyfills": "^0.24.0",
     "vitest": "^4.0.14",
     "zustand": "^5.0.8"
-  },
-  "dependencies": {
-    "redent": "^4.0.0",
-    "reselect": "^5.1.1",
-    "set-cookie-parser": "^2.7.2"
   }
 }


### PR DESCRIPTION
## Summary
- Remove unused dependencies from `src/app/package.json` identified via knip analysis
- Removed packages: `redent`, `reselect`, `set-cookie-parser`, `fuzzysearch`, `@types/fuzzysearch`
- No imports for these packages exist in the codebase

## Test plan
- [x] `npm install` succeeds
- [x] `npm run test:app` passes all tests
- [x] `npm run build:app` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)