### PR TITLE
fix(ci): trigger code scan when PR moves from draft to ready

### DIFF
--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -2,7 +2,7 @@ name: Promptfoo Code Scan
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   security-scan:


### PR DESCRIPTION
Add `ready_for_review` event type to pull_request trigger.