### PR TITLE
feat(app): extend UI component interfaces for data-testid support

### DIFF
--- a/src/app/src/components/ui/code.tsx
+++ b/src/app/src/components/ui/code.tsx
@@ -1,13 +1,15 @@
+import * as React from 'react';
+
 import { cn } from '@app/lib/utils';
 
-interface CodeProps {
-  children: React.ReactNode;
-  className?: string;
-}
+interface CodeProps extends React.ComponentProps<'pre'> {}
 
-function Code({ children, className }: CodeProps) {
+function Code({ children, className, ...props }: CodeProps) {
   return (
-    <pre className={cn('p-2 mb-2 rounded bg-muted font-mono text-sm overflow-x-auto', className)}>
+    <pre
+      className={cn('p-2 mb-2 rounded bg-muted font-mono text-sm overflow-x-auto', className)}
+      {...props}
+    >
       {children}
     </pre>
   );

--- a/src/app/src/components/ui/combobox.tsx
+++ b/src/app/src/components/ui/combobox.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 
@@ -11,16 +12,13 @@ export interface ComboboxOption {
   description?: string;
 }
 
-interface ComboboxProps {
+interface ComboboxProps extends Omit<React.ComponentProps<'input'>, 'onChange' | 'value' | 'type'> {
   options: ComboboxOption[];
   value?: string;
   onChange: (value: string) => void;
-  placeholder?: string;
   emptyMessage?: string;
-  disabled?: boolean;
   clearable?: boolean;
   label?: string;
-  className?: string;
 }
 
 function Combobox({
@@ -33,6 +31,7 @@ function Combobox({
   clearable = true,
   label,
   className,
+  ...props
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -207,6 +206,7 @@ function Combobox({
         <PopoverAnchor asChild>
           <div className="relative">
             <input
+              {...props}
               id={inputId}
               ref={inputRef}
               type="text"

--- a/src/app/src/components/ui/copy-button.tsx
+++ b/src/app/src/components/ui/copy-button.tsx
@@ -1,15 +1,20 @@
+import * as React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cn } from '@app/lib/utils';
 import { Check, Copy } from 'lucide-react';
 
-interface CopyButtonProps {
+interface CopyButtonProps extends Omit<React.ComponentProps<'button'>, 'value'> {
   value: string;
-  className?: string;
   iconSize?: string;
 }
 
-export function CopyButton({ value, className, iconSize = 'h-3.5 w-3.5' }: CopyButtonProps) {
+export function CopyButton({
+  value,
+  className,
+  iconSize = 'h-3.5 w-3.5',
+  ...props
+}: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -49,6 +54,7 @@ export function CopyButton({ value, className, iconSize = 'h-3.5 w-3.5' }: CopyB
         className,
       )}
       aria-label={copied ? 'Copied' : 'Copy'}
+      {...props}
     >
       {copied ? (
         <Check className={cn(iconSize, 'text-emerald-600 dark:text-emerald-400')} />

--- a/src/app/src/components/ui/gauge.tsx
+++ b/src/app/src/components/ui/gauge.tsx
@@ -1,11 +1,12 @@
+import * as React from 'react';
+
 import { cn } from '@app/lib/utils';
 
-interface GaugeProps {
+interface GaugeProps extends Omit<React.ComponentProps<'div'>, 'value'> {
   value: number;
   max?: number;
   size?: number;
   strokeWidth?: number;
-  className?: string;
   showValue?: boolean;
   formatValue?: (value: number) => string;
 }
@@ -22,6 +23,7 @@ export function Gauge({
   className,
   showValue = true,
   formatValue = (v) => `${Math.round(v)}%`,
+  ...props
 }: GaugeProps) {
   // Normalize value to 0-100 range
   const normalizedValue = Math.min(Math.max((value / max) * 100, 0), 100);
@@ -50,6 +52,7 @@ export function Gauge({
       aria-valuemin={0}
       aria-valuemax={max}
       aria-label="Progress gauge"
+      {...props}
     >
       <svg
         width={size}

--- a/src/app/src/components/ui/json-textarea.tsx
+++ b/src/app/src/components/ui/json-textarea.tsx
@@ -5,14 +5,19 @@ import { HelperText } from './helper-text';
 import { Label } from './label';
 import { Textarea } from './textarea';
 
-interface JsonTextareaProps {
+interface JsonTextareaProps extends Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
   label: string;
   defaultValue?: string;
   onChange?: (parsed: unknown) => void;
-  className?: string;
 }
 
-const JsonTextarea = ({ label, defaultValue = '', onChange, className }: JsonTextareaProps) => {
+const JsonTextarea = ({
+  label,
+  defaultValue = '',
+  onChange,
+  className,
+  ...props
+}: JsonTextareaProps) => {
   const [value, setValue] = React.useState(defaultValue);
   const [error, setError] = React.useState(false);
 
@@ -32,7 +37,7 @@ const JsonTextarea = ({ label, defaultValue = '', onChange, className }: JsonTex
   };
 
   return (
-    <div className={cn('flex flex-col', className)}>
+    <div className={cn('flex flex-col', className)} {...props}>
       <Label>{label}</Label>
       <Textarea
         value={value}

--- a/src/app/src/components/ui/navigation-sidebar.tsx
+++ b/src/app/src/components/ui/navigation-sidebar.tsx
@@ -62,7 +62,8 @@ function StatusIndicator({
   return <span className={cn('ml-auto size-2 shrink-0 rounded-full', statusColors[status])} />;
 }
 
-export interface NavigationSidebarProps {
+export interface NavigationSidebarProps
+  extends Omit<React.ComponentProps<'div'>, 'header' | 'footer'> {
   /** Array of navigation items to display */
   items: NavigationItem[];
   /** Currently active item id */
@@ -73,8 +74,6 @@ export interface NavigationSidebarProps {
   header?: React.ReactNode;
   /** Optional footer content */
   footer?: React.ReactNode;
-  /** Additional className for the container */
-  className?: string;
   /** If true, sidebar collapses to icons only and expands on hover */
   collapsible?: boolean;
 }
@@ -238,6 +237,7 @@ export function NavigationSidebar({
   footer,
   className,
   collapsible = false,
+  ...props
 }: NavigationSidebarProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => getDefaultExpandedIds(items));
   const [isHovered, setIsHovered] = useState(false);
@@ -351,6 +351,7 @@ export function NavigationSidebar({
           'py-4',
           className,
         )}
+        {...props}
       >
         {!isCollapsed && header && <div className="mb-4">{header}</div>}
 


### PR DESCRIPTION
## Summary
- Update custom UI components to extend React element types so standard HTML attributes like `data-testid` pass through via props spreading
- Affected components: `code.tsx`, `combobox.tsx`, `copy-button.tsx`, `gauge.tsx`, `json-textarea.tsx`, `navigation-sidebar.tsx`
- Each component now extends the appropriate `React.ComponentProps<'element'>` type and spreads `{...props}` to the root element

## Test plan
- [ ] Verify TypeScript compiles without errors
- [ ] Test that `data-testid` can be passed to each updated component
- [ ] Verify existing component behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)