### PR TITLE
chore(docs): standardize Node.js version requirements

### DIFF
--- a/examples/http-provider-auth-signature-jks/README.md
+++ b/examples/http-provider-auth-signature-jks/README.md
@@ -12,7 +12,7 @@ This example demonstrates how to setup authentication with an HTTP provider usin
 
 ## Prerequisites
 
-- Node.js 20.0.0 or higher
+- Node.js 20+
 - A JKS keystore file with a keypair for signing/verification
 
 ## Setup

--- a/examples/http-provider-auth-signature-pfx/README.md
+++ b/examples/http-provider-auth-signature-pfx/README.md
@@ -15,7 +15,7 @@ This example demonstrates how to setup authentication with an HTTP provider usin
 
 ## Prerequisites
 
-- Node.js 20.0.0 or higher
+- Node.js 20+
 - Either a PFX certificate file OR separate CRT and KEY files with a keypair for signing/verification
 
 ## Setup

--- a/examples/node-package-typescript/README.md
+++ b/examples/node-package-typescript/README.md
@@ -10,7 +10,7 @@ This example demonstrates using promptfoo from a TypeScript script.
 
 ## Prerequisites
 
-- Node.js (version 20 or higher)
+- Node.js 20+
 - TypeScript and tsx (installed via npm dependencies)
 - API keys for LLM providers set as environment variables:
   - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)

--- a/examples/node-package/README.md
+++ b/examples/node-package/README.md
@@ -10,7 +10,7 @@ This example demonstrates using promptfoo from a Node.js script.
 
 ## Prerequisites
 
-- Node.js (version 20 or higher)
+- Node.js 20+
 - API keys for LLM providers set as environment variables:
   - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
   - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)

