### PR TITLE
fix(webui): prevent form submission during ime composition

### DIFF
--- a/src/app/src/pages/eval/components/ConfirmEvalNameDialog.tsx
+++ b/src/app/src/pages/eval/components/ConfirmEvalNameDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@app/components/ui/input';
 import { Label } from '@app/components/ui/label';
 import { Spinner } from '@app/components/ui/spinner';
 import { cn } from '@app/lib/utils';
+import { isInputComposing } from '@app/utils/keyboard';
 import { AlertTriangle } from 'lucide-react';
 
 interface ConfirmEvalNameDialogProps {
@@ -92,9 +93,12 @@ export const ConfirmEvalNameDialog = ({
     }
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault();
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (isInputComposing(e)) {
+      return;
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
       handleConfirm();
     }
   };

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -4,6 +4,7 @@ import { Button } from '@app/components/ui/button';
 import { Input } from '@app/components/ui/input';
 import { Label } from '@app/components/ui/label';
 import { useTelemetry } from '@app/hooks/useTelemetry';
+import { isInputComposing } from '@app/utils/keyboard';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import LoadExampleButton from '../LoadExampleButton';
 import PageWrapper from '../PageWrapper';
@@ -167,6 +168,9 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
               updateConfig('target', newTarget);
             }}
             onKeyDown={(e) => {
+              if (isInputComposing(e)) {
+                return;
+              }
               if (e.key === 'Enter' && hasTargetName && !showTargetTypeSection) {
                 setShowTargetTypeSection(true);
                 recordEvent('feature_used', {

--- a/src/app/src/utils/keyboard.test.ts
+++ b/src/app/src/utils/keyboard.test.ts
@@ -1,0 +1,33 @@
+import type { KeyboardEvent } from 'react';
+
+import { describe, expect, it } from 'vitest';
+import { isInputComposing } from './keyboard';
+
+function createKeyboardEvent(
+  isComposing: boolean,
+  keyCode: number,
+): KeyboardEvent<HTMLInputElement> {
+  return {
+    nativeEvent: { isComposing, keyCode },
+  } as unknown as KeyboardEvent<HTMLInputElement>;
+}
+
+describe('isInputComposing', () => {
+  // Basic cases
+  it('returns true when isComposing is true', () => {
+    expect(isInputComposing(createKeyboardEvent(true, 13))).toBe(true);
+  });
+
+  it('returns true when keyCode is 229', () => {
+    expect(isInputComposing(createKeyboardEvent(false, 229))).toBe(true);
+  });
+
+  it('returns false when not composing and keyCode is not 229', () => {
+    expect(isInputComposing(createKeyboardEvent(false, 13))).toBe(false);
+  });
+
+  // Browser-specific: Safari sets isComposing=false but keyCode=229 on confirm
+  it('handles Safari IME confirm (isComposing=false, keyCode=229)', () => {
+    expect(isInputComposing(createKeyboardEvent(false, 229))).toBe(true);
+  });
+});

--- a/src/app/src/utils/keyboard.ts
+++ b/src/app/src/utils/keyboard.ts
@@ -1,0 +1,26 @@
+import type { KeyboardEvent } from 'react';
+
+/**
+ * Check if a keyboard event should be ignored due to IME (Input Method Editor) composition.
+ *
+ * IME allows users to input characters for East Asian languages (Japanese, Chinese, Korean)
+ * using phonetic input. Keys like Enter, Escape, and Arrow keys are used during composition.
+ *
+ * When to use:
+ * - Custom `onKeyDown` handlers that trigger actions (submit, cancel, etc.) in free-form text inputs
+ *
+ * Not needed for:
+ * - Browser default behavior like `<form onSubmit>`
+ * - Non-text inputs (email, number, etc.)
+ *
+ * Browser compatibility:
+ * - Chrome/Firefox: `isComposing` is `true` during composition
+ * - Safari: `isComposing` may be `false` on composition confirm, but `keyCode` is `229`
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing
+ */
+export function isInputComposing(e: KeyboardEvent): boolean {
+  // keyCode 229 is used as a fallback for Safari compatibility.
+  // keyCode is deprecated but there's no alternative for this Safari behavior.
+  return e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229;
+}


### PR DESCRIPTION
Fixes #7185

## Summary

Add `isInputComposing` utility to prevent IME users from accidentally submitting forms when pressing Enter to confirm character selection.

Use this for custom `onKeyDown` handlers in free-form text inputs. See JSDoc in `keyboard.ts` for details.


## Existing Keyboard Handlers Review

I searched the repository for `onKeyDown` and `handleKeyDown`, and fixed the two obvious places:
- `ConfirmEvalNameDialog.tsx` - eval name
- `TargetTypeSelection.tsx` - target name

And I tested in my local environment with `npm run dev` and Japanese IME:

- [x] Manual: Japanese IME on `/eval/:id` - rename dialog
- [x] Manual: Japanese IME on `/redteam/setup` - target name

There may be other places that need this fix, but I'm not familiar with all features. I added detailed JSDoc comments to the utility for future reference.