### PR TITLE
docs: document CSV assertion syntax and defaultTest usage

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -386,12 +386,29 @@ Here's an example tests.csv:
 
 All assertion types can be used in `__expected`. The column supports exactly one assertion.
 
-- `is-json` and `contains-json` are supported directly, and do not require any value
-- `fn` indicates `javascript` type. For example: `fn:output.includes('foo')`
-- `file://` indicates an external file relative to your config. For example: `file://custom_assertion.py` or `file://customAssertion.js`
-- `similar` takes a threshold value. For example: `similar(0.8):hello world`
-- `grade` indicates `llm-rubric`. For example: `grade: does not mention being an AI`
-- By default, `__expected` will use type `equals`
+### Assertion string syntax
+
+The general format is `type:value` or `type(threshold):value`. Values without a prefix default to `equals`.
+
+| Syntax                     | Type            | Example                                     |
+| -------------------------- | --------------- | ------------------------------------------- |
+| `value`                    | `equals`        | `Paris`                                     |
+| `contains:value`           | `contains`      | `contains:Paris`                            |
+| `icontains:value`          | `icontains`     | `icontains:paris`                           |
+| `starts-with:value`        | `starts-with`   | `starts-with:The answer`                    |
+| `regex:pattern`            | `regex`         | `regex:^Hello.*world$`                      |
+| `is-json`                  | `is-json`       | `is-json`                                   |
+| `contains-json`            | `contains-json` | `contains-json`                             |
+| `similar(threshold):value` | `similar`       | `similar(0.8):Hello world`                  |
+| `llm-rubric:criteria`      | `llm-rubric`    | `llm-rubric:Is helpful and accurate`        |
+| `grade:criteria`           | `llm-rubric`    | `grade:Does not mention being an AI`        |
+| `factuality:reference`     | `factuality`    | `factuality:Paris is the capital of France` |
+| `javascript:code`          | `javascript`    | `javascript:output.length < 100`            |
+| `fn:code`                  | `javascript`    | `fn:output.includes('hello')`               |
+| `python:code`              | `python`        | `python:len(output) > 10`                   |
+| `file://path`              | External file   | `file://assertions/custom.js`               |
+| `not-type:value`           | Negated         | `not-contains:error`                        |
+| `levenshtein(N):value`     | `levenshtein`   | `levenshtein(5):expected text`              |
 
 When the `__expected` field is provided, the success and failure statistics in the evaluation summary will be based on whether the expected criteria are met.
 

--- a/site/docs/configuration/expected-outputs/model-graded/factuality.md
+++ b/site/docs/configuration/expected-outputs/model-graded/factuality.md
@@ -136,6 +136,18 @@ The factuality checker will parse either format:
 - A single letter response like "A" or "(A)"
 - A JSON object: `{"category": "A", "reason": "Detailed explanation..."}`
 
