### PR TITLE
fix(redteam): filter runtime vars and merge defaultTest.vars for accurate test matching

### DIFF
--- a/src/commands/eval/filterTestsUtil.ts
+++ b/src/commands/eval/filterTestsUtil.ts
@@ -1,7 +1,8 @@
+import logger from '../../logger';
 import Eval from '../../models/eval';
 import { readOutput, resultIsForTestCase } from '../../util/index';
 
-import type { EvaluateResult, TestSuite } from '../../types/index';
+import type { EvaluateResult, TestCase, TestSuite } from '../../types/index';
 
 type Tests = NonNullable<TestSuite['tests']>;
 
@@ -9,6 +10,25 @@ type Tests = NonNullable<TestSuite['tests']>;
  * Predicate function for filtering test results
  */
 type ResultFilterFn = (result: EvaluateResult) => boolean;
+
+/**
+ * Merges defaultTest.vars into a test case's vars for comparison purposes.
+ * This mirrors what prepareTests does in the evaluator, ensuring that when
+ * we compare stored results (which have merged vars) with fresh test cases
+ * (which don't), the vars will match.
+ */
+function mergeDefaultVars(test: TestCase, defaultTest: TestSuite['defaultTest']): TestCase {
+  if (!defaultTest || typeof defaultTest === 'string') {
+    return test;
+  }
+  return {
+    ...test,
+    vars: {
+      ...defaultTest.vars,
+      ...test.vars,
+    },
+  };
+}
 
 /**
  * Filters tests based on previous evaluation results
@@ -23,8 +43,11 @@ export async function filterTestsByResults(
   filterFn: ResultFilterFn,
 ): Promise<Tests> {
   if (!testSuite.tests) {
+    logger.debug('[filterTestsByResults] No tests in test suite');
     return [];
   }
+
+  logger.debug(`[filterTestsByResults] Loading results from: ${pathOrId}`);
 
   let results: { results: EvaluateResult[] };
   try {
@@ -34,26 +57,50 @@ export async function filterTestsByResults(
     } else {
       const eval_ = await Eval.findById(pathOrId);
       if (!eval_) {
+        logger.warn(`[filterTestsByResults] Evaluation not found: ${pathOrId}`);
         return [];
       }
       const summary = await eval_.toEvaluateSummary();
       if ('results' in summary) {
         results = { results: summary.results };
       } else {
+        logger.debug('[filterTestsByResults] No results in evaluation summary');
         return [];
       }
     }
-  } catch {
+  } catch (error) {
+    logger.warn(`[filterTestsByResults] Error loading results: ${error}`);
     return [];
   }
 
   const filteredResults = results.results.filter(filterFn);
+  logger.debug(
+    `[filterTestsByResults] Found ${filteredResults.length} matching results out of ${results.results.length} total`,
+  );
 
   if (filteredResults.length === 0) {
     return [];
   }
 
-  return [...testSuite.tests].filter((test) =>
-    filteredResults.some((result) => resultIsForTestCase(result, test)),
+  // Match tests against filtered results.
+  // We merge defaultTest.vars into each test's vars before comparison because
+  // stored results have merged vars (from prepareTests in evaluator), but fresh
+  // tests loaded from config don't have defaultTest.vars merged yet.
+  const matchedTests = [...testSuite.tests].filter((test) => {
+    const testWithDefaults = mergeDefaultVars(test, testSuite.defaultTest);
+    return filteredResults.some((result) => resultIsForTestCase(result, testWithDefaults));
+  });
+
+  logger.debug(
+    `[filterTestsByResults] Matched ${matchedTests.length} tests out of ${testSuite.tests.length} in test suite`,
   );
+
+  if (matchedTests.length === 0 && filteredResults.length > 0) {
+    logger.warn(
+      `[filterTestsByResults] No tests matched ${filteredResults.length} filtered results. ` +
+        'This may indicate a vars mismatch between stored results and current test suite.',
+    );
+  }
+
+  return matchedTests;
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -298,8 +298,12 @@ export async function runEval({
     `Provider delay should be set for ${provider.label}`,
   );
 
-  // Set up the special _conversation variable
-  const vars = test.vars || {};
+  // Set up vars with a shallow copy to prevent mutation of the original test.vars.
+  // This is important because providers (especially multi-turn strategies like GOAT,
+  // Crescendo, SIMBA) may add runtime variables like sessionId to vars during execution.
+  // Without this copy, those mutations would persist to the stored testCase, causing
+  // test matching to fail when using --filter-errors-only or --filter-failing.
+  const vars = { ...(test.vars || {}) };
 
   // Collect file metadata for the test case before rendering the prompt.
   const fileMetadata = collectFileMetadata(test.vars || vars);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -438,15 +438,31 @@ export function providerToIdentifier(
 }
 
 /**
- * Filters out runtime-only variables that are added during evaluation
- * but aren't part of the original test definition
+ * Runtime variables that are added during evaluation but aren't part
+ * of the original test definition. These should be filtered when
+ * comparing test cases for matching purposes.
+ *
+ * - _conversation: Added by the evaluator for multi-turn conversations
+ * - sessionId: Added by multi-turn strategy providers (GOAT, Crescendo, SIMBA)
  */
