### PR TITLE
feat(app): add apiBaseUrl field to provider configuration UI

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.test.tsx
@@ -22,6 +22,7 @@ describe('FoundationModelConfiguration', () => {
       max_tokens: 1024,
       top_p: 0.9,
       apiKey: 'test-key-123',
+      apiBaseUrl: 'https://custom.api.example.com/v1',
     },
   };
 
@@ -45,11 +46,13 @@ describe('FoundationModelConfiguration', () => {
     const maxTokensInput = screen.getByLabelText('Max Tokens');
     const topPInput = screen.getByLabelText('Top P');
     const apiKeyInput = screen.getByLabelText('API Key');
+    const apiBaseUrlInput = screen.getByLabelText('API Base URL');
 
     expect(temperatureInput).toHaveValue(0.7);
     expect(maxTokensInput).toHaveValue(1024);
     expect(topPInput).toHaveValue(0.9);
     expect(apiKeyInput).toHaveValue('test-key-123');
+    expect(apiBaseUrlInput).toHaveValue('https://custom.api.example.com/v1');
 
     fireEvent.change(temperatureInput, { target: { value: '0.8' } });
     expect(mockUpdateCustomTarget).toHaveBeenCalledWith('temperature', 0.8);
@@ -62,6 +65,12 @@ describe('FoundationModelConfiguration', () => {
 
     fireEvent.change(apiKeyInput, { target: { value: 'new-api-key' } });
     expect(mockUpdateCustomTarget).toHaveBeenCalledWith('apiKey', 'new-api-key');
+
+    fireEvent.change(apiBaseUrlInput, { target: { value: 'https://new.api.example.com/v2' } });
+    expect(mockUpdateCustomTarget).toHaveBeenCalledWith(
+      'apiBaseUrl',
+      'https://new.api.example.com/v2',
+    );
   });
 
   it('should display the initial Model ID from selectedTarget.id when rendered', () => {
@@ -135,6 +144,25 @@ describe('FoundationModelConfiguration', () => {
     const temperatureInput = screen.getByLabelText('Temperature');
     fireEvent.change(temperatureInput, { target: { value: '' } });
     expect(mockUpdateCustomTarget).toHaveBeenCalledWith('temperature', undefined);
+  });
+
+  it('should call updateCustomTarget with undefined when API Base URL field is cleared', () => {
+    renderWithTheme(
+      <FoundationModelConfiguration
+        selectedTarget={initialTarget}
+        updateCustomTarget={mockUpdateCustomTarget}
+        providerType="openai"
+      />,
+    );
+
+    const accordionSummary = screen.getByRole('button', { name: /Advanced Configuration/ });
+    fireEvent.click(accordionSummary);
+
+    const apiBaseUrlInput = screen.getByLabelText('API Base URL');
+    expect(apiBaseUrlInput).toHaveValue('https://custom.api.example.com/v1');
+
+    fireEvent.change(apiBaseUrlInput, { target: { value: '' } });
+    expect(mockUpdateCustomTarget).toHaveBeenCalledWith('apiBaseUrl', undefined);
   });
 
   it('should display the correct Model ID placeholder for the azure provider', () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
@@ -215,6 +215,20 @@ const FoundationModelConfiguration = ({
                 Optional - defaults to {providerInfo.envVar} environment variable
               </p>
             </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="api-base-url">API Base URL</Label>
+              <Input
+                id="api-base-url"
+                type="url"
+                value={selectedTarget.config?.apiBaseUrl ?? ''}
+                onChange={(e) => updateCustomTarget('apiBaseUrl', e.target.value || undefined)}
+                placeholder="https://api.openai.com/v1"
+              />
+              <p className="text-sm text-muted-foreground">
+                For proxies, local models (Ollama, LMStudio), or custom API endpoints
+              </p>
+            </div>
           </div>
         </SetupSection>
       </div>


### PR DESCRIPTION
## Summary

Adds an **API Base URL** field to the provider configuration UI for foundation model providers (OpenAI, Anthropic, Google, Vertex, Mistral, Cohere, Groq, DeepSeek, Azure, OpenRouter, Perplexity, Cerebras).

This enables users to configure custom endpoints directly in the web UI for:
- API proxies and gateways
- Local models with OpenAI-compatible APIs (Ollama, LMStudio, vLLM)
- Enterprise/self-hosted deployments
- Custom API endpoints

The field appears in the Advanced Configuration section alongside the existing API Key field.

## Test plan

- [x] Unit tests added for apiBaseUrl field display and onChange behavior
- [x] Verified field appears in UI and updates provider config correctly
- [x] All 14 existing tests pass

Closes #4536