### PR TITLE
feat(fetch): add Cloudflare 524 timeout to transient error retry

### DIFF
--- a/site/docs/configuration/rate-limits.md
+++ b/site/docs/configuration/rate-limits.md
@@ -29,6 +29,19 @@ Promptfoo parses rate limit headers from major providers:
 | Azure OpenAI | `x-ratelimit-remaining-requests`, `retry-after-ms`, `retry-after`                                                |
 | Generic      | `retry-after`, `ratelimit-remaining`, `ratelimit-reset`                                                          |
 
+### Transient Error Handling
+
+Promptfoo automatically retries requests that fail with transient server errors:
+
+| Status Code | Description         | Retry Condition                                      |
+| ----------- | ------------------- | ---------------------------------------------------- |
+| 502         | Bad Gateway         | Status text contains "bad gateway"                   |
+| 503         | Service Unavailable | Status text contains "service unavailable"           |
+| 504         | Gateway Timeout     | Status text contains "gateway timeout"               |
+| 524         | A Timeout Occurred  | Status text contains "timeout" (Cloudflare-specific) |
+
+These errors are retried up to 3 times with exponential backoff (1s, 2s, 4s). The status text check ensures that permanent failures (like authentication errors that happen to use 502) are not retried.
+
 ### How Adaptive Concurrency Works
 
 The scheduler uses AIMD (Additive Increase, Multiplicative Decrease) to optimize throughput:

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -180,7 +180,7 @@ export async function fetchWithProxy(
     finalOptions.dispatcher = getOrCreateAgent(tlsOptions);
   }
 
-  // Transient error retry logic (502/503/504 with matching status text)
+  // Transient error retry logic (502/503/504/524 with matching status text)
   const maxTransientRetries = options.disableTransientRetries ? 0 : 3;
 
   for (let attempt = 0; attempt <= maxTransientRetries; attempt++) {
@@ -301,6 +301,8 @@ export function isTransientError(response: Response): boolean {
       return statusText.includes('service unavailable');
     case 504:
       return statusText.includes('gateway timeout');
+    case 524: // Cloudflare-specific timeout error
+      return statusText.includes('timeout');
     default:
       return false;
   }


### PR DESCRIPTION
## Summary

- Add support for Cloudflare's 524 "A Timeout Occurred" status code in transient error retry logic
- This error occurs when Cloudflare cannot reach the origin server within the timeout period
- Updates documentation for transient error handling in rate-limits.md and http.md

## Test plan

- [x] Added unit tests for `isTransientError` with 524 status code
- [x] Added tests for `fetchWithProxy` retry behavior with 524 errors
- [x] Tests verify case-insensitive matching of "timeout" in status text
- [x] Tests verify non-matching 524 responses are not retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)