### PR TITLE
fix(cli): downgrade missing blob reference log

### DIFF
--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -131,7 +131,7 @@ export async function recordBlobReference(
   const provider = getBlobStorageProvider();
   const exists = await provider.exists(hash).catch(() => false);
   if (!exists) {
-    logger.warn('[BlobStorage] Attempted to record reference for missing blob', {
+    logger.debug('[BlobStorage] Attempted to record reference for missing blob', {
       hash,
       evalId: refContext.evalId,
       location: refContext.location,


### PR DESCRIPTION
## Summary

Lowers missing blob reference log to debug so expected misses don't warn, i.e.:

```
[BlobStorage] Attempted to record reference for missing blob
{
  "hash": "6df7ad6fa338938ca8df918456e299f68e78953f4494db13832dbd04bc719ff5",
  "evalId": "eval-rJS-2025-12-23T03:03:35",
  "location": "response.metadata.blobUris[0]"
}
```

## Testing

- [x]  Run a scan that generates binary artifacts and verify that the warning-level messages no longer appear