### PR TITLE
fix(table): display sessionIds array from multi-turn strategies

### DIFF
--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -67,10 +67,13 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     // Multi-turn strategies (IterativeMeta, Crescendo, etc.) store multiple sessionIds in metadata.sessionIds array
     // Single-turn strategies store a single sessionId in metadata.sessionId
     if (!result.vars?.sessionId) {
-      const metadataSessionIds = result.metadata?.sessionIds as string[] | undefined;
+      const metadataSessionIds = result.metadata?.sessionIds;
       if (Array.isArray(metadataSessionIds) && metadataSessionIds.length > 0) {
         result.vars = result.vars || {};
-        result.vars.sessionId = metadataSessionIds.join(', ');
+        result.vars.sessionId = metadataSessionIds
+          .filter((id) => id != null && id !== '')
+          .map(String)
+          .join('\n');
         varsForHeader.add('sessionId');
       } else if (result.metadata?.sessionId) {
         result.vars = result.vars || {};

--- a/test/util/convertEvalResultsToTable.test.ts
+++ b/test/util/convertEvalResultsToTable.test.ts
@@ -942,7 +942,7 @@ describe('convertResultsToTable', () => {
     // sessionIds array should be joined and copied to vars.sessionId
     expect(result.head.vars).toContain('sessionId');
     const sessionIdIndex = result.head.vars.indexOf('sessionId');
-    expect(result.body[0].vars[sessionIdIndex]).toBe('session-1, session-2, session-3');
+    expect(result.body[0].vars[sessionIdIndex]).toBe('session-1\nsession-2\nsession-3');
   });
 
   it('should prefer sessionIds array over sessionId when both exist', () => {
@@ -994,7 +994,7 @@ describe('convertResultsToTable', () => {
     const result = convertResultsToTable(resultsFile);
     // sessionIds array should take precedence over sessionId
     const sessionIdIndex = result.head.vars.indexOf('sessionId');
-    expect(result.body[0].vars[sessionIdIndex]).toBe('multi-1, multi-2');
+    expect(result.body[0].vars[sessionIdIndex]).toBe('multi-1\nmulti-2');
   });
 
   it('should fall back to sessionId when sessionIds is empty array', () => {
@@ -1098,5 +1098,243 @@ describe('convertResultsToTable', () => {
     // Single-element sessionIds should work without trailing comma
     const sessionIdIndex = result.head.vars.indexOf('sessionId');
     expect(result.body[0].vars[sessionIdIndex]).toBe('only-session');
+  });
+
+  it('should ignore non-array sessionIds and fall back to sessionId', () => {
+    const resultsFile: ResultsFile = {
+      version: 4,
+      prompts: [
+        {
+          raw: 'test prompt',
+          display: 'test prompt',
+          id: 'prompt1',
+        } as CompletedPrompt,
+      ],
+      results: {
+        results: [
+          {
+            id: 'test1',
+            testIdx: 0,
+            promptIdx: 0,
+            vars: {
+              question: 'What is AI?',
+            },
+            metadata: {
+              sessionId: 'fallback-session',
+              sessionIds: 'not-an-array' as unknown as string[],
+            },
+            prompt: {
+              raw: 'test prompt',
+              label: 'Test Prompt',
+            },
+            response: {
+              output: 'test output',
+            },
+            provider: {
+              id: 'test-provider',
+            },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+        ],
+      },
+    };
+
+    const result = convertResultsToTable(resultsFile);
+    // Non-array sessionIds should be ignored, falling back to sessionId
+    const sessionIdIndex = result.head.vars.indexOf('sessionId');
+    expect(result.body[0].vars[sessionIdIndex]).toBe('fallback-session');
+  });
+
+  it('should handle multiple results with varying sessionIds array configurations', () => {
+    const resultsFile: ResultsFile = {
+      version: 4,
+      prompts: [
+        {
+          raw: 'test prompt',
+          display: 'test prompt',
+          id: 'prompt1',
+        } as CompletedPrompt,
+      ],
+      results: {
+        results: [
+          // Result 0: Has sessionIds array (multi-turn)
+          {
+            id: 'test1',
+            testIdx: 0,
+            promptIdx: 0,
+            vars: {
+              question: 'Question 1',
+            },
+            metadata: {
+              sessionIds: ['multi-1a', 'multi-1b', 'multi-1c'],
+            },
+            prompt: { raw: 'test prompt', label: 'Test Prompt' },
+            response: { output: 'output 1' },
+            provider: { id: 'test-provider' },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+          // Result 1: Has single sessionId (single-turn)
+          {
+            id: 'test2',
+            testIdx: 1,
+            promptIdx: 0,
+            vars: {
+              question: 'Question 2',
+            },
+            metadata: {
+              sessionId: 'single-session-2',
+            },
+            prompt: { raw: 'test prompt', label: 'Test Prompt' },
+            response: { output: 'output 2' },
+            provider: { id: 'test-provider' },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+          // Result 2: Has both sessionIds and sessionId (sessionIds takes precedence)
+          {
+            id: 'test3',
+            testIdx: 2,
+            promptIdx: 0,
+            vars: {
+              question: 'Question 3',
+            },
+            metadata: {
+              sessionId: 'ignored-session',
+              sessionIds: ['multi-3a', 'multi-3b'],
+            },
+            prompt: { raw: 'test prompt', label: 'Test Prompt' },
+            response: { output: 'output 3' },
+            provider: { id: 'test-provider' },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+          // Result 3: No sessionId or sessionIds
+          {
+            id: 'test4',
+            testIdx: 3,
+            promptIdx: 0,
+            vars: {
+              question: 'Question 4',
+            },
+            prompt: { raw: 'test prompt', label: 'Test Prompt' },
+            response: { output: 'output 4' },
+            provider: { id: 'test-provider' },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+        ],
+      },
+    };
+
+    const result = convertResultsToTable(resultsFile);
+
+    // sessionId column should exist
+    expect(result.head.vars).toContain('sessionId');
+    const sessionIdIndex = result.head.vars.indexOf('sessionId');
+
+    // Result 0: sessionIds array joined with newlines
+    expect(result.body[0].vars[sessionIdIndex]).toBe('multi-1a\nmulti-1b\nmulti-1c');
+
+    // Result 1: single sessionId
+    expect(result.body[1].vars[sessionIdIndex]).toBe('single-session-2');
+
+    // Result 2: sessionIds array takes precedence
+    expect(result.body[2].vars[sessionIdIndex]).toBe('multi-3a\nmulti-3b');
+
+    // Result 3: no sessionId (empty string)
+    expect(result.body[3].vars[sessionIdIndex]).toBe('');
+  });
+
+  it('should filter out null, undefined, empty strings, and convert non-strings in sessionIds array', () => {
+    const resultsFile: ResultsFile = {
+      version: 4,
+      prompts: [
+        {
+          raw: 'test prompt',
+          display: 'test prompt',
+          id: 'prompt1',
+        } as CompletedPrompt,
+      ],
+      results: {
+        results: [
+          {
+            id: 'test1',
+            testIdx: 0,
+            promptIdx: 0,
+            vars: {
+              question: 'What is AI?',
+            },
+            metadata: {
+              // Array with mixed types: valid strings, null, undefined, empty string, number
+              sessionIds: [
+                'session-1',
+                null,
+                undefined,
+                '',
+                'session-2',
+                123,
+                'session-3',
+              ] as unknown as string[],
+            },
+            prompt: {
+              raw: 'test prompt',
+              label: 'Test Prompt',
+            },
+            response: {
+              output: 'test output',
+            },
+            provider: {
+              id: 'test-provider',
+            },
+            success: true,
+            promptId: 'prompt1',
+            testCase: {},
+            // @ts-ignore
+            failureReason: 'none',
+            score: 1,
+            latencyMs: 100,
+            namedScores: {},
+          },
+        ],
+      },
+    };
+
+    const result = convertResultsToTable(resultsFile);
+    // Should filter out null, undefined, empty strings and convert number to string
+    expect(result.head.vars).toContain('sessionId');
+    const sessionIdIndex = result.head.vars.indexOf('sessionId');
+    expect(result.body[0].vars[sessionIdIndex]).toBe('session-1\nsession-2\n123\nsession-3');
   });
 });

--- a/test/util/exportToFile/convertTestResultsToTableRow.test.ts
+++ b/test/util/exportToFile/convertTestResultsToTableRow.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it } from 'vitest';
+import { convertTestResultsToTableRow } from '../../../src/util/exportToFile/index';
+
+import type EvalResult from '../../../src/models/evalResult';
+
+/**
+ * Creates a minimal mock EvalResult for testing.
+ * We use a partial type and cast to avoid needing the full EvalResult class.
+ */
+function createMockEvalResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  const defaultResult = {
+    id: 'test-id',
+    testIdx: 0,
+    promptIdx: 0,
+    description: 'Test description',
+    testCase: {
+      vars: {},
+    },
+    prompt: {
+      raw: 'test prompt',
+    },
+    response: {
+      output: 'test output',
+    },
+    provider: {
+      id: 'test-provider',
+      label: 'Test Provider',
+    },
+    success: true,
+    score: 1,
+    latencyMs: 100,
+    error: undefined,
+    metadata: undefined,
+    namedScores: {},
+    gradingResult: undefined,
+    cost: 0,
+  };
+
+  return {
+    ...defaultResult,
+    ...overrides,
+    testCase: {
+      ...defaultResult.testCase,
+      ...(overrides.testCase || {}),
+    },
+    prompt: {
+      ...defaultResult.prompt,
+      ...(overrides.prompt || {}),
+    },
+    response: {
+      ...defaultResult.response,
+      ...(overrides.response || {}),
+    },
+    provider: {
+      ...defaultResult.provider,
+      ...(overrides.provider || {}),
+    },
+  } as EvalResult;
+}
+
+describe('convertTestResultsToTableRow', () => {
+  describe('basic functionality', () => {
+    it('should convert results to table row format', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { question: 'What is AI?' } },
+        }),
+      ];
+      const varsForHeader = ['question'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.description).toBe('Test description');
+      expect(row.vars).toEqual(['What is AI?']);
+      expect(row.testIdx).toBe(0);
+      expect(row.outputs).toHaveLength(1);
+      expect(row.outputs[0].text).toBe('test output');
+    });
+
+    it('should handle multiple variables', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: {
+            vars: {
+              question: 'What is AI?',
+              context: 'Some context',
+              temperature: 0.5,
+            },
+          },
+        }),
+      ];
+      const varsForHeader = ['context', 'question', 'temperature'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['Some context', 'What is AI?', '0.5']);
+    });
+
+    it('should handle missing variables', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { question: 'What is AI?' } },
+        }),
+      ];
+      const varsForHeader = ['question', 'missingVar'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['What is AI?', '']);
+    });
+
+    it('should handle object variables as JSON', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: {
+            vars: {
+              config: { nested: 'value', count: 42 },
+            },
+          },
+        }),
+      ];
+      const varsForHeader = ['config'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars[0]).toBe('{"nested":"value","count":42}');
+    });
+  });
+
+  describe('sessionId handling', () => {
+    it('should use sessionId from testCase.vars when present', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { sessionId: 'user-session-123' } },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['user-session-123']);
+    });
+
+    it('should use metadata.sessionId when vars.sessionId is not present', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: { sessionId: 'metadata-session-456' },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['metadata-session-456']);
+    });
+
+    it('should use metadata.sessionId when vars.sessionId is empty string', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { sessionId: '' } },
+          metadata: { sessionId: 'metadata-session-789' },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['metadata-session-789']);
+    });
+
+    it('should not overwrite non-empty vars.sessionId with metadata.sessionId', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { sessionId: 'user-provided-session' } },
+          metadata: { sessionId: 'should-be-ignored' },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['user-provided-session']);
+    });
+
+    it('should return empty string when no sessionId is available', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: {},
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['']);
+    });
+  });
+
+  describe('sessionIds array handling (multi-turn strategies)', () => {
+    it('should join sessionIds array with newlines', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: { sessionIds: ['session-1', 'session-2', 'session-3'] },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['session-1\nsession-2\nsession-3']);
+    });
+
+    it('should handle single-element sessionIds array', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: { sessionIds: ['only-session'] },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['only-session']);
+    });
+
+    it('should prefer sessionIds array over sessionId when both exist', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: {
+            sessionId: 'single-session',
+            sessionIds: ['multi-1', 'multi-2'],
+          },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['multi-1\nmulti-2']);
+    });
+
+    it('should fall back to sessionId when sessionIds is empty array', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: {
+            sessionId: 'fallback-session',
+            sessionIds: [],
+          },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['fallback-session']);
+    });
+
+    it('should ignore non-array sessionIds and use sessionId instead', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: {
+            sessionId: 'fallback-session',
+            sessionIds: 'not-an-array' as unknown as string[],
+          },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['fallback-session']);
+    });
+
+    it('should not use sessionIds array if vars.sessionId is provided', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { sessionId: 'user-provided' } },
+          metadata: { sessionIds: ['should-be-ignored-1', 'should-be-ignored-2'] },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['user-provided']);
+    });
+  });
+
+  describe('combined scenarios', () => {
+    it('should handle sessionId with other variables', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: {
+            vars: {
+              question: 'What is AI?',
+              context: 'Some context',
+            },
+          },
+          metadata: { sessionIds: ['session-a', 'session-b'] },
+        }),
+      ];
+      const varsForHeader = ['context', 'question', 'sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['Some context', 'What is AI?', 'session-a\nsession-b']);
+    });
+
+    it('should handle edge case with undefined metadata', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { question: 'What is AI?' } },
+          metadata: undefined,
+        }),
+      ];
+      const varsForHeader = ['question', 'sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.vars).toEqual(['What is AI?', '']);
+    });
+
+    it('should handle non-string sessionId values in metadata', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: {} },
+          metadata: { sessionId: { complex: 'object' } as unknown as string },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      // Should be JSON stringified
+      expect(row.vars[0]).toBe('{"complex":"object"}');
+    });
+
+    it('should handle non-string sessionId values in vars', () => {
+      const results = [
+        createMockEvalResult({
+          testCase: { vars: { sessionId: { complex: 'object' } as unknown as string } },
+        }),
+      ];
+      const varsForHeader = ['sessionId'];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      // Should be JSON stringified
+      expect(row.vars[0]).toBe('{"complex":"object"}');
+    });
+  });
+
+  describe('output formatting', () => {
+    it('should format successful output correctly', () => {
+      const results = [
+        createMockEvalResult({
+          success: true,
+          response: { output: 'The answer is 42' },
+        }),
+      ];
+      const varsForHeader: string[] = [];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.outputs[0].text).toBe('The answer is 42');
+      expect(row.outputs[0].pass).toBe(true);
+    });
+
+    it('should format error output correctly', () => {
+      const results = [
+        createMockEvalResult({
+          success: false,
+          error: 'Provider error occurred',
+          response: { output: '' },
+        }),
+      ];
+      const varsForHeader: string[] = [];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.outputs[0].text).toBe('Provider error occurred');
+      expect(row.outputs[0].pass).toBe(false);
+    });
+
+    it('should handle null output', () => {
+      const results = [
+        createMockEvalResult({
+          response: { output: null },
+          error: 'Null response',
+        }),
+      ];
+      const varsForHeader: string[] = [];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.outputs[0].text).toBe('Null response');
+    });
+
+    it('should handle object output', () => {
+      const results = [
+        createMockEvalResult({
+          response: { output: { key: 'value', nested: { data: 123 } } },
+        }),
+      ];
+      const varsForHeader: string[] = [];
+
+      const row = convertTestResultsToTableRow(results, varsForHeader);
+
+      expect(row.outputs[0].text).toBe('{"key":"value","nested":{"data":123}}');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Multi-turn strategies (IterativeMeta, Crescendo, etc.) store multiple session IDs in `metadata.sessionIds` as an array
- The table display was only checking `metadata.sessionId` (singular), causing blank sessionId columns for these strategies
- Now checks both `metadata.sessionIds` (array) and `metadata.sessionId` (string), with the array taking precedence
- Array values are joined with commas for display

## Test plan

- [x] Added 4 new test cases for sessionIds array handling
- [x] All 19 tests pass
- [x] Manual verification with IterativeMeta/Crescendo strategy runs

<img width="3838" height="1951" alt="image" src="https://github.com/user-attachments/assets/52c914fd-9867-4184-b534-df3b0551dfa5" />