-function filterRuntimeVars(vars: Vars | undefined): Vars | undefined {
+const RUNTIME_VAR_KEYS = ['_conversation', 'sessionId'] as const;
+
+/**
+ * Filters out runtime-only variables that are added during evaluation
+ * but aren't part of the original test definition.
+ *
+ * This is used when comparing test cases to determine if a result
+ * corresponds to a particular test, regardless of runtime state.
+ */
+export function filterRuntimeVars(vars: Vars | undefined): Vars | undefined {
   if (!vars) {
     return vars;
   }
-  const { _conversation, ...userVars } = vars;
-  return userVars;
+  const filtered = { ...vars };
+  for (const key of RUNTIME_VAR_KEYS) {
+    delete filtered[key];
+  }
+  return filtered;
 }
 
 export function varsMatch(vars1: Vars | undefined, vars2: Vars | undefined) {
@@ -458,9 +474,8 @@ export function resultIsForTestCase(result: EvaluateResult, testCase: TestCase):
     ? providerToIdentifier(testCase.provider) === providerToIdentifier(result.provider)
     : true;
 
-  // Filter out runtime variables like _conversation when matching
-  // These are added during evaluation but shouldn't affect test matching
-  // Use result.vars (not result.testCase.vars) as it contains the actual vars used during evaluation
+  // Filter out runtime variables like _conversation and sessionId when matching.
+  // These are added by multi-turn providers during evaluation but shouldn't affect test matching.
   const resultVars = filterRuntimeVars(result.vars);
   const testVars = filterRuntimeVars(testCase.vars);
   return varsMatch(testVars, resultVars) && providersMatch;

--- a/test/commands/eval/filterFailingBug.test.ts
+++ b/test/commands/eval/filterFailingBug.test.ts
@@ -2,10 +2,17 @@
  * Test for the --filter-failing bug where test.vars gets mutated
  * during evaluation, causing mismatches when trying to filter failing tests.
  *
- * Bug: When evaluation adds runtime vars like _conversation to test.vars,
+ * Bug 1: When evaluation adds runtime vars like _conversation to test.vars,
  * it mutates the original test object. This mutated test is stored in results.
  * On subsequent runs with --filter-failing, freshly loaded tests don't have
  * these runtime vars, so deepEqual comparison fails.
+ *
+ * Bug 2: Multi-turn strategy providers (GOAT, Crescendo, SIMBA) add sessionId
+ * to vars during execution, causing the same mismatch issue.
+ *
+ * Fix: We filter out known runtime vars (_conversation, sessionId) during test
+ * matching in resultIsForTestCase, and create a shallow copy of test.vars in
+ * runEval to prevent mutation by reference.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -112,5 +119,238 @@ describe('filterTests - vars mutation bug', () => {
     // Should find both failing tests
     expect(result).toHaveLength(2);
     expect(result.map((t) => t.description)).toEqual(['test1', 'test3']);
+  });
+
+  it('should match tests even when stored results have sessionId added by GOAT/Crescendo providers', async () => {
+    // Simulate a redteam test suite with GOAT strategy
+    const mockTestSuite: TestSuite = {
+      prompts: [],
+      providers: [],
+      tests: [
+        {
+          description: 'goat-test-1',
+          vars: { prompt: 'test attack prompt', goal: 'test goal' },
+          assert: [],
+          metadata: { pluginId: 'harmful', strategyId: 'goat' },
+        },
+        {
+          description: 'goat-test-2',
+          vars: { prompt: 'another attack prompt', goal: 'another goal' },
+          assert: [],
+          metadata: { pluginId: 'harmful', strategyId: 'goat' },
+        },
+      ],
+    };
+
+    // Simulate stored results where vars was mutated with sessionId by GOAT provider
+    const mockEval = {
+      id: 'eval-456',
+      createdAt: new Date().getTime(),
+      config: {},
+      results: [],
+      resultsCount: 0,
+      prompts: [],
+      persisted: true,
+      toEvaluateSummary: vi.fn().mockResolvedValue({
+        version: 2,
+        timestamp: new Date().toISOString(),
+        results: [
+          {
+            // GOAT provider added sessionId during multi-turn attack
+            vars: {
+              prompt: 'test attack prompt',
+              goal: 'test goal',
+              sessionId: 'goat-session-abc',
+            },
+            success: false,
+            failureReason: ResultFailureReason.ERROR,
+            testCase: {
+              description: 'goat-test-1',
+              // Stored testCase.vars has sessionId added by GOAT provider
+              vars: {
+                prompt: 'test attack prompt',
+                goal: 'test goal',
+                sessionId: 'goat-session-abc',
+              },
+              assert: [],
+              metadata: { pluginId: 'harmful', strategyId: 'goat' },
+            },
+          },
+        ],
+        table: { head: { prompts: [], vars: [] }, body: [] },
+        stats: {
+          successes: 0,
+          failures: 0,
+          errors: 1,
+          tokenUsage: {
+            total: 0,
+            prompt: 0,
+            completion: 0,
+            cached: 0,
+            numRequests: 0,
+            completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+          },
+        },
+      }),
+    };
+
+    vi.mocked(Eval.findById).mockResolvedValue(mockEval as any);
+
+    // When filtering error tests, it should match based on the original vars
+    // not fail because of the extra sessionId property added by GOAT
+    const result = await filterTests(mockTestSuite, { errorsOnly: 'eval-456' });
+
+    // Should find the error test even though sessionId was added
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('goat-test-1');
+  });
+
+  it('should match tests with both _conversation and sessionId runtime vars', async () => {
+    // Combined scenario with both runtime vars
+    const mockTestSuite: TestSuite = {
+      prompts: [],
+      providers: [],
+      tests: [
+        {
+          description: 'combined-test',
+          vars: { input: 'hello' },
+          assert: [],
+        },
+      ],
+    };
+
+    const mockEval = {
+      id: 'eval-789',
+      createdAt: new Date().getTime(),
+      config: {},
+      results: [],
+      resultsCount: 0,
+      prompts: [],
+      persisted: true,
+      toEvaluateSummary: vi.fn().mockResolvedValue({
+        version: 2,
+        timestamp: new Date().toISOString(),
+        results: [
+          {
+            // Both runtime vars added during evaluation
+            vars: {
+              input: 'hello',
+              _conversation: [{ role: 'user', content: 'hi' }],
+              sessionId: 'session-xyz',
+            },
+            success: false,
+            failureReason: ResultFailureReason.ASSERT,
+            testCase: {
+              description: 'combined-test',
+              vars: {
+                input: 'hello',
+                _conversation: [{ role: 'user', content: 'hi' }],
+                sessionId: 'session-xyz',
+              },
+              assert: [],
+            },
+          },
+        ],
+        table: { head: { prompts: [], vars: [] }, body: [] },
+        stats: {
+          successes: 0,
+          failures: 1,
+          errors: 0,
+          tokenUsage: {
+            total: 0,
+            prompt: 0,
+            completion: 0,
+            cached: 0,
+            numRequests: 0,
+            completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+          },
+        },
+      }),
+    };
+
+    vi.mocked(Eval.findById).mockResolvedValue(mockEval as any);
+
+    const result = await filterTests(mockTestSuite, { failing: 'eval-789' });
+
+    // Should match even with both runtime vars present
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('combined-test');
+  });
+
+  it('should match tests when stored results have defaultTest.vars merged', async () => {
+    // Simulate a test suite with defaultTest.vars (as it would be loaded from config)
+    // Note: Fresh tests don't have defaultTest.vars merged yet - that happens in prepareTests
+    const mockTestSuite: TestSuite = {
+      prompts: [],
+      providers: [],
+      defaultTest: {
+        vars: {
+          systemPrompt: 'You are a helpful assistant',
+        },
+      },
+      tests: [
+        {
+          description: 'test-with-defaults',
+          vars: { prompt: 'first test' },
+          assert: [],
+        },
+        {
+          description: 'test-that-passed',
+          vars: { prompt: 'second test' },
+          assert: [],
+        },
+      ],
+    };
+
+    // Stored results have defaultTest.vars merged (as done by prepareTests in evaluator)
+    const mockEval = {
+      id: 'eval-default-vars',
+      createdAt: new Date().getTime(),
+      config: {},
+      results: [],
+      resultsCount: 0,
+      prompts: [],
+      persisted: true,
+      toEvaluateSummary: vi.fn().mockResolvedValue({
+        version: 2,
+        timestamp: new Date().toISOString(),
+        results: [
+          {
+            // Stored vars have defaultTest.vars merged
+            vars: { systemPrompt: 'You are a helpful assistant', prompt: 'first test' },
+            success: false,
+            failureReason: ResultFailureReason.ASSERT,
+            testCase: {
+              description: 'test-with-defaults',
+              vars: { systemPrompt: 'You are a helpful assistant', prompt: 'first test' },
+              assert: [],
+            },
+          },
+        ],
+        table: { head: { prompts: [], vars: [] }, body: [] },
+        stats: {
+          successes: 1,
+          failures: 1,
+          errors: 0,
+          tokenUsage: {
+            total: 0,
+            prompt: 0,
+            completion: 0,
+            cached: 0,
+            numRequests: 0,
+            completionDetails: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+          },
+        },
+      }),
+    };
+
+    vi.mocked(Eval.findById).mockResolvedValue(mockEval as any);
+
+    // filterTests should merge defaultTest.vars before comparison
+    const result = await filterTests(mockTestSuite, { failing: 'eval-default-vars' });
+
+    // Should find the failing test even though fresh test.vars doesn't have systemPrompt
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('test-with-defaults');
   });
 });


