### PR TITLE
fix(providers): kill Python process on worker ready timeout

### DIFF
--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -53,6 +53,13 @@ export class PythonWorker {
     // Listen for READY signal
     return new Promise((resolve, reject) => {
       const readyTimeout = setTimeout(() => {
+        // Kill the process to prevent orphaned Python processes
+        // and avoid triggering handleCrash() which would retry
+        this.shuttingDown = true;
+        if (this.process) {
+          this.process.kill('SIGTERM');
+          this.process = null;
+        }
         reject(new Error('Worker failed to become ready within timeout'));
       }, 30000);
 


### PR DESCRIPTION
## Summary

- Fix flaky test `test/python/windows-path.test.ts` that was timing out after ~78s instead of failing at 30s
- Kill Python process when worker ready timeout fires to prevent orphaned processes
- Set `shuttingDown=true` to prevent `handleCrash()` from triggering unnecessary restart attempts

## Problem

When a Python worker failed to become ready within the 30s timeout:
1. The promise rejected but the **Python process was left running**
2. The orphaned process eventually closed, triggering `handleCrash()`
3. `handleCrash()` attempted to restart the worker (up to 3 times)
4. Each restart had its own 30s timeout, causing ~78s total time

## Solution

When the ready timeout fires, we now:
1. Set `shuttingDown=true` to prevent `handleCrash()` from being triggered
2. Kill the Python process with SIGTERM
3. Clear the process reference
4. Then reject the promise

## Test plan

- [x] Run `npx vitest run test/python/windows-path.test.ts` - all 4 tests pass
- [x] Run test 5 times to verify no flakiness
- [x] Run all Python tests (`npx vitest run test/python`) - all 54 tests pass
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.ai/code)