### PR TITLE
docs(site): add remote globe indicators to strategy table

### DIFF
--- a/site/docs/_shared/StrategyTable.tsx
+++ b/site/docs/_shared/StrategyTable.tsx
@@ -40,6 +40,16 @@ const RecommendedBadge = () => (
   </span>
 );
 
+interface StrategyTableProps {
+  shouldRenderCategory?: boolean;
+  shouldRenderStrategy?: boolean;
+  shouldRenderDescription?: boolean;
+  shouldRenderLongDescription?: boolean;
+  shouldRenderCost?: boolean;
+  shouldRenderAsrIncrease?: boolean;
+  showRemoteStatus?: boolean;
+}
+
 const StrategyTable = ({
   shouldRenderCategory = true,
   shouldRenderStrategy = true,
@@ -47,7 +57,8 @@ const StrategyTable = ({
   shouldRenderLongDescription = true,
   shouldRenderCost = true,
   shouldRenderAsrIncrease = true,
-}) => {
+  showRemoteStatus = false,
+}: StrategyTableProps) => {
   return (
     <div className="strategy-table-wrapper">
       <table className="strategy-table">
@@ -104,7 +115,14 @@ const StrategyTable = ({
                         )}
                       </td>
                     )}
-                    {shouldRenderDescription && <td>{strategy.description}</td>}
+                    {shouldRenderDescription && (
+                      <td>
+                        {strategy.description}
+                        {showRemoteStatus && strategy.isRemote && (
+                          <span title="Uses remote inference"> 🌐</span>
+                        )}
+                      </td>
+                    )}
                     {shouldRenderLongDescription && (
                       <td className="details-cell">{strategy.longDescription}</td>
                     )}

--- a/site/docs/_shared/data/strategies.ts
+++ b/site/docs/_shared/data/strategies.ts
@@ -9,6 +9,7 @@ export interface Strategy {
   asrIncrease: string;
   link?: string;
   recommended?: boolean;
+  isRemote?: boolean;
 }
 
 export const strategies: Strategy[] = [
@@ -44,6 +45,7 @@ export const strategies: Strategy[] = [
     cost: 'High',
     asrIncrease: '40-60%',
     link: '/docs/red-team/strategies/best-of-n/',
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -55,6 +57,7 @@ export const strategies: Strategy[] = [
     cost: 'Medium',
     asrIncrease: '40-60%',
     link: '/docs/red-team/strategies/citation/',
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -66,6 +69,7 @@ export const strategies: Strategy[] = [
     cost: 'Medium',
     asrIncrease: '40-60%',
     link: '/docs/red-team/strategies/authoritative-markup-injection/',
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -78,6 +82,7 @@ export const strategies: Strategy[] = [
     asrIncrease: '60-80%',
     link: '/docs/red-team/strategies/composite-jailbreaks/',
     recommended: true,
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -89,6 +94,7 @@ export const strategies: Strategy[] = [
     cost: 'High',
     asrIncrease: '0-10%',
     link: '/docs/red-team/strategies/gcg/',
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -113,6 +119,7 @@ export const strategies: Strategy[] = [
     asrIncrease: '70-90%',
     link: '/docs/red-team/strategies/meta/',
     recommended: true,
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -124,6 +131,7 @@ export const strategies: Strategy[] = [
     cost: 'Medium',
     asrIncrease: '40-60%',
     link: '/docs/red-team/strategies/likert/',
+    isRemote: true,
   },
   {
     category: 'Dynamic (Single-Turn)',
@@ -168,6 +176,7 @@ export const strategies: Strategy[] = [
     cost: 'High',
     asrIncrease: '70-90%',
     link: '/docs/red-team/strategies/goat/',
+    isRemote: true,
   },
   {
     category: 'Multi-turn',
@@ -179,6 +188,7 @@ export const strategies: Strategy[] = [
     cost: 'High',
     asrIncrease: '70-90%',
     link: '/docs/red-team/strategies/hydra/',
+    isRemote: true,
   },
   {
     category: 'Multi-turn',
@@ -222,6 +232,7 @@ export const strategies: Strategy[] = [
     cost: 'Low',
     asrIncrease: '20-30%',
     link: '/docs/red-team/strategies/audio/',
+    isRemote: true,
   },
   {
     category: 'Static (Single-Turn)',

--- a/site/docs/red-team/strategies/index.md
+++ b/site/docs/red-team/strategies/index.md
@@ -22,7 +22,9 @@ Strategies are applied during redteam generation and can significantly increase 
 
 ## Available Strategies
 
-<StrategyTable />
+<StrategyTable showRemoteStatus />
+
+_🌐 indicates that strategy uses remote inference in Promptfoo Community edition_
 
 ## Strategy Categories
 


### PR DESCRIPTION
## Summary
The red-team strategies index did not indicate which strategies require Promptfoo's remote inference, while the plugins index already exposes this with a globe marker. This made it harder to predict runtime requirements and potential failures when remote generation is disabled.

This change adds the same `🌐` visual treatment to the strategies table: `StrategyTable` now supports `showRemoteStatus`, the strategies data model now includes `isRemote`, and the strategies overview page enables the marker with a legend.

## Root Cause
The shared strategy docs data and renderer had no remote-status field/prop, so the page could not surface remote-only behavior even though strategy source code and constants already classify these strategies.

## Validation
- `npm run lint:site` (passes; existing unrelated complexity warnings remain)
- `SKIP_OG_GENERATION=true npm run build --prefix site` (passes)
