### PR TITLE
fix: updated azure:resoponses to allow for Entra ID (mirroring azure:chat)

### DIFF
--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -211,13 +211,6 @@ export class AzureResponsesProvider extends AzureGenericProvider {
       );
     }
 
-    if (!this.authHeaders || !this.authHeaders['api-key']) {
-      throw new Error(
-        'Azure API authentication failed. Set AZURE_API_KEY environment variable or configure apiKey in provider config.\n' +
-          'You can also use Microsoft Entra ID authentication.',
-      );
-    }
-
     // Validate response_format for better UX
     if (
       this.config.response_format &&


### PR DESCRIPTION
I noticed that the azure:responses provider throws an auth error when using managed identity, whereas azure:chat doesn't. 

Here's a very basic yaml calling responses (while using managed identity via "az login"):
<img width="1166" height="761" alt="image" src="https://github.com/user-attachments/assets/4af28cf4-a6af-42e7-a5b4-52028dee0bad" />

If use the same yaml but with azure:chat, it works. 

From investigating the issue, it's due to an if statement in responses that doesn't exist in the chat version. In chat.ts, if az login hasn't been run, then the code still falls back to AZURE_API_KEY.  I mirrored the chat.ts by removing the if statement, retested and its working:

<img width="1615" height="493" alt="image" src="https://github.com/user-attachments/assets/d0b4affb-bbaf-4520-9e65-7cd1d9c69e85" />

I retested using an AZURE_API_KEY it still works after the change. 

