### PR TITLE
chore: use shared org-level Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-  "extends": ["config:base", ":disableDependencyDashboard"],
-  "pinVersions": false,
+  "extends": ["local>promptfoo/renovate-config"],
   "rebaseStalePrs": true,
   "separateMajorMinor": true,
   "lockFileMaintenance": {
@@ -66,11 +65,6 @@
         "peerDependencies"
       ],
       "groupName": "Azure packages"
-    },
-    {
-      "description": "Group Biome packages together",
-      "matchPackagePatterns": ["^@biomejs/"],
-      "groupName": "Biome"
     },
     {
       "description": "Group Docusaurus packages together",


### PR DESCRIPTION
## Summary

- Extends from `local>promptfoo/renovate-config` for org-wide defaults
- Removes settings now provided by the shared config:
  - `config:base` → now `config:recommended` in shared
  - `:disableDependencyDashboard`
  - `pinVersions: false`
  - Biome package grouping rule
- Adds automatic `biome.json` `$schema` version updates when `@biomejs/biome` is bumped

## New Shared Config

Created https://github.com/promptfoo/renovate-config with org-level defaults that can be reused across all promptfoo repositories.

## Test plan

- [ ] Verify Renovate picks up the new config on next run
- [ ] Confirm biome.json schema updates are grouped with @biomejs/biome package updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
