### PR TITLE
fix(redteam): prevent nunjucks error on template syntax in attack prompts

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -354,7 +354,10 @@ export async function runEval({
 
   try {
     // Render the prompt
-    const renderedPrompt = await renderPrompt(prompt, vars, filters, provider);
+    // For redteam tests, skip rendering the inject variable to prevent double-rendering of
+    // attack payloads that may contain template syntax (e.g., {{purpose | trim}})
+    const skipRenderVars = isRedteam ? [testSuite?.redteam?.injectVar ?? 'prompt'] : undefined;
+    const renderedPrompt = await renderPrompt(prompt, vars, filters, provider, skipRenderVars);
     let renderedJson = undefined;
     try {
       renderedJson = JSON.parse(renderedPrompt);


### PR DESCRIPTION
## Summary

Fixes an issue where redteam evaluations fail with `TypeError: Cannot read properties of undefined (reading 'replace')` when attack prompts contain nunjucks template syntax like `{{purpose | trim}}`.

**Root cause:** Attack prompts generated by remote services or LLMs may contain literal template syntax. During evaluation, `renderPrompt()` attempts to render these through nunjucks, but variables like `purpose` are undefined at evaluation time (they were only available during test generation). The `trim` filter then fails when calling `.replace()` on undefined.

**Fix:** Skip template rendering for the redteam inject variable by passing `skipRenderVars` to `renderPrompt()`. This ensures attack payloads are passed through to the target system as-is, which is the intended behavior documented in the `skipRenderVars` parameter.

## Changes

- `src/evaluator.ts`: Pass `skipRenderVars` with the inject variable name for redteam tests
- `test/evaluator.test.ts`: Add integration tests for the fix
- `test/evaluatorHelpers-skiprender.test.ts`: Add unit test for the specific error scenario

## Test plan

- [x] Added unit test reproducing the exact error scenario (`{{purpose | trim}}` in attack prompt)
- [x] Added integration test for explicit `injectVar` configuration
- [x] Added integration test for default `injectVar` fallback (`'prompt'`)
- [x] All existing tests pass