### PR TITLE
fix: Langfuse variable type conversion 

### DIFF
--- a/src/integrations/langfuse.ts
+++ b/src/integrations/langfuse.ts
@@ -55,8 +55,12 @@ export async function getPrompt(
     }
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: FIXME: this is almost certainly a bug.  According to langfuse, this is supposed to be Record<string, string>.
-  const compiledPrompt = prompt.compile(vars as any);
+  // Convert VarValue to strings since Langfuse compile() expects Record<string, string>
+  const stringVars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    stringVars[key] = typeof value === 'string' ? value : JSON.stringify(value);
+  }
+  const compiledPrompt = prompt.compile(stringVars);
   if (typeof compiledPrompt !== 'string') {
     return JSON.stringify(compiledPrompt);
   }

--- a/test/integrations/langfuse.test.ts
+++ b/test/integrations/langfuse.test.ts
@@ -274,5 +274,32 @@ describe('langfuse integration', () => {
       });
       expect(result).toBe('Staging content');
     });
+
+    it('should convert non-string variables to strings for Langfuse compile()', async () => {
+      const mockPrompt = {
+        compile: vi.fn().mockReturnValue('Result with converted vars'),
+      };
+      mocks.mockGetPrompt.mockResolvedValue(mockPrompt);
+
+      const { getPrompt } = await import('../../src/integrations/langfuse');
+      const vars = {
+        name: 'John',
+        age: 30,
+        active: true,
+        metadata: { key: 'value' },
+        tags: ['a', 'b'],
+      };
+      const result = await getPrompt('test-prompt', vars, 'text', 1);
+
+      // Langfuse compile() expects Record<string, string>, so non-strings should be JSON stringified
+      expect(mockPrompt.compile).toHaveBeenCalledWith({
+        name: 'John',
+        age: '30',
+        active: 'true',
+        metadata: '{"key":"value"}',
+        tags: '["a","b"]',
+      });
+      expect(result).toBe('Result with converted vars');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Removes the `any` type assertion and implements proper type conversion for variables passed to Langfuse's `compile()` method, which expects `Record<string, string>`.

## Changes
- **Type Safety**: Replaced `as any` cast with explicit variable conversion logic that properly handles non-string types
- **Variable Conversion**: Implemented conversion of non-string values (numbers, booleans, objects, arrays) to strings using JSON serialization where appropriate
- **Test Coverage**: Added comprehensive test case verifying that all variable types are correctly converted before being passed to `compile()`

## Implementation Details
The fix converts all variable values to strings by:
- Keeping string values as-is
- Converting other types (numbers, booleans, objects, arrays) to their JSON string representation using `JSON.stringify()`

This ensures type safety while maintaining compatibility with Langfuse's API requirements and eliminates the previous `biome-ignore` lint suppression.

https://claude.ai/code/session_01EQDuJsjW7k3giHL6PCYUeq