### PR TITLE
feat(codeScan): add fork PR authentication support

### DIFF
--- a/code-scan-action/action.yml
+++ b/code-scan-action/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'GitHub token for authentication (default: github.token)'
     required: false
     default: ${{ github.token }}
+  enable-fork-prs:
+    description: 'Enable scanning PRs from forked repositories'
+    required: false
+    default: 'false'
 
 runs:
   using: 'node20'

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -52,7 +52,7 @@ async function run(): Promise<void> {
     core.info('🔍 Starting Promptfoo Code Scan...');
 
     // Validate we're in a PR context
-    const context = getGitHubContext();
+    const context = await getGitHubContext(githubToken);
     core.info(`📋 Scanning PR #${context.number} in ${context.owner}/${context.repo}`);
 
     // Check if this is a setup PR (workflow file addition) - detect early to skip CLI installation
@@ -81,10 +81,12 @@ async function run(): Promise<void> {
       // Set as environment variable for CLI to use
       process.env.GITHUB_OIDC_TOKEN = oidcToken;
     } catch (error) {
-      core.warning(
-        `Failed to get OIDC token: ${error instanceof Error ? error.message : String(error)}`,
+      // OIDC tokens are not available for fork PRs (GitHub security restriction)
+      // For fork PRs, the server will use PR-based authentication instead
+      core.info(
+        `OIDC token not available: ${error instanceof Error ? error.message : String(error)}`,
       );
-      core.warning('Comment posting to PRs will not work without OIDC token');
+      core.info('For fork PRs, this is expected. Authentication will use PR context instead.');
     }
 
     // Generate config file if not provided

--- a/site/docs/code-scanning/github-action.md
+++ b/site/docs/code-scanning/github-action.md
@@ -48,8 +48,26 @@ Most CLI options from [`promptfoo code-scans run`](/docs/code-scanning/cli) can 
 | `config-path`      | Path to `.promptfoo-code-scan.yaml` config file                  | Auto-detected               |
 | `guidance`         | Custom guidance to tailor the scan (see [CLI docs][1])           | None                        |
 | `guidance-file`    | Path to file containing custom guidance (see [CLI docs][1])      | None                        |
+| `enable-fork-prs`  | Enable scanning PRs from forked repositories                     | `false`                     |
 
 [1]: [More on custom guidance](/docs/code-scanning/cli#custom-guidance)
+
+### Fork Pull Requests
+
+By default, code scanning is disabled for fork PRs. This is because any GitHub user can open a fork PR on public repositories.
+
+To enable scanning of fork PRs, add `enable-fork-prs: true` to your workflow:
+
+```yaml
+- name: Run Promptfoo Code Scan
+  uses: promptfoo/code-scan-action@v1
+  with:
+    enable-fork-prs: true
+```
+
+If you experience any issues, you can disable this setting at any time.
+
+Alternatively, maintainers can trigger scans on specific fork PRs by requesting a review from `@promptfoo-scanner`. This requires write access to the repository.
 
 ### Examples
 

--- a/src/codeScan/scanner/index.ts
+++ b/src/codeScan/scanner/index.ts
@@ -132,8 +132,22 @@ export async function executeScan(repoPath: string, options: ScanOptions): Promi
     const abortController = new AbortController();
     cleanupRefs.abortController = abortController; // Update ref for signal handlers
 
+    // Parse PR context early for auth (if --github-pr provided)
+    // This is needed for fork PR authentication where OIDC is unavailable
+    let parsedPR: { owner: string; repo: string; number: number } | undefined;
+    if (options.githubPr) {
+      const parsed = parseGitHubPr(options.githubPr);
+      if (!parsed) {
+        throw new Error(
+          `Invalid --github-pr format: "${options.githubPr}". Expected format: owner/repo#number (e.g., promptfoo/promptfoo#123)`,
+        );
+      }
+      parsedPR = parsed;
+    }
+
     // Resolve auth credentials for socket.io
-    const auth = resolveAuthCredentials(options.apiKey);
+    // Pass PR context for fork PR authentication fallback
+    const auth = resolveAuthCredentials(options.apiKey, parsedPR);
 
     // Determine API host URL
     const apiHost = resolveApiHost(options, config);
@@ -234,27 +248,21 @@ export async function executeScan(repoPath: string, options: ScanOptions): Promi
     logger.debug(`Commits: ${metadata.commitMessages.length}`);
 
     // Build pull request context if --github-pr flag provided
+    // Reuse parsedPR from earlier (already validated for auth)
     let pullRequest: PullRequestContext | undefined = undefined;
-    if (options.githubPr) {
-      const parsed = parseGitHubPr(options.githubPr);
-      if (!parsed) {
-        throw new Error(
-          `Invalid --github-pr format: "${options.githubPr}". Expected format: owner/repo#number (e.g., promptfoo/promptfoo#123)`,
-        );
-      }
-
+    if (parsedPR) {
       // Get current commit SHA
       const currentCommit = await git.revparse(['HEAD']);
 
       pullRequest = {
-        owner: parsed.owner,
-        repo: parsed.repo,
-        number: parsed.number,
+        owner: parsedPR.owner,
+        repo: parsedPR.repo,
+        number: parsedPR.number,
         sha: currentCommit.trim(),
       };
 
       logger.debug(
-        `GitHub PR context: ${parsed.owner}/${parsed.repo}#${parsed.number} (${pullRequest.sha.substring(0, 7)})`,
+        `GitHub PR context: ${parsedPR.owner}/${parsedPR.repo}#${parsedPR.number} (${pullRequest.sha.substring(0, 7)})`,
       );
     }
 

--- a/src/codeScan/util/auth.ts
+++ b/src/codeScan/util/auth.ts
@@ -24,11 +24,16 @@ try {
  * 2. PROMPTFOO_API_KEY environment variable
  * 3. API key from promptfoo auth (cloudConfig)
  * 4. GitHub OIDC token (environment variable)
+ * 5. Fork PR context (for fork PRs where OIDC is unavailable)
  *
  * @param apiKey Optional API key from CLI arg or config file
+ * @param forkPR Optional fork PR context for authentication
  * @returns Resolved auth credentials
  */
-export function resolveAuthCredentials(apiKey?: string): SocketAuthCredentials {
+export function resolveAuthCredentials(
+  apiKey?: string,
+  forkPR?: { owner: string; repo: string; number: number },
+): SocketAuthCredentials {
   // 1. API key from argument (CLI --api-key or config file)
   if (apiKey) {
     logger.debug('Using API key from CLI/config');
@@ -62,6 +67,12 @@ export function resolveAuthCredentials(apiKey?: string): SocketAuthCredentials {
     return {
       oidcToken,
     };
+  }
+
+  // 5. Fork PR context (for fork PRs where OIDC is unavailable)
+  if (forkPR) {
+    logger.debug('Using fork PR context for authentication');
+    return { forkPR };
   }
 
   // No auth found

--- a/src/types/codeScan.ts
+++ b/src/types/codeScan.ts
@@ -299,6 +299,12 @@ export interface JsonRpcMessage {
 export interface SocketAuthCredentials {
   apiKey?: string;
   oidcToken?: string;
+  // Fork PR authentication (when OIDC unavailable due to GitHub blocking OIDC for forks)
+  forkPR?: {
+    owner: string;
+    repo: string;
+    number: number;
+  };
 }
 
 // GitHub types

--- a/test/code-scan-action/github.test.ts
+++ b/test/code-scan-action/github.test.ts
@@ -82,8 +82,8 @@ describe('GitHub API Client', () => {
   });
 
   describe('getGitHubContext', () => {
-    it('should extract context from github.context', () => {
-      const context = getGitHubContext();
+    it('should extract context from github.context', async () => {
+      const context = await getGitHubContext('test-token');
 
       expect(context).toEqual({
         owner: 'test-owner',
@@ -93,12 +93,12 @@ describe('GitHub API Client', () => {
       });
     });
 
-    it('should throw error when not in PR context', () => {
+    it('should throw error when not in PR context', async () => {
       const originalPayload = github.context.payload;
       github.context.payload = {};
 
-      expect(() => getGitHubContext()).toThrow(
-        'This action can only be run on pull_request events',
+      await expect(getGitHubContext('test-token')).rejects.toThrow(
+        'This action requires a pull_request event or workflow_dispatch with pr_number input',
       );
 
       github.context.payload = originalPayload;


### PR DESCRIPTION
## Summary

Fork PRs can't get OIDC tokens from GitHub Actions (GitHub blocks this for security). This adds an alternative auth flow using PR context credentials.

- Add `forkPR` to `SocketAuthCredentials` type
- Pass PR context in auth when OIDC is unavailable
- Add `enable-fork-prs` action input for opt-in auto-scanning
- Support `workflow_dispatch` with `pr_number` input for manual re-scans
- Document fork PR scanning options

## How fork PR auth works

1. Fork PR opened → Action detects no OIDC, sends `forkPR` credentials instead
2. Server validates: checks if `enable-fork-prs: true` in workflow OR maintainer approval exists
3. If neither → rejects with helpful PR comment explaining options
4. If valid → scan proceeds normally

## Manual re-scan via workflow_dispatch

Users can add `workflow_dispatch` trigger for manual scans:

```yaml
on:
  pull_request:
  workflow_dispatch:
    inputs:
      pr_number:
        description: 'PR number to scan'
        required: true
```

The action auto-detects `workflow_dispatch` and reads `pr_number` from inputs.

## Test plan

- [x] Local testing with mock fork PR credentials
- [ ] E2E test with real fork PR against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)