### PR TITLE
fix(test): resolve flaky google live provider test

### DIFF
--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -652,6 +652,9 @@ describe('GoogleLiveProvider', () => {
       json: vi.fn().mockResolvedValue({ counter: 5 }),
     } as any);
 
+    // Clear any call history from previous tests to ensure accurate count
+    mockFetchWithProxy.mockClear();
+
     const response = await provider.callApi('Add to the counter until it reaches 5');
     expect(response).toEqual({
       output: {


### PR DESCRIPTION
## Summary
- Fix flaky test `should handle function tool calls to a spawned stateful api` in `test/providers/google/live.test.ts`
- Add `mockFetchWithProxy.mockClear()` before API call to prevent test pollution

## Problem
The test was intermittently failing with:
```
expected [ …(7) ] to have a length of 6 but got 7
```

When tests run in random order, async callbacks scheduled via `setImmediate` from previous tests could add unexpected calls to the mock's call history, causing the count assertion to fail.

## Solution
Clear the mock's call history after setting up the mock implementation but before making the API call. This ensures only calls made during the test's own execution are counted.

## Test plan
- [x] Verified test passes consistently with multiple runs
- [x] All 43 tests in the file pass