### PR TITLE
docs: clarify commit policy - always create new commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ npm run local -- eval -c config.yaml --no-cache
 
 - **NEVER** commit/push directly to main
 - **NEVER** use `--force` without explicit approval
-- **ALWAYS create new commits** - never amend, squash, or rebase existing commits unless the user explicitly asks (e.g., "amend the last commit", "squash these", "rebase onto main")
+- **ALWAYS create new commits** - never amend, squash, or rebase unless explicitly asked
 - All changes go through pull requests
 
 **Standard workflow:**

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -16,38 +16,11 @@
 
 All changes to main MUST go through pull requests.
 
-## Commit Policy: Always Create New Commits
+## Commit Policy
 
-**Default behavior:** Create fresh commits. Never modify existing commit history.
+**"Explicitly asked"** = user says "amend", "squash", "rebase", or "fix up the commit".
 
-**Forbidden without explicit user request:**
-
-- `git commit --amend`
-- `git rebase -i` or any interactive rebase
-- `git reset` followed by recommitting
-- `git push --force` or `--force-with-lease`
-- Squashing commits
-
-**"Explicit request" means the user literally says:**
-
-- "amend the last commit" / "update the commit message"
-- "squash these commits together"
-- "rebase onto main"
-- "fix up the previous commit"
-
-Vague approval like "looks good" or "go ahead" is NOT permission to amend.
-
-**If you make a mistake:** Create a new fix commit rather than amending:
-
-```bash
-git commit -m "fix(scope): correct typo in previous commit"
-```
-
-**Why this matters:**
-
-- Preserves history for debugging and auditing
-- Avoids force-push conflicts in collaboration
-- Keeps clear record of incremental progress
+"Looks good" or "go ahead" is NOT permission to rewrite history.
 
 ## Standard Workflow
 


### PR DESCRIPTION
## Summary

Strengthens git commit guidance for AI agents to prevent unwanted history modifications:

- Adds explicit "ALWAYS create new commits" rule to AGENTS.md
- Adds dedicated "Commit Policy" section to git-workflow.md
- Clarifies what constitutes an "explicit request" to amend (e.g., user must literally say "amend", "squash", "rebase")
- Explains that vague approval is not permission to modify history

## Why

The previous guidance only stated what NOT to do (`--amend`, `--force`) without clearly stating the default behavior (create new commits). This led to ambiguity about when amending was acceptable.