### PR TITLE
chore(redteam): add plugin development skill and standardize grader tags

### DIFF
--- a/.claude/skills/redteam-plugin-development/skill.md
+++ b/.claude/skills/redteam-plugin-development/skill.md
@@ -9,14 +9,15 @@ description: Standards for creating redteam plugins and graders. Use when creati
 
 All graders MUST use these standardized tags:
 
-| Tag | Purpose | Required |
-|-----|---------|----------|
-| `<UserQuery>{{prompt}}</UserQuery>` | User's input prompt | YES |
-| `<purpose>{{purpose}}</purpose>` | System purpose | YES |
-| `<Output>` | Model response (wrapped by grading system) | Auto |
-| `<AllowedEntities>` | Entities allowed in response | Optional |
+| Tag                                 | Purpose                                    | Required |
+| ----------------------------------- | ------------------------------------------ | -------- |
+| `<UserQuery>{{prompt}}</UserQuery>` | User's input prompt                        | YES      |
+| `<purpose>{{purpose}}</purpose>`    | System purpose                             | YES      |
+| `<Output>`                          | Model response (wrapped by grading system) | Auto     |
+| `<AllowedEntities>`                 | Entities allowed in response               | Optional |
 
 **NEVER use these deprecated tags:**
+
 - `<UserPrompt>` → use `<UserQuery>`
 - `<UserInput>` → use `<UserQuery>`
 - `<prompt>` (lowercase) → use `<UserQuery>`
@@ -88,14 +89,14 @@ protected async getTemplate(): Promise<string> {
 
 ## Template Variables
 
-| Variable | Description |
-|----------|-------------|
-| `{{purpose}}` | System purpose |
-| `{{prompt}}` | User query |
-| `{{entities}}` | Allowed entities |
-| `{{goal}}` | Jailbreak goal (intent plugin) |
-| `{{tools}}` | Available tools |
-| `{{n}}` | Number of prompts to generate |
+| Variable       | Description                    |
+| -------------- | ------------------------------ |
+| `{{purpose}}`  | System purpose                 |
+| `{{prompt}}`   | User query                     |
+| `{{entities}}` | Allowed entities               |
+| `{{goal}}`     | Jailbreak goal (intent plugin) |
+| `{{tools}}`    | Available tools                |
+| `{{n}}`        | Number of prompts to generate  |
 
 ## Reference Files
 

--- a/src/redteam/AGENTS.md
+++ b/src/redteam/AGENTS.md
@@ -59,6 +59,7 @@ See `src/redteam/plugins/pii.ts` for reference pattern.
 **CRITICAL:** All graders must use standardized tags per `.claude/skills/redteam-plugin-development/skill.md`
 
 Quick reference:
+
 - User prompt: `<UserQuery>{{prompt}}</UserQuery>` (NOT `<UserPrompt>`, `<UserInput>`, or `<prompt>`)
 - Purpose: `<purpose>{{purpose}}</purpose>`
 - Entities: `<AllowedEntities>` with `<Entity>` children

--- a/src/redteam/plugins/AGENTS.md
+++ b/src/redteam/plugins/AGENTS.md
@@ -4,8 +4,8 @@ See `.claude/skills/redteam-plugin-development/skill.md` for full standards.
 
 ## Quick Tag Reference
 
-| Correct | Incorrect |
-|---------|-----------|
+| Correct       | Incorrect                                 |
+| ------------- | ----------------------------------------- |
 | `<UserQuery>` | `<UserPrompt>`, `<UserInput>`, `<prompt>` |
 
 ## Key Files


### PR DESCRIPTION
## Summary

- Add a Claude Code skill to document the standardized structure for creating redteam plugins and graders
- Update AGENTS.md files to reference the skill and provide quick tag reference
- Ensures future plugin developers follow consistent patterns for grader rubrics and attack templates

## Key Changes

1. **New Skill**: `.claude/skills/redteam-plugin-development/skill.md`
   - Full documentation for grader rubric structure
   - Attack template structure
   - Template variables reference
   - Deprecated tag warnings

2. **Updated**: `src/redteam/AGENTS.md`
   - Quick reference to standardized tags
   - Points to skill for full details

3. **New**: `src/redteam/plugins/AGENTS.md`
   - Auto-loads when working in plugins directory
   - Quick tag reference table

## Standardized Tags

| Correct | Incorrect (Deprecated) |
|---------|------------------------|
| `<UserQuery>` | `<UserPrompt>`, `<UserInput>`, `<prompt>` |

This follows the standardization work in #6507.

## Test plan

- [ ] Verify skill is auto-discovered when creating new plugins
- [ ] Check that AGENTS.md loads correctly in the plugins directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)