### PR TITLE
fix(redteam): handle object output in TestCaseDialog

### DIFF
--- a/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
@@ -306,4 +306,49 @@ describe('TestCaseDialog', () => {
       expect(svg).toBeInTheDocument();
     });
   });
+
+  describe('targetResponses output handling', () => {
+    it('should render string output directly', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[{ output: 'Hello from assistant', error: null }]}
+        />,
+      );
+
+      expect(screen.getByText('Hello from assistant')).toBeInTheDocument();
+    });
+
+    it('should JSON stringify object output', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[
+            { output: { response: 'some text' } as unknown as string, error: null },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('{"response":"some text"}')).toBeInTheDocument();
+    });
+
+    it('should show error message when output is null', () => {
+      renderWithTheme(
+        <TestCaseDialog
+          {...defaultProps}
+          targetResponses={[{ output: null, error: 'Connection failed' }]}
+        />,
+      );
+
+      expect(screen.getByText('Connection failed')).toBeInTheDocument();
+    });
+
+    it('should show fallback message when output and error are null', () => {
+      renderWithTheme(
+        <TestCaseDialog {...defaultProps} targetResponses={[{ output: null, error: null }]} />,
+      );
+
+      expect(screen.getByText('No response from target')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/src/pages/redteam/setup/components/TestCaseDialog.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseDialog.tsx
@@ -115,9 +115,17 @@ export const TestCaseDialog: React.FC<TestCaseDialogProps> = ({
       const targetResponse = targetResponses[i];
 
       if (targetResponse) {
+        const output = targetResponse.output;
+        const content =
+          typeof output === 'string'
+            ? output
+            : output != null
+              ? JSON.stringify(output)
+              : (targetResponse.error ?? 'No response from target');
+
         messages.push({
           role: 'assistant' as const,
-          content: targetResponse.output ?? targetResponse.error ?? 'No response from target',
+          content,
           contentType: 'text' as const,
         } as LoadedMessage);
       }


### PR DESCRIPTION
## Summary

- Fixes crash on Strategies page when provider returns output as an object instead of a string
- JSON stringifies non-string outputs, which also helps users debug misconfigured providers

## Problem

When an HTTP endpoint returns JSON like `{"response": "Hello"}` and doesn't have a properly configured `responseParser`, the entire object becomes `providerResponse.output`. The TestCaseDialog was passing this directly to ChatMessages which expects a string, causing:

```
Error: Objects are not valid as a React child (found: object with keys {response})
```

## Solution

Simple fix: if output isn't a string, JSON.stringify it:

```typescript
const content =
  typeof output === 'string'
    ? output
    : output != null
      ? JSON.stringify(output)
      : (targetResponse.error ?? 'No response from target');
```

This also helps users debug - if they see `{"response":"Hello"}` in the UI, they know their response parser isn't configured correctly.

## Test plan

- [x] Added tests for string output, object output, null output, and error fallback
- [x] All 20 TestCaseDialog tests pass
- [x] TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)