### PR TITLE
feat(app): add renderOption prop to Combobox component

### DIFF
--- a/src/app/src/components/ui/combobox.tsx
+++ b/src/app/src/components/ui/combobox.tsx
@@ -19,6 +19,11 @@ interface ComboboxProps extends Omit<React.ComponentProps<'input'>, 'onChange' |
   emptyMessage?: string;
   clearable?: boolean;
   label?: string;
+  renderOption?: (
+    option: ComboboxOption,
+    isSelected: boolean,
+    isHighlighted: boolean,
+  ) => React.ReactNode;
 }
 
 function Combobox({
@@ -30,6 +35,7 @@ function Combobox({
   disabled = false,
   clearable = true,
   label,
+  renderOption,
   className,
   ...props
 }: ComboboxProps) {
@@ -319,11 +325,17 @@ function Combobox({
                   <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
                     {option.value === value && <Check className="h-4 w-4" />}
                   </span>
-                  <span className="truncate">{option.label}</span>
-                  {option.description && (
-                    <span className="ml-2 text-muted-foreground truncate">
-                      · {option.description}
-                    </span>
+                  {renderOption ? (
+                    renderOption(option, option.value === value, index === highlightedIndex)
+                  ) : (
+                    <>
+                      <span className="truncate">{option.label}</span>
+                      {option.description && (
+                        <span className="ml-2 text-muted-foreground truncate">
+                          · {option.description}
+                        </span>
+                      )}
+                    </>
                   )}
                 </button>
               ))

--- a/src/app/src/index.css
+++ b/src/app/src/index.css
@@ -366,6 +366,13 @@ textarea {
   box-sizing: border-box;
 }
 
+/* Hide native search cancel button (Chrome/Safari) - we render our own */
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 @media print {
   header,
   footer,


### PR DESCRIPTION
## Summary
- Adds a `renderOption` callback prop to the Combobox component for custom option rendering (same pattern as MUI Autocomplete's `renderOption`)
- Hides native search cancel button in Chrome/Safari since the Combobox renders its own clear button

## Test plan
- [ ] Verify Combobox works with default rendering (no `renderOption`)
- [ ] Verify Combobox works with custom `renderOption` callback
- [ ] Verify clear button still works in Chrome/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)