### PR TITLE
fix(providers): treat vertex MAX_TOKENS as success instead of error

### DIFF
--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -1491,10 +1491,13 @@ describe('VertexChatProvider.callGeminiApi', () => {
 
       const response = await provider.callGeminiApi('test prompt');
 
-      expect(response.error).toContain('Gemini API error due to reaching maximum token limit');
-      expect(response.error).toContain('1000 output tokens used');
-      expect(response.error).toContain('... (truncated)');
-      expect(response.guardrails).toBeUndefined();
+      expect(response.error).toBeUndefined();
+      expect(response.output).toBe(longOutput);
+      expect(response.tokenUsage).toEqual({
+        total: 1100,
+        prompt: 100,
+        completion: 1000,
+      });
     });
 
     it('should handle MAX_TOKENS finishReason with short output (no truncation)', async () => {
@@ -1537,10 +1540,13 @@ describe('VertexChatProvider.callGeminiApi', () => {
 
       const response = await provider.callGeminiApi('test prompt');
 
-      expect(response.error).toBe(
-        'Gemini API error due to reaching maximum token limit. 10 output tokens used. Output generated: Short response',
-      );
-      expect(response.error).not.toContain('truncated');
+      expect(response.error).toBeUndefined();
+      expect(response.output).toBe(shortOutput);
+      expect(response.tokenUsage).toEqual({
+        total: 110,
+        prompt: 100,
+        completion: 10,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Changed the Vertex provider's handling of `MAX_TOKENS` finish reason to treat it as a successful completion that returns the generated output, rather than as an error.

Previously, when Vertex Gemini models reached the maximum token limit, the provider would return an error with a truncated preview of the output. This made it impossible to evaluate or use the partial response that was actually generated.

Now, the provider returns the full generated output with proper token usage tracking, allowing evaluations to work with the partial completion.

## Changes

- Modified `callGeminiApi()` to continue processing instead of returning error when `finishReason === 'MAX_TOKENS'`
- Changed logging from `logger.error` to `logger.debug` since this is no longer an error condition
- Updated tests to verify the new behavior returns output instead of error

## Test plan

- ✅ All 53 vertex provider tests pass
- ✅ Code passes linting and formatting checks
- Updated existing tests for MAX_TOKENS scenarios to verify:
  - No error is returned
  - Full output is available in response
  - Token usage is properly tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)