### PR TITLE
feat(app): add NavigationSidebar component and enhance Tabs

### DIFF
--- a/src/app/src/components/ui/index.ts
+++ b/src/app/src/components/ui/index.ts
@@ -62,6 +62,7 @@ export {
   NavigationMenuViewport,
   navigationMenuTriggerStyle,
 } from './navigation-menu';
+export { NavigationSidebar } from './navigation-sidebar';
 export { NumberInput } from './number-input';
 export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from './popover';
 export { Progress } from './progress';
@@ -102,6 +103,12 @@ export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tool
 
 export type { CheckboxProps } from './checkbox';
 export type { InputProps } from './input';
+export type {
+  NavigationItem,
+  NavigationItemStatus,
+  NavigationSidebarProps,
+} from './navigation-sidebar';
 export type { RadioGroupItemProps, RadioGroupProps } from './radio-group';
 export type { SelectTriggerProps } from './select';
+export type { TabsListProps, TabsListVariant, TabsProps, TabsTriggerProps } from './tabs';
 export type { TextareaProps } from './textarea';

--- a/src/app/src/components/ui/navigation-sidebar.stories.tsx
+++ b/src/app/src/components/ui/navigation-sidebar.stories.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'react';
+
+import {
+  AlertTriangle,
+  Bug,
+  CheckCircle,
+  Database,
+  FileText,
+  GraduationCap,
+  History,
+  Key,
+  LayoutDashboard,
+  Lock,
+  Settings,
+  Shield,
+  SlidersHorizontal,
+  User,
+  Users,
+  XCircle,
+} from 'lucide-react';
+import { type NavigationItem, NavigationSidebar } from './navigation-sidebar';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof NavigationSidebar> = {
+  title: 'UI/NavigationSidebar',
+  component: NavigationSidebar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-[500px] bg-muted/30">
+        <Story />
+        <div className="flex-1 p-8">
+          <div className="rounded-lg border border-border bg-background p-6">
+            <h2 className="text-lg font-semibold">Content Area</h2>
+            <p className="text-sm text-muted-foreground mt-2">
+              This is where your page content would go.
+            </p>
+          </div>
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationSidebar>;
+
+const defaultItems: NavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: <LayoutDashboard className="size-4" /> },
+  { id: 'settings', label: 'Settings', icon: <Settings className="size-4" /> },
+  { id: 'vulnerabilities', label: 'Vulnerabilities', icon: <Bug className="size-4" /> },
+  { id: 'history', label: 'Scan History', icon: <History className="size-4" /> },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return <NavigationSidebar items={defaultItems} activeId={activeId} onNavigate={setActiveId} />;
+  },
+};
+
+const itemsWithDisabled: NavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: <LayoutDashboard className="size-4" /> },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: <Settings className="size-4" />,
+    disabled: true,
+    tooltip: 'Only available for cloud targets',
+  },
+  { id: 'vulnerabilities', label: 'Vulnerabilities', icon: <Bug className="size-4" /> },
+  { id: 'history', label: 'Scan History', icon: <History className="size-4" /> },
+  {
+    id: 'grading',
+    label: 'Grading Examples',
+    icon: <GraduationCap className="size-4" />,
+    disabled: true,
+    tooltip: 'Upgrade to Pro to access this feature',
+  },
+  { id: 'severities', label: 'Plugin Severities', icon: <SlidersHorizontal className="size-4" /> },
+];
+
+export const WithDisabledItems: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar items={itemsWithDisabled} activeId={activeId} onNavigate={setActiveId} />
+    );
+  },
+};
+
+export const WithHeader: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar
+        items={defaultItems}
+        activeId={activeId}
+        onNavigate={setActiveId}
+        header={
+          <div className="rounded-md border border-border bg-muted/50 px-3 py-2">
+            <p className="text-xs font-medium text-muted-foreground">Current Target</p>
+            <p className="text-sm font-semibold truncate">Production API v2</p>
+          </div>
+        }
+      />
+    );
+  },
+};
+
+export const WithFooter: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar
+        items={defaultItems}
+        activeId={activeId}
+        onNavigate={setActiveId}
+        footer={
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Users className="size-4" />
+            <span>Team Settings</span>
+          </div>
+        }
+      />
+    );
+  },
+};
+
+const simpleItems: NavigationItem[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'analytics', label: 'Analytics' },
+  { id: 'reports', label: 'Reports' },
+  { id: 'settings', label: 'Settings' },
+];
+
+export const WithoutIcons: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('overview');
+    return <NavigationSidebar items={simpleItems} activeId={activeId} onNavigate={setActiveId} />;
+  },
+};
+
+const itemsWithStatus: NavigationItem[] = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    icon: <LayoutDashboard className="size-4" />,
+    status: 'success',
+  },
+  {
+    id: 'vulnerabilities',
+    label: 'Vulnerabilities',
+    icon: <Bug className="size-4" />,
+    status: 'error',
+    tooltip: '3 critical vulnerabilities found',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: <Settings className="size-4" />,
+    status: 'warning',
+    tooltip: 'Configuration incomplete',
+  },
+  {
+    id: 'history',
+    label: 'Scan History',
+    icon: <History className="size-4" />,
+    status: 'info',
+  },
+];
+
+export const WithStatusIndicators: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar items={itemsWithStatus} activeId={activeId} onNavigate={setActiveId} />
+    );
+  },
+};
+
+const itemsWithStatusIcons: NavigationItem[] = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    icon: <LayoutDashboard className="size-4" />,
+    status: 'success',
+    statusIcon: <CheckCircle className="size-4" />,
+  },
+  {
+    id: 'vulnerabilities',
+    label: 'Vulnerabilities',
+    icon: <Bug className="size-4" />,
+    status: 'error',
+    statusIcon: <XCircle className="size-4" />,
+    tooltip: '3 critical vulnerabilities found',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: <Settings className="size-4" />,
+    status: 'warning',
+    statusIcon: <AlertTriangle className="size-4" />,
+    tooltip: 'Configuration incomplete',
+  },
+  { id: 'history', label: 'Scan History', icon: <History className="size-4" /> },
+];
+
+export const WithStatusIcons: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar
+        items={itemsWithStatusIcons}
+        activeId={activeId}
+        onNavigate={setActiveId}
+      />
+    );
+  },
+};
+
+const nestedItems: NavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: <LayoutDashboard className="size-4" /> },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: <Settings className="size-4" />,
+    defaultExpanded: true,
+    children: [
+      { id: 'settings-general', label: 'General', icon: <SlidersHorizontal className="size-4" /> },
+      { id: 'settings-profile', label: 'Profile', icon: <User className="size-4" /> },
+      {
+        id: 'settings-security',
+        label: 'Security',
+        icon: <Shield className="size-4" />,
+        children: [
+          {
+            id: 'settings-security-auth',
+            label: 'Authentication',
+            icon: <Key className="size-4" />,
+          },
+          {
+            id: 'settings-security-permissions',
+            label: 'Permissions',
+            icon: <Lock className="size-4" />,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'data',
+    label: 'Data',
+    icon: <Database className="size-4" />,
+    children: [
+      { id: 'data-imports', label: 'Imports' },
+      { id: 'data-exports', label: 'Exports' },
+    ],
+  },
+  { id: 'history', label: 'History', icon: <History className="size-4" /> },
+];
+
+export const NestedItems: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return <NavigationSidebar items={nestedItems} activeId={activeId} onNavigate={setActiveId} />;
+  },
+};
+
+const deeplyNestedItems: NavigationItem[] = [
+  { id: 'home', label: 'Home', icon: <LayoutDashboard className="size-4" /> },
+  {
+    id: 'docs',
+    label: 'Documentation',
+    icon: <FileText className="size-4" />,
+    defaultExpanded: true,
+    children: [
+      {
+        id: 'docs-guides',
+        label: 'Guides',
+        defaultExpanded: true,
+        children: [
+          {
+            id: 'docs-guides-getting-started',
+            label: 'Getting Started',
+            children: [
+              { id: 'docs-guides-getting-started-install', label: 'Installation' },
+              { id: 'docs-guides-getting-started-config', label: 'Configuration' },
+              { id: 'docs-guides-getting-started-first-run', label: 'First Run' },
+            ],
+          },
+          { id: 'docs-guides-advanced', label: 'Advanced Usage' },
+        ],
+      },
+      { id: 'docs-api', label: 'API Reference' },
+      { id: 'docs-faq', label: 'FAQ' },
+    ],
+  },
+  { id: 'support', label: 'Support', icon: <Users className="size-4" /> },
+];
+
+export const DeeplyNested: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('home');
+    return (
+      <NavigationSidebar items={deeplyNestedItems} activeId={activeId} onNavigate={setActiveId} />
+    );
+  },
+};
+
+const nestedWithStatus: NavigationItem[] = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    icon: <LayoutDashboard className="size-4" />,
+    status: 'success',
+  },
+  {
+    id: 'security',
+    label: 'Security',
+    icon: <Shield className="size-4" />,
+    defaultExpanded: true,
+    children: [
+      { id: 'security-auth', label: 'Authentication', status: 'success' },
+      {
+        id: 'security-permissions',
+        label: 'Permissions',
+        status: 'warning',
+        tooltip: '2 roles need review',
+      },
+      {
+        id: 'security-audit',
+        label: 'Audit Log',
+        status: 'error',
+        tooltip: '5 failed login attempts',
+      },
+    ],
+  },
+  { id: 'settings', label: 'Settings', icon: <Settings className="size-4" /> },
+];
+
+export const NestedWithStatus: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar items={nestedWithStatus} activeId={activeId} onNavigate={setActiveId} />
+    );
+  },
+};
+
+const itemsWithGroups: NavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: <LayoutDashboard className="size-4" /> },
+  {
+    id: 'main-group',
+    label: 'Main',
+    group: true,
+    children: [
+      { id: 'vulnerabilities', label: 'Vulnerabilities', icon: <Bug className="size-4" /> },
+      { id: 'history', label: 'Scan History', icon: <History className="size-4" /> },
+    ],
+  },
+  {
+    id: 'settings-group',
+    label: 'Settings',
+    group: true,
+    icon: <Settings className="size-4" />,
+    children: [
+      { id: 'settings-general', label: 'General', icon: <SlidersHorizontal className="size-4" /> },
+      { id: 'settings-security', label: 'Security', icon: <Shield className="size-4" /> },
+      { id: 'settings-users', label: 'Users', icon: <Users className="size-4" /> },
+    ],
+  },
+];
+
+export const WithGroups: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar items={itemsWithGroups} activeId={activeId} onNavigate={setActiveId} />
+    );
+  },
+};
+
+export const Collapsible: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar
+        items={defaultItems}
+        activeId={activeId}
+        onNavigate={setActiveId}
+        collapsible
+      />
+    );
+  },
+};
+
+export const CollapsibleWithGroups: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState('dashboard');
+    return (
+      <NavigationSidebar
+        items={itemsWithGroups}
+        activeId={activeId}
+        onNavigate={setActiveId}
+        collapsible
+      />
+    );
+  },
+};

--- a/src/app/src/components/ui/navigation-sidebar.tsx
+++ b/src/app/src/components/ui/navigation-sidebar.tsx
@@ -1,0 +1,365 @@
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@app/components/ui/tooltip';
+import { cn } from '@app/lib/utils';
+import { ChevronRight } from 'lucide-react';
+
+export type NavigationItemStatus = 'error' | 'warning' | 'success' | 'info';
+
+export interface NavigationItem {
+  /** Unique identifier for the navigation item */
+  id: string;
+  /** Display label for the item */
+  label: string;
+  /** Icon element to display (typically a Lucide icon) */
+  icon?: React.ReactNode;
+  /** Whether the item is disabled */
+  disabled?: boolean;
+  /** Tooltip text to show when item is disabled or for status */
+  tooltip?: string;
+  /** Status indicator (shows colored dot or custom icon) */
+  status?: NavigationItemStatus;
+  /** Custom status icon (overrides the default dot) */
+  statusIcon?: React.ReactNode;
+  /** Nested child items (up to 3 levels deep) */
+  children?: NavigationItem[];
+  /** Whether the item starts expanded (only applies to items with children) */
+  defaultExpanded?: boolean;
+  /** If true, item is a non-selectable group header (always expanded, no navigation) */
+  group?: boolean;
+}
+
+const statusColors: Record<NavigationItemStatus, string> = {
+  error: 'bg-red-500',
+  warning: 'bg-amber-500',
+  success: 'bg-emerald-500',
+  info: 'bg-blue-500',
+};
+
+const statusIconColors: Record<NavigationItemStatus, string> = {
+  error: 'text-red-500',
+  warning: 'text-amber-500',
+  success: 'text-emerald-500',
+  info: 'text-blue-500',
+};
+
+function StatusIndicator({
+  status,
+  statusIcon,
+}: {
+  status: NavigationItemStatus;
+  statusIcon?: React.ReactNode;
+}) {
+  if (statusIcon) {
+    return <span className={cn('ml-auto shrink-0', statusIconColors[status])}>{statusIcon}</span>;
+  }
+  return <span className={cn('ml-auto size-2 shrink-0 rounded-full', statusColors[status])} />;
+}
+
+export interface NavigationSidebarProps {
+  /** Array of navigation items to display */
+  items: NavigationItem[];
+  /** Currently active item id */
+  activeId?: string;
+  /** Callback when a navigation item is selected */
+  onNavigate?: (id: string) => void;
+  /** Optional header content (e.g., a combobox or title) */
+  header?: React.ReactNode;
+  /** Optional footer content */
+  footer?: React.ReactNode;
+  /** Additional className for the container */
+  className?: string;
+  /** If true, sidebar collapses to icons only and expands on hover */
+  collapsible?: boolean;
+}
+
+// Indentation padding for each nesting level
+const levelPadding: Record<number, string> = {
+  0: 'pl-3',
+  1: 'pl-7',
+  2: 'pl-11',
+};
+
+interface NavigationItemButtonProps {
+  item: NavigationItem;
+  level: number;
+  isActive: boolean;
+  isExpanded: boolean;
+  isCollapsed: boolean;
+  onSelect: (id: string) => void;
+  onToggleExpand: (id: string) => void;
+}
+
+function NavigationItemButton({
+  item,
+  level,
+  isActive,
+  isExpanded,
+  isCollapsed,
+  onSelect,
+  onToggleExpand,
+}: NavigationItemButtonProps) {
+  const hasChildren = item.children && item.children.length > 0;
+
+  const handleClick = () => {
+    if (item.disabled) {
+      return;
+    }
+    onSelect(item.id);
+  };
+
+  const handleChevronClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleExpand(item.id);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  const button = (
+    <button
+      type="button"
+      role="treeitem"
+      aria-expanded={hasChildren ? isExpanded : undefined}
+      aria-selected={isActive}
+      disabled={item.disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-lg h-10 text-left text-sm font-medium',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        isActive
+          ? 'border-l-2 border-l-primary bg-primary/10 text-primary'
+          : 'bg-white dark:bg-zinc-900 text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+        item.disabled && 'cursor-not-allowed opacity-50',
+        isCollapsed ? 'justify-center px-2' : cn('pr-3', levelPadding[level] || 'pl-3'),
+      )}
+    >
+      {item.icon && <span className="size-4 shrink-0">{item.icon}</span>}
+      {!isCollapsed && (
+        <>
+          <span className="flex-1 truncate">{item.label}</span>
+          {item.status && <StatusIndicator status={item.status} statusIcon={item.statusIcon} />}
+          {hasChildren && (
+            <button
+              type="button"
+              onClick={handleChevronClick}
+              className="p-1 -m-1 rounded hover:bg-muted"
+            >
+              <ChevronRight
+                className={cn('size-4 shrink-0 text-muted-foreground', isExpanded && 'rotate-90')}
+              />
+            </button>
+          )}
+        </>
+      )}
+    </button>
+  );
+
+  if (item.tooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="w-full">{button}</span>
+        </TooltipTrigger>
+        <TooltipContent side="right">{item.tooltip}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return button;
+}
+
+function findItemById(items: NavigationItem[], id: string): NavigationItem | undefined {
+  for (const item of items) {
+    if (item.id === id) {
+      return item;
+    }
+    if (item.children) {
+      const found = findItemById(item.children, id);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
+function findAncestorIds(
+  items: NavigationItem[],
+  targetId: string,
+  path: string[] = [],
+): string[] | null {
+  for (const item of items) {
+    if (item.id === targetId) {
+      return path;
+    }
+    if (item.children) {
+      const found = findAncestorIds(item.children, targetId, [...path, item.id]);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+function getDefaultExpandedIds(items: NavigationItem[]): Set<string> {
+  const ids = new Set<string>();
+  const traverse = (items: NavigationItem[]) => {
+    for (const item of items) {
+      if (item.children && item.defaultExpanded) {
+        ids.add(item.id);
+      }
+      if (item.children) {
+        traverse(item.children);
+      }
+    }
+  };
+  traverse(items);
+  return ids;
+}
+
+export function NavigationSidebar({
+  items,
+  activeId,
+  onNavigate,
+  header,
+  footer,
+  className,
+  collapsible = false,
+}: NavigationSidebarProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => getDefaultExpandedIds(items));
+  const [isHovered, setIsHovered] = useState(false);
+  const isCollapsed = collapsible && !isHovered;
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      const item = findItemById(items, id);
+      if (item && !item.disabled && onNavigate) {
+        onNavigate(id);
+        // Keep ancestors expanded, and open this item's children if it has any
+        const ancestors = findAncestorIds(items, id) || [];
+        const newExpanded = new Set(ancestors);
+        if (item.children && item.children.length > 0) {
+          newExpanded.add(id);
+        }
+        setExpandedIds(newExpanded);
+      }
+    },
+    [items, onNavigate],
+  );
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderItems = (items: NavigationItem[], level: number) => {
+    if (level > 2) {
+      return null; // Max 3 levels (0, 1, 2)
+    }
+    // When collapsed, only render top-level non-group items
+    if (isCollapsed && level > 0) {
+      return null;
+    }
+
+    return items.map((item) => {
+      const hasChildren = item.children && item.children.length > 0;
+      const isExpanded = item.group || expandedIds.has(item.id);
+      const isActive = item.id === activeId;
+
+      // Group headers are non-interactive labels
+      if (item.group) {
+        if (isCollapsed) {
+          // When collapsed, show a separator and render group children
+          return (
+            <div key={item.id} className="pt-3 first:pt-0">
+              <div className="mb-2 border-t border-border" />
+              {hasChildren && renderItems(item.children!, level)}
+            </div>
+          );
+        }
+        return (
+          <div key={item.id} className="pt-4 first:pt-0">
+            <div className="flex items-center gap-2 px-3 py-2">
+              {item.icon && (
+                <span className="size-4 shrink-0 text-muted-foreground">{item.icon}</span>
+              )}
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {item.label}
+              </span>
+            </div>
+            {hasChildren && <div className="mt-1">{renderItems(item.children!, level)}</div>}
+          </div>
+        );
+      }
+
+      return (
+        <div key={item.id}>
+          <NavigationItemButton
+            item={item}
+            level={isCollapsed ? 0 : level}
+            isActive={isActive}
+            isExpanded={isExpanded}
+            isCollapsed={isCollapsed}
+            onSelect={handleSelect}
+            onToggleExpand={handleToggleExpand}
+          />
+          {hasChildren && !isCollapsed && (
+            <div
+              className={cn(
+                'grid transition-[grid-template-rows] duration-200 ease-out',
+                isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+              )}
+            >
+              <div className="overflow-hidden">
+                <div className="mt-1">{renderItems(item.children!, level + 1)}</div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <TooltipProvider>
+      <div
+        onMouseEnter={() => collapsible && setIsHovered(true)}
+        onMouseLeave={() => collapsible && setIsHovered(false)}
+        className={cn(
+          'sticky top-0 flex h-full shrink-0 flex-col border-r border-border bg-white dark:bg-zinc-900 overflow-y-auto overflow-x-hidden transition-[width] duration-200 ease-out',
+          isCollapsed ? 'w-14 px-2' : 'w-60 px-4',
+          'py-4',
+          className,
+        )}
+      >
+        {!isCollapsed && header && <div className="mb-4">{header}</div>}
+
+        <nav role="tree" aria-label="Navigation" className="flex-1 space-y-1">
+          {renderItems(items, 0)}
+        </nav>
+
+        {!isCollapsed && footer && <div className="mt-4 pt-4 border-t border-border">{footer}</div>}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/app/src/components/ui/tabs.stories.tsx
+++ b/src/app/src/components/ui/tabs.stories.tsx
@@ -1,3 +1,4 @@
+import { Home, Settings, User } from 'lucide-react';
 import { Button } from './button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './card';
 import { Input } from './input';
@@ -163,11 +164,11 @@ export const DisabledTab: Story = {
   ),
 };
 
-// Full width tabs
+// Full width tabs using fullWidth prop
 export const FullWidth: Story = {
   render: () => (
     <Tabs defaultValue="all" className="w-full">
-      <TabsList className="w-full">
+      <TabsList fullWidth>
         <TabsTrigger value="all" className="flex-1">
           All
         </TabsTrigger>
@@ -186,6 +187,195 @@ export const FullWidth: Story = {
       </TabsContent>
       <TabsContent value="failed">
         <p className="text-sm text-muted-foreground p-4">Showing failed results</p>
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+// Line variant
+export const LineVariant: Story = {
+  render: () => (
+    <Tabs defaultValue="overview" className="w-full">
+      <TabsList variant="line">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="analytics">Analytics</TabsTrigger>
+        <TabsTrigger value="reports">Reports</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        <div className="p-4">
+          <h3 className="font-medium">Overview</h3>
+          <p className="text-sm text-muted-foreground mt-2">
+            View your dashboard overview and key metrics.
+          </p>
+        </div>
+      </TabsContent>
+      <TabsContent value="analytics">
+        <div className="p-4">
+          <h3 className="font-medium">Analytics</h3>
+          <p className="text-sm text-muted-foreground mt-2">Analyze your data and trends.</p>
+        </div>
+      </TabsContent>
+      <TabsContent value="reports">
+        <div className="p-4">
+          <h3 className="font-medium">Reports</h3>
+          <p className="text-sm text-muted-foreground mt-2">Generate and view reports.</p>
+        </div>
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+// Vertical orientation with pill variant
+export const VerticalPill: Story = {
+  render: () => (
+    <Tabs defaultValue="home" orientation="vertical" className="flex gap-4 w-full">
+      <TabsList>
+        <TabsTrigger value="home">Home</TabsTrigger>
+        <TabsTrigger value="profile">Profile</TabsTrigger>
+        <TabsTrigger value="settings">Settings</TabsTrigger>
+      </TabsList>
+      <div className="flex-1">
+        <TabsContent value="home">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Home</h3>
+            <p className="text-sm text-muted-foreground mt-2">Welcome to your dashboard.</p>
+          </div>
+        </TabsContent>
+        <TabsContent value="profile">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Profile</h3>
+            <p className="text-sm text-muted-foreground mt-2">Manage your profile settings.</p>
+          </div>
+        </TabsContent>
+        <TabsContent value="settings">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Settings</h3>
+            <p className="text-sm text-muted-foreground mt-2">Configure your application.</p>
+          </div>
+        </TabsContent>
+      </div>
+    </Tabs>
+  ),
+};
+
+// Vertical orientation with line variant
+export const VerticalLine: Story = {
+  render: () => (
+    <Tabs defaultValue="home" orientation="vertical" className="flex gap-4 w-full">
+      <TabsList variant="line">
+        <TabsTrigger value="home">Home</TabsTrigger>
+        <TabsTrigger value="profile">Profile</TabsTrigger>
+        <TabsTrigger value="settings">Settings</TabsTrigger>
+      </TabsList>
+      <div className="flex-1">
+        <TabsContent value="home">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Home</h3>
+            <p className="text-sm text-muted-foreground mt-2">Welcome to your dashboard.</p>
+          </div>
+        </TabsContent>
+        <TabsContent value="profile">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Profile</h3>
+            <p className="text-sm text-muted-foreground mt-2">Manage your profile settings.</p>
+          </div>
+        </TabsContent>
+        <TabsContent value="settings">
+          <div className="p-4 border rounded-lg">
+            <h3 className="font-medium">Settings</h3>
+            <p className="text-sm text-muted-foreground mt-2">Configure your application.</p>
+          </div>
+        </TabsContent>
+      </div>
+    </Tabs>
+  ),
+};
+
+// With icons
+export const WithIcons: Story = {
+  render: () => (
+    <Tabs defaultValue="home" className="w-[400px]">
+      <TabsList>
+        <TabsTrigger value="home" icon={<Home />}>
+          Home
+        </TabsTrigger>
+        <TabsTrigger value="profile" icon={<User />}>
+          Profile
+        </TabsTrigger>
+        <TabsTrigger value="settings" icon={<Settings />}>
+          Settings
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="home">
+        <p className="text-sm text-muted-foreground">Home content</p>
+      </TabsContent>
+      <TabsContent value="profile">
+        <p className="text-sm text-muted-foreground">Profile content</p>
+      </TabsContent>
+      <TabsContent value="settings">
+        <p className="text-sm text-muted-foreground">Settings content</p>
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+// With icons at end
+export const WithIconsEnd: Story = {
+  render: () => (
+    <Tabs defaultValue="home" className="w-[400px]">
+      <TabsList>
+        <TabsTrigger value="home" icon={<Home />} iconPosition="end">
+          Home
+        </TabsTrigger>
+        <TabsTrigger value="profile" icon={<User />} iconPosition="end">
+          Profile
+        </TabsTrigger>
+        <TabsTrigger value="settings" icon={<Settings />} iconPosition="end">
+          Settings
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="home">
+        <p className="text-sm text-muted-foreground">Home content</p>
+      </TabsContent>
+      <TabsContent value="profile">
+        <p className="text-sm text-muted-foreground">Profile content</p>
+      </TabsContent>
+      <TabsContent value="settings">
+        <p className="text-sm text-muted-foreground">Settings content</p>
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+// Line variant with icons
+export const LineWithIcons: Story = {
+  render: () => (
+    <Tabs defaultValue="home" className="w-full">
+      <TabsList variant="line">
+        <TabsTrigger value="home" icon={<Home />}>
+          Home
+        </TabsTrigger>
+        <TabsTrigger value="profile" icon={<User />}>
+          Profile
+        </TabsTrigger>
+        <TabsTrigger value="settings" icon={<Settings />}>
+          Settings
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="home">
+        <div className="p-4">
+          <p className="text-sm text-muted-foreground">Home content</p>
+        </div>
+      </TabsContent>
+      <TabsContent value="profile">
+        <div className="p-4">
+          <p className="text-sm text-muted-foreground">Profile content</p>
+        </div>
+      </TabsContent>
+      <TabsContent value="settings">
+        <div className="p-4">
+          <p className="text-sm text-muted-foreground">Settings content</p>
+        </div>
       </TabsContent>
     </Tabs>
   ),

--- a/src/app/src/components/ui/tabs.test.tsx
+++ b/src/app/src/components/ui/tabs.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Computer, Settings } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
 
@@ -68,7 +69,7 @@ describe('TabsList', () => {
     expect(tablist).toBeInTheDocument();
   });
 
-  it('applies correct styles', () => {
+  it('applies correct styles for pill variant (default)', () => {
     render(
       <Tabs defaultValue="tab1">
         <TabsList>
@@ -77,7 +78,34 @@ describe('TabsList', () => {
       </Tabs>,
     );
     const tablist = screen.getByRole('tablist');
-    expect(tablist).toHaveClass('inline-flex', 'h-10', 'rounded-md', 'bg-muted');
+    expect(tablist).toHaveClass('inline-flex', 'rounded-md', 'bg-muted');
+    expect(tablist).toHaveAttribute('data-variant', 'pill');
+  });
+
+  it('applies correct styles for line variant', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList variant="line">
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveClass('bg-transparent');
+    expect(tablist).toHaveAttribute('data-variant', 'line');
+    expect(tablist).not.toHaveClass('rounded-md', 'bg-muted');
+  });
+
+  it('applies fullWidth class when fullWidth is true', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList fullWidth>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveClass('w-full');
   });
 
   it('applies custom className', () => {
@@ -115,7 +143,7 @@ describe('TabsTrigger', () => {
       </Tabs>,
     );
     const trigger = screen.getByRole('tab', { name: 'Tab' });
-    expect(trigger).toHaveClass('inline-flex', 'items-center', 'justify-center');
+    expect(trigger).toHaveClass('inline-flex', 'items-center');
   });
 
   it('applies custom className', () => {
@@ -144,6 +172,41 @@ describe('TabsTrigger', () => {
     );
     const trigger = screen.getByRole('tab', { name: 'Disabled' });
     expect(trigger).toHaveAttribute('data-disabled', '');
+  });
+
+  it('renders with icon at start position', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1" icon={<Computer data-testid="computer-icon" />}>
+            Local Files
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    expect(screen.getByTestId('computer-icon')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Local Files/i })).toBeInTheDocument();
+  });
+
+  it('renders with icon at end position', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger
+            value="tab1"
+            icon={<Settings data-testid="settings-icon" />}
+            iconPosition="end"
+          >
+            Settings
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    expect(screen.getByRole('tab', { name: /Settings/i })).toBeInTheDocument();
+    expect(screen.getByTestId('settings-icon')).toBeInTheDocument();
+    // Icon should come after the text in the DOM when iconPosition="end"
+    const iconWrapper = screen.getByTestId('settings-icon').parentElement;
+    expect(iconWrapper).toHaveClass('ml-2');
   });
 });
 
@@ -195,5 +258,113 @@ describe('Tabs composition', () => {
     expect(screen.getByRole('tab', { name: 'Password' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
     expect(screen.getByText('Account settings')).toBeInTheDocument();
+  });
+
+  it('renders tabs with line variant and icons', () => {
+    render(
+      <Tabs defaultValue="local">
+        <TabsList variant="line">
+          <TabsTrigger value="local" icon={<Computer data-testid="computer-icon" />}>
+            Local Files
+          </TabsTrigger>
+          <TabsTrigger value="settings" icon={<Settings data-testid="settings-icon" />}>
+            Settings
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="local">Local content</TabsContent>
+        <TabsContent value="settings">Settings content</TabsContent>
+      </Tabs>,
+    );
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveAttribute('data-variant', 'line');
+    expect(screen.getByTestId('computer-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-icon')).toBeInTheDocument();
+    expect(screen.getByText('Local content')).toBeInTheDocument();
+  });
+
+  it('renders full width tabs', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList variant="line" fullWidth>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+          <TabsTrigger value="tab3">Tab 3</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+        <TabsContent value="tab3">Content 3</TabsContent>
+      </Tabs>,
+    );
+
+    const tablist = screen.getByRole('tablist');
+    // Line variant always has w-full via group-data classes
+    expect(tablist).toHaveAttribute('data-variant', 'line');
+
+    // Verify tab switching still works
+    await user.click(screen.getByRole('tab', { name: 'Tab 2' }));
+    expect(screen.getByText('Content 2')).toBeInTheDocument();
+  });
+});
+
+describe('Tabs vertical orientation', () => {
+  it('renders vertical tabs with correct orientation attribute', () => {
+    render(
+      <Tabs defaultValue="dashboard" orientation="vertical">
+        <TabsList variant="line">
+          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+        <TabsContent value="dashboard">Dashboard content</TabsContent>
+        <TabsContent value="settings">Settings content</TabsContent>
+      </Tabs>,
+    );
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('renders vertical tabs with icons', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="dashboard" orientation="vertical">
+        <TabsList variant="line">
+          <TabsTrigger value="dashboard" icon={<Computer data-testid="dashboard-icon" />}>
+            Dashboard
+          </TabsTrigger>
+          <TabsTrigger value="settings" icon={<Settings data-testid="settings-icon" />}>
+            Settings
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="dashboard">Dashboard content</TabsContent>
+        <TabsContent value="settings">Settings content</TabsContent>
+      </Tabs>,
+    );
+
+    expect(screen.getByTestId('dashboard-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-icon')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard content')).toBeInTheDocument();
+
+    // Verify tab switching works
+    await user.click(screen.getByRole('tab', { name: /Settings/i }));
+    expect(screen.getByText('Settings content')).toBeInTheDocument();
+  });
+
+  it('renders vertical pill variant tabs', () => {
+    render(
+      <Tabs defaultValue="tab1" orientation="vertical">
+        <TabsList variant="pill">
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>,
+    );
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
+    expect(tablist).toHaveAttribute('data-variant', 'pill');
   });
 });

--- a/src/app/src/components/ui/tabs.tsx
+++ b/src/app/src/components/ui/tabs.tsx
@@ -3,14 +3,72 @@ import * as React from 'react';
 import { cn } from '@app/lib/utils';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-const Tabs = TabsPrimitive.Root;
+type TabsListVariant = 'pill' | 'line';
 
-function TabsList({ className, ref, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+interface TabsProps extends React.ComponentProps<typeof TabsPrimitive.Root> {
+  /**
+   * Orientation of the tabs
+   * @default 'horizontal'
+   */
+  orientation?: 'horizontal' | 'vertical';
+}
+
+function Tabs({ className, orientation = 'horizontal', ...props }: TabsProps) {
+  return (
+    <TabsPrimitive.Root
+      orientation={orientation}
+      data-orientation={orientation}
+      className={cn('group', className)}
+      {...props}
+    />
+  );
+}
+
+interface TabsListProps extends React.ComponentProps<typeof TabsPrimitive.List> {
+  /**
+   * Visual style variant for the tabs
+   * - `pill`: Rounded pill-style tabs with muted background (default)
+   * - `line`: Underline-style tabs with border indicator
+   */
+  variant?: TabsListVariant;
+  /**
+   * When true, tabs will stretch to fill the full width/height of the container
+   */
+  fullWidth?: boolean;
+}
+
+function TabsList({
+  className,
+  ref,
+  variant = 'pill',
+  fullWidth = false,
+  ...props
+}: TabsListProps) {
   return (
     <TabsPrimitive.List
       ref={ref}
+      data-variant={variant}
       className={cn(
-        'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+        // Base styles
+        'group/list inline-flex items-center text-muted-foreground',
+        // Horizontal orientation (default)
+        'group-data-[orientation=horizontal]:flex-row',
+        // Vertical orientation
+        'group-data-[orientation=vertical]:flex-col group-data-[orientation=vertical]:items-stretch',
+        // Pill variant
+        variant === 'pill' && [
+          'justify-center rounded-md bg-muted p-1',
+          'group-data-[orientation=horizontal]:h-10',
+          'group-data-[orientation=vertical]:h-auto group-data-[orientation=vertical]:w-full',
+          fullWidth && 'w-full',
+        ],
+        // Line variant - horizontal
+        variant === 'line' && [
+          'h-auto gap-0 bg-transparent p-0',
+          'group-data-[orientation=horizontal]:w-full group-data-[orientation=horizontal]:justify-start group-data-[orientation=horizontal]:border-b group-data-[orientation=horizontal]:border-border',
+          // Line variant - vertical
+          'group-data-[orientation=vertical]:w-full group-data-[orientation=vertical]:border-r group-data-[orientation=vertical]:border-border',
+        ],
         className,
       )}
       {...props}
@@ -18,20 +76,58 @@ function TabsList({ className, ref, ...props }: React.ComponentProps<typeof Tabs
   );
 }
 
+interface TabsTriggerProps extends React.ComponentProps<typeof TabsPrimitive.Trigger> {
+  /**
+   * Optional icon to display alongside the tab label
+   */
+  icon?: React.ReactNode;
+  /**
+   * Position of the icon relative to the label
+   * @default 'start'
+   */
+  iconPosition?: 'start' | 'end';
+}
+
 function TabsTrigger({
   className,
   ref,
+  children,
+  icon,
+  iconPosition = 'start',
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: TabsTriggerProps) {
   return (
     <TabsPrimitive.Trigger
       ref={ref}
       className={cn(
-        'inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+        // Base styles
+        'inline-flex cursor-pointer items-center whitespace-nowrap text-sm font-medium transition-all',
+        'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:pointer-events-none disabled:opacity-50',
+        // Horizontal alignment
+        'group-data-[orientation=horizontal]:justify-center',
+        // Vertical alignment
+        'group-data-[orientation=vertical]:justify-start group-data-[orientation=vertical]:w-full',
+        // Pill variant styles
+        'group-data-[variant=pill]/list:rounded-sm group-data-[variant=pill]/list:px-3 group-data-[variant=pill]/list:py-1.5',
+        'group-data-[variant=pill]/list:data-[state=active]:bg-background group-data-[variant=pill]/list:data-[state=active]:text-foreground group-data-[variant=pill]/list:data-[state=active]:shadow-sm',
+        // Line variant styles - horizontal
+        'group-data-[variant=line]/list:relative group-data-[variant=line]/list:rounded-none group-data-[variant=line]/list:bg-transparent group-data-[variant=line]/list:px-4 group-data-[variant=line]/list:py-3',
+        'group-data-[variant=line]/list:hover:text-foreground',
+        // Line variant - horizontal specific (bottom border indicator)
+        'group-data-[orientation=horizontal]:group-data-[variant=line]/list:flex-1 group-data-[orientation=horizontal]:group-data-[variant=line]/list:border-b-2 group-data-[orientation=horizontal]:group-data-[variant=line]/list:border-transparent',
+        'group-data-[orientation=horizontal]:group-data-[variant=line]/list:data-[state=active]:border-primary group-data-[orientation=horizontal]:group-data-[variant=line]/list:data-[state=active]:text-foreground',
+        // Line variant - vertical specific (right border indicator)
+        'group-data-[orientation=vertical]:group-data-[variant=line]/list:border-r-2 group-data-[orientation=vertical]:group-data-[variant=line]/list:border-transparent',
+        'group-data-[orientation=vertical]:group-data-[variant=line]/list:data-[state=active]:border-primary group-data-[orientation=vertical]:group-data-[variant=line]/list:data-[state=active]:text-foreground',
         className,
       )}
       {...props}
-    />
+    >
+      {icon && iconPosition === 'start' && <span className="mr-2 size-4 shrink-0">{icon}</span>}
+      {children}
+      {icon && iconPosition === 'end' && <span className="ml-2 size-4 shrink-0">{icon}</span>}
+    </TabsPrimitive.Trigger>
   );
 }
 
@@ -44,8 +140,13 @@ function TabsContent({
     <TabsPrimitive.Content
       ref={ref}
       className={cn(
-        'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-        'data-[state=active]:animate-in data-[state=active]:fade-in-0 data-[state=active]:slide-in-from-bottom-1 data-[state=active]:duration-150',
+        'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        // Horizontal - content below tabs
+        'group-data-[orientation=horizontal]:mt-2',
+        // Vertical - content beside tabs
+        'group-data-[orientation=vertical]:ml-0 group-data-[orientation=vertical]:flex-1',
+        // Animation
+        'data-[state=active]:animate-in data-[state=active]:fade-in-0 data-[state=active]:duration-150',
         className,
       )}
       {...props}
@@ -54,3 +155,4 @@ function TabsContent({
 }
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };
+export type { TabsProps, TabsListVariant, TabsListProps, TabsTriggerProps };


### PR DESCRIPTION
## Summary

- Add new `NavigationSidebar` component with nested items, status indicators, collapsible mode, and group headers
- Enhance `Tabs` component with orientation, variant (pill/line), fullWidth, and icon support

## Changes

### NavigationSidebar (new component)
- Support for nested navigation items (up to 3 levels deep)
- Status indicators (error, warning, success, info) with optional custom icons
- Disabled states with tooltip support
- Header and footer slots for custom content
- Collapsible mode that shrinks to icons and expands on hover
- Group headers for organizing navigation sections

### Tabs (enhanced)
- `orientation` prop for horizontal/vertical layouts
- `variant` prop for pill (default) or line styles
- `fullWidth` prop for stretch-to-fill behavior
- Icon support with `icon` and `iconPosition` props on TabsTrigger

## Screenshots

### NavigationSidebar - Default
![NavigationSidebar Default](https://iili.io/fS0fbHB.png)

### NavigationSidebar - Nested Items
![NavigationSidebar Nested](https://iili.io/fS0qdiJ.png)

### Tabs - Line Variant
![Tabs Line Variant](https://iili.io/fS0qFlR.png)

## Test plan
- [x] Stories added for all variations
- [x] Unit tests for Tabs component updated
- [x] Visual review in Storybook
- [x] Test keyboard navigation
- [x] Test in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)