### PR TITLE
chore(cli): add show command recovery hints

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -82,6 +82,7 @@ export async function handleEval(id: string) {
   const eval_ = await Eval.findById(id);
   if (!eval_) {
     logger.error(`No evaluation found with ID ${id}`);
+    logger.info(`Run ${chalk.green('promptfoo list evals')} to see available evaluation IDs.`);
     process.exitCode = 1;
     return;
   }
@@ -184,6 +185,7 @@ export async function showCommand(program: Command) {
           return handleEval(latestEval.id);
         }
         logger.error('No eval found');
+        logger.info(`Run ${chalk.green('promptfoo eval')} to create one.`);
         process.exitCode = 1;
         return;
       }
@@ -204,6 +206,9 @@ export async function showCommand(program: Command) {
       }
 
       logger.error(`No resource found with ID ${id}`);
+      logger.info(
+        `Run ${chalk.green('promptfoo list evals')}, ${chalk.green('promptfoo list prompts')}, or ${chalk.green('promptfoo list datasets')} to see available IDs.`,
+      );
       process.exitCode = 1;
     });
 
@@ -217,6 +222,7 @@ export async function showCommand(program: Command) {
           return handleEval(latestEval.id);
         }
         logger.error('No eval found');
+        logger.info(`Run ${chalk.green('promptfoo eval')} to create one.`);
         process.exitCode = 1;
         return;
       }


### PR DESCRIPTION
Improves `promptfoo show` error UX by adding direct next-step commands.