### PR TITLE
fix(commands): use streaming iteration in recalculatePromptMetrics to avoid OOM

### DIFF
--- a/test/commands/retry.test.ts
+++ b/test/commands/retry.test.ts
@@ -498,5 +498,587 @@ describe('retry command', () => {
       expect(evalRecord.prompts[0].metrics?.namedScores?.accuracy).toBeCloseTo(1.6, 1);
       expect(evalRecord.prompts[0].metrics?.namedScores?.relevance).toBeCloseTo(1.7, 1);
     });
+
+    it('should accumulate metrics correctly across multiple batches', async () => {
+      // Test that metrics accumulate correctly when results span multiple batch boundaries
+      // Batch size is 1000 (by testIdx), so results at testIdx 0-999, 1000-1999, 2000-2999 are in different batches
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results spanning 3 batches (testIdx 0, 1000, 2000)
+      await db.insert(evalResultsTable).values([
+        // Batch 1 (testIdx 0-999)
+        {
+          id: `${evalRecord.id}-batch1-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          latencyMs: 100,
+          cost: 0.01,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { accuracy: 0.9 },
+        },
+        {
+          id: `${evalRecord.id}-batch1-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 500,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          latencyMs: 100,
+          cost: 0.01,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { accuracy: 0.8 },
+        },
+        // Batch 2 (testIdx 1000-1999)
+        {
+          id: `${evalRecord.id}-batch2-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1000,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: false,
+          score: 0,
+          latencyMs: 200,
+          cost: 0.02,
+          failureReason: ResultFailureReason.ASSERT,
+          namedScores: { accuracy: 0.5 },
+        },
+        {
+          id: `${evalRecord.id}-batch2-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1500,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: false,
+          score: 0,
+          latencyMs: 200,
+          cost: 0.02,
+          failureReason: ResultFailureReason.ERROR,
+          namedScores: { accuracy: 0.3 },
+        },
+        // Batch 3 (testIdx 2000-2999)
+        {
+          id: `${evalRecord.id}-batch3-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 2000,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          latencyMs: 150,
+          cost: 0.015,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { accuracy: 1.0 },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Verify accumulated metrics across all batches
+      expect(evalRecord.prompts[0].metrics?.testPassCount).toBe(3);
+      expect(evalRecord.prompts[0].metrics?.testFailCount).toBe(1);
+      expect(evalRecord.prompts[0].metrics?.testErrorCount).toBe(1);
+      expect(evalRecord.prompts[0].metrics?.score).toBe(3); // 1+1+0+0+1
+      expect(evalRecord.prompts[0].metrics?.totalLatencyMs).toBe(750); // 100+100+200+200+150
+      expect(evalRecord.prompts[0].metrics?.cost).toBeCloseTo(0.075, 3); // 0.01+0.01+0.02+0.02+0.015
+      expect(evalRecord.prompts[0].metrics?.namedScores?.accuracy).toBeCloseTo(3.5, 1); // 0.9+0.8+0.5+0.3+1.0
+    });
+
+    it('should handle results at exact batch boundary (testIdx 999 and 1000)', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results at exact batch boundary
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-boundary-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 999, // Last index of batch 1
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { boundary_test: 0.5 },
+        },
+        {
+          id: `${evalRecord.id}-boundary-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1000, // First index of batch 2
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { boundary_test: 0.5 },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Both results should be counted
+      expect(evalRecord.prompts[0].metrics?.testPassCount).toBe(2);
+      expect(evalRecord.prompts[0].metrics?.score).toBe(2);
+      expect(evalRecord.prompts[0].metrics?.namedScores?.boundary_test).toBeCloseTo(1.0, 1);
+    });
+
+    it('should handle single result edge case', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-single`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 0.75,
+          latencyMs: 42,
+          cost: 0.005,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: { quality: 0.9 },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      expect(evalRecord.prompts[0].metrics?.testPassCount).toBe(1);
+      expect(evalRecord.prompts[0].metrics?.testFailCount).toBe(0);
+      expect(evalRecord.prompts[0].metrics?.score).toBe(0.75);
+      expect(evalRecord.prompts[0].metrics?.totalLatencyMs).toBe(42);
+      expect(evalRecord.prompts[0].metrics?.cost).toBe(0.005);
+      expect(evalRecord.prompts[0].metrics?.namedScores?.quality).toBe(0.9);
+    });
+
+    it('should use fetchResultsBatched for streaming iteration', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert a result
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-stream-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+      ]);
+
+      // Spy on fetchResultsBatched to verify it's called
+      const fetchSpy = vi.spyOn(evalRecord, 'fetchResultsBatched');
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Verify fetchResultsBatched was called with batch size 1000
+      expect(fetchSpy).toHaveBeenCalledWith(1000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      fetchSpy.mockRestore();
+    });
+
+    it('should accumulate assertion counts from componentResults', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results with gradingResult containing componentResults
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-assert-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'passed',
+            componentResults: [
+              { pass: true, score: 1, reason: 'passed' },
+              { pass: true, score: 1, reason: 'passed' },
+              { pass: false, score: 0, reason: 'failed' },
+            ],
+          },
+        },
+        {
+          id: `${evalRecord.id}-assert-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: false,
+          score: 0,
+          failureReason: ResultFailureReason.ASSERT,
+          namedScores: {},
+          gradingResult: {
+            pass: false,
+            score: 0,
+            reason: 'failed',
+            componentResults: [
+              { pass: false, score: 0, reason: 'failed' },
+              { pass: false, score: 0, reason: 'failed' },
+            ],
+          },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Verify assertion counts: 2 pass + 1 fail from first result, 2 fail from second result
+      expect(evalRecord.prompts[0].metrics?.assertPassCount).toBe(2);
+      expect(evalRecord.prompts[0].metrics?.assertFailCount).toBe(3);
+    });
+
+    it('should accumulate token usage from response', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results with token usage in response
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-token-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          response: {
+            output: 'test output 1',
+            tokenUsage: {
+              prompt: 100,
+              completion: 50,
+              total: 150,
+            },
+          },
+        },
+        {
+          id: `${evalRecord.id}-token-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          response: {
+            output: 'test output 2',
+            tokenUsage: {
+              prompt: 200,
+              completion: 100,
+              total: 300,
+            },
+          },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Verify token usage accumulation
+      expect(evalRecord.prompts[0].metrics?.tokenUsage).toBeDefined();
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.prompt).toBe(300); // 100 + 200
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.completion).toBe(150); // 50 + 100
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.total).toBe(450); // 150 + 300
+    });
+
+    it('should accumulate assertion token usage from gradingResult', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results with assertion token usage in gradingResult
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-atoken-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'passed',
+            tokensUsed: {
+              total: 50,
+              prompt: 30,
+              completion: 20,
+            },
+          },
+        },
+        {
+          id: `${evalRecord.id}-atoken-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'passed',
+            tokensUsed: {
+              total: 75,
+              prompt: 45,
+              completion: 30,
+            },
+          },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Verify assertion token usage accumulation
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions).toBeDefined();
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions?.total).toBe(125); // 50 + 75
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions?.prompt).toBe(75); // 30 + 45
+      expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions?.completion).toBe(50); // 20 + 30
+    });
+
+    it('should skip results with invalid promptIdx', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert results - one valid, one with invalid promptIdx
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-valid`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+        {
+          id: `${evalRecord.id}-invalid`,
+          evalId: evalRecord.id,
+          promptIdx: 999, // Invalid promptIdx - no prompt at this index
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+      ]);
+
+      // Should not throw and should only count the valid result
+      await recalculatePromptMetrics(evalRecord);
+
+      // Only the valid result should be counted
+      expect(evalRecord.prompts[0].metrics?.testPassCount).toBe(1);
+      expect(evalRecord.prompts[0].metrics?.score).toBe(1);
+    });
+
+    it('should not call addPrompts when eval is not persisted', async () => {
+      // Create a non-persisted eval using the constructor directly
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+      const evalRecord = new Eval(
+        {},
+        {
+          prompts: [mockPrompt],
+          persisted: false, // Non-persisted eval
+        },
+      );
+
+      // Spy on addPrompts
+      const addPromptsSpy = vi.spyOn(evalRecord, 'addPrompts');
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // addPrompts should NOT be called since eval is not persisted
+      expect(addPromptsSpy).not.toHaveBeenCalled();
+
+      addPromptsSpy.mockRestore();
+    });
+
+    it('should rethrow error when batch iteration fails', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Mock fetchResultsBatched to throw an error
+      const mockError = new Error('Database connection failed');
+      vi.spyOn(evalRecord, 'fetchResultsBatched').mockImplementation(async function* () {
+        throw mockError;
+      });
+
+      // Should rethrow the error
+      await expect(recalculatePromptMetrics(evalRecord)).rejects.toThrow(
+        'Database connection failed',
+      );
+    });
+
+    it('should handle results with null/undefined optional fields', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      // Insert result with minimal fields (no latencyMs, cost, response, gradingResult)
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-minimal`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          // No latencyMs, cost, response, or gradingResult
+        },
+      ]);
+
+      // Should handle gracefully without errors
+      await recalculatePromptMetrics(evalRecord);
+
+      expect(evalRecord.prompts[0].metrics?.testPassCount).toBe(1);
+      expect(evalRecord.prompts[0].metrics?.totalLatencyMs).toBe(0);
+      expect(evalRecord.prompts[0].metrics?.cost).toBe(0);
+      expect(evalRecord.prompts[0].metrics?.assertPassCount).toBe(0);
+      expect(evalRecord.prompts[0].metrics?.assertFailCount).toBe(0);
+    });
+
+    it('should handle results with null score', async () => {
+      const evalRecord = await Eval.create({}, []);
+      const db = getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-null-score`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: null as unknown as number, // Explicitly null score
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+        {
+          id: `${evalRecord.id}-valid-score`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 0.5,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      // Null score should be treated as 0
+      expect(evalRecord.prompts[0].metrics?.score).toBe(0.5);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes OOM errors when retrying evaluations with large result sets (40K+ rows with deep multi-turn)
- Changed `recalculatePromptMetrics` to use `fetchResultsBatched()` for streaming iteration instead of `loadResults()` which loads all results into memory
- Added timing and progress logging for observability

## Test plan

- [x] Added comprehensive unit tests for batched processing
- [x] Tests cover batch boundary edge cases, single result, invalid promptIdx, token usage accumulation
- [x] Run existing retry tests: `npx vitest test/commands/retry.test.ts`
- [x] Verify build passes: `npm run build`
- [x] Test `retry` the pre-existing and new way

OLD (load all)
- FATAL ERROR: Reached heap limit at ~100K results
- 48.8MB → OOM

NEW (streaming)
- Completed 500K results
- ~25MB stable
The streaming implementation prevents OOM by keeping memory bounded to O(batch_size) instead of O(total_results).


🤖 Generated with [Claude Code](https://claude.com/claude-code)