### PR TITLE
chore: add vitest typings

### DIFF
--- a/src/app/tsconfig.app.json
+++ b/src/app/tsconfig.app.json
@@ -18,6 +18,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client", "node"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Added explicit test typings to src/app/tsconfig.app.json (vitest/globals, @testing-library/jest-dom, vite/client, node) so the app build’s tsc -b recognizes Vitest globals and no longer fails on describe/it/expect in UI tests during the Docker build.