### PR TITLE
fix(eval): honor provider maxRetries across retry layers

### DIFF
--- a/site/docs/configuration/rate-limits.md
+++ b/site/docs/configuration/rate-limits.md
@@ -13,7 +13,7 @@ Promptfoo automatically handles rate limits from LLM providers. When a provider 
 
 Rate limit handling is built into the evaluator and requires no configuration:
 
-- **Automatic retry**: Failed requests are retried up to 3 times with exponential backoff
+- **Automatic retry**: Failed requests are retried up to 3 times with exponential backoff by default (or provider `maxRetries` when set)
 - **Header-aware delays**: Respects `retry-after` headers from providers
 - **Adaptive concurrency**: Reduces concurrent requests when rate limits are hit
 - **Per-provider isolation**: Each provider and API key has separate rate limit tracking
@@ -96,8 +96,21 @@ PROMPTFOO_DELAY_MS=1000 promptfoo eval
 
 Promptfoo has two retry layers:
 
-1. **Provider-level retry** (scheduler): Retries `callApi()` with 1-second base backoff, up to 3 times
-2. **HTTP-level retry**: Retries failed HTTP requests with configurable backoff
+1. **Provider-level retry** (scheduler): Retries `callApi()` with 1-second base backoff, up to 3 times by default. If a provider config includes `maxRetries`, the scheduler uses that value instead (including `0` to disable scheduler retries).
+2. **HTTP-level retry**: Retries failed HTTP requests. Default is 4 retries when no provider override is available.
+
+When provider config includes `maxRetries`, promptfoo also uses that value as the default for HTTP-level retries (unless a provider explicitly passes a different retry value for a specific call).
+
+For calls that use `fetchWithRetries`, promptfoo disables `fetchWithProxy` transient retries to avoid retry amplification. For direct `fetchWithProxy` calls, transient retries (502/503/504/524) still apply by default, but are disabled when `maxRetries: 0` is set in provider config during eval execution.
+
+Example provider config:
+
+```yaml
+providers:
+  - id: openai:chat:gpt-4.1-mini
+    config:
+      maxRetries: 0 # Disable scheduler + default HTTP retries for this provider
+```
 
 Environment variables for the scheduler:
 

