### PR TITLE
fix(app): show charts for meaningful uniform scores

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -1035,7 +1035,121 @@ describe('ResultsView Chart Rendering', () => {
     expect(resultsCharts).toBeNull();
   });
 
-  it('should not render ResultsCharts if all scores are the same', async () => {
+  it('should not render ResultsCharts if all scores are binary edge values (all 1s)', async () => {
+    vi.mocked(useTableStore).mockReturnValue({
+      author: 'Test Author',
+      table: {
+        head: {
+          prompts: [
+            {
+              label: 'Test Prompt 1',
+              provider: 'openai:gpt-4',
+              raw: 'Test prompt 1',
+            },
+            {
+              label: 'Test Prompt 2',
+              provider: 'openai:gpt-3.5-turbo',
+              raw: 'Test prompt 2',
+            },
+          ],
+          vars: ['input'],
+        },
+        body: [{ outputs: [{ score: 1 }, { score: 1 }] }],
+      },
+      config: {
+        description: 'Test Evaluation',
+        sharing: true,
+        tags: { env: 'test' },
+      },
+      setConfig: vi.fn(),
+      evalId: 'test-eval-id',
+      setAuthor: vi.fn(),
+      filteredResultsCount: 10,
+      totalResultsCount: 15,
+      highlightedResultsCount: 2,
+      filters: {
+        appliedCount: 0,
+        values: {},
+      },
+      removeFilter: vi.fn(),
+    });
+
+    await act(async () => {
+      renderWithRouter(
+        <ResultsView
+          recentEvals={mockRecentEvals}
+          onRecentEvalSelected={mockOnRecentEvalSelected}
+          defaultEvalId="test-eval-id"
+        />,
+      );
+    });
+
+    const showChartsButton = screen.queryByText('Show Charts');
+    expect(showChartsButton).toBeNull();
+
+    const resultsCharts = screen.queryByTestId('results-charts');
+    expect(resultsCharts).toBeNull();
+  });
+
+  it('should not render ResultsCharts if all scores are binary edge values (all 0s)', async () => {
+    vi.mocked(useTableStore).mockReturnValue({
+      author: 'Test Author',
+      table: {
+        head: {
+          prompts: [
+            {
+              label: 'Test Prompt 1',
+              provider: 'openai:gpt-4',
+              raw: 'Test prompt 1',
+            },
+            {
+              label: 'Test Prompt 2',
+              provider: 'openai:gpt-3.5-turbo',
+              raw: 'Test prompt 2',
+            },
+          ],
+          vars: ['input'],
+        },
+        body: [{ outputs: [{ score: 0 }, { score: 0 }] }],
+      },
+      config: {
+        description: 'Test Evaluation',
+        sharing: true,
+        tags: { env: 'test' },
+      },
+      setConfig: vi.fn(),
+      evalId: 'test-eval-id',
+      setAuthor: vi.fn(),
+      filteredResultsCount: 10,
+      totalResultsCount: 15,
+      highlightedResultsCount: 2,
+      filters: {
+        appliedCount: 0,
+        values: {},
+      },
+      removeFilter: vi.fn(),
+    });
+
+    await act(async () => {
+      renderWithRouter(
+        <ResultsView
+          recentEvals={mockRecentEvals}
+          onRecentEvalSelected={mockOnRecentEvalSelected}
+          defaultEvalId="test-eval-id"
+        />,
+      );
+    });
+
+    const showChartsButton = screen.queryByText('Show Charts');
+    expect(showChartsButton).toBeNull();
+
+    const resultsCharts = screen.queryByTestId('results-charts');
+    expect(resultsCharts).toBeNull();
+  });
+
+  it('should render ResultsCharts if all scores are uniform but not binary edge values', async () => {
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1100);
+
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1084,11 +1198,9 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    const showChartsButton = screen.queryByText('Show Charts');
-    expect(showChartsButton).toBeNull();
-
-    const resultsCharts = screen.queryByTestId('results-charts');
-    expect(resultsCharts).toBeNull();
+    // Uniform score of 0.8 is meaningful (graded assertion), should show charts
+    const showChartsButton = screen.queryByText('Hide Charts');
+    expect(showChartsButton).toBeInTheDocument();
   });
 
   it('should not render ResultsCharts if there are no valid scores', async () => {

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -518,14 +518,23 @@ export default function ResultsView({
       .filter((score) => typeof score === 'number' && !Number.isNaN(score));
   }, [table]);
 
+  // Determine if charts should be rendered based on score variance
+  const uniqueScores = React.useMemo(() => new Set(resultsChartsScores), [resultsChartsScores]);
+  const hasVariedScores = uniqueScores.size > 1;
+  // When all scores are identical, still show charts if the uniform score
+  // is not a binary edge value (0 or 1). Graded assertions (like llm-rubric)
+  // can produce meaningful uniform scores (e.g., 0.85) that users want to visualize.
+  const hasMeaningfulUniformScore =
+    uniqueScores.size === 1 && ![0, 1].includes([...uniqueScores][0]);
+
   const canRenderResultsCharts =
     table &&
     config &&
     table.head.prompts.length > 1 &&
     // No valid scores available
     resultsChartsScores.length > 0 &&
-    // All scores are the same, charts not useful.
-    new Set(resultsChartsScores).size > 1;
+    // Show charts if scores vary OR if uniform score is meaningful (not binary 0/1)
+    (hasVariedScores || hasMeaningfulUniformScore);
   const [renderResultsCharts, setRenderResultsCharts] = React.useState(window.innerHeight >= 1100);
 
   const [resultsTableZoom, setResultsTableZoom] = React.useState(1);


### PR DESCRIPTION
## Summary
- Fixes the "Show charts" toggle not appearing when all scores are identical but meaningful (non-binary)
- Charts are now shown when scores are uniform but not binary edge values (0 or 1)
- Graded assertions (like llm-rubric) can produce meaningful uniform scores (e.g., 0.85) that users want to visualize

## Changes
- Added logic to distinguish between binary edge values (0 or 1) and meaningful uniform scores
- Updated tests to cover the new behavior

Fixes #6951

## Test plan
- [x] All 34 tests in ResultsView.test.tsx pass
- [x] Scores of all 1s → charts hidden (binary pass)
- [x] Scores of all 0s → charts hidden (binary fail)  
- [x] Scores of all 0.8s → charts shown (meaningful uniform score)

🤖 Generated with [Claude Code](https://claude.ai/code)