### PR TITLE
fix(app): wrap DataTable body cells in overflow-hidden container

### DIFF
--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -441,23 +441,26 @@ describe('DataTable', () => {
   });
 
   describe('cell content wrapper', () => {
-    it('should wrap body cell content in a div with overflow-hidden', () => {
+    it('should wrap data cell content in a div with overflow-hidden but not select cells', () => {
       const data: TestRow[] = [{ id: '1', name: 'Test Item' }];
 
-      render(<DataTable columns={columns} data={data} />);
+      render(<DataTable columns={columns} data={data} enableRowSelection />);
 
       const table = screen.getByRole('table');
       const tbody = table.querySelector('tbody');
       const firstRow = tbody?.querySelector('tr');
       const cells = firstRow?.querySelectorAll('td');
 
-      // Each cell should have a wrapper div with overflow-hidden
-      for (const cell of Array.from(cells ?? [])) {
-        const wrapper = cell.querySelector(':scope > div');
-        expect(wrapper).not.toBeNull();
-        expect(wrapper?.className).toContain('overflow-hidden');
-        expect(wrapper?.className).toContain('min-w-0');
-      }
+      // First cell is the select column - should NOT have the overflow wrapper
+      const selectCell = cells?.[0];
+      const selectWrapper = selectCell?.querySelector(':scope > div.overflow-hidden');
+      expect(selectWrapper).toBeNull();
+
+      // Data cells should have the overflow wrapper
+      const dataCell = cells?.[1];
+      const dataWrapper = dataCell?.querySelector(':scope > div.overflow-hidden');
+      expect(dataWrapper).not.toBeNull();
+      expect(dataWrapper?.className).toContain('min-w-0');
     });
 
     it('should render cell text content inside the overflow wrapper', () => {

--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -459,9 +459,13 @@ export function DataTable<TData, TValue = unknown>({
                               : undefined
                           }
                         >
-                          <div className="overflow-hidden min-w-0">
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </div>
+                          {cell.column.id === 'select' ? (
+                            flexRender(cell.column.columnDef.cell, cell.getContext())
+                          ) : (
+                            <div className="overflow-hidden min-w-0">
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </div>
+                          )}
                         </td>
                       );
                     })}


### PR DESCRIPTION
## Summary

- Wraps DataTable body cell content in `<div className="overflow-hidden min-w-0">` 
- `overflow: hidden` on `display: table-cell` is not reliably defined by the CSS spec — it only formally applies to block/flex/grid containers. This caused inline-block children (buttons, links) with `truncate` to overflow fixed-width cells and become invisible in production
- The wrapper `<div>` is a block element (reliable `overflow: hidden`) that constrains to the `<td>` width and clips any overflowing content
- Header cells already use this pattern (line 378-386), body cells did not

## Context

Reported by a customer after the MUI DataGrid → TanStack DataTable migration. Names longer than the column width (250px) were completely invisible. Root cause: the `<button>` was inline-block, grew to ~360px (text width), and the `<td>`'s `overflow: hidden` didn't reliably clip it.

Without the wrapper, every cell renderer has to independently add `block w-full min-w-0` to any inline element — a footgun. With the wrapper, the block div clips overflow for any cell content.

## Test plan

- [ ] All DataTable instances render correctly (targets, evals, datasets, prompts, history, audit logs, reports, etc.)
- [ ] Long text (40+ chars) in clickable cells (buttons, links) is visible and clipped
- [ ] Cell click handlers work through the wrapper div
- [ ] Row selection checkboxes work (select all, individual select)
- [ ] Column sorting still works
- [ ] Dropdown menus / popovers in action columns still open (they use portals, should be unaffected)
- [ ] Column resizing works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)