### PR TITLE
test: suppress noisy stdout output and speed up slow tests

### DIFF
--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -10,6 +10,19 @@ import { loadApiProviders } from '../../src/providers/index';
 
 import type { ProviderOptionsMap } from '../../src/types/index';
 
+vi.mock('../../src/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/logger')>();
+  return {
+    ...actual,
+    default: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
 vi.mock('proxy-agent', async (importOriginal) => {
   return {
     ...(await importOriginal()),

--- a/test/providers/elevenlabs/agents/index.test.ts
+++ b/test/providers/elevenlabs/agents/index.test.ts
@@ -4,6 +4,14 @@ import { ElevenLabsAgentsProvider } from '../../../../src/providers/elevenlabs/a
 import type { AgentSimulationResponse } from '../../../../src/providers/elevenlabs/agents/types';
 
 // Mock dependencies
+vi.mock('../../../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 vi.mock('../../../../src/providers/elevenlabs/client');
 vi.mock('../../../../src/providers/elevenlabs/cache');
 vi.mock('../../../../src/providers/elevenlabs/cost-tracker', () => {

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -6,6 +6,14 @@ import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 
 import type { ApiProvider } from '../../../src/types/index';
 
+vi.mock('../../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
     ...(await importOriginal()),

--- a/test/validators/redteam.test.ts
+++ b/test/validators/redteam.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
   ALIASED_PLUGIN_MAPPINGS,
@@ -18,6 +18,14 @@ import {
   RedteamStrategySchema,
   strategyIdSchema,
 } from '../../src/validators/redteam';
+
+beforeEach(() => {
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('RedteamConfigSchema', () => {
   it('should validate basic config', () => {


### PR DESCRIPTION
## Summary
- Mock logger in 4 test files where source code logger calls leak to CI stdout (ElevenLabs client/agents, cloudflare-gateway, purpose extractor)
- Add fake timers to ElevenLabs client tests to eliminate real `setTimeout` retry delays (~3s → 6ms)
- Suppress `console.debug` deprecation warnings in redteam validator tests

## Test plan
- [x] All 132 tests pass across all 5 files
- [x] Verified 10 consecutive runs with random test ordering — 0 failures
- [x] No stdout noise in test output