### PR TITLE
ci: add Prettier formatting to Tusk workflows

### DIFF
--- a/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
@@ -87,23 +87,29 @@ jobs:
             set -e
 
             FILE_PATH="{{file}}"
+
+            # Validate no shell metacharacters in file path
+            if [[ "$FILE_PATH" =~ [\;\|\&\$\`\<\>\(\)] ]]; then
+              echo "Error: Invalid characters in file path: $FILE_PATH"
+              exit 1
+            fi
+
             EXT="${FILE_PATH##*.}"
             FULL_PATH="src/app/$FILE_PATH"
 
             cd ../..
 
-            # Format based on file extension
+            # Format based on file extension (use -- to prevent flag injection)
             case "$EXT" in
               js|jsx|mjs|cjs|ts|tsx|json)
-                npx @biomejs/biome format --write "$FULL_PATH"
-                npx @biomejs/biome lint --write "$FULL_PATH"
+                npx @biomejs/biome format --write -- "$FULL_PATH"
+                npx @biomejs/biome lint --write -- "$FULL_PATH"
                 ;;
               css|scss|html|md|mdc|mdx|yaml|yml)
-                npx prettier --write "$FULL_PATH"
+                npx prettier --write -- "$FULL_PATH"
                 ;;
               *)
-                # For other extensions, try Biome first
-                npx @biomejs/biome check --write "$FULL_PATH" 2>/dev/null || true
+                echo "Skipping unsupported file type: $FILE_PATH"
                 ;;
             esac
 

--- a/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
@@ -80,19 +80,25 @@ jobs:
           # Format with Biome (JS/TS/JSON) and Prettier (CSS/MD/YAML), then lint
           lintScript: |
             FILE="{{file}}"
+
+            # Validate no shell metacharacters in file path
+            if [[ "$FILE" =~ [\;\|\&\$\`\<\>\(\)] ]]; then
+              echo "Error: Invalid characters in file path: $FILE"
+              exit 1
+            fi
+
             EXT="${FILE##*.}"
 
-            # Format based on file extension
+            # Format based on file extension (use -- to prevent flag injection)
             case "$EXT" in
               js|jsx|mjs|cjs|ts|tsx|json)
-                npx @biomejs/biome check --write "$FILE"
+                npx @biomejs/biome check --write -- "$FILE"
                 ;;
               css|scss|html|md|mdc|mdx|yaml|yml)
-                npx prettier --write "$FILE"
+                npx prettier --write -- "$FILE"
                 ;;
               *)
-                # For other extensions, try Biome first
-                npx @biomejs/biome check --write "$FILE" 2>/dev/null || true
+                echo "Skipping unsupported file type: $FILE"
                 ;;
             esac
 


### PR DESCRIPTION
## Summary

Fixes Tusk workflows to use the correct formatter based on file type. The repo uses both Biome AND Prettier, but the Tusk `lintScript` was only running Biome.

**File types and their formatters:**
| Extension | Formatter |
|-----------|-----------|
| `.js`, `.jsx`, `.ts`, `.tsx`, `.json` | Biome |
| `.css`, `.scss`, `.html`, `.md`, `.yaml`, `.yml` | Prettier |

## Problem

When Tusk touched CSS, Markdown, or YAML files, they weren't being formatted with Prettier, causing CI formatting checks to fail after Tusk created a PR.

## Solution

Updated `lintScript` in both Tusk workflows to:
1. Extract file extension
2. Run Biome for JS/TS/JSON files
3. Run Prettier for CSS/HTML/MD/YAML files
4. Fallback to Biome for unknown extensions

## Files Changed

- `.github/workflows/tusk-test-runner-vitest-unit-tests.yml`
- `.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml`

## Test Plan

- [ ] Verify YAML syntax is valid (CI: GitHub Actions Lint)
- [ ] Test Tusk workflow on a PR that touches both `.ts` and `.css` files