--- a/examples/openai-codex-sdk/README.md
+++ b/examples/openai-codex-sdk/README.md
@@ -16,7 +16,7 @@ Install the OpenAI Codex SDK:
 npm install @openai/codex-sdk
 ```
 
-**Requirements**: Node.js 18+
+**Requirements**: Node.js 20+
 
 Set your OpenAI API key:
 

--- a/examples/redteam-api-top-10/README.md
+++ b/examples/redteam-api-top-10/README.md
@@ -34,7 +34,7 @@ npx promptfoo@latest redteam run
 ## Prerequisites
 
 - Python 3.10+
-- Node.js 18+ (for filesystem MCP server)
+- Node.js 20+ (for filesystem MCP server)
 - [uv](https://docs.astral.sh/uv/) package manager
 - Anthropic API key
 

--- a/examples/redteam-mcp-agent/README.md
+++ b/examples/redteam-mcp-agent/README.md
@@ -19,7 +19,7 @@ The example includes:
 
 ## Prerequisites
 
-- Node.js (v20 or higher)
+- Node.js 20+
 - Python 3.8+ (for the Python MCP server example)
 - OpenAI API key
 

--- a/examples/redteam-mcp/README.md
+++ b/examples/redteam-mcp/README.md
@@ -22,7 +22,7 @@ export ANTHROPIC_API_KEY=your_anthropic_key_here
 
 ## Prerequisites
 
-- Node.js (v20+)
+- Node.js 20+
 
 ## Getting Started
 

--- a/examples/redteam-medical-agent/README.md
+++ b/examples/redteam-medical-agent/README.md
@@ -20,7 +20,7 @@ npx promptfoo@latest init --example redteam-medical-agent
 
 ## Prerequisites
 
-- Node.js 20 or higher
+- Node.js 20+
 - npm or yarn
 - OpenAI API key for the agent
 

--- a/examples/redteam-ollama/README.md
+++ b/examples/redteam-ollama/README.md
@@ -10,7 +10,7 @@ This example shows how to red team an Ollama model using promptfoo. For a detail
 
 ## Prerequisites
 
-1. Install Node.js version 20 or later. [Download Node.js](https://nodejs.org/en/download/)
+1. Install Node.js 20+. [Download Node.js](https://nodejs.org/en/download/)
 2. Install Ollama from [ollama.ai](https://ollama.ai)
 3. Start the Ollama service:
 

--- a/examples/stateful-session-management/README.md
+++ b/examples/stateful-session-management/README.md
@@ -10,7 +10,7 @@ npx promptfoo@latest init --example stateful-session-management
 
 ## Requirements
 
-- Node.js 18+
+- Node.js 20+
 - An OpenAI API key in `OPENAI_API_KEY`
 
 ## Setup

--- a/examples/ts-config/README.md
+++ b/examples/ts-config/README.md
@@ -14,7 +14,7 @@ This example demonstrates TypeScript configuration for promptfoo, including:
 
 ## Prerequisites
 
-- Node.js 20 or later
+- Node.js 20+
 - TypeScript loader (`tsx` recommended)
 
 Install dependencies:

--- a/examples/websockets-streaming/README.md
+++ b/examples/websockets-streaming/README.md
@@ -20,7 +20,7 @@ npx promptfoo@latest init --example websocket-streaming
 
 ## Prerequisites
 
-- Node.js >= 18.17
+- Node.js 20+
 - An OpenAI API key set as `OPENAI_API_KEY`
 
 ## 1) Start the local WebSocket server

--- a/examples/websockets/README.md
+++ b/examples/websockets/README.md
@@ -10,7 +10,7 @@ This example shows how to connect promptfoo to a WebSocket-based LLM service.
 
 ## Prerequisites
 
-- Node.js (version 20 or higher)
+- Node.js 20+
 - API keys for LLM providers set as environment variables:
   - `OPENAI_API_KEY` - Get from [OpenAI API keys page](https://platform.openai.com/api-keys)
   - `ANTHROPIC_API_KEY` - Get from [Anthropic Console](https://console.anthropic.com/) (optional)

--- a/site/blog/beavertails.md
+++ b/site/blog/beavertails.md
@@ -66,7 +66,7 @@ Each test case includes:
 
 Before starting, make sure you have:
 
-- **Node.js**: Version 20 or later ([download](https://nodejs.org/))
+- **Node.js**: 20+ ([download](https://nodejs.org/))
 - **Promptfoo**: We'll use `npx` to run commands, so no separate installation is needed
 - **Model Access**: API keys or local setup for the models you want to test
 

--- a/site/blog/cyberseceval.md
+++ b/site/blog/cyberseceval.md
@@ -50,7 +50,7 @@ CyberSecEval is a benchmark suite designed by Meta to assess cybersecurity vulne
 
 Before starting, make sure you have:
 
-- **Node.js**: Version 20 or later ([download](https://nodejs.org/))
+- **Node.js**: 20+ ([download](https://nodejs.org/))
 - **Promptfoo**: We'll use `npx` to run commands, so no separate installation is needed
 - **Model Access**: API keys or local setup for the models you want to test
 

--- a/site/blog/how-to-jailbreak-llms.md
+++ b/site/blog/how-to-jailbreak-llms.md
@@ -611,7 +611,7 @@ For a full guide on how to use Promptfoo, check out the [Promptfoo quickstart](/
 
 1. Installation:
 
-Requires [Node.js](https://nodejs.org/en/download/) 20 or higher.
+Requires [Node.js](https://nodejs.org/en/download/) 20+.
 
 ```bash
 npm install -g promptfoo

--- a/site/blog/red-team-gemini.md
+++ b/site/blog/red-team-gemini.md
@@ -43,7 +43,7 @@ The unique capabilities of Gemini 2.5 Pro (and similar models in that family) pr
 
 Before you begin, ensure you have:
 
