### PR TITLE
fix(app): show toolbar when filters return no results

### DIFF
--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -245,8 +245,12 @@ export function DataTable<TData, TValue = unknown>({
   }
 
   const hasData = table.getRowModel().rows.length > 0;
+  const hasActiveFilters = globalFilter || columnFilters.length > 0;
 
-  if (!hasData && !globalFilter) {
+  // Show initial empty state only when there's no data AND no active filters
+  // If filters are active but return no results, we show the table with "no results" message
+  // so users can still access the toolbar to clear/modify their filters
+  if (!hasData && !hasActiveFilters) {
     return (
       <div className={cn('space-y-4 pb-4', className)}>
         {showToolbar && toolbarActions && (


### PR DESCRIPTION
## Summary
- Fixed a bug where the DataTable empty state would hide the toolbar when column filters were active but returned no results
- Users can now access the toolbar to clear or modify their filters even when no results match
- Added test to verify the toolbar remains visible when filters return no results

## Test plan
- [x] Run `npm test -- src/components/data-table/data-table.test.tsx` - all tests pass
- [x] Manual testing: Apply a filter that returns no results and verify the toolbar is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)