### PR TITLE
test: resolve lint errors in smoke tests

### DIFF
--- a/test/smoke/advanced-features.test.ts
+++ b/test/smoke/advanced-features.test.ts
@@ -18,6 +18,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/cli.test.ts
+++ b/test/smoke/cli.test.ts
@@ -6,9 +6,10 @@
  *
  * @see docs/plans/smoke-tests.md for the full checklist
  */
-import { execSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/configs-and-providers.test.ts
+++ b/test/smoke/configs-and-providers.test.ts
@@ -9,6 +9,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/eval.test.ts
+++ b/test/smoke/eval.test.ts
@@ -9,6 +9,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary
@@ -59,7 +60,7 @@ describe('Eval Smoke Tests', () => {
   describe('1.4 Eval Command', () => {
     it('1.4.1 - runs basic eval with echo provider', () => {
       const configPath = path.join(FIXTURES_DIR, 'configs/basic.yaml');
-      const { stdout, stderr, exitCode } = runCli(['eval', '-c', configPath, '--no-cache']);
+      const { stdout, exitCode } = runCli(['eval', '-c', configPath, '--no-cache']);
 
       // Should complete successfully
       expect(exitCode).toBe(0);

--- a/test/smoke/features-and-assertions.test.ts
+++ b/test/smoke/features-and-assertions.test.ts
@@ -9,6 +9,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/filters-and-flags.test.ts
+++ b/test/smoke/filters-and-flags.test.ts
@@ -10,6 +10,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary
@@ -647,7 +648,7 @@ describe('Output Flag Tests', () => {
     const configPath = path.join(CONFIGS_DIR, 'basic.yaml');
     const outputPath = path.join(OUTPUT_DIR, 'no-write-output.json');
 
-    const { exitCode, stdout } = runCli(
+    const { exitCode } = runCli(
       ['eval', '-c', configPath, '-o', outputPath, '--no-cache', '--no-write'],
       { cwd: CONFIGS_DIR },
     );
@@ -656,9 +657,6 @@ describe('Output Flag Tests', () => {
 
     // The eval should still complete and write to the output file
     expect(fs.existsSync(outputPath)).toBe(true);
-
-    // Check that stdout doesn't mention storing to database
-    // (This is a soft check - the main thing is it doesn't error)
   });
 });
 

--- a/test/smoke/fixtures/providers/grader-function.js
+++ b/test/smoke/fixtures/providers/grader-function.js
@@ -5,7 +5,7 @@
  * This is a grader that always passes.
  */
 
-module.exports = async function (prompt, context) {
+module.exports = async function (_prompt, context) {
   // Simple grader that checks if output contains expected content
   const output = context.vars?.output || '';
   const pass = output.length > 0;

--- a/test/smoke/js-ts-and-data.test.ts
+++ b/test/smoke/js-ts-and-data.test.ts
@@ -9,6 +9,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/output-and-assertions.test.ts
+++ b/test/smoke/output-and-assertions.test.ts
@@ -18,6 +18,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary

--- a/test/smoke/regression-0120.test.ts
+++ b/test/smoke/regression-0120.test.ts
@@ -16,6 +16,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary
@@ -223,14 +224,7 @@ describe('0.120.x Regression Tests', () => {
         const configPath = path.join(FIXTURES_DIR, 'configs/max-concurrency-config.yaml');
         const outputPath = path.join(OUTPUT_DIR, 'max-concurrency-output.json');
 
-        const { exitCode, stderr } = runCli([
-          'eval',
-          '-c',
-          configPath,
-          '-o',
-          outputPath,
-          '--no-cache',
-        ]);
+        const { exitCode } = runCli(['eval', '-c', configPath, '-o', outputPath, '--no-cache']);
 
         expect(exitCode).toBe(0);
 

--- a/test/smoke/regression-recent.test.ts
+++ b/test/smoke/regression-recent.test.ts
@@ -13,6 +13,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Path to the built CLI binary


### PR DESCRIPTION
## Summary

Fixes style check failures on main introduced in #6669 (smoke tests).

**Issues fixed:**
- Removed unused import `execSync` from `cli.test.ts`
- Removed unused variables (`stderr`, `stdout`) in `eval.test.ts`, `filters-and-flags.test.ts`, and `regression-0120.test.ts`
- Prefixed unused function parameter with underscore in `grader-function.js`
- Fixed import organization (added blank line between node and vitest imports) in 10 files

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)