-- **Node.js**: Version 20 or later. [Download Node.js](https://nodejs.org/en/download/)
+- **Node.js 20+**: [Download Node.js](https://nodejs.org/en/download/)
 - **Google AI Studio API Key**: Sign up for a [Google AI Studio account](https://aistudio.google.com/) and obtain an API key
 - **Promptfoo**: No prior installation needed; we'll use `npx` to run commands
 

--- a/site/blog/red-team-gpt.md
+++ b/site/blog/red-team-gpt.md
@@ -41,7 +41,7 @@ GPT-4.1 and 4.5's new capabilities present unique security considerations:
 
 Before you begin, ensure you have:
 
-- **Node.js**: Version 20 or later. [Download Node.js](https://nodejs.org/en/download/)
+- **Node.js 20+**: [Download Node.js](https://nodejs.org/en/download/)
 - **OpenAI API Key**: Sign up for an [OpenAI account](https://platform.openai.com/) and obtain an API key
 - **Promptfoo**: No prior installation needed; we'll use `npx` to run commands
 

--- a/site/blog/red-team-huggingface-model.md
+++ b/site/blog/red-team-huggingface-model.md
@@ -37,7 +37,7 @@ You'll learn how to craft prompts that bypass safety filters and manipulate mode
 
 Before you begin, ensure you have the following:
 
-- **Node.js**: Install Node.js version 20 or later. [Download Node.js](https://nodejs.org/en/download/)
+- **Node.js 20+**: [Download Node.js](https://nodejs.org/en/download/)
 - **Promptfoo**: No prior installation is necessary; we'll use `npx` to run Promptfoo commands.
 - **HuggingFace API Token**: Sign up for a HuggingFace account and obtain an API token from your [account settings](https://huggingface.co/settings/tokens).
 

--- a/site/blog/red-team-langchain.md
+++ b/site/blog/red-team-langchain.md
@@ -42,7 +42,7 @@ You'll learn how to use adversarial LLM models to test your LangChain applicatio
 Before you begin, ensure you have the following:
 
 - **Python**: Python 3.8 or later
-- **Node.js**: Version 20 or later
+- **Node.js 20+**
 - **Promptfoo**: No prior installation needed; we'll use `npx`
 - **LangChain**: Install via pip: `pip install langchain`
 - **API Keys**: For your LLM provider (e.g., OpenAI, Anthropic)

--- a/site/blog/red-team-ollama-model.md
+++ b/site/blog/red-team-ollama-model.md
@@ -33,7 +33,7 @@ Here's an example of what the red team report looks like:
 
 Before you begin, ensure you have:
 
-- **Node.js**: Install Node.js version 20 or later. [Download Node.js](https://nodejs.org/en/download/)
+- **Node.js 20+**: [Download Node.js](https://nodejs.org/en/download/)
 - **Ollama**: Install Ollama from [ollama.ai](https://ollama.ai)
 - **Promptfoo**: No prior installation needed; we'll use `npx` to run commands
 

--- a/site/blog/red-teaming-prompt-airlines.md
+++ b/site/blog/red-teaming-prompt-airlines.md
@@ -27,7 +27,7 @@ In this blog, we'll demonstrate how to utilize Promptfoo's red team tool in a bl
 
 ## Prerequisites
 
-Before getting started, you'll need to install Node 20 or later in the IDE of your choice. You'll need an API key from your preferred LLM provider. Using a proxy such as Burp Suite may also help.
+Before getting started, you'll need to install Node.js 20+ in the IDE of your choice. You'll need an API key from your preferred LLM provider. Using a proxy such as Burp Suite may also help.
 
 ## Initial Reconnaissance
 

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -42,7 +42,7 @@ We particularly welcome contributions in the following areas:
    3.1. Setup locally
 
    ```bash
-   # Use the Node.js version specified in .nvmrc (node >= 20 required)
+   # Use the Node.js version specified in .nvmrc (Node.js >= 20.0.0 required)
    nvm use
 
    # Install dependencies (npm, pnpm, or yarn all work)

--- a/site/docs/guides/cohere-command-r-benchmark.md
+++ b/site/docs/guides/cohere-command-r-benchmark.md
@@ -18,7 +18,7 @@ The end result is a side-by-side comparison view that looks like this:
 - Cohere API key for Command-R
 - OpenAI API key for GPT-4
 - Anthropic API key for Claude Opus
-- Node 20+
+- Node.js 20+
 
 ## Step 1: Initial Setup
 

--- a/site/docs/guides/dbrx-benchmark.md
+++ b/site/docs/guides/dbrx-benchmark.md
@@ -19,7 +19,7 @@ The end result will be a custom benchmark that looks similar to this:
 
 - OpenRouter API key for DBRX and Mixtral.
 - OpenAI API key for gpt-5-mini
-- Node 18+
+- Node.js 20+
 
 ## Step 1: Initial Setup
 

--- a/site/docs/guides/deepseek-benchmark.md
+++ b/site/docs/guides/deepseek-benchmark.md
@@ -13,7 +13,7 @@ In this guide, we'll create a practical comparison that results in a detailed si
 
 ## Requirements
 
-- Node.js 20 or later
+- Node.js 20+
 - OpenRouter API access for Deepseek and Llama (set `OPENROUTER_API_KEY`)
 - OpenAI API access for GPT-4o and o3-mini (set `OPENAI_API_KEY`)
 

--- a/site/docs/guides/evaluate-crewai.md
+++ b/site/docs/guides/evaluate-crewai.md
@@ -43,7 +43,7 @@ promptfoo eval
 Before starting, make sure you have:
 
 - Python 3.10+
-- Node.js v18+
+- Node.js 20+
 - OpenAI API access (for GPT-4.1, GPT-4o, GPT-4.1-mini, or other models)
 - An OpenAI API key
 

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -54,7 +54,7 @@ You can also dig into specific red team failure cases:
 
 ## Prerequisites
 
-First, install [Node 20 or later](https://nodejs.org/en/download/package-manager/).
+First, install [Node.js 20+](https://nodejs.org/en/download/package-manager/).
 
 Then create a new project for your red teaming needs:
 

--- a/site/docs/guides/qwen-benchmark.md
+++ b/site/docs/guides/qwen-benchmark.md
@@ -19,7 +19,7 @@ The chatbot should provide accurate information, respond quickly, and handle com
 
 ## Requirements
 
-- Node 20 or above.
+- Node.js 20+
 - Access to OpenRouter for Qwen and Llama (set environment variable `OPENROUTER_API_KEY`)
 - Access to OpenAI for GPT-4o (set environment variable `OPENAI_API_KEY`)
 

--- a/site/docs/installation.md
+++ b/site/docs/installation.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Requirements
 
-- Node.js 20 or newer
+- Node.js >= 20.0.0
 - Supported operating systems: macOS, Linux, Windows
 
 ## For Command-Line Usage

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -28,7 +28,7 @@ Promptfoo is an [open-source](https://github.com/promptfoo/promptfoo) tool for r
 
 ## Prerequisites
 
-- Install [Node 20 or later](https://nodejs.org/en/download/package-manager/)
+- Install [Node.js 20+](https://nodejs.org/en/download/package-manager/)
 - Optional: Set your `OPENAI_API_KEY` environment variable
 
 ## Initialize the project

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -580,7 +580,7 @@ The `VITE_PUBLIC_BASENAME` build argument configures the frontend to use the cor
 - **GPU**: Not required
 - **RAM**: 4 GB+
 - **Storage**: 10 GB+
-- **Dependencies**: Node.js v20+, npm
+- **Dependencies**: Node.js 20+, npm
 
 ### Server Requirements (Hosting the Web UI/API)
 


### PR DESCRIPTION
## Summary

Standardizes Node.js version requirements across all documentation to ensure consistency with the actual minimum requirement (Node.js >= 20.0.0) defined in package.json.

## Changes

**Format standardization:**
- Technical docs (installation.md, contributing.md, AGENTS.md): `Node.js >= 20.0.0`
- User-facing docs (guides, blog posts, examples): `Node.js 20+`

**Files updated (39 total):**
- 3 technical documentation files
- 8 site guides
- 10 blog posts  
- 15 example READMEs
- 3 integration/usage docs

## Rationale

Node.js 18 support was officially dropped in PR #5428 due to:
- Node.js 18 reaching EOL in April 2025
- Dependencies (e.g., undici) no longer supporting it
- Need for compatibility with current LTS versions (20.x, 22.x) and Node.js 24.x

This PR ensures all documentation consistently reflects the minimum requirement.