### PR TITLE
test(redteam): mock validateSharpDependency in synthesize tests

### DIFF
--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -50,6 +50,10 @@ vi.mock('../../src/redteam/strategies', async () => ({
 
 vi.mock('../../src/util/apiHealth');
 vi.mock('../../src/redteam/remoteGeneration');
+vi.mock('../../src/redteam/sharpAvailability', async () => ({
+  ...(await vi.importActual('../../src/redteam/sharpAvailability')),
+  validateSharpDependency: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('../../src/redteam/util', async () => ({
   ...(await vi.importActual('../../src/redteam/util')),
   extractGoalFromPrompt: vi.fn().mockResolvedValue('mocked goal'),


### PR DESCRIPTION
## Summary
- Mock `validateSharpDependency` from `src/redteam/sharpAvailability.ts` in the redteam synthesize test suite
- Fixes CI failure where the "should support multilingual test cases for image strategy" test throws because the optional `sharp` dependency isn't installed
- Consistent with existing mock patterns in the file (e.g., `validateStrategies`)

## Test plan
- [x] Verified the specific failing test passes: `npx vitest run test/redteam/index.test.ts -t "should support multilingual test cases for image strategy"`
- [x] Verified all 118 tests in the file pass: `npx vitest run test/redteam/index.test.ts`
- [x] Verified tests pass with the exact CI seed that caused the failure: `--sequence.seed=1770328024047`
- [x] Lint and format clean: `npm run l && npm run f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)