### PR TITLE
feat(redteam): add job persistence for browser-based evaluations

### DIFF
--- a/src/app/src/stores/redteamJobStore.ts
+++ b/src/app/src/stores/redteamJobStore.ts
@@ -1,11 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-interface RedteamJobState {
+export interface RedteamJobState {
   jobId: string | null;
   startedAt: number | null;
+  _hasHydrated: boolean;
   setJob: (jobId: string) => void;
   clearJob: () => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const useRedteamJobStore = create<RedteamJobState>()(
@@ -13,11 +15,16 @@ export const useRedteamJobStore = create<RedteamJobState>()(
     (set) => ({
       jobId: null,
       startedAt: null,
+      _hasHydrated: false,
       setJob: (jobId: string) => set({ jobId, startedAt: Date.now() }),
       clearJob: () => set({ jobId: null, startedAt: null }),
+      setHasHydrated: (hasHydrated: boolean) => set({ _hasHydrated: hasHydrated }),
     }),
     {
       name: 'promptfoo-redteam-job',
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary

- Add Zustand store with localStorage persistence to track running job IDs
- Implement job recovery on page mount - checks server for running jobs and reconnects
- Extract polling logic into reusable `startPolling` callback
- Handle jobs that completed while user navigated away

Users can now:
- Start a red team evaluation, navigate away, and return to see the job still running
- Return to a completed job and see results immediately
- Have job state persist across browser sessions via localStorage

## Test plan

- [x] Start job → navigate to /evals → return → see running job with logs
- [x] Start job → wait for completion while on different page → return → see results
- [x] Start job → close tab → reopen → see running job (if server still has it)
- [x] Complete job → navigate away → return → no stale "running" state
- [x] All 44 job persistence tests pass (5 store + 39 Review component)
- [x] All 2046 app tests pass
- [x] TypeScript compiles cleanly
- [x] Linting passes