### PR TITLE
docs: update security policy and responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,76 +2,85 @@
 
 Promptfoo takes security seriously. We appreciate responsible disclosure and will work with you to address valid issues.
 
-## Security Model and Assumptions
+## Security Model
 
-Promptfoo is a developer tool that runs in your environment with your user permissions.
+Promptfoo is a developer tool that runs in your environment with your user permissions. It is designed to be **permissive by default**.
 
-Some Promptfoo features intentionally execute user-provided code (for example, loading JavaScript for custom assertions, providers, transforms, or other extensions). This code execution is **not sandboxed** and should be treated the same way you would treat running a Node.js script locally.
+Some features intentionally execute user-provided code (custom assertions, providers, transforms, plugins). This code execution is **not sandboxed** and should be treated the same way you would treat running a Node.js script locally.
 
 **Important:** Treat Promptfoo configuration files and any referenced scripts as **trusted code**. Do not run Promptfoo against untrusted configs, prompt packs, or pull requests without isolation.
 
+### Trust Boundaries
+
+**Trusted inputs (treated as code):**
+
+- Promptfoo config files (`promptfooconfig.yaml`, etc.)
+- Referenced local scripts and modules
+- Custom JS assertions, providers, transforms, and plugins
+
+**Untrusted inputs (must remain data-only):**
+
+- Prompt text, test cases, and fixtures
+- Model outputs and grader outputs
+- Remote content fetched during evaluation
+
+A vulnerability exists when untrusted inputs can trigger code execution, file access, or network access without explicit configuration.
+
 ## Hardening Recommendations
 
-If you need to run Promptfoo in higher-risk contexts (CI, shared machines, evaluating third-party configs), consider:
+If you run Promptfoo in higher-risk contexts (CI, shared machines, third-party configs):
 
-- Run inside a container or VM with minimal privileges.
-- Use a dedicated, least-privileged API key for model providers.
-- Avoid placing secrets in prompts, fixtures, or config files.
-- Restrict network egress when feasible (especially if running third-party JS).
-- Use read-only mounts where possible and avoid running with access to sensitive files.
-- In CI: do not run Promptfoo with secrets on untrusted PRs (for example, from forks).
+- Run inside a container or VM with minimal privileges
+- Use dedicated, least-privileged API keys
+- Avoid placing secrets in prompts, fixtures, or config files
+- Restrict network egress when running third-party code
+- In CI: do not run Promptfoo with secrets on untrusted PRs (e.g., from forks)
 
 ## Supported Versions
 
-We provide security fixes for supported versions only.
-
-| Version                  | Supported |
-| ------------------------ | --------- |
-| `main` branch            | ✅        |
-| Latest published release | ✅        |
-| Older releases           | ❌        |
-
-If you are unsure whether your version is supported, report anyway and include the version/commit SHA.
+| Version                  | Supported        |
+| ------------------------ | ---------------- |
+| Latest published release | ✅               |
+| `main` branch            | ✅ (best effort) |
+| Older releases           | ❌               |
 
 ## Reporting a Vulnerability
 
-Please **do not** open a public GitHub issue for security reports.
+**Do not** open a public GitHub issue for security reports.
 
-Instead, report privately via one of these channels:
+Report privately via:
 
-- **GitHub Security Advisories:** Use the repo's "Report a vulnerability" button (preferred).
+- **GitHub Security Advisories:** "Report a vulnerability" button (preferred)
 - **Email:** security@promptfoo.dev (fallback: support@promptfoo.dev)
 
 We will acknowledge your report within **1 business day**.
 
-Please include:
+For safe harbor provisions and full process details, see our [Responsible Disclosure Policy](https://www.promptfoo.dev/responsible-disclosure-policy/).
 
-- A clear description of the issue and security impact
-- Steps to reproduce (or a proof-of-concept)
-- Affected versions and environment details
-- Whether the issue is remotely exploitable or requires local access
-- Any relevant logs, screenshots, or links
-- Your preferred name/handle for credit (optional)
+## Scope
 
-For our full disclosure policy, safe harbor provisions, and additional details, see our [Responsible Disclosure Policy](https://www.promptfoo.dev/responsible-disclosure-policy/).
+**In scope:**
 
-## What We Consider a Vulnerability
+- Code execution, file access, or network access triggered by **untrusted data inputs** (prompts, test cases, fixtures, model outputs) without explicit configuration enabling it
+- Bypasses of documented restrictions or isolation boundaries
+- Unexpected secret exposure or credential leakage to unconfigured destinations
+- Path traversal or arbitrary file read/write from data-only inputs
+- Vulnerabilities in CLI, config parsing, or web UI affecting confidentiality, integrity, or availability
+- Algorithmic complexity DoS (crafted input causing hang/crash with modest input size)
 
-We generally consider the following **in scope**:
+**Out of scope:**
 
-- Code execution, file access, or network access that occurs **without clear user intent** or without an explicit feature enabling it
-- Loading or executing code from unexpected locations (for example, remote sources) without clear user intent or guardrails
-- Path traversal, arbitrary file read/write, credential exfiltration, or privilege escalation beyond what a user would reasonably expect from running Promptfoo
-- Vulnerabilities in the CLI, config parsing, web UI, or any shipped integrations that allow an attacker to impact confidentiality, integrity, or availability
-
-The following are generally **out of scope** (or "expected behavior"), unless there is a bypass of a stated guardrail:
-
-- Arbitrary code execution when a user explicitly enables or supplies executable JavaScript or scripts (for example, custom assertions/providers/transforms)
-- Vulnerabilities that require a user to run untrusted code/configuration with full local privileges
-- Issues in third-party dependencies that do not materially change Promptfoo's security posture (please report upstream too)
+- Code execution from **explicitly configured** custom code (JS assertions, providers, transforms, plugins configured in your config file)
+- Issues requiring the user to run untrusted configs or scripts with local privileges
+- Third-party dependency issues that don't materially affect Promptfoo's security posture (report upstream)
 - Social engineering, phishing, or physical attacks
-- Denial of service from unreasonable traffic volumes
+- Volumetric denial of service
 
-If you are unsure whether something is in scope, report it anyway.
+**Examples of out-of-scope reports:**
+
+- "A malicious custom assertion reads `process.env` and posts it to a webhook" → Expected behavior; custom code runs with your permissions
+- "A third-party prompt pack includes a transform that runs shell commands" → Expected behavior; don't run untrusted configs
+
+If unsure whether something is in scope, report it anyway.
 
 Thank you for helping keep Promptfoo and its users safe.

--- a/site/src/pages/responsible-disclosure-policy.md
+++ b/site/src/pages/responsible-disclosure-policy.md
@@ -4,64 +4,81 @@ description: Report security vulnerabilities in Promptfoo responsibly - guidelin
 
 # Responsible Vulnerability Disclosure Policy
 
-Promptfoo values the security and privacy of our users, customers, and the broader community. We welcome responsible disclosure of vulnerabilities to help us ensure the ongoing security of our open source projects, cloud services, and on-premises deployments.
+Promptfoo values the security and privacy of our users, customers, and the broader community. We welcome responsible disclosure of vulnerabilities.
 
 ## Scope
 
-This policy covers vulnerabilities discovered in:
+This policy covers vulnerabilities in:
 
-- Promptfoo Open Source Software
-- Promptfoo Cloud Services
-- Promptfoo On-premises Software Components
+- **Promptfoo Open Source Software** (CLI, libraries)
+- **Promptfoo Cloud Services**
+- **Promptfoo On-premises Components**
 
-For technical details on our security model, hardening recommendations, and what we consider in-scope vs. out-of-scope, see our [SECURITY.md](https://github.com/promptfoo/promptfoo/blob/main/SECURITY.md) on GitHub.
+For technical details on our security model, trust boundaries, and hardening recommendations, see [SECURITY.md](https://github.com/promptfoo/promptfoo/blob/main/SECURITY.md) on GitHub.
+
+### Open Source (CLI)
+
+The OSS CLI runs in your environment with your user permissions. It is **permissive by default** and executes user-configured code (assertions, providers, transforms, plugins) without sandboxing.
+
+**In scope for OSS:** vulnerabilities where untrusted data inputs (prompts, test cases, model outputs) can trigger code execution, file access, or network access without explicit configuration.
+
+**Out of scope for OSS:** code execution from explicitly configured custom code, since this is expected behavior.
+
+### Cloud Services
+
+Promptfoo Cloud operates with higher isolation expectations. The following are **in scope and treated as critical**:
+
+- Cross-tenant data access or isolation failures
+- Sandbox escapes or privilege escalation
+- Access to Promptfoo internal systems or credentials
+- Unauthorized data exposure between accounts
 
 ## Reporting Vulnerabilities
 
-If you discover a potential vulnerability, please report it privately:
+**Do not** open a public GitHub issue for security reports.
 
-- **GitHub Security Advisories:** Use the repo's "Report a vulnerability" button (preferred).
+Report privately via:
+
+- **GitHub Security Advisories:** "Report a vulnerability" button (preferred)
 - **Email:** security@promptfoo.dev (fallback: support@promptfoo.dev)
 
-Please **do not** open a public GitHub issue for security reports.
+Include:
 
-Include the following details:
-
-- Description and steps to reproduce the vulnerability
-- Software version and/or cloud environment where the issue was discovered
-- Potential security impact
-- Whether the issue is remotely exploitable or requires local access
-- Your contact information for follow-up (optional)
+- Description and steps to reproduce
+- Affected version or environment
+- Security impact assessment
+- Whether remotely exploitable or requires local access
+- Your contact info for follow-up (optional)
 
 ## Response Time
 
-We will acknowledge your report within **1 business day** and keep you informed throughout the remediation process.
+We will acknowledge your report within **1 business day** and keep you informed throughout remediation.
 
 ## Responsible Disclosure Guidelines
 
 When researching or disclosing vulnerabilities:
 
-- Do not exploit the vulnerability beyond the minimal testing needed to demonstrate the issue.
-- Do not disclose the vulnerability publicly or to third parties before it is resolved.
-- Allow Promptfoo reasonable time to investigate and remediate the issue before public disclosure.
+- Do not exploit beyond minimal testing needed to demonstrate the issue
+- Do not disclose publicly or to third parties before resolution
+- Allow reasonable time for investigation and remediation
 
 ## Coordinated Disclosure
 
 We ask that you keep details private until:
 
 - A fix is released, or
-- We agree on a disclosure date.
+- We agree on a disclosure date
 
-We will work with you to establish a reasonable timeline for public disclosure.
+We will work with you to establish a reasonable timeline.
 
 ## Our Commitment
 
-Upon receiving your disclosure, Promptfoo commits to:
+Upon receiving your disclosure, we commit to:
 
-- Acknowledge your report within 1 business day.
-- Keep you informed throughout the remediation process.
-- Work diligently to resolve vulnerabilities in a timely manner.
-- Provide recognition (with your consent) for your responsible disclosure in our security acknowledgments, changelogs, or other public communications.
+- Acknowledge within 1 business day
+- Keep you informed throughout remediation
+- Resolve vulnerabilities in a timely manner
+- Credit you (with consent) in security acknowledgments or changelogs
 
 ## Safe Harbor
 
@@ -74,13 +91,15 @@ If you act in good faith and follow this policy, we will not pursue legal action
 
 ## Out-of-Scope
 
-The following items are out-of-scope for our vulnerability disclosure program:
+The following are out-of-scope:
 
-- Issues related to social engineering or phishing attacks
-- Vulnerabilities affecting outdated versions of Promptfoo software (not actively supported)
-- Non-security-related bugs or functionality requests
-- Denial of service from unreasonable traffic volumes
+- Code execution from explicitly configured custom code in OSS (expected behavior)
+- Issues requiring users to run untrusted configs with local privileges
+- Social engineering, phishing, or physical attacks
+- Volumetric denial of service
+- Vulnerabilities in unsupported versions
+- Non-security bugs or feature requests
 
-If you are unsure whether something is in scope, report it anyway.
+If unsure whether something is in scope, report it anyway.
 
-Thank you for helping us protect Promptfoo users and improve our software's security.
+Thank you for helping protect Promptfoo users.


### PR DESCRIPTION
## Summary

Updates both security policy files with a split-by-audience approach:

**SECURITY.md** (GitHub - developer/researcher focused):
- Security model explaining unsandboxed code execution
- Hardening recommendations for CI/shared environments
- Detailed in-scope/out-of-scope technical definitions
- 1 business day response time commitment
- Links to website for full disclosure policy

**Responsible Disclosure Policy** (website - general audience):
- Safe harbor provisions (new)
- Coordinated disclosure section (new)
- 1 business day response time commitment (new)
- GitHub Security Advisories as preferred reporting channel
- Links to SECURITY.md for technical details

Both files cross-reference each other so users find all relevant information.

## Test plan

- [x] SECURITY.md renders correctly on GitHub
- [x] Website policy renders correctly (check with `npm run dev` in site/)
- [x] Cross-links between files are valid