### PR TITLE
ci: add lockfile-lint to validate supply chain integrity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,10 @@ jobs:
         run: |
           npm run depcheck
 
+      - name: Validate lockfile integrity
+        run: |
+          npx lockfile-lint --path package-lock.json --allowed-hosts npm --validate-https
+
   shell-format:
     name: Shell Format Check
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- Adds `lockfile-lint` to the style-check CI job to validate lockfile integrity
- Catches supply chain attacks via lockfile poisoning before merge

## What it validates

| Check | Protection |
|-------|-----------|
| `--allowed-hosts npm` | Blocks packages from non-npm registries (typosquatting) |
| `--validate-https` | Blocks HTTP URLs (downgrade attacks) |

## Why

Open source projects accept PRs from external contributors. A malicious PR could modify `package-lock.json` to:
- Point to an attacker-controlled registry
- Use HTTP URLs that can be MITM'd

This lightweight check (~1 second) provides defense-in-depth against these vectors.

## Test plan

- [x] Verified locally: `npx lockfile-lint --path package-lock.json --allowed-hosts npm --validate-https` passes
- [ ] CI runs and passes