### PR TITLE
chore(code-scan): bump action version to 0.1.4

### DIFF
--- a/code-scan-action/package-lock.json
+++ b/code-scan-action/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@promptfoo/code-scan-action",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@promptfoo/code-scan-action",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@actions/core": "^2.0.2",
         "@actions/exec": "^2.0.0",

--- a/code-scan-action/package.json
+++ b/code-scan-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptfoo/code-scan-action",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "GitHub Action for scanning PRs with promptfoo code-scan",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps the code-scan-action version to 0.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)