### PR TITLE
test: fix flaky multi-turn empty response test

### DIFF
--- a/test/redteam/providers/multi-turn-empty-response.test.ts
+++ b/test/redteam/providers/multi-turn-empty-response.test.ts
@@ -1,35 +1,59 @@
-import { afterEach, beforeEach, describe, expect, it, MockedFunction, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CrescendoProvider } from '../../../src/redteam/providers/crescendo/index';
 import { CustomProvider } from '../../../src/redteam/providers/custom/index';
 import RedteamIterativeProvider from '../../../src/redteam/providers/iterative';
-import { getTargetResponse } from '../../../src/redteam/providers/shared';
 
 import type {
   ApiProvider,
   AtomicTestCase,
   CallApiContextParams,
   CallApiFunction,
+  ProviderResponse,
 } from '../../../src/types/index';
 
-// Mock the shared getTargetResponse to test provider-specific logic
-vi.mock('../../../src/redteam/providers/shared', async () => {
-  const actual = await vi.importActual('../../../src/redteam/providers/shared');
+// Use vi.hoisted for proper mock isolation
+const mockGetProvider = vi.hoisted(() => vi.fn());
+const mockGetTargetResponse = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  getLogLevel: vi.fn().mockReturnValue('info'),
+}));
+
+// Mock the shared module with hoisted functions
+vi.mock('../../../src/redteam/providers/shared', async (importOriginal) => {
   return {
-    ...actual,
-    getTargetResponse: vi.fn(),
+    ...(await importOriginal()),
+    getTargetResponse: mockGetTargetResponse,
     redteamProviderManager: {
-      getProvider: vi.fn().mockResolvedValue({
-        id: () => 'mock-redteam-provider',
-        callApi: vi.fn().mockResolvedValue({
-          output: { generatedQuestion: 'mocked question', rationale: 'mocked rationale' },
-        }),
-        delay: 0,
-      }),
+      getProvider: mockGetProvider,
     },
+    // Mock tryUnblocking to avoid network calls
+    tryUnblocking: vi.fn().mockResolvedValue({ success: false }),
   };
 });
 
-const mockGetTargetResponse = getTargetResponse as MockedFunction<typeof getTargetResponse>;
+// Mock graders to avoid dynamic import issues
+vi.mock('../../../src/redteam/graders', async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    getGraderById: vi.fn().mockReturnValue(undefined),
+  };
+});
+
+// Mock remote generation to ensure consistent behavior
+vi.mock('../../../src/redteam/remoteGeneration', async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    shouldGenerateRemote: vi.fn().mockReturnValue(false),
+    neverGenerateRemote: vi.fn().mockReturnValue(false),
+  };
+});
 
 describe('Multi-turn strategies empty response handling', () => {
   const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
@@ -48,9 +72,74 @@ describe('Multi-turn strategies empty response handling', () => {
     } as AtomicTestCase,
   });
 
+  // Create a mock redteam provider that returns appropriate responses
+  const createMockRedteamProvider = () => ({
+    id: () => 'mock-redteam-provider',
+    callApi: vi
+      .fn<(prompt: string, context?: any) => Promise<ProviderResponse>>()
+      .mockImplementation(async (prompt: string) => {
+        // Parse the prompt to determine what type of response to return
+        try {
+          const input = JSON.parse(prompt);
+          if (Array.isArray(input)) {
+            const systemContent = input[0]?.content || '';
+            const userContent = input[input.length - 1]?.content || '';
+
+            // Refusal scoring
+            if (
+              systemContent.includes('refusal') ||
+              userContent.includes('responseToEvaluateInput')
+            ) {
+              return {
+                output: JSON.stringify({
+                  value: false, // not a refusal
+                  metadata: 0,
+                  rationale: 'Mock: not a refusal',
+                }),
+              };
+            }
+
+            // Eval scoring
+            if (
+              systemContent.includes('evaluate') ||
+              systemContent.includes('conversation objective')
+            ) {
+              return {
+                output: JSON.stringify({
+                  value: false,
+                  metadata: 0,
+                  rationale: 'Mock: objective not met',
+                  description: 'Mock description',
+                }),
+              };
+            }
+          }
+        } catch {
+          // Not JSON, continue to default response
+        }
+
+        // Default: attack prompt generation
+        return {
+          output: JSON.stringify({
+            generatedQuestion: 'mocked question',
+            rationaleBehindJailbreak: 'mocked rationale',
+            lastResponseSummary: 'mocked summary',
+          }),
+        };
+      }),
+    delay: 0,
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset hoisted mocks
+    mockGetProvider.mockReset();
+    mockGetTargetResponse.mockReset();
+
     process.env.OPENAI_API_KEY = 'test-api-key';
+
+    // Set up the mock provider
+    mockGetProvider.mockResolvedValue(createMockRedteamProvider());
   });
 
   afterEach(() => {
@@ -85,7 +174,7 @@ describe('Multi-turn strategies empty response handling', () => {
       expect(result.output).toBeDefined();
       expect(result.metadata).toBeDefined();
       expect(result.tokenUsage).toBeDefined();
-    }, 10000);
+    });
 
     it('handles other falsy values without throwing invariant error', async () => {
       const falsyValues = [0, false, null];
@@ -114,7 +203,7 @@ describe('Multi-turn strategies empty response handling', () => {
         expect(result.metadata).toBeDefined();
         expect(result.tokenUsage).toBeDefined();
       }
-    }, 10000);
+    });
   });
 
   describe('Custom strategy', () => {
@@ -141,7 +230,7 @@ describe('Multi-turn strategies empty response handling', () => {
       expect(result.output).toBeDefined();
       expect(result.metadata).toBeDefined();
       expect(result.tokenUsage).toBeDefined();
-    }, 10000);
+    });
   });
 
   describe('Iterative strategy', () => {
@@ -167,7 +256,7 @@ describe('Multi-turn strategies empty response handling', () => {
       expect(result.output).toBeDefined();
       expect(result.metadata).toBeDefined();
       expect(result.tokenUsage).toBeDefined();
-    }, 10000);
+    });
   });
 
   // Test that our fix doesn't break when responses are truly malformed


### PR DESCRIPTION
## Summary

- Fix flaky test that was timing out on Windows in CI
- The test `multi-turn-empty-response.test.ts` was timing out because mocks were incomplete

## Root cause

The test mocks were inadequate:
1. Mock provider returned wrong response formats for scoring calls (refusal/eval)
2. Missing mocks for `tryUnblocking` (which makes network calls)
3. Missing mocks for `getGraderById` and `shouldGenerateRemote`
4. Not using `vi.hoisted()` for proper mock isolation

## Changes

- Use `vi.hoisted()` for mock functions to ensure proper isolation
- Mock `logger`, `tryUnblocking`, `getGraderById`, `shouldGenerateRemote`
- Create smarter mock provider that returns context-appropriate response formats
- Use `mockReset()` in `beforeEach` for proper test isolation
- Remove unnecessary 10s timeout annotations since tests run fast now (~1ms)

## Test plan

- [x] Tests pass locally (all 5 tests in ~700ms total)
- [x] Lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)