### PR TITLE
fix(webui): improve test cases table formatting in eval creator

### DIFF
--- a/src/app/src/components/ui/icons.tsx
+++ b/src/app/src/components/ui/icons.tsx
@@ -8,6 +8,7 @@
 
 export {
   AlertCircle as AlertCircleIcon,
+  AlertTriangle as AlertTriangleIcon,
   AlertTriangle as WarningIcon,
   ArrowLeft as ArrowBackIcon,
   ArrowRight as ArrowForwardIcon,

--- a/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
+++ b/src/app/src/pages/eval-creator/components/EvaluateTestSuiteCreator.tsx
@@ -446,13 +446,12 @@ const EvaluateTestSuiteCreator = () => {
                         <InfoBox variant="info">
                           <strong>Variables detected:</strong>{' '}
                           {varsList.map((v, i) => (
-                            <code
-                              key={v}
-                              className="bg-primary/20 text-primary px-1.5 py-0.5 rounded text-xs ml-1"
-                            >
-                              {v}
-                              {i < varsList.length - 1 ? ',' : ''}
-                            </code>
+                            <span key={v}>
+                              <code className="bg-primary/20 text-primary px-1.5 py-0.5 rounded text-xs">
+                                {v}
+                              </code>
+                              {i < varsList.length - 1 ? ', ' : ''}
+                            </span>
                           ))}
                           <p className="mt-2">
                             These variables will need values in your test cases below. Each test
@@ -536,13 +535,12 @@ const EvaluateTestSuiteCreator = () => {
                           <strong>Required variables:</strong> Each test case must provide values
                           for{' '}
                           {varsList.map((v, i) => (
-                            <code
-                              key={v}
-                              className="bg-primary/20 text-primary px-1.5 py-0.5 rounded text-xs ml-1"
-                            >
-                              {v}
-                              {i < varsList.length - 1 ? ',' : ''}
-                            </code>
+                            <span key={v}>
+                              <code className="bg-primary/20 text-primary px-1.5 py-0.5 rounded text-xs">
+                                {v}
+                              </code>
+                              {i < varsList.length - 1 ? ', ' : ''}
+                            </span>
                           ))}
                           <p className="mt-2">
                             Add assertions to automatically check if responses meet your quality

--- a/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
+++ b/src/app/src/pages/eval-creator/components/TestCasesSection.tsx
@@ -9,7 +9,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@app/components/ui/dialog';
-import { ContentCopyIcon, DeleteIcon, EditIcon, UploadIcon } from '@app/components/ui/icons';
+import {
+  AlertTriangleIcon,
+  ContentCopyIcon,
+  DeleteIcon,
+  EditIcon,
+  UploadIcon,
+} from '@app/components/ui/icons';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tooltip';
 import { useToast } from '@app/hooks/useToast';
 import { cn } from '@app/lib/utils';
@@ -288,79 +294,110 @@ const TestCasesSection = ({ varsList }: TestCasesSectionProps) => {
                 </td>
               </tr>
             ) : (
-              testCases.map((testCase, index) => (
-                <tr
-                  key={index}
-                  onClick={() => {
-                    setEditingTestCaseIndex(index);
-                    setTestCaseDialogOpen(true);
-                  }}
-                  className={cn(
-                    'border-b border-border cursor-pointer',
-                    'hover:bg-muted/50 transition-colors',
-                  )}
-                >
-                  <td className="px-4 py-3 text-sm">
-                    {testCase.description || `Test Case #${index + 1}`}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
-                    {testCase.assert?.length || 0} assertions
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground font-mono text-xs">
-                    {Object.entries(testCase.vars || {})
-                      .map(([k, v]) => `${k}=${v}`)
-                      .join(', ')}
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setEditingTestCaseIndex(index);
-                              setTestCaseDialogOpen(true);
-                            }}
-                          >
-                            <EditIcon className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Edit</TooltipContent>
-                      </Tooltip>
+              testCases.map((testCase, index) => {
+                const testCaseVars = Object.keys(testCase.vars || {});
+                const missingVars = varsList.filter((v) => !testCaseVars.includes(v));
+                const hasMissingVars = varsList.length > 0 && missingVars.length > 0;
 
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(event) => handleDuplicateTestCase(event, index)}
-                            aria-label="Duplicate test case"
-                          >
-                            <ContentCopyIcon className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Duplicate</TooltipContent>
-                      </Tooltip>
+                return (
+                  <tr
+                    key={index}
+                    onClick={() => {
+                      setEditingTestCaseIndex(index);
+                      setTestCaseDialogOpen(true);
+                    }}
+                    className={cn(
+                      'border-b border-border cursor-pointer',
+                      'hover:bg-muted/50 transition-colors',
+                      hasMissingVars && 'bg-amber-50/50 dark:bg-amber-950/20',
+                    )}
+                  >
+                    <td className="px-4 py-3 text-sm">
+                      <div className="flex items-center gap-2">
+                        {hasMissingVars && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <AlertTriangleIcon className="h-4 w-4 text-amber-500 flex-shrink-0" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Missing variables: {missingVars.join(', ')}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                        {testCase.description || (
+                          <span className="text-muted-foreground italic">
+                            Test Case #{index + 1}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      {testCase.assert?.length ? (
+                        `${testCase.assert.length} assertion${testCase.assert.length === 1 ? '' : 's'}`
+                      ) : (
+                        <span className="text-muted-foreground/60">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground font-mono text-xs">
+                      {Object.keys(testCase.vars || {}).length > 0 ? (
+                        Object.entries(testCase.vars || {})
+                          .map(([k, v]) => `${k}=${v}`)
+                          .join(', ')
+                      ) : (
+                        <span className="font-sans text-muted-foreground/60">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setEditingTestCaseIndex(index);
+                                setTestCaseDialogOpen(true);
+                              }}
+                            >
+                              <EditIcon className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Edit</TooltipContent>
+                        </Tooltip>
 
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(event) => handleRemoveTestCase(event, index)}
-                            aria-label="Delete test case"
-                          >
-                            <DeleteIcon className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Delete</TooltipContent>
-                      </Tooltip>
-                    </div>
-                  </td>
-                </tr>
-              ))
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(event) => handleDuplicateTestCase(event, index)}
+                              aria-label="Duplicate test case"
+                            >
+                              <ContentCopyIcon className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Duplicate</TooltipContent>
+                        </Tooltip>
+
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(event) => handleRemoveTestCase(event, index)}
+                              aria-label="Delete test case"
+                            >
+                              <DeleteIcon className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Delete</TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary

- Show em-dash (—) instead of blank for empty variables/assertions columns
- Style placeholder test case names ("Test Case #N") in italic muted text  
- Add warning indicator (amber background + icon) for test cases missing required variables
- Fix comma styling in variable badges - comma now appears outside the highlighted code element

## Screenshots

### Variable badges with comma fix
The comma now appears outside the highlighted badges:

![Variables detected](https://iili.io/fWoTCBa.png)

### Test cases table with formatting improvements
Empty test case shows em-dash (—) for empty columns, italic placeholder name:

![Test cases table](https://iili.io/fWoTupI.png)

## Changes

**TestCasesSection.tsx:**
- Empty Variables column now shows `—` instead of blank
- Empty Assertions column shows `—` instead of "0 assertions"
- Generic "Test Case #N" placeholders styled in italic muted text
- Rows with missing required variables get amber background highlight
- Warning icon with tooltip shows which variables are missing

**EvaluateTestSuiteCreator.tsx:**
- Fixed comma placement in "Variables detected" and "Required variables" info boxes
- Commas now render outside the highlighted `<code>` badges

**icons.tsx:**
- Added `AlertTriangleIcon` export

## Test plan

- [ ] Navigate to eval creator page (/setup)
- [ ] Add test cases with and without variables/assertions
- [ ] Verify empty columns show "—" instead of blank
- [ ] Verify test cases without descriptions show italic placeholder
- [ ] Add a prompt with variables, then add test cases missing those variables
- [ ] Verify warning icon appears with tooltip showing missing variables
- [ ] Check "Variables detected" info box shows commas outside highlighted badges