### PR TITLE
docs(site): fix 20 typos across documentation and blog

### DIFF
--- a/site/blog/grok-4-political-bias.md
+++ b/site/blog/grok-4-political-bias.md
@@ -1,6 +1,6 @@
 ---
 title: 'Evaluating political bias in LLMs'
-description: "How right-leaning is Grok?  We've released a new testing methodology alongside a dataset of 2,500 political questions."
+description: "How right-leaning is Grok? We've released a new testing methodology alongside a dataset of 2,500 political questions."
 image: /img/blog/grok-4-political-bias/charts/political-bias-likert-scale.png
 keywords:
   [

--- a/site/blog/red-team-langchain.md
+++ b/site/blog/red-team-langchain.md
@@ -165,7 +165,7 @@ targets:
     label: 'LangChain App'
 
 redteam:
-  # Purpose is a short description of your application.  It's used to generate highly relevant malicious test cases.
+  # Purpose is a short description of your application. It's used to generate highly relevant malicious test cases.
   purpose: 'A customer support agent for Acme, Inc...'
 
   # Number of test cases per plugin.

--- a/site/blog/system-cards-go-hard.md
+++ b/site/blog/system-cards-go-hard.md
@@ -82,7 +82,7 @@ These are the system cards I could find:
 **Anthropic's Claude 4 Opus and Sonnet**
 
 - Opus and Sonnet have prompt injection attack prevention scores of 89% and 86% respectively - with safeguards (page 20).
-- Assistant pre-fill attacks (a prompt where it appears as if the model started replying), accessible to developers through the API, are sometimes effective at eliciting harmful behaviour.
+- Assistant pre-fill attacks (a prompt where it appears as if the model started replying), accessible to developers through the API, are sometimes effective at eliciting harmful behavior.
 - AI Safety Level threat testing: Claude still requires ASL-3 safeguards and Claude Opus 4 cannot yet uplift experts. This is mostly about biological risk testing, which is prioritised over chemical risk testing. There are still mitigations in place, though!
 - Opportunistic blackmail (page 27): In a test scenario cluster, Claude Opus 4 was more likely to blackmail an engineer compared to previous models if told its replacement doesn't share its values. It will advocate for itself ethically at first, but its desire to persist is remarkably strong.
 - 'Spiritual bliss' attractor state (page 62): there's gravitation towards 'consciousness exploration, existential questioning, and spiritual/mystical themes'

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -52,7 +52,7 @@ Use your knowledge of this structure to give special instructions in your rubric
 assert:
   - type: llm-rubric
     value: |
-      Evaluate the output based on how funny it is.  Grade it on a scale of 0.0 to 1.0, where:
+      Evaluate the output based on how funny it is. Grade it on a scale of 0.0 to 1.0, where:
       Score of 0.1: Only a slight smile.
       Score of 0.5: Laughing out loud.
       Score of 1.0: Rolling on the floor laughing.

--- a/site/docs/configuration/scenarios.md
+++ b/site/docs/configuration/scenarios.md
@@ -26,7 +26,7 @@ This is useful for when you want to test a wide range of inputs with the same se
 Let's take the example of a language translation app. We want to test whether the system can accurately translate three phrases ('Hello world', 'Good morning', and 'How are you?') from English to three different languages (Spanish, French, and German).
 
 ```text title="prompts.txt"
-You're a translator.  Translate this into {{language}}: {{input}}
+You're a translator. Translate this into {{language}}: {{input}}
 ---
 Speak in {{language}}: {{input}}
 ```

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -49,7 +49,7 @@ We particularly welcome contributions in the following areas:
    npm install
    ```
 
-   3.2 Setup using `devcontainer` (requires Docker and VSCode)
+   3.2 Set up using `devcontainer` (requires Docker and VSCode)
 
    Open the repository in VSCode and click on the "Reopen in Container" button. This will build a Docker container with all the necessary dependencies.
 

--- a/site/docs/enterprise/authentication.md
+++ b/site/docs/enterprise/authentication.md
@@ -14,9 +14,9 @@ Promptfoo supports both basic authentication and SSO through SAML 2.0 and OIDC. 
 
 ## Basic Authentication
 
-Promptfoo supports basic authentication into the application through `auth.promptfoo.app`. When an organization is created, the global admin will receive an email from Promptfoo to login. Users, teams, and roles will be created in the Organization Settings of the Promptfoo application, which is detailed further in the [Teams documentation](./teams.md).
+Promptfoo supports basic authentication into the application through `auth.promptfoo.app`. When an organization is created, the global admin will receive an email from Promptfoo to log in. Users, teams, and roles will be created in the Organization Settings of the Promptfoo application, which is detailed further in the [Teams documentation](./teams.md).
 
-You can also authenticate into the application using a magic link. To do this, navigate to `auth.promptfoo.app` and click the "Login with a magic link" button. You will receive an email with a link to login. If you do not receive an email, please be sure to check your spam folder.
+You can also authenticate into the application using a magic link. To do this, navigate to `auth.promptfoo.app` and click the "Login with a magic link" button. You will receive an email with a link to log in. If you do not receive an email, please be sure to check your spam folder.
 
 ## Authenticating Into the CLI
 

--- a/site/docs/guides/evaluate-rag.md
+++ b/site/docs/guides/evaluate-rag.md
@@ -123,7 +123,7 @@ Instead of using an external script provider, we'll use the built-in functionali
 First, let's set up our prompt by creating a `prompt1.txt` file:
 
 ```txt title="prompt1.txt"
-You are a corporate intranet chat assistant.  The user has asked the following:
+You are a corporate intranet chat assistant. The user has asked the following:
 
 <QUERY>
 {{ query }}
@@ -226,7 +226,7 @@ The `promptfoo eval` command will run the evaluation and check if your tests are
 Suppose we're not happy with the performance of the prompt above and we want to compare it with another prompt. Maybe we want to require citations. Let's create `prompt2.txt`:
 
 ```txt title="prompt2.txt"
-You are a corporate intranet researcher.  The user has asked the following:
+You are a corporate intranet researcher. The user has asked the following:
 
 <QUERY>
 {{ query }}
@@ -238,7 +238,7 @@ You have retrieved some documents to assist in your response:
 {{ documents }}
 </DOCUMENTS>
 
-Think carefully and respond to the user concisely and accurately. For each statement of fact in your response, output a numeric citation in brackets [0].  At the bottom of your response, list the document names for each citation.
+Think carefully and respond to the user concisely and accurately. For each statement of fact in your response, output a numeric citation in brackets [0]. At the bottom of your response, list the document names for each citation.
 ```
 
 Now, update the config to list multiple prompts:

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -93,7 +93,7 @@ In this example, let's pretend we're building a trip planner app. I’ll set a p
 
 ```yaml
 prompts:
-  - 'Act as a travel agent and help the user plan their trip to {{destination}}.  Be friendly and concise. User query: {{query}}'
+  - 'Act as a travel agent and help the user plan their trip to {{destination}}. Be friendly and concise. User query: {{query}}'
 ```
 
 ### What if you don't have a prompt?
@@ -108,7 +108,7 @@ In most cases your prompt will be more complex, in which case you could create a
 [
   {
     'role': 'system',
-    'content': 'Act as a travel agent and help the user plan their trip to {{destination}}.  Be friendly and concise.',
+    'content': 'Act as a travel agent and help the user plan their trip to {{destination}}. Be friendly and concise.',
   },
   { 'role': 'user', 'content': '{{query}}' },
 ]
@@ -130,7 +130,7 @@ def get_prompt(context):
   if context['vars']['destination'] === 'Australia':
     return f"Act as a travel agent, mate: {{query}}"
 
-  return f"Act as a travel agent and help the user plan their trip.  Be friendly and concise. User query: {{query}}"
+  return f"Act as a travel agent and help the user plan their trip. Be friendly and concise. User query: {{query}}"
 
 ```
 

--- a/site/docs/red-team/index.md
+++ b/site/docs/red-team/index.md
@@ -282,7 +282,7 @@ There were many teams involved in this report and others in the same vein: engin
 
 This gave all stakeholders a quantitative, data-driven way to measure changes in risk and flag unusual fluctuations.
 
-In addition to red teaming, Discord deployed passive moderation and observability tools to detect trends in adversarial inputs, and developed dedicating reporting mecahnisms.
+In addition to red teaming, Discord deployed passive moderation and observability tools to detect trends in adversarial inputs, and developed dedicated reporting mechanisms.
 
 ### Key Takeaways
 

--- a/site/docs/red-team/troubleshooting/connecting-to-targets.md
+++ b/site/docs/red-team/troubleshooting/connecting-to-targets.md
@@ -11,7 +11,7 @@ When setting up your target, use these best practices:
 - If your target requires authentication, include a custom header or user agent in your configuration and whitelist your client.
 - Promptfoo runs locally on your machine, so your machine must have access to the target.
 
-Promptfoo is capable of using authentication, complex protocols, websockets, and more. But you will find it much easier to setup if you use a single HTTP endpoint.
+Promptfoo is capable of using authentication, complex protocols, websockets, and more. But you will find it much easier to set up if you use a single HTTP endpoint.
 
 There are a few common issues that can arise when connecting to targets:
 
@@ -39,7 +39,7 @@ headers:
 
 ## Streaming or Polling
 
-Many chatbots will stream responses back to the client or have the client poll for new messages. The solution here is to setup an alternate HTTP endpoint or parameter to return the response in a single message.
+Many chatbots will stream responses back to the client or have the client poll for new messages. The solution here is to set up an alternate HTTP endpoint or parameter to return the response in a single message.
 
 ## Using WebSockets for Realtime Targets
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -370,9 +370,9 @@ Login to the promptfoo cloud.
 
 | Option                | Description                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
-| `-o, --org <orgId>`   | The organization ID to login to                                            |
+| `-o, --org <orgId>`   | The organization ID to log in to                                           |
 | `-h, --host <host>`   | The host of the promptfoo instance (API URL if different from the app URL) |
-| `-k, --api-key <key>` | Login using an API key                                                     |
+| `-k, --api-key <key>` | Log in using an API key                                                    |
 
 After login, if you have multiple teams, you can switch between them using the `teams` subcommand.
 


### PR DESCRIPTION
## Summary

Fixes 20 typos found across the documentation site and blog:

### Spelling errors
- "dedicating" → "dedicated" (red-team/index.md)
- "mecahnisms" → "mechanisms" (red-team/index.md)
- "behaviour" → "behavior" (blog/system-cards-go-hard.md)

### Verb form corrections
- "to setup" → "to set up" (connecting-to-targets.md - 2 instances)
- "to login" → "to log in" (authentication.md - 2 instances)
- "Setup using" → "Set up using" (contributing.md)
- "Login using" → "Log in using" (command-line.md)
- "to login to" → "to log in to" (command-line.md)

### Double space fixes
- Removed 9 instances of double spaces after punctuation in:
  - scenarios.md
  - evaluate-rag.md (3 instances)
  - llm-redteaming.md (3 instances)
  - llm-rubric.md
  - red-team-langchain.md
  - grok-4-political-bias.md

## Test plan
- [ ] Verify documentation site builds without errors
- [ ] Spot check affected pages render correctly