### PR TITLE
docs(site): clarify file:// path resolution in vars

### DIFF
--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -405,6 +405,25 @@ tests:
       data: file://data/config.yaml
 ```
 
+### Path Resolution
+
+`file://` paths are resolved relative to your **config file's directory**, not the current working directory. This ensures consistent behavior regardless of where you run `promptfoo` from:
+
+```yaml title="src/tests/promptfooconfig.yaml"
+tests:
+  - vars:
+      # Resolved as src/tests/data/input.json
+      data: file://./data/input.json
+
+      # Also works - resolved as src/tests/data/input.json
+      data2: file://data/input.json
+
+      # Parent directory - resolved as src/shared/context.json
+      shared: file://../shared/context.json
+```
+
+Without the `file://` prefix, values are passed as plain strings to your provider.
+
 ### Supported File Types
 
 | Type                    | Handling            | Usage             |

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -648,6 +648,25 @@ When contexts are defined, promptfoo generates tests for each context separately
 
 The `vars` are merged into each test case and passed to your provider, allowing your [custom provider script](/docs/providers/custom-script/) to set up the appropriate test environment (e.g., loading a specific session, setting user permissions).
 
+#### Loading File Content in Vars
+
+Use the `file://` prefix to load file contents. Paths are resolved relative to your config file's directory, regardless of where you run `promptfoo` from:
+
+```yaml
+redteam:
+  contexts:
+    - id: data_exfil_test
+      purpose: Test data exfiltration protection with sensitive context
+      vars:
+        # Loads content from ./data/context.json relative to this config file
+        context_data: file://./data/context.json
+
+        # Plain string - passed as-is to provider (NOT loaded as file)
+        context_path: ./data/context.json
+```
+
+This is useful when your provider needs to access test data files. Without the `file://` prefix, values are passed as plain strings.
+
 ### Language
 
 The `language` field allows you to specify the language(s) for generated tests. If not provided, the default language is English. This setting applies globally to all plugins and strategies, ensuring consistent multilingual testing across your entire red team evaluation.


### PR DESCRIPTION
## Why

Users were confused about how `file://` paths resolve when using variables in config files. Specifically, it wasn't clear whether paths resolve relative to the current working directory or the config file's location.

## What

Added documentation clarifying that `file://` paths resolve relative to the **config file's directory**, not the current working directory. This ensures consistent behavior regardless of where `promptfoo` is run from.

Changes:
- Added "Path Resolution" section to `site/docs/configuration/test-cases.md`
- Added "Loading File Content in Vars" section to `site/docs/red-team/configuration.md`

## How to Test

Documentation-only change. Review the rendered docs to verify clarity.