### PR TITLE
chore(deps): group PostHog packages with monthly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -152,6 +152,14 @@
       "groupName": "langfuse"
     },
     {
+      "description": "Group PostHog packages together with monthly updates to reduce noise",
+      "matchPackagePatterns": ["^posthog-"],
+      "groupName": "PostHog packages",
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "description": "Group OpenTelemetry packages together",
       "matchPackagePatterns": ["^@opentelemetry/"],
       "groupName": "OpenTelemetry"


### PR DESCRIPTION
## Summary
- Groups `posthog-js` and `posthog-node` into a single Renovate PR instead of separate ones
- Sets monthly schedule (first of the month) to reduce PR noise from frequent PostHog releases
- Closes #7622 and #7623

## Test plan
- [ ] Verify Renovate picks up the new grouping rule on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)