### PR TITLE
fix(webui): improve eval dialog tab styling

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -407,14 +407,14 @@ export default function EvalOutputPromptDialog({
           <TabsList className="w-full justify-start rounded-none border-b border-border bg-transparent px-4 h-auto py-0">
             <TabsTrigger
               value="prompt-output"
-              className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent py-3"
+              className="-mb-px rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none py-3"
             >
               {hasOutputContent ? 'Prompt & Output' : 'Prompt'}
             </TabsTrigger>
             {hasEvaluationData && (
               <TabsTrigger
                 value="evaluation"
-                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent py-3"
+                className="-mb-px rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none py-3"
               >
                 Evaluation
               </TabsTrigger>
@@ -422,7 +422,7 @@ export default function EvalOutputPromptDialog({
             {hasMessagesData && (
               <TabsTrigger
                 value="messages"
-                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent py-3"
+                className="-mb-px rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none py-3"
               >
                 Messages
               </TabsTrigger>
@@ -430,7 +430,7 @@ export default function EvalOutputPromptDialog({
             {hasMetadata && (
               <TabsTrigger
                 value="metadata"
-                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent py-3"
+                className="-mb-px rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none py-3"
               >
                 Metadata
               </TabsTrigger>
@@ -438,7 +438,7 @@ export default function EvalOutputPromptDialog({
             {hasTracesData && (
               <TabsTrigger
                 value="traces"
-                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent py-3"
+                className="-mb-px rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none py-3"
               >
                 Traces
               </TabsTrigger>


### PR DESCRIPTION
## Summary

This PR fixes the tab styling in the eval details dialog to provide a cleaner, more professional appearance.

### Changes

- **Removed box shadow** from active tabs (added `data-[state=active]:shadow-none`)
- **Fixed double underline issue** by adding negative margin (`-mb-px`) so active tab's border overlaps the list border
- Tabs now display a clean single blue underline when selected instead of a boxy appearance

### Before & After

Before 

<img width="456" height="303" alt="Screenshot 2026-01-04 at 3 17 34 AM" src="https://github.com/user-attachments/assets/1f01f622-327a-43d2-878f-1f6fc8ac722e" />

After 

<img width="468" height="311" alt="Screenshot 2026-01-04 at 3 17 17 AM" src="https://github.com/user-attachments/assets/adae2987-3e4a-4606-a347-21149b98eee1" />
<img width="445" height="303" alt="Screenshot 2026-01-04 at 3 17 11 AM" src="https://github.com/user-attachments/assets/5b5b3425-97db-4605-8d59-cf45d7eebfa2" />
<img width="496" height="486" alt="Screenshot 2026-01-04 at 3 17 05 AM" src="https://github.com/user-attachments/assets/c2766e8a-2fc2-4ca6-9840-d31515b51421" />
<img width="468" height="439" alt="Screenshot 2026-01-04 at 3 01 53 AM" src="https://github.com/user-attachments/assets/a542a9a4-ae11-41eb-a9fe-eb7f755a59bb" />


## Testing


Verified in both light and dark modes:
1. Open eval results at localhost:3000/eval
2. Click on any result to open the details panel
3. Switch between tabs (Prompt & Output, Evaluation, etc.)
4. Confirm single blue underline appears under active tab
5. Confirm no box shadow or double-line effect