### PR TITLE
chore: update CODEOWNERS to scope site/ reviews to content only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,8 +78,10 @@
 # DOCUMENTATION
 # ============================================================================
 
-/site/                      @typpo @mldangelo @swarnap      # Marketing site (landing pages)
+/site/                      @typpo @mldangelo               # Marketing site (infra/config)
 /site/docs/                 @typpo @mldangelo               # Technical documentation
+/site/src/pages/**/*.tsx    @swarnap @typpo @mldangelo      # Landing page content
+/site/src/pages/**/*.md     @swarnap @typpo @mldangelo      # Landing page markdown
 /site/blog/                 @swarnap @mldangelo             # Blog posts
 /CONTRIBUTING.md            @mldangelo                      # Contributing guide
 /site/docs/contributing.md  @mldangelo                      # Contributing docs


### PR DESCRIPTION
## Summary
- Remove @swarnap from general `/site/` ownership (covers config, package.json, CSS, components)
- Add specific patterns for landing page content files (`/site/src/pages/**/*.tsx` and `*.md`)
- Keep @swarnap on `/site/blog/` for blog post reviews

This scopes site reviews to marketing copy changes only, excluding infrastructure/config files.

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm changes to `/site/package.json` don't request review from @swarnap
- [ ] Confirm changes to `/site/src/pages/index.tsx` do request review from @swarnap
