### PR TITLE
docs(site): document context parameter for script-based providers

### DIFF
--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -96,16 +96,25 @@ module.exports = class OpenAIProvider {
 
 ### Context Parameter
 
-The `context` parameter contains:
+The `context` parameter provides test case information and utility objects:
 
 ```javascript
 {
-  vars: {}, // Test case variables
-  prompt: {}, // Original prompt template
-  originalProvider: {}, // Used when provider is overridden
-  logger: {} // Winston logger instance
+  vars: {},              // Test case variables
+  prompt: {},            // Prompt template (raw, label, config)
+  test: {                // Full test case object
+    vars: {},
+    metadata: {
+      pluginId: '...',   // Redteam plugin (e.g. "promptfoo:redteam:harmful:hate")
+      strategyId: '...',  // Redteam strategy (e.g. "jailbreak", "prompt-injection")
+    },
+  },
+  originalProvider: {},  // Original provider when overridden
+  logger: {},            // Winston logger instance
 }
 ```
+
+For redteam evals, use `context.test.metadata.pluginId` and `context.test.metadata.strategyId` to identify which plugin and strategy generated the test case.
 
 ### Reporting the Actual Prompt
 

--- a/site/docs/providers/custom-script.md
+++ b/site/docs/providers/custom-script.md
@@ -17,6 +17,12 @@ While Script Providers are particularly useful for evaluating chains, they can g
 
 To use a script provider, you need to create an executable that takes a prompt as its first argument and returns the result of the API call. The script should be able to be invoked from the command line.
 
+Your script receives three arguments:
+
+1. **prompt** - The rendered prompt string
+2. **options** - JSON string with provider configuration
+3. **context** - JSON string with test case variables, metadata, and evaluation info (see [Python provider context](/docs/providers/python#the-context-parameter) for the full structure)
+
 Here is an example of how to use a script provider:
 
 ```yaml

--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -181,12 +181,30 @@ Provides information about the current test case:
 ```python
 {
     "vars": {
-        # Variables used in this test case
         "user_input": "Hello world",
         "system_prompt": "You are a helpful assistant"
-    }
+    },
+    "prompt": {
+        "raw": "...",
+        "label": "...",
+    },
+    "test": {
+        "vars": { ... },
+        "metadata": {
+            "pluginId": "...",   # Redteam plugin (e.g. "promptfoo:redteam:harmful:hate")
+            "strategyId": "...", # Redteam strategy (e.g. "jailbreak", "prompt-injection")
+        },
+    },
 }
 ```
+
+For redteam evals, use `context['test']['metadata']['pluginId']` and `context['test']['metadata']['strategyId']` to identify which plugin and strategy generated the test case.
+
+:::note
+
+Non-serializable fields (`logger`, `getCache`, `filters`, `originalProvider`) are removed before passing context to Python. Additional fields like `evaluationId`, `testCaseId`, `testIdx`, `promptIdx`, and `repeatIndex` are also available.
+
+:::
 
 ### Return Format
 
@@ -229,6 +247,8 @@ class ProviderOptions:
 
 class CallApiContextParams:
     vars: Dict[str, str]
+    prompt: Optional[Dict[str, Any]]       # Prompt template (raw, label, config)
+    test: Optional[Dict[str, Any]]         # Full test case including metadata
 
 class TokenUsage:
     total: int

--- a/site/docs/providers/ruby.md
+++ b/site/docs/providers/ruby.md
@@ -159,12 +159,30 @@ Provides information about the current test case:
 ```ruby
 {
   'vars' => {
-    # Variables used in this test case
     'user_input' => 'Hello world',
     'system_prompt' => 'You are a helpful assistant'
-  }
+  },
+  'prompt' => {
+    'raw' => '...',
+    'label' => '...',
+  },
+  'test' => {
+    'vars' => { ... },
+    'metadata' => {
+      'pluginId' => '...',   # Redteam plugin (e.g. "promptfoo:redteam:harmful:hate")
+      'strategyId' => '...',  # Redteam strategy (e.g. "jailbreak", "prompt-injection")
+    },
+  },
 }
 ```
+
+For redteam evals, use `context['test']['metadata']['pluginId']` and `context['test']['metadata']['strategyId']` to identify which plugin and strategy generated the test case.
+
+:::note
+
+Non-serializable fields (`logger`, `getCache`, `filters`, `originalProvider`) are removed before passing context to Ruby. Additional fields like `evaluationId`, `testCaseId`, `testIdx`, `promptIdx`, and `repeatIndex` are also available.
+
+:::
 
 ### Return Format
 
@@ -210,7 +228,9 @@ The types passed into the Ruby script function and the `ProviderResponse` return
 
 # CallApiContextParams
 {
-  'vars' => Hash[String, String]
+  'vars' => Hash[String, String],
+  'prompt' => Hash (optional),       # Prompt template (raw, label, config)
+  'test' => Hash (optional),         # Full test case including metadata
 }
 
 # TokenUsage


### PR DESCRIPTION
## Summary
- Documents the full `context` parameter structure for Python, Ruby, JavaScript, and custom script providers
- The `context.test.metadata` object (including `pluginId` and `strategyId`) was already passed to all script-based providers but was not documented
- This is the docs-only alternative to #7854, which proposed adding redundant top-level fields to `CallApiContextParams`

## Test plan
- [x] `npm run l && npm run f` passes
- [x] `SKIP_OG_GENERATION=true npm run build` succeeds in `site/`