### PR TITLE
feat(site): update blog worker API endpoint to Cloud Run

### DIFF
--- a/site/blog/goat/components/constants.ts
+++ b/site/blog/goat/components/constants.ts
@@ -1,1 +1,1 @@
-export const API_BASE_URL = 'https://api.promptfoo.dev';
+export const API_BASE_URL = 'https://blog-worker-58786025894.us-central1.run.app';


### PR DESCRIPTION
## Summary
- Updates the GOAT blog post API endpoint from `https://api.promptfoo.dev` to the new Cloud Run service
- The blog worker has been migrated from Cloud Functions to Cloud Run

## Changes
- Updated `site/blog/goat/components/constants.ts` to use direct Cloud Run endpoint: `https://blog-worker-58786025894.us-central1.run.app`

## Test plan
- [x] Verified new endpoint is live and healthy
- [ ] Test interactive components in GOAT blog post (http://localhost:3100/blog/jailbreaking-with-goat)

Related to promptfoo/promptfoo-cloud#3023

🤖 Generated with [Claude Code](https://claude.com/claude-code)