### PR TITLE
test(redteam): fix flaky generate test by resetting extractMcpToolsInfo mock

### DIFF
--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -185,6 +185,8 @@ describe('doGenerateRedteam', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset mock implementations that persist across tests (clearAllMocks only clears call history)
+    vi.mocked(extractMcpToolsInfo).mockReset();
     mockProvider = {
       id: () => 'test-provider',
       callApi: vi.fn().mockResolvedValue({ output: 'test output' }),


### PR DESCRIPTION
## Summary
- Fixed flaky test "should use single purpose mode when no contexts are defined" in `test/redteam/commands/generate.test.ts`
- Added `vi.mocked(extractMcpToolsInfo).mockReset()` in `beforeEach` to properly reset mock implementations between tests

## Root Cause
The test was flaky because `vi.clearAllMocks()` only clears call history (`.mock.calls`, `.mock.results`), **not** mock implementations set via `mockResolvedValue()`. When tests ran in random order and the MCP tools test ran first, its mock implementation persisted, causing the purpose field to unexpectedly include MCP tools info.

## Test plan
- [x] Verified fix by running the test file multiple times with different random seeds
- [x] All 43 tests in the file pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)