### PR TITLE
ci: add timeout-minutes to workflows

### DIFF
--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -15,6 +15,7 @@ jobs:
     name: calibreapp/image-actions
     permissions: write-all
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,6 +378,7 @@ jobs:
     name: Share Test
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -435,6 +436,7 @@ jobs:
   redteam:
     name: Redteam (Production API)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -460,6 +462,7 @@ jobs:
     name: Redteam (Staging API)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   security-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -78,6 +79,7 @@ jobs:
   build:
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: release-please
     permissions:
       contents: read
@@ -96,6 +98,7 @@ jobs:
     if: needs.release-please.outputs.release_created
     needs: [build, release-please]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
@@ -24,6 +24,7 @@ jobs:
   test-action:
     name: Tusk Test Runner
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     env:
       PROMPTFOO_DISABLE_TELEMETRY: 1

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,6 +11,7 @@ jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:


### PR DESCRIPTION
## Summary

Add `timeout-minutes` to CI workflow jobs that were missing them. This prevents CI jobs from running indefinitely and blocking PRs.

**main.yml jobs:**
- `share-test`: 10 minutes
- `redteam`: 10 minutes  
- `redteam-staging`: 10 minutes

**Other workflows:**
- `image-actions.yml`: 10 minutes
- `promptfoo-code-scan.yml`: 15 minutes
- `release-please.yml`: release-please (15min), build (10min), publish-npm (15min)
- `tusk-test-runner-vitest-unit-tests.yml`: 10 minutes
- `validate-pr-title.yml`: 5 minutes

## Test plan
- [ ] Verify CI workflows complete successfully
- [ ] Verify timeouts are reasonable for typical job durations