### PR TITLE
chore: enable noDuplicateClasses and update biome schema

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -40,6 +40,7 @@
   "assist": {
     "actions": {
       "source": {
+        "noDuplicateClasses": "on",
         "organizeImports": {
           "level": "on",
           "options": {


### PR DESCRIPTION
## Summary

- Enable the `noDuplicateClasses` Biome assist action to detect and auto-fix duplicate CSS classes in JSX (`className`, `class`, `clsx`, `cn`, `cva`)
- Update Biome schema version from 2.4.4 to 2.4.5 to match the installed CLI version

The `noDuplicateClasses` rule was added upstream in [biomejs/biome#8623](https://github.com/biomejs/biome/pull/8623) and is available since Biome 2.4.0. No existing violations in the codebase.

## Test plan

- [x] `npx biome check --only=source/noDuplicateClasses src/ test/` passes with no violations
- [x] Schema version warning resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)