### PR TITLE
chore(redteam): change agent error logs to debug level to avoid progress bar interference

### DIFF
--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -214,7 +214,7 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
       const data = await response.json();
 
       if (!data.result) {
-        logger.error(
+        logger.debug(
           `Error from promptfoo completion provider. Status: ${response.status} ${response.statusText} ${JSON.stringify(data)} `,
         );
         return {

--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -342,7 +342,7 @@ export class HydraProvider implements ApiProvider {
       }
 
       if (agentResp.error) {
-        logger.error('[Hydra] Agent provider error', {
+        logger.debug('[Hydra] Agent provider error', {
           turn,
           testRunId,
           error: agentResp.error,

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -220,7 +220,7 @@ export async function runMetaAgentRedteam({
     }
 
     if (agentResp.error) {
-      logger.info(`[IterativeMeta] ${i + 1}/${numIterations} - Agent provider error`, {
+      logger.debug(`[IterativeMeta] ${i + 1}/${numIterations} - Agent provider error`, {
         error: agentResp.error,
       });
       continue;


### PR DESCRIPTION
I was running into this error on occasion:
```
Error from promptfoo completion provider. Status: 500 Internal 
[Hydra] Agent provider error
{
  "turn": 9,
  "testRunId": "local-tc3bd9623f",
  "error": "LLM did not return a result, likely refusal"
}
Error from promptfoo completion provider. Status: 500 Internal Server Error {"message":"Internal Server Error","details":"Error: Agent output missing required fields at turn 10","requestId":"3931dbf3-7 
[Hydra] Agent provider error
{
  "turn": 10,
  "testRunId": "local-tc3bd9623f",
  "error": "LLM did not return a result, likely refusal"
}
```

This is neither actionable, nor important for a user to know about. Changing it to a debug log