### PR TITLE
feat(types): add pluginId and strategyId to EvaluateTableOutput

### DIFF
--- a/src/server/utils/evalTableUtils.ts
+++ b/src/server/utils/evalTableUtils.ts
@@ -94,7 +94,11 @@ export function evalTableToCsv(
     if (isRedteam) {
       const firstOutputMetadata = row.outputs[0]?.metadata;
       for (const key of redteamKeys) {
-        const value = firstOutputMetadata?.[key];
+        let value = firstOutputMetadata?.[key];
+        // Default strategyId to 'basic' for strategy-less tests
+        if (key === 'strategyId' && (value === null || value === undefined)) {
+          value = 'basic';
+        }
         if (value === null || value === undefined) {
           rowValues.push('');
         } else if (


### PR DESCRIPTION
## Summary

Adds optional `pluginId` and `strategyId` fields to the `EvaluateTableOutput` interface.

These fields already exist in `EvalResult` but weren't exposed in the table output structure, requiring consumers to inject them into `metadata` as a workaround.

Helps to unblock https://github.com/promptfoo/promptfoo-cloud/pull/2677 without needing to make large changes to the metadata model.

## Changes

- Added `pluginId?: string | null` to `EvaluateTableOutput`
- Added `strategyId?: string | null` to `EvaluateTableOutput`
- Added test validating the new fields work correctly

## Motivation

This enables cleaner access patterns:
- Before: `output.metadata?.pluginId`
- After: `output.pluginId`

Used by promptfoo-cloud for CSV export with framework mapping.

## Test plan

- [x] Added unit test for new fields
- [x] All existing tests pass (27/27)
- [x] Verified that CSV export presents plugin and strategy columns