### PR TITLE
fix(app): prevent pagination bar from floating on short eval tables

### DIFF
--- a/src/app/src/index.css
+++ b/src/app/src/index.css
@@ -210,6 +210,9 @@
   --z-dropdown: 1400;
   --z-tooltip: 1500;
 
+  /* Layout dimensions */
+  --nav-height: 3.5rem; /* Navigation bar height (h-14 = 56px) */
+
   /* Design tokens - Light mode (aligned with MUI theme) */
   --background: 210 40% 98%; /* #f8fafc - slate-50 */
   --foreground: 222.2 47.4% 11.2%; /* #0f172a - slate-900 */

--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -505,7 +505,7 @@ table.results-table,
 
 .results-table-sticky {
   position: sticky;
-  top: 3.5rem; /* Account for navigation height (h-14) */
+  top: var(--nav-height); /* Navigation height defined in index.css */
   z-index: 10;
   transition: transform 0.2s ease-out;
   background: #fff;

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -546,7 +546,7 @@ export default function ResultsView({
         className="px-4 pt-4 flex flex-col"
         style={{
           isolation: 'isolate',
-          minHeight: 'calc(100vh - 3.5rem - var(--update-banner-height, 0px))',
+          minHeight: 'calc(100vh - var(--nav-height) - var(--update-banner-height, 0px))',
         }}
       >
         <Card className="p-4 mb-4 bg-white dark:bg-zinc-900 shrink-0">


### PR DESCRIPTION
## Summary

- Fixes the pagination bar floating at the bottom of the viewport with a visible gap when eval tables have few rows
- Adds flex layout to ResultsView wrapper so `flexGrow: 1` on the table container works correctly
- Pagination now stays directly below table content for short tables, and sticks to viewport bottom for long tables

## Changes

- Add `flex flex-col` to wrapper div
- Add `minHeight: calc(100vh - 3.5rem - var(--update-banner-height, 0px))` to fill viewport
- Add `shrink-0` to Card to prevent flex growth

## Screenshots

### Before
<img width="1413" height="940" alt="Screenshot 2026-01-10 at 5 13 55 PM" src="https://github.com/user-attachments/assets/517eded9-bc6e-4619-b8b1-55d0faa6a225" />

### After
<img width="1411" height="951" alt="Screenshot 2026-01-10 at 5 13 21 PM" src="https://github.com/user-attachments/assets/cb67c5cd-99a9-4436-ba99-82d87cd329e8" />

## Test plan

- [ ] Short table (1-5 rows): pagination at bottom, no floating gap
- [ ] Long table (100+ rows): pagination sticks to viewport bottom while scrolling
- [ ] Sticky header still works
- [ ] Zoom slider works at all levels
- [ ] Dark mode appearance correct
- [ ] UpdateBanner visible/hidden: layout adjusts correctly