### PR TITLE
fix(bedrock): improve Knowledge Base provider backwards compatibility

### DIFF
--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1288,7 +1288,7 @@ providers:
       knowledgeBaseId: 'YOUR_KNOWLEDGE_BASE_ID'
       temperature: 0.0
       max_tokens: 1000
-      numberOfResults: 5 # Optional: number of chunks to retrieve (default: 5)
+      numberOfResults: 5 # Optional: number of chunks to retrieve (AWS default when not specified)
 ```
 
 The provider ID follows this pattern: `bedrock:kb:[REGIONAL_MODEL_ID]`
@@ -1304,7 +1304,7 @@ Configuration options include:
 - `region`: AWS region where your Knowledge Base is deployed (e.g., 'us-east-1', 'us-east-2', 'eu-west-1')
 - `temperature`: Controls randomness in response generation (default: 0.0)
 - `max_tokens`: Maximum number of tokens in the generated response
-- `numberOfResults`: Number of chunks to retrieve from the knowledge base (default: 5, optional)
+- `numberOfResults`: Number of chunks to retrieve from the knowledge base (optional, uses AWS default when not specified)
 - `accessKeyId`, `secretAccessKey`, `sessionToken`: AWS credentials (if not using environment variables or IAM roles)
 - `profile`: AWS profile name for SSO authentication
 

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -200,13 +200,15 @@ export class AwsBedrockKnowledgeBaseProvider
       knowledgeBaseConfiguration.modelArn = modelArn;
     }
 
-    // Add retrieval configuration with numberOfResults (default: 5)
-    const numberOfResults = this.kbConfig.numberOfResults ?? 5;
-    knowledgeBaseConfiguration.retrievalConfiguration = {
-      vectorSearchConfiguration: {
-        numberOfResults,
-      },
-    };
+    // Only add retrieval configuration when numberOfResults is explicitly configured
+    // This preserves backwards compatibility with AWS default behavior
+    if (this.kbConfig.numberOfResults !== undefined) {
+      knowledgeBaseConfiguration.retrievalConfiguration = {
+        vectorSearchConfiguration: {
+          numberOfResults: this.kbConfig.numberOfResults,
+        },
+      };
+    }
 
     const params: RetrieveAndGenerateCommandInput = {
       input: { text: prompt },


### PR DESCRIPTION
## Summary

- Only send `retrievalConfiguration` when `numberOfResults` is explicitly configured (preserves backwards compatibility)
- Enable 3 previously skipped tests by fixing ESM-compatible mocks for `@smithy/node-http-handler` and `proxy-agent`
- Update documentation to reflect AWS default behavior

## Background

PR #6738 introduced a `numberOfResults` configuration option for the Bedrock Knowledge Base provider but always sent `retrievalConfiguration` with a default value of 5. This changes the API call behavior from the original implementation which didn't send `retrievalConfiguration` at all.

## Changes

1. **Backwards compatibility**: Only include `retrievalConfiguration` in the API call when the user explicitly sets `numberOfResults`. This lets AWS use its default behavior when not specified.

2. **Enabled skipped tests**: Fixed the ESM mocks for `@smithy/node-http-handler` and `proxy-agent` by adding `__esModule: true` and proper export structure. This enables 3 tests that were previously skipped due to "dynamic import limitations".

3. **Documentation update**: Clarified that `numberOfResults` uses AWS default when not specified, rather than implying a default of 5.

## Test plan

- [x] All 17 Knowledge Base tests pass (previously 14 passed, 3 skipped)
- [x] All 372 Bedrock provider tests pass
- [x] Linting passes
- [x] Formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)