### PR TITLE
fix(esm): suppress spurious error logs during config file discovery

### DIFF
--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -116,7 +116,8 @@ describe('ESM utilities', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as NodeJS.ErrnoException).code).toBe('ENOENT');
       expect((error as NodeJS.ErrnoException).path).toBe(nonExistentPath);
-      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('ESM import failed'));
+      // Should NOT log error for missing files - this is expected during config discovery
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('logs debug information during import process', async () => {


### PR DESCRIPTION
## Summary

- Fix spurious "ESM import failed" error messages during startup when no JS/TS config files exist
- Only log errors for genuine import failures, not expected file-not-found cases during config discovery

## Problem

During startup, `loadDefaultConfig()` probes for config files with multiple extensions (yaml, yml, json, cjs, cts, js, mjs, mts, ts). For JS/TS extensions, `importModule()` was logging error messages for every non-existent file:

```
ESM import failed: Error: Cannot find module '/path/to/promptfooconfig.cjs' ...
ESM import failed: Error: Cannot find module '/path/to/promptfooconfig.cts' ...
ESM import failed: Error: Cannot find module '/path/to/promptfooconfig.js' ...
... (12+ messages)
```

This cluttered the output during normal operation.

## Solution

Restructure error handling in `importModule()` to distinguish between:

| Scenario | Behavior |
|----------|----------|
| `ERR_MODULE_NOT_FOUND` + file doesn't exist | Silent ENOENT thrown (expected during discovery) |
| `ERR_MODULE_NOT_FOUND` + file exists | Log error (genuine - missing dependency) |
| Other errors | Log error (genuine failures) |

## Test plan

- [x] `npm test -- test/esm.test.ts` - all 31 tests pass
- [x] `npm test -- test/util/config` - all 88 tests pass
- [x] Manual test: `npx tsx src/main.ts eval -c examples/getting-started/promptfooconfig.yaml` - no spurious errors
- [x] Manual test: non-existent provider file shows clear ENOENT message
- [x] Manual test: provider with missing dependency still logs error