### PR TITLE
fix(webui): fix table header overlap in eval selector dialog

### DIFF
--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -313,7 +313,7 @@ export function DataTable<TData, TValue = unknown>({
         style={maxHeight ? { maxHeight } : undefined}
       >
         <table className="w-full" style={{ tableLayout: 'fixed' }}>
-          <thead className="bg-muted/50 sticky top-0 z-10">
+          <thead className="bg-zinc-100 dark:bg-zinc-800 sticky top-0 z-10">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id} className="border-b border-border">
                 {headerGroup.headers.map((header) => {
@@ -325,7 +325,7 @@ export function DataTable<TData, TValue = unknown>({
                     <th
                       key={header.id}
                       className={cn(
-                        'px-4 py-3 text-left text-sm font-semibold relative',
+                        'px-4 py-3 text-left text-sm font-semibold relative overflow-hidden',
                         canSort && 'cursor-pointer select-none hover:bg-muted/80',
                       )}
                       style={{
@@ -334,10 +334,12 @@ export function DataTable<TData, TValue = unknown>({
                       onClick={header.column.getToggleSortingHandler()}
                     >
                       {header.isPlaceholder ? null : (
-                        <div className="flex items-center gap-1">
-                          {flexRender(header.column.columnDef.header, header.getContext())}
+                        <div className="flex items-center gap-1 min-w-0">
+                          <span className="truncate">
+                            {flexRender(header.column.columnDef.header, header.getContext())}
+                          </span>
                           {canSort && (
-                            <span className="ml-1">
+                            <span className="shrink-0">
                               {sortDirection === 'asc' ? (
                                 <ArrowUp className="size-4" />
                               ) : sortDirection === 'desc' ? (

--- a/src/app/src/pages/evals/components/EvalsTable.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.tsx
@@ -256,6 +256,7 @@ export default function EvalsTable({
             </Tooltip>
           );
         },
+        size: 250,
       },
       {
         accessorKey: 'passRate',


### PR DESCRIPTION
## Summary

- Fixed visual overlap between table header row and data rows in the eval selector dialog
- The issue was caused by the sticky header using a semi-transparent background (`bg-muted/50`) which allowed scrolled content to show through
- Added proper overflow handling to prevent column content from exceeding boundaries

## Changes

**`data-table.tsx`:**
- Changed thead background from `bg-muted/50` to solid `bg-zinc-100 dark:bg-zinc-800`
- Added `overflow-hidden` to `<th>` elements
- Added `min-w-0` to header flex container for proper width constraints
- Wrapped header text in `<span className="truncate">` for text truncation
- Changed sort icon wrapper to `shrink-0` to maintain icon size

**`EvalsTable.tsx`:**
- Added explicit `size: 250` to Description column (was the only column without a defined width)

## Test plan

- [x] Verified in light mode - header properly separated from rows
- [x] Verified in dark mode - header properly separated from rows
- [x] Tested sticky header behavior on scroll in both modes
- [x] Verified column alignment and sort icon positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)