### PR TITLE
fix(site): remove homepage code box scrollbars

### DIFF
--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -684,7 +684,7 @@ html {
   font-family: 'Courier New', Courier, monospace;
   font-size: 0.95rem;
   font-weight: 600;
-  overflow-x: auto;
+  overflow: hidden;
   white-space: pre-wrap;
   word-wrap: break-word;
   position: relative;


### PR DESCRIPTION
The [homepage](https://www.promptfoo.dev/) has a code box for the 'redteam setup' command which has unnecessary scrollbars. Even when the page width is minimized to the point where you think a scrollbar could be needed, the text wraps so there is no need for scrollbars. 

Before:
<img width="450" height="127" alt="Screenshot 2025-12-13 at 9 15 28 PM" src="https://github.com/user-attachments/assets/f5010637-b40d-4f0f-815e-59cba039f2ac" />

After:
<img width="461" height="107" alt="Screenshot 2025-12-13 at 9 16 13 PM" src="https://github.com/user-attachments/assets/0b669a7e-5c8c-46b5-8ef1-566e64e61452" />

I removed the scrollbars for a cleaner look.