### PR TITLE
build(ci): use correct PROMPTFOOBOT variable/secret names

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.PROMPTFOO_APP_ID }}
-          private-key: ${{ secrets.PROMPTFOO_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.PROMPTFOOBOT_APP_ID }}
+          private-key: ${{ secrets.PROMPTFOOBOT_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
software was a mistake

## Summary
- Fix the GitHub App token configuration in release-please workflow to use the correct org-level variable/secret names (`PROMPTFOOBOT_APP_ID` and `PROMPTFOOBOT_APP_PRIVATE_KEY`)

## Test plan
- [ ] Verify release-please workflow runs without the `appId option is required` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)