### PR TITLE
fix: guard getEnvString against cliState TDZ in bundled output

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -427,13 +427,20 @@ export type EnvVarKey = keyof EnvVars;
 export function getEnvString(key: EnvVarKey): string | undefined;
 export function getEnvString(key: EnvVarKey, defaultValue: string): string;
 export function getEnvString(key: EnvVarKey, defaultValue?: string): string | undefined {
-  // First check if the key exists in CLI state env config
-  if (cliState.config?.env && typeof cliState.config.env === 'object') {
-    // Handle both ProviderEnvOverridesSchema and Record<string, string|number|boolean> type
-    const envValue = cliState.config.env[key as keyof typeof cliState.config.env];
-    if (envValue !== undefined) {
-      return String(envValue);
+  // First check if the key exists in CLI state env config.
+  // The try-catch guards against TDZ errors when bundlers reorder module
+  // initialization (e.g. rolldown), causing cliState to be accessed before
+  // its module has been evaluated.
+  try {
+    if (cliState.config?.env && typeof cliState.config.env === 'object') {
+      // Handle both ProviderEnvOverridesSchema and Record<string, string|number|boolean> type
+      const envValue = cliState.config.env[key as keyof typeof cliState.config.env];
+      if (envValue !== undefined) {
+        return String(envValue);
+      }
     }
+  } catch {
+    // cliState not yet initialized — fall through to process.env
   }
 
   // Fallback to process.env


### PR DESCRIPTION
## Summary
- Adds a try-catch in `getEnvString()` to handle the case where `cliState` is accessed before its module has been evaluated (Temporal Dead Zone error)
- This occurs when bundlers like rolldown reorder module initialization, exposed by the rolldown rc.1 -> rc.3 upgrade in #7692
- The circular dependency chain is: `fetch` -> `providers/shared` -> `getEnvInt` (module scope) -> `getEnvString` -> `cliState` (TDZ)
- When caught, the function gracefully falls through to `process.env`

## Test plan
- [x] All 75 envars tests pass
- [ ] Merge into #7692 (lock file maintenance) to verify Share Test passes