### PR TITLE
fix(app): resolve z-index stacking for filters in evals modal

### DIFF
--- a/src/app/src/components/ui/dialog.tsx
+++ b/src/app/src/components/ui/dialog.tsx
@@ -21,10 +21,9 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        'fixed inset-0 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'fixed inset-0 z-[var(--z-modal-backdrop)] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
-      style={{ zIndex: 1400 }}
       {...props}
     />
   );
@@ -42,10 +41,9 @@ function DialogContent({
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          'fixed left-[50%] top-[50%] z-[var(--z-modal)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
           className,
         )}
-        style={{ zIndex: 1400 }}
         {...props}
       >
         {children}

--- a/src/app/src/components/ui/dropdown-menu.tsx
+++ b/src/app/src/components/ui/dropdown-menu.tsx
@@ -50,7 +50,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       ref={ref}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-[var(--z-dropdown)] min-w-[8rem] overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function DropdownMenuContent({
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 min-w-[8rem] overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-md',
+          'z-[var(--z-dropdown)] min-w-[8rem] overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-md',
           'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}

--- a/src/app/src/components/ui/popover.tsx
+++ b/src/app/src/components/ui/popover.tsx
@@ -23,7 +23,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-72 rounded-md border border-border bg-white dark:bg-zinc-900 p-4 text-foreground shadow-md outline-none',
+          'z-[var(--z-dropdown)] w-72 rounded-md border border-border bg-white dark:bg-zinc-900 p-4 text-foreground shadow-md outline-none',
           'data-[state=open]:animate-in data-[state=closed]:animate-out',
           'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
           'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',

--- a/src/app/src/components/ui/select.tsx
+++ b/src/app/src/components/ui/select.tsx
@@ -77,7 +77,7 @@ function SelectContent({
       <SelectPrimitive.Content
         ref={ref}
         className={cn(
-          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-white dark:bg-zinc-900 text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'relative z-[var(--z-dropdown)] max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-white dark:bg-zinc-900 text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,

--- a/src/app/src/components/ui/tooltip.tsx
+++ b/src/app/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ function TooltipContent({
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 overflow-hidden rounded-md bg-foreground px-2.5 py-1.5 text-xs text-background shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-[var(--z-tooltip)] overflow-hidden rounded-md bg-foreground px-2.5 py-1.5 text-xs text-background shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}
         {...props}

--- a/src/app/src/index.css
+++ b/src/app/src/index.css
@@ -66,6 +66,14 @@
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 
+  /* Z-index scale for layered components
+   * Modal < Dropdown ensures nested dropdowns appear above modals
+   * Values >= 1300 for MUI compatibility during migration */
+  --z-modal-backdrop: 1300;
+  --z-modal: 1310;
+  --z-dropdown: 1400;
+  --z-tooltip: 1500;
+
   /* Design tokens - Light mode (aligned with MUI theme) */
   --background: 210 40% 98%; /* #f8fafc - slate-50 */
   --foreground: 222.2 47.4% 11.2%; /* #0f172a - slate-900 */


### PR DESCRIPTION
## Summary

Fixes filters, dropdowns, and other portaled components being hidden behind the dialog overlay in the `EvalSelectorDialog` modal.

**Root cause:** The `Dialog` component used inline `style={{ zIndex: 1400 }}` while `Popover`, `Select`, `DropdownMenu`, and `Tooltip` used Tailwind's `z-50` (z-index: 50). Since all these components portal to `<body>`, the dropdowns rendered behind the modal overlay.

**Solution:** Introduce semantic z-index tokens as CSS custom properties and update all portaled UI components to use them consistently.

## Changes

- Add z-index scale to `index.css`:
  - `--z-modal-backdrop: 1300`
  - `--z-modal: 1310`
  - `--z-dropdown: 1400`
  - `--z-tooltip: 1500`
- Update `Dialog` to use `z-[var(--z-modal)]` instead of inline styles
- Update `Popover`, `Select`, `DropdownMenu` to use `z-[var(--z-dropdown)]`
- Update `Tooltip` to use `z-[var(--z-tooltip)]`
- Document z-index scale and patterns in `MIGRATION.md`

## Why these values?

| Layer | Value | Rationale |
|-------|-------|-----------|
| Modal backdrop | 1300 | Matches MUI modal z-index for migration compatibility |
| Modal content | 1310 | Slightly above backdrop |
| Dropdowns | 1400 | **Above modals** so nested dropdowns work |
| Tooltips | 1500 | Always on top |

## Test plan

- [ ] Open the evals list modal (`EvalSelectorDialog`)
- [ ] Click the "Filters" button in the DataTable toolbar
- [ ] Verify the filter popover appears above the modal
- [ ] Test Select dropdowns inside the filter popover
- [ ] Verify tooltips still work correctly

cc @faizanminhas