### PR TITLE
test(scheduler): fix flaky retrying event test

### DIFF
--- a/test/scheduler/providerRateLimitState.test.ts
+++ b/test/scheduler/providerRateLimitState.test.ts
@@ -224,7 +224,9 @@ describe('ProviderRateLimitState', () => {
           return 'success';
         },
         {
-          getRetryAfter: () => 1,
+          // Use 0 for immediate retry to avoid timing-dependent flakiness
+          // (non-zero values race against slot queue's resetAt timer)
+          getRetryAfter: () => 0,
         },
       );
 


### PR DESCRIPTION
## Summary
- Fix flaky test `should emit retrying event` in `providerRateLimitState.test.ts`
- Use `getRetryAfter: () => 0` (immediate retry) instead of `1` to avoid timing races

## Root Cause
The test was using `getRetryAfter: () => 1` which set a 1ms retry delay. Due to timer resolution variance (especially on macOS), the slot queue's rate limit window sometimes hadn't expired when the retry attempt called `acquire()`, causing it to block until the reset timer fired. This created a timing race that caused intermittent 30-second timeouts.

## Fix
Using `getRetryAfter: () => 0` means:
- `markRateLimited(0)` sets `resetAt = Date.now()` (immediate)
- `getRetryDelay(..., 0)` returns 0 (no sleep)
- When `acquire()` checks quota, `Date.now() >= resetAt` is always true

## Test plan
- [x] Run the specific test 20+ times - all pass
- [x] Run the full test file 5 times - all 25 tests pass each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)