### PR TITLE
fix: use correct drizzle migrations path for npm/npx installs

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -54,10 +54,10 @@ export async function runDbMigrations(): Promise<void> {
         const dir = getCurrentDir();
         let migrationsFolder: string;
         if (dir.includes('dist/src')) {
-          // When running from bundled server (e.g., dist/src/server/index.js)
-          // Navigate to project root and find drizzle folder
+          // When running from bundled dist (e.g., npx promptfoo or dist/src/main.js)
+          // Navigate to project root and find drizzle folder in dist
           const projectRoot = dir.split('dist/src')[0];
-          migrationsFolder = path.join(projectRoot, 'drizzle');
+          migrationsFolder = path.join(projectRoot, 'dist', 'drizzle');
         }
         // PF Cloud runtime scans:
         else if (dir.includes('dist/server/src')) {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -70,7 +70,7 @@ describe('migrate', () => {
 
       expect(mockMigrate).toHaveBeenCalledTimes(1);
       expect(mockMigrate).toHaveBeenCalledWith(mockDb, {
-        migrationsFolder: path.join('/project/', 'drizzle'),
+        migrationsFolder: path.join('/project/', 'dist', 'drizzle'),
       });
     });
 


### PR DESCRIPTION
## Summary
- Fixes database migration error when running via `npx promptfoo@latest`
- The `dist/src` path check was looking for `drizzle/` at package root, but it's at `dist/drizzle/` in the published npm package

## Problem
Running `npx promptfoo@latest` fails with:
```
Error: Can't find meta/_journal.json file
```

This happens because only `dist/` is published to npm (per `package.json` `files` field), so `drizzle/` doesn't exist at the package root - only `dist/drizzle/` does.

## Test plan
- [x] Updated unit tests pass
- [ ] Test with `npx promptfoo@latest` after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)