### PR TITLE
docs(agents): add Zustand store testing patterns

### DIFF
--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -91,7 +91,7 @@ See `src/app/src/hooks/usePageMeta.test.ts` for patterns. Use `vi.fn()` for mock
 
 ## Key Patterns
 
-- **Zustand stores**: See `src/app/src/store/` for patterns
+- **Zustand stores**: See `src/app/src/store/` for implementation patterns; see `test/AGENTS.md` "Zustand Store Testing" section for testing patterns
 - **Custom hooks**: See `src/app/src/hooks/` for patterns
 - **New components**: Use `components/ui/` primitives, compose with Tailwind
 - **Icons**: Use Lucide React


### PR DESCRIPTION
## Summary
- Added comprehensive guidance for testing components that use Zustand stores
- Documents integration testing patterns with real stores as the preferred approach
- Includes patterns for store state reset, async assertions, and test references

## Key Changes
- `test/AGENTS.md`: New "Zustand Store Testing" section with detailed patterns
- `src/app/AGENTS.md`: Cross-reference to testing patterns documentation