### PR TITLE
docs(cli): add documentation for promptfoo retry command

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -267,6 +267,34 @@ Deletes a specific resource.
 | ----------- | -------------------------- |
 | `eval <id>` | Delete an evaluation by id |
 
+## `promptfoo retry <evalId>`
+
+Retry all ERROR results from a specific evaluation. This command finds test cases that resulted in errors (e.g., from network issues, rate limits, or API failures), removes them from the database, and re-runs only those test cases. The results are updated in place in the original evaluation.
+
+| Option                       | Description                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `-c, --config <path>`        | Path to configuration file (optional, uses original eval config if not provided) |
+| `-v, --verbose`              | Verbose output                                                                   |
+| `--max-concurrency <number>` | Maximum number of concurrent evaluations                                         |
+| `--delay <number>`           | Delay between evaluations in milliseconds                                        |
+
+Examples:
+
+```sh
+# Retry errors from a specific evaluation
+promptfoo retry eval-abc123
+
+# Retry with a different config file
+promptfoo retry eval-abc123 -c updated-config.yaml
+
+# Retry with verbose output and limited concurrency
+promptfoo retry eval-abc123 -v --max-concurrency 2
+```
+
+:::tip
+Unlike `--filter-errors-only` which creates a new evaluation, `promptfoo retry` updates the original evaluation in place. Use `retry` when you want to fix errors in an existing eval without creating duplicates.
+:::
+
 ## `promptfoo import <filepath>`
 
 Import an eval file from JSON format.


### PR DESCRIPTION
## Summary

- Adds documentation for the `promptfoo retry <evalId>` command to the CLI reference
- The command was added in PR #5647 but was not fully documented

## Changes

- Documents all command options (`-c`, `-v`, `--max-concurrency`, `--delay`)
- Adds usage examples
- Explains the difference from `--filter-errors-only` (updates in place vs creates new eval)

## Test plan

- [x] Verify documentation renders correctly on the site
<img width="3825" height="1920" alt="image" src="https://github.com/user-attachments/assets/c5d2f329-7adc-45e7-aed9-713cf9bc5056" />

---

:robot: Generated with [Claude Code](https://claude.ai/code)