### PR TITLE
chore: fix formatting in sharpAvailability test

### DIFF
--- a/test/redteam/sharpAvailability.test.ts
+++ b/test/redteam/sharpAvailability.test.ts
@@ -45,7 +45,10 @@ describe('validateSharpDependency', () => {
   describe('when sharp is not required', () => {
     it('should not throw when no sharp-dependent features are used', async () => {
       const strategies = [{ id: 'base64' }, { id: 'jailbreak' }];
-      const plugins = [{ id: 'harmful', numTests: 5 }, { id: 'pii', numTests: 3 }];
+      const plugins = [
+        { id: 'harmful', numTests: 5 },
+        { id: 'pii', numTests: 3 },
+      ];
 
       await expect(validateSharpDependency(strategies, plugins)).resolves.not.toThrow();
     });


### PR DESCRIPTION
## Summary
- Fix formatting issue in `test/redteam/sharpAvailability.test.ts` from #7222

## Test plan
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)