### PR TITLE
fix(ci): use valid Vitest 4 reporter in Tusk workflow

### DIFF
--- a/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
@@ -99,7 +99,7 @@ jobs:
             npx tsc --build --noEmit --incremental
 
           # The script to run Vitest tests for individual files
-          testScript: 'npx vitest run {{file}} --reporter=basic'
+          testScript: 'npx vitest run {{file}} --reporter=default'
 
           coverageScript: |
             npx vitest run {{testFilePaths}} \


### PR DESCRIPTION
## Summary
- Fix Tusk app test runner failing due to invalid reporter

The `--reporter=basic` option doesn't exist in Vitest 4, causing all test runs to crash with:
```
Error: Failed to load custom Reporter from basic
```

Changed to `--reporter=default` which is valid in Vitest 4.

## Test plan
- [ ] Verify Tusk can run app tests on the next PR