### PR TITLE
fix(test): add missing writeFileSync mock to fix flaky provider test

### DIFF
--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -82,6 +82,7 @@ vi.mock('../../src/esm', async () => ({
 const mockFsReadFileSync = vi.hoisted(() => vi.fn());
 const mockFsExistsSync = vi.hoisted(() => vi.fn());
 const mockFsMkdirSync = vi.hoisted(() => vi.fn());
+const mockFsWriteFileSync = vi.hoisted(() => vi.fn());
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
@@ -91,10 +92,12 @@ vi.mock('fs', async (importOriginal) => {
       readFileSync: mockFsReadFileSync,
       existsSync: mockFsExistsSync,
       mkdirSync: mockFsMkdirSync,
+      writeFileSync: mockFsWriteFileSync,
     },
     readFileSync: mockFsReadFileSync,
     existsSync: mockFsExistsSync,
     mkdirSync: mockFsMkdirSync,
+    writeFileSync: mockFsWriteFileSync,
   };
 });
 


### PR DESCRIPTION
## Summary

- Fixes flaky test `test/providers/index.test.ts` that was failing intermittently on Windows CI
- Added `writeFileSync` to the `fs` mock that was missing

## Root Cause

The test mocked `fs.existsSync` and `fs.mkdirSync` but **not** `fs.writeFileSync`. When importing `AwsBedrockCompletionProvider`, the module initialization chain triggers:

1. `bedrock/base.ts` → imports `telemetry`
2. `telemetry.ts` → creates `new Telemetry()`
3. Telemetry constructor → calls `getUserId()`
4. `getUserId()` → calls `readGlobalConfig()`

In `readGlobalConfig()`:
- `fs.existsSync(configFilePath)` → **mocked**, returns `undefined` (falsy)
- `fs.mkdirSync(configDir, ...)` → **mocked**, does nothing
- `fs.writeFileSync(configFilePath, ...)` → **NOT mocked**, uses real fs → **FAILS**

The real `writeFileSync` failed because the mocked `mkdirSync` never actually created the directory.

## Why It Was Flaky

In some test orderings, the `.local/vitest/config` directory already existed from other tests or setup, so the write succeeded. On Windows CI with a fresh environment, it consistently failed.

## Test plan

- [x] Ran 80+ test iterations with random shuffle, different seeds, fresh directories, and module isolation
- [x] Simulated original CI shard conditions (5 test files together) - 10/10 passes
- [x] Verified fix works when `.local/vitest/config` directory doesn't exist

🤖 Generated with [Claude Code](https://claude.ai/code)