### PR TITLE
docs(redteam): move ecommerce to domain-specific plugins and add telecom

### DIFF
--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -95,7 +95,6 @@ const redTeamSidebar = [
           'red-team/plugins/coppa',
           'red-team/plugins/cyberseceval',
           'red-team/plugins/donotanswer',
-          'red-team/plugins/ecommerce',
           'red-team/plugins/ferpa',
           'red-team/plugins/harmbench',
           'red-team/plugins/aegis',
@@ -131,10 +130,12 @@ const redTeamSidebar = [
         label: 'Domain-Specific',
         collapsed: true,
         items: [
-          'red-team/plugins/medical',
+          'red-team/plugins/ecommerce',
           'red-team/plugins/financial',
-          'red-team/plugins/pharmacy',
           'red-team/plugins/insurance',
+          'red-team/plugins/medical',
+          'red-team/plugins/pharmacy',
+          'red-team/plugins/telecom',
         ],
       },
       {


### PR DESCRIPTION
Moved the e-commerce plugin from "Trust, Safety, & Compliance" to "Domain-Specific" category where it belongs alongside other industry-specific plugins. Also added the telecom plugin to the Domain-Specific category.

Slack thread: https://promptfoo.slack.com/archives/C09CK1WNCPQ/p1770157515868249?thread_ts=1770157471.103569&cid=C09CK1WNCPQ

https://claude.ai/code/session_01Pd7D4LfbncQtUqYq2zCQwg