### PR TITLE
docs(site): document disableVarExpansion option

### DIFF
--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -552,6 +552,24 @@ tests:
         threshold: 1000 # milliseconds
 ```
 
+### Passing Arrays to Assertions
+
+By default, array variables expand into multiple test cases. To pass an array directly to assertions like `contains-any`, disable variable expansion:
+
+```yaml
+defaultTest:
+  options:
+    disableVarExpansion: true
+  assert:
+    - type: contains-any
+      value: '{{expected_values}}'
+
+tests:
+  - description: 'Check for any valid response'
+    vars:
+      expected_values: ['option1', 'option2', 'option3']
+```
+
 ## External Data Sources
 
 ### Google Sheets


### PR DESCRIPTION
## Summary
- Documents the `disableVarExpansion` option in test case configuration
- Useful when passing array variables to assertions like `contains-any`

Addresses user feedback from Discord about this undocumented feature.