### PR TITLE
fix(redteam): prevent infinite loop in Plugins page when selecting presets

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
@@ -1043,7 +1043,7 @@ describe('Plugins', () => {
       // updatePlugins should be called a bounded number of times (not infinite)
       // With the normalized comparison fix, it should be called once per user interaction
       await waitFor(() => {
-        expect(mockUpdatePlugins.mock.calls.length).toBeLessThan(50);
+        expect(mockUpdatePlugins.mock.calls.length).toBeLessThan(5);
       });
     });
 
@@ -1111,8 +1111,8 @@ describe('Plugins', () => {
       });
 
       // With the infinite loop bug, updateCallCount would be very high or the test would hang
-      // With the normalized comparison fix, it should be a small bounded number
-      expect(updateCallCount).toBeLessThan(20);
+      // With the normalized comparison fix, it should be called at most once or twice
+      expect(updateCallCount).toBeLessThan(5);
     });
 
     it('should skip updatePlugins when normalized plugins are equal', async () => {


### PR DESCRIPTION
## Summary

- Fixes infinite loop crash when selecting presets (e.g., EU AI Act) on the Plugins page
- The `useEffect` that syncs `selectedPlugins` to config had a dependency cycle: effect runs → `updatePlugins()` modifies `config.plugins` → effect runs again → infinite loop

## Root Cause

The `updatePlugins()` function has merge logic that can produce output different from input (spreading existing plugin properties). When the effect compares the newly constructed plugins with current state, they may differ even though they're semantically equivalent, causing unnecessary updates and infinite loops.

## Fix

Added normalized comparison before calling `updatePlugins()`:
- Normalizes plugins to only compare meaningful properties (`id` and `config`)
- Only calls `updatePlugins()` when there's an actual semantic change
- Properly keeps `config.plugins` in the dependency array (correct React pattern)

This addresses the root cause rather than working around it with `getState()`.

## Test plan

- [x] Unit tests pass (`npm test -- --run src/pages/redteam/setup/components/Plugins.test.tsx`)
- [x] TypeScript compilation passes
- [x] Linting passes
- [ ] Manual test: Select EU AI Act preset on Plugins page - should not crash