### PR TITLE
fix(redteam): honor config.model for openai:chat

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -133,6 +133,13 @@ interface ProviderFactory {
   ) => Promise<ApiProvider>;
 }
 
+function getConfiguredOpenAiModel(providerOptions: ProviderOptions): string | undefined {
+  const configuredModel = providerOptions.config?.model;
+  return typeof configuredModel === 'string' && configuredModel.trim().length > 0
+    ? configuredModel
+    : undefined;
+}
+
 export const providerMap: ProviderFactory[] = [
   createScriptBasedProviderFactory('exec', null, ScriptCompletionProvider),
   createScriptBasedProviderFactory('golang', 'go', GolangProvider),
@@ -881,6 +888,7 @@ export const providerMap: ProviderFactory[] = [
       const splits = providerPath.split(':');
       const modelType = splits[1];
       const modelName = splits.slice(2).join(':');
+      const configuredModel = getConfiguredOpenAiModel(providerOptions);
 
       // Codex SDK providers (openai:codex-sdk or openai:codex)
       if (modelType === 'codex-sdk' || modelType === 'codex') {
@@ -891,30 +899,45 @@ export const providerMap: ProviderFactory[] = [
         });
       }
       if (modelType === 'chat') {
-        return new OpenAiChatCompletionProvider(modelName || 'gpt-4.1-2025-04-14', providerOptions);
+        return new OpenAiChatCompletionProvider(
+          modelName || configuredModel || 'gpt-4.1-2025-04-14',
+          providerOptions,
+        );
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {
-        return new OpenAiEmbeddingProvider(modelName || 'text-embedding-3-large', providerOptions);
+        return new OpenAiEmbeddingProvider(
+          modelName || configuredModel || 'text-embedding-3-large',
+          providerOptions,
+        );
       }
       if (modelType === 'completion') {
-        return new OpenAiCompletionProvider(modelName || 'gpt-3.5-turbo-instruct', providerOptions);
+        return new OpenAiCompletionProvider(
+          modelName || configuredModel || 'gpt-3.5-turbo-instruct',
+          providerOptions,
+        );
       }
       if (modelType === 'moderation') {
-        return new OpenAiModerationProvider(modelName || 'omni-moderation-latest', providerOptions);
+        return new OpenAiModerationProvider(
+          modelName || configuredModel || 'omni-moderation-latest',
+          providerOptions,
+        );
       }
       if (modelType === 'realtime') {
         return new OpenAiRealtimeProvider(
-          modelName || 'gpt-4o-realtime-preview-2024-12-17',
+          modelName || configuredModel || 'gpt-4o-realtime-preview-2024-12-17',
           providerOptions,
         );
       }
       if (modelType === 'responses') {
-        return new OpenAiResponsesProvider(modelName || 'gpt-4.1-2025-04-14', providerOptions);
+        return new OpenAiResponsesProvider(
+          modelName || configuredModel || 'gpt-4.1-2025-04-14',
+          providerOptions,
+        );
       }
       if (modelType === 'transcription') {
         const { OpenAiTranscriptionProvider } = await import('./openai/transcription');
         return new OpenAiTranscriptionProvider(
-          modelName || 'gpt-4o-transcribe-diarize',
+          modelName || configuredModel || 'gpt-4o-transcribe-diarize',
           providerOptions,
         );
       }

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -484,6 +484,18 @@ describe('loadApiProvider', () => {
     expect(provider).toBeDefined();
   });
 
+  it('should load OpenAI chat provider with model from config when ID has no model', async () => {
+    const provider = await loadApiProvider('openai:chat', {
+      options: {
+        config: {
+          model: 'DeepSeek-R1',
+        },
+      },
+    });
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('DeepSeek-R1', expect.any(Object));
+    expect(provider).toBeDefined();
+  });
+
   it('should load OpenAI embedding provider', async () => {
     const provider = await loadApiProvider('openai:embedding');
     expect(OpenAiEmbeddingProvider).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- fix OpenAI provider resolution so `openai:chat` uses `config.model` when the provider id omits a model segment
- keep existing behavior when a model is provided in the id (`openai:chat:<model>`), which still takes precedence
- add regression coverage for `loadApiProvider('openai:chat', { config: { model: 'DeepSeek-R1' } })`

## Why
Issue #7880 reports redteam generation still calling `gpt-4.1-2025-04-14` even when users set:
- `redteam.provider.id: openai:chat`
- `redteam.provider.config.model: <non-OpenAI model>`

Root cause: the OpenAI registry factory ignored `config.model` for `openai:chat` and fell back to the default model.

## Changes
- `src/providers/registry.ts`
  - add `getConfiguredOpenAiModel(...)`
  - use `modelName || configuredModel || <default>` in OpenAI factory branches
- `test/providers.test.ts`
  - add test asserting `config.model` is used when id is `openai:chat`

## Validation
- `npm run l`
- `npm run f`
- `npx vitest test/providers.test.ts -t "OpenAI chat provider"`
- `npx vitest test/providers/index.test.ts -t "openai:chat"`
- local redteam e2e repro with a mock OpenAI-compatible endpoint:
  - full `redteam run --force` passed generation + eval
  - all captured provider calls used `DeepSeek-R1`
  - no calls to `gpt-4.1-2025-04-14`

Fixes #7880
