### PR TITLE
test(redteam): avoid interactive email prompts

### DIFF
--- a/test/redteam/commands/crossSessionLeakGenerate.test.ts
+++ b/test/redteam/commands/crossSessionLeakGenerate.test.ts
@@ -5,6 +5,15 @@ import * as configModule from '../../../src/util/config/load';
 
 import type { RedteamCliGenerateOptions } from '../../../src/redteam/types';
 
+// Prevent interactive email prompts in generate flow.
+vi.mock('../../../src/globalConfig/accounts', async (importOriginal) => ({
+  ...(await importOriginal()),
+  checkEmailStatusAndMaybeExit: vi.fn().mockResolvedValue('ok'),
+  getAuthor: vi.fn().mockReturnValue(null),
+  getUserEmail: vi.fn().mockReturnValue(null),
+  promptForEmailUnverified: vi.fn().mockResolvedValue({ emailNeedsValidation: false }),
+}));
+
 vi.mock('../../../src/redteam', async (importOriginal) => {
   return {
     ...(await importOriginal()),

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -186,6 +186,9 @@ vi.mock('../../../src/globalConfig/accounts', async (importOriginal) => {
     getAuthor: vi.fn(),
     getUserEmail: vi.fn(),
     getUserId: vi.fn().mockReturnValue('test-id'),
+    // Avoid interactive prompts in tests.
+    promptForEmailUnverified: vi.fn().mockResolvedValue({ emailNeedsValidation: false }),
+    checkEmailStatusAndMaybeExit: vi.fn().mockResolvedValue('ok'),
   };
 });
 vi.mock('../../../src/providers', async (importOriginal) => {


### PR DESCRIPTION
Mock email verification helpers in redteam generate tests so local test runs do not block on interactive input.