### PR TITLE
fix(evals): browser back button fix on evals results table

### DIFF
--- a/src/app/src/pages/eval/components/Eval.test.tsx
+++ b/src/app/src/pages/eval/components/Eval.test.tsx
@@ -6,6 +6,10 @@ import Eval from './Eval';
 import { useResultsViewSettingsStore, useTableStore } from './store';
 import type { EvaluateTable } from '@promptfoo/types';
 
+const { mockSetSearchParams } = vi.hoisted(() => ({
+  mockSetSearchParams: vi.fn(),
+}));
+
 vi.mock('@app/utils/api');
 vi.mock('@app/hooks/useToast', () => ({
   useToast: () => ({
@@ -40,12 +44,13 @@ vi.mock('socket.io-client', () => ({
     disconnect: vi.fn(),
   })),
 }));
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
     useNavigate: () => vi.fn(),
-    useSearchParams: () => [new URLSearchParams()],
+    useSearchParams: () => [new URLSearchParams(), mockSetSearchParams],
     useParams: () => ({}),
   };
 });
@@ -363,5 +368,103 @@ describe('Eval', () => {
     const resultsView = container.querySelector('[data-testid="results-view"]');
     expect(resultsView).toBeInTheDocument();
     expect(resultsView?.getAttribute('data-default-eval-id')).toBe('eval-2');
+  });
+
+  it('should call setSearchParams with { replace: true } when clearing filters', async () => {
+    let subscriptionCallback: ((filters: any) => void) | null = null;
+
+    // Mock subscribe to capture the callback and trigger it
+    (useTableStore as any).subscribe = vi.fn((selector, callback) => {
+      if (selector.toString().includes('filters')) {
+        subscriptionCallback = callback;
+      }
+      return vi.fn(); // unsubscribe function
+    });
+
+    const mockFilters = {
+      values: {},
+      appliedCount: 0, // Filters cleared
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      ...baseMockTableStore,
+      filters: mockFilters,
+    });
+
+    mockSetSearchParams.mockClear();
+
+    render(
+      <MemoryRouter>
+        <Eval fetchId="test-eval" />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // Trigger the subscription callback manually
+    if (subscriptionCallback) {
+      await act(async () => {
+        subscriptionCallback!(mockFilters);
+      });
+    }
+
+    // Should call setSearchParams with replace: true when clearing filters
+    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true });
+  });
+
+  it('should call setSearchParams with { replace: true } when applying filters', async () => {
+    let subscriptionCallback: ((filters: any) => void) | null = null;
+
+    // Mock subscribe to capture the callback and trigger it
+    (useTableStore as any).subscribe = vi.fn((selector, callback) => {
+      if (selector.toString().includes('filters')) {
+        subscriptionCallback = callback;
+      }
+      return vi.fn(); // unsubscribe function
+    });
+
+    const mockFilters = {
+      values: {
+        filter1: {
+          id: 'filter1',
+          type: 'text' as const,
+          operator: 'contains' as const,
+          value: 'test',
+          field: 'text',
+          logicOperator: 'and' as const,
+          sortIndex: 0,
+        },
+      },
+      appliedCount: 1,
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      ...baseMockTableStore,
+      filters: mockFilters,
+    });
+
+    mockSetSearchParams.mockClear();
+
+    render(
+      <MemoryRouter>
+        <Eval fetchId="test-eval" />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // Trigger the subscription callback manually
+    if (subscriptionCallback) {
+      await act(async () => {
+        subscriptionCallback!(mockFilters);
+      });
+    }
+
+    // Should call setSearchParams with replace: true when applying filters
+    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true });
   });
 });

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -144,20 +144,26 @@ export default function Eval({ fetchId }: EvalOptions) {
         // Do search params need to be removed?
         if (_filters.appliedCount === 0) {
           // clear the search params
-          setSearchParams((prev) => {
-            prev.delete('filter');
-            return prev;
-          });
+          setSearchParams(
+            (prev) => {
+              prev.delete('filter');
+              return prev;
+            },
+            { replace: true },
+          );
         } else if (_filters.appliedCount > 0) {
           // Serialize the filters to a JSON string
           const serializedFilters = JSON.stringify(Object.values(_filters.values));
           // Check whether the serialized filters are already in the search params
           if (_searchParams.get('filter') !== serializedFilters) {
             // Add each filter to the search params
-            setSearchParams((prev) => {
-              prev.set('filter', serializedFilters);
-              return prev;
-            });
+            setSearchParams(
+              (prev) => {
+                prev.set('filter', serializedFilters);
+                return prev;
+              },
+              { replace: true },
+            );
           }
         }
       },

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -216,7 +216,7 @@ export default function ResultsView({
 
   const handleSearchTextChange = React.useCallback(
     (text: string) => {
-      setSearchParams((prev) => ({ ...prev, search: text }));
+      setSearchParams((prev) => ({ ...prev, search: text }), { replace: true });
       setSearchText(text);
     },
     [setSearchParams],


### PR DESCRIPTION
## Summary
- Verifies component doesn't pollute browser history on mount
- Documents that `handleSearchTextChange` uses `{ replace: true }` for search updates


#### Demo
https://github.com/user-attachments/assets/6f276baf-d862-459d-9cd7-568fdae28bf1

