### PR TITLE
chore: Add unknown option details to CLI error logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -182,8 +182,13 @@ async function main() {
     .version(VERSION)
     .showHelpAfterError()
     .showSuggestionAfterError()
-    .on('option:*', function () {
-      logger.error('Invalid option(s)');
+    .on('option:*', function (this: Command) {
+      const unknownArgs = this.args.filter((arg) => arg.startsWith('-'));
+      if (unknownArgs.length > 0) {
+        logger.error(`Invalid option(s): ${unknownArgs.join(', ')}`);
+      } else {
+        logger.error('Invalid option(s)');
+      }
       program.help();
       process.exitCode = 1;
     });


### PR DESCRIPTION
## Summary
- Log which unknown flags were supplied before showing help, improving feedback for invalid CLI options
- Keep existing behavior of showing help and setting a non-zero exit code after reporting the error

## Testing
- Not run (not requested)