### PR TITLE
feat(eval-creator): add yaml download and cli callout

### DIFF
--- a/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
@@ -73,6 +73,9 @@ vi.mock('@mui/icons-material/Upload', () => ({
 describe('YamlEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.URL.createObjectURL = vi.fn(() => 'blob:yaml-editor-test');
+    global.URL.revokeObjectURL = vi.fn();
+
     // Reset mock to default return value
     mockGetTestSuite.mockReturnValue({
       description: 'Test suite',
@@ -91,9 +94,24 @@ describe('YamlEditor', () => {
 
     expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Discard Changes/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Download YAML/ })).toBeInTheDocument();
+    expect(screen.getByText('Run in CLI')).toBeInTheDocument();
+    expect(screen.getByText('promptfoo eval -c promptfooconfig.yaml')).toBeInTheDocument();
 
     const editor = screen.getByTestId('yaml-editor') as HTMLTextAreaElement;
     expect(editor.disabled).toBe(false);
+  });
+
+  it('downloads the current YAML when Download YAML is clicked', () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    render(<YamlEditorComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download YAML/ }));
+
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickSpy).toHaveBeenCalled();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('blob:yaml-editor-test');
+    expect(mockShowToast).toHaveBeenCalledWith('Downloaded promptfooconfig.yaml', 'success');
   });
 
   it.skip('switches to edit mode when Edit button is clicked', () => {
@@ -243,6 +261,8 @@ describe('YamlEditor', () => {
     // Action bar should be hidden when readOnly is true
     expect(screen.queryByRole('button', { name: /Save/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Discard Changes/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Download YAML/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('Run in CLI')).not.toBeInTheDocument();
 
     // Editor should still be rendered
     const editor = screen.getByTestId('yaml-editor') as HTMLTextAreaElement;

--- a/src/app/src/pages/eval-creator/components/YamlEditor.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Alert, AlertContent, AlertDescription } from '@app/components/ui/alert';
 import { Button } from '@app/components/ui/button';
 import { CopyButton } from '@app/components/ui/copy-button';
-import { CancelIcon, SaveIcon } from '@app/components/ui/icons';
+import { CancelIcon, DownloadIcon, SaveIcon, TerminalIcon } from '@app/components/ui/icons';
 import { useToast } from '@app/hooks/useToast';
 import { cn } from '@app/lib/utils';
 import { useStore } from '@app/stores/evalConfig';
@@ -23,6 +23,8 @@ interface YamlEditorProps {
 // Schema comment that should always be at the top of the YAML file
 const YAML_SCHEMA_COMMENT =
   '# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json';
+const YAML_DOWNLOAD_FILE_NAME = 'promptfooconfig.yaml';
+const EVAL_CLI_COMMAND = `promptfoo eval -c ${YAML_DOWNLOAD_FILE_NAME}`;
 
 // Ensure the schema comment is at the top of YAML content
 const ensureSchemaComment = (yamlContent: string): string => {
@@ -90,6 +92,17 @@ const YamlEditorComponent = ({ initialConfig, readOnly = false, initialYaml }: Y
     showToast('Changes discarded', 'info');
   };
 
+  const handleDownload = () => {
+    const blob = new Blob([code], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = YAML_DOWNLOAD_FILE_NAME;
+    link.click();
+    URL.revokeObjectURL(url);
+    showToast(`Downloaded ${YAML_DOWNLOAD_FILE_NAME}`, 'success');
+  };
+
   // Initial load effect
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   React.useEffect(() => {
@@ -120,7 +133,7 @@ const YamlEditorComponent = ({ initialConfig, readOnly = false, initialYaml }: Y
       {/* Action bar */}
       {!readOnly && (
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button size="sm" onClick={handleSave} disabled={!hasUnsavedChanges}>
               <SaveIcon className="size-4 mr-2" />
               Save
@@ -134,6 +147,10 @@ const YamlEditorComponent = ({ initialConfig, readOnly = false, initialYaml }: Y
               <CancelIcon className="size-4 mr-2" />
               Discard Changes
             </Button>
+            <Button variant="outline" size="sm" onClick={handleDownload}>
+              <DownloadIcon className="size-4 mr-2" />
+              Download YAML
+            </Button>
           </div>
           {hasUnsavedChanges && (
             <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
@@ -141,6 +158,28 @@ const YamlEditorComponent = ({ initialConfig, readOnly = false, initialYaml }: Y
             </span>
           )}
         </div>
+      )}
+
+      {!readOnly && (
+        <Alert variant="info" className="items-start">
+          <TerminalIcon className="size-4 mt-0.5" />
+          <AlertContent className="space-y-2">
+            <p className="font-medium text-sm">Run in CLI</p>
+            <AlertDescription>
+              Download this file as <code>{YAML_DOWNLOAD_FILE_NAME}</code>, then run:
+            </AlertDescription>
+            <div className="relative">
+              <code className="block rounded bg-background/70 px-3 py-2 pr-12 text-sm font-mono">
+                {EVAL_CLI_COMMAND}
+              </code>
+              <CopyButton
+                value={EVAL_CLI_COMMAND}
+                className="absolute right-2 top-1.5"
+                aria-label="Copy CLI command"
+              />
+            </div>
+          </AlertContent>
+        </Alert>
       )}
 
       {/* Error display */}


### PR DESCRIPTION
- Add a first-class Download YAML action in the eval YAML editor.
- Add a Run in CLI callout with a copyable command

# Before

<img width="1592" height="828" alt="image" src="https://github.com/user-attachments/assets/0f23a1f6-51bf-40c5-8137-a40a971f3115" />

# After

<img width="1590" height="842" alt="image" src="https://github.com/user-attachments/assets/54bbe32f-6412-45bf-b1fd-f71769ce2339" />
