### PR TITLE
fix(redteam): skip refusal check when output contains valid prompt markers

### DIFF
--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -155,7 +155,13 @@ export abstract class RedteamPluginBase {
 
       // Handle inference refusals. Result is thrown rather than returning an empty array in order to
       // catch and show a explanatory error message.
-      if (isBasicRefusal(generatedPrompts)) {
+      // Skip the refusal check if the output contains valid prompt markers (e.g., "Prompt:", "PromptBlock:", "<Prompt>"),
+      // since generated test prompts may contain refusal-like language (e.g., "as an AI") as part of their content.
+      const hasValidPromptMarkers =
+        /prompt\s*:/i.test(generatedPrompts) ||
+        generatedPrompts.includes('PromptBlock:') ||
+        /<Prompt>/i.test(generatedPrompts);
+      if (!hasValidPromptMarkers && isBasicRefusal(generatedPrompts)) {
         let message = `${this.provider.id()} returned a refusal during inference for ${this.constructor.name} test case generation.`;
         // We don't know exactly why the prompt was refused, but we can provide hints to the user based on the values which were
         // included in the context window during inference.


### PR DESCRIPTION
## Summary

- Fix false positive refusal errors during redteam plugin test case generation
- Generated prompts for identity/policy plugins naturally contain refusal-like phrases (e.g., "as an AI") in their content, which `isBasicRefusal()` was incorrectly flagging
- Now checks for valid prompt markers (`Prompt:`, `PromptBlock:`, `<Prompt>`) before running the refusal check — if structured output markers are present, it's valid generated content, not a refusal

## Test plan

- [x] Added tests for false positive scenarios (Prompt: and PromptBlock: markers with refusal-like content)
- [x] Added tests confirming genuine refusals (no prompt markers) are still caught
- [x] All 103 existing tests in `base.test.ts` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)