### PR TITLE
fix(deps): migrate renovate config and fix npm lockfile generation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,12 @@
 {
   "extends": ["local>promptfoo/renovate-config"],
-  "rebaseStalePrs": true,
+  "rebaseWhen": "behind-base-branch",
   "separateMajorMinor": true,
   "rangeStrategy": "bump",
   "postUpdateOptions": [],
+  "constraints": {
+    "npm": ">= 11"
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -192,7 +195,7 @@
     },
     {
       "description": "Group example directory updates to reduce noise",
-      "matchPaths": ["examples/**/package.json"],
+      "matchFileNames": ["examples/**/package.json"],
       "groupName": "Example dependencies",
       "schedule": ["before 6am on the first day of the month"]
     },


### PR DESCRIPTION
## Summary

- Migrate deprecated `rebaseStalePrs` to `rebaseWhen: "behind-base-branch"`
- Migrate deprecated `matchPaths` to `matchFileNames`
- Add `constraints: { "npm": ">= 11" }` to fix transitive dependency issues in lockfile generation

## Problem

Renovate PRs were failing CI with errors like:
```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: @redis/client@1.6.1 from lock file
npm error Missing: pg@8.17.2 from lock file
```

This happens because Renovate's lockfile generation with older npm versions misses transitive dependencies.

## Solution

Adding `constraints: { "npm": ">= 11" }` forces Renovate to use npm 11+ which handles lockfiles correctly. This is the recommended fix per [renovatebot/renovate#31984](https://github.com/renovatebot/renovate/discussions/31984).

## Test plan

- [x] Config validates successfully with `renovate-config-validator`
- [ ] Monitor next Renovate PRs to verify lockfiles are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)