### PR TITLE
fix(ci): use gh pr diff for full reviews to avoid false positives

### DIFF
--- a/.github/prompts/claude-code-review.md
+++ b/.github/prompts/claude-code-review.md
@@ -10,8 +10,10 @@ This is promptfoo, an open-source LLM evaluation framework and AI agent security
 
 ## Instructions
 
-1. Run `git diff {{BASE_SHA}}..{{HEAD_SHA}}` to see the changes
-   - If the diff command fails, fall back to `gh pr diff {{PR_NUMBER}}` instead
+1. Get the PR diff using the appropriate method for the review scope:
+   - For **full reviews**: Run `gh pr diff {{PR_NUMBER}}` to see all changes in the PR
+   - For **incremental reviews**: Run `git diff {{BASE_SHA}}..{{HEAD_SHA}}` to see only new commits
+   - **IMPORTANT:** Never use `git diff BASE..HEAD` for full reviews - it shows incorrect results when the branch is behind main
 2. For incremental reviews, run `gh pr view {{PR_NUMBER}} --comments` to see previous review feedback
 3. **IMPORTANT:** Only review the changes shown in this diff - do not re-review previously reviewed code
 4. **IMPORTANT:** Do not re-report issues already mentioned in previous reviews unless they appear in new code


### PR DESCRIPTION
## Summary

Fixes the code review bot reporting false positives about files not changed in the PR.

**Root Cause:** The bot was using `git diff BASE_SHA..HEAD_SHA` which shows **all differences** between the two commits, not just the PR's changes. When a branch is behind main (doesn't have recent merges), changes from other merged PRs appear as "deletions" in the diff.

**Example:** PR #7189 (historyStore fix) was flagged for IME composition issues from PR #7186, because the branch didn't have those changes yet.

## Solution

- Use `gh pr diff` for **full reviews** - this correctly computes the merge-base diff showing only actual PR changes
- Keep `git diff BASE..HEAD` for **incremental reviews** - these review specific commit ranges after a push, where the two-dot diff is correct

## Test plan

- [ ] Verify next PR review uses `gh pr diff` for full scope reviews
- [ ] Check that the review only reports issues in actual PR changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)