### PR TITLE
fix(redteam): preserve provider config in browser flow

### DIFF
--- a/src/app/src/pages/redteam/setup/types.ts
+++ b/src/app/src/pages/redteam/setup/types.ts
@@ -78,6 +78,8 @@ export interface Config {
   defaultTest?: TestCase;
   extensions?: string[];
   language?: string | string[]; // Global language configuration
+  // Provider used for generating adversarial inputs (redteam provider)
+  provider?: string | CoreProviderOptions;
 }
 
 export interface ProviderOptions {

--- a/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
+++ b/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
@@ -9,6 +9,7 @@ const orderRedTeam = (redteam: Partial<RedteamFileConfig>): Record<string, unkno
   const orderedRedTeam: Record<string, unknown> = {};
   const redTeamOrder = [
     'purpose',
+    'provider',
     'entities',
     'plugins',
     'testGenerationInstructions',

--- a/src/redteam/sharedFrontend.ts
+++ b/src/redteam/sharedFrontend.ts
@@ -56,6 +56,7 @@ export function getUnifiedConfig(
     redteam: {
       purpose: config.purpose,
       numTests: config.numTests,
+      ...(config.provider && { provider: config.provider }),
       ...(config.maxConcurrency && { maxConcurrency: config.maxConcurrency }),
       ...(config.language && { language: config.language }),
       ...(config.frameworks &&

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -282,6 +282,7 @@ export interface SavedRedteamConfig {
   numTests?: number;
   maxConcurrency?: number;
   language?: string | string[];
+  provider?: string | ProviderOptions;
   applicationDefinition: {
     purpose?: string;
     features?: string;

--- a/test/redteam/sharedFrontend.test.ts
+++ b/test/redteam/sharedFrontend.test.ts
@@ -211,4 +211,46 @@ describe('getUnifiedConfig', () => {
 
     expect(result.redteam.frameworks).toEqual(['owasp:llm', 'nist:ai:measure']);
   });
+
+  it('should include provider when provided as string', () => {
+    const configWithProvider: SavedRedteamConfig = {
+      ...baseConfig,
+      provider: 'openai:chat:gpt-4',
+    };
+
+    const result = getUnifiedConfig(configWithProvider);
+
+    expect(result.redteam.provider).toBe('openai:chat:gpt-4');
+  });
+
+  it('should include provider when provided as object', () => {
+    const configWithProvider: SavedRedteamConfig = {
+      ...baseConfig,
+      provider: {
+        id: 'openai:chat',
+        config: {
+          apiBaseUrl: 'http://192.168.1.1:1111/v1',
+          apiKey: 'sk-test',
+          model: 'Qwen3-test',
+        },
+      },
+    };
+
+    const result = getUnifiedConfig(configWithProvider);
+
+    expect(result.redteam.provider).toEqual({
+      id: 'openai:chat',
+      config: {
+        apiBaseUrl: 'http://192.168.1.1:1111/v1',
+        apiKey: 'sk-test',
+        model: 'Qwen3-test',
+      },
+    });
+  });
+
+  it('should not include provider when not provided', () => {
+    const result = getUnifiedConfig(baseConfig);
+
+    expect(result.redteam.provider).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #7329. The custom `redteam.provider` configuration was being ignored when using "Run Directly in Browser".

**Root Cause:** The `provider` field was missing from three locations in the browser flow:
1. `SavedRedteamConfig` interface in `src/redteam/types.ts`
2. Frontend `Config` interface in `src/app/src/pages/redteam/setup/types.ts`  
3. `getUnifiedConfig` function in `src/redteam/sharedFrontend.ts`

This caused the browser flow to always use the default provider instead of the user's custom provider configuration.

**Changes:**
- Added `provider` field to `SavedRedteamConfig` interface
- Added `provider` field to frontend `Config` interface
- Added provider passthrough in `getUnifiedConfig`
- Added `provider` to YAML field ordering for consistent output
- Added 3 test cases to verify provider field handling

## Test plan

- [x] Unit tests pass (17 tests including 3 new provider tests)
- [x] E2E verified with mock OpenAI server - browser flow correctly sends requests to custom provider endpoint with custom model and API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)