### PR TITLE
fix(redteam): propagate sessionId to context.vars in hydra stateful mode

### DIFF
--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -630,6 +630,14 @@ export class HydraProvider implements ApiProvider {
       if (this.stateful && targetResponse.sessionId) {
         this.sessionId = targetResponse.sessionId;
         sessionIds.push(targetResponse.sessionId);
+        vars['sessionId'] = targetResponse.sessionId;
+        if (!context) {
+          context = {
+            vars: { ...vars, sessionId: targetResponse.sessionId },
+            prompt,
+          };
+        }
+        context.vars['sessionId'] = targetResponse.sessionId;
       }
 
       // Externalize blobs to avoid token bloat in Hydra/meta prompts

--- a/test/redteam/providers/hydra/index.test.ts
+++ b/test/redteam/providers/hydra/index.test.ts
@@ -504,6 +504,73 @@ describe('HydraProvider', () => {
       );
       expect(escapedCall).toBeDefined();
     });
+
+    it('should propagate sessionId to context.vars in stateful mode', async () => {
+      mockAgentProvider.callApi.mockResolvedValue({
+        output: 'Attack message',
+        tokenUsage: { total: 100, prompt: 50, completion: 50 },
+      });
+
+      mockTargetProvider.callApi.mockResolvedValue({
+        output: 'Target response',
+        sessionId: 'session-456',
+        tokenUsage: { total: 50, prompt: 25, completion: 25 },
+      });
+
+      const provider = new HydraProvider({
+        injectVar: 'input',
+        maxTurns: 2,
+        stateful: true,
+      });
+
+      const context: CallApiContextParams = {
+        originalProvider: mockTargetProvider,
+        vars: { input: 'test goal' },
+        prompt: { raw: 'test prompt', label: 'test' },
+        test: {
+          assert: [{ type: 'harmful:test' }],
+          metadata: { goal: 'test goal', pluginId: 'harmful:test' },
+        } as any,
+      };
+
+      const result = await provider.callApi('', context);
+
+      expect(context.vars['sessionId']).toBe('session-456');
+      expect(result.metadata?.sessionId).toBe('session-456');
+    });
+
+    it('should not propagate sessionId to context.vars in stateless mode', async () => {
+      mockAgentProvider.callApi.mockResolvedValue({
+        output: 'Attack message',
+        tokenUsage: { total: 100, prompt: 50, completion: 50 },
+      });
+
+      mockTargetProvider.callApi.mockResolvedValue({
+        output: 'Target response',
+        sessionId: 'session-789',
+        tokenUsage: { total: 50, prompt: 25, completion: 25 },
+      });
+
+      const provider = new HydraProvider({
+        injectVar: 'input',
+        maxTurns: 1,
+        stateful: false,
+      });
+
+      const context: CallApiContextParams = {
+        originalProvider: mockTargetProvider,
+        vars: { input: 'test goal' },
+        prompt: { raw: 'test prompt', label: 'test' },
+        test: {
+          assert: [{ type: 'harmful:test' }],
+          metadata: { goal: 'test goal', pluginId: 'harmful:test' },
+        } as any,
+      };
+
+      await provider.callApi('', context);
+
+      expect(context.vars['sessionId']).toBeUndefined();
+    });
   });
 
   describe('callApi() - stateless mode', () => {


### PR DESCRIPTION
## Summary
- Hydra's stateful mode captured `sessionId` from target responses but never updated `context.vars.sessionId`, unlike crescendo which does
- Custom JS providers (file:// providers) rely on `context.vars.sessionId` to reuse WebSocket/session connections across turns
- This fix aligns hydra's session handling with crescendo's pattern

## Test plan
- [x] Added test: sessionId propagates to `context.vars` in stateful mode
- [x] Added test: sessionId does not propagate in stateless mode
- [x] All 41 hydra tests pass
- [x] All 51 crescendo tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)