### PR TITLE
fix(deps): pin pem to stable 1.14.x version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "openai": "^6.14.0",
         "opener": "^1.5.2",
         "ora": "^9.0.0",
-        "pem": "^1.15.1",
+        "pem": "~1.14.8",
         "posthog-node": "^5.14.0",
         "protobufjs": "^8.0.0",
         "proxy-agent": "^6.5.0",
@@ -30135,7 +30135,9 @@
       }
     },
     "node_modules/pem": {
-      "version": "1.15.1",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.8.tgz",
+      "integrity": "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==",
       "license": "MIT",
       "dependencies": {
         "es6-promisify": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "openai": "^6.14.0",
     "opener": "^1.5.2",
     "ora": "^9.0.0",
-    "pem": "^1.15.1",
+    "pem": "~1.14.8",
     "posthog-node": "^5.14.0",
     "protobufjs": "^8.0.0",
     "proxy-agent": "^6.5.0",


### PR DESCRIPTION
## Summary

Pins the `pem` package to `~1.14.8` to avoid the deprecated 1.15.x version.

**Root cause:** Version 1.15.1 was accidentally published and deprecated with "published by mistake". The stable line is 1.14.x (latest: 1.14.8).

Using `~1.14.8` (instead of `^1.14.8`) ensures we stay on `>=1.14.8 <1.15.0`, avoiding the deprecated 1.15.x releases.

## Changes

- `pem`: `^1.15.1` → `~1.14.8`
- Updated `package-lock.json` to resolve to 1.14.8

## Test Plan

- [x] `npm install` no longer shows pem deprecation warning
- [x] No code changes required - API is identical between versions