### PR TITLE
fix(ci): replace raven-actions/actionlint with direct download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -624,9 +624,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Run actionlint
-        id: actionlint
-        uses: raven-actions/actionlint@v2
+      - name: Install and run actionlint
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint
 
   ruby:
     name: Check Ruby


### PR DESCRIPTION
## Summary

We have CI failing on `main`

Examples:

- https://github.com/promptfoo/promptfoo/actions/runs/21491313471/job/61920182536  - https://github.com/promptfoo/promptfoo/actions/runs/21491333295/job/61915071482

We need to replace `raven-actions/actionlint@v2` with direct download and execution of actionlint

## Problem
The `raven-actions/actionlint@v2` action was failing in main with:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in 
/home/runner/work/promptfoo/promptfoo/node_modules/@actions/tool-cache/package.json
```

The action runs `npm install @actions/tool-cache` into the project's node_modules, and that package has an exports field issue that breaks `actions/github-script`.

## Solution
Use the official download script from rhysd/actionlint to download and run the binary directly, avoiding npm entirely.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)