### PR TITLE
fix(util): handle path-only URLs in sanitizeUrl

### DIFF
--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1280,6 +1280,45 @@ describe('sanitizeUrl', () => {
     });
   });
 
+  describe('path-only URLs', () => {
+    it('should handle simple path-only URLs', () => {
+      const url = '/api/openai/completion';
+      expect(sanitizeUrl(url)).toBe('/api/openai/completion');
+    });
+
+    it('should not emit a warning for path-only URLs', () => {
+      sanitizeUrl('/api/openai/completion');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should sanitize sensitive query params in path-only URLs', () => {
+      const url = '/api/endpoint?api_key=secret123&data=public';
+      const result = sanitizeUrl(url);
+      expect(result).toBe('/api/endpoint?api_key=%5BREDACTED%5D&data=public');
+    });
+
+    it('should handle path-only URL with fragment', () => {
+      const url = '/api/endpoint?token=secret#section';
+      const result = sanitizeUrl(url);
+      expect(result).toBe('/api/endpoint?token=%5BREDACTED%5D#section');
+    });
+
+    it('should handle path-only URL with no query params', () => {
+      const url = '/api/v1/users';
+      expect(sanitizeUrl(url)).toBe('/api/v1/users');
+    });
+
+    it('should handle root path', () => {
+      expect(sanitizeUrl('/')).toBe('/');
+    });
+
+    it('should not treat protocol-relative URLs as path-only', () => {
+      const url = '//example.com/api?api_key=secret123';
+      // Protocol-relative URLs fail new URL() and fall through to the catch
+      expect(sanitizeUrl(url)).toBe(url);
+    });
+  });
+
   describe('error handling', () => {
     it('should handle URL parsing errors gracefully', () => {
       const invalidUrl = 'ht!tp://invalid';


### PR DESCRIPTION
## Summary
- `sanitizeUrl()` now handles path-only URLs (e.g., `/api/openai/completion`) that occur in raw HTTP request mode, instead of throwing `Invalid URL` and logging a confusing warning
- Uses a dummy base URL for `new URL()` parsing when the input is a path-only string, then strips it from the result

## Test plan
- [x] Added tests for path-only URLs: simple paths, paths with sensitive query params, fragments, root path
- [x] Verified no console warning is emitted for path-only URLs
- [x] All 170 existing sanitizer tests still pass
- [x] Verified protocol-relative URLs (`//example.com/...`) are not affected

Closes ENG-1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)