### PR TITLE
fix: Entra id support in azure:responses provider

### DIFF
--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -210,7 +210,7 @@ export class AzureResponsesProvider extends AzureGenericProvider {
           'Example: AZURE_API_HOST=your-resource.openai.azure.com',
       );
     }
-    if (!this.authHeaders || (!this.authHeaders['api-key'] && !this.authHeaders.Authorization)) {
+    if (!this.authHeaders['api-key'] && !this.authHeaders.Authorization) {
       throw new Error(
         'Azure API authentication failed. Set AZURE_API_KEY environment variable or configure apiKey in provider config.\n' +
           'You can also use Microsoft Entra ID authentication.',

--- a/test/providers/azure/assistant.test.ts
+++ b/test/providers/azure/assistant.test.ts
@@ -22,7 +22,9 @@ describe('Azure Assistant Provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    vi.spyOn(AzureAssistantProvider.prototype as any, 'getAuthHeaders').mockResolvedValue({});
+    vi.spyOn(AzureAssistantProvider.prototype as any, 'getAuthHeaders').mockResolvedValue({
+      'api-key': 'test-key',
+    });
 
     provider = new AzureAssistantProvider('test-deployment', {
       config: {
@@ -30,6 +32,9 @@ describe('Azure Assistant Provider', () => {
         apiHost: 'test.azure.com',
       },
     });
+
+    // Set authHeaders on the instance (simulating what initialize() does)
+    (provider as any).authHeaders = { 'api-key': 'test-key' };
 
     // Set up test spies on provider's private methods
     vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
@@ -74,16 +79,53 @@ describe('Azure Assistant Provider', () => {
   });
 
   describe('callApi', () => {
-    it('should throw an error if API key is not set', async () => {
-      vi.spyOn(provider as any, 'getApiKey').mockReturnValue(null);
+    it('should throw an error if authentication is not set', async () => {
+      // Mock authHeaders to be empty (no api-key and no Authorization)
+      Object.defineProperty(provider, 'authHeaders', {
+        get: () => ({}),
+        configurable: true,
+      });
 
-      await expect(provider.callApi('test prompt')).rejects.toThrow('Azure API key must be set');
+      await expect(provider.callApi('test prompt')).rejects.toThrow(
+        'Azure API authentication failed',
+      );
     });
 
     it('should throw an error if API host is not set', async () => {
       vi.spyOn(provider as any, 'getApiBaseUrl').mockReturnValue(null);
 
       await expect(provider.callApi('test prompt')).rejects.toThrow('Azure API host must be set');
+    });
+
+    it('should accept Entra ID authentication with Authorization header', async () => {
+      // Set authHeaders to use Authorization (Entra ID) instead of api-key
+      (provider as any).authHeaders = { Authorization: 'Bearer test-entra-token' };
+
+      // Mock processCompletedRun to return a successful result
+      vi.spyOn(provider as any, 'processCompletedRun').mockResolvedValue({
+        output: 'Hello from Entra ID!',
+      });
+
+      // Mock the API call sequence for a successful completion
+      const mockThreadResponse = { id: 'thread-123', object: 'thread', created_at: Date.now() };
+      const mockRunResponse = {
+        id: 'run-123',
+        object: 'run',
+        created_at: Date.now(),
+        status: 'completed',
+      };
+
+      (provider as any).makeRequest
+        .mockResolvedValueOnce(mockThreadResponse) // Thread creation
+        .mockResolvedValueOnce({}) // Message creation
+        .mockResolvedValueOnce(mockRunResponse) // Run creation
+        .mockResolvedValueOnce(mockRunResponse); // Run polling
+
+      const result = await provider.callApi('Hello');
+
+      // Verify the call succeeded (no error about missing API key)
+      expect(result.error).toBeUndefined();
+      expect(result.output).toContain('Hello from Entra ID!');
     });
 
     it('should create a thread, add a message, and run an assistant', async () => {
@@ -275,6 +317,9 @@ describe('Azure Assistant Provider', () => {
         },
       });
 
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
+
       // Set up private methods mocking
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({
@@ -374,6 +419,9 @@ describe('Azure Assistant Provider', () => {
         },
       });
 
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
+
       // Set up private methods mocking
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({
@@ -442,6 +490,9 @@ describe('Azure Assistant Provider', () => {
           functionToolCallbacks: functionCallbacks as any,
         },
       });
+
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
 
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({
@@ -516,6 +567,9 @@ describe('Azure Assistant Provider', () => {
           functionToolCallbacks: functionCallbacks,
         },
       });
+
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
 
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({
@@ -1260,6 +1314,9 @@ describe('Azure Assistant Provider', () => {
         },
       });
 
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
+
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({
         'Content-Type': 'application/json',
@@ -1369,6 +1426,9 @@ describe('Azure Assistant Provider', () => {
           },
         },
       });
+
+      // Set authHeaders on the instance
+      (provider as any).authHeaders = { 'api-key': 'test-key' };
 
       vi.spyOn(provider as any, 'makeRequest').mockImplementation(vi.fn());
       vi.spyOn(provider as any, 'getHeaders').mockResolvedValue({

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -275,6 +275,52 @@ describe('AzureResponsesProvider', () => {
       );
     });
 
+    it('should accept Entra ID authentication with Authorization header', async () => {
+      const mockResponse = {
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Hello from Entra ID auth!',
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 8,
+        },
+      };
+
+      mockFetchWithCache.mockResolvedValue({
+        data: mockResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const provider = new AzureResponsesProvider('gpt-4.1-test');
+
+      // Mock ensureInitialized to set authHeaders with Authorization (Entra ID)
+      vi.spyOn(provider, 'ensureInitialized').mockImplementation(async function () {
+        (provider as any).authHeaders = { Authorization: 'Bearer test-entra-token' };
+      });
+
+      const result = await provider.callApi('Hello');
+
+      // Verify the call succeeded (no error about missing authentication)
+      expect(result).toMatchObject({
+        output: 'Hello from Entra ID auth!',
+        cached: false,
+      });
+
+      // Verify the API was called (auth check passed)
+      expect(mockFetchWithCache).toHaveBeenCalled();
+    });
+
     it('should validate external response_format files', async () => {
       const provider = new AzureResponsesProvider('gpt-4.1-test', {
         config: { response_format: 'file://missing.json' as any },


### PR DESCRIPTION
I noticed that the azure:responses provider throws an auth error when using managed identity, whereas azure:chat doesn't.

Here's a very basic yaml calling responses (while using managed identity via "az login"):
<img width="949" height="769" alt="image" src="https://github.com/user-attachments/assets/d52c03ea-5de3-4351-bf51-95c4d376b4fc" />

If use the same yaml but with azure:chat, it works.

From investigating the issue, it's due to an if statement.  The or check for; bearer or api key means that if the api key is not there, it will always throw.  I've updated the or to what i think was the original intention. 

Now entra id and api key works.  
<img width="1460" height="563" alt="image" src="https://github.com/user-attachments/assets/7fa4f153-7875-4f22-8057-03c0d20773bb" />


I also checked that api key or entra id correctly throws an error. 