### PR TITLE
test: fix flaky retry test eval ID collisions

### DIFF
--- a/test/commands/retry.test.ts
+++ b/test/commands/retry.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -11,6 +13,11 @@ import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import { ResultFailureReason } from '../../src/types/index';
 import { shouldShareResults } from '../../src/util/sharing';
+
+/** Generate a unique eval ID to avoid UNIQUE constraint collisions when tests run in the same second */
+function uniqueEvalId(): string {
+  return `eval-test-${randomUUID()}`;
+}
 
 describe('retry command', () => {
   beforeAll(async () => {
@@ -26,7 +33,7 @@ describe('retry command', () => {
 
     beforeEach(async () => {
       // Create a new eval for each test
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       evalId = evalRecord.id;
 
       const db = getDb();
@@ -101,7 +108,7 @@ describe('retry command', () => {
     });
 
     it('should return empty array if no ERROR results', async () => {
-      const emptyEval = await Eval.create({}, []);
+      const emptyEval = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
 
       await db.insert(evalResultsTable).values([
@@ -127,7 +134,7 @@ describe('retry command', () => {
 
   describe('deleteErrorResults', () => {
     it('should delete specified results', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
 
@@ -180,7 +187,7 @@ describe('retry command', () => {
     });
 
     it('should delete multiple results in a single batch operation', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
 
@@ -284,7 +291,7 @@ describe('retry command', () => {
   describe('recalculatePromptMetrics', () => {
     it('should recalculate metrics after results change', async () => {
       // Create an eval with prompts
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -340,7 +347,7 @@ describe('retry command', () => {
     });
 
     it('should count ERROR results correctly', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -384,7 +391,7 @@ describe('retry command', () => {
     });
 
     it('should handle multiple prompts', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt1 = {
@@ -440,7 +447,7 @@ describe('retry command', () => {
     });
 
     it('should handle empty results', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
 
       await evalRecord.addPrompts([mockPrompt]);
@@ -456,7 +463,7 @@ describe('retry command', () => {
     });
 
     it('should accumulate named scores correctly', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -502,7 +509,7 @@ describe('retry command', () => {
     it('should accumulate metrics correctly across multiple batches', async () => {
       // Test that metrics accumulate correctly when results span multiple batch boundaries
       // Batch size is 1000 (by testIdx), so results at testIdx 0-999, 1000-1999, 2000-2999 are in different batches
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -604,7 +611,7 @@ describe('retry command', () => {
     });
 
     it('should handle results at exact batch boundary (testIdx 999 and 1000)', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -650,7 +657,7 @@ describe('retry command', () => {
     });
 
     it('should handle single result edge case', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -686,7 +693,7 @@ describe('retry command', () => {
     });
 
     it('should use fetchResultsBatched for streaming iteration', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -723,7 +730,7 @@ describe('retry command', () => {
     });
 
     it('should accumulate assertion counts from componentResults', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -787,7 +794,7 @@ describe('retry command', () => {
     });
 
     it('should accumulate token usage from response', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -850,7 +857,7 @@ describe('retry command', () => {
     });
 
     it('should accumulate assertion token usage from gradingResult', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -917,7 +924,7 @@ describe('retry command', () => {
     });
 
     it('should skip results with invalid promptIdx', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -985,7 +992,7 @@ describe('retry command', () => {
     });
 
     it('should rethrow error when batch iteration fails', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
 
       await evalRecord.addPrompts([mockPrompt]);
@@ -1003,7 +1010,7 @@ describe('retry command', () => {
     });
 
     it('should handle results with null/undefined optional fields', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
@@ -1039,7 +1046,7 @@ describe('retry command', () => {
     });
 
     it('should handle results with null score', async () => {
-      const evalRecord = await Eval.create({}, []);
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = getDb();
       const mockProvider = { id: 'test-provider' };
       const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };


### PR DESCRIPTION
## Summary
- Use `crypto.randomUUID()` for eval IDs in `test/commands/retry.test.ts` to prevent `UNIQUE constraint failed: evals.id` errors when tests run within the same second
- The default `createEvalId()` uses a 3-char random sequence + second-precision timestamp, which can collide when multiple tests execute in the same second (~0.08% chance per run with 20 evals)

## Test plan
- [x] All 28 tests pass with `npx vitest run test/commands/retry.test.ts`
- [x] Verified with 5 different random seeds (`--sequence.seed=42,999,12345,67890,11111`)
- [x] Lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)