### PR TITLE
fix(code-scan): add null check to fix action build

### DIFF
--- a/code-scan-action/src/github.ts
+++ b/code-scan-action/src/github.ts
@@ -179,9 +179,10 @@ export async function postReviewComments(
           return {
             path: c.file!,
             line: c.line || undefined,
-            start_line: c.startLine && c.startLine < c.line ? c.startLine : undefined,
+            start_line: c.startLine && c.line && c.startLine < c.line ? c.startLine : undefined,
             side: 'RIGHT' as const,
-            start_side: c.startLine && c.startLine < c.line ? ('RIGHT' as const) : undefined,
+            start_side:
+              c.startLine && c.line && c.startLine < c.line ? ('RIGHT' as const) : undefined,
             body,
           };
         }),


### PR DESCRIPTION
## Summary
- Adds explicit null checks for `c.line` when comparing `c.startLine < c.line` in `github.ts`
- TypeScript 5.9.3 requires these checks since `c.line` could be null

## Test plan
- [x] Build passes with `npm run build` in code-scan-action