### PR TITLE
docs(site): improve proxy and network configuration discoverability

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -59,7 +59,7 @@ No, Promptfoo operates locally, and all data remains on your machine. The only e
 
 No, we do not collect any personally identifiable information (PII).
 
-### How do I use a proxy with Promptfoo?
+### How do I configure Promptfoo for corporate networks or proxies?
 
 Promptfoo proxy settings are configured through environment variables:
 

--- a/site/docs/usage/troubleshooting.md
+++ b/site/docs/usage/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 60
-description: Debug and resolve common promptfoo issues with solutions for memory optimization, API configuration, Node.js errors, and native builds in your LLM testing pipeline
+description: Debug and resolve common promptfoo issues with solutions for memory optimization, API configuration, Node.js errors, native builds, and network/proxy setup in your LLM testing pipeline
 ---
 
 # Troubleshooting
@@ -178,6 +178,39 @@ npm install --build-from-source
 # or
 npm rebuild
 ```
+
+## Network and proxy issues
+
+If you're behind a corporate proxy or firewall and having trouble connecting to LLM APIs:
+
+### Configure proxy settings
+
+Set standard proxy environment variables before running promptfoo:
+
+```bash
+# Set proxy for HTTPS requests (most common)
+export HTTPS_PROXY=http://proxy.company.com:8080
+
+# With authentication if needed
+export HTTPS_PROXY=http://username:password@proxy.company.com:8080
+
+# Exclude specific hosts from proxying
+export NO_PROXY=localhost,127.0.0.1,internal.domain.com
+```
+
+### Custom CA certificates
+
+For environments with custom certificate authorities:
+
+```bash
+export PROMPTFOO_CA_CERT_PATH=/path/to/ca-bundle.crt
+```
+
+### Verify your configuration
+
+Run `promptfoo debug` to see detected proxy settings and verify your network configuration is correct.
+
+See the [FAQ](/docs/faq/#how-do-i-configure-promptfoo-for-corporate-networks-or-proxies) for complete proxy and SSL configuration details.
 
 ## OpenAI API key is not set
 


### PR DESCRIPTION
## Summary

Improves discoverability of proxy and network configuration documentation for users deploying Promptfoo in corporate/internal network environments.

- Add "Network and proxy issues" section to troubleshooting guide with quick solutions
- Rename FAQ section to "How do I configure Promptfoo for corporate networks or proxies?" for better searchability
- Update troubleshooting page description to include network/proxy keywords

Relates to #7274

## Test plan

- [ ] Verify documentation site builds successfully
- [ ] Check that FAQ anchor link works correctly
- [ ] Confirm troubleshooting section displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)