### PR TITLE
fix(build): exclude Nunjucks template fixture from TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "test/code-scan-action/**/*",
     "test/codeScans/**/*",
     "test/database/**/*",
+    "test/fixtures/rubric-json-template/**/*",
     "test/matchers/**/*",
     "test/site/",
     "test/testCase/**/*",


### PR DESCRIPTION
## Summary
- Excludes the Nunjucks template test fixture from TypeScript compilation to fix `npm run tsc` failures

## Background
PR #6554 added support for Nunjucks templates in JSON rubricPrompt files and included a test fixture at `test/fixtures/rubric-json-template/rubric.json`. The fixture intentionally contains Nunjucks syntax (not valid JSON) to test this functionality.

The `biome.json` was updated to exclude this fixture from linting, but `tsconfig.json` was not updated, causing `npm run tsc` to fail when parsing the fixture as JSON.

## Test plan
- [x] `npm run build` passes
- [x] `npm run tsc` passes (was failing before this fix)
- [x] All 9403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)