### PR TITLE
fix(ci): remove packageManager to allow pnpm/yarn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,7 +588,7 @@ npx npm-check-updates --target latest
 
 - Use CommonJS modules (type: "commonjs" in package.json)
 - Node.js version requirement (>=20.0.0). Use `nvm use` to align with `.nvmrc` (currently v24.7.0).
-- npm version is pinned via `packageManager` in package.json. Run `corepack enable npm` once (corepack ships with Node.js) to auto-use the correct version.
+- npm version is constrained via `engines.npm` in package.json. The `.npmrc` sets `engine-strict=true` to enforce this. Alternative package managers (pnpm, yarn) are also supported.
 - Follow file structure: core logic in src/, tests in test/
 - Examples belong in examples/ with clear README.md
 - Document provider configurations following examples in existing code

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "node": ">=20.0.0",
     "npm": ">=10.0.0 <11.0.0 || >=11.6.4"
   },
-  "packageManager": "npm@11.6.4",
   "bin": {
     "promptfoo": "dist/src/main.js",
     "pf": "dist/src/main.js"

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -45,9 +45,7 @@ We particularly welcome contributions in the following areas:
    # Use the Node.js version specified in .nvmrc (node >= 20 required)
    nvm use
 
-   # Enable corepack for npm (corepack ships with Node.js)
-   corepack enable npm
-
+   # Install dependencies (npm, pnpm, or yarn all work)
    npm install
    ```
 


### PR DESCRIPTION
## Summary

Removes the `packageManager` field that was blocking pnpm and yarn usage due to corepack enforcement.

**Problem:** PR #6498 added `"packageManager": "npm@11.6.4"` to pin the npm version via corepack. However, this also blocks alternative package managers entirely:

```
▶ pnpm local
 ERROR  This project is configured to use npm
```

**Solution:** Remove `packageManager` field while keeping npm version enforcement via:
- `engines.npm` constraint in package.json (blocks npm 11.0.0-11.6.3)
- `engine-strict=true` in .npmrc

This approach:
- ✅ Blocks problematic npm versions that cause lockfile issues
- ✅ Allows pnpm/yarn users to use their preferred package manager
- ✅ CI workflows already handle npm upgrades for Node 24.x (#6483)

## Changes

1. **package.json** - Remove `packageManager` field
2. **AGENTS.md** - Update documentation to reflect new approach
3. **site/docs/contributing.md** - Remove corepack setup instructions

## Test plan

- [ ] CI passes (npm version still enforced via engines)
- [ ] `pnpm install` works locally
- [ ] `yarn install` works locally
- [ ] `npm install` with bad npm version (11.6.2) still blocked

Fixes: https://github.com/promptfoo/promptfoo/pull/6483#issuecomment-2868543737

🤖 Generated with [Claude Code](https://claude.com/claude-code)