### PR TITLE
test: fix flaky eval and summary tests with proper mock isolation

### DIFF
--- a/test/commands/eval/summary.test.ts
+++ b/test/commands/eval/summary.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { generateEvalSummary } from '../../../src/commands/eval/summary';
 import { stripAnsi } from '../../util/utils';
 
@@ -31,7 +31,12 @@ describe('generateEvalSummary', () => {
   let mockTracker: MockTracker & TokenUsageTracker;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     mockTracker = createMockTracker() as MockTracker & TokenUsageTracker;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   describe('completion message', () => {


### PR DESCRIPTION
## Summary

- Fix flaky tests in `test/commands/eval.test.ts` and `test/commands/eval/summary.test.ts` that were timing out on Windows CI
- Add complete mock setup in `beforeEach` for all required dependencies after `vi.resetAllMocks()`
- Add `afterEach` cleanup hooks to both test files for proper mock isolation

## Problem

The "Sharing Precedence" tests in `eval.test.ts` used `vi.resetAllMocks()` but only re-configured a subset of required mocks. This left critical mocks like `TokenUsageTracker.getInstance()`, `promptForEmailUnverified()`, and `checkEmailStatusAndMaybeExit()` unconfigured, causing tests to hang or behave unexpectedly depending on execution order.

## Test plan

- [x] Run tests with random order 10+ times - all pass
- [x] Tests complete in ~100-130ms (previously timing out at 30s)
- [x] Lint and format pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)