### PR TITLE
ci: skip Claude Code review workflow for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,8 +15,12 @@ concurrency:
 
 jobs:
   claude-review:
-    # Skip for bot PRs (dependabot, etc.) due to OIDC token limitations in pull_request_target
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.type != 'Bot'
+    # Skip for bot PRs and fork PRs due to OIDC token limitations in pull_request_target
+    # Fork PRs fail because the actor in OIDC context is the fork contributor (read-only)
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

Fixes the CI failure when the Claude Code review workflow runs on pull requests from forks.

## Problem

The workflow was failing on fork PRs with this error:
```
Warning: Actor has insufficient permissions: read
Error: Prepare step failed with error: Actor does not have write permissions to the repository
```

Even though the workflow uses `pull_request_target` and provides `GITHUB_TOKEN` with write permissions, the Claude Code action's OIDC authentication still checks the **PR author's** permissions. For fork contributors, this is always `read` on the base repository.

## Solution

Skip the Claude Code review workflow for cross-repository (fork) PRs by adding a condition:
```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

This is similar to how we skip bot PRs due to OIDC token limitations.

## Testing

The workflow will now:
- ✅ Run on internal PRs (same repository)
- ⏭️ Skip on fork PRs (cross-repository)
- ⏭️ Skip on bot PRs (dependabot, etc.)
- ⏭️ Skip on draft PRs

## Related

This is a follow-up to #6940 which added OIDC authentication. The limitation is in how OIDC tokens work with `pull_request_target` - the actor context remains the fork contributor rather than the workflow's service account.