### PR TITLE
build(ci): configure Renovate to include optional dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "rebaseStalePrs": true,
   "separateMajorMinor": true,
   "rangeStrategy": "bump",
+  "npmInstallArgs": ["--include=optional"],
   "postUpdateOptions": [],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Fixes CI failures on Renovate PRs caused by missing optional dependencies in the lockfile.

## Problem

Renovate was generating lockfiles that excluded optional dependencies (`natural`, `pg`, `@redis/client`), causing CI to fail with:
```
npm error Missing: @redis/client@1.6.1 from lock file
npm error Missing: pg@8.17.2 from lock file
```

This affected all recent Renovate PRs like #7194, #7193, etc.

## Root Cause

- `natural` is an optional dependency in `package.json`
- When Renovate updates packages, it wasn't including optional dependencies in lockfile generation
- `npm ci` in CI expects all dependencies (including optional ones) to be in the lockfile

## Solution

Added `npmInstallArgs: ["--include=optional"]` to `renovate.json` to ensure Renovate includes optional dependencies when generating lockfiles, matching CI behavior.

## Test Plan

- CI should pass on this PR
- Future Renovate PRs should include optional dependencies in their lockfiles