### PR TITLE
docs(site): add CookieYes cookie consent banner

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -38,6 +38,14 @@ const config: Config = {
 
   headTags: [
     {
+      tagName: 'script',
+      attributes: {
+        id: 'cookieyes',
+        type: 'text/javascript',
+        src: 'https://cdn-cookieyes.com/client_data/0c4c12c97cdbe66d31c0acccf3269a4e/script.js',
+      },
+    },
+    {
       tagName: 'link',
       attributes: {
         rel: 'preconnect',

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -483,10 +483,6 @@ const sidebars = {
     },
     {
       type: 'doc',
-      id: 'write-for-promptfoo',
-    },
-    {
-      type: 'doc',
       id: 'faq',
     },
     {


### PR DESCRIPTION
## Summary
- Adds CookieYes cookie consent banner script to the documentation site
- Removes stale sidebar reference to deleted `write-for-promptfoo` doc

## Test plan
- [ ] Verify the cookie banner appears on the production docs site after deployment
- [ ] Check that the banner functions correctly for cookie consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)