### PR TITLE
fix(python): increase test timeout for worker integration tests

### DIFF
--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -4,7 +4,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { PythonWorker } from '../../src/python/worker';
 
 // Windows CI has severe filesystem delays (antivirus, etc.) - allow up to 90s
-const TEST_TIMEOUT = process.platform === 'win32' ? 90000 : 5000;
+// Non-Windows CI can also have timing variance with Python IPC, so use 15s (matching windows-path.test.ts)
+const TEST_TIMEOUT = process.platform === 'win32' ? 90000 : 15000;
 
 // Skip on Windows CI due to aggressive file security policies blocking temp file IPC
 // Works fine on local Windows and all other platforms

--- a/test/python/workerPool.test.ts
+++ b/test/python/workerPool.test.ts
@@ -4,7 +4,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { PythonWorkerPool } from '../../src/python/workerPool';
 
 // Windows CI has severe filesystem delays (antivirus, etc.) - allow up to 90s
-const TEST_TIMEOUT = process.platform === 'win32' ? 90000 : 5000;
+// Non-Windows CI can also have timing variance with Python IPC, so use 15s (matching windows-path.test.ts)
+const TEST_TIMEOUT = process.platform === 'win32' ? 90000 : 15000;
 
 // Skip on Windows CI due to aggressive file security policies blocking temp file IPC
 // Works fine on local Windows and all other platforms


### PR DESCRIPTION
## Summary
- Increased `TEST_TIMEOUT` from 5000ms to 15000ms for non-Windows platforms in `worker.test.ts` and `workerPool.test.ts`
- Fixes flaky CI failure in "should handle Python errors gracefully" test that was timing out on ubuntu-latest (took 5882ms vs 5000ms limit)
- Aligns with other Python integration tests (`windows-path.test.ts`, `pythonCompletion.unicode.test.ts`) that already use 15000ms

## Context
The Python worker tests spawn real Python processes and perform IPC via temp files. This inherently has timing variance in CI environments where resources are shared. The test performs:
1. Python process initialization
2. Three sequential IPC calls (success, error, success)
3. File I/O for each call

On a busy CI node, this can exceed 5 seconds. The fix gives adequate headroom while remaining reasonable for detecting actual performance regressions.

## Test plan
- [x] Ran `npx vitest run test/python/worker.test.ts test/python/workerPool.test.ts` - all 15 tests pass
- [x] Ran `npm run l` - no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)