### PR TITLE
fix(ci): update latest Docker tag on releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -251,7 +251,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
## Summary

- Fix the `latest` Docker tag not being updated when new versions are released
- The condition now also triggers on `release` events, not just pushes to main

**Root cause**: The `latest` tag was only set when `github.ref == 'refs/heads/main'`, but releases have `refs/tags/v*` as their ref. This caused `latest` to only update when the Dockerfile was modified on main, not on actual releases.

Fixes #6475

## Test plan

- [ ] Verify the workflow syntax is valid
- [ ] Next release should update both version tag and `latest` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)