### PR TITLE
fix(blog): display correct blog post dates regardless of user timezone

### DIFF
--- a/site/src/components/Blog/BlogPostCard.tsx
+++ b/site/src/components/Blog/BlogPostCard.tsx
@@ -13,10 +13,7 @@ export default function BlogPostCard({ post }: BlogPostCardProps): React.ReactEl
   const author = metadata.authors[0];
 
   // Format date with UTC timezone to avoid timezone conversion issues
-  const formattedDate = new Date(date).toLocaleDateString('en-US', {
-    day: 'numeric',
-    month: 'numeric',
-    year: 'numeric',
+  const formattedDate = new Date(date).toLocaleDateString(undefined, {
     timeZone: 'UTC',
   });
 

--- a/site/src/components/Blog/FeaturedBlogPost.tsx
+++ b/site/src/components/Blog/FeaturedBlogPost.tsx
@@ -13,10 +13,7 @@ export default function FeaturedBlogPost({ post }: FeaturedBlogPostProps): React
   const author = metadata.authors[0];
 
   // Format date with UTC timezone to avoid timezone conversion issues
-  const formattedDate = new Date(date).toLocaleDateString('en-US', {
-    day: 'numeric',
-    month: 'numeric',
-    year: 'numeric',
+  const formattedDate = new Date(date).toLocaleDateString(undefined, {
     timeZone: 'UTC',
   });
 


### PR DESCRIPTION
To recreate the issue, visit the main [blog page](https://www.promptfoo.dev/blog/) and look at the dates listed on the blog post cards. Then click on any given post and look at the date that appears on the actual blog post. 

For example, for the [Real-Time Fact Checking for LLM Outputs](https://www.promptfoo.dev/blog/llm-search-rubric-assertions/) blog, the date listed on the [blog page](https://www.promptfoo.dev/blog/) is "11/27/2025", while when you actually look at the heading of the post it says "November 28, 2025". This applies for all blog posts. 

This bug was caused by JS treating the date on a blog post as if it was at Midnight UTC, so when it got converted to local time on the client, it would display the date of the previous day for US Time Zones. On the other hand, the actual posts were getting their date directly from the date in the docs. 

I changed it so that the dates are explicitly displayed in UTC on the cards so we match the system that Docusaurus uses internally.