### PR TITLE
chore: pin npm version via corepack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,6 +588,7 @@ npx npm-check-updates --target latest
 
 - Use CommonJS modules (type: "commonjs" in package.json)
 - Node.js version requirement (>=20.0.0). Use `nvm use` to align with `.nvmrc` (currently v24.7.0).
+- npm version is pinned via `packageManager` in package.json. Run `corepack enable npm` once (corepack ships with Node.js) to auto-use the correct version.
 - Follow file structure: core logic in src/, tests in test/
 - Examples belong in examples/ with clear README.md
 - Document provider configurations following examples in existing code

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node": ">=20.0.0",
     "npm": ">=10.0.0 <11.0.0 || >=11.6.4"
   },
+  "packageManager": "npm@11.6.4",
   "bin": {
     "promptfoo": "dist/src/main.js",
     "pf": "dist/src/main.js"

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -42,8 +42,12 @@ We particularly welcome contributions in the following areas:
    3.1. Setup locally
 
    ```bash
-   # We recommend using the Node.js version specified in the .nvmrc file (ensure node >= 20)
+   # Use the Node.js version specified in .nvmrc (node >= 20 required)
    nvm use
+
+   # Enable corepack for npm (corepack ships with Node.js)
+   corepack enable npm
+
    npm install
    ```
 


### PR DESCRIPTION
## Summary

- Add `packageManager` field to package.json to pin npm@11.6.4 via corepack
- Ensures all contributors use a compatible npm version that satisfies the engines requirement (`>=10.0.0 <11.0.0 || >=11.6.4`)
- Update contributing docs and AGENTS.md with corepack setup instructions

## Background

npm 11.5.1 (which ships with Node.js 24.7.0) falls in the unsupported gap of the engines requirement. Corepack, which ships with Node.js, allows pinning the exact npm version per-project.

## Setup for contributors

```bash
nvm use
corepack enable npm  # one-time setup
npm install
```

## Test plan

- [x] Verified `corepack enable npm` uses npm@11.6.4
- [x] Verified `npm install` succeeds without engine errors