### PR TITLE
docs(security): clarify local web server trust model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,10 @@ Some features intentionally execute user-provided code (custom assertions, provi
 
 **Important:** Treat Promptfoo configuration files and any referenced scripts as **trusted code**. Do not run Promptfoo against untrusted configs, prompt packs, or pull requests without isolation.
 
+### Local Web Server
+
+The local web server (`promptfoo view`) is a **single-user development tool** intended for use on your local machine. The web API executes evaluations with the same privileges as the CLI — inputs to the API (including provider configurations, transforms, and assertions) are treated as **trusted code**, equivalent to a local config file. The server is not designed to be exposed to untrusted networks or users.
+
 ### Trust Boundaries
 
 **Trusted inputs (treated as code):**
@@ -35,6 +39,8 @@ If you run Promptfoo in higher-risk contexts (CI, shared machines, third-party c
 - Avoid placing secrets in prompts, fixtures, or config files
 - Restrict network egress when running third-party code
 - In CI: do not run Promptfoo with secrets on untrusted PRs (e.g., from forks)
+- Do not expose the local web server to untrusted networks or the public internet
+- Use a reverse proxy with authentication if you need remote access to the web UI
 
 ## Supported Versions
 
@@ -65,12 +71,13 @@ For safe harbor provisions and full process details, see our [Responsible Disclo
 - Bypasses of documented restrictions or isolation boundaries
 - Unexpected secret exposure or credential leakage to unconfigured destinations
 - Path traversal or arbitrary file read/write from data-only inputs
-- Vulnerabilities in CLI, config parsing, or web UI affecting confidentiality, integrity, or availability
+- Vulnerabilities in CLI, config parsing, or web UI affecting confidentiality, integrity, or availability beyond the intended trust model described above
 - Algorithmic complexity DoS (crafted input causing hang/crash with modest input size)
 
 **Out of scope:**
 
 - Code execution from **explicitly configured** custom code (JS assertions, providers, transforms, plugins configured in your config file)
+- Code execution via the **local web API** — the local server has the same trust level as the CLI and executes evaluation configurations with user privileges (see [Local Web Server](#local-web-server))
 - Issues requiring the user to run untrusted configs or scripts with local privileges
 - Network requests triggered by content in **user-controlled config files** (test variables, prompts, fixtures defined in your config) — users are responsible for what they put in their own configs
 - Third-party dependency issues that don't materially affect Promptfoo's security posture (report upstream)
@@ -82,6 +89,7 @@ For safe harbor provisions and full process details, see our [Responsible Disclo
 - "A malicious custom assertion reads `process.env` and posts it to a webhook" → Expected behavior; custom code runs with your permissions
 - "A third-party prompt pack includes a transform that runs shell commands" → Expected behavior; don't run untrusted configs
 - "The Web UI fetches a URL when a test variable contains a URL" → Expected behavior; users control their own config content
+- "The local web API executes provider transforms as code" → Expected behavior; the web API has the same trust model as the CLI
 
 If unsure whether something is in scope, report it anyway.
 


### PR DESCRIPTION
## Summary

- Adds a "Local Web Server" subsection to the security model documenting that the local web API has the same trust level as the CLI
- Adds hardening guidance for the local server (don't expose to untrusted networks, use reverse proxy for remote access)
- Clarifies in-scope/out-of-scope boundaries for web API code execution
- Adds out-of-scope example for web API executing provider transforms

## Context

Prompted by a security advisory (GHSA-cj7m-vx4p-977q) reporting that `/api/eval/job` executes provider `transformResponse` strings as code via `new Function()`. This is by design — the local server executes evaluation configs with the same privileges as `promptfoo eval` on the CLI. The policy needed to make this trust model explicit.

## Test plan

- [ ] Review that the policy language is clear and internally consistent
- [ ] Verify the in-scope entry for web UI no longer contradicts the out-of-scope entry for web API