### PR TITLE
fix(cli): ensure process exits on SIGINT during view command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,9 @@ export const shutdownGracefully = async (): Promise<void> => {
   try {
     await withTimeout(telemetry.shutdown(), 'telemetry.shutdown()');
   } catch (error) {
-    logger.debug(`Error during telemetry shutdown: ${error}`);
+    logger.debug('[shutdownGracefully] Telemetry shutdown failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   logger.debug('Closing logger file transports');

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -339,6 +339,7 @@ describe('shutdownGracefully', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.resetAllMocks();
     process.exit = originalExit;
   });
 


### PR DESCRIPTION
## Summary

- Fix critical bug where `promptfoo view` wouldn't terminate on Ctrl+C if cleanup operations hung
- Move force-exit timeout to the BEGINNING of `shutdownGracefully()` to guarantee exit
- Add individual 1s timeouts to each cleanup operation (`telemetry.shutdown`, `closeLogger`, `dispatcher.destroy`)

## Problem

When running `promptfoo view` and pressing Ctrl+C, the process sometimes wouldn't terminate, requiring users to manually find the PID and kill it. This happened because:

1. The force-exit timeout was placed **after** all `await` calls in `shutdownGracefully()`
2. If any cleanup operation hung forever, the timeout code was never reached
3. The process would stay alive indefinitely

## Solution

1. Set up the 3-second force-exit timeout **before** any async operations
2. Wrap each cleanup operation in a 1-second `Promise.race` timeout
3. Clear timeouts properly when operations complete normally

## Test plan

- [x] All existing tests pass
- [x] Added 8 new tests for shutdown timeout scenarios
- [x] Manual verification: `promptfoo view` now terminates within 1 second of SIGINT

🤖 Generated with [Claude Code](https://claude.com/claude-code)