### PR TITLE
fix(providers): handle Vertex AI global region endpoint

### DIFF
--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -2259,4 +2259,39 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       );
     });
   });
+
+  describe('getApiHost', () => {
+    it('should return global endpoint without region prefix for region: global', () => {
+      const provider = new VertexChatProvider('gemini-pro', { config: { region: 'global' } });
+      expect(provider.getApiHost()).toBe('aiplatform.googleapis.com');
+    });
+
+    it('should return regional endpoint for non-global regions', () => {
+      const provider = new VertexChatProvider('gemini-pro', { config: { region: 'us-central1' } });
+      expect(provider.getApiHost()).toBe('us-central1-aiplatform.googleapis.com');
+    });
+
+    it('should use custom apiHost over default', () => {
+      const provider = new VertexChatProvider('gemini-pro', {
+        config: { region: 'global', apiHost: 'custom.example.com' },
+      });
+      expect(provider.getApiHost()).toBe('custom.example.com');
+    });
+
+    it('should use VERTEX_API_HOST from env override', () => {
+      const provider = new VertexChatProvider('gemini-pro', {
+        config: { region: 'global' },
+        env: { VERTEX_API_HOST: 'env.example.com' },
+      });
+      expect(provider.getApiHost()).toBe('env.example.com');
+    });
+
+    it('should prioritize configApiHost over env override', () => {
+      const provider = new VertexChatProvider('gemini-pro', {
+        config: { region: 'global', apiHost: 'config.example.com' },
+        env: { VERTEX_API_HOST: 'env.example.com' },
+      });
+      expect(provider.getApiHost()).toBe('config.example.com');
+    });
+  });
 });


### PR DESCRIPTION
Resolves #6569

`region: global` → `aiplatform.googleapis.com` (no prefix)
other regions → `{region}-aiplatform.googleapis.com`

References:
- [Vertex AI locations documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations)
- [Gemini model versions and lifecycle](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions)

---

I've checked the following current models work with `aiplatform.googleapis.com` (global endpoint):
- text generation:
  - `gemini-3-pro-preview`
  - `gemini-2.5-pro`
  - `gemini-2.5-flash`
  - `gemini-2.5-flash-lite`
  - `gemini-2.0-flash-001`
  - `gemini-2.0-flash-lite-001`
- embedding:
  - `gemini-embedding-001`
  - `text-embedding-005`
  - `text-multilingual-embedding-002`

[check_global_endpoint.sh](https://gist.github.com/pokutuna/62816ca3e44b8bd99e5c9587e31ecff0)
