### PR TITLE
fix(config): resolve env variables from config env section in provider IDs

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -162,6 +162,41 @@ export async function dereferenceConfig(rawConfig: UnifiedConfig): Promise<Unifi
   return config;
 }
 
+/**
+ * Renders environment variable templates in a config object using two-pass rendering.
+ * This handles nested templates in config.env (fixes #7079).
+ *
+ * Pass 1: Render config.env values using only process.env (isolated from cliState)
+ * Pass 2: Render full config using pre-rendered config.env as overrides
+ *
+ * @param config - The config object to render
+ * @returns The config with env templates rendered
+ */
+function renderConfigEnvTemplates<T extends { env?: Record<string, string> }>(config: T): T {
+  // Respect PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS - use empty object if disabled
+  const processEnvDisabled = getEnvBool(
+    'PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS',
+    getEnvBool('PROMPTFOO_SELF_HOSTED', false),
+  );
+  const baseEnvForFirstPass = processEnvDisabled ? {} : process.env;
+
+  // First pass: render config.env values using only process.env (replaceBase=true)
+  // This avoids pulling stale cliState.config?.env in watch/reload scenarios
+  const rawConfigEnv = config.env;
+  const renderedConfigEnv = rawConfigEnv
+    ? (renderEnvOnlyInObject(rawConfigEnv, baseEnvForFirstPass, true) as Record<string, string>)
+    : undefined;
+
+  // Filter out undefined values from renderedConfigEnv (common in JS configs: env: { FOO: process.env.FOO })
+  // Note: To explicitly mask a process.env var, use empty string instead of undefined
+  const filteredConfigEnv = renderedConfigEnv
+    ? Object.fromEntries(Object.entries(renderedConfigEnv).filter(([, v]) => v !== undefined))
+    : undefined;
+
+  // Second pass: render full config using pre-rendered config.env as overrides
+  return renderEnvOnlyInObject(config, filteredConfigEnv);
+}
+
 export async function readConfig(configPath: string): Promise<UnifiedConfig> {
   let ret: UnifiedConfig & {
     targets?: UnifiedConfig['providers'];
@@ -176,7 +211,7 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
     // Render environment variable templates (e.g., {{ env.VAR }}) before validation.
     // This allows env vars to be used in paths and other config values.
     // Runtime templates like {{ vars.x }} are preserved for later evaluation.
-    const renderedConfig = renderEnvOnlyInObject(dereferencedConfig);
+    const renderedConfig = renderConfigEnvTemplates(dereferencedConfig as UnifiedConfig);
 
     // Validator requires `prompts`, but prompts is not actually required for redteam.
     // We create a relaxed schema for validation that makes prompts optional
@@ -209,7 +244,7 @@ export async function readConfig(configPath: string): Promise<UnifiedConfig> {
 
     // Render environment variable templates for JS configs too.
     // This ensures consistent behavior across config file types.
-    const renderedConfig = renderEnvOnlyInObject(imported as UnifiedConfig);
+    const renderedConfig = renderConfigEnvTemplates(imported as UnifiedConfig);
 
     const validationResult = UnifiedConfigSchema.safeParse(renderedConfig);
     if (!validationResult.success) {


### PR DESCRIPTION
## Summary

Fixes #7079 where custom provider IDs with environment variable placeholders (e.g., `{{env.APPLICATION}}`) stopped working in version 0.120.x when the env vars were defined in the config's `env:` section rather than in `process.env`.

**Root cause:** `renderEnvOnlyInObject()` was called without passing the config's `env` section as overrides, so env vars defined in the config weren't available during template rendering. This caused URLs like `https://{{env.APPLICATION}}.{{env.BASE_URL}}/api/...` to render as `https://./api///myEndpoint` (empty values).

**Changes:**
- Two-pass rendering: first render config.env values using process.env, then render full config using pre-rendered config.env as overrides
- Add `replaceBase` parameter to `renderEnvOnlyInObject()` to isolate first pass from stale `cliState.config?.env` in watch/reload scenarios  
- Filter out undefined values from config.env to prevent rendering `{{env.X}}` to empty string (common in JS configs: `env: { FOO: process.env.FOO }`)
- Respect `PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS` setting
- Check that env var value is not undefined before rendering (not just key existence)

## Test plan

- [x] Added 8 new regression tests covering:
  - Process.env variables in provider ID URLs
  - Undefined env var template preservation
  - Mixed defined/undefined env vars
  - Env vars in provider config headers
  - Config env section substitution (exact #7079 scenario)
  - Nested templates in config.env values (two-pass rendering)
  - JS config pattern with undefined values
- [x] All 82 tests in `load.test.ts` pass
- [x] All 51 tests in `render.test.ts` pass
- [x] TypeScript compilation passes
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)