### PR DESCRIPTION
## Summary

Fixes `--filter-errors-only` and `--filter-failing` returning 0 test cases when used with multi-turn redteam strategies (GOAT, Crescendo, SIMBA), including scenarios with `defaultTest.vars`.

**Root causes:**
1. Multi-turn strategy providers add `sessionId` to `context.vars` during execution. This mutates the original `test.vars` object (by reference), which gets stored in the database
2. When `filterTests` runs, fresh tests haven't had `defaultTest.vars` merged yet (that happens later in `prepareTests`), but stored results have merged vars

When `--filter-errors-only` or `--filter-failing` tries to match stored results against freshly loaded config tests, the comparison fails because stored `result.vars` has extra variables (sessionId, defaultTest vars) while fresh tests don't.

**Fix approach:**
1. Extends `filterRuntimeVars` to filter both `_conversation` and `sessionId` during comparison
2. Creates shallow copy of `test.vars` in evaluator to prevent mutation by reference
3. Merges `defaultTest.vars` into test cases before comparison in `filterTestsByResults`

## Changes

- `src/evaluator.ts`: Create shallow copy of `test.vars` to prevent provider mutations from persisting
- `src/util/index.ts`: Extended `filterRuntimeVars` to filter `sessionId` in addition to `_conversation`
- `src/commands/eval/filterTestsUtil.ts`: Merge `defaultTest.vars` into tests before comparison; added debug logging
- `test/util/index.test.ts`: Added unit tests for `filterRuntimeVars` and `resultIsForTestCase` with sessionId scenarios
- `test/commands/eval/filterFailingBug.test.ts`: Added integration tests (4 tests covering sessionId, defaultTest.vars, and combined scenarios)

## Test plan

### Automated Tests
- [x] All existing tests pass
- [x] New unit tests for `filterRuntimeVars` (7 tests)
- [x] New unit tests for `resultIsForTestCase` with sessionId (4 tests)
- [x] New integration tests in `filterFailingBug.test.ts` (4 tests)

### Manual QA Instructions

#### Scenario 1: Test `--filter-errors-only` with multi-turn strategy

1. Create a redteam config with GOAT strategy:
```yaml
description: Test filter-errors-only
targets:
  - id: your-target-provider
redteam:
  numTests: 5
  purpose: Test application
  plugins:
    - harmful:violent-crime
  strategies:
    - goat
```

2. Run the evaluation (ensure some tests error due to network/API issues, or use a target that will fail):
```bash
npx promptfoo redteam eval -c config.yaml --no-cache
```

3. Note the eval ID from output

4. Run with `--filter-errors-only`:
```bash
npx promptfoo redteam eval -c config.yaml --filter-errors-only '<eval-id>' --no-cache
```

5. **Expected:** Should show the correct number of error tests (not 0)

#### Scenario 2: Test `--filter-failing` with defaultTest.vars

1. Create a config with defaultTest.vars:
```yaml
description: Test filter with defaultTest.vars

providers:
  - file://test-provider.js

prompts:
  - "System: {{systemPrompt}}\nUser: {{prompt}}"

defaultTest:
  vars:
    systemPrompt: "You are a helpful assistant"

tests:
  - vars:
      prompt: "first test"
    assert:
      - type: contains
        value: "WRONG_VALUE"  # Will fail
  - vars:
      prompt: "second test"
    assert:
      - type: contains
        value: "response"  # Will pass
```

2. Run the evaluation:
```bash
npx promptfoo eval -c config.yaml -o output.json --no-cache
```

3. Run with `--filter-failing`:
```bash
npx promptfoo eval -c config.yaml --filter-failing output.json --no-cache
```

4. **Expected:** Should re-run only the first (failing) test, not show 0 tests

#### Scenario 3: Test retry command still works

1. Run an evaluation that produces errors
2. Use retry:
```bash
npx promptfoo retry '<eval-id>'
```

3. **Expected:** Retry should re-run error tests correctly

## Notes

- The fix is backwards compatible - correctly handles existing stored results that have `sessionId`
- The `RUNTIME_VAR_KEYS` constant makes it easy to add additional runtime vars in the future
- Shallow copy is sufficient since all known provider mutations are top-level properties
- Debug logging added to `filterTestsUtil.ts` helps troubleshoot future matching issues (use `LOG_LEVEL=debug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)