### PR TITLE
docs(site): add November 2025 - January 2026 release highlights

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -76,7 +76,7 @@ This month we shipped **adaptive rate limiting**, **Transformers.js for local in
 #### New Plugins
 
 - **[Telecom](/docs/red-team/plugins/telecom/)** - Industry-specific red team plugins for telecommunications AI systems
-- **[RAG Source Attribution](/docs/red-team/plugins/)** - Test whether RAG systems properly attribute sources in their responses
+- **[RAG Source Attribution](/docs/red-team/plugins/rag-source-attribution/)** - Test whether RAG systems properly attribute sources in their responses
 
 #### Multi-Input Testing
 
@@ -260,7 +260,7 @@ This month we shipped **Hydra multi-turn strategy**, **code scanning**, **Claude
 
 #### Hydra Strategy
 
-**[Hydra](/docs/red-team/strategies/hydra/)** is a new advanced multi-turn red team strategy that adapts dynamically based on target responses, using sophisticated conversation techniques to probe for vulnerabilities.
+**[Hydra](/docs/red-team/strategies/hydra/)** is a new advanced multi-turn red team strategy that adapts dynamically based on target responses, using conversation techniques to probe for vulnerabilities.
 
 #### Code Scanning
 


### PR DESCRIPTION
## Summary

Adds curated release highlights for three months that were missing from the docs:

### November 2025
- Hydra multi-turn strategy
- Code scanning
- Claude Opus 4.5 support
- VS Code red team extension
- FERPA and Ecommerce plugins

### December 2025
- Video generation providers (OpenAI Sora, Google Veo)
- OWASP Agentic AI Top 10 threat mapping
- xAI Voice Agent provider
- Multi-modal attack strategies
- OpenTelemetry tracing with GenAI conventions

### January 2026
- Adaptive rate limit scheduler
- Transformers.js for local inference
- Telecom red team plugins
- Vercel and Cloudflare AI gateways
- RAG source attribution plugin
- Multi-input red team testing
- WatsonX enhanced support

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Check all doc links are valid
- [ ] Confirm style matches existing release notes

🤖 Generated with [Claude Code](https://claude.ai/code)