### PR TITLE
ci: pin ruff version to prevent formatting drift

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install ruff
+          pip install ruff==0.15.1
 
       - name: Check Formatting
         run: |


### PR DESCRIPTION
## Summary
- Pin `ruff` to `0.15.1` in CI to prevent formatting drift when new ruff versions are released
- Currently `pip install ruff` installs the latest version, which can introduce new formatting rules and break CI for PRs formatted with an older version

## Test plan
- [ ] CI Python formatting check passes with pinned version
- [ ] Existing Python files remain unchanged (verified locally with ruff 0.15.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)