### PR TITLE
fix: use npm environment variables for version detection

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -3,14 +3,9 @@
  *
  * This module uses compile-time injection:
  * - At build time (tsdown): Constants are injected via `define` and inlined
- * - In development/test (Node.js): Reads from package.json at runtime
- * - In browser builds: Falls back to defaults (frontend has its own mechanism)
- *
- * Note: The frontend app (src/app) uses its own version mechanism via
- * import.meta.env.VITE_PROMPTFOO_VERSION defined in vite.config.ts
+ * - In development (npm scripts): Uses npm_package_* environment variables
+ * - In browser builds: Falls back to defaults (frontend uses VITE_PROMPTFOO_VERSION)
  */
-
-import { createRequire } from 'node:module';
 
 // Build-time constants injected by tsdown's `define` option.
 // In development/test environments, these remain undefined.
@@ -19,69 +14,13 @@ declare const __PROMPTFOO_POSTHOG_KEY__: string | undefined;
 declare const __PROMPTFOO_ENGINES_NODE__: string | undefined;
 
 /**
- * Reads package.json at runtime for Node.js development/test environments.
- * Returns null in browser environments to allow fallback to defaults.
- */
-function readPackageJsonSync(): { version: string; engines: { node: string } } | null {
-  // Skip in browser environments
-  if (typeof window !== 'undefined') {
-    return null;
-  }
-
-  try {
-    // In ESM, require is not available. Use createRequire to get a require function.
-    const require = createRequire(import.meta.url);
-    const fs = require('fs');
-    const path = require('path');
-    const url = require('url');
-
-    // Get __dirname equivalent in ESM
-    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-
-    // Try multiple possible locations for package.json
-    const possiblePaths = [
-      path.join(__dirname, '../package.json'),
-      path.join(__dirname, '../../package.json'),
-      path.join(process.cwd(), 'package.json'),
-    ];
-
-    for (const pkgPath of possiblePaths) {
-      try {
-        if (fs.existsSync(pkgPath)) {
-          const content = fs.readFileSync(pkgPath, 'utf8');
-          const pkg = JSON.parse(content);
-          if (pkg.name === 'promptfoo') {
-            return pkg;
-          }
-        }
-      } catch {
-        // Try next path
-      }
-    }
-  } catch {
-    // Node.js APIs not available or failed (e.g., in browser build or pure ESM)
-  }
-
-  return null;
-}
-
-// Cache the package.json read
-let _packageJson: { version: string; engines: { node: string } } | null | undefined;
-function getPackageJson(): { version: string; engines: { node: string } } | null {
-  if (_packageJson === undefined) {
-    _packageJson = readPackageJsonSync();
-  }
-  return _packageJson;
-}
-
-/**
  * Application version from package.json.
- * Injected at build time, read from package.json in dev/test.
+ * Injected at build time, or read from npm environment in development.
  */
 export const VERSION: string =
   typeof __PROMPTFOO_VERSION__ !== 'undefined'
     ? __PROMPTFOO_VERSION__
-    : (getPackageJson()?.version ?? '0.0.0-development');
+    : (process.env.npm_package_version ?? '0.0.0-development');
 
 /**
  * PostHog analytics key.
@@ -99,5 +38,5 @@ export const ENGINES = {
   node:
     typeof __PROMPTFOO_ENGINES_NODE__ !== 'undefined'
       ? __PROMPTFOO_ENGINES_NODE__
-      : (getPackageJson()?.engines.node ?? '>=20.0.0'),
+      : (process.env.npm_package_engines_node ?? '>=20.0.0'),
 } as const;


### PR DESCRIPTION
## Summary

Fixes version detection in development mode showing `0.0.0-development` instead of the actual version when running via `npm run local`.

## Problem

After the ESM migration, running `npm run local -- eval` would show:
```
⚠️ The current version of promptfoo 0.0.0-development is lower than the latest available version 0.119.14.
```

The original code used bare `require()` calls which don't exist in ESM. The initial fix attempt used `createRequire` from `node:module`, but this broke Vite's frontend build because `node-stdlib-browser` doesn't polyfill `createRequire`.

## Solution

Instead of reading `package.json` at runtime, use npm's built-in environment variables. When running via npm scripts, npm automatically sets:
- `npm_package_version` → package version
- `npm_package_engines_node` → engine requirements

This eliminates:
- ❌ All `node:fs`, `node:path`, `node:url` imports
- ❌ File I/O at startup  
- ❌ ~60 lines of complex file-finding logic
- ❌ Vite build warnings/errors

The version is now resolved as:
1. **Production build**: `__PROMPTFOO_VERSION__` injected by tsdown at compile time
2. **Development** (`npm run local`): `process.env.npm_package_version` set by npm
3. **Fallback**: `'0.0.0-development'`

## Test plan

- [x] `npm run local -- --version` shows `0.119.14`
- [x] `npm run local -- eval --help` shows no version warning
- [x] `npm run build` succeeds with no Vite warnings
- [x] `node dist/src/main.js --version` shows `0.119.14`
- [x] All CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)