### PR TITLE
fix(redteam): persist custom provider selection when changing tabs

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -25,7 +25,10 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
   const { config, updateConfig, providerType, setProviderType } = useRedTeamConfig();
 
   // Check if we have a complete saved configuration
-  const hasCompleteSavedConfig = Boolean(config.target?.label?.trim() && config.target?.id);
+  // For custom providers, id is intentionally empty but providerType is set to 'custom'
+  const hasCompleteSavedConfig = Boolean(
+    config.target?.label?.trim() && (config.target?.id || providerType === 'custom'),
+  );
 
   const [selectedTarget, setSelectedTarget] = useState<ProviderOptions>(() => {
     // If we have a complete saved config, use it. Otherwise start fresh without a label


### PR DESCRIPTION
## Summary

Fixes #6729

- Custom provider selection was lost when navigating between tabs in the red team setup wizard
- Root cause: custom providers intentionally use an empty `id` string, but `hasCompleteSavedConfig` only checked if `id` was present
- The fix adds a check for `providerType === 'custom'` to recognize that a custom provider has been selected even when the `id` is empty

## Changes

**`TargetTypeSelection.tsx`**
- Updated `hasCompleteSavedConfig` check to include `providerType === 'custom'` condition

**`TargetTypeSelection.test.tsx`**
- Added 5 tests for custom provider persistence scenarios

## Test plan

1. Start red team setup (`/redteam/setup`)
2. Enter a target name (e.g., "my-custom-target")
3. Click "Next: Select Target Type"
4. Select "Custom Provider" from the list
5. Navigate to another tab (e.g., "Plugins")
6. Navigate back to "Target" tab
7. **Verify**: Target type selector is still visible with "Custom Provider" selected
8. **Verify**: The target name is preserved