### PR TITLE
fix(app): wrap DataTable body cell content in block container

### DIFF
--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -459,7 +459,9 @@ export function DataTable<TData, TValue = unknown>({
                               : undefined
                           }
                         >
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          <div className="min-w-0">
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </div>
                         </td>
                       );
                     })}


### PR DESCRIPTION
## Summary

- Wraps DataTable body cell content in a `<div className="min-w-0">` block container
- Header cells already do this (line 378-386), but body cells rendered content directly into the `<td>` with no wrapper
- This caused inline-block children (buttons, links) with `truncate` to overflow fixed-width cells and become invisible
- Reported by a customer after the MUI DataGrid → TanStack DataTable migration (#3482 in cloud)

## Context

In `table-layout: fixed`, the `<td>` gets `overflow-hidden text-ellipsis` and a fixed width. But `overflow` on `display: table-cell` doesn't reliably constrain inline-block children. Without a block-level wrapper, every cell renderer has to independently add `block w-full min-w-0` to any inline element — a footgun that will repeatedly cause invisible text for long content.

The `<div className="min-w-0">` wrapper is block by default, so it constrains to the `<td>` width, and `min-w-0` lets it shrink below content size. This matches what header cells already do.

## Test plan

- [ ] Verify all DataTable instances render correctly (targets list, evals, datasets, prompts, history, users)
- [ ] Verify long text (40+ chars) in clickable cells truncates with ellipsis
- [ ] Verify cell click handlers still work through the wrapper div
- [ ] Verify column resizing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)