--- a/src/scheduler/providerRateLimitState.ts
+++ b/src/scheduler/providerRateLimitState.ts
@@ -131,11 +131,13 @@ export class ProviderRateLimitState extends EventEmitter {
       getHeaders?: (result: T) => Record<string, string> | undefined;
       isRateLimited?: (result: T | undefined, error?: Error) => boolean;
       getRetryAfter?: (result: T | undefined, error?: Error) => number | undefined;
+      retryPolicy?: RetryPolicy;
     },
   ): Promise<T> {
     this.totalRequests++;
     let attempt = 0;
     let lastError: Error | undefined;
+    const retryPolicy = options.retryPolicy ?? this.retryPolicy;
 
     while (true) {
       // Acquire slot (may wait for rate limit window via queue)
@@ -177,10 +179,10 @@ export class ProviderRateLimitState extends EventEmitter {
           this.handleRateLimit(retryAfterMs);
 
           // Check if we should retry
-          if (shouldRetry(attempt, undefined, true, this.retryPolicy)) {
+          if (shouldRetry(attempt, undefined, true, retryPolicy)) {
             attempt++;
             this.retriedRequests++;
-            const delay = getRetryDelay(attempt, this.retryPolicy, retryAfterMs);
+            const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
 
             this.emit('request:retrying', {
               rateLimitKey: this.rateLimitKey,
@@ -229,10 +231,10 @@ export class ProviderRateLimitState extends EventEmitter {
         }
 
         // Check if we should retry
-        if (shouldRetry(attempt, lastError, isRateLimited, this.retryPolicy)) {
+        if (shouldRetry(attempt, lastError, isRateLimited, retryPolicy)) {
           attempt++;
           this.retriedRequests++;
-          const delay = getRetryDelay(attempt, this.retryPolicy, retryAfterMs);
+          const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
 
           this.emit('request:retrying', {
             rateLimitKey: this.rateLimitKey,

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from 'events';
 
 import { getEnvBool, getEnvInt } from '../envars';
-import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
-import { DEFAULT_RETRY_POLICY, type RetryPolicy } from './retryPolicy';
-import { getRateLimitKey } from './rateLimitKey';
 import { runWithFetchRetryContext } from '../util/fetch/retryContext';
+import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
+import { getRateLimitKey } from './rateLimitKey';
+import { DEFAULT_RETRY_POLICY, type RetryPolicy } from './retryPolicy';
 
 import type { ApiProvider } from '../types/providers';
 

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -2,7 +2,9 @@ import { EventEmitter } from 'events';
 
 import { getEnvBool, getEnvInt } from '../envars';
 import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
+import { DEFAULT_RETRY_POLICY, type RetryPolicy } from './retryPolicy';
 import { getRateLimitKey } from './rateLimitKey';
+import { runWithFetchRetryContext } from '../util/fetch/retryContext';
 
 import type { ApiProvider } from '../types/providers';
 
@@ -48,9 +50,11 @@ export class RateLimitRegistry extends EventEmitter {
       getRetryAfter?: (result: T | undefined, error?: Error) => number | undefined;
     },
   ): Promise<T> {
+    const providerMaxRetries = this.getProviderMaxRetries(provider);
+
     // If disabled, just call directly
     if (!this.enabled) {
-      return callFn();
+      return runWithFetchRetryContext(providerMaxRetries, () => callFn());
     }
 
     const rateLimitKey = getRateLimitKey(provider);
@@ -66,11 +70,15 @@ export class RateLimitRegistry extends EventEmitter {
     });
 
     try {
-      const result = await state.executeWithRetry(requestId, callFn, {
-        getHeaders: options?.getHeaders,
-        isRateLimited: options?.isRateLimited,
-        getRetryAfter: options?.getRetryAfter,
-      });
+      const providerRetryPolicy = this.getProviderRetryPolicy(providerMaxRetries);
+      const result = await runWithFetchRetryContext(providerMaxRetries, () =>
+        state.executeWithRetry(requestId, callFn, {
+          getHeaders: options?.getHeaders,
+          isRateLimited: options?.isRateLimited,
+          getRetryAfter: options?.getRetryAfter,
+          retryPolicy: providerRetryPolicy,
+        }),
+      );
 
       this.emit('request:completed', {
         rateLimitKey,
@@ -86,6 +94,37 @@ export class RateLimitRegistry extends EventEmitter {
       });
       throw error;
     }
+  }
+
+  private getProviderRetryPolicy(maxRetries: number | undefined): RetryPolicy | undefined {
+    if (maxRetries === undefined) {
+      return undefined;
+    }
+    return {
+      ...DEFAULT_RETRY_POLICY,
+      maxRetries,
+    };
+  }
+
+  private getProviderMaxRetries(provider: ApiProvider): number | undefined {
+    const rawMaxRetries: unknown =
+      provider.config && typeof provider.config === 'object'
+        ? (provider.config as { maxRetries?: unknown }).maxRetries
+        : undefined;
+    return this.parseMaxRetries(rawMaxRetries);
+  }
+
+  private parseMaxRetries(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (/^\d+$/.test(trimmed)) {
+        return Number(trimmed);
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -13,6 +13,7 @@ import invariant from '../../util/invariant';
 import { sleep } from '../../util/time';
 import { sanitizeUrl } from '../sanitizer';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
+import { getFetchRetryContextMaxRetries } from './retryContext';
 
 import type { SystemError } from './errors';
 import type { FetchOptions } from './types';
@@ -180,14 +181,17 @@ export async function fetchWithProxy(
     finalOptions.dispatcher = getOrCreateAgent(tlsOptions);
   }
 
-  // Transient error retry logic (502/503/504/524 with matching status text)
-  const maxTransientRetries = options.disableTransientRetries ? 0 : 3;
+  // Transient error retry logic (502/503/504/524 with matching status text).
+  // If provider config sets maxRetries=0, disable transient retries via async context.
+  const contextMaxRetries = getFetchRetryContextMaxRetries();
+  const disableTransientRetries = options.disableTransientRetries ?? (contextMaxRetries === 0);
+  const maxTransientRetries = disableTransientRetries ? 0 : 3;
 
   for (let attempt = 0; attempt <= maxTransientRetries; attempt++) {
     const response = await monkeyPatchFetch(finalUrl, finalOptions);
 
     if (
-      !options.disableTransientRetries &&
+      !disableTransientRetries &&
       isTransientError(response) &&
       attempt < maxTransientRetries
     ) {
@@ -319,7 +323,8 @@ export async function fetchWithRetries(
   timeout: number,
   maxRetries?: number,
 ): Promise<Response> {
-  maxRetries = Math.max(0, maxRetries ?? 4);
+  const contextMaxRetries = getFetchRetryContextMaxRetries();
+  maxRetries = Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
 
   let lastErrorMessage: string | undefined;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -184,17 +184,13 @@ export async function fetchWithProxy(
   // Transient error retry logic (502/503/504/524 with matching status text).
   // If provider config sets maxRetries=0, disable transient retries via async context.
   const contextMaxRetries = getFetchRetryContextMaxRetries();
-  const disableTransientRetries = options.disableTransientRetries ?? (contextMaxRetries === 0);
+  const disableTransientRetries = options.disableTransientRetries ?? contextMaxRetries === 0;
   const maxTransientRetries = disableTransientRetries ? 0 : 3;
 
   for (let attempt = 0; attempt <= maxTransientRetries; attempt++) {
     const response = await monkeyPatchFetch(finalUrl, finalOptions);
 
-    if (
-      !disableTransientRetries &&
-      isTransientError(response) &&
-      attempt < maxTransientRetries
-    ) {
+    if (!disableTransientRetries && isTransientError(response) && attempt < maxTransientRetries) {
       const backoffMs = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
       logger.debug(
         `Transient error (${response.status} ${response.statusText}), retry ${attempt + 1}/${maxTransientRetries} after ${backoffMs}ms`,

--- a/src/util/fetch/retryContext.ts
+++ b/src/util/fetch/retryContext.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface FetchRetryContext {
+  maxRetries?: number;
+}
+
+const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
+
+export function runWithFetchRetryContext<T>(
+  maxRetries: number | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (maxRetries === undefined) {
+    return fn();
+  }
+  return fetchRetryContext.run({ maxRetries }, fn);
+}
+
+export function getFetchRetryContextMaxRetries(): number | undefined {
+  return fetchRetryContext.getStore()?.maxRetries;
+}

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -17,6 +17,7 @@ import {
   isRateLimited,
   isTransientError,
 } from '../src/util/fetch/index';
+import { runWithFetchRetryContext } from '../src/util/fetch/retryContext';
 import { sleep } from '../src/util/time';
 import { createMockResponse } from './util/utils';
 
@@ -944,6 +945,28 @@ describe('fetchWithRetries', () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
+  it('should use retry context maxRetries when argument is undefined', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      runWithFetchRetryContext(0, () => fetchWithRetries('https://example.com', {}, 1000)),
+    ).rejects.toThrow('Request failed after 0 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should prefer explicit maxRetries over retry context', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      runWithFetchRetryContext(0, () => fetchWithRetries('https://example.com', {}, 1000, 2)),
+    ).rejects.toThrow('Request failed after 2 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
   it('should make retries+1 total attempts', async () => {
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
@@ -1605,6 +1628,46 @@ describe('fetchWithProxy transient error retries', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result).toBe(transientResponse);
     expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should disable transient retries when retry context maxRetries is 0', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(transientResponse);
+    global.fetch = mockFetch;
+
+    const result = await runWithFetchRetryContext(0, () => fetchWithProxy('https://example.com'));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(transientResponse);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should let explicit disableTransientRetries=false override retry context', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+    const successResponse = createMockResponse({ ok: true });
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(transientResponse)
+      .mockResolvedValueOnce(successResponse);
+    global.fetch = mockFetch;
+
+    const result = await runWithFetchRetryContext(0, () =>
+      fetchWithProxy('https://example.com', {
+        disableTransientRetries: false,
+      }),
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toBe(successResponse);
+    expect(sleep).toHaveBeenCalledTimes(1);
   });
 
   it('should retry on 524 A Timeout Occurred (Cloudflare)', async () => {

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
+import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContext';
+
+import type { ApiProvider } from '../../src/types/providers';
+
+function createProvider(maxRetries?: unknown): ApiProvider {
+  const config =
+    maxRetries === undefined
+      ? {}
+      : {
+          maxRetries,
+        };
+  return {
+    id: () => 'test-provider',
+    config,
+    callApi: vi.fn(),
+  } as unknown as ApiProvider;
+}
+
+async function runRateLimitedCall(maxRetries?: unknown): Promise<number> {
+  const registry = new RateLimitRegistry({
+    maxConcurrency: 1,
+    queueTimeoutMs: 100,
+  });
+  const provider = createProvider(maxRetries);
+  const callFn = vi.fn().mockResolvedValue({ status: 429 });
+
+  try {
+    await expect(
+      registry.execute(provider, callFn, {
+        isRateLimited: (result) => (result as { status?: number } | undefined)?.status === 429,
+        getRetryAfter: () => 0,
+      }),
+    ).rejects.toThrow('Rate limit exceeded');
+  } finally {
+    registry.dispose();
+  }
+
+  return callFn.mock.calls.length;
+}
+
+describe('RateLimitRegistry integration - provider maxRetries', () => {
+  it('should propagate provider maxRetries to fetch retry context', async () => {
+    const registry = new RateLimitRegistry({
+      maxConcurrency: 1,
+      queueTimeoutMs: 100,
+    });
+    const provider = createProvider(0);
+    const callFn = vi.fn().mockImplementation(async () => getFetchRetryContextMaxRetries());
+
+    try {
+      const contextValue = await registry.execute(provider, callFn);
+      expect(contextValue).toBe(0);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('should propagate fetch retry context when scheduler is disabled', async () => {
+    process.env.PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER = 'true';
+    const registry = new RateLimitRegistry({
+      maxConcurrency: 1,
+      queueTimeoutMs: 100,
+    });
+    const provider = createProvider(0);
+    const callFn = vi.fn().mockImplementation(async () => getFetchRetryContextMaxRetries());
+
+    try {
+      const contextValue = await registry.execute(provider, callFn);
+      expect(contextValue).toBe(0);
+    } finally {
+      registry.dispose();
+      delete process.env.PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER;
+    }
+  });
+
+  it('should not retry when provider maxRetries is 0', async () => {
+    const attempts = await runRateLimitedCall(0);
+    expect(attempts).toBe(1);
+  });
+
+  it('should retry provider maxRetries + 1 total attempts', async () => {
+    const attempts = await runRateLimitedCall(2);
+    expect(attempts).toBe(3);
+  });
+
+  it('should parse numeric string maxRetries values', async () => {
+    const attempts = await runRateLimitedCall('2');
+    expect(attempts).toBe(3);
+  });
+
+  it('should use default scheduler retries when provider maxRetries is not set', async () => {
+    const attempts = await runRateLimitedCall(undefined);
+    expect(attempts).toBe(4);
+  });
+
+  it('should ignore invalid negative maxRetries and use default scheduler retries', async () => {
+    const attempts = await runRateLimitedCall(-1);
+    expect(attempts).toBe(4);
+  });
+
+  it('should ignore invalid non-integer string maxRetries values', async () => {
+    const attempts = await runRateLimitedCall('2.5');
+    expect(attempts).toBe(4);
+  });
+});

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-
 import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
 import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContext';
 

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -253,6 +253,7 @@ describe('RateLimitRegistry', () => {
           getHeaders: undefined,
           isRateLimited: undefined,
           getRetryAfter: undefined,
+          retryPolicy: undefined,
         },
       );
       expect(result).toBe('state-result');
@@ -277,6 +278,125 @@ describe('RateLimitRegistry', () => {
         getHeaders,
         isRateLimited,
         getRetryAfter,
+        retryPolicy: undefined,
+      });
+    });
+
+    it('should honor scheduler retries when provider maxRetries is 0', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const providerWithNoRetries = {
+        ...mockProvider,
+        config: {
+          ...mockProvider.config,
+          maxRetries: 0,
+        },
+      } as ApiProvider;
+
+      const callFn = vi.fn();
+      await registry.execute(providerWithNoRetries, callFn);
+
+      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
+        getHeaders: undefined,
+        isRateLimited: undefined,
+        getRetryAfter: undefined,
+        retryPolicy: expect.objectContaining({
+          maxRetries: 0,
+        }),
+      });
+    });
+
+    it('should honor scheduler retries when provider maxRetries is \"0\"', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const providerWithStringNoRetries = {
+        ...mockProvider,
+        config: {
+          ...mockProvider.config,
+          maxRetries: '0',
+        },
+      } as ApiProvider;
+
+      const callFn = vi.fn();
+      await registry.execute(providerWithStringNoRetries, callFn);
+
+      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
+        getHeaders: undefined,
+        isRateLimited: undefined,
+        getRetryAfter: undefined,
+        retryPolicy: expect.objectContaining({
+          maxRetries: 0,
+        }),
+      });
+    });
+
+    it('should honor scheduler retries when provider maxRetries is a numeric string', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const providerWithStringRetries = {
+        ...mockProvider,
+        config: {
+          ...mockProvider.config,
+          maxRetries: '2',
+        },
+      } as ApiProvider;
+
+      const callFn = vi.fn();
+      await registry.execute(providerWithStringRetries, callFn);
+
+      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
+        getHeaders: undefined,
+        isRateLimited: undefined,
+        getRetryAfter: undefined,
+        retryPolicy: expect.objectContaining({
+          maxRetries: 2,
+        }),
+      });
+    });
+
+    it('should honor scheduler retries when provider maxRetries is greater than 0', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const providerWithTwoRetries = {
+        ...mockProvider,
+        config: {
+          ...mockProvider.config,
+          maxRetries: 2,
+        },
+      } as ApiProvider;
+
+      const callFn = vi.fn();
+      await registry.execute(providerWithTwoRetries, callFn);
+
+      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
+        getHeaders: undefined,
+        isRateLimited: undefined,
+        getRetryAfter: undefined,
+        retryPolicy: expect.objectContaining({
+          maxRetries: 2,
+        }),
+      });
+    });
+
+    it('should ignore negative provider maxRetries values', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const providerWithNegativeRetries = {
+        ...mockProvider,
+        config: {
+          ...mockProvider.config,
+          maxRetries: -1,
+        },
+      } as ApiProvider;
+
+      const callFn = vi.fn();
+      await registry.execute(providerWithNegativeRetries, callFn);
+
+      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
+        getHeaders: undefined,
+        isRateLimited: undefined,
+        getRetryAfter: undefined,
+        retryPolicy: undefined,
       });
     });
 


### PR DESCRIPTION
## Summary
- honor provider `config.maxRetries` in the adaptive scheduler retry policy (supports non-negative integer values)
- propagate provider `maxRetries` to fetch-level retries via async context so providers that do not pass explicit retry args still inherit the setting
- disable `fetchWithProxy` transient retries when provider `maxRetries` is `0` during eval execution
- add/expand scheduler + fetch tests for wiring and behavior, including scheduler-disabled context propagation
- document layered retry behavior and provide a YAML example

Fixes #7727

## Testing
- `npx vitest run test/fetch.test.ts test/scheduler/rateLimitRegistry.behavior.test.ts test/scheduler/rateLimitRegistry.test.ts test/scheduler/providerRateLimitState.test.ts`
- `npx @biomejs/biome lint src/util/fetch/index.ts src/util/fetch/retryContext.ts src/scheduler/rateLimitRegistry.ts src/scheduler/providerRateLimitState.ts test/fetch.test.ts test/scheduler/rateLimitRegistry.behavior.test.ts test/scheduler/rateLimitRegistry.test.ts`
- `npx prettier --check site/docs/configuration/rate-limits.md`
