### PR TITLE
chore(eval): error on unknown positional args

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -1095,7 +1095,9 @@ export function evalCommand(
           evalCmd.help();
           return;
         }
-        logger.warn(`Unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]}?`);
+        logger.error(`Unknown command: ${command.args[0]}. Did you mean -c ${command.args[0]}?`);
+        process.exitCode = 1;
+        return;
       }
 
       if (validatedOpts.help) {


### PR DESCRIPTION
Fails fast on stray positional args 