### PR TITLE
feat(bedrock): configurable numberOfResults for Bedrock Knowledge Base

### DIFF
--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1288,6 +1288,7 @@ providers:
       knowledgeBaseId: 'YOUR_KNOWLEDGE_BASE_ID'
       temperature: 0.0
       max_tokens: 1000
+      numberOfResults: 5 # Optional: number of chunks to retrieve (default: 5)
 ```
 
 The provider ID follows this pattern: `bedrock:kb:[REGIONAL_MODEL_ID]`
@@ -1303,6 +1304,7 @@ Configuration options include:
 - `region`: AWS region where your Knowledge Base is deployed (e.g., 'us-east-1', 'us-east-2', 'eu-west-1')
 - `temperature`: Controls randomness in response generation (default: 0.0)
 - `max_tokens`: Maximum number of tokens in the generated response
+- `numberOfResults`: Number of chunks to retrieve from the knowledge base (default: 5, optional)
 - `accessKeyId`, `secretAccessKey`, `sessionToken`: AWS credentials (if not using environment variables or IAM roles)
 - `profile`: AWS profile name for SSO authentication
 
@@ -1316,13 +1318,13 @@ prompts:
   - 'Tell me about quantum computing.'
 
 providers:
-  # Knowledge Base provider
   - id: bedrock:kb:us.anthropic.claude-3-7-sonnet-20250219-v1:0
     config:
       region: 'us-east-2'
       knowledgeBaseId: 'YOUR_KNOWLEDGE_BASE_ID'
       temperature: 0.0
       max_tokens: 1000
+      numberOfResults: 10
 
   # Regular Claude model for comparison
   - id: bedrock:us.anthropic.claude-3-5-sonnet-20241022-v2:0

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -28,6 +28,7 @@ interface BedrockKnowledgeBaseOptions {
   max_tokens?: number;
   top_p?: number;
   top_k?: number;
+  numberOfResults?: number;
 }
 
 // Define citation types for metadata
@@ -198,6 +199,14 @@ export class AwsBedrockKnowledgeBaseProvider
     if (this.kbConfig.modelArn || this.modelName !== 'default') {
       knowledgeBaseConfiguration.modelArn = modelArn;
     }
+
+    // Add retrieval configuration with numberOfResults (default: 5)
+    const numberOfResults = this.kbConfig.numberOfResults ?? 5;
+    knowledgeBaseConfiguration.retrievalConfiguration = {
+      vectorSearchConfiguration: {
+        numberOfResults,
+      },
+    };
 
     const params: RetrieveAndGenerateCommandInput = {
       input: { text: prompt },


### PR DESCRIPTION
## Description
Makes the Bedrock Knowledge Base provider's `numberOfResults` parameter configurable from `promptfooconfig.yaml`, allowing users to control how many chunks are retrieved from the knowledge base.

## Changes
- Add `numberOfResults` option to `BedrockKnowledgeBaseOptions` interface
- Set default value of 5 chunks when not provided
- Include `retrievalConfiguration` with `vectorSearchConfiguration` in API calls
- Add comprehensive tests for default and custom values
- Update AWS Bedrock documentation with configuration examples

## Testing
- All existing tests pass (10103 passed)
- Added 3 new tests covering default, custom, and cache key scenarios
- Feature is fully backward compatible

## Files Changed
- `src/providers/bedrock/knowledgeBase.ts` - Core implementation
- `test/providers/bedrock/knowledgeBase.test.ts` - Test coverage
- `site/docs/providers/aws-bedrock.md` - Documentation updates