### PR TITLE
docs(site): add remote Ollama server setup to ollama docs

### DIFF
--- a/site/docs/providers/ollama.md
+++ b/site/docs/providers/ollama.md
@@ -199,6 +199,26 @@ Popular Ollama embedding models include:
 - `ollama:embeddings:mxbai-embed-large` - High-quality embeddings
 - `ollama:embeddings:all-minilm` - Lightweight, fast embeddings
 
+## Using a Remote Ollama Server
+
+To connect to Ollama running on another machine (e.g., a more powerful server on your local network), set `OLLAMA_BASE_URL` to the remote address:
+
+```bash
+export OLLAMA_BASE_URL="http://192.168.1.100:11434"
+```
+
+Or in a `.env` file:
+
+```
+OLLAMA_BASE_URL=http://192.168.1.100:11434
+```
+
+```bash
+promptfoo eval -c promptfooconfig.yaml --env-file .env
+```
+
+Make sure the Ollama server is listening on `0.0.0.0` so it accepts remote connections. For Docker Compose, this is typically the default. If running Ollama directly, set `OLLAMA_HOST=0.0.0.0:11434` before starting the server.
+
 ## `localhost` and IPv4 vs IPv6
 
 If locally developing with `localhost` (promptfoo's default),


### PR DESCRIPTION
## Summary
- Add a "Using a Remote Ollama Server" section to the Ollama provider docs
- Documents how to set `OLLAMA_BASE_URL` for connecting to Ollama on another machine
- Notes the need for Ollama to listen on `0.0.0.0` for remote connections

Closes #7968

## Test plan
- [ ] Verify docs build: `cd site && SKIP_OG_GENERATION=true npm run build`