### PR TITLE
fix(cli): filter providers before instantiation

### DIFF
--- a/src/commands/eval/filterProviders.ts
+++ b/src/commands/eval/filterProviders.ts
@@ -1,5 +1,94 @@
-import type { ApiProvider } from '../../types/index';
+import type { ApiProvider, TestSuiteConfig } from '../../types/index';
+import type { ProviderOptions, ProviderOptionsMap } from '../../types/providers';
 
+/**
+ * Extracts the id and label from a raw provider config without instantiating it.
+ * Handles all provider config formats: string, function, ProviderOptions, ProviderOptionsMap.
+ */
+function getProviderIdAndLabel(
+  provider: string | ProviderOptions | ProviderOptionsMap | ((...args: unknown[]) => unknown),
+  index: number,
+): { id: string; label?: string } {
+  if (typeof provider === 'string') {
+    return { id: provider };
+  }
+
+  if (typeof provider === 'function') {
+    const label = (provider as { label?: string }).label;
+    return {
+      id: label ?? `custom-function-${index}`,
+      label,
+    };
+  }
+
+  // Check if it's a ProviderOptions object (has 'id' field)
+  if ('id' in provider && typeof (provider as ProviderOptions).id === 'string') {
+    const opts = provider as ProviderOptions;
+    return {
+      id: opts.id!,
+      label: opts.label,
+    };
+  }
+
+  // It's a ProviderOptionsMap: { "provider-id": { label: "..." } }
+  const keys = Object.keys(provider);
+  if (keys.length > 0) {
+    const id = keys[0];
+    const opts = (provider as ProviderOptionsMap)[id];
+    return {
+      id: opts.id || id,
+      label: opts.label,
+    };
+  }
+
+  return { id: `unknown-${index}` };
+}
+
+/**
+ * Filters raw provider configs BEFORE instantiation.
+ * This prevents providers from being loaded if they don't match the filter,
+ * which is important when providers validate env vars or other resources on construction.
+ */
+export function filterProviderConfigs(
+  providers: TestSuiteConfig['providers'],
+  filterOption?: string,
+): TestSuiteConfig['providers'] {
+  if (!filterOption) {
+    return providers;
+  }
+
+  // Handle non-array cases
+  if (typeof providers === 'string') {
+    const filterRegex = new RegExp(filterOption);
+    return filterRegex.test(providers) ? providers : [];
+  }
+
+  if (typeof providers === 'function') {
+    const filterRegex = new RegExp(filterOption);
+    const label = (providers as { label?: string }).label;
+    const id = label ?? 'custom-function';
+    if (filterRegex.test(id) || (label && filterRegex.test(label))) {
+      return providers;
+    }
+    return [];
+  }
+
+  if (!Array.isArray(providers)) {
+    return providers;
+  }
+
+  const filterRegex = new RegExp(filterOption);
+
+  return providers.filter((provider, index) => {
+    const { id, label } = getProviderIdAndLabel(provider, index);
+    return filterRegex.test(id) || (label && filterRegex.test(label));
+  });
+}
+
+/**
+ * Filters instantiated providers by id or label.
+ * This is kept for backwards compatibility and as a safety net.
+ */
 export function filterProviders(
   providers: ApiProvider[],
   filterProvidersOption?: string,

--- a/test/commands/eval/filterProviders.test.ts
+++ b/test/commands/eval/filterProviders.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { filterProviders } from '../../../src/commands/eval/filterProviders';
+import { filterProviderConfigs, filterProviders } from '../../../src/commands/eval/filterProviders';
 
-import type { ApiProvider } from '../../../src/types/index';
+import type { ApiProvider, TestSuiteConfig } from '../../../src/types/index';
+import type { ProviderOptions, ProviderOptionsMap } from '../../../src/types/providers';
 
 describe('filterProviders', () => {
   const mockProviders: ApiProvider[] = [
@@ -68,5 +69,159 @@ describe('filterProviders', () => {
   it('should handle case sensitivity', () => {
     const result = filterProviders(mockProviders, 'GPT');
     expect(result).toHaveLength(2);
+  });
+});
+
+describe('filterProviderConfigs', () => {
+  describe('string providers', () => {
+    it('should return the string if it matches the filter', () => {
+      const result = filterProviderConfigs('openai:gpt-4', 'openai');
+      expect(result).toBe('openai:gpt-4');
+    });
+
+    it('should return empty array if string does not match', () => {
+      const result = filterProviderConfigs('openai:gpt-4', 'anthropic');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle regex patterns for strings', () => {
+      const result = filterProviderConfigs('openai:gpt-4', 'gpt-[0-9]');
+      expect(result).toBe('openai:gpt-4');
+    });
+  });
+
+  describe('function providers', () => {
+    it('should filter function provider by label', () => {
+      const fn = Object.assign(async () => ({ output: '' }), { label: 'MyFunction' });
+      const result = filterProviderConfigs(fn, 'MyFunction');
+      expect(result).toBe(fn);
+    });
+
+    it('should filter function provider without label by default id', () => {
+      const fn = async () => ({ output: '' });
+      const result = filterProviderConfigs(fn, 'custom-function');
+      expect(result).toBe(fn);
+    });
+
+    it('should return empty array if function label does not match', () => {
+      const fn = Object.assign(async () => ({ output: '' }), { label: 'MyFunction' });
+      const result = filterProviderConfigs(fn, 'OtherFunction');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('array of providers', () => {
+    it('should return all providers if no filter is provided', () => {
+      const providers = ['openai:gpt-4', 'anthropic:claude-2'];
+      const result = filterProviderConfigs(providers);
+      expect(result).toEqual(providers);
+    });
+
+    it('should filter string providers in array', () => {
+      const providers = ['openai:gpt-4', 'openai:gpt-3.5-turbo', 'anthropic:claude-2'];
+      const result = filterProviderConfigs(providers, 'openai');
+      expect(result).toEqual(['openai:gpt-4', 'openai:gpt-3.5-turbo']);
+    });
+
+    it('should filter ProviderOptions by id', () => {
+      const providers: ProviderOptions[] = [
+        { id: 'openai:gpt-4', label: 'GPT-4' },
+        { id: 'anthropic:claude-2', label: 'Claude' },
+      ];
+      const result = filterProviderConfigs(providers, 'openai');
+      expect(result).toHaveLength(1);
+      expect((result as ProviderOptions[])[0].id).toBe('openai:gpt-4');
+    });
+
+    it('should filter ProviderOptions by label', () => {
+      const providers: ProviderOptions[] = [
+        { id: 'openai:gpt-4', label: 'Dev' },
+        { id: 'openai:gpt-4', label: 'Stage' },
+        { id: 'openai:gpt-4', label: 'Prod' },
+      ];
+      const result = filterProviderConfigs(providers, 'Dev');
+      expect(result).toHaveLength(1);
+      expect((result as ProviderOptions[])[0].label).toBe('Dev');
+    });
+
+    it('should filter ProviderOptionsMap by key (provider id)', () => {
+      const providers: ProviderOptionsMap[] = [
+        { 'openai:gpt-4': { label: 'Dev' } },
+        { 'anthropic:claude-2': { label: 'Stage' } },
+      ];
+      const result = filterProviderConfigs(providers, 'openai');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should filter ProviderOptionsMap by nested label', () => {
+      const providers: ProviderOptionsMap[] = [
+        { 'openai:gpt-4': { label: 'Dev' } },
+        { 'openai:gpt-4': { label: 'Stage' } },
+      ];
+      const result = filterProviderConfigs(providers, 'Stage');
+      expect(result).toHaveLength(1);
+      expect((result as ProviderOptionsMap[])[0]['openai:gpt-4'].label).toBe('Stage');
+    });
+
+    it('should handle mixed array of provider types', () => {
+      const fn = Object.assign(async () => ({ output: '' }), { label: 'CustomDev' });
+      const providers: TestSuiteConfig['providers'] = [
+        'openai:gpt-4',
+        { id: 'anthropic:claude-2', label: 'ClaudeDev' },
+        { 'google:gemini': { label: 'GeminiDev' } } as ProviderOptionsMap,
+        fn,
+      ];
+      const result = filterProviderConfigs(providers, 'Dev');
+      expect(result).toHaveLength(3);
+    });
+
+    it('should return empty array if no providers match', () => {
+      const providers = ['openai:gpt-4', 'anthropic:claude-2'];
+      const result = filterProviderConfigs(providers, 'nonexistent');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('regex patterns', () => {
+    it('should support complex regex patterns', () => {
+      const providers: ProviderOptions[] = [
+        { id: 'openai:gpt-4', label: 'Dev-US' },
+        { id: 'openai:gpt-4', label: 'Dev-EU' },
+        { id: 'openai:gpt-4', label: 'Prod-US' },
+      ];
+      const result = filterProviderConfigs(providers, 'Dev-.*');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should match either id or label with regex', () => {
+      const providers: ProviderOptions[] = [
+        { id: 'openai:gpt-4', label: 'Production' },
+        { id: 'anthropic:claude-sonnet', label: 'Dev' },
+      ];
+      const result = filterProviderConfigs(providers, '(gpt|sonnet)');
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty array', () => {
+      const result = filterProviderConfigs([], 'anything');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle provider without label filtering by id only', () => {
+      const providers: ProviderOptions[] = [{ id: 'openai:gpt-4' }];
+      const result = filterProviderConfigs(providers, 'gpt-4');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should handle ProviderOptionsMap with overridden id', () => {
+      const providers: ProviderOptionsMap[] = [
+        { 'file://custom.js': { id: 'my-custom-id', label: 'Dev' } },
+      ];
+      // Should match the overridden id, not the key
+      const result = filterProviderConfigs(providers, 'my-custom-id');
+      expect(result).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1861

- `--filter-providers`/`--filter-targets` now filters provider configs **before** instantiation
- Providers that don't match the filter are never loaded, preventing env var validation failures
- Added `filterProviderConfigs()` function to handle all provider config formats (strings, functions, ProviderOptions, ProviderOptionsMap)

## Test plan

- [x] Added 19 unit tests for `filterProviderConfigs()`
- [x] All 284 related tests pass
- [x] Manual testing with custom provider that validates env vars on construction
- [x] Verified regex filtering works
- [x] Backwards compatible - no changes when filter not specified