### PR TITLE
feat(site): add proof banner linking to code scanning blog post

### DIFF
--- a/site/src/pages/code-scanning.tsx
+++ b/site/src/pages/code-scanning.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
+import ArticleIcon from '@mui/icons-material/Article';
 import CodeIcon from '@mui/icons-material/Code';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import IntegrationInstructionsIcon from '@mui/icons-material/IntegrationInstructions';
@@ -244,6 +245,29 @@ function VulnerabilityTypesSection() {
   );
 }
 
+function ProofBannerSection() {
+  return (
+    <section className={styles.proofBanner}>
+      <div className={clsx('container', styles.proofBannerContainer)}>
+        <ArticleIcon className={styles.proofBannerIcon} />
+        <div className={styles.proofBannerContent}>
+          <h3 className={styles.proofBannerTitle}>See it in action</h3>
+          <p className={styles.proofBannerText}>
+            We tested the scanner against real CVEs in LangChain, Vanna.AI, and LlamaIndex. Read the
+            technical deep dive to see how it catches vulnerabilities that other tools miss.
+          </p>
+        </div>
+        <Link
+          className={clsx('button button--secondary', styles.proofBannerButton)}
+          to="/blog/building-a-security-scanner-for-llm-apps"
+        >
+          Read the technical breakdown
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 function BenefitsSection() {
   return (
     <section className={styles.benefitsSection}>
@@ -336,6 +360,7 @@ export default function CodeScanning(): React.ReactElement {
           <IntegrationOptionsSection />
           <SeeItInActionSection />
           <VulnerabilityTypesSection />
+          <ProofBannerSection />
           <BenefitsSection />
           <CallToActionSection />
         </main>

--- a/site/src/pages/code-scanning/github-action.tsx
+++ b/site/src/pages/code-scanning/github-action.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
+import ArticleIcon from '@mui/icons-material/Article';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import BiotechIcon from '@mui/icons-material/Biotech';
-import BuildIcon from '@mui/icons-material/Build';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import VolumeOffIcon from '@mui/icons-material/VolumeOff';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import LogoContainer from '../../components/LogoContainer';
@@ -120,6 +120,29 @@ function VulnerabilityTypesSection() {
   );
 }
 
+function ProofBannerSection() {
+  return (
+    <section className={styles.proofBanner}>
+      <div className={clsx('container', styles.proofBannerContainer)}>
+        <ArticleIcon className={styles.proofBannerIcon} />
+        <div className={styles.proofBannerContent}>
+          <h3 className={styles.proofBannerTitle}>See it in action</h3>
+          <p className={styles.proofBannerText}>
+            We tested the scanner against real CVEs in LangChain, Vanna.AI, and LlamaIndex. Read the
+            technical deep dive to see how it catches vulnerabilities that other tools miss.
+          </p>
+        </div>
+        <Link
+          className={clsx('button button--secondary', styles.proofBannerButton)}
+          to="/blog/building-a-security-scanner-for-llm-apps"
+        >
+          Read the technical breakdown
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 function BenefitsSection() {
   return (
     <section className={styles.benefitsSection}>
@@ -209,6 +232,7 @@ export default function GitHubAction(): React.ReactElement {
         <GitHubActionHeader />
         <main className={styles.mainContent}>
           <VulnerabilityTypesSection />
+          <ProofBannerSection />
           <BenefitsSection />
           <CallToActionSection />
         </main>

--- a/site/src/pages/landing-page.module.css
+++ b/site/src/pages/landing-page.module.css
@@ -2179,3 +2179,109 @@ section {
     font-size: 1.1rem;
   }
 }
+
+/* ========================================
+   PROOF BANNER SECTION
+   Callout linking to technical blog post
+   ======================================== */
+
+.proofBanner {
+  padding: 0;
+  margin: 0 auto;
+  max-width: 1100px;
+  width: 100%;
+}
+
+.proofBannerContainer {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+  background: linear-gradient(135deg, rgba(229, 58, 58, 0.08) 0%, rgba(229, 58, 58, 0.04) 100%);
+  border: 1px solid rgba(229, 58, 58, 0.2);
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.proofBannerContainer:hover {
+  border-color: rgba(229, 58, 58, 0.4);
+  box-shadow: 0 4px 16px rgba(229, 58, 58, 0.1);
+}
+
+[data-theme='dark'] .proofBannerContainer {
+  background: linear-gradient(135deg, rgba(229, 58, 58, 0.12) 0%, rgba(229, 58, 58, 0.06) 100%);
+  border-color: rgba(229, 58, 58, 0.3);
+}
+
+[data-theme='dark'] .proofBannerContainer:hover {
+  border-color: rgba(229, 58, 58, 0.5);
+  box-shadow: 0 4px 16px rgba(229, 58, 58, 0.15);
+}
+
+.proofBannerIcon {
+  font-size: 2.5rem !important;
+  color: var(--pf-red-base, #e53a3a);
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .proofBannerIcon {
+  color: var(--pf-red-light, #ff7a7a);
+}
+
+.proofBannerContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.proofBannerTitle {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 0.25rem 0;
+}
+
+[data-theme='dark'] .proofBannerTitle {
+  color: #f5f5f5;
+}
+
+.proofBannerText {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #64748b;
+  margin: 0;
+}
+
+[data-theme='dark'] .proofBannerText {
+  color: #94a3b8;
+}
+
+.proofBannerButton {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .proofBannerContainer {
+    flex-direction: column;
+    text-align: center;
+    padding: 1.5rem;
+    gap: 1rem;
+  }
+
+  .proofBannerIcon {
+    font-size: 2rem !important;
+  }
+
+  .proofBannerTitle {
+    font-size: 1rem;
+  }
+
+  .proofBannerText {
+    font-size: 0.875rem;
+  }
+
+  .proofBannerButton {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a callout banner to code scanning landing pages that links to the technical blog post about building the security scanner. This addresses a content gap where the landing pages make claims about vulnerability detection but don't provide proof.

**Changes:**
- Add `ProofBannerSection` component to `/code-scanning/` index page
- Add `ProofBannerSection` component to `/code-scanning/github-action/` page  
- Add responsive CSS styles with dark mode support
- Remove unused `BuildIcon` import

**Placement:** After the vulnerability types section, following the narrative "here's what we detect" → "here's proof it works"

## Screenshots

The banner appears as a horizontal callout with:
- Article icon (red accent)
- Title: "See it in action"
- Text mentioning CVEs in LangChain, Vanna.AI, and LlamaIndex
- CTA button linking to `/blog/building-a-security-scanner-for-llm-apps`

## Test plan

- [ ] Visit `/code-scanning/` and verify banner appears after vulnerability cards
- [ ] Visit `/code-scanning/github-action/` and verify banner appears after vulnerability cards
- [ ] Test dark mode styling
- [ ] Test mobile responsive layout (banner stacks vertically)
- [ ] Verify link navigates to blog post correctly