### PR TITLE
fix(webui): Support password encrypted keys for PEM certs

### DIFF
--- a/examples/http-provider-tls/README.md
+++ b/examples/http-provider-tls/README.md
@@ -1,20 +1,65 @@
-# HTTP Provider with TLS PFX Certificates
+# HTTP Provider with TLS Certificates
 
-This example demonstrates how to configure the HTTP provider with TLS/SSL certificates, specifically focusing on PFX (PKCS#12) certificate bundles.
+This example demonstrates how to configure the HTTP provider with TLS/SSL certificates for mutual TLS (mTLS) authentication.
 
 ## Overview
 
-The HTTP provider supports multiple ways to provide PFX certificates for mutual TLS authentication:
+The HTTP provider supports multiple certificate formats for mutual TLS authentication:
 
-1. **File Path**: Reference a PFX file on disk
-2. **Inline Base64**: Embed the certificate as a base64-encoded string
-3. **Environment Variables**: Load certificates from environment variables
+1. **PEM (Separate cert/key files)**: Traditional format with separate certificate and key files
+2. **PEM with Encrypted Key**: PEM format where the private key is password-protected
+3. **PFX/PKCS#12**: Combined certificate bundle format
+
+Each format can be provided via:
+
+- **File Path**: Reference files on disk
+- **Inline Content**: Embed certificate content directly (base64 for binary formats)
+- **Environment Variables**: Load from environment variables
+
+## PEM Certificate Options
+
+### Using Unencrypted PEM Files
+
+The simplest approach - separate certificate and key files:
+
+```yaml
+tls:
+  certPath: '/path/to/client-cert.pem'
+  keyPath: '/path/to/client-key.pem'
+```
+
+### Using Encrypted PEM Private Key
+
+When your private key is password-protected (starts with `BEGIN ENCRYPTED PRIVATE KEY`):
+
+```yaml
+tls:
+  certPath: '/path/to/client-cert.pem'
+  keyPath: '/path/to/client-key-encrypted.pem'
+  passphrase: 'your-key-password'
+```
+
+### Using Inline PEM Content
+
+Embed certificates directly in your configuration:
+
+```yaml
+tls:
+  cert: |
+    -----BEGIN CERTIFICATE-----
+    MIIDxTCCAq2gAwIBAgIJAL...
+    -----END CERTIFICATE-----
+  key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvQIBADANBgkqhkiG9w0B...
+    -----END PRIVATE KEY-----
+```
 
 ## PFX Certificate Options
 
 ### Using File Path
 
-The traditional approach - reference a PFX file on the filesystem:
+Reference a PFX file on the filesystem:
 
 ```yaml
 tls:
@@ -82,16 +127,21 @@ Then copy the content (excluding the BEGIN/END headers) to use as the `pfx` valu
 
 ## TLS Configuration Options
 
-| Option               | Description                                              |
-| -------------------- | -------------------------------------------------------- |
-| `pfx`                | Inline PFX certificate (base64-encoded string or Buffer) |
-| `pfxPath`            | Path to PFX file on disk                                 |
-| `passphrase`         | Password for the PFX certificate                         |
-| `ca`                 | CA certificate for server verification                   |
-| `rejectUnauthorized` | Verify server certificates (always `true` in production) |
-| `minVersion`         | Minimum TLS version (e.g., 'TLSv1.2')                    |
-| `maxVersion`         | Maximum TLS version (e.g., 'TLSv1.3')                    |
-| `ciphers`            | Cipher suite specification                               |
+| Option               | Description                                               |
+| -------------------- | --------------------------------------------------------- |
+| `cert`               | Inline PEM certificate content                            |
+| `certPath`           | Path to PEM certificate file                              |
+| `key`                | Inline PEM private key content                            |
+| `keyPath`            | Path to PEM private key file                              |
+| `pfx`                | Inline PFX certificate (base64-encoded string or Buffer)  |
+| `pfxPath`            | Path to PFX file on disk                                  |
+| `passphrase`         | Password for encrypted PEM private key or PFX certificate |
+| `ca`                 | CA certificate content for server verification            |
+| `caPath`             | Path to CA certificate file                               |
+| `rejectUnauthorized` | Verify server certificates (always `true` in production)  |
+| `minVersion`         | Minimum TLS version (e.g., 'TLSv1.2')                     |
+| `maxVersion`         | Maximum TLS version (e.g., 'TLSv1.3')                     |
+| `ciphers`            | Cipher suite specification                                |
 
 ## Troubleshooting
 

--- a/examples/http-provider-tls/generate-test-certs.sh
+++ b/examples/http-provider-tls/generate-test-certs.sh
@@ -96,19 +96,25 @@ openssl pkcs12 -export -out client.pfx \
   -inkey client-key.pem -in client-cert.pem \
   -certfile ca-cert.pem -password pass:testpassword
 
+# Generate encrypted client private key (for testing passphrase with PEM)
+echo -e "${GREEN}10. Creating encrypted client private key...${NC}"
+openssl rsa -aes256 -in client-key.pem -out client-key-encrypted.pem \
+  -passout pass:testpassword
+
 # Clean up temporary files
 rm -f *.csr *.cnf *.srl
 
 # Display certificate information
 echo -e "\n${GREEN}✅ Certificates generated successfully!${NC}"
 echo -e "\nGenerated files:"
-echo "  📄 ca-cert.pem       - Certificate Authority certificate"
-echo "  🔑 ca-key.pem        - CA private key (keep secure!)"
-echo "  📄 server-cert.pem   - Server certificate"
-echo "  🔑 server-key.pem    - Server private key"
-echo "  📄 client-cert.pem   - Client certificate"
-echo "  🔑 client-key.pem    - Client private key"
-echo "  📦 client.pfx        - Client certificate bundle (password: testpassword)"
+echo "  📄 ca-cert.pem              - Certificate Authority certificate"
+echo "  🔑 ca-key.pem               - CA private key (keep secure!)"
+echo "  📄 server-cert.pem          - Server certificate"
+echo "  🔑 server-key.pem           - Server private key"
+echo "  📄 client-cert.pem          - Client certificate"
+echo "  🔑 client-key.pem           - Client private key (unencrypted)"
+echo "  🔑 client-key-encrypted.pem - Client private key (encrypted, password: testpassword)"
+echo "  📦 client.pfx               - Client certificate bundle (password: testpassword)"
 
 echo -e "\n${YELLOW}Certificate Details:${NC}"
 echo "CA Certificate:"

--- a/examples/http-provider-tls/mock-server.js
+++ b/examples/http-provider-tls/mock-server.js
@@ -7,9 +7,13 @@
  * - Custom TLS options
  */
 
-const https = require('https');
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import https from 'node:https';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Configuration
 const PORT = process.env.PORT || 8443;

--- a/src/app/src/pages/redteam/setup/components/Targets/tabs/TlsHttpsConfigTab.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/tabs/TlsHttpsConfigTab.tsx
@@ -110,7 +110,7 @@ const TlsHttpsConfigTab: React.FC<TlsHttpsConfigTabProps> = ({
                   pfx: certType !== 'pfx' ? undefined : selectedTarget.config?.tls?.pfx,
                   pfxPath: certType !== 'pfx' ? undefined : selectedTarget.config?.tls?.pfxPath,
                   passphrase:
-                    certType !== 'pfx' && certType !== 'jks'
+                    certType !== 'pfx' && certType !== 'jks' && certType !== 'pem'
                       ? undefined
                       : selectedTarget.config?.tls?.passphrase,
                   jksPath: certType !== 'jks' ? undefined : selectedTarget.config?.tls?.jksPath,
@@ -381,6 +381,23 @@ const TlsHttpsConfigTab: React.FC<TlsHttpsConfigTabProps> = ({
                     }
                   />
                 )}
+              </div>
+
+              {/* Private Key Password (Optional) */}
+              <div className="rounded-lg border border-border p-4 space-y-4">
+                <h4 className="font-medium">Private Key Password (Optional)</h4>
+                <SensitiveTextField
+                  label="Password"
+                  placeholder="Enter password for encrypted private key"
+                  value={selectedTarget.config?.tls?.passphrase || ''}
+                  onChange={(e) =>
+                    updateCustomTarget('tls', {
+                      ...selectedTarget.config?.tls,
+                      passphrase: e.target.value,
+                    })
+                  }
+                  helperText="Required only if your private key file is encrypted (e.g., starts with 'BEGIN ENCRYPTED PRIVATE KEY')"
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
Ensures that the UI allows for passphrases to be specified for PEM certs. Tested via the `http-provider-tls` example, which has been expanded to include this use case.