### PR TITLE
fix(test): make Python concurrency test environment-independent

### DIFF
--- a/test/python/python.integration.test.ts
+++ b/test/python/python.integration.test.ts
@@ -163,8 +163,14 @@ counter = 0
 def call_api(prompt, options, context):
     global counter
     counter += 1
+    start_time = time.time()
     time.sleep(0.1)  # 100ms
-    return {"output": f"Worker count: {counter}"}
+    end_time = time.time()
+    return {
+        "output": f"Worker count: {counter}",
+        "start_time": start_time,
+        "end_time": end_time
+    }
 `);
 
     const provider = new PythonProvider(`file://${scriptPath}`, {
@@ -176,8 +182,6 @@ def call_api(prompt, options, context):
 
     await provider.initialize();
 
-    const start = Date.now();
-
     // 4 concurrent calls with 4 workers should run in parallel
     const results = await Promise.all([
       provider.callApi('1'),
@@ -186,11 +190,18 @@ def call_api(prompt, options, context):
       provider.callApi('4'),
     ]);
 
-    const duration = Date.now() - start;
+    // Extract timestamps from results
+    const startTimes = results.map((r) => (r as any).start_time as number);
+    const endTimes = results.map((r) => (r as any).end_time as number);
 
-    // Each call takes 100ms, with 4 workers they run in parallel
-    // Total time should be ~100ms, not 400ms
-    expect(duration).toBeLessThan(300); // Allow some overhead
+    // Verify parallelization by checking execution overlap:
+    // If parallel: the last call to start begins before the first call ends
+    // If sequential: each call starts after the previous ends (no overlap)
+    const maxStartTime = Math.max(...startTimes);
+    const minEndTime = Math.min(...endTimes);
+
+    // For true parallel execution, there must be overlap
+    expect(maxStartTime).toBeLessThan(minEndTime);
 
     // Each worker maintains its own counter
     results.forEach((r) => {


### PR DESCRIPTION
## Summary

- Fix flaky `should work with multiple workers (concurrency)` test that was failing in CI
- Replace absolute timing assertion with overlap detection

## Problem

The test was asserting that 4 parallel workers complete in < 300ms, but CI took 585ms due to environment overhead:

```
AssertionError: expected 585 to be less than 300
```

Absolute timing thresholds are inherently flaky because:
- CI environments have variable performance
- System load affects timing
- Different machines have different speeds

## Solution

Instead of checking absolute timing, the test now verifies **execution overlap** using timestamps from the Python workers:

```
If parallel:   |---call1---|
               |---call2---|
               |---call3---|
               |---call4---|
               └─ maxStart < minEnd (overlap exists)

If sequential: |---call1---|
                           |---call2---|
                                       |---call3---|
                                                   |---call4---|
               └─ maxStart > minEnd (no overlap)
```

The key assertion `expect(maxStartTime).toBeLessThan(minEndTime)` proves parallelization regardless of how slow the CI environment is—it only cares that the calls ran concurrently, not how long they took in wall-clock time.

This approach is:
- **Environment-independent**: Works the same on fast local machines and slow CI
- **Directly tests the property we care about**: Concurrent execution, not speed
- **Immune to system load**: Even if everything takes 10x longer, overlap still proves parallelism

## Test plan

- [x] `npm run test:integration` passes (14/14 tests)
- [x] `npm run l && npm run f` passes