### PR TITLE
feat(redteam): add severity field to PolicyObjectSchema

### DIFF
--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -21,6 +21,7 @@ export const PolicyObjectSchema = z.object({
   }),
   text: z.string().optional(),
   name: z.string().optional(),
+  severity: SeveritySchema.optional(),
 });
 export type PolicyObject = z.infer<typeof PolicyObjectSchema>;
 export type Policy = string | PolicyObject; // Policy Text or Policy ID


### PR DESCRIPTION
## Summary
- Adds optional `severity` field to `PolicyObjectSchema` using the existing `SeveritySchema`
- Enables severity to flow naturally on `PolicyObject` when loaded from the database in cloud

## Test plan
- [x] `npx vitest run test/redteam/plugins/policy` — 60/60 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)