### PR TITLE
fix: serialize Error objects properly in log context

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -270,11 +270,26 @@ export function sanitizeObject(
     }
 
     // Use safeStringify only to handle circular references
+    // Custom replacer to handle Error objects which don't serialize properly
+    // (Error objects have no enumerable properties, so JSON.stringify returns "{}")
     const safeObj = JSON.parse(
-      safeStringify(obj, undefined, undefined, {
-        depthLimit: Number.MAX_SAFE_INTEGER,
-        edgesLimit: Number.MAX_SAFE_INTEGER,
-      }),
+      safeStringify(
+        obj,
+        (_key, val) => {
+          if (val instanceof Error) {
+            return {
+              name: val.name,
+              message: val.message,
+            };
+          }
+          return val;
+        },
+        undefined,
+        {
+          depthLimit: Number.MAX_SAFE_INTEGER,
+          edgesLimit: Number.MAX_SAFE_INTEGER,
+        },
+      ),
     );
 
     // Apply recursive sanitization with depth limiting

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -523,11 +523,14 @@ describe('sanitizeObject', () => {
       expect(result.regex).toEqual({});
     });
 
-    it('should convert Error objects to empty objects via JSON', () => {
+    it('should serialize Error objects with name and message', () => {
       const error = new Error('test error');
       const result = sanitizeObject({ error });
-      // Error objects get serialized to empty objects (message is non-enumerable)
-      expect(result.error).toEqual({});
+      // Error objects are properly serialized with their properties
+      expect(result.error).toEqual({
+        name: 'Error',
+        message: 'test error',
+      });
     });
 
     it('should convert Map objects to empty objects via JSON', () => {


### PR DESCRIPTION
## Summary
- Fixed Error objects being logged as `{}` instead of showing the actual error message
- Added a custom replacer function to `safeStringify` that converts Error instances to plain objects with `name` and `message` properties

## Problem
Error objects have no enumerable own properties, so `JSON.stringify(new Error("msg"))` returns `"{}"`. This caused errors from providers (like Python) to be logged as `error: {}` instead of the actual error message.

## Solution
Added a custom JSON replacer in `sanitizeObject` that detects Error instances and converts them to `{ name, message }` before serialization.

## Test plan
- [x] Updated existing test to verify Error objects serialize with name and message
- [x] Ran `npx vitest run test/util/sanitizer.test.ts` - all 163 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)