### PR TITLE
fix(ci): prevent database migration race condition in Docker tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,23 +87,10 @@ jobs:
       - name: Run Docker container for testing
         run: docker run -d --name promptfoo-container -p 3000:3000 local-test-image:latest
 
-      - name: Verify Python and promptfoo
-        run: |
-          echo "Checking Python version:"
-          if ! docker exec promptfoo-container python --version; then
-            echo "Python check failed"
-            exit 1
-          fi
-
-          echo "Checking promptfoo version:"
-          if ! docker exec promptfoo-container promptfoo --version; then
-            echo "promptfoo check failed"
-            exit 1
-          fi
-
       - name: Run health check
         run: |
-          # Loop to check if the server is up
+          # Wait for server to be fully ready (including database migrations)
+          # before running any CLI commands that also trigger migrations
           for ((retry=1; retry<=10; retry++)); do
             if curl -f http://localhost:3000/health; then
               echo -e "\nHealth check passed"
@@ -118,6 +105,20 @@ jobs:
           # If health check did not pass after retries, exit with an error
           if [ -z "$HEALTH_CHECK_PASS" ]; then
             echo -e "\nHealth check failed after multiple attempts" >&2
+            exit 1
+          fi
+
+      - name: Verify Python and promptfoo
+        run: |
+          echo "Checking Python version:"
+          if ! docker exec promptfoo-container python --version; then
+            echo "Python check failed"
+            exit 1
+          fi
+
+          echo "Checking promptfoo version:"
+          if ! docker exec promptfoo-container promptfoo --version; then
+            echo "promptfoo check failed"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Fixes a race condition in the Docker CI workflow that caused intermittent failures with:

```
SqliteError: table `datasets` already exists
```

## Root Cause

Both the server and CLI run database migrations at startup:
- Server: `startServer()` → `runDbMigrations()`
- CLI: `main()` → `runDbMigrations()`

The previous CI step order was:
1. Start Docker container (server begins migrations)
2. Run `promptfoo --version` (CLI also runs migrations)
3. Run health check

When `promptfoo --version` executed before the server finished its migrations, both processes would race to create the same tables.

## Fix

Reorder steps so the health check runs first:
1. Start Docker container
2. **Run health check** (waits for server to be ready, including migrations)
3. Run `promptfoo --version` (migrations already complete)

## Evidence

This issue caused the Docker test failure in [PR #6758](https://github.com/promptfoo/promptfoo/pull/6758) and has been a source of intermittent CI failures.