### PR TITLE
feat(app): enhance Combobox with label and clearable props

### DIFF
--- a/src/app/src/components/ui/combobox.stories.tsx
+++ b/src/app/src/components/ui/combobox.stories.tsx
@@ -190,3 +190,39 @@ export const ManyOptions: Story = {
     );
   },
 };
+
+// With label
+export const WithLabel: Story = {
+  render: function LabeledCombobox() {
+    const [value, setValue] = useState('');
+    return (
+      <div className="w-[350px]">
+        <Combobox
+          label="AI Model"
+          options={modelOptions}
+          value={value}
+          onChange={setValue}
+          placeholder="Select a model..."
+        />
+      </div>
+    );
+  },
+};
+
+// Not clearable
+export const NotClearable: Story = {
+  render: function NotClearableCombobox() {
+    const [value, setValue] = useState('gpt-4');
+    return (
+      <div className="w-[350px]">
+        <Combobox
+          options={modelOptions}
+          value={value}
+          onChange={setValue}
+          placeholder="Select a model..."
+          clearable={false}
+        />
+      </div>
+    );
+  },
+};

--- a/src/app/src/components/ui/combobox.test.tsx
+++ b/src/app/src/components/ui/combobox.test.tsx
@@ -322,6 +322,35 @@ describe('Combobox', () => {
       const input = screen.getByRole('combobox');
       expect(input).toHaveFocus();
     });
+
+    it('does not show clear button when clearable is false', () => {
+      render(<Combobox options={mockOptions} value="apple" onChange={vi.fn()} clearable={false} />);
+      expect(screen.queryByLabelText('Clear selection')).not.toBeInTheDocument();
+    });
+
+    it('shows clear button by default (clearable=true)', () => {
+      render(<Combobox options={mockOptions} value="apple" onChange={vi.fn()} />);
+      expect(screen.getByLabelText('Clear selection')).toBeInTheDocument();
+    });
+  });
+
+  describe('label prop', () => {
+    it('renders label when provided', () => {
+      render(<Combobox options={mockOptions} onChange={vi.fn()} label="Select a fruit" />);
+      expect(screen.getByText('Select a fruit')).toBeInTheDocument();
+    });
+
+    it('does not render label when not provided', () => {
+      render(<Combobox options={mockOptions} onChange={vi.fn()} />);
+      expect(screen.queryByText('Select a fruit')).not.toBeInTheDocument();
+    });
+
+    it('label is associated with input via htmlFor', () => {
+      render(<Combobox options={mockOptions} onChange={vi.fn()} label="Select a fruit" />);
+      const label = screen.getByText('Select a fruit');
+      const input = screen.getByRole('combobox');
+      expect(label).toHaveAttribute('for', input.id);
+    });
   });
 
   describe('keyboard navigation', () => {

--- a/src/app/src/components/ui/combobox.tsx
+++ b/src/app/src/components/ui/combobox.tsx
@@ -18,6 +18,8 @@ interface ComboboxProps {
   placeholder?: string;
   emptyMessage?: string;
   disabled?: boolean;
+  clearable?: boolean;
+  label?: string;
   className?: string;
 }
 
@@ -28,6 +30,8 @@ function Combobox({
   placeholder = 'Search...',
   emptyMessage = 'No results found.',
   disabled = false,
+  clearable = true,
+  label,
   className,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
@@ -100,6 +104,8 @@ function Combobox({
 
   const handleInputFocus = useCallback(() => {
     setOpen(true);
+    // Select all text on focus so user can immediately type to search
+    inputRef.current?.select();
   }, []);
 
   const handleInputClick = useCallback(() => {
@@ -187,113 +193,122 @@ function Combobox({
   }, [highlightedIndex]);
 
   const showDropdown = open && options.length > 0;
-  const showClearButton = !!value && !disabled;
+  const showClearButton = clearable && !!value && !disabled;
+  const inputId = `${listboxId}-input`;
 
   return (
-    <Popover open={showDropdown}>
-      <PopoverAnchor asChild>
-        <div className="relative">
-          <input
-            ref={inputRef}
-            type="text"
-            role="combobox"
-            aria-expanded={showDropdown}
-            aria-haspopup="listbox"
-            aria-autocomplete="list"
-            aria-controls={listboxId}
-            aria-activedescendant={
-              highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : undefined
-            }
-            disabled={disabled}
-            value={inputValue}
-            onChange={handleInputChange}
-            onFocus={handleInputFocus}
-            onClick={handleInputClick}
-            onBlur={handleInputBlur}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className={cn(
-              'flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-foreground ring-offset-background',
-              'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-              showClearButton ? 'pr-16' : 'pr-8',
-              className,
-            )}
-          />
-          <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
-            {showClearButton && (
-              <button
-                type="button"
-                data-combobox-clear
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={handleClear}
-                className="p-1 rounded hover:bg-muted transition-colors"
-                aria-label="Clear selection"
-              >
-                <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
-              </button>
-            )}
-            <ChevronDown
-              data-testid="combobox-chevron"
-              className="h-4 w-4 opacity-50 pointer-events-none"
+    <div className="flex flex-col">
+      {label && (
+        <label htmlFor={inputId} className="mb-1.5 text-xs font-medium text-muted-foreground">
+          {label}
+        </label>
+      )}
+      <Popover open={showDropdown}>
+        <PopoverAnchor asChild>
+          <div className="relative">
+            <input
+              id={inputId}
+              ref={inputRef}
+              type="text"
+              role="combobox"
+              aria-expanded={showDropdown}
+              aria-haspopup="listbox"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-activedescendant={
+                highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : undefined
+              }
+              disabled={disabled}
+              value={inputValue}
+              onChange={handleInputChange}
+              onFocus={handleInputFocus}
+              onClick={handleInputClick}
+              onBlur={handleInputBlur}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              className={cn(
+                'flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-foreground ring-offset-background',
+                'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                showClearButton ? 'pr-16' : 'pr-8',
+                className,
+              )}
             />
+            <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+              {showClearButton && (
+                <button
+                  type="button"
+                  data-combobox-clear
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={handleClear}
+                  className="p-1 rounded hover:bg-muted transition-colors"
+                  aria-label="Clear selection"
+                >
+                  <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                </button>
+              )}
+              <ChevronDown
+                data-testid="combobox-chevron"
+                className="h-4 w-4 opacity-50 pointer-events-none"
+              />
+            </div>
           </div>
-        </div>
-      </PopoverAnchor>
-      <PopoverContent
-        data-combobox-content
-        className="w-(--radix-popover-trigger-width) p-1"
-        align="start"
-        sideOffset={4}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onInteractOutside={(e) => {
-          // Don't close if clicking the input or clear button
-          const target = e.target as Node;
-          if (
-            inputRef.current?.contains(target) ||
-            (target as HTMLElement)?.closest?.('[data-combobox-clear]')
-          ) {
-            e.preventDefault();
-          }
-        }}
-      >
-        <div ref={listRef} id={listboxId} className="max-h-60 overflow-y-auto" role="listbox">
-          {filteredOptions.length === 0 ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">{emptyMessage}</div>
-          ) : (
-            filteredOptions.map((option, index) => (
-              <button
-                key={option.value}
-                id={`${listboxId}-option-${index}`}
-                type="button"
-                role="option"
-                aria-selected={option.value === value}
-                data-highlighted={index === highlightedIndex || undefined}
-                onMouseDown={(e) => e.preventDefault()} // Prevent blur
-                onClick={() => handleSelect(option.value)}
-                onMouseEnter={() => setHighlightedIndex(index)}
-                className={cn(
-                  'relative flex w-full cursor-pointer select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm outline-none',
-                  'hover:bg-accent hover:text-accent-foreground',
-                  index === highlightedIndex && 'bg-accent text-accent-foreground',
-                  option.value === value && 'font-medium',
-                )}
-              >
-                <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-                  {option.value === value && <Check className="h-4 w-4" />}
-                </span>
-                <span className="truncate">{option.label}</span>
-                {option.description && (
-                  <span className="ml-2 text-muted-foreground truncate">
-                    · {option.description}
+        </PopoverAnchor>
+        <PopoverContent
+          data-combobox-content
+          className="w-(--radix-popover-trigger-width) p-1"
+          align="start"
+          sideOffset={4}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            // Don't close if clicking the input or clear button
+            const target = e.target as Node;
+            if (
+              inputRef.current?.contains(target) ||
+              (target as HTMLElement)?.closest?.('[data-combobox-clear]')
+            ) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <div ref={listRef} id={listboxId} className="max-h-60 overflow-y-auto" role="listbox">
+            {filteredOptions.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">{emptyMessage}</div>
+            ) : (
+              filteredOptions.map((option, index) => (
+                <button
+                  key={option.value}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  aria-selected={option.value === value}
+                  data-highlighted={index === highlightedIndex || undefined}
+                  onMouseDown={(e) => e.preventDefault()} // Prevent blur
+                  onClick={() => handleSelect(option.value)}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  className={cn(
+                    'relative flex w-full cursor-pointer select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm outline-none',
+                    'hover:bg-accent hover:text-accent-foreground',
+                    index === highlightedIndex && 'bg-accent text-accent-foreground',
+                    option.value === value && 'font-medium',
+                  )}
+                >
+                  <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                    {option.value === value && <Check className="h-4 w-4" />}
                   </span>
-                )}
-              </button>
-            ))
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+                  <span className="truncate">{option.label}</span>
+                  {option.description && (
+                    <span className="ml-2 text-muted-foreground truncate">
+                      · {option.description}
+                    </span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `label` prop to render a label above the combobox
- Add `clearable` prop (default: true) to control clear button visibility
- Select all text on focus for easier search/replace

## Changes

### New Props
- **`label`**: Optional string to render a label above the combobox, properly associated with the input via `htmlFor`
- **`clearable`**: Boolean (default: `true`) to control whether the clear button is shown when a value is selected

### Behavior Changes
- Text is now selected on focus, allowing users to immediately type to search/replace

## Test plan
- [x] Added tests for `clearable={false}` hiding clear button
- [x] Added tests for `label` prop rendering and accessibility
- [x] All 52 existing tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)