+## Using Factuality with CSV
+
+Use the `factuality:` prefix in `__expected` columns:
+
+```csv title="tests.csv"
+question,__expected
+"What does GPT stand for?","factuality:Generative Pre-trained Transformer"
+"What is photosynthesis?","factuality:Plants convert sunlight into chemical energy"
+```
+
+To apply factuality to all rows, see [CSV with defaultTest](/docs/configuration/test-cases#csv-with-defaulttest).
+
 ## See Also
 
 - [Model-graded metrics](/docs/configuration/expected-outputs/model-graded) for more options

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -166,6 +166,15 @@ input,__expected
 "What's the weather?","llm-rubric: Provides weather information"
 ```
 
+Values without a type prefix default to `equals`:
+
+| `__expected` value                | Assertion type               |
+| --------------------------------- | ---------------------------- |
+| `Paris`                           | `equals`                     |
+| `contains:Paris`                  | `contains`                   |
+| `factuality:The capital is Paris` | `factuality`                 |
+| `similar(0.8):Hello there`        | `similar` with 0.8 threshold |
+
 Multiple assertions:
 
 ```csv title="test_cases.csv"
@@ -186,17 +195,17 @@ If you write `"contains-any: <b> </span>"`, promptfoo treats `<b> </span>` as a 
 
 ### Special CSV Columns
 
-| Column                                                      | Purpose                                          | Example                                                           |
-| ----------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
-| `__expected`                                                | Single assertion                                 | `contains: Paris`                                                 |
-| `__expected1`, `__expected2`, ...                           | Multiple assertions                              | `equals: 42`                                                      |
-| `__description`                                             | Test description                                 | `Basic math test`                                                 |
-| `__prefix`                                                  | Prepend to prompt                                | `You must answer: `                                               |
-| `__suffix`                                                  | Append to prompt                                 | ` (be concise)`                                                   |
-| `__metric`                                                  | Metric name for assertions                       | `accuracy`                                                        |
-| `__threshold`                                               | Pass threshold (applies to all asserts)          | `0.8`                                                             |
-| `__metadata:*`                                              | Filterable metadata                              | See below                                                         |
-| `__config:__expected:<key>` or `__config:__expectedN:<key>` | Set configuration for all or specific assertions | `__config:__expected:threshold`, `__config:__expected2:threshold` |
+| Column                                                      | Purpose                                                  | Example                                                           |
+| ----------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------- |
+| `__expected`                                                | Single assertion                                         | `contains: Paris`                                                 |
+| `__expected1`, `__expected2`, ...                           | Multiple assertions                                      | `equals: 42`                                                      |
+| `__description`                                             | Test description                                         | `Basic math test`                                                 |
+| `__prefix`                                                  | Prepend to prompt                                        | `You must answer: `                                               |
+| `__suffix`                                                  | Append to prompt                                         | ` (be concise)`                                                   |
+| `__metric`                                                  | Display name in reports (does not change assertion type) | `accuracy`                                                        |
+| `__threshold`                                               | Pass threshold (applies to all asserts)                  | `0.8`                                                             |
+| `__metadata:*`                                              | Filterable metadata                                      | See below                                                         |
+| `__config:__expected:<key>` or `__config:__expectedN:<key>` | Set configuration for all or specific assertions         | `__config:__expected:threshold`, `__config:__expected2:threshold` |
 
 Using `__metadata` without a key is not supported. Specify the metadata field like `__metadata:category`.
 If a CSV file includes a `__metadata` column without a key, Promptfoo logs a warning and ignores the column.
@@ -242,6 +251,29 @@ Access in prompts:
 prompts:
   - 'Query: {{query}}, Location: {{(context | load).location}}'
 ```
+
+### CSV with defaultTest
+
+Apply the same assertions to all tests loaded from a CSV file using [`defaultTest`](/docs/configuration/guide#default-test-cases):
+
+```yaml title="promptfooconfig.yaml"
+defaultTest:
+  assert:
+    - type: factuality
+      value: '{{reference_answer}}'
+  options:
+    provider: openai:gpt-5.2
+
+tests: file://tests.csv
+```
+
+```csv title="tests.csv"
+question,reference_answer
+"What does GPT stand for?","Generative Pre-trained Transformer"
+"What is the capital of France?","Paris is the capital of France"
+```
+
+Use regular column names (like `reference_answer`) instead of `__expected` when referencing values in `defaultTest` assertions. The `__expected` column automatically creates assertions per row.
 
 ## Dynamic Test Generation
 


### PR DESCRIPTION
## Summary

Improves documentation for using CSV test files with assertions, addressing the confusion reported in #1889.

**Changes:**
- Add assertion string syntax reference table showing all supported formats (`contains:`, `factuality:`, `similar(0.8):`, etc.)
- Add "CSV with defaultTest" section demonstrating how to apply assertions to all tests loaded from a CSV file
- Clarify that `__expected` values without a type prefix default to `equals`
- Clarify that `__metric` is for display names in reports, not for changing assertion types
- Add CSV usage example to factuality docs

## Test plan

- [ ] Verify pages render correctly at:
  - `/docs/configuration/test-cases#csv-with-assertions`
  - `/docs/configuration/test-cases#csv-with-defaulttest`
  - `/docs/configuration/expected-outputs#assertion-string-syntax`
  - `/docs/configuration/expected-outputs/model-graded/factuality#using-factuality-with-csv`

Closes #1889