### PR TITLE
docs: improve PR conventions with description and type guidance

### DIFF
--- a/docs/agents/pr-conventions.md
+++ b/docs/agents/pr-conventions.md
@@ -9,15 +9,23 @@ PR titles follow Conventional Commits format. They become squash-merge commit me
 <type>(<scope>)!: <description>  # Breaking changes
 ```
 
+### Description Guidelines
+
+- **Imperative mood**: "add feature" not "added" or "adds"
+- **Lowercase**: except proper nouns and acronyms (FERPA, OAuth, MUI)
+- **No trailing period**
+- **Be specific**: describe what changed, not that something changed
+- **~50 characters**: GitHub truncates long titles
+
 ## Types
 
 | Type       | Use For                                               |
 | ---------- | ----------------------------------------------------- |
-| `feat`     | New feature or capability                             |
-| `fix`      | Bug fix in application code                           |
-| `chore`    | Maintenance, upgrades, non-breaking refactors         |
-| `refactor` | Code refactoring without behavior change              |
-| `docs`     | Documentation only                                    |
+| `feat`     | New CLI feature or major webui feature                |
+| `fix`      | Bug fix in CLI or major webui bug fix                 |
+| `chore`    | Maintenance, upgrades, minor fixes, non-user-facing   |
+| `refactor` | Code restructuring without behavior change            |
+| `docs`     | Documentation only (use with `site` scope for site/)  |
 | `test`     | Test-only changes (new tests, test fixes, test infra) |
 | `ci`       | CI/CD changes                                         |
 | `revert`   | Revert previous change                                |
@@ -41,6 +49,23 @@ Use `fix:` when fixing bugs in **application code** (even if tests are included)
 - Bug fix in `src/` with accompanying test changes → `fix:`
 - Lint error in test file only → `test:`
 
+### Type Selection for Mixed Changes
+
+Use the **primary change** to determine type:
+
+| PR Contains                       | Type       | Why                              |
+| --------------------------------- | ---------- | -------------------------------- |
+| Bug fix + new tests               | `fix`      | Fix is primary, tests support it |
+| Feature + documentation           | `feat`     | Feature is primary               |
+| Only test changes                 | `test`     | No application code changed      |
+| Only doc changes                  | `docs`     | No application code changed      |
+| Minor webui fix (styling, typos)  | `chore`    | Not a major user-facing fix      |
+| Refactor + minor fixes discovered | `refactor` | Refactor was the intent          |
+
+**Major webui changes** = new pages, significant UX changes, core functionality bugs
+
+**Minor webui changes** = styling tweaks, copy changes, internal refactors → use `chore`
+
 ## Scope Selection (Priority Order)
 
 ### 1. Feature Domains (HIGHEST PRIORITY)
@@ -53,14 +78,15 @@ Use `fix:` when fixing bugs in **application code** (even if tests are included)
 - Documentation, examples
 - **ANY change that touches redteam functionality**
 
-**Other feature domains:** `providers`, `assertions`, `eval`/`evaluator`, `api`
+**Other feature domains:** `providers`, `assertions`, `eval`, `api`, `db`
 
 ### 2. Product Areas
 
 - `webui` - React app in `src/app/`
 - `cli` - CLI in `src/`
 - `server` - Web server in `src/server/`
-- `site` - Documentation site in `site/`
+
+**Note:** Documentation site changes use `docs(site):`, not a standalone `site` scope.
 
 ### 3. Technical/Infrastructure
 
@@ -121,8 +147,11 @@ feat(redteam): add validate target CLI command
 
 ```plaintext
 feat(redteam): add FERPA compliance plugin
-fix(providers): support function providers in assertions
-feat(webui): add eval results filter permalinking
+feat(cli): add --json output flag to eval command
+fix(cli): handle empty config file gracefully
+fix(webui): fix pagination crash on empty results
+chore(webui): update button styling on settings page
+docs(site): add guide for custom providers
 chore(deps): update Material-UI monorepo to v8 (major)
 fix(deps): update dependency better-sqlite3 to v12.4.6
 feat(api)!: simplify provider interface
@@ -134,11 +163,16 @@ test(redteam): fix flaky plugin integration tests
 ❌ **Bad:**
 
 ```plaintext
-feat: add new redteam thing      # Missing (redteam) scope
-fix(webui): red team checkbox    # Should be fix(redteam)
-chore(webui): update dependency  # Should be chore(deps)
-feat: stuff                      # Too vague
-fix(test): resolve lint errors   # Should be test: (test-only changes)
+feat: add new redteam thing         # Missing (redteam) scope
+fix(webui): red team checkbox       # Should be fix(redteam)
+chore(webui): update dependency     # Should be chore(deps)
+feat: stuff                         # Too vague
+fix: bug fix                        # What bug? Be specific
+Fix(cli): Add feature               # Wrong case, not imperative
+fix(test): resolve lint errors      # Should be test: (test-only)
+docs: update site                   # Should be docs(site):
+site: update guides                 # Should be docs(site):
+feat(webui): minor styling update   # Minor = chore, not feat
 ```
 
 ## Draft Mode Required


### PR DESCRIPTION
## Summary

- Add description guidelines (imperative mood, lowercase, specific, ~50 chars)
- Clarify that `feat`/`fix` are for CLI or major webui features only
- Add type selection rules for mixed changes (major vs minor webui)
- Fix site scope: use `docs(site):` not standalone `site`
- Add `db` to feature domain scopes, prefer `eval` over `evaluator`
- Expand good/bad examples with more cases

## Test plan

- [ ] Review updated guidelines for clarity and completeness