### PR TITLE
test: add missing vitest imports to toolCallF1.test.ts

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -33,12 +33,12 @@ npm run test:integration
 **Reference files:**
 
 - **Vitest (frontend)**: `src/app/src/hooks/usePageMeta.test.ts` - explicit imports
-- **Vitest (backend)**: `test/assertions/contains.test.ts` - uses globals (no imports needed)
+- **Vitest (backend)**: `test/assertions/contains.test.ts` - explicit imports
 
-Backend Vitest tests use `globals: true` so `describe`, `it`, `expect`, `vi` are available without imports.
+All tests require explicit imports from vitest:
 
 ```typescript
-import { vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => {
   vi.resetAllMocks(); // Prevents test pollution
@@ -82,8 +82,8 @@ See `test/providers/openai-codex-sdk.test.ts` for reference patterns.
 
 - Config: `vitest.config.ts` (main tests) and `vitest.integration.config.ts` (integration tests)
 - Setup: `vitest.setup.ts`
-- Globals enabled: `describe`, `it`, `expect`, `beforeEach`, `afterEach` available without imports
-- For mocking utilities, import from `vitest`: `import { vi } from 'vitest'`
+- Globals disabled: All test utilities must be explicitly imported from `vitest`
+- Import `describe`, `it`, `expect`, `beforeEach`, `afterEach`, `vi` from `vitest`
 
 ## Best Practices
 

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { handleToolCallF1 } from '../../src/assertions/toolCallF1';
 
 import type { ApiProvider, AssertionParams, AtomicTestCase } from '../../src/types/index';


### PR DESCRIPTION
## Summary
- Added missing vitest imports (`describe`, `expect`, `it`) to `test/assertions/toolCallF1.test.ts`
- Updated `test/AGENTS.md` to reflect that globals are now disabled and all tests require explicit imports

## Context
The recent change to disable vitest globals (#6578) missed this test file, causing CI failures on main with:
```
ReferenceError: describe is not defined
❯ test/assertions/toolCallF1.test.ts:33:1
```

## Test plan
- [x] `npx vitest run test/assertions/toolCallF1.test.ts` passes
- [x] Full test suite passes (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)