### PR TITLE
fix(app): remove underline from navbar dropdown items

### DIFF
--- a/src/app/src/components/Navigation.tsx
+++ b/src/app/src/components/Navigation.tsx
@@ -92,8 +92,8 @@ function NavDropdown({ label, items, isActiveCheck }: NavDropdownProps) {
                 <Link
                   to={item.href}
                   className={cn(
-                    'block select-none rounded-lg px-3 py-2.5 outline-none transition-colors',
-                    'hover:bg-accent',
+                    'block select-none rounded-lg px-3 py-2.5 outline-none transition-colors no-underline',
+                    'hover:bg-accent hover:no-underline',
                     'focus:bg-accent',
                     index !== items.length - 1 && 'mb-0.5',
                   )}


### PR DESCRIPTION
dropdown menu links were getting underlined on hover from global css

now it looks like this

<img width="343" height="264" alt="image" src="https://github.com/user-attachments/assets/56975c09-87d1-4c1c-8102-c989f4ceb297" />
