### PR TITLE
fix(app): use solid background for update banner in dark mode

### DIFF
--- a/src/app/src/components/UpdateBanner.tsx
+++ b/src/app/src/components/UpdateBanner.tsx
@@ -101,6 +101,8 @@ export default function UpdateBanner() {
       className={cn(
         'rounded-none py-2 px-4 relative z-(--z-banner)',
         'flex items-center justify-between gap-4',
+        // Use solid background to prevent content showing through the banner
+        'dark:bg-blue-950',
       )}
     >
       <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

- Fixes the update banner's semi-transparent background in dark mode that caused page content to bleed through
- Adds `dark:bg-blue-950` override to the UpdateBanner component for a solid background

## Test plan

- [x] Verified in browser with dark mode enabled
- [x] All UpdateBanner tests pass
- [x] Lint checks pass

**Before (content bleeding through):**
The banner's `info` variant uses `bg-blue-950/50` (50% opacity) in dark mode, causing the page title and description to show through.

**After (solid background):**
The banner now has a solid `bg-blue-950` background in dark mode, properly occluding content below.

🤖 Generated with [Claude Code](https://claude.ai/code)