### PR TITLE
docs(site): add AI-assisted contributions section

### DIFF
--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -459,12 +459,12 @@ If you open a pull request, you are responsible for what you submit. AI can help
 
 ### Prove the change works
 
-A pull request should include enough evidence that a reviewer can trust the change without recreating your entire process.
+A pull request should include clear instructions so that a reviewer can verify correctness by running the code locally. Don't make reviewers reverse-engineer how to test your change.
 
 **What to include:**
 
 - What changed and why (a few sentences is fine)
-- How you verified it works
+- Steps to reproduce or verify the change (commands, config files, expected output)
 - Any tradeoffs or edge cases you considered
 
 If the change is hard to demonstrate, include something concrete: a minimal repro, a log excerpt, a screenshot, or a short recording.
@@ -483,6 +483,10 @@ If you can't explain a non-trivial part of your PR, revise it until you can.
 ### No hypothetical platform support
 
 Don't submit changes for environments you cannot actually run or test. If you want to add support for a platform you don't have access to, open an issue or discussion describing what you need and what you can verify today.
+
+### Maintain agent guidance files
+
+This repository uses `AGENTS.md` files to provide context to AI coding assistants. If your changes affect how agents should work in a particular area (new patterns, conventions, or gotchas), update the relevant `AGENTS.md` file following existing patterns. See the root `AGENTS.md` for the directory structure and conventions.
 
 ### Disclosure
 


### PR DESCRIPTION
## Summary

Adds an "AI-Assisted Contributions" section to the contributing docs. The stance: we welcome AI tools, but you own your changes.

**Key points:**
- Focus on outcomes, not tools
- You're responsible for correctness, security, maintainability
- Prove the change works (include verification steps)
- Be able to explain your diff
- No hypothetical platform support
- Disclosure is optional

Inspired by https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md — but taking a more welcoming approach since promptfoo is literally an LLM testing tool.

## Discussion

@Promptfoo(l)s: what do you think? Is this the right tone? Too soft? Too long? Missing anything?

Debate welcome.