### PR TITLE
fix(matchers): handle missing context-faithfulness verdicts

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1537,16 +1537,24 @@ export async function matchesContextFaithfulness(
   let finalAnswer = 'Final verdict for each statement in order:';
   finalAnswer = finalAnswer.toLowerCase();
   let verdicts = resp.output.toLowerCase().trim();
-  let score: number;
-  if (verdicts.includes(finalAnswer)) {
-    verdicts = verdicts.slice(verdicts.indexOf(finalAnswer) + finalAnswer.length);
-    score =
-      verdicts.split('.').filter((answer) => answer.trim() !== '' && !answer.includes('yes'))
-        .length / statements.length;
-  } else {
-    score = (verdicts.split('verdict: no').length - 1) / statements.length;
+  let score = 0;
+  if (statements.length > 0) {
+    if (verdicts.includes(finalAnswer)) {
+      verdicts = verdicts.slice(verdicts.indexOf(finalAnswer) + finalAnswer.length);
+      const parsedVerdicts = verdicts.split('.').filter((answer) => answer.trim() !== '');
+      if (parsedVerdicts.length > 0) {
+        score =
+          1 - parsedVerdicts.filter((answer) => !answer.includes('yes')).length / statements.length;
+      }
+    } else {
+      const noVerdictCount = verdicts.split('verdict: no').length - 1;
+      const yesVerdictCount = verdicts.split('verdict: yes').length - 1;
+      if (noVerdictCount + yesVerdictCount > 0) {
+        score = 1 - noVerdictCount / statements.length;
+      }
+    }
   }
-  score = 1 - score;
+  score = Math.min(1, Math.max(0, score));
   const pass = score >= threshold - Number.EPSILON;
   return {
     pass,

--- a/test/matchers/context-faithfulness.test.ts
+++ b/test/matchers/context-faithfulness.test.ts
@@ -48,7 +48,9 @@ describe('matchesContextFaithfulness', () => {
         });
       });
 
-    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
 
     await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
       pass: true,
@@ -86,7 +88,9 @@ describe('matchesContextFaithfulness', () => {
         });
       });
 
-    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
 
     await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
       pass: false,
@@ -118,6 +122,87 @@ describe('matchesContextFaithfulness', () => {
       cached: 0,
       completionDetails: expect.any(Object),
       numRequests: 0,
+    });
+  });
+
+  it('should fail when no verdict markers are returned', async () => {
+    const query = 'Query text';
+    const output = 'Output text';
+    const context = 'Context text';
+    const threshold = 0.5;
+
+    const mockCallApi = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Statement 1\nStatement 2\nStatement 3',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output:
+            'I apologize, but I cannot create statements or provide an analysis based on the given context.',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      });
+
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
+
+    await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
+      pass: false,
+      reason: 'Faithfulness 0.00 is < 0.5',
+      score: 0,
+      tokensUsed: {
+        total: expect.any(Number),
+        prompt: expect.any(Number),
+        completion: expect.any(Number),
+        cached: expect.any(Number),
+        completionDetails: expect.any(Object),
+        numRequests: 0,
+      },
+    });
+  });
+
+  it('should clamp score when verdict count exceeds statement count', async () => {
+    const query = 'Query text';
+    const output = 'Output text';
+    const context = 'Context text';
+    const threshold = 0.5;
+
+    const mockCallApi = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Statement 1\nStatement 2\nStatement 3',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'verdict: no\nverdict: no\nverdict: no\nverdict: no\nverdict: no',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      });
+
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
+
+    await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
+      pass: false,
+      reason: 'Faithfulness 0.00 is < 0.5',
+      score: 0,
+      tokensUsed: {
+        total: expect.any(Number),
+        prompt: expect.any(Number),
+        completion: expect.any(Number),
+        cached: expect.any(Number),
+        completionDetails: expect.any(Object),
+        numRequests: 0,
+      },
     });
   });
 


### PR DESCRIPTION
Prevent context-faithfulness from incorrectly passing when the grader output has no parseable verdict markers.

Clamp the computed score to [0, 1] and add regression tests for both missing-verdict output and excessive `verdict: no` counts.

https://linear.app/promptfooo/issue/ENG-341/faithfulness-calculation-with-no-verdicts-not-covered
