### PR TITLE
docs(site): improve installation page for Windows users

### DIFF
--- a/site/docs/installation.md
+++ b/site/docs/installation.md
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 ## For Command-Line Usage
 
-Install promptfoo using [npm](https://nodejs.org/en/download) or [npx](https://nodejs.org/en/download):
+Install promptfoo using [npm](https://nodejs.org/en/download), [npx](https://nodejs.org/en/download), or [Homebrew](https://brew.sh) (Mac, Linux):
 
 <Tabs groupId="promptfoo-command">
   <TabItem value="npm" label="npm" default>


### PR DESCRIPTION
## Summary

- Add "(Mac, Linux)" label to brew tabs so Windows users know npm/npx are their options
- Update Node.js requirement to match package.json (20.20+ or 22.22+)
- Reorder OS list to put Windows first
- Update version example to current (0.120.20)
- Add "windows" to keywords for SEO

## Test plan

- [ ] Verify docs build: `cd site && SKIP_OG_GENERATION=true npm run build`
- [ ] Review installation page renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)