### PR TITLE
fix: Handle rendering error when a raw response is returned in test generation modal

### DIFF
--- a/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
@@ -306,4 +306,101 @@ describe('TestCaseDialog', () => {
       expect(svg).toBeInTheDocument();
     });
   });
+
+  describe('target response output formats', () => {
+    it('should render string output directly', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[{ output: 'This is a string response', error: null }]}
+        />,
+      );
+
+      expect(screen.getByText('This is a string response')).toBeInTheDocument();
+    });
+
+    it('should extract response from object with response key', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { response: 'Extracted from response key' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Extracted from response key')).toBeInTheDocument();
+    });
+
+    it('should extract text from object with text key', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { text: 'Extracted from text key' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Extracted from text key')).toBeInTheDocument();
+    });
+
+    it('should extract content from object with content key', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { content: 'Extracted from content key' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Extracted from content key')).toBeInTheDocument();
+    });
+
+    it('should extract message from object with message key', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { message: 'Extracted from message key' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Extracted from message key')).toBeInTheDocument();
+    });
+
+    it('should stringify unknown object formats', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { unknownKey: 'some value' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('{"unknownKey":"some value"}')).toBeInTheDocument();
+    });
+
+    it('should show error when output is null and error exists', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[{ output: null, error: 'An error occurred' }]}
+        />,
+      );
+
+      expect(screen.getByText('An error occurred')).toBeInTheDocument();
+    });
+
+    it('should show default message when both output and error are null', () => {
+      renderWithTheme(
+        <TestCaseDialog {...defaultProps} targetResponses={[{ output: null, error: null }]} />,
+      );
+
+      expect(screen.getByText('No response from target')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/src/pages/redteam/setup/components/testCaseGenerationTypes.ts
+++ b/src/app/src/pages/redteam/setup/components/testCaseGenerationTypes.ts
@@ -19,7 +19,8 @@ export interface GeneratedTestCase {
 }
 
 export interface TargetResponse {
-  output: string | null;
+  // Output can be a string or an object (some providers return structured responses)
+  output: string | Record<string, unknown> | null;
   error: string | null;
 }
 


### PR DESCRIPTION
Was running into an issue using the new strategy simulation feature with the example target- seems like the raw response was being interpolated into the JSX, causing an exception. This should handle that