### PR TITLE
fix(providers): respect PROMPTFOO_PYTHON env var in Python providers

### DIFF
--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { getCache, isCacheEnabled } from '../cache';
 import logger from '../logger';
-import { getEnvInt } from '../python/pythonUtils';
+import { getConfiguredPythonPath, getEnvInt } from '../python/pythonUtils';
 import { PythonWorkerPool } from '../python/workerPool';
 import { sha256 } from '../util/createHash';
 import { processConfigFileReferences } from '../util/fileReference';
@@ -90,7 +90,7 @@ export class PythonProvider implements ApiProvider {
           absPath,
           this.functionName || 'call_api',
           workerCount,
-          this.config.pythonExecutable,
+          getConfiguredPythonPath(this.config.pythonExecutable),
           this.config.timeout,
         );
 

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -28,6 +28,26 @@ export function getEnvInt(key: string): number | undefined {
   return isNaN(parsed) ? undefined : parsed;
 }
 
+/**
+ * Resolves the Python executable path from explicit config and environment.
+ * This centralizes the fallback logic: configPath > PROMPTFOO_PYTHON env var.
+ *
+ * Note: Does NOT apply the final 'python' default - that's handled by
+ * validatePythonPath. This preserves the distinction between "explicitly
+ * configured" (should fail if invalid) and "using system default" (should
+ * try fallback detection).
+ *
+ * @param configPath - Explicitly configured Python path from provider config
+ * @returns The configured path, or undefined if neither config nor env var is set
+ */
+export function getConfiguredPythonPath(configPath?: string): string | undefined {
+  if (configPath) {
+    return configPath;
+  }
+  const envPath = getEnvString('PROMPTFOO_PYTHON');
+  return envPath || undefined;
+}
+
 export const state: {
   cachedPythonPath: string | null;
   validationPromise: Promise<string> | null;
@@ -289,7 +309,7 @@ export async function runPython(
     os.tmpdir(),
     `promptfoo-python-output-json-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
   );
-  const customPath = options.pythonExecutable || getEnvString('PROMPTFOO_PYTHON');
+  const customPath = getConfiguredPythonPath(options.pythonExecutable);
   let pythonPath = customPath || 'python';
 
   pythonPath = await validatePythonPath(pythonPath, typeof customPath === 'string');

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -70,6 +70,54 @@ describe('Python Utils', () => {
     vi.mocked(getEnvBool).mockReturnValue(false);
   });
 
+  describe('getConfiguredPythonPath', () => {
+    it('should return explicit config path when provided', () => {
+      const result = pythonUtils.getConfiguredPythonPath('/custom/python/path');
+      expect(result).toBe('/custom/python/path');
+    });
+
+    it('should return PROMPTFOO_PYTHON when config path is not provided', () => {
+      vi.mocked(getEnvString).mockReturnValue('/env/python/path');
+
+      const result = pythonUtils.getConfiguredPythonPath(undefined);
+
+      expect(result).toBe('/env/python/path');
+      expect(getEnvString).toHaveBeenCalledWith('PROMPTFOO_PYTHON');
+    });
+
+    it('should prioritize config path over PROMPTFOO_PYTHON', () => {
+      vi.mocked(getEnvString).mockReturnValue('/env/python/path');
+
+      const result = pythonUtils.getConfiguredPythonPath('/config/python/path');
+
+      expect(result).toBe('/config/python/path');
+    });
+
+    it('should return undefined when neither config nor env var is set', () => {
+      vi.mocked(getEnvString).mockReturnValue('');
+
+      const result = pythonUtils.getConfiguredPythonPath(undefined);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when config is empty string and env var is not set', () => {
+      vi.mocked(getEnvString).mockReturnValue('');
+
+      const result = pythonUtils.getConfiguredPythonPath('');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return PROMPTFOO_PYTHON when config is empty string', () => {
+      vi.mocked(getEnvString).mockReturnValue('/env/python');
+
+      const result = pythonUtils.getConfiguredPythonPath('');
+
+      expect(result).toBe('/env/python');
+    });
+  });
+
   describe('getSysExecutable', () => {
     it('should return Python executable path from sys.executable', async () => {
       // Mock for Unix-like systems (not Windows)


### PR DESCRIPTION
## Summary

Fixes #6819

Custom Python providers were ignoring the `PROMPTFOO_PYTHON` environment variable, always falling back to the system default Python instead of using the configured virtual environment.

**Root cause:** `PythonProvider.initialize()` only passed `config.pythonExecutable` to the worker pool without checking `PROMPTFOO_PYTHON` as a fallback.

**Changes:**
- Add centralized `getConfiguredPythonPath()` utility in `pythonUtils.ts` that handles the fallback chain: `config.pythonExecutable` > `PROMPTFOO_PYTHON` > `undefined`
- Update `PythonProvider.initialize()` to use the new utility
- Refactor `runPython()` to use the same utility for DRY consistency
- Add comprehensive unit and integration tests

**Priority chain (now correct):**
1. `config.pythonExecutable` (explicit config in promptfooconfig.yaml)
2. `PROMPTFOO_PYTHON` (environment variable)
3. System default (`'python'`)

## Test plan

- [x] Added 6 unit tests for `getConfiguredPythonPath()` 
- [x] Added 4 integration tests for `PythonProvider` PROMPTFOO_PYTHON handling
- [x] All 98 Python-related tests pass
- [x] TypeScript compiles successfully
- [x] Linting passes