### PR TITLE
docs(site): correct Michael D'Angelo's GitHub link

### DIFF
--- a/site/blog/authors.yml
+++ b/site/blog/authors.yml
@@ -31,7 +31,7 @@ ian:
 michael:
   name: Michael D'Angelo
   title: CTO & Co-founder
-  url: https://github.com/mdangelo
+  url: https://github.com/mldangelo
   image_url: /img/team/michael.jpeg
 
 shuo:


### PR DESCRIPTION
## Summary
- Fixed Michael D'Angelo's GitHub link in the blog authors configuration
- The URL was pointing to `mdangelo` (Mario D'Angelo) instead of `mldangelo` (Michael D'Angelo)

## Test plan
- [ ] Verify the author link on blog posts by Michael correctly navigates to https://github.com/mldangelo

🤖 Generated with [Claude Code](https://claude.ai/code)