### PR TITLE
ci(deps): remove npmDedupe from renovate postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": ["local>promptfoo/renovate-config"],
   "rebaseStalePrs": true,
   "separateMajorMinor": true,
-  "postUpdateOptions": ["npmDedupe"],
+  "postUpdateOptions": [],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## Summary
- Removes `npmDedupe` from Renovate's `postUpdateOptions` to fix CI failures

## Problem
The `npmDedupe` option was causing Renovate to incorrectly remove optional dependencies from `package-lock.json`. This caused `npm ci` to fail with errors like:

```
npm error Missing: @redis/client@1.6.1 from lock file
npm error Missing: pg@8.17.1 from lock file
```

This was blocking PR #7104 and potentially other Renovate PRs.

## Solution
Remove `npmDedupe` from `postUpdateOptions`. The lockfile maintenance schedule (1st and 15th of each month) will still handle deduplication periodically.

## Test plan
- [ ] Merge this PR
- [ ] Rebase/retry PR #7104 to verify the fix


🤖 Generated with [Claude Code](https://claude.com/claude-code)