### PR TITLE
chore(deps): fix npm audit vulnerability in preact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30947,7 +30947,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.28.0",
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "dev": true,
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## Summary

- Bump preact from 10.28.0 to 10.28.2 to address CVE-2026-22028 (JSON VNode injection vulnerability, high severity)

## Test plan

- [x] Ran `npm audit` - reports 0 vulnerabilities