### PR TITLE
docs: clarify custom provider usage for dataset generation

### DIFF
--- a/site/docs/configuration/datasets.md
+++ b/site/docs/configuration/datasets.md
@@ -129,3 +129,44 @@ For example:
 ```sh
 promptfoo generate dataset --config path_to_config.yaml --output path_to_output.yaml --instructions "Consider edge cases related to international travel"
 ```
+
+### Using a custom provider
+
+The `--provider` flag specifies the LLM used to generate test cases. This is separate from the providers in your config file (which are the targets being tested).
+
+By default, dataset generation uses OpenAI (`OPENAI_API_KEY`). To use a different provider, set the appropriate environment variables:
+
+```bash
+# Azure OpenAI
+export AZURE_OPENAI_API_KEY=your-key
+export AZURE_API_HOST=your-host.openai.azure.com
+export AZURE_OPENAI_DEPLOYMENT_NAME=your-deployment
+
+promptfoo generate dataset
+```
+
+Alternatively, use the `--provider` flag with any supported provider:
+
+```bash
+promptfoo generate dataset --provider openai:chat:gpt-5-mini
+```
+
+For more control, create a provider config file:
+
+```yaml title="synthesis-provider.yaml"
+id: openai:responses:gpt-5.2
+config:
+  reasoning:
+    effort: medium
+  max_output_tokens: 4096
+```
+
+```bash
+promptfoo generate dataset --provider file://synthesis-provider.yaml
+```
+
+You can also use a Python provider:
+
+```bash
+promptfoo generate dataset --provider file://synthesis-provider.py
+```


### PR DESCRIPTION
## Summary

- Clarify that `--provider` specifies the LLM used to generate test cases (not the target being tested)
- Document environment variable approach for Azure OpenAI
- Document YAML config file approach with reasoning settings
- Document Python provider option

Closes #1828