### PR TITLE
docs(redteam): clarify that target provider does not affect attack generation

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -707,9 +707,7 @@ Testing in "low-resource" languages (languages with less training data) often re
 
 ## Providers
 
-The `redteam.provider` field allows you to specify a provider configuration for the "attacker" model, i.e. the model that generates adversarial _inputs_.
-
-Note that this is separate from the "target" model(s), which are set in the top-level [`providers` configuration](/docs/configuration/guide/).
+The `redteam.provider` field allows you to specify a provider configuration for the "attacker" model, i.e. the model that generates adversarial _inputs_. This is separate from the "target" model(s) set in top-level `targets`/`providers` — configuring your target does **not** affect attack generation.
 
 A common use case is to use an alternative platform like [Azure](/docs/providers/azure/), [Bedrock](/docs/providers/aws-bedrock), or [HuggingFace](/docs/providers/huggingface/).
 
@@ -755,6 +753,17 @@ A local model via [ollama](/docs/providers/ollama/) would look similar:
 ```yaml
 redteam:
   provider: ollama:chat:llama3.3
+```
+
+For an OpenAI-compatible API (e.g., local models with vLLM, LM Studio, or other OpenAI-compatible servers):
+
+```yaml
+redteam:
+  provider:
+    id: openai:chat:my-model-name
+    config:
+      apiBaseUrl: http://localhost:8000/v1
+      apiKey: '{{ env.LOCAL_API_KEY }}'
 ```
 
 :::warning

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -85,6 +85,10 @@ If you just want to try out a quick example, click "Load Example" at the top of 
 
 Next, configure Promptfoo to communicate with your target application or model.
 
+:::note
+The target defines the model being tested. Attack generation uses a separate provider (defaults to OpenAI). See [Providers](/docs/red-team/configuration/#providers) to configure a custom attack model.
+:::
+
 Because the Promptfoo scanner runs locally on your machine, it can attack any endpoint accessible from your machine or network.
 
 [See below](#alternative-test-specific-prompts-and-models) for more info on how to talk with non-HTTP targets such as models (local or remote) or custom code.


### PR DESCRIPTION
## Summary
- Clarifies in `configuration.md` that `redteam.provider` is separate from `targets`/`providers` and that configuring the target does **not** affect attack generation
- Adds OpenAI-compatible API example (vLLM, LM Studio) to the provider config section
- Adds a note in `quickstart.md` pointing users to the provider docs when configuring a target

Closes #7329

## Test plan
- [x] `SKIP_OG_GENERATION=true npm run build` passes with no broken anchors