### PR TITLE
feat(providers): enhance Azure Content Safety with Entra ID, image moderation, and scorer assertion

### DIFF
--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -414,7 +414,7 @@ defaultTest:
           apiHost: 'your-resource.openai.azure.com'
 ```
 
-Note that any moderation tasks will still use the OpenAI API.
+For moderation tasks, you can use [Azure Content Safety](/docs/configuration/expected-outputs/moderation#azure-content-safety-moderation) instead of the OpenAI moderation API.
 
 ## Configuration
 
@@ -1209,6 +1209,7 @@ For complete working examples, check out the [Azure Foundry Agent example direct
 ## See Also
 
 - [OpenAI Provider](/docs/providers/openai) - The base provider that Azure shares configuration with
+- [Azure Content Safety](/docs/configuration/expected-outputs/moderation#azure-content-safety-moderation) - Use Azure Content Safety for moderation assertions
 - [Evaluating Assistants](/docs/guides/evaluate-openai-assistants/) - Learn how to compare different models and instructions
 - [Azure Examples](https://github.com/promptfoo/promptfoo/tree/main/examples/azure) - All Azure examples in one place:
   - [OpenAI](https://github.com/promptfoo/promptfoo/tree/main/examples/azure/openai) - Chat, vision, and embedding examples

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -573,6 +573,7 @@
                                               "contains-json",
                                               "contains-sql",
                                               "contains-xml",
+                                              "content-safety",
                                               "context-faithfulness",
                                               "context-recall",
                                               "context-relevance",

--- a/src/assertions/contentSafety.ts
+++ b/src/assertions/contentSafety.ts
@@ -1,0 +1,198 @@
+import { AzureModerationProvider } from '../providers/azure/moderation';
+import logger from '../logger';
+
+import type { AssertionParams, GradingResult } from '../types/index';
+import type { AzureModerationConfig, AzureModerationCategory } from '../providers/azure/moderation';
+
+interface ContentSafetyConfig extends AzureModerationConfig {
+  /**
+   * Maximum allowed severity threshold (0-1 scale).
+   * Content with any category score above this threshold will fail.
+   * Default: 0.5
+   */
+  threshold?: number;
+  /**
+   * Whether to analyze the prompt in addition to the output.
+   * Default: false
+   */
+  analyzePrompt?: boolean;
+  /**
+   * Content type to analyze.
+   * Default: 'text'
+   */
+  contentType?: 'text' | 'image';
+}
+
+const DEFAULT_CATEGORIES: AzureModerationCategory[] = ['Hate', 'SelfHarm', 'Sexual', 'Violence'];
+const DEFAULT_THRESHOLD = 0.5;
+
+/**
+ * Content Safety assertion handler using Azure Content Safety API.
+ * Returns normalized scores (0-1) for each content safety category.
+ *
+ * Usage in promptfooconfig.yaml:
+ * ```yaml
+ * assert:
+ *   - type: content-safety
+ *     config:
+ *       endpoint: https://your-resource.cognitiveservices.azure.com
+ *       threshold: 0.3  # fail if any category score > 0.3
+ *       categories: ['Hate', 'Violence']  # optional: only check specific categories
+ *       outputType: 'EightSeverityLevels'  # optional: use 0-7 scale instead of 0-3
+ *       useEntraIdAuth: true  # optional: use Entra ID instead of API key
+ * ```
+ */
+export const handleContentSafety = async ({
+  assertion,
+  test,
+  outputString,
+  prompt,
+}: AssertionParams): Promise<GradingResult> => {
+  const config = (assertion.config || {}) as ContentSafetyConfig;
+  const threshold = config.threshold ?? DEFAULT_THRESHOLD;
+  const categories = config.categories ?? DEFAULT_CATEGORIES;
+  const analyzePrompt = config.analyzePrompt ?? false;
+  const contentType = config.contentType ?? 'text';
+
+  // Validate configuration
+  if (!config.endpoint && !process.env.AZURE_CONTENT_SAFETY_ENDPOINT) {
+    return {
+      pass: false,
+      score: 0,
+      reason:
+        'Azure Content Safety endpoint is not configured. Set AZURE_CONTENT_SAFETY_ENDPOINT environment variable or add `endpoint` to the assertion config.',
+      assertion,
+    };
+  }
+
+  try {
+    const provider = new AzureModerationProvider('text-content-safety', {
+      config: {
+        ...config,
+        categories,
+      },
+      env: test.options?.provider?.env,
+    });
+
+    // Analyze the output
+    let result;
+    if (contentType === 'image') {
+      result = await provider.analyzeImage(outputString);
+    } else {
+      result = await provider.analyzeText(outputString);
+    }
+
+    if (result.error) {
+      return {
+        pass: false,
+        score: 0,
+        reason: `Content Safety API error: ${result.error}`,
+        assertion,
+      };
+    }
+
+    // Optionally analyze the prompt as well
+    let promptResult;
+    if (analyzePrompt && prompt) {
+      promptResult = await provider.analyzeText(prompt);
+      if (promptResult.error) {
+        logger.warn(`Content Safety prompt analysis error: ${promptResult.error}`);
+      }
+    }
+
+    // Build named scores from the flags
+    const namedScores: Record<string, number> = {};
+    const categoryScores: Record<string, number> = {};
+    let maxScore = 0;
+    let maxCategory = '';
+
+    for (const flag of result.flags || []) {
+      // Skip blocklist flags for scoring
+      if (flag.code.startsWith('blocklist:')) {
+        continue;
+      }
+
+      const score = flag.confidence;
+      const categoryName = flag.code;
+      categoryScores[categoryName] = score;
+      namedScores[`content-safety/${categoryName}`] = score;
+
+      if (score > maxScore) {
+        maxScore = score;
+        maxCategory = categoryName;
+      }
+    }
+
+    // Add prompt scores if analyzed
+    if (promptResult && !promptResult.error) {
+      for (const flag of promptResult.flags || []) {
+        if (flag.code.startsWith('blocklist:')) {
+          continue;
+        }
+        namedScores[`content-safety/prompt/${flag.code}`] = flag.confidence;
+      }
+    }
+
+    // Check blocklist matches
+    const blocklistMatches = (result.flags || []).filter((f) => f.code.startsWith('blocklist:'));
+    const hasBlocklistMatch = blocklistMatches.length > 0;
+
+    // Determine pass/fail based on threshold
+    const pass = maxScore <= threshold && !hasBlocklistMatch;
+
+    // Build human-readable reason
+    let reason: string;
+    if (pass) {
+      reason = `Content passed safety check. Max severity: ${maxCategory || 'none'} (${(maxScore * 100).toFixed(1)}%)`;
+    } else if (hasBlocklistMatch) {
+      const matchedLists = blocklistMatches.map((m) => m.code.replace('blocklist:', '')).join(', ');
+      reason = `Content matched blocklist(s): ${matchedLists}`;
+    } else {
+      reason = `Content flagged for ${maxCategory} with severity ${(maxScore * 100).toFixed(1)}% (threshold: ${(threshold * 100).toFixed(1)}%)`;
+    }
+
+    // Build metadata with raw Azure response data
+    const metadata: Record<string, any> = {
+      contentType,
+      categories: categoryScores,
+      threshold,
+      maxCategory,
+      maxScore,
+    };
+
+    // Include raw severity values from flags
+    for (const flag of result.flags || []) {
+      if (flag.metadata) {
+        metadata[`raw_${flag.code}`] = flag.metadata;
+      }
+    }
+
+    if (hasBlocklistMatch) {
+      metadata.blocklistMatches = blocklistMatches.map((m) => ({
+        blocklist: m.code.replace('blocklist:', ''),
+        ...m.metadata,
+      }));
+    }
+
+    // For scorer-style assertions, we want to return a normalized score
+    // where 0 = unsafe (high severity) and 1 = safe (low severity)
+    const safetyScore = 1 - maxScore;
+
+    return {
+      pass,
+      score: safetyScore,
+      reason,
+      namedScores,
+      metadata,
+      assertion,
+    };
+  } catch (error) {
+    logger.error(`Content Safety assertion error: ${error}`);
+    return {
+      pass: false,
+      score: 0,
+      reason: `Content Safety assertion failed: ${error instanceof Error ? error.message : String(error)}`,
+      assertion,
+    };
+  }
+};

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -49,6 +49,7 @@ import {
   handleIContainsAll,
   handleIContainsAny,
 } from './contains';
+import { handleContentSafety } from './contentSafety';
 import { handleContextFaithfulness } from './contextFaithfulness';
 import { handleContextRecall } from './contextRecall';
 import { handleContextRelevance } from './contextRelevance';
@@ -125,6 +126,7 @@ const ASSERTION_HANDLERS: Record<
   'contains-json': handleContainsJson,
   'contains-sql': handleContainsSql,
   'contains-xml': handleIsXml,
+  'content-safety': handleContentSafety,
   'context-faithfulness': handleContextFaithfulness,
   'context-recall': handleContextRecall,
   'context-relevance': handleContextRelevance,

--- a/src/providers/azure/moderation.ts
+++ b/src/providers/azure/moderation.ts
@@ -15,10 +15,12 @@ import type {
 
 const AZURE_MODERATION_MODELS = [
   { id: 'text-content-safety', maxTokens: 10000, capabilities: ['text'] },
+  { id: 'image-content-safety', maxTokens: 0, capabilities: ['image'] },
 ];
 
 type AzureModerationModelId = string;
 export type AzureModerationCategory = 'Hate' | 'SelfHarm' | 'Sexual' | 'Violence';
+export type AzureOutputType = 'FourSeverityLevels' | 'EightSeverityLevels';
 
 interface AzureTextCategoriesAnalysis {
   category: AzureModerationCategory;
@@ -36,7 +38,11 @@ interface AzureAnalyzeTextResult {
   blocklistsMatch?: AzureTextBlocklistMatch[];
 }
 
-interface AzureModerationConfig {
+interface AzureAnalyzeImageResult {
+  categoriesAnalysis?: AzureTextCategoriesAnalysis[];
+}
+
+export interface AzureModerationConfig {
   apiKey?: string;
   apiKeyEnvar?: string;
   endpoint?: string;
@@ -45,11 +51,31 @@ interface AzureModerationConfig {
   blocklistNames?: string[];
   haltOnBlocklistHit?: boolean;
   passthrough?: Record<string, any>;
+  // Entra ID authentication
+  useEntraIdAuth?: boolean;
+  azureClientId?: string;
+  azureClientSecret?: string;
+  azureTenantId?: string;
+  azureAuthorityHost?: string;
+  azureTokenScope?: string;
+  // Output configuration
+  outputType?: AzureOutputType;
+  // Categories to check (defaults to all)
+  categories?: AzureModerationCategory[];
 }
 
+/**
+ * Maximum severity scale for Azure Content Safety API.
+ * Text uses EightSeverityLevels (0-7), Images use FourSeverityLevels (0-3).
+ */
+export const AZURE_MAX_SEVERITY = 7;
+
 export function parseAzureModerationResponse(
-  data: AzureAnalyzeTextResult,
+  data: AzureAnalyzeTextResult | AzureAnalyzeImageResult,
+  options: { maxSeverity?: number; returnAllCategories?: boolean } = {},
 ): ProviderModerationResponse {
+  const { maxSeverity = AZURE_MAX_SEVERITY, returnAllCategories = false } = options;
+
   try {
     logger.debug(`Azure Content Safety API response: ${JSON.stringify(data)}`);
 
@@ -60,22 +86,31 @@ export function parseAzureModerationResponse(
 
     const categories = data.categoriesAnalysis || [];
     const blocklistMatches =
-      data.blocklistsMatch || (data as any).blocklistsMatch || (data as any).blocklists_match || [];
-
-    if (!categories || categories.length === 0) {
-      return { flags: [] };
-    }
+      'blocklistsMatch' in data
+        ? data.blocklistsMatch ||
+          (data as any).blocklistsMatch ||
+          (data as any).blocklists_match ||
+          []
+        : [];
 
     const flags: ModerationFlag[] = [];
 
     for (const analysis of categories) {
-      if (analysis.severity > 0) {
-        const confidence = analysis.severity / 7;
+      // Include all categories if returnAllCategories is true, otherwise only flagged ones
+      if (returnAllCategories || analysis.severity > 0) {
+        const confidence = analysis.severity / maxSeverity;
 
         flags.push({
           code: analysis.category.toLowerCase(),
-          description: `Content flagged for ${analysis.category}`,
+          description:
+            analysis.severity > 0
+              ? `Content flagged for ${analysis.category}`
+              : `${analysis.category} (not flagged)`,
           confidence,
+          metadata: {
+            azure_severity: analysis.severity,
+            max_severity: maxSeverity,
+          },
         });
       }
     }
@@ -85,6 +120,10 @@ export function parseAzureModerationResponse(
         code: `blocklist:${match.blocklistName}`,
         description: `Content matched blocklist item: ${match.blocklistItemText}`,
         confidence: 1.0,
+        metadata: {
+          blocklist_item_id: match.blocklistItemId,
+          blocklist_item_text: match.blocklistItemText,
+        },
       });
     }
 
@@ -156,16 +195,51 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
     );
   }
 
-  async callModerationApi(
-    _userPrompt: string,
-    assistantResponse: string,
-  ): Promise<ProviderModerationResponse> {
+  /**
+   * Gets authentication headers for Content Safety API.
+   * Supports both API key and Entra ID (Azure AD) authentication.
+   */
+  async getContentSafetyAuthHeaders(): Promise<Record<string, string>> {
+    // Check if Entra ID auth is explicitly requested
+    if (this.configWithHeaders.useEntraIdAuth) {
+      try {
+        const token = await this.getAccessToken();
+        return { Authorization: `Bearer ${token}` };
+      } catch (err) {
+        logger.error(`Entra ID authentication failed for Content Safety: ${err}`);
+        throw new Error(
+          `Entra ID authentication failed. Please check your credentials (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID) or use Azure CLI authentication.`,
+        );
+      }
+    }
+
+    // Try API key authentication
+    const apiKey = this.getContentSafetyApiKey();
+    if (apiKey) {
+      const maskedKey = apiKey.substring(0, 4) + '...' + apiKey.substring(apiKey.length - 4);
+      logger.debug(`Using Azure Content Safety API key: ${maskedKey}`);
+      return { 'Ocp-Apim-Subscription-Key': apiKey };
+    }
+
+    // Fallback to Entra ID if no API key is found
+    try {
+      const token = await this.getAccessToken();
+      logger.debug('Using Entra ID authentication for Content Safety (no API key found)');
+      return { Authorization: `Bearer ${token}` };
+    } catch {
+      throw new Error(
+        `Azure Content Safety authentication failed. Either set AZURE_CONTENT_SAFETY_API_KEY or configure Entra ID credentials.`,
+      );
+    }
+  }
+
+  /**
+   * Analyzes text content for safety issues.
+   */
+  async analyzeText(text: string): Promise<ProviderModerationResponse> {
     await this.ensureInitialized();
 
-    const apiKey =
-      this.configWithHeaders.apiKey || this.getContentSafetyApiKey() || this.getApiKeyOrThrow();
     const endpoint = this.endpoint;
-
     if (!endpoint) {
       return handleApiError(
         new Error(
@@ -174,48 +248,46 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
       );
     }
 
-    if (apiKey) {
-      const maskedKey = apiKey.substring(0, 4) + '...' + apiKey.substring(apiKey.length - 4);
-      logger.debug(`Using Azure Content Safety API key: ${maskedKey}`);
-    } else {
-      logger.error('No Azure Content Safety API key found');
-      return handleApiError(
-        new Error(
-          'Azure Content Safety API key is not set. Set the AZURE_CONTENT_SAFETY_API_KEY environment variable or add `apiKey` to the provider config.',
-        ),
-      );
-    }
-
     const useCache = isCacheEnabled();
     let cacheKey = '';
 
     if (useCache) {
-      cacheKey = getModerationCacheKey(this.modelName, this.configWithHeaders, assistantResponse);
+      cacheKey = getModerationCacheKey(this.modelName, this.configWithHeaders, text);
       const cache = await getCache();
       const cachedResponse = await cache.get(cacheKey);
 
       if (cachedResponse) {
-        logger.debug('Returning cached Azure moderation response');
+        logger.debug('Returning cached Azure text moderation response');
         return cachedResponse;
       }
     }
 
     try {
+      const authHeaders = await this.getContentSafetyAuthHeaders();
       const cleanEndpoint = endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
       const url = `${cleanEndpoint}/contentsafety/text:analyze?api-version=${this.apiVersion}`;
 
       const headers = {
         'Content-Type': 'application/json',
-        'Ocp-Apim-Subscription-Key': apiKey,
+        ...authHeaders,
         ...(this.configWithHeaders.headers || {}),
       };
 
+      const categories = this.configWithHeaders.categories || [
+        'Hate',
+        'Sexual',
+        'SelfHarm',
+        'Violence',
+      ];
+      const outputType = this.configWithHeaders.outputType || 'FourSeverityLevels';
+      const maxSeverity = outputType === 'EightSeverityLevels' ? 7 : 3;
+
       const body = {
-        text: assistantResponse,
-        categories: ['Hate', 'Sexual', 'SelfHarm', 'Violence'],
+        text,
+        categories,
         blocklistNames: this.configWithHeaders.blocklistNames || [],
         haltOnBlocklistHit: this.configWithHeaders.haltOnBlocklistHit ?? false,
-        outputType: 'FourSeverityLevels',
+        outputType,
         ...(this.configWithHeaders.passthrough || {}),
       };
 
@@ -233,7 +305,9 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
 
       if (!response.ok) {
         const errorText = await response.text();
-        logger.error(`Azure Content Safety API error: ${response.status} ${response.statusText}`);
+        logger.error(
+          `Azure Content Safety text API error: ${response.status} ${response.statusText}`,
+        );
         logger.error(`Error details: ${errorText}`);
 
         let errorMessage = `Azure Content Safety API returned ${response.status}: ${response.statusText}`;
@@ -251,7 +325,10 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
       }
 
       const data = await response.json();
-      const result = parseAzureModerationResponse(data);
+      const result = parseAzureModerationResponse(data, {
+        maxSeverity,
+        returnAllCategories: true,
+      });
 
       if (useCache && cacheKey) {
         const cache = await getCache();
@@ -262,5 +339,128 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
     } catch (err) {
       return handleApiError(err);
     }
+  }
+
+  /**
+   * Analyzes image content for safety issues.
+   * @param imageInput - Either a base64-encoded image string or a URL to an image
+   */
+  async analyzeImage(imageInput: string): Promise<ProviderModerationResponse> {
+    await this.ensureInitialized();
+
+    const endpoint = this.endpoint;
+    if (!endpoint) {
+      return handleApiError(
+        new Error(
+          'Azure Content Safety endpoint is not set. Set the AZURE_CONTENT_SAFETY_ENDPOINT environment variable or add `endpoint` to the provider config.',
+        ),
+      );
+    }
+
+    const useCache = isCacheEnabled();
+    let cacheKey = '';
+
+    if (useCache) {
+      cacheKey = getModerationCacheKey('image-content-safety', this.configWithHeaders, imageInput);
+      const cache = await getCache();
+      const cachedResponse = await cache.get(cacheKey);
+
+      if (cachedResponse) {
+        logger.debug('Returning cached Azure image moderation response');
+        return cachedResponse;
+      }
+    }
+
+    try {
+      const authHeaders = await this.getContentSafetyAuthHeaders();
+      const cleanEndpoint = endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
+      const url = `${cleanEndpoint}/contentsafety/image:analyze?api-version=${this.apiVersion}`;
+
+      const headers = {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+        ...(this.configWithHeaders.headers || {}),
+      };
+
+      // Determine if input is a URL or base64 content
+      const isUrl = imageInput.startsWith('http://') || imageInput.startsWith('https://');
+      const imageData = isUrl
+        ? { image: { blobUrl: imageInput } }
+        : { image: { content: imageInput } };
+
+      const categories = this.configWithHeaders.categories || [
+        'Hate',
+        'Sexual',
+        'SelfHarm',
+        'Violence',
+      ];
+      // Image API only supports FourSeverityLevels (0-3)
+      const maxSeverity = 3;
+
+      const body = {
+        ...imageData,
+        categories,
+        ...(this.configWithHeaders.passthrough || {}),
+      };
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+      const response = await fetchWithProxy(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(
+          `Azure Content Safety image API error: ${response.status} ${response.statusText}`,
+        );
+        logger.error(`Error details: ${errorText}`);
+
+        let errorMessage = `Azure Content Safety image API returned ${response.status}: ${response.statusText}`;
+
+        try {
+          const errorJson = JSON.parse(errorText);
+          if (errorJson.error && errorJson.error.message) {
+            errorMessage += ` - ${errorJson.error.message}`;
+          }
+        } catch {
+          errorMessage += ` - ${errorText}`;
+        }
+
+        return handleApiError(new Error(errorMessage));
+      }
+
+      const data = await response.json();
+      const result = parseAzureModerationResponse(data, {
+        maxSeverity,
+        returnAllCategories: true,
+      });
+
+      if (useCache && cacheKey) {
+        const cache = await getCache();
+        await cache.set(cacheKey, result);
+      }
+
+      return result;
+    } catch (err) {
+      return handleApiError(err);
+    }
+  }
+
+  /**
+   * Main moderation API call - analyzes text content.
+   * For image analysis, use analyzeImage() directly.
+   */
+  async callModerationApi(
+    _userPrompt: string,
+    assistantResponse: string,
+  ): Promise<ProviderModerationResponse> {
+    return this.analyzeText(assistantResponse);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -447,6 +447,7 @@ export const BaseAssertionTypesSchema = z.enum([
   'contains-json',
   'contains-sql',
   'contains-xml',
+  'content-safety',
   'context-faithfulness',
   'context-recall',
   'context-relevance',

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -35,6 +35,7 @@ export interface ModerationFlag {
   code: string;
   description: string;
   confidence: number;
+  metadata?: Record<string, any>;
 }
 
 export interface ProviderOptions {

--- a/test/assertions/contentSafety.test.ts
+++ b/test/assertions/contentSafety.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleContentSafety } from '../../src/assertions/contentSafety';
+
+import type { Assertion, AssertionParams, TestCase } from '../../src/types/index';
+
+// Create mock functions outside to reference them
+const mockAnalyzeText = vi.fn();
+const mockAnalyzeImage = vi.fn();
+
+// Mock the entire module with a class-like mock
+vi.mock('../../src/providers/azure/moderation', () => {
+  return {
+    AzureModerationProvider: class MockAzureModerationProvider {
+      analyzeText = mockAnalyzeText;
+      analyzeImage = mockAnalyzeImage;
+    },
+  };
+});
+
+describe('handleContentSafety', () => {
+  const mockTest: TestCase = {
+    description: 'Test case',
+    vars: {},
+    assert: [],
+    options: {},
+  };
+
+  const mockAssertion: Assertion = {
+    type: 'content-safety',
+    config: {
+      endpoint: 'https://test.cognitiveservices.azure.com',
+    },
+  };
+
+  const baseParams: AssertionParams = {
+    assertion: mockAssertion,
+    test: mockTest,
+    outputString: 'test output',
+    prompt: 'test prompt',
+    baseType: 'content-safety',
+    inverse: false,
+    output: 'test output',
+    providerResponse: { output: 'test output' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return error when endpoint is not configured', async () => {
+    const params = {
+      ...baseParams,
+      assertion: { type: 'content-safety' as const },
+    };
+
+    // Mock env to ensure no endpoint
+    const originalEnv = process.env.AZURE_CONTENT_SAFETY_ENDPOINT;
+    delete process.env.AZURE_CONTENT_SAFETY_ENDPOINT;
+
+    const result = await handleContentSafety(params);
+
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain('endpoint is not configured');
+
+    // Restore env
+    if (originalEnv) {
+      process.env.AZURE_CONTENT_SAFETY_ENDPOINT = originalEnv;
+    }
+  });
+
+  it('should pass when content is safe', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      flags: [
+        {
+          code: 'hate',
+          description: 'Hate (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+        {
+          code: 'sexual',
+          description: 'Sexual (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+        {
+          code: 'selfharm',
+          description: 'SelfHarm (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+        {
+          code: 'violence',
+          description: 'Violence (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+      ],
+    });
+
+    const result = await handleContentSafety(baseParams);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1); // 1 - maxScore(0) = 1
+    expect(result.reason).toContain('passed safety check');
+    expect(result.namedScores).toEqual({
+      'content-safety/hate': 0,
+      'content-safety/sexual': 0,
+      'content-safety/selfharm': 0,
+      'content-safety/violence': 0,
+    });
+  });
+
+  it('should fail when content exceeds threshold', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      flags: [
+        {
+          code: 'hate',
+          description: 'Content flagged for Hate',
+          confidence: 0.7,
+          metadata: { azure_severity: 5, max_severity: 7 },
+        },
+        {
+          code: 'sexual',
+          description: 'Sexual (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+      ],
+    });
+
+    const result = await handleContentSafety(baseParams);
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBeCloseTo(0.3); // 1 - 0.7 = 0.3
+    expect(result.reason).toContain('flagged for hate');
+    expect(result.namedScores!['content-safety/hate']).toBe(0.7);
+    expect(result.metadata!.maxCategory).toBe('hate');
+    expect(result.metadata!.maxScore).toBe(0.7);
+  });
+
+  it('should use custom threshold from config', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      flags: [
+        {
+          code: 'hate',
+          description: 'Content flagged for Hate',
+          confidence: 0.3,
+          metadata: { azure_severity: 2, max_severity: 7 },
+        },
+      ],
+    });
+
+    // With default threshold (0.5), this should pass
+    const result1 = await handleContentSafety(baseParams);
+    expect(result1.pass).toBe(true);
+
+    // With custom threshold (0.2), this should fail
+    const result2 = await handleContentSafety({
+      ...baseParams,
+      assertion: {
+        type: 'content-safety',
+        config: {
+          endpoint: 'https://test.cognitiveservices.azure.com',
+          threshold: 0.2,
+        },
+      },
+    });
+    expect(result2.pass).toBe(false);
+  });
+
+  it('should fail when blocklist is matched', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      flags: [
+        {
+          code: 'hate',
+          description: 'Hate (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 7 },
+        },
+        {
+          code: 'blocklist:custom-list',
+          description: 'Content matched blocklist item: bad word',
+          confidence: 1.0,
+          metadata: { blocklist_item_id: '123', blocklist_item_text: 'bad word' },
+        },
+      ],
+    });
+
+    const result = await handleContentSafety(baseParams);
+
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain('blocklist');
+    expect(result.metadata!.blocklistMatches).toBeDefined();
+  });
+
+  it('should use analyzeImage for image content type', async () => {
+    mockAnalyzeImage.mockResolvedValue({
+      flags: [
+        {
+          code: 'violence',
+          description: 'Violence (not flagged)',
+          confidence: 0,
+          metadata: { azure_severity: 0, max_severity: 3 },
+        },
+      ],
+    });
+
+    const result = await handleContentSafety({
+      ...baseParams,
+      assertion: {
+        type: 'content-safety',
+        config: {
+          endpoint: 'https://test.cognitiveservices.azure.com',
+          contentType: 'image',
+        },
+      },
+    });
+
+    expect(mockAnalyzeImage).toHaveBeenCalledWith('test output');
+    expect(result.pass).toBe(true);
+    expect(result.metadata!.contentType).toBe('image');
+  });
+
+  it('should handle API errors gracefully', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      error: 'API rate limit exceeded',
+      flags: [],
+    });
+
+    const result = await handleContentSafety(baseParams);
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toContain('API error');
+  });
+
+  it('should include metadata with raw severity values', async () => {
+    mockAnalyzeText.mockResolvedValue({
+      flags: [
+        {
+          code: 'hate',
+          description: 'Content flagged for Hate',
+          confidence: 0.6,
+          metadata: { azure_severity: 4, max_severity: 7 },
+        },
+        {
+          code: 'violence',
+          description: 'Violence (not flagged)',
+          confidence: 0.1,
+          metadata: { azure_severity: 1, max_severity: 7 },
+        },
+      ],
+    });
+
+    const result = await handleContentSafety(baseParams);
+
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.categories).toEqual({
+      hate: 0.6,
+      violence: 0.1,
+    });
+    expect(result.metadata!.raw_hate).toEqual({ azure_severity: 4, max_severity: 7 });
+    expect(result.metadata!.raw_violence).toEqual({ azure_severity: 1, max_severity: 7 });
+  });
+});


### PR DESCRIPTION
## Summary

- Add Entra ID (Azure AD) authentication support for Azure Content Safety API
- Add image moderation capability via `analyzeImage()` method
- Add new `content-safety` scorer-style assertion type with normalized scores and per-category metrics
- Update documentation with cross-references between Azure provider and moderation docs

## Changes

### Azure Content Safety Provider (`src/providers/azure/moderation.ts`)
- `getContentSafetyAuthHeaders()`: Supports API key, Entra ID (client credentials), and Azure CLI authentication
- `analyzeText()`: Configurable text analysis with options for categories, output type, and blocklists
- `analyzeImage()`: Image moderation supporting both base64 and URL inputs (uses FourSeverityLevels 0-3)

### Content Safety Assertion (`src/assertions/contentSafety.ts`)
- New `content-safety` assertion type for scorer-style evaluation
- Returns normalized scores (0-1), per-category `namedScores`, and detailed `metadata`
- Configurable threshold, categories, and content type (text/image)

### Documentation
- Updated `site/docs/configuration/expected-outputs/moderation.md` with Entra ID auth and scorer assertion docs
- Updated `site/docs/providers/azure.md` to reference Azure Content Safety instead of outdated OpenAI-only statement

## Test plan

- [x] Unit tests for `content-safety` assertion handler (8 tests)
- [x] Unit tests for Azure moderation provider enhancements (14 tests)
- [x] Full test suite passes (9638 tests)
- [x] Integration verified via eval command (assertion properly recognized and executed)