### PR TITLE
feat(providers): add enhanced parameters and chat support for WatsonX

### DIFF
--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -191,3 +191,107 @@ providers:
   - watsonx:mistralai/mistral-large
   - watsonx:mistralai/mixtral-8x7b-instruct-v01
 ```
+
+## Configuration Options
+
+### Text Generation Parameters
+
+The WatsonX provider supports the full range of text generation parameters from the IBM SDK:
+
+| Parameter             | Type     | Description                                |
+| --------------------- | -------- | ------------------------------------------ |
+| `maxNewTokens`        | number   | Maximum tokens to generate (default: 100)  |
+| `minNewTokens`        | number   | Minimum tokens before stop sequences apply |
+| `temperature`         | number   | Sampling temperature (0-2)                 |
+| `topP`                | number   | Nucleus sampling parameter (0-1)           |
+| `topK`                | number   | Top-k sampling parameter                   |
+| `decodingMethod`      | string   | `'greedy'` or `'sample'`                   |
+| `stopSequences`       | string[] | Sequences that cause generation to stop    |
+| `repetitionPenalty`   | number   | Penalty for repeated tokens                |
+| `randomSeed`          | number   | Seed for reproducible outputs              |
+| `timeLimit`           | number   | Time limit in milliseconds                 |
+| `truncateInputTokens` | number   | Max input tokens before truncation         |
+| `includeStopSequence` | boolean  | Include stop sequence in output            |
+| `lengthPenalty`       | object   | Length penalty configuration               |
+
+#### Example with Parameters
+
+```yaml
+providers:
+  - id: watsonx:ibm/granite-3-3-8b-instruct
+    config:
+      temperature: 0.7
+      topP: 0.9
+      topK: 50
+      maxNewTokens: 1024
+      stopSequences: ['END', 'STOP']
+      repetitionPenalty: 1.1
+      decodingMethod: sample
+```
+
+#### Length Penalty
+
+For more control over output length:
+
+```yaml
+providers:
+  - id: watsonx:ibm/granite-3-3-8b-instruct
+    config:
+      lengthPenalty:
+        decayFactor: 1.5
+        startIndex: 10
+```
+
+## Chat Mode
+
+WatsonX also supports chat-style interactions using the `textChat` API. Use the `watsonx:chat:` prefix:
+
+```yaml
+providers:
+  - id: watsonx:chat:ibm/granite-3-3-8b-instruct
+    config:
+      temperature: 0.7
+      maxNewTokens: 1024
+```
+
+Chat mode automatically parses messages in JSON format:
+
+```yaml
+prompts:
+  - |
+    [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "{{question}}"}
+    ]
+
+providers:
+  - watsonx:chat:ibm/granite-3-3-8b-instruct
+```
+
+For plain text prompts, the chat provider automatically wraps them as a user message.
+
+### Chat vs Text Generation
+
+| Feature         | Text Generation (`watsonx:`) | Chat (`watsonx:chat:`)       |
+| --------------- | ---------------------------- | ---------------------------- |
+| API Method      | `generateText`               | `textChat`                   |
+| Input Format    | Plain text                   | Messages array or plain text |
+| Best For        | Completion tasks             | Conversational applications  |
+| System Messages | Not supported                | Supported                    |
+
+## Environment Variables
+
+| Variable                  | Description                                 |
+| ------------------------- | ------------------------------------------- |
+| `WATSONX_AI_APIKEY`       | IBM Cloud API key for IAM authentication    |
+| `WATSONX_AI_BEARER_TOKEN` | Bearer token for token-based authentication |
+| `WATSONX_AI_PROJECT_ID`   | WatsonX project ID                          |
+| `WATSONX_AI_AUTH_TYPE`    | Force auth type: `iam` or `bearertoken`     |
+
+## Migrating from IBM BAM
+
+The IBM BAM provider has been deprecated (sunset March 2025). To migrate:
+
+1. Change provider prefix from `bam:` to `watsonx:`
+2. Update authentication to use WatsonX credentials
+3. Update model IDs to WatsonX equivalents (e.g., `ibm/granite-3-3-8b-instruct`)

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -105,7 +105,7 @@ import { createSnowflakeProvider } from './snowflake';
 import { createTogetherAiProvider } from './togetherai';
 import { createTrueFoundryProvider } from './truefoundry';
 import { VoyageEmbeddingProvider } from './voyage';
-import { WatsonXProvider } from './watsonx';
+import { WatsonXChatProvider, WatsonXProvider } from './watsonx';
 import { WebhookProvider } from './webhook';
 import { WebSocketProvider } from './websocket';
 import { createXAIProvider } from './xai/chat';
@@ -1114,6 +1114,15 @@ export const providerMap: ProviderFactory[] = [
       _context: LoadApiProviderContext,
     ) => {
       const splits = providerPath.split(':');
+      const modelType = splits[1];
+
+      // Support watsonx:chat:<model> for chat API
+      if (modelType === 'chat') {
+        const modelName = splits.slice(2).join(':');
+        return new WatsonXChatProvider(modelName, providerOptions);
+      }
+
+      // Default: watsonx:<model> for text generation
       const modelName = splits.slice(1).join(':');
       return new WatsonXProvider(modelName, providerOptions);
     },

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -7,7 +7,7 @@ import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import invariant from '../util/invariant';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
-import { calculateCost, REQUEST_TIMEOUT_MS } from './shared';
+import { calculateCost, parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
 import type { WatsonXAI as WatsonXAIClient } from '@ibm-cloud/watsonx-ai';
 import type { BearerTokenAuthenticator, IamAuthenticator } from 'ibm-cloud-sdk-core';
 
@@ -22,7 +22,22 @@ import type {
 import type { ProviderOptions } from '../types/providers';
 
 interface TextGenRequestParametersModel {
-  max_new_tokens: number;
+  max_new_tokens?: number;
+  min_new_tokens?: number;
+  decoding_method?: 'greedy' | 'sample';
+  length_penalty?: {
+    decay_factor?: number;
+    start_index?: number;
+  };
+  random_seed?: number;
+  stop_sequences?: string[];
+  temperature?: number;
+  time_limit?: number;
+  top_k?: number;
+  top_p?: number;
+  repetition_penalty?: number;
+  truncate_input_tokens?: number;
+  include_stop_sequence?: boolean;
 }
 
 interface TextGenRequestParams {
@@ -33,15 +48,37 @@ interface TextGenRequestParams {
 }
 
 const ConfigSchema = z.object({
+  // Authentication options
   apiKey: z.string().optional(),
   apiKeyEnvar: z.string().optional(),
   apiBearerToken: z.string().optional(),
   apiBearerTokenEnvar: z.string().optional(),
+
+  // Service configuration
   serviceUrl: z.string().optional(),
   version: z.string().optional(),
   projectId: z.string().optional(),
   modelId: z.string().optional(),
+
+  // Text generation parameters
   maxNewTokens: z.number().optional(),
+  minNewTokens: z.number().optional(),
+  decodingMethod: z.enum(['greedy', 'sample']).optional(),
+  lengthPenalty: z
+    .object({
+      decayFactor: z.number().optional(),
+      startIndex: z.number().optional(),
+    })
+    .optional(),
+  randomSeed: z.number().optional(),
+  stopSequences: z.array(z.string()).optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  timeLimit: z.number().optional(),
+  topK: z.number().optional(),
+  topP: z.number().min(0).max(1).optional(),
+  repetitionPenalty: z.number().optional(),
+  truncateInputTokens: z.number().optional(),
+  includeStopSequence: z.boolean().optional(),
 });
 
 const TextGenResponseSchema = z.object({
@@ -370,17 +407,26 @@ export class WatsonXProvider implements ApiProvider {
       return result;
     };
 
-    return withGenAISpan(spanContext, () => this.callApiInternal(prompt), resultExtractor);
+    return withGenAISpan(spanContext, () => this.callApiInternal(prompt, context), resultExtractor);
   }
 
-  private async callApiInternal(prompt: string): Promise<ProviderResponse> {
+  private async callApiInternal(
+    prompt: string,
+    context?: CallApiContextParams,
+  ): Promise<ProviderResponse> {
     const client = await this.getClient();
+
+    // Merge configs: provider config -> prompt-level config
+    const config = {
+      ...this.config,
+      ...context?.prompt?.config,
+    };
 
     const modelId = this.getModelId();
     const projectId = this.getProjectId();
 
     const cache = getCache();
-    const configHash = generateConfigHash(this.options.config);
+    const configHash = generateConfigHash(config);
     const cacheKey = `watsonx:${this.modelName}:${configHash}:${prompt}`;
     const cacheEnabled = isCacheEnabled();
     if (cacheEnabled) {
@@ -395,15 +441,43 @@ export class WatsonXProvider implements ApiProvider {
     }
 
     try {
-      const textGenRequestParametersModel: TextGenRequestParametersModel = {
-        max_new_tokens: this.options.config.maxNewTokens || 100,
+      // Build parameters with conditional inclusion
+      const parameters: TextGenRequestParametersModel = {
+        max_new_tokens: config.maxNewTokens || 100,
+        ...(config.minNewTokens !== undefined && { min_new_tokens: config.minNewTokens }),
+        ...(config.decodingMethod && { decoding_method: config.decodingMethod }),
+        ...(config.lengthPenalty && {
+          length_penalty: {
+            ...(config.lengthPenalty.decayFactor !== undefined && {
+              decay_factor: config.lengthPenalty.decayFactor,
+            }),
+            ...(config.lengthPenalty.startIndex !== undefined && {
+              start_index: config.lengthPenalty.startIndex,
+            }),
+          },
+        }),
+        ...(config.randomSeed !== undefined && { random_seed: config.randomSeed }),
+        ...(config.stopSequences?.length && { stop_sequences: config.stopSequences }),
+        ...(config.temperature !== undefined && { temperature: config.temperature }),
+        ...(config.timeLimit !== undefined && { time_limit: config.timeLimit }),
+        ...(config.topK !== undefined && { top_k: config.topK }),
+        ...(config.topP !== undefined && { top_p: config.topP }),
+        ...(config.repetitionPenalty !== undefined && {
+          repetition_penalty: config.repetitionPenalty,
+        }),
+        ...(config.truncateInputTokens !== undefined && {
+          truncate_input_tokens: config.truncateInputTokens,
+        }),
+        ...(config.includeStopSequence !== undefined && {
+          include_stop_sequence: config.includeStopSequence,
+        }),
       };
 
       const params: TextGenRequestParams = {
         input: prompt,
         modelId,
         projectId,
-        parameters: textGenRequestParametersModel,
+        parameters,
       };
 
       const apiResponse = await client.generateText(params);
@@ -423,7 +497,7 @@ export class WatsonXProvider implements ApiProvider {
 
       providerResponse.cost = await calculateWatsonXCost(
         this.modelName,
-        this.options.config,
+        config,
         providerResponse.tokenUsage?.prompt,
         providerResponse.tokenUsage?.completion,
       );
@@ -442,5 +516,108 @@ export class WatsonXProvider implements ApiProvider {
         tokenUsage: createEmptyTokenUsage(),
       };
     }
+  }
+}
+
+/**
+ * WatsonX Chat Provider using the textChat API for messages-based interactions.
+ */
+export class WatsonXChatProvider extends WatsonXProvider {
+  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
+    const client = await this.getClient();
+
+    // Merge configs: provider config -> prompt-level config
+    const config = {
+      ...this.config,
+      ...context?.prompt?.config,
+    };
+
+    const modelId = this.getModelId();
+    const projectId = this.getProjectId();
+
+    const cache = getCache();
+    const configHash = generateConfigHash(config);
+    const cacheKey = `watsonx:chat:${this.modelName}:${configHash}:${prompt}`;
+    const cacheEnabled = isCacheEnabled();
+    if (cacheEnabled) {
+      const cachedResponse = await cache.get(cacheKey);
+      if (cachedResponse) {
+        logger.debug(
+          `Watsonx Chat: Returning cached response for prompt with config "${configHash}"`,
+        );
+        const resp = JSON.parse(cachedResponse as string) as ProviderResponse;
+        return { ...resp, cached: true };
+      }
+    }
+
+    try {
+      // Parse chat messages using shared utility
+      const messages = parseChatPrompt(prompt, [{ role: 'user' as const, content: prompt }]);
+
+      // Build chat params
+      const params: Record<string, any> = {
+        modelId,
+        projectId,
+        messages,
+        ...(config.temperature !== undefined && { temperature: config.temperature }),
+        ...(config.maxNewTokens !== undefined && { maxTokens: config.maxNewTokens }),
+        ...(config.topP !== undefined && { topP: config.topP }),
+        ...(config.stopSequences?.length && { stop: config.stopSequences }),
+        ...(config.randomSeed !== undefined && { seed: config.randomSeed }),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await (client as any).textChat(params);
+      const result = response.result as any;
+
+      const providerResponse = this.convertChatResponse(result);
+
+      providerResponse.cost = await calculateWatsonXCost(
+        this.modelName,
+        config,
+        providerResponse.tokenUsage?.prompt,
+        providerResponse.tokenUsage?.completion,
+      );
+
+      if (isCacheEnabled()) {
+        await cache.set(cacheKey, JSON.stringify(providerResponse));
+      }
+
+      return providerResponse;
+    } catch (err) {
+      logger.error(`Watsonx Chat: API call error: ${String(err)}`);
+
+      return {
+        error: `API call error: ${String(err)}`,
+        output: '',
+        tokenUsage: createEmptyTokenUsage(),
+      };
+    }
+  }
+
+  private convertChatResponse(result: any): ProviderResponse {
+    const choice = result?.choices?.[0];
+    const message = choice?.message;
+
+    // Handle tool calls if present
+    if (message?.tool_calls?.length) {
+      return {
+        output: JSON.stringify(message.tool_calls),
+        tokenUsage: {
+          prompt: result?.usage?.prompt_tokens,
+          completion: result?.usage?.completion_tokens,
+          total: result?.usage?.total_tokens,
+        },
+      };
+    }
+
+    return {
+      output: message?.content || '',
+      tokenUsage: {
+        prompt: result?.usage?.prompt_tokens,
+        completion: result?.usage?.completion_tokens,
+        total: result?.usage?.total_tokens,
+      },
+    };
   }
 }


### PR DESCRIPTION
## Summary

Enhances the WatsonX provider to support the full range of SDK capabilities:

- **Text generation parameters**: temperature, topP, topK, stopSequences, repetitionPenalty, decodingMethod, lengthPenalty, minNewTokens, randomSeed, timeLimit, truncateInputTokens, includeStopSequence
- **Config merging**: Prompt-level config now overrides provider config
- **Chat API support**: New `WatsonXChatProvider` class using the `textChat` SDK method
- **Provider pattern**: Support `watsonx:chat:<model>` for chat mode

## Usage

### Text Generation with Parameters
```yaml
providers:
  - id: watsonx:ibm/granite-3-3-8b-instruct
    config:
      temperature: 0.7
      topP: 0.9
      topK: 50
      maxNewTokens: 1024
      stopSequences: ["END", "STOP"]
      repetitionPenalty: 1.1
      decodingMethod: sample
```

### Chat Mode
```yaml
providers:
  - id: watsonx:chat:ibm/granite-3-3-8b-instruct
    config:
      temperature: 0.7
      maxNewTokens: 1024
```

## Test plan

- [x] Unit tests for new text generation parameters
- [x] Unit tests for config merging
- [x] Unit tests for WatsonXChatProvider (message parsing, response handling, error handling)
- [x] All 25 tests passing
- [x] Lint and format passing