### PR TITLE
docs: clarify lint/format timing and add no-reexports rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,8 @@ git checkout main && git pull origin main   # Always start fresh
 git checkout -b feature/your-branch-name    # New branch for changes
 # Make changes...
 git add <specific-files>                    # Never blindly add everything
+npm run l && npm run f                      # Lint and format before commit/push
 git commit -m "type(scope): description"    # Conventional commit format
-npm run l && npm run f                      # Lint and format
 git fetch origin main && git merge origin/main  # Sync with main
 git push -u origin feature/your-branch-name # Push branch
 ```
@@ -208,6 +208,7 @@ EOF
 - Use `async/await` for asynchronous code
 - Use Vitest for all tests (both `test/` and `src/app/`)
 - Use consistent error handling with proper type checks
+- Avoid re-exporting from files; import directly from the source module
 
 **Before committing:** `npm run l && npm run f`
 


### PR DESCRIPTION
## Summary

- Move `npm run l && npm run f` before commit in the git workflow (was incorrectly placed after)
- Add code style guideline to avoid re-exporting from files