### PR TITLE
fix(deps): upgrade undici to 6.23.0 to address CVE-2026-22036

### DIFF
--- a/code-scan-action/package-lock.json
+++ b/code-scan-action/package-lock.json
@@ -99,15 +99,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@jest/diff-sequences": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
@@ -431,7 +422,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -760,7 +750,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -932,9 +921,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.8.tgz",
-      "integrity": "sha512-r0bBaXu5Swb05doFYO2kTWHMovJnNVbCsII0fhesM8bNRlLhXIuckley4a2DaD+vOdmm5G+zGkQZAPZsF80+YQ==",
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1429,15 +1418,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/code-scan-action/package.json
+++ b/code-scan-action/package.json
@@ -25,5 +25,8 @@
     "@types/node": "^24.10.8",
     "@vercel/ncc": "^0.38.4",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "undici": "^6.23.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm override to force `undici` to `^6.23.0` in code-scan-action
- Addresses Dependabot alert #238: unbounded decompression chain vulnerability (CVE-2026-22036)

## Context
The `@actions/github` and `@actions/http-client` packages specify `undici@^5.28.5`, but the security fix only exists in version 6.23.0+. Since the upstream packages haven't updated their dependency ranges, an npm override is required.

## Verification
- `npm audit` shows 0 vulnerabilities
- `npm run build` succeeds
- `npm ls undici` confirms version 6.23.0

## Test plan
- [x] Verified `npm audit` passes with no vulnerabilities
- [x] Verified build succeeds
- [ ] CI passes

Fixes #238

🤖 Generated with [Claude Code](https://claude.ai/code)