### PR TITLE
fix(ci): resolve release workflow and devcontainer build failures

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,15 +1,14 @@
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22
 
-# Install additional OS packages including Python 3.11
+# Install additional OS packages including Python
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-    jq htop python3.11 python3.11-venv \
+    jq htop python3 python3-venv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set Python 3.11 as the default python and python3
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+# Set python3 as the default python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 # Set up npm directories and cache directory
 RUN mkdir -p /home/node/.promptfoo && \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           TAG_NAME="${{ steps.release.outputs.tag_name }}"
           echo "Renaming release to: $TAG_NAME"
-          gh release edit "$TAG_NAME" --title "$TAG_NAME"
+          gh release edit "$TAG_NAME" --title "$TAG_NAME" --repo ${{ github.repository }}
 
       # Format CHANGELOG.md after release-please creates/updates the PR
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `--repo` flag to `gh release edit` command in release-please workflow to fix "not a git repository" error (the command runs before the checkout step)
- Update Dockerfile.dev from `python3.11` to `python3` since Debian Trixie (base image) no longer packages Python 3.11

## Test plan

- [ ] Verify release workflow succeeds on next release
- [ ] Verify devcontainer prebuild succeeds