### PR TITLE
fix(webui): handle object outputs in eval prompt dialog

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -750,7 +750,9 @@ function EvalOutputCell({
       {showPrompts && firstOutput.prompt && (
         <div className="prompt">
           <span className="pill">Prompt</span>
-          {output.prompt}
+          {typeof output.prompt === 'string'
+            ? output.prompt
+            : JSON.stringify(output.prompt, null, 2)}
         </div>
       )}
       {/* Show response audio from redteam history if available (target's audio response) */}

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -1147,4 +1147,37 @@ describe('EvalOutputPromptDialog traces tab visibility', () => {
     });
     expect(screen.queryByRole('tab', { name: 'Traces' })).not.toBeInTheDocument();
   });
+
+  describe('object content handling (issue #768)', () => {
+    it('safely renders prompt when passed as object instead of string', async () => {
+      // This tests the fix for GitHub issue #768 where custom providers
+      // return objects for output/prompt causing React Error #31
+      const propsWithObjectPrompt = {
+        ...defaultProps,
+        // Simulate object being passed where string is expected (runtime type mismatch)
+        prompt: { statement: 'test statement', reason: 'test reason', verdict: 'pass' } as any,
+      };
+
+      // Should not throw React Error #31
+      expect(() => render(<EvalOutputPromptDialog {...propsWithObjectPrompt} />)).not.toThrow();
+
+      await waitFor(() => {
+        // Object should be serialized to JSON string
+        expect(screen.getByText(/test statement/)).toBeInTheDocument();
+      });
+    });
+
+    it('safely renders output when passed as object instead of string', async () => {
+      const propsWithObjectOutput = {
+        ...defaultProps,
+        output: { statement: 'output statement', reason: 'output reason', verdict: 'fail' } as any,
+      };
+
+      expect(() => render(<EvalOutputPromptDialog {...propsWithObjectOutput} />)).not.toThrow();
+
+      await waitFor(() => {
+        expect(screen.getByText(/output statement/)).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -69,18 +69,21 @@ function CodeDisplay({
   onMouseLeave,
   showCopyButton = false,
 }: CodeDisplayProps) {
+  // Ensure content is a string - handles cases where providers return objects
+  const safeContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+
   // Improved code detection logic
   const isCode =
-    /^[\s]*[{[]/.test(content) || // JSON-like (starts with { or [)
-    /^#\s/.test(content) || // Markdown headers (starts with # )
-    /```/.test(content) || // Code blocks (contains ```)
-    /^\s*[\w-]+\s*:/.test(content) || // YAML/config-like (key: value)
-    /^\s*<\w+/.test(content) || // XML/HTML-like (starts with <tag)
-    content.includes('function ') || // JavaScript functions
-    content.includes('class ') || // Class definitions
-    content.includes('import ') || // Import statements
-    /^\s*def\s+/.test(content) || // Python functions
-    /^\s*\w+\s*\(/.test(content); // Function calls
+    /^[\s]*[{[]/.test(safeContent) || // JSON-like (starts with { or [)
+    /^#\s/.test(safeContent) || // Markdown headers (starts with # )
+    /```/.test(safeContent) || // Code blocks (contains ```)
+    /^\s*[\w-]+\s*:/.test(safeContent) || // YAML/config-like (key: value)
+    /^\s*<\w+/.test(safeContent) || // XML/HTML-like (starts with <tag)
+    safeContent.includes('function ') || // JavaScript functions
+    safeContent.includes('class ') || // Class definitions
+    safeContent.includes('import ') || // Import statements
+    /^\s*def\s+/.test(safeContent) || // Python functions
+    /^\s*\w+\s*\(/.test(safeContent); // Function calls
 
   return (
     <Box mb={2}>
@@ -121,11 +124,11 @@ function CodeDisplay({
                 wordBreak: 'break-word',
               }}
             >
-              {content}
+              {safeContent}
             </pre>
           ) : (
             <Typography variant="body1" sx={textContentTypographySx}>
-              {content}
+              {safeContent}
             </Typography>
           )}
         </Box>


### PR DESCRIPTION
## Summary
- Fix React Error #31 ("Objects are not valid as a React child") when clicking magnifying glass icon in Web UI
- When custom providers (e.g., Python) return dictionary objects instead of strings for output or prompt fields, the UI now handles them gracefully by JSON stringifying

## Problem
When using custom Python providers that return dictionaries for output (e.g., `{"statement": "...", "reason": "...", "verdict": "pass"}`), clicking the magnifying glass 🔎 to view details would crash the UI with:

```
Minified React error #31; visit https://reactjs.org/docs/error-decoder.html?invariant=31
```

This is "Objects are not valid as a React child" - React cannot render plain JavaScript objects directly in JSX.

## Solution
Added defensive string conversion in two locations:

1. **`EvalOutputPromptDialog.tsx`** - `CodeDisplay` function now converts objects to JSON strings:
   ```typescript
   const safeContent = typeof content === 'string' 
     ? content 
     : JSON.stringify(content, null, 2);
   ```

2. **`EvalOutputCell.tsx`** - Fixed direct rendering of `output.prompt` with same pattern

## Test plan
- [x] Added 2 new test cases for object handling in `EvalOutputPromptDialog.test.tsx`
- [x] All 54 tests pass in EvalOutputPromptDialog.test.tsx  
- [x] All 63 tests pass in EvalOutputCell.test.tsx
- [x] Lint and format checks pass
- [x] TypeScript compilation passes

Fixes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)