### PR TITLE
fix(app): add compact markdown styling for eval table cells (#1657)

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -784,7 +784,8 @@ thead .header-dismiss {
   padding: 0.1em 0.3em;
   background: var(--variable-background-color);
   border-radius: 3px;
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
 /* Code blocks - compact styling */
@@ -792,7 +793,8 @@ thead .header-dismiss {
   margin: 0.4em 0;
   padding: 0.5em;
   font-size: 0.85em;
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
   background: var(--variable-background-color);
   border-radius: 4px;
   overflow-x: auto;
@@ -874,8 +876,8 @@ thead .header-dismiss {
 }
 
 /* Also override for any language-specific code */
-[data-theme='dark'] .results-table tr .cell pre code[class*="language-"],
-[data-theme='dark'] .results-table tr .cell code[class*="language-"] {
+[data-theme='dark'] .results-table tr .cell pre code[class*='language-'],
+[data-theme='dark'] .results-table tr .cell code[class*='language-'] {
   text-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- Adds CSS styling to make rendered markdown more compact and readable in eval table cells
- Previously, markdown elements used browser defaults which resulted in oversized fonts and excessive margins

### Changes
- Reduced heading sizes (1.15em down to 1em)
- Compact margins on all elements
- Visible list bullets with proper indentation  
- Styled blockquotes with accent border and subtle background
- Compact code blocks with proper monospace font stack
- Table styling with borders, header backgrounds, and alternating rows
- **GitHub-style dark mode** with high-contrast code blocks
- **Fixed blurry text** by removing Prism.js text-shadow in dark mode

Closes #1657

## Screenshots

### Light Mode
![Light Mode](https://iili.io/fVkoDkx.png)

### Dark Mode  
![Dark Mode](https://iili.io/fVkxQnI.png)

## Test plan
- Enable "Render Markdown" in Table Settings on an eval page
- Verify markdown content displays with compact styling
- Check that code blocks use monospace font and have crisp, sharp text
- Verify lists show bullets properly
- Verify tables have proper borders and styling
- Test in both light and dark modes