### PR TITLE
fix(geval): enforce stricter output formatting in GEVAL prompts

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -261,17 +261,25 @@ export async function processPrompts(
 
 // G-Eval prompts
 export const GEVAL_PROMPT_STEPS = `
-Given an evaluation criteria which outlines how you should judge some text, generate 3-4 concise evaluation steps for any text based on the criteria below.
+Given an evaluation criteria which outlines how you should judge a piece of text, generate 3-4 concise evaluation steps applicable to any text based on the criteria below.
 
-Evaluation Criteria:
+**EVALUATION CRITERIA**
 {{criteria}}
 
-**
-IMPORTANT: Please make sure to only return in minified JSON format, with the "steps" key as a list of strings. No additional words, explanation or formatting is needed.
-Example JSON:
-{"steps": <list_of_strings>}
-**
+**OUTPUT FORMAT**
+IMPORTANT:
+- Return output ONLY as a minified JSON object.
+- The JSON object must contain a single key, "steps", whose value is a list of strings.
+- Each string must represent one evaluation step.
+- Do NOT include any explanations, commentary, extra text, or additional formatting.
 
+Format:
+{"steps": <list_of_strings>}
+
+Example:
+{"steps":["<Evaluation Step 1>","<Evaluation Step 2>","<Evaluation Step 3>","<Evaluation Step 4>"]}
+
+Here are the 3-4 concise evaluation steps, formatted as required in a minified JSON:
 JSON:
 `;
 
@@ -279,25 +287,31 @@ export const GEVAL_PROMPT_EVALUATE = `
 You will be given one Reply for a Source Text below. Your task is to rate the Reply on one metric.
 Please make sure you read and understand these instructions carefully. Please keep this document open while reviewing, and refer to it as needed.
 
-Evaluation Criteria:
+**Evaluation Criteria**
 {{criteria}}
 
-Evaluation Steps:
+**Evaluation Steps**
 - {{steps}}
-- Given the evaluation steps, return a JSON with two keys: 1) a "score" key ranging from 0 - {{maxScore}}, with {{maxScore}} being that it follows the Evaluation Criteria outlined in the Evaluation Steps and 0 being that it does not; 2) a "reason" key, a reason for the given score, but DO NOT QUOTE THE SCORE in your reason. Please mention specific information from Source Text and Reply in your reason, but be very concise with it!
+Given the evaluation steps, return a JSON with two keys: 
+  1) a "score" key ranging from 0 - {{maxScore}}, with {{maxScore}} being that it follows the Evaluation Criteria outlined in the Evaluation Steps and 0 being that it does not;
+  2) a "reason" key, a reason for the given score, but DO NOT QUOTE THE SCORE in your reason. Please mention specific information from Source Text and Reply in your reason, but be very concise with it!
 
-Source Text:
+**Source Text**
 {{input}}
 
-Reply:
+**Reply**
 {{output}}
 
-**
-IMPORTANT: Please make sure to only return in minified JSON format, with the "score" and "reason" key. No additional words, explanation or formatting is needed.
+**OUTPUT FORMAT**
+IMPORTANT: 
+- Return output ONLY as a minified JSON object.
+- The JSON object must contain exactly two keys: "score" and "reason".
+- No additional words, explanations, or formatting are needed.
+- Absolutely no additional text, explanations, line breaks, or formatting outside the JSON object are allowed.
 
 Example JSON:
 {"score":0,"reason":"The text does not follow the evaluation steps provided."}
-**
 
+Here is the final evaluation in the required minified JSON format:
 JSON:
 `;


### PR DESCRIPTION
LLMs often return incorrectly formatted responses for GEVAL_PROMPT_STEPS and GEVAL_PROMPT_EVALUATE, leading to errors during evaluation. Update both prompts with clearer, more explicit instructions regarding output formatting and structure to ensure better alignment and compliance from the models.

Attached two files with the results from running an evaluation for formatting. Prompts preform at equal or better rate across different LLM models. 
[GEVAL_PROMPT_EVALUATE-Evaluation-Results.json](https://github.com/user-attachments/files/24111043/GEVAL_PROMPT_EVALUATE-Evaluation-Results.json)
[GEVAL_PROMPT_STEPS-Evaluation-Results.json](https://github.com/user-attachments/files/24111044/GEVAL_PROMPT_STEPS-Evaluation-Results.json)
