### PR TITLE
fix(ci): increase claude-review max-turns from 10 to 30

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,4 +77,4 @@ jobs:
 
             Post your review as a single comment using `gh pr comment ${{ github.event.pull_request.number }}`.
             Use ✅ if no critical issues, ⚠️ if issues found.
-          claude_args: '--max-turns 10 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--max-turns 30 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary

The `claude-review` GitHub Action was failing with `error_max_turns` because 10 turns was insufficient for completing thorough security reviews on larger PRs.

## Changes

- Increased `--max-turns` from 10 to 30 in `.github/workflows/claude-code-review.yml`

## Impact

This provides adequate room for the Claude Code agent to:
- Read multiple files
- Analyze complex changes  
- Run security checks
- Post comprehensive review comments

Without exhausting the turn limit prematurely.

## Workflow Validation Note

⚠️ This PR will show a workflow failure because GitHub's security feature prevents modified workflow files from running in PRs (to prevent malicious code execution). The workflow can only execute using the version from the main branch.

**This is expected behavior** - once merged, the updated workflow will work correctly for all future PRs.