### PR TITLE
fix(providers): handle system messages in Vertex Claude API calls

### DIFF
--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -399,6 +399,7 @@ export interface ClaudeRequest {
   temperature?: number;
   top_p?: number;
   top_k?: number;
+  system?: Array<{ type: string; text: string }>;
   messages: ClaudeMessage[];
 }
 

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -11,6 +11,7 @@ import { fetchWithProxy } from '../../util/fetch/index';
 import { maybeLoadFromExternalFile } from '../../util/file';
 import { renderVarsInObject } from '../../util/index';
 import { isValidJson } from '../../util/json';
+import { parseMessages } from '../anthropic/util';
 import { parseChatPrompt, REQUEST_TIMEOUT_MS } from '../shared';
 import { GoogleGenericProvider, type GoogleProviderOptions } from './base';
 import {
@@ -217,17 +218,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
   }
 
   async callClaudeApi(prompt: string, _context?: CallApiContextParams): Promise<ProviderResponse> {
-    const messages = parseChatPrompt(prompt, [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: prompt,
-          },
-        ],
-      },
-    ]);
+    const { system, extractedMessages } = parseMessages(prompt);
 
     const body: ClaudeRequest = {
       anthropic_version:
@@ -237,7 +228,8 @@ export class VertexChatProvider extends GoogleGenericProvider {
       temperature: this.config.temperature,
       top_p: this.config.top_p || this.config.topP,
       top_k: this.config.top_k || this.config.topK,
-      messages,
+      ...(system ? { system } : {}),
+      messages: extractedMessages as ClaudeRequest['messages'],
     };
 
     const cache = await getCache();

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -2095,6 +2095,173 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
     );
   });
 
+  it('should extract system messages to top-level system parameter', async () => {
+    provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022');
+
+    const mockResponse = {
+      data: {
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-v2@20241022',
+        content: [{ type: 'text', text: 'Response from Claude' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 20,
+          output_tokens: 30,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+
+    vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
+      client: {
+        request: mockRequest,
+      } as unknown as JSONClient,
+      projectId: 'test-project-id',
+    });
+
+    vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation(function (creds) {
+      if (typeof creds === 'object') {
+        return JSON.stringify(creds);
+      }
+      return creds;
+    });
+    vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
+
+    await provider.callClaudeApi(
+      JSON.stringify([
+        { role: 'system', content: 'You are a helpful assistant' },
+        { role: 'user', content: 'Hello' },
+      ]),
+    );
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          system: [{ type: 'text', text: 'You are a helpful assistant' }],
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+        }),
+      }),
+    );
+  });
+
+  it('should not include system parameter when no system message is present (plain string)', async () => {
+    provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022');
+
+    const mockResponse = {
+      data: {
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-v2@20241022',
+        content: [{ type: 'text', text: 'Response from Claude' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 20,
+          output_tokens: 30,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+
+    vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
+      client: {
+        request: mockRequest,
+      } as unknown as JSONClient,
+      projectId: 'test-project-id',
+    });
+
+    vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation(function (creds) {
+      if (typeof creds === 'object') {
+        return JSON.stringify(creds);
+      }
+      return creds;
+    });
+    vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
+
+    await provider.callClaudeApi('Hello');
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+        }),
+      }),
+    );
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          system: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it('should not include system parameter when structured messages have no system role', async () => {
+    provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022');
+
+    const mockResponse = {
+      data: {
+        id: 'test-id',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-3-5-sonnet-v2@20241022',
+        content: [{ type: 'text', text: 'Response from Claude' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 20,
+          output_tokens: 30,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+
+    vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
+      client: {
+        request: mockRequest,
+      } as unknown as JSONClient,
+      projectId: 'test-project-id',
+    });
+
+    vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation(function (creds) {
+      if (typeof creds === 'object') {
+        return JSON.stringify(creds);
+      }
+      return creds;
+    });
+    vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
+
+    await provider.callClaudeApi(JSON.stringify([{ role: 'user', content: 'Hello' }]));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+        }),
+      }),
+    );
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          system: expect.anything(),
+        }),
+      }),
+    );
+  });
+
   describe('responseSchema handling', () => {
     let provider: VertexChatProvider;
 


### PR DESCRIPTION
## Summary

When using `vertex:claude-*` models, prompts containing a system message fail because Claude's Messages API requires system prompts as a top-level `system` parameter — not as a message in the `messages` array. This breaks any feature where promptfoo constructs prompts with system messages internally, such as `llm-rubric` grading.

- Extract system messages from the messages array into the top-level `system` parameter on the `rawPredict` request body
- Reuse existing `parseMessages()` from the Anthropic provider
- Add `system` field to the `ClaudeRequest` type

Minimal config to reproduce, which before this fix would fail with `Unexpected role "system"`, but after the fix passes as expected:

```yaml
providers:
  - echo
prompts:
  - "The capital of France is Paris."
defaultTest:
  options:
    provider: vertex:claude-sonnet-4-6
tests:
  - assert:
      - type: llm-rubric
        value: The response correctly states that Paris is the capital of France.
```

## Test plan
- [x] Unit tests: system message extraction, plain string input,
  structured user-only input (no system)
- [x] Manual: `llm-rubric` with `vertex:claude-sonnet-4-6` grader
  passes (previously failed with "Unexpected role system")
- [x] Existing tests unaffected (56/56 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
