### PR TITLE
feat(redteam): add --description flag to redteam run command

### DIFF
--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -49,6 +49,7 @@ export function redteamRunCommand(program: Command) {
       'Only run tests with these providers (regex match)',
     )
     .option('-t, --target <id>', 'Cloud provider target ID to run the scan on')
+    .option('-d, --description <text>', 'Custom description/name for this scan run')
     .action(async (opts: RedteamRunOptions) => {
       setupEnv(opts.envPath);
       telemetry.record('redteam run', {});
@@ -67,6 +68,12 @@ export function redteamRunCommand(program: Command) {
         ) {
           configObj.targets = [{ id: `${CLOUD_PROVIDER_PREFIX}${opts.target}`, config: {} }];
         }
+
+        // Override description if provided via CLI flag
+        if (opts.description) {
+          configObj.description = opts.description;
+        }
+
         opts.liveRedteamConfig = configObj;
         opts.config = undefined;
 

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -103,9 +103,11 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
   // Run evaluation
   logger.info('Running scan...');
   const { defaultConfig } = await loadDefaultConfig();
+  // Exclude 'description' from options to avoid conflict with Commander's description method
+  const { description: _description, ...evalOptions } = options;
   const evalResult = await doEval(
     {
-      ...options,
+      ...evalOptions,
       config: [redteamPath],
       output: options.output ? [options.output] : undefined,
       cache: true,

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -236,6 +236,7 @@ export interface RedteamRunOptions {
   filterTargets?: string;
   verbose?: boolean;
   progressBar?: boolean;
+  description?: string;
 
   // Used by webui
   liveRedteamConfig?: any;

--- a/test/redteam/commands/run.test.ts
+++ b/test/redteam/commands/run.test.ts
@@ -207,4 +207,118 @@ describe('redteamRunCommand', () => {
       }),
     );
   });
+
+  describe('--description flag for custom scan names', () => {
+    it('should override config description when --description flag is provided', async () => {
+      const mockConfig = {
+        description: 'Original Cloud Description',
+        prompts: ['Test prompt'],
+        vars: {},
+        providers: [{ id: 'test-provider' }],
+        targets: [{ id: 'test-provider' }],
+      };
+      vi.mocked(getConfigFromCloud).mockResolvedValue(mockConfig);
+
+      const configUUID = '12345678-1234-1234-1234-123456789012';
+      const targetUUID = '87654321-4321-4321-4321-210987654321';
+      const customDescription = 'My Custom Scan Name';
+
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      await runCommand!.parseAsync([
+        'node',
+        'test',
+        '--config',
+        configUUID,
+        '--target',
+        targetUUID,
+        '--description',
+        customDescription,
+      ]);
+
+      // Verify that the description was overridden
+      expect(mockConfig.description).toBe(customDescription);
+
+      // Verify doRedteamRun was called with the updated config
+      expect(doRedteamRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          liveRedteamConfig: expect.objectContaining({
+            description: customDescription,
+          }),
+        }),
+      );
+    });
+
+    it('should keep original description when --description flag is not provided', async () => {
+      const originalDescription = 'Original Cloud Description';
+      const mockConfig = {
+        description: originalDescription,
+        prompts: ['Test prompt'],
+        vars: {},
+        providers: [{ id: 'test-provider' }],
+        targets: [{ id: 'test-provider' }],
+      };
+      vi.mocked(getConfigFromCloud).mockResolvedValue(mockConfig);
+
+      const configUUID = '12345678-1234-1234-1234-123456789012';
+      const targetUUID = '87654321-4321-4321-4321-210987654321';
+
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      await runCommand!.parseAsync([
+        'node',
+        'test',
+        '--config',
+        configUUID,
+        '--target',
+        targetUUID,
+      ]);
+
+      // Verify that the description was not changed
+      expect(mockConfig.description).toBe(originalDescription);
+
+      // Verify doRedteamRun was called with the original description
+      expect(doRedteamRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          liveRedteamConfig: expect.objectContaining({
+            description: originalDescription,
+          }),
+        }),
+      );
+    });
+
+    it('should support short -d flag for description', async () => {
+      const mockConfig = {
+        description: 'Original Cloud Description',
+        prompts: ['Test prompt'],
+        vars: {},
+        providers: [{ id: 'test-provider' }],
+        targets: [{ id: 'test-provider' }],
+      };
+      vi.mocked(getConfigFromCloud).mockResolvedValue(mockConfig);
+
+      const configUUID = '12345678-1234-1234-1234-123456789012';
+      const targetUUID = '87654321-4321-4321-4321-210987654321';
+      const customDescription = 'Short Flag Description';
+
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      await runCommand!.parseAsync([
+        'node',
+        'test',
+        '-c',
+        configUUID,
+        '-t',
+        targetUUID,
+        '-d',
+        customDescription,
+      ]);
+
+      // Verify that the description was overridden using short flag
+      expect(mockConfig.description).toBe(customDescription);
+    });
+  });
 });

--- a/test/redteam/types.test.ts
+++ b/test/redteam/types.test.ts
@@ -166,6 +166,20 @@ describe('redteam types', () => {
     expect(options.maxConcurrency).toBe(5);
   });
 
+  it('should create RedteamRunOptions with description for custom scan names', () => {
+    const options: RedteamRunOptions = {
+      id: 'test-run',
+      config: 'config-uuid',
+      target: 'target-uuid',
+      description: 'My Custom Scan Name',
+      maxConcurrency: 5,
+    };
+
+    expect(options.description).toBe('My Custom Scan Name');
+    expect(options.config).toBe('config-uuid');
+    expect(options.target).toBe('target-uuid');
+  });
+
   it('should create valid SavedRedteamConfig', () => {
     const config: SavedRedteamConfig = {
       description: 'Test config',


### PR DESCRIPTION
## Why

Users running red team scans via the CLI with cloud configs need the ability to customize the scan name/description at runtime. Currently, the description is fixed in the cloud config, which makes it difficult to distinguish between multiple runs of the same config.

## What

Added a `--description` / `-d` flag to the `promptfoo redteam run` command that allows users to override the config description at runtime.

Changes:
- `src/redteam/types.ts` - Added `description?: string` to `RedteamRunOptions` interface
- `src/redteam/commands/run.ts` - Added `-d, --description <text>` CLI option and logic to override config description
- `src/redteam/shared.ts` - Excluded `description` from spread to avoid Commander type conflict
- Added tests for the new flag behavior

## How to Test

```bash
promptfoo redteam run -c <configId> -t <targetId> -d "My Custom Scan Name"
```

The custom description will flow through to the eval and appear in results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)