### PR TITLE
chore(deps): add protobufjs and sharp to pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,9 @@
       "better-sqlite3",
       "core-js",
       "core-js-pure",
-      "esbuild"
+      "esbuild",
+      "protobufjs",
+      "sharp"
     ],
     "ignoredBuiltDependencies": []
   }


### PR DESCRIPTION
## Summary

Adds `protobufjs` and `sharp` to the `pnpm.onlyBuiltDependencies` array in package.json.

These packages have native dependencies that need to be built during installation. Adding them to `onlyBuiltDependencies` allows pnpm to build them properly.