### PR TITLE
chore(providers): expose redteam plugin/strategy in call context

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -400,6 +400,14 @@ export async function runEval({
         ...prompt,
         config: mergedPromptConfig,
       };
+      const pluginId =
+        test.metadata && typeof test.metadata.pluginId === 'string'
+          ? test.metadata.pluginId
+          : undefined;
+      const strategyId =
+        test.metadata && typeof test.metadata.strategyId === 'string'
+          ? test.metadata.strategyId
+          : undefined;
       const callApiContext: CallApiContextParams = {
         // Always included
         vars,
@@ -414,6 +422,8 @@ export async function runEval({
         logger: logger as unknown as winston.Logger,
         getCache,
         repeatIndex,
+        pluginId,
+        strategyId,
       };
 
       if (repeatIndex > 0) {

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -69,6 +69,14 @@ export interface CallApiContextParams {
   // This was added so we have access to the grader inside the provider.
   // Vars and prompts should be access using the arguments above.
   test?: AtomicTestCase;
+  /**
+   * Redteam plugin identifier for the current test, when available.
+   */
+  pluginId?: string;
+  /**
+   * Redteam strategy identifier for the current test, when available.
+   */
+  strategyId?: string;
   bustCache?: boolean;
 
   // W3C Trace Context headers

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -4196,6 +4196,32 @@ describe('runEval', () => {
     expect(mockProvider.callApi).toHaveBeenCalledWith('Test prompt', expect.anything(), undefined);
   });
 
+  it('should include pluginId and strategyId in provider call context', async () => {
+    const results = await runEval({
+      ...defaultOptions,
+      provider: mockProvider,
+      prompt: { raw: 'Test prompt', label: 'test-label' },
+      test: {
+        metadata: {
+          pluginId: 'promptfoo:redteam:policy',
+          strategyId: 'custom:doc',
+        },
+      },
+      conversations: {},
+      registers: {},
+    });
+
+    expect(results[0].success).toBe(true);
+    expect(mockProvider.callApi).toHaveBeenCalledWith(
+      'Test prompt',
+      expect.objectContaining({
+        pluginId: 'promptfoo:redteam:policy',
+        strategyId: 'custom:doc',
+      }),
+      undefined,
+    );
+  });
+
   it('should handle conversation history', async () => {
     const conversations = {} as Record<string, any>;
 

--- a/test/providers/pythonCompletion.test.ts
+++ b/test/providers/pythonCompletion.test.ts
@@ -208,6 +208,35 @@ describe('PythonProvider', () => {
       ]);
     });
 
+    it('should preserve plugin and strategy IDs in sanitized context', async () => {
+      const provider = new PythonProvider('script.py');
+      mockPoolInstance.execute.mockResolvedValue({ output: 'test output' });
+
+      await provider.callApi('test prompt', {
+        vars: { question: 'hello' },
+        pluginId: 'promptfoo:redteam:policy',
+        strategyId: 'custom:doc',
+        logger: { debug: vi.fn() },
+        getCache: vi.fn(),
+        filters: { uppercase: () => '' },
+        originalProvider: {
+          id: () => 'test-target',
+          callApi: vi.fn(),
+        },
+      } as any);
+
+      const callArgs = mockPoolInstance.execute.mock.calls[0][1];
+      expect(callArgs[2]).toMatchObject({
+        vars: { question: 'hello' },
+        pluginId: 'promptfoo:redteam:policy',
+        strategyId: 'custom:doc',
+      });
+      expect(callArgs[2].logger).toBeUndefined();
+      expect(callArgs[2].getCache).toBeUndefined();
+      expect(callArgs[2].filters).toBeUndefined();
+      expect(callArgs[2].originalProvider).toBeUndefined();
+    });
+
     describe('error handling', () => {
       it('should throw a specific error when Python script returns invalid result', async () => {
         const provider = new PythonProvider('script.py');


### PR DESCRIPTION
Add `pluginId` and `strategyId` fields to call_api context