### PR TITLE
ci: increase test job timeout to 15 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
   test:
     needs: ci-config
     name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}${{ matrix.shard && format(' (shard {0}/3)', matrix.shard) || '' }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
macOS runners with a cold node_modules cache (e.g. dependency update PRs that change package-lock.json) exceed the 10-minute limit.