### PR TITLE
fix(cli): use npx commands in README when init run via npx

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -242,17 +242,19 @@ module.exports = function (varName, prompt, otherVars) {
 };
 `;
 
-const DEFAULT_README = `To get started, set your OPENAI_API_KEY environment variable, or other required keys for the providers you selected.
+function getDefaultReadme(): string {
+  return `To get started, set your OPENAI_API_KEY environment variable, or other required keys for the providers you selected.
 
 Next, edit promptfooconfig.yaml.
 
 Then run:
 \`\`\`
-promptfoo eval
+${promptfooCommand('eval')}
 \`\`\`
 
-Afterwards, you can view the results by running \`promptfoo view\`
+Afterwards, you can view the results by running \`${promptfooCommand('view')}\`
 `;
+}
 
 function recordOnboardingStep(step: string, properties: EventProperties = {}) {
   telemetry.record('funnel', {
@@ -625,7 +627,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
 
   await writeFile({
     file: 'README.md',
-    contents: DEFAULT_README,
+    contents: getDefaultReadme(),
     required: false,
   });
 


### PR DESCRIPTION
## Summary
- When users run `npx promptfoo@latest init`, the generated README.md now correctly instructs them to use `npx promptfoo@latest eval` instead of `promptfoo eval`
- Converts static `DEFAULT_README` constant to `getDefaultReadme()` function that uses the existing `promptfooCommand()` utility

## Problem
Users running `npx promptfoo@latest init` would get a README telling them to run `promptfoo eval`, which fails with "command not found" since they don't have promptfoo installed globally.

## Solution
The `promptfooCommand()` utility already exists and detects whether the user ran via npx, brew, or global npm install. This PR uses that utility when generating the README content.

## Test plan
- [x] Verified npx user gets `npx promptfoo@latest eval` in README
- [x] Verified global user gets `promptfoo eval` in README  
- [x] `npm run build` passes
- [x] `test/onboarding.test.ts` passes (8 tests)
- [x] `test/commands/init.test.ts` passes (16 tests)
- [x] `test/util/promptfooCommand.test.ts` passes (26 tests)

Closes #7326

🤖 Generated with [Claude Code](https://claude.ai/code)