### PR TITLE
ci(docker): add build attestation to multi-arch workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -290,6 +290,10 @@ jobs:
           echo "$INSPECT_OUTPUT"
           # Extract the manifest digest (first Digest: line)
           DIGEST=$(echo "$INSPECT_OUTPUT" | grep -m1 "^Digest:" | awk '{print $2}')
+          if [ -z "$DIGEST" ]; then
+            echo "Error: Failed to extract manifest digest from inspect output"
+            exit 1
+          fi
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "Manifest digest: $DIGEST"
 

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -59,6 +59,9 @@ docker pull ghcr.io/promptfoo/promptfoo:latest
 
 # Or pull a specific version
 # docker pull ghcr.io/promptfoo/promptfoo:0.109.1
+
+# You can verify image authenticity with:
+# gh attestation verify oci://ghcr.io/promptfoo/promptfoo:latest --owner promptfoo
 ```
 
 ### 2. Run the Container


### PR DESCRIPTION
## Summary

Adds SLSA build provenance attestation to the Docker image workflow using GitHub's `actions/attest-build-provenance` action.

## Changes

- Added `id-token: write` and `attestations: write` permissions
- Modified `merge-docker-digests` job to output the manifest digest
- Added new `attest-docker-image` job that creates signed provenance attestation

## Benefits

- Cryptographically signed build provenance (SLSA Level 2+)
- Users can verify the image was built by this workflow using `gh attestation verify`
- Improves supply chain security by proving where and how the image was built

## Verification

After merge, users can verify attestations with:
```bash
gh attestation verify oci://ghcr.io/promptfoo/promptfoo:latest --owner promptfoo
```