### PR TITLE
fix(ci): add missing permissions for docker attestation workflow call

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -123,6 +123,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/docker.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Fixes release-please workflow startup_failure that started after #6963 was merged
- The docker.yml attestation job requires `id-token: write` and `attestations: write` permissions
- When calling docker.yml as a reusable workflow, release-please.yml must grant these permissions to the called workflow

## Root Cause
The `attest-docker-image` job in docker.yml needs OIDC token and attestation permissions:
```yaml
permissions:
  id-token: write
  attestations: write
  packages: write
```

But release-please.yml's `docker` job only granted:
```yaml
permissions:
  contents: read
  packages: write
```

GitHub validates reusable workflow permissions at workflow startup time, causing `startup_failure` even though the docker job only runs when `release_created` is true.

## Test plan
- [ ] Merge this PR and verify the next release-please run succeeds
- [ ] Alternatively, manually trigger the workflow via workflow_dispatch to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)