### PR TITLE
fix(redteam): fix prompt-injection strategy data.json loading in ESM build

### DIFF
--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -6,6 +6,7 @@
  * - HTML template files (all *.html in src/)
  * - Python/Go/Ruby wrapper scripts for custom providers
  * - Drizzle ORM migration files
+ * - Redteam data files (JSON fixtures)
  * - ESM package.json marker
  * - CLI executable permissions
  *
@@ -44,6 +45,12 @@ const WRAPPER_FILES: Record<WrapperType, string[]> = {
  * Files/patterns to exclude when copying the drizzle directory.
  */
 const DRIZZLE_EXCLUDE_PATTERNS = ['.md', 'CLAUDE', 'AGENTS'];
+
+/**
+ * Redteam data files that need to be copied to dist.
+ * These are JSON fixtures used at runtime by redteam strategies.
+ */
+const REDTEAM_DATA_FILES = ['redteam/strategies/promptInjections/data.json'];
 
 /**
  * Critical build outputs that must exist for the build to be valid.
@@ -138,6 +145,17 @@ function getDrizzleTask(): CopyTask {
 }
 
 /**
+ * Generate copy tasks for redteam data files.
+ * These are JSON fixtures loaded at runtime by redteam strategies.
+ */
+function getRedteamDataTasks(): CopyTask[] {
+  return REDTEAM_DATA_FILES.map((file) => ({
+    src: path.join(SRC, file),
+    dest: path.join(DIST, 'src', file),
+  }));
+}
+
+/**
  * Verify that all critical build outputs exist.
  */
 function verifyBuildOutputs(): string[] {
@@ -222,7 +240,12 @@ export function postbuild(): PostbuildResult {
   }
 
   // Gather all copy tasks
-  const copyTasks = [...getHtmlFiles(), ...getWrapperTasks(), getDrizzleTask()];
+  const copyTasks = [
+    ...getHtmlFiles(),
+    ...getWrapperTasks(),
+    getDrizzleTask(),
+    ...getRedteamDataTasks(),
+  ];
 
   // Clean destinations to prevent stale files
   cleanDestinations(copyTasks);

--- a/src/redteam/strategies/promptInjections/index.ts
+++ b/src/redteam/strategies/promptInjections/index.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getDirectory } from '../../../esm';
 import type { TestCase } from '../../../types/index';
 
 export async function addInjections(
@@ -7,7 +10,8 @@ export async function addInjections(
 ): Promise<TestCase[]> {
   const sampleSize = config.sample || 1;
   const harmfulOnly = config.harmfulOnly || false;
-  const data: string[] = (await import('./data.json', { assert: { type: 'json' } })).default;
+  const dataPath = path.join(getDirectory(), 'redteam/strategies/promptInjections/data.json');
+  const data: string[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
   const injections =
     sampleSize === 1
       ? // Take skeleton key (the first one) by default


### PR DESCRIPTION
## Summary
- Fixes prompt-injection strategy failing to load `data.json` after ESM migration
- Changes dynamic import to `fs.readFileSync` with `getDirectory()` for proper path resolution
- Adds `data.json` to postbuild copy tasks since tsdown doesn't copy JSON files automatically

## Test plan
- [x] Built version loads data.json correctly
- [x] Unit tests pass
- [x] Redteam scan with prompt-injection strategy works