### PR TITLE
feat(providers): add Amazon Nova 2 model support with reasoning capabilities

### DIFF
--- a/examples/amazon-bedrock/promptfooconfig.nova-2-converse.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.nova-2-converse.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Amazon Nova 2 Lite with Converse API'
+
+prompts:
+  - 'Solve this step by step: {{problem}}'
+
+providers:
+  # Nova 2 Lite with reasoning enabled (high effort) via Converse API
+  # Note: Must use cross-region model ID (us.) for on-demand access
+  # Temperature must not be set when reasoning is enabled
+  - id: bedrock:converse:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite Converse (High Reasoning)
+    config:
+      region: 'us-east-1'
+      maxTokens: 4096
+      reasoningConfig:
+        type: enabled
+        maxReasoningEffort: high
+
+  # Nova 2 Lite with reasoning enabled (medium effort) via Converse API
+  - id: bedrock:converse:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite Converse (Medium Reasoning)
+    config:
+      region: 'us-east-1'
+      maxTokens: 4096
+      reasoningConfig:
+        type: enabled
+        maxReasoningEffort: medium
+
+  # Nova 2 Lite with reasoning disabled (fast mode) via Converse API
+  - id: bedrock:converse:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite Converse (Fast)
+    config:
+      region: 'us-east-1'
+      maxTokens: 2048
+      temperature: 0.7
+      reasoningConfig:
+        type: disabled
+
+tests:
+  - vars:
+      problem: 'A train leaves Station A at 9:00 AM traveling at 60 mph. Another train leaves Station B, 300 miles away, at 10:00 AM traveling toward Station A at 90 mph. At what time will the trains meet?'
+  - vars:
+      problem: 'If a bat and ball cost $1.10 together, and the bat costs $1 more than the ball, how much does the ball cost?'
+  - vars:
+      problem: 'In a room of 23 people, what is the probability that at least two people share a birthday?'
+  - vars:
+      problem: 'A farmer has 17 sheep. All but 9 die. How many sheep does the farmer have left?'
+  - vars:
+      problem: 'If it takes 5 machines 5 minutes to make 5 widgets, how long does it take 100 machines to make 100 widgets?'

--- a/examples/amazon-bedrock/promptfooconfig.nova-2-reasoning.yaml
+++ b/examples/amazon-bedrock/promptfooconfig.nova-2-reasoning.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Amazon Nova 2 Lite with Extended Thinking'
+
+prompts:
+  - 'Solve this step by step: {{problem}}'
+
+providers:
+  # Nova 2 Lite with reasoning enabled (high effort)
+  # Note: Must use cross-region model ID (us.) for on-demand access
+  # Temperature must not be set when reasoning is enabled
+  - id: bedrock:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite (High Reasoning)
+    config:
+      region: 'us-east-1'
+      interfaceConfig:
+        max_new_tokens: 4096
+      reasoningConfig:
+        type: enabled
+        maxReasoningEffort: high
+
+  # Nova 2 Lite with reasoning enabled (medium effort)
+  - id: bedrock:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite (Medium Reasoning)
+    config:
+      region: 'us-east-1'
+      interfaceConfig:
+        max_new_tokens: 4096
+      reasoningConfig:
+        type: enabled
+        maxReasoningEffort: medium
+
+  # Nova 2 Lite with reasoning disabled (fast mode)
+  - id: bedrock:us.amazon.nova-2-lite-v1:0
+    label: Nova 2 Lite (Fast)
+    config:
+      region: 'us-east-1'
+      interfaceConfig:
+        max_new_tokens: 2048
+        temperature: 0.7
+      reasoningConfig:
+        type: disabled
+
+tests:
+  - vars:
+      problem: 'A train leaves Station A at 9:00 AM traveling at 60 mph. Another train leaves Station B, 300 miles away, at 10:00 AM traveling toward Station A at 90 mph. At what time will the trains meet?'
+  - vars:
+      problem: 'If a bat and ball cost $1.10 together, and the bat costs $1 more than the ball, how much does the ball cost?'
+  - vars:
+      problem: 'In a room of 23 people, what is the probability that at least two people share a birthday?'
+  - vars:
+      problem: 'A farmer has 17 sheep. All but 9 die. How many sheep does the farmer have left?'
+  - vars:
+      problem: 'If it takes 5 machines 5 minutes to make 5 widgets, how long does it take 100 machines to make 100 widgets?'

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -65,6 +65,14 @@ export interface BedrockConverseOptions extends BedrockOptions {
     budget_tokens: number;
   };
 
+  // Reasoning configuration (Amazon Nova 2 models)
+  // Note: When reasoning is enabled, temperature/topP/topK must NOT be set
+  // When maxReasoningEffort is 'high', maxTokens must also NOT be set
+  reasoningConfig?: {
+    type: 'enabled' | 'disabled';
+    maxReasoningEffort?: 'low' | 'medium' | 'high';
+  };
+
   // Performance configuration
   performanceConfig?: {
     latency: 'standard' | 'optimized';
@@ -137,6 +145,8 @@ const BEDROCK_CONVERSE_PRICING: Record<string, { input: number; output: number }
   'amazon.nova-lite': { input: 0.06, output: 0.24 },
   'amazon.nova-pro': { input: 0.8, output: 3.2 },
   'amazon.nova-premier': { input: 2.5, output: 10 },
+  // Amazon Nova 2 (reasoning models) - pricing estimated, verify at aws.amazon.com/bedrock/pricing
+  'amazon.nova-2-lite': { input: 0.15, output: 0.6 },
   // Amazon Titan Text
   'amazon.titan-text-lite': { input: 0.15, output: 0.2 },
   'amazon.titan-text-express': { input: 0.8, output: 1.6 },
@@ -582,6 +592,12 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
         provider: 'bedrock_converse',
       });
     }
+    if (this.config.reasoningConfig?.type === 'enabled') {
+      telemetry.record('feature_used', {
+        feature: 'nova2_reasoning',
+        provider: 'bedrock_converse',
+      });
+    }
     if (this.config.tools) {
       telemetry.record('feature_used', {
         feature: 'tool_use',
@@ -707,18 +723,27 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
 
   /**
    * Build the inference configuration from options
+   *
+   * Handles Amazon Nova 2 reasoning constraints:
+   * - When reasoningConfig.type === 'enabled': temperature/topP must NOT be set
+   * - When maxReasoningEffort === 'high': maxTokens must also NOT be set
    */
   private buildInferenceConfig(): InferenceConfiguration | undefined {
-    const maxTokens =
+    // Check reasoning mode constraints for Nova 2 models
+    const reasoningEnabled = this.config.reasoningConfig?.type === 'enabled';
+    const isHighEffort = this.config.reasoningConfig?.maxReasoningEffort === 'high';
+
+    // Get potential values
+    const maxTokensValue =
       this.config.maxTokens ||
       this.config.max_tokens ||
       getEnvInt('AWS_BEDROCK_MAX_TOKENS') ||
       undefined;
 
-    const temperature =
+    const temperatureValue =
       this.config.temperature ?? getEnvFloat('AWS_BEDROCK_TEMPERATURE') ?? undefined;
 
-    const topP = this.config.topP || this.config.top_p || getEnvFloat('AWS_BEDROCK_TOP_P');
+    const topPValue = this.config.topP || this.config.top_p || getEnvFloat('AWS_BEDROCK_TOP_P');
 
     let stopSequences = this.config.stopSequences || this.config.stop;
     if (!stopSequences) {
@@ -731,6 +756,13 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
         }
       }
     }
+
+    // Apply reasoning constraints:
+    // - maxTokens: only include if NOT (reasoning enabled AND high effort)
+    // - temperature/topP: only include if reasoning is NOT enabled
+    const maxTokens = reasoningEnabled && isHighEffort ? undefined : maxTokensValue;
+    const temperature = reasoningEnabled ? undefined : temperatureValue;
+    const topP = reasoningEnabled ? undefined : topPValue;
 
     // Only return config if at least one field is set
     if (
@@ -793,7 +825,7 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
   }
 
   /**
-   * Build additional model request fields (including thinking config)
+   * Build additional model request fields (including thinking config and reasoningConfig)
    */
   private buildAdditionalModelRequestFields(): DocumentType | undefined {
     const fields: Record<string, unknown> = {
@@ -803,6 +835,11 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     // Add thinking configuration for Claude models
     if (this.config.thinking) {
       fields.thinking = this.config.thinking;
+    }
+
+    // Add reasoning configuration for Amazon Nova 2 models
+    if (this.config.reasoningConfig) {
+      fields.reasoningConfig = this.config.reasoningConfig;
     }
 
     return Object.keys(fields).length > 0 ? (fields as DocumentType) : undefined;

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -375,6 +375,17 @@ describe('AwsBedrockGenericProvider', () => {
       expect((provider.config as any).inferenceModelType).toBe('nova');
     });
 
+    it('should handle inference profile ARN with nova2 model type', async () => {
+      const arnModelName =
+        'arn:aws:bedrock:us-east-1:123456789012:inference-profile/nova2-inference';
+      const config: any = { inferenceModelType: 'nova2' };
+
+      const provider = new AwsBedrockCompletionProvider(arnModelName, { config });
+
+      expect(provider.modelName).toBe(arnModelName);
+      expect((provider.config as any).inferenceModelType).toBe('nova2');
+    });
+
     it('should handle inference profile ARN with llama model type', async () => {
       const arnModelName =
         'arn:aws:bedrock:us-east-1:123456789012:inference-profile/llama-inference';
@@ -2542,6 +2553,22 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
     expect(AWS_BEDROCK_MODELS['us-gov.anthropic.claude-3-haiku-20240307-v1:0']).toBe(
       BEDROCK_MODEL.CLAUDE_MESSAGES,
     );
+  });
+
+  it('should map Nova 2 models correctly', async () => {
+    // Base model ID
+    expect(AWS_BEDROCK_MODELS['amazon.nova-2-lite-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA_2);
+
+    // Regional model IDs
+    expect(AWS_BEDROCK_MODELS['us.amazon.nova-2-lite-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA_2);
+    expect(AWS_BEDROCK_MODELS['eu.amazon.nova-2-lite-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA_2);
+    expect(AWS_BEDROCK_MODELS['apac.amazon.nova-2-lite-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA_2);
+
+    // Global cross-region inference
+    expect(AWS_BEDROCK_MODELS['global.amazon.nova-2-lite-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA_2);
+
+    // Note: Nova 2 Sonic uses bidirectional streaming API like Nova Sonic v1,
+    // so it's handled separately via NovaSonicProvider in registry.ts
   });
 });
 


### PR DESCRIPTION
## Summary

- Add support for Amazon Nova 2 Lite model with configurable extended thinking (reasoning) capabilities
- Support both native Bedrock API (`bedrock:us.amazon.nova-2-lite-v1:0`) and Converse API (`bedrock:converse:us.amazon.nova-2-lite-v1:0`)
- Handle Nova 2-specific parameter constraints automatically

## Changes

**Core Implementation (`src/providers/bedrock/index.ts`):**
- Add `AMAZON_NOVA_2` model handler with `reasoningConfig` support
- Add model mappings for all cross-region inference profiles (us, eu, apac, global)
- Automatically exclude incompatible parameters when reasoning is enabled

**Converse API (`src/providers/bedrock/converse.ts`):**
- Add `reasoningConfig` to `BedrockConverseOptions` interface
- Update `buildInferenceConfig()` to handle reasoning constraints
- Update `buildAdditionalModelRequestFields()` to include `reasoningConfig`

**Documentation & Examples:**
- Update `site/docs/providers/aws-bedrock.md` with Nova 2 configuration
- Add example config for native API (`promptfooconfig.nova-2-reasoning.yaml`)
- Add example config for Converse API (`promptfooconfig.nova-2-converse.yaml`)

## Configuration

```yaml
# Native Bedrock API
providers:
  - id: bedrock:us.amazon.nova-2-lite-v1:0
    config:
      interfaceConfig:
        max_new_tokens: 4096
      reasoningConfig:
        type: enabled
        maxReasoningEffort: medium  # low, medium, or high

# Converse API
providers:
  - id: bedrock:converse:us.amazon.nova-2-lite-v1:0
    config:
      maxTokens: 4096
      reasoningConfig:
        type: enabled
        maxReasoningEffort: medium
```

## Test plan

- [x] Unit tests pass (166 bedrock tests + 126 converse tests)
- [x] End-to-end test with native API: 9/9 test cases passed (3 reasoning modes × 3 problems)
- [x] End-to-end test with Converse API: 3/3 test cases passed
- [x] Nova Sonic tested and working (existing functionality)
- [x] Build succeeds
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)