### PR TITLE
fix: Add missed await for async operations

### DIFF
--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -140,7 +140,7 @@ export async function recordBlobReference(
   }
 
   const db = getDb();
-  const existing = db
+  const existing = await db
     .select({ id: blobReferencesTable.id })
     .from(blobReferencesTable)
     .where(
@@ -155,7 +155,8 @@ export async function recordBlobReference(
     return;
   }
 
-  db.insert(blobReferencesTable)
+  await db
+    .insert(blobReferencesTable)
     .values({
       id: randomUUID(),
       blobHash: hash,

--- a/src/server/routes/blobs.ts
+++ b/src/server/routes/blobs.ts
@@ -28,7 +28,7 @@ blobsRouter.get('/:hash', async (req: Request, res: Response): Promise<void> => 
   }
 
   const db = getDb();
-  const asset = db
+  const asset = await db
     .select({
       hash: blobAssetsTable.hash,
       mimeType: blobAssetsTable.mimeType,
@@ -50,7 +50,7 @@ blobsRouter.get('/:hash', async (req: Request, res: Response): Promise<void> => 
   // - Verify the requesting user has access to the evaluation (reference.evalId)
   // - Check user/team ownership before serving the blob
   // - Implement proper session/token-based authentication
-  const reference = db
+  const reference = await db
     .select({ evalId: blobReferencesTable.evalId })
     .from(blobReferencesTable)
     .where(eq(blobReferencesTable.blobHash, hash))


### PR DESCRIPTION
Hi!

My AI assistant highlighted that looks like some async operations have missed `await` keyword. And I'm inclined to agree with him, because `await` is used in [similar case](https://github.com/promptfoo/promptfoo/blob/e20ae6ad3f780b5024f22ee76b4cac8218af604c/src/models/modelAudit.ts#L170-L175) already in project. Also as I know db interaction involves I/O operations which are usually async in nodejs. And as I see in drizzle docs, it uses `await` widely:
- https://orm.drizzle.team/docs/get-started-sqlite
- https://orm.drizzle.team/docs/transactions

Could you please check if my pr makes sense?