### PR TITLE
fix(redteam): show pointer cursor on setup tabs and filters

### DIFF
--- a/src/app/src/components/ui/collapsible.tsx
+++ b/src/app/src/components/ui/collapsible.tsx
@@ -1,8 +1,23 @@
+import * as React from 'react';
+
+import { cn } from '@app/lib/utils';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
 const Collapsible = CollapsiblePrimitive.Root;
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+function CollapsibleTrigger({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      ref={ref}
+      className={cn('cursor-pointer disabled:cursor-not-allowed', className)}
+      {...props}
+    />
+  );
+}
 
 const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
 

--- a/src/app/src/components/ui/tabs.tsx
+++ b/src/app/src/components/ui/tabs.tsx
@@ -94,11 +94,15 @@ function TabsTrigger({
   children,
   icon,
   iconPosition = 'start',
+  style,
   ...props
 }: TabsTriggerProps) {
+  const triggerStyle = props.disabled ? style : { ...style, cursor: 'pointer' };
+
   return (
     <TabsPrimitive.Trigger
       ref={ref}
+      style={triggerStyle}
       className={cn(
         // Base styles
         'inline-flex cursor-pointer items-center whitespace-nowrap text-sm font-medium transition-all',

--- a/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
@@ -355,6 +355,18 @@ describe('Plugins', () => {
       expect(screen.getByRole('tab', { name: /Custom Policies/ })).toBeInTheDocument();
     });
 
+    it('should use pointer cursor styles on tab triggers', () => {
+      renderWithProviders(<Plugins onNext={mockOnNext} onBack={mockOnBack} />);
+
+      expect(screen.getByRole('tab', { name: /Plugins/ })).toHaveStyle({ cursor: 'pointer' });
+      expect(screen.getByRole('tab', { name: /Custom Intents/ })).toHaveStyle({
+        cursor: 'pointer',
+      });
+      expect(screen.getByRole('tab', { name: /Custom Policies/ })).toHaveStyle({
+        cursor: 'pointer',
+      });
+    });
+
     it('should have the Plugins tab selected by default', () => {
       renderWithProviders(<Plugins onNext={mockOnNext} onBack={mockOnBack} />);
 

--- a/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
@@ -228,6 +228,20 @@ describe('PluginsTab', () => {
         expect(screen.getByTestId(`plugin-list-item-${brandPlugins[0]}`)).toBeInTheDocument();
       });
 
+      test('Category filter tabs use pointer cursor', async () => {
+        renderComponent();
+
+        expect(screen.getByRole('button', { name: 'All' })).toHaveClass('cursor-pointer');
+        expect(screen.getByRole('button', { name: /Security & Access Control/i })).toHaveClass(
+          'cursor-pointer',
+        );
+        expect(screen.getByRole('button', { name: /Compliance & Legal/i })).toHaveClass(
+          'cursor-pointer',
+        );
+        expect(screen.getByRole('button', { name: 'Select all' })).toHaveClass('cursor-pointer');
+        expect(screen.getByRole('button', { name: 'Select none' })).toHaveClass('cursor-pointer');
+      });
+
       test('Selecting "All" renders correct plugins', async () => {
         const user = userEvent.setup();
 

--- a/src/app/src/pages/redteam/setup/components/PluginsTab.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginsTab.tsx
@@ -440,7 +440,7 @@ export default function PluginsTab({
                 type="button"
                 onClick={() => setSelectedCategory(undefined)}
                 className={cn(
-                  'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-sm font-medium transition-all',
+                  'inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-sm font-medium transition-all',
                   selectedCategory === undefined
                     ? 'border-primary bg-primary text-primary-foreground shadow-sm'
                     : 'border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-muted/50 hover:text-foreground',
@@ -454,7 +454,7 @@ export default function PluginsTab({
                   type="button"
                   onClick={() => handleCategoryToggle(filter.key)}
                   className={cn(
-                    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-sm font-medium transition-all',
+                    'inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-sm font-medium transition-all',
                     selectedCategory === filter.key
                       ? 'border-primary bg-primary text-primary-foreground shadow-sm'
                       : 'border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-muted/50 hover:text-foreground',
@@ -495,7 +495,7 @@ export default function PluginsTab({
             <div className="mb-4 flex justify-end gap-4">
               <button
                 type="button"
-                className="text-sm text-primary hover:underline"
+                className="cursor-pointer text-sm text-primary hover:underline"
                 onClick={() => {
                   // Collect all filtered plugins and merge with existing selection
                   setSelectedPlugins(
@@ -507,7 +507,7 @@ export default function PluginsTab({
               </button>
               <button
                 type="button"
-                className="text-sm text-primary hover:underline"
+                className="cursor-pointer text-sm text-primary hover:underline"
                 onClick={() => {
                   // Remove only the filtered plugins from selection
                   const filteredPluginIds = new Set(filteredPlugins.map((p) => p.plugin));


### PR DESCRIPTION
Use shared UI wrappers so redteam setup tabs and collapsible triggers consistently show pointer cursors.
Update PluginsTab category and bulk action controls to include cursor-pointer.
Add test coverage for Plugins tabs and PluginsTab category controls, including the new cursor expectations.