### PR TITLE
fix(app): prevent duplicate fail reasons in eval results carousel

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -257,7 +257,8 @@ function EvalOutputCell({
   }
 
   // Include provider-level error if present (e.g., from Python provider returning error)
-  if (output.error) {
+  // Only add for true provider errors (ERROR), not assertion failures (ASSERT) which are already in componentResults
+  if (output.error && output.failureReason === ResultFailureReason.ERROR) {
     failReasons.unshift(output.error);
   }
 


### PR DESCRIPTION
## Summary

- Fixes issue where the fail reason carousel showed duplicate entries for assertion failures
- When an assertion fails, `output.error` is set to the same reason as the failed assertion (in `evaluator.ts`)
- PR #6552 added code to display `output.error` in the carousel for provider errors (#1037), but this also caused assertion failures to be duplicated since they appear in both `output.error` and `componentResults`
- The fix only adds `output.error` to `failReasons` when `failureReason === ResultFailureReason.ERROR` (true provider errors), not `ASSERT` (assertion failures already in `componentResults`)

## Root Cause

Two different scenarios set `output.error` in `evaluator.ts`:

1. **Provider errors** (line 494-497): `ret.error = response.error` with `failureReason = ERROR`
2. **Assertion failures** (line 568-571): `ret.error = checkResult.reason` with `failureReason = ASSERT`

The frontend was adding `output.error` unconditionally, causing duplication for assertion failures.

## Test Plan

- [x] Added unit test verifying assertion failures don't duplicate the error message
- [x] Verified existing provider error tests still pass (4 tests)
- [x] All 86 EvalOutputCell tests pass
- [x] E2E tested both scenarios:
  - Provider error: error displays correctly ✅
  - Assertion failure: no duplication ✅

Fixes #6915