### PR TITLE
fix(providers): use Responses API for gpt-5.1-codex-max

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -273,23 +273,27 @@ GPT-5.1-Codex-Max is OpenAI's frontier agentic coding model, built on an updated
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:chat:gpt-5.1-codex-max
+  - id: openai:responses:gpt-5.1-codex-max
     config:
       reasoning:
         effort: 'medium' # Recommended for most tasks
-      max_completion_tokens: 25000 # Reserve space for reasoning and outputs
+      max_output_tokens: 25000 # Reserve space for reasoning and outputs
 ```
 
 For latency-insensitive tasks requiring maximum quality:
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:chat:gpt-5.1-codex-max
+  - id: openai:responses:gpt-5.1-codex-max
     config:
       reasoning:
         effort: 'xhigh' # Extra high reasoning for best results
-      max_completion_tokens: 40000
+      max_output_tokens: 40000
 ```
+
+:::warning
+GPT-5.1-Codex-Max is only available through the Responses API (`openai:responses:`). It does not work with the Chat Completions API (`openai:chat:`).
+:::
 
 #### Reasoning Effort Levels
 

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -51,6 +51,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'gpt-5.1-mini',
     'gpt-5.1-nano',
     'gpt-5.1-codex',
+    'gpt-5.1-codex-max',
     // Audio models
     'gpt-audio',
     'gpt-audio-2025-08-28',

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -309,14 +309,7 @@ export const OPENAI_CHAT_MODELS = [
       output: 2 / 1e6,
     },
   })),
-  ...['gpt-5.1-codex'].map((model) => ({
-    id: model,
-    cost: {
-      input: 1.25 / 1e6,
-      output: 10 / 1e6,
-    },
-  })),
-  ...['gpt-5.1-codex-max'].map((model) => ({
+  ...['gpt-5.1-codex', 'gpt-5.1-codex-max'].map((model) => ({
     id: model,
     cost: {
       input: 1.25 / 1e6,


### PR DESCRIPTION
## Summary

- GPT-5.1-Codex-Max only works with the Responses API, not Chat Completions
- Add model to `OPENAI_RESPONSES_MODEL_NAMES` in `responses.ts`
- Update docs to use `openai:responses:` provider prefix
- Add warning about Responses API requirement

## Test plan

- [x] Verified model works via `openai:responses:gpt-5.1-codex-max`
- [x] Confirmed Chat Completions API returns 404 for this model