### PR TITLE
docs(site): add latencyMs to Python provider return format

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -209,6 +209,7 @@ def call_api(prompt, options, context):
     result["cost"] = 0.0025  # in dollars
     result["cached"] = False
     result["logProbs"] = [-0.5, -0.3, -0.1]
+    result["latencyMs"] = 150  # custom latency in milliseconds
 
     # Error handling
     if something_went_wrong:
@@ -241,6 +242,7 @@ class ProviderResponse:
     cost: Optional[float]
     cached: Optional[bool]
     logProbs: Optional[List[float]]
+    latencyMs: Optional[int]  # overrides measured latency
     metadata: Optional[Dict[str, Any]]
 
 class ProviderEmbeddingResponse:


### PR DESCRIPTION
## Summary

- Documents the `latencyMs` field in Python provider responses
- When returned, this value overrides the measured latency

This allows users to exclude preprocessing time from latency calculations by returning only the actual LLM call time.

## Context

Discord issue: User wanted to run preprocessing scripts before LLM calls without that time being included in latency metrics. The `latencyMs` return field was already supported but not documented.

## Example usage

```python
def call_api(prompt, options, context):
    # Preprocessing (not counted in latency)
    do_preprocessing()
    
    # Measure only the LLM call
    start = time.time()
    response = call_llm(prompt)
    llm_latency_ms = (time.time() - start) * 1000
    
    return {
        "output": response,
        "latencyMs": llm_latency_ms
    }
```