### PR TITLE
chore: optimize renovate config to reduce PR noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,13 +28,6 @@
       "enabled": false
     },
     {
-      "description": "Vercel AI SDK: monthly updates to reduce noise from frequent patch releases",
-      "matchPackageNames": ["ai"],
-      "schedule": ["before 6am on the first day of the month"],
-      "rangeStrategy": "bump",
-      "minimumReleaseAge": "7 days"
-    },
-    {
       "description": "Group @inquirer packages together",
       "matchPackagePatterns": ["^@inquirer/"],
       "groupName": "@inquirer packages"
@@ -73,12 +66,9 @@
       "groupName": "Azure packages"
     },
     {
-      "description": "Storybook monorepo: monthly updates to reduce noise from frequent patch releases",
+      "description": "Group Storybook monorepo packages together",
       "matchPackagePatterns": ["^@storybook/", "^storybook$", "^@chromatic-com/storybook"],
-      "groupName": "Storybook monorepo",
-      "schedule": ["before 6am on the first day of the month"],
-      "rangeStrategy": "bump",
-      "minimumReleaseAge": "7 days"
+      "groupName": "Storybook monorepo"
     },
     {
       "description": "Group Docusaurus packages together",
@@ -152,12 +142,15 @@
       "groupName": "langfuse"
     },
     {
-      "description": "Group PostHog packages together with monthly updates to reduce noise",
+      "description": "Group PostHog packages together across all dependency types",
       "matchPackagePatterns": ["^posthog-"],
-      "groupName": "PostHog packages",
-      "schedule": ["before 6am on the first day of the month"],
-      "rangeStrategy": "bump",
-      "minimumReleaseAge": "7 days"
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "groupName": "PostHog packages"
     },
     {
       "description": "Group OpenTelemetry packages together",
@@ -211,12 +204,9 @@
       "groupName": "socket.io"
     },
     {
-      "description": "Keep undici in sync across root and code-scan-action, monthly updates to reduce noise",
+      "description": "Keep undici in sync across root and code-scan-action",
       "matchPackageNames": ["undici"],
-      "groupName": "undici",
-      "schedule": ["before 6am on the first day of the month"],
-      "rangeStrategy": "bump",
-      "minimumReleaseAge": "7 days"
+      "groupName": "undici"
     },
     {
       "description": "Group all @types packages together",
@@ -268,6 +258,65 @@
       "matchDatasources": ["npm"],
       "matchDepTypes": ["optionalDependencies"],
       "minimumReleaseAge": "2 days"
+    },
+
+    {
+      "description": "@opencode-ai/sdk: weekly updates to reduce noise from daily releases",
+      "matchPackageNames": ["@opencode-ai/sdk"],
+      "schedule": ["before 6am on Monday"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "AWS SDK packages: weekly updates to reduce noise",
+      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
+      "schedule": ["before 6am on Monday"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Biome: weekly updates",
+      "matchPackageNames": ["@biomejs/biome"],
+      "schedule": ["before 6am on Monday"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Dev tooling: weekly updates (low urgency)",
+      "matchPackageNames": ["hono", "knip"],
+      "schedule": ["before 6am on Monday"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "framer-motion: monthly updates (animation library, low urgency)",
+      "matchPackageNames": ["framer-motion"],
+      "schedule": ["before 6am on the first day of the month"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Vercel AI SDK: monthly updates to reduce noise from frequent patch releases",
+      "matchPackageNames": ["ai"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Storybook: monthly updates to reduce noise from frequent patch releases",
+      "matchPackagePatterns": ["^@storybook/", "^storybook$", "^@chromatic-com/storybook"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "PostHog packages: monthly updates to reduce noise from frequent patch releases",
+      "matchPackagePatterns": ["^posthog-"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "undici: monthly updates to reduce noise",
+      "matchPackageNames": ["undici"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Restructure `packageRules` to separate grouping rules from schedule rules, placing schedule overrides at the end of the array so they take precedence over general `minimumReleaseAge` rules
- Fix broken monthly schedules for PostHog, undici, Vercel AI SDK, and Storybook (these were being overridden by later general rules)
- Add `matchDepTypes` to PostHog grouping for cross-workspace matching (`posthog-js` is a devDep in app workspace, `posthog-node` is a dep in root)
- Add weekly schedules for high-frequency packages: `@opencode-ai/sdk`, AWS SDK, `@biomejs/biome`, `hono`, `knip`
- Add monthly schedule for `framer-motion` (docs site animation library)

Based on analysis of 145 Renovate PRs in the first 16 days of Feb 2026 (~9/day). Should reduce volume by ~40-50 PRs per 16-day period.

## Test plan

- [x] `renovate-config-validator` passes locally
- [ ] CI renovate config validation passes