### PR TITLE
docs(site): feature indirect prompt injection blog post

### DIFF
--- a/site/blog/asr-not-portable-metric.md
+++ b/site/blog/asr-not-portable-metric.md
@@ -2,7 +2,6 @@
 title: "Why Attack Success Rate (ASR) Isn't Comparable Across Jailbreak Papers Without a Shared Threat Model"
 description: "Attack Success Rate (ASR) is the most commonly reported metric for LLM red teaming, but it changes with attempt budget, prompt sets, and judge choice. Here's how to interpret ASR and report it so results are comparable."
 image: /img/blog/asr-not-portable-metric/asr-header.jpg
-featured: true
 keywords:
   [
     ASR,

--- a/site/blog/indirect-prompt-injection-web-agents.md
+++ b/site/blog/indirect-prompt-injection-web-agents.md
@@ -1,7 +1,8 @@
 ---
-title: 'Testing agents that browse the web: indirect prompt injection via dynamic pages'
-description: 'Introducing the indirect-web-pwn strategy — test whether AI agents with web browsing can be tricked into following malicious instructions or exfiltrating data through dynamically generated web pages.'
+title: 'Indirect Prompt Injection in Web-Browsing Agents'
+description: 'Test if AI browsing agents follow malicious instructions or leak data with the indirect-web-pwn strategy.'
 image: /img/docs/indirect-web-pwn-architecture.png
+featured: true
 keywords:
   [
     indirect prompt injection,


### PR DESCRIPTION
## Summary
- Feature Yash's indirect prompt injection blog post on the blog homepage
- Remove featured flag from the ASR blog post
- Update title and description for better SEO

## Changes
- `blog/indirect-prompt-injection-web-agents.md`: Added `featured: true`, updated title to "Indirect Prompt Injection in Web-Browsing Agents", shortened description for SEO
- `blog/asr-not-portable-metric.md`: Removed `featured: true`

## Test plan
- [x] Verify featured blog appears on blog homepage
- [x] Verify SEO metadata is correct