### PR TITLE
fix(test): make Google Live provider test order-agnostic

### DIFF
--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -671,21 +671,27 @@ describe('GoogleLiveProvider', () => {
     });
 
     // Check the specific calls made to the stateful API
+    // Note: Function call order may vary due to async processing, but all calls should be made
     const getCallUrls = mockFetchWithProxy.mock.calls.map((call) => call[0]);
-    const expectedUrls = [
-      'http://127.0.0.1:5000/get_count',
-      'http://127.0.0.1:5000/add_one',
-      'http://127.0.0.1:5000/get_count',
-      'http://127.0.0.1:5000/add_one',
-      'http://127.0.0.1:5000/get_count',
-      'http://127.0.0.1:5000/get_state',
-    ];
 
-    expect(getCallUrls).toEqual(expectedUrls);
+    // Verify total number of calls (5 function calls + 1 get_state)
+    expect(getCallUrls).toHaveLength(6);
+
+    // Verify get_state was called last (this is deterministic - happens in finalizeResponse)
     expect(mockFetchWithProxy).toHaveBeenLastCalledWith(
       'http://127.0.0.1:5000/get_state',
       undefined,
     );
+
+    // Verify all expected function calls were made (order may vary due to async)
+    const functionCallUrls = getCallUrls.slice(0, -1); // All except last (get_state)
+    expect(functionCallUrls.sort()).toEqual([
+      'http://127.0.0.1:5000/add_one',
+      'http://127.0.0.1:5000/add_one',
+      'http://127.0.0.1:5000/get_count',
+      'http://127.0.0.1:5000/get_count',
+      'http://127.0.0.1:5000/get_count',
+    ]);
   });
   describe('Python executable integration', () => {
     it('should handle Python executable validation correctly', async () => {


### PR DESCRIPTION
## Summary
- Fixes flaky test "should handle function tool calls to a spawned stateful api" in `test/providers/google/live.test.ts`

## Root Cause
The test used `setImmediate` to enqueue multiple WebSocket messages, but each `onmessage` handler is async. While messages fire in order on the event loop, the async handlers run concurrently, and the `await tryGetThenPost()` calls can resolve in any order, making the mock call order non-deterministic.

## Fix
Changed assertions to be order-agnostic:
- Verify total number of fetch calls (6)
- Verify `get_state` was called last (this is deterministic since it happens in `finalizeResponse` after WebSocket processing)
- Verify all expected function calls were made using sorted array comparison

## Test plan
- [x] Ran test 5+ times locally - all passed
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)