### PR TITLE
fix(helm): correct Docker registry domain from fghcr.io to ghcr.io

### DIFF
--- a/helm/chart/promptfoo/values.yaml
+++ b/helm/chart/promptfoo/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: fghcr.io/promptfoo/promptfoo
+  repository: ghcr.io/promptfoo/promptfoo
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: v1.0.0


### PR DESCRIPTION
## Summary

Fixes a typo in the Helm chart values where the GitHub Container Registry domain was incorrectly specified as `fghcr.io` instead of `ghcr.io`. This typo was causing Renovate to fail when attempting to look up the Docker package dependency.

## Changes

- Updated `helm/chart/promptfoo/values.yaml` line 8: `fghcr.io/promptfoo/promptfoo` → `ghcr.io/promptfoo/promptfoo`

## Test plan

- Verify that the correct registry domain (`ghcr.io`) is now used in the Helm chart
- Renovate should successfully look up the Docker image on its next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)