### PR TITLE
docs(examples): add Claude Opus 4.5 to Azure examples

### DIFF
--- a/examples/azure/claude/promptfooconfig.yaml
+++ b/examples/azure/claude/promptfooconfig.yaml
@@ -12,7 +12,7 @@ providers:
       apiVersion: '2025-11-15-preview'
       max_tokens: 1024
       temperature: 0.7
-  
+
   - id: azure:chat:claude-sonnet-4-5-20250929
     label: claude-sonnet-4-5
     config:


### PR DESCRIPTION
Adds Claude Opus 4.5 (claude-opus-4-5-20251101) to the Azure Claude examples.
This model was released in November 2025 and is the most capable Claude model available on Azure AI Foundry.