### PR TITLE
fix(ci): add code-scan-action to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 # ============================================================================
 
 /src/codeScan/   @danenania                          # 2.5k lines - Dane (91%)
+/code-scan-action/  @danenania                          # GitHub Action for code scan
 /src/validators/ @faizanminhas @mldangelo                # 1.5k lines - Faizan (55%)
 
 # ============================================================================
@@ -46,6 +47,7 @@
 # ============================================================================
 
 /test/codeScans/   @danenania
+/test/code-scan-action/  @danenania                      # Tests for GitHub Action
 /test/redteam/     @mldangelo @MrFlounder @will-holley
 /test/validators/  @faizanminhas @mldangelo
 /test/providers/   @MrFlounder @mldangelo                # Provider tests


### PR DESCRIPTION
## Summary
- Adds `@danenania` as owner for `/code-scan-action/` and `/test/code-scan-action/` directories
- These directories are part of the code scan domain that @danenania already owns (`/src/codeScan/` and `/test/codeScans/`)

## Context
PR #6892 modified `code-scan-action/` without @danenania being tagged as a reviewer because the directory was missing from CODEOWNERS.

## Test plan
- [x] CODEOWNERS syntax is valid
- [ ] Future PRs touching code-scan-action will correctly tag @danenania

🤖 Generated with [Claude Code](https://claude.com/claude-code)