### PR TITLE
docs: add guidance to avoid running view command during development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ npm run local -- eval -c path/to/config.yaml
 
 This ensures you're testing with your current changes instead of the installed version.
 
+**Don't run `npm run local -- view`** unless explicitly asked. Assume the user already has `npm run dev` running in a separate terminal. The `view` command serves static production builds without hot reload, while the dev server at http://localhost:3000 provides HMR for faster iteration.
+
 **Important:** Always use `--` before additional flags when using `npm run local`:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds guidance to AGENTS.md to avoid running `npm run local -- view` during development
- Agents should assume `npm run dev` is already running, which provides HMR at http://localhost:3000

## Test plan
- [x] Verify AGENTS.md is correctly updated