### PR TITLE
test: stabilize flaky envPath integration test

### DIFF
--- a/test/integration/envPath.test.ts
+++ b/test/integration/envPath.test.ts
@@ -17,10 +17,38 @@ import { setupEnv } from '../../src/util/index';
 vi.mock('../../src/cache');
 vi.mock('../../src/evaluator');
 vi.mock('../../src/globalConfig/accounts');
+vi.mock('../../src/globalConfig/cloud', () => ({
+  cloudConfig: {
+    isEnabled: vi.fn().mockReturnValue(false),
+  },
+}));
 vi.mock('../../src/migrate');
+vi.mock('../../src/models/eval', () => {
+  const MockEval = function (this: any) {
+    this.id = 'test-eval-id';
+    this.prompts = [];
+    this.clearResults = vi.fn();
+    this.shared = false;
+    this.getTable = vi.fn().mockResolvedValue({ body: [] });
+  };
+  MockEval.create = vi.fn().mockResolvedValue({
+    id: 'test-eval-id',
+    prompts: [],
+    clearResults: vi.fn(),
+    shared: false,
+    getTable: vi.fn().mockResolvedValue({ body: [] }),
+  });
+  MockEval.latest = vi.fn().mockResolvedValue(null);
+  MockEval.findById = vi.fn().mockResolvedValue(null);
+  return { default: MockEval };
+});
 vi.mock('../../src/providers');
 vi.mock('../../src/share');
 vi.mock('../../src/table');
+vi.mock('../../src/util/cloud', () => ({
+  checkCloudPermissions: vi.fn().mockResolvedValue(undefined),
+  getOrgContext: vi.fn().mockResolvedValue(null),
+}));
 vi.mock('../../src/util', async () => {
   const actual = await vi.importActual('../../src/util');
   return {


### PR DESCRIPTION
## Summary
- Fixes flaky test timeout on Windows CI for `should load multiple env files from config array` in `test/integration/envPath.test.ts`
- Adds mocks for cloud-related modules that were causing the test to hang

## Root Cause
The test was timing out because `doEval` executed through its entire code path, including unmocked cloud-related functions (`cloudConfig.isEnabled()`, `getOrgContext()`, `checkCloudPermissions()`). These functions could make HTTP calls or perform blocking operations, causing the 30-second timeout on Windows CI.

## Changes
Added mocks for previously unmocked modules:
- `globalConfig/cloud`: mocked `cloudConfig.isEnabled()` to return `false`
- `util/cloud`: mocked `checkCloudPermissions()` and `getOrgContext()` to resolve immediately
- `models/eval`: mocked the `Eval` class with constructor and static methods

## Test plan
- [x] All 8 tests in `test/integration/envPath.test.ts` pass
- [x] Tests now complete in ~31ms instead of timing out at 30s
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)