### PR TITLE
fix: python wrapper.py path resolution bug:

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build:clean": "shx rm -rf dist",
     "build:watch": "NODE_OPTIONS='--max-old-space-size=8192' tsdown --watch",
     "build": "concurrently -g \"NODE_OPTIONS='--max-old-space-size=8192' tsdown\" \"npm run build:app\" && npm run post-build",
-    "post-build": "shx cp src/*.html dist/src && shx cp src/python/wrapper.py dist/src/python && shx cp src/python/persistent_wrapper.py dist/src/python && shx mkdir -p dist/src/golang && shx cp src/golang/wrapper.go dist/src/golang && shx mkdir -p dist/src/ruby && shx cp src/ruby/wrapper.rb dist/src/ruby && shx rm -rf dist/drizzle && shx cp -r drizzle dist/drizzle && shx rm -f dist/drizzle/CLAUDE.md dist/drizzle/AGENTS.md && echo '{\"type\": \"module\"}' > dist/src/package.json && shx chmod +x dist/src/main.js",
+    "post-build": "shx cp src/*.html dist/src && shx mkdir -p dist/src/python && shx cp src/python/wrapper.py dist/src/python && shx cp src/python/persistent_wrapper.py dist/src/python && shx mkdir -p dist/src/golang && shx cp src/golang/wrapper.go dist/src/golang && shx mkdir -p dist/src/ruby && shx cp src/ruby/wrapper.rb dist/src/ruby && shx rm -rf dist/drizzle && shx cp -r drizzle dist/drizzle && shx rm -f dist/drizzle/CLAUDE.md dist/drizzle/AGENTS.md && echo '{\"type\": \"module\"}' > dist/src/package.json && shx chmod +x dist/src/main.js",
     "citation:generate": "tsx scripts/generateCitation.ts",
     "db:generate": "npx drizzle-kit generate",
     "db:migrate": "tsx src/migrate.ts",

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -15,6 +15,15 @@ function getCurrentDir(): string {
   return currentDir;
 }
 
+// Get the directory containing Python wrapper scripts
+// Handles both development (src/python/) and production (dist/src/python/) paths
+function getPythonScriptDir(): string {
+  const dir = getCurrentDir();
+  // If we're already in a 'python' directory (development), use it as-is
+  // Otherwise, append 'python' subdirectory (production dist build)
+  return path.basename(dir) === 'python' ? dir : path.join(dir, 'python');
+}
+
 import { PythonShell } from 'python-shell';
 import { getEnvBool, getEnvString } from '../envars';
 import logger from '../logger';
@@ -310,7 +319,7 @@ export async function runPython(
     env: process.env,
     mode: 'binary',
     pythonPath,
-    scriptPath: getCurrentDir(),
+    scriptPath: getPythonScriptDir(),
     // When `inherit` is used, `import pdb; pdb.set_trace()` will work.
     ...(getEnvBool('PROMPTFOO_PYTHON_DEBUG_ENABLED') && { stdio: 'inherit' }),
   };

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -11,6 +11,14 @@ import { validatePythonPath } from './pythonUtils';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Get the directory containing Python wrapper scripts
+// Handles both development (src/python/) and production (dist/src/python/) paths
+function getPythonScriptDir(): string {
+  // If we're already in a 'python' directory (development), use it as-is
+  // Otherwise, append 'python' subdirectory (production dist build)
+  return path.basename(__dirname) === 'python' ? __dirname : path.join(__dirname, 'python');
+}
+
 export class PythonWorker {
   private process: PythonShell | null = null;
   private ready: boolean = false;
@@ -37,7 +45,7 @@ export class PythonWorker {
   }
 
   private async startWorker(): Promise<void> {
-    const wrapperPath = path.join(__dirname, 'persistent_wrapper.py');
+    const wrapperPath = path.join(getPythonScriptDir(), 'persistent_wrapper.py');
 
     // Validate and resolve Python path using smart detection (tries python3, then python)
     const resolvedPythonPath = await validatePythonPath(

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -453,6 +453,31 @@ describe('Python Utils', () => {
       );
     });
 
+    it('should use python subdirectory for wrapper.py scriptPath', async () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ type: 'final_result', data: 'test_result' }),
+      );
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {});
+      mockExecFileAsync.mockResolvedValue({ stdout: 'Python 3.8.10\n', stderr: '' });
+
+      mockPythonShellInstance.end.mockImplementation((callback: any) => {
+        callback(null);
+      });
+
+      const scriptPath = '/path/to/script.py';
+      await pythonUtils.runPython(scriptPath, 'test_method', ['arg1', 'arg2']);
+
+      // Verify PythonShell was called with scriptPath ending in 'python'
+      // This works for both development (src/python/) and production (dist/src/python/)
+      expect(PythonShell).toHaveBeenCalledWith(
+        'wrapper.py',
+        expect.objectContaining({
+          scriptPath: expect.stringMatching(/python$/),
+        }),
+      );
+    });
+
     it('should throw an error if Python script returns invalid JSON', async () => {
       vi.mocked(fs.writeFileSync).mockImplementation(() => {});
       vi.mocked(fs.readFileSync).mockReturnValue('invalid json');


### PR DESCRIPTION
Running the build, we were seeing this error for python providers:

```
2025-12-04T20:33:23.467Z [ERROR]: Error running Python script: /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/faizan/workspace/promptfoo/dist/src/wrapper.py': [Errno 2] No such file or directory

Stack Trace: Error: /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/faizan/workspace/promptfoo/dist/src/wrapper.py': [Errno 2] No such file or directory

    at PythonShell.parseError (/Users/faizan/workspace/promptfoo/node_modules/python-shell/index.ts:383:21)
    at terminateIfNeeded (/Users/faizan/workspace/promptfoo/node_modules/python-shell/index.ts:239:32)
    at ChildProcess.<anonymous> (/Users/faizan/workspace/promptfoo/node_modules/python-shell/index.ts:230:13)
    at ChildProcess.emit (node:events:507:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

This was likely due to the way the path is resolved from the recent ESM migration; I verified that the correct path is resolved now. 

Summary

  The root cause is bundler behavior. The tsdown bundler
  (configured in tsdown.config.ts) flattens the directory
  structure during compilation:

  - Development: TypeScript files maintain their directory
  structure → src/python/pythonUtils.ts runs from
  src/python/
  - Production: Bundler outputs everything to dist/src/ with
   hashed filenames → pythonUtils-D3k6iGdX.js runs from
  dist/src/

  This is intentional bundler behavior for optimization
  (code splitting, tree shaking, cache busting). The fix I
  implemented detects which environment we're in by checking
   if the current directory basename is already 'python',
  making it work correctly in both scenarios.