### PR TITLE
fix(app): use nullish coalescing for probe count fallback

### DIFF
--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -704,7 +704,7 @@ const App = () => {
                     <Badge variant="secondary">
                       <strong>Depth:</strong>{' '}
                       {(
-                        selectedPrompt?.metrics?.tokenUsage?.numRequests || tableData.length
+                        selectedPrompt?.metrics?.tokenUsage?.numRequests ?? tableData.length
                       ).toLocaleString()}{' '}
                       probes
                     </Badge>


### PR DESCRIPTION
## Summary
- Fixed probe count display using `||` operator which treats 0 as falsy, causing incorrect fallback to `tableData.length` when `numRequests` is 0
- Changed to `??` (nullish coalescing) to only fallback when the value is null or undefined

## Problem
When displaying probe count in the red team report, the code used:
```typescript
selectedPrompt?.metrics?.tokenUsage?.numRequests || tableData.length
```

The `||` operator treats `0` as falsy, so when `numRequests` was 0 (or not yet populated), it would incorrectly fall back to showing the test case count (`tableData.length`) instead of the actual probe count.

## Solution
Changed to nullish coalescing (`??`) which only falls back when the value is `null` or `undefined`:
```typescript
selectedPrompt?.metrics?.tokenUsage?.numRequests ?? tableData.length
```

## Test plan
- [ ] Verify red team reports show correct probe count when `numRequests` is 0
- [ ] Verify red team reports show correct probe count when `numRequests` has a value
- [ ] Verify fallback to `tableData.length` still works when `numRequests` is undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)