### PR TITLE
feat(eval): support multiple --filter-metadata flags with AND logic

### DIFF
--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -361,6 +361,9 @@ Filter tests:
 promptfoo eval --filter-metadata category=math
 promptfoo eval --filter-metadata difficulty=easy
 promptfoo eval --filter-metadata tags=ai
+
+# Multiple filters use AND logic (tests must match ALL conditions)
+promptfoo eval --filter-metadata category=math --filter-metadata difficulty=easy
 ```
 
 ### JSON in CSV

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -80,45 +80,45 @@ All specified files must exist or an error is thrown.
 
 By default the `eval` command will read the `promptfooconfig.yaml` configuration file in your current directory. But, if you're looking to override certain parameters you can supply optional arguments:
 
-| Option                              | Description                                                                   |
-| ----------------------------------- | ----------------------------------------------------------------------------- |
-| `-a, --assertions <path>`           | Path to assertions file                                                       |
-| `-c, --config <paths...>`           | Path to configuration file(s). Automatically loads promptfooconfig.yaml       |
-| `--delay <number>`                  | Delay between each test (in milliseconds)                                     |
-| `--description <description>`       | Description of the eval run                                                   |
-| `--filter-failing <path or id>`     | Filter tests that failed in a previous evaluation (by file path or eval ID)   |
-| `--filter-errors-only <path or id>` | Filter tests that resulted in errors in a previous evaluation                 |
-| `-n, --filter-first-n <number>`     | Only run the first N tests                                                    |
-| `--filter-sample <number>`          | Only run a random sample of N tests                                           |
-| `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair                      |
-| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern                    |
-| `--filter-providers <providers>`    | Only run tests with these providers (regex match on provider `id` or `label`) |
-| `--filter-targets <targets>`        | Only run tests with these targets (alias for --filter-providers)              |
-| `--grader <provider>`               | Model that will grade outputs                                                 |
-| `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                        |
-| `--model-outputs <path>`            | Path to JSON containing list of LLM output strings                            |
-| `--no-cache`                        | Do not read or write results to disk cache                                    |
-| `--no-progress-bar`                 | Do not show progress bar                                                      |
-| `--no-table`                        | Do not output table in CLI                                                    |
-| `--no-write`                        | Do not write results to promptfoo directory                                   |
-| `--resume [evalId]`                 | Resume a paused/incomplete evaluation. If `evalId` is omitted, resumes latest |
-| `--retry-errors`                    | Retry all ERROR results from the latest evaluation                            |
-| `-o, --output <paths...>`           | Path(s) to output file (csv, txt, json, jsonl, yaml, yml, html, xml)          |
-| `-p, --prompts <paths...>`          | Paths to prompt files (.txt)                                                  |
-| `--prompt-prefix <path>`            | Prefix prepended to every prompt                                              |
-| `--prompt-suffix <path>`            | Suffix appended to every prompt                                               |
-| `-r, --providers <name or path...>` | Provider names or paths to custom API caller modules                          |
-| `--remote`                          | Force remote inference wherever possible (used for red teams)                 |
-| `--repeat <number>`                 | Number of times to run each test                                              |
-| `--share`                           | Create a shareable URL                                                        |
-| `--no-share`                        | Do not create a shareable URL, this overrides the config file                 |
-| `--suggest-prompts <number>`        | Generate N new prompts and append them to the prompt list                     |
-| `--table`                           | Output table in CLI                                                           |
-| `--table-cell-max-length <number>`  | Truncate console table cells to this length                                   |
-| `-t, --tests <path>`                | Path to CSV with test cases                                                   |
-| `--var <key=value>`                 | Set a variable in key=value format                                            |
-| `-v, --vars <path>`                 | Path to CSV with test cases (alias for --tests)                               |
-| `-w, --watch`                       | Watch for changes in config and re-run                                        |
+| Option                              | Description                                                                                              |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `-a, --assertions <path>`           | Path to assertions file                                                                                  |
+| `-c, --config <paths...>`           | Path to configuration file(s). Automatically loads promptfooconfig.yaml                                  |
+| `--delay <number>`                  | Delay between each test (in milliseconds)                                                                |
+| `--description <description>`       | Description of the eval run                                                                              |
+| `--filter-failing <path or id>`     | Filter tests that failed in a previous evaluation (by file path or eval ID)                              |
+| `--filter-errors-only <path or id>` | Filter tests that resulted in errors in a previous evaluation                                            |
+| `-n, --filter-first-n <number>`     | Only run the first N tests                                                                               |
+| `--filter-sample <number>`          | Only run a random sample of N tests                                                                      |
+| `--filter-metadata <key=value>`     | Only run tests whose metadata matches the key=value pair. Can be specified multiple times for AND logic. |
+| `--filter-pattern <pattern>`        | Only run tests whose description matches the regex pattern                                               |
+| `--filter-providers <providers>`    | Only run tests with these providers (regex match on provider `id` or `label`)                            |
+| `--filter-targets <targets>`        | Only run tests with these targets (alias for --filter-providers)                                         |
+| `--grader <provider>`               | Model that will grade outputs                                                                            |
+| `-j, --max-concurrency <number>`    | Maximum number of concurrent API calls                                                                   |
+| `--model-outputs <path>`            | Path to JSON containing list of LLM output strings                                                       |
+| `--no-cache`                        | Do not read or write results to disk cache                                                               |
+| `--no-progress-bar`                 | Do not show progress bar                                                                                 |
+| `--no-table`                        | Do not output table in CLI                                                                               |
+| `--no-write`                        | Do not write results to promptfoo directory                                                              |
+| `--resume [evalId]`                 | Resume a paused/incomplete evaluation. If `evalId` is omitted, resumes latest                            |
+| `--retry-errors`                    | Retry all ERROR results from the latest evaluation                                                       |
+| `-o, --output <paths...>`           | Path(s) to output file (csv, txt, json, jsonl, yaml, yml, html, xml)                                     |
+| `-p, --prompts <paths...>`          | Paths to prompt files (.txt)                                                                             |
+| `--prompt-prefix <path>`            | Prefix prepended to every prompt                                                                         |
+| `--prompt-suffix <path>`            | Suffix appended to every prompt                                                                          |
+| `-r, --providers <name or path...>` | Provider names or paths to custom API caller modules                                                     |
+| `--remote`                          | Force remote inference wherever possible (used for red teams)                                            |
+| `--repeat <number>`                 | Number of times to run each test                                                                         |
+| `--share`                           | Create a shareable URL                                                                                   |
+| `--no-share`                        | Do not create a shareable URL, this overrides the config file                                            |
+| `--suggest-prompts <number>`        | Generate N new prompts and append them to the prompt list                                                |
+| `--table`                           | Output table in CLI                                                                                      |
+| `--table-cell-max-length <number>`  | Truncate console table cells to this length                                                              |
+| `-t, --tests <path>`                | Path to CSV with test cases                                                                              |
+| `--var <key=value>`                 | Set a variable in key=value format                                                                       |
+| `-v, --vars <path>`                 | Path to CSV with test cases (alias for --tests)                                                          |
+| `-w, --watch`                       | Watch for changes in config and re-run                                                                   |
 
 The `eval` command will return exit code `100` when there is at least 1 test case failure or when the pass rate is below the threshold set by `PROMPTFOO_PASS_RATE_THRESHOLD`. It will return exit code `1` for any other error. The exit code for failed tests can be overridden with environment variable `PROMPTFOO_FAILED_TEST_EXIT_CODE`.
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -2863,7 +2863,17 @@
           "maximum": 9007199254740991
         },
         "filterMetadata": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "filterPattern": {
           "type": "string"

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -982,7 +982,10 @@ export function evalCommand(
     )
     .option(
       '--filter-metadata <key=value>',
-      'Only run tests whose metadata matches the key=value pair (e.g. --filter-metadata pluginId=debug-access)',
+      'Only run tests whose metadata matches the key=value pair. Can be specified multiple times for AND logic (e.g. --filter-metadata type=unit --filter-metadata env=prod)',
+      (value: string, previous: string[] | undefined) => {
+        return previous ? [...previous, value] : [value];
+      },
     )
 
     // Output configuration

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,7 +89,7 @@ export const CommandLineOptionsSchema = z.object({
   filterFailing: z.string().optional(),
   filterFailingOnly: z.string().optional(),
   filterFirstN: z.coerce.number().int().positive().optional(),
-  filterMetadata: z.string().optional(),
+  filterMetadata: z.union([z.string(), z.array(z.string())]).optional(),
   filterPattern: z.string().optional(),
   filterProviders: z.string().optional(),
   filterSample: z.coerce.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

- Allow `--filter-metadata` to be specified multiple times with AND logic
- Tests must match ALL specified metadata conditions to be included
- Backward compatible: single value usage unchanged

## Usage

```bash
# Single filter (existing behavior)
promptfoo eval --filter-metadata type=unit

# Multiple filters with AND logic (new)
promptfoo eval --filter-metadata type=unit --filter-metadata env=prod

# Three+ filters
promptfoo eval --filter-metadata type=unit --filter-metadata env=prod --filter-metadata priority=high
```

## Changes

| File | Change |
|------|--------|
| `src/commands/eval.ts` | CLI option collects array via callback |
| `src/types/index.ts` | Type supports `string \| string[]` |
| `src/commands/eval/filterTests.ts` | Filter logic handles array with AND |
| `site/static/config-schema.json` | Auto-regenerated |
| `site/docs/usage/command-line.md` | Updated description |
| `site/docs/configuration/test-cases.md` | Added multi-filter example |

## Test plan

- [x] 11 new unit tests in `test/commands/eval/filterTests.test.ts`
- [x] 3 new smoke tests in `test/smoke/filters-and-flags.test.ts`
- [x] Manual QA with various filter combinations
- [x] Backward compatibility verified (single string still works)

Closes #7312

🤖 Generated with [Claude Code](https://claude.ai/code)