### PR TITLE
chore: add MIT license to internal packages

### DIFF
--- a/code-scan-action/package-lock.json
+++ b/code-scan-action/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@promptfoo/code-scan-action",
       "version": "0.1.4",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",
         "@actions/exec": "^2.0.0",

--- a/code-scan-action/package.json
+++ b/code-scan-action/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@promptfoo/code-scan-action",
   "version": "0.1.4",
+  "license": "MIT",
   "description": "GitHub Action for scanning PRs with promptfoo code-scan",
   "private": true,
   "main": "dist/index.js",

--- a/examples/claude-agent-sdk/advanced/workspace/package.json
+++ b/examples/claude-agent-sdk/advanced/workspace/package.json
@@ -1,6 +1,8 @@
 {
   "name": "auth-module",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "description": "Simple authentication module for refactoring",
   "main": "auth.js",
   "scripts": {

--- a/examples/claude-agent-sdk/working-dir/sample-project/package.json
+++ b/examples/claude-agent-sdk/working-dir/sample-project/package.json
@@ -1,6 +1,8 @@
 {
   "name": "sample-api",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "description": "A simple Express API for testing Claude Agent SDK",
   "main": "index.js",
   "scripts": {

--- a/examples/node-package-typescript/package.json
+++ b/examples/node-package-typescript/package.json
@@ -1,6 +1,8 @@
 {
   "name": "simple-import",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/examples/node-package/package.json
+++ b/examples/node-package/package.json
@@ -1,6 +1,8 @@
 {
   "name": "simple-import",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/examples/openai-agents-basic/package.json
+++ b/examples/openai-agents-basic/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@promptfoo/openai-agents-basic-example",
   "version": "1.0.0",
+  "license": "MIT",
   "private": true,
   "description": "D&D adventure game with OpenAI Agents SDK - dungeon master with dice rolling and character management",
   "type": "module",

--- a/examples/opentelemetry-tracing/package.json
+++ b/examples/opentelemetry-tracing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@promptfoo/opentelemetry-tracing-example",
   "version": "1.0.0",
+  "license": "MIT",
   "private": true,
   "description": "OpenTelemetry tracing integration with Promptfoo evaluations",
   "scripts": {

--- a/examples/redteam-mcp-agent/package.json
+++ b/examples/redteam-mcp-agent/package.json
@@ -8,7 +8,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
+  "private": true,
   "description": "",
   "dependencies": {
     "@faker-js/faker": "^10.2.0",

--- a/examples/redteam-medical-agent/package.json
+++ b/examples/redteam-medical-agent/package.json
@@ -1,6 +1,8 @@
 {
   "name": "redteam-medical-agent",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "description": "Medical agent example for promptfoo red team testing",
   "main": "src/server.js",
   "scripts": {

--- a/examples/redteam-tracing-example/package.json
+++ b/examples/redteam-tracing-example/package.json
@@ -1,6 +1,7 @@
 {
   "name": "redteam-tracing-example",
   "version": "1.0.0",
+  "license": "MIT",
   "description": "Example of red team testing with tracing enabled",
   "private": true,
   "scripts": {

--- a/examples/ts-config/package.json
+++ b/examples/ts-config/package.json
@@ -1,6 +1,8 @@
 {
   "name": "ts-config-example",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "description": "TypeScript configuration example for promptfoo with dynamic schema generation",
   "scripts": {
     "eval": "NODE_OPTIONS=\"--import tsx\" promptfoo eval -c promptfooconfig.ts",

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -1,6 +1,8 @@
 {
   "name": "vercel-ai-sdk",
   "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
   "type": "module",
   "dependencies": {
     "ai": "^6.0.55",

--- a/examples/websockets-streaming/server/package.json
+++ b/examples/websockets-streaming/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openai-ws-server",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "description": "Express server with WebSocket endpoint that calls OpenAI Responses API",

--- a/examples/websockets/test-server/package.json
+++ b/examples/websockets/test-server/package.json
@@ -6,7 +6,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
+  "private": true,
   "description": "",
   "dependencies": {
     "ws": "^8.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -43966,6 +43966,7 @@
     },
     "src/app": {
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Add missing `"license": "MIT"` field to 15 package.json files
- Add `"private": true` to example packages to prevent accidental npm publish
- Update lock files

**Affected packages:**
- `src/app/package.json` (web UI)
- `code-scan-action/package.json` (GitHub Action)
- 13 example packages

This ensures all packages in the repo have proper license metadata for compliance tooling.

## Test plan

- [x] `npm install` succeeds at root
- [x] Lock files updated

🤖 Generated with [Claude Code](https://claude.ai/code)