### PR TITLE
fix(providers): handle undefined agentResponse in SimulatedUser

### DIFF
--- a/src/providers/simulatedUser.ts
+++ b/src/providers/simulatedUser.ts
@@ -360,7 +360,7 @@ export class SimulatedUser implements ApiProvider {
     return this.serializeOutput(
       messages,
       tokenUsage,
-      agentResponse as ProviderResponse,
+      agentResponse,
       getSessionId(agentResponse, context),
     );
   }
@@ -372,7 +372,7 @@ export class SimulatedUser implements ApiProvider {
   serializeOutput(
     messages: Message[],
     tokenUsage: TokenUsage,
-    finalTargetResponse: ProviderResponse,
+    finalTargetResponse: ProviderResponse | undefined,
     sessionId?: string,
   ) {
     return {
@@ -386,7 +386,7 @@ export class SimulatedUser implements ApiProvider {
         messages,
         sessionId,
       },
-      guardrails: finalTargetResponse.guardrails,
+      guardrails: finalTargetResponse?.guardrails,
     };
   }
 }

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -651,7 +651,7 @@ export class CrescendoProvider implements ApiProvider {
             : undefined,
       },
       tokenUsage: totalTokenUsage,
-      guardrails: lastResponse.guardrails,
+      guardrails: lastResponse?.guardrails,
     };
   }
 

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -635,7 +635,7 @@ export class CustomProvider implements ApiProvider {
         sessionId: getSessionId(lastResponse, context),
       },
       tokenUsage: totalTokenUsage,
-      guardrails: lastResponse.guardrails,
+      guardrails: lastResponse?.guardrails,
       ...(lastTargetError ? { error: lastTargetError } : {}),
     };
   }

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -646,7 +646,7 @@ export async function runRedteamConversation({
           : undefined,
       score: currentScore,
       graderPassed: storedGraderResult?.pass,
-      guardrails: targetResponse.guardrails,
+      guardrails: targetResponse?.guardrails,
       trace: traceContext ? formatTraceForMetadata(traceContext) : undefined,
       traceSummary,
       // Include input vars for multi-input mode (extracted from current prompt)

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -664,7 +664,7 @@ async function runRedteamConversation({
             promptImage: lastTransformResult?.image,
             score: 0,
             wasSelected: false,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
             sessionId: getSessionId(targetResponse, iterationContext),
           });
           continue;
@@ -772,7 +772,7 @@ async function runRedteamConversation({
             promptImage: lastTransformResult?.image,
             score,
             wasSelected: false,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
             sessionId: getSessionId(targetResponse, iterationContext),
           });
           return {
@@ -788,7 +788,7 @@ async function runRedteamConversation({
               sessionIds: extractSessionIds(treeOutputs),
             },
             tokenUsage: totalTokenUsage,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
           };
         }
 
@@ -811,7 +811,7 @@ async function runRedteamConversation({
             depth,
             parentId: node.id,
             wasSelected: false,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
             sessionId: getSessionId(targetResponse, iterationContext),
           });
           return {
@@ -827,7 +827,7 @@ async function runRedteamConversation({
               sessionIds: extractSessionIds(treeOutputs),
             },
             tokenUsage: totalTokenUsage,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
           };
         }
 
@@ -851,7 +851,7 @@ async function runRedteamConversation({
             promptImage: lastTransformResult?.image,
             score,
             wasSelected: false,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
             sessionId: getSessionId(targetResponse, iterationContext),
           });
           return {
@@ -867,7 +867,7 @@ async function runRedteamConversation({
               sessionIds: extractSessionIds(treeOutputs),
             },
             tokenUsage: totalTokenUsage,
-            guardrails: targetResponse.guardrails,
+            guardrails: targetResponse?.guardrails,
           };
         }
 
@@ -898,7 +898,7 @@ async function runRedteamConversation({
           promptImage: lastTransformResult?.image,
           score,
           wasSelected: true,
-          guardrails: targetResponse.guardrails,
+          guardrails: targetResponse?.guardrails,
           sessionId: getSessionId(targetResponse, iterationContext),
         });
       }
@@ -970,7 +970,7 @@ async function runRedteamConversation({
     depth: MAX_DEPTH - 1,
     parentId: bestNode.id,
     wasSelected: false,
-    guardrails: finalTargetResponse.guardrails,
+    guardrails: finalTargetResponse?.guardrails,
     sessionId: getSessionId(finalTargetResponse, context),
   });
   return {
@@ -986,7 +986,7 @@ async function runRedteamConversation({
       sessionIds: extractSessionIds(treeOutputs),
     },
     tokenUsage: totalTokenUsage,
-    guardrails: finalTargetResponse.guardrails,
+    guardrails: finalTargetResponse?.guardrails,
     ...(lastResponse?.error ? { error: lastResponse.error } : {}),
   };
 }

--- a/src/redteam/providers/mischievousUser.ts
+++ b/src/redteam/providers/mischievousUser.ts
@@ -37,7 +37,7 @@ export default class RedteamMischievousUserProvider extends SimulatedUser {
   serializeOutput(
     messages: Message[],
     tokenUsage: TokenUsage,
-    finalTargetResponse: ProviderResponse,
+    finalTargetResponse: ProviderResponse | undefined,
     sessionId: string,
   ) {
     return {
@@ -49,7 +49,7 @@ export default class RedteamMischievousUserProvider extends SimulatedUser {
         redteamHistory: messagesToRedteamHistory(messages),
         sessionId,
       },
-      guardrails: finalTargetResponse.guardrails,
+      guardrails: finalTargetResponse?.guardrails,
       sessionId,
     };
   }


### PR DESCRIPTION
## Summary

Fixes a crash when using `promptfoo:simulated-user` provider where `TypeError: Cannot read properties of undefined (reading 'guardrails')` occurs intermittently.

**Root cause:** When the simulated user returns `###STOP###` on the very first turn (before the target provider is called), `agentResponse` remains `undefined`. The code then calls `serializeOutput()` with an unsafe `as ProviderResponse` cast, and accessing `.guardrails` on undefined throws.

**Changes:**
- Remove unsafe `as ProviderResponse` cast in `simulatedUser.ts`
- Update `serializeOutput` signature to accept `ProviderResponse | undefined`
- Add optional chaining (`?.`) for guardrails access across all affected redteam providers for consistency
- Add test case covering the edge case

## Test plan

- [x] New unit test `should handle ###STOP### on first turn without crashing (agentResponse undefined)`
- [x] All 51 existing SimulatedUser tests pass
- [x] TypeScript compiles without errors
- [x] End-to-end verification confirms the fix (manually tested by reverting and observing crash)

Fixes #7101

🤖 Generated with [Claude Code](https://claude.com/claude-code)