### PR TITLE
feat(providers): expose all choices in metadata when n > 1

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -158,6 +158,20 @@ interface OpenAiConfig {
 }
 ```
 
+### Generating Multiple Responses
+
+Use `passthrough` to set OpenAI's `n` parameter for generating multiple responses in a single request:
+
+```yaml
+providers:
+  - id: openai:chat:gpt-4o
+    config:
+      passthrough:
+        n: 3 # Generate 3 responses
+```
+
+When `n > 1`, the primary `output` contains the first choice's content, and all generated choices are available in the response metadata under `metadata.choices`. Each choice includes the full response object with `message`, `finish_reason`, and `index`.
+
 ## Models
 
 ### GPT-4.1

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -805,6 +805,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
             statusText,
             headers: responseHeaders ?? {},
           },
+          // Include all choices for multi-response requests (n > 1)
+          ...(data.choices.length > 1 && { choices: data.choices }),
         },
       };
     } catch (err) {

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -116,6 +116,55 @@ describe('OpenAI Provider', () => {
       expect(result.metadata?.http?.headers).toEqual(mockHeaders);
     });
 
+    it('should include all choices in metadata when n > 1', async () => {
+      const mockChoices = [
+        { message: { content: 'First response' }, index: 0 },
+        { message: { content: 'Second response' }, index: 1 },
+        { message: { content: 'Third response' }, index: 2 },
+      ];
+      const mockResponse = {
+        data: {
+          choices: mockChoices,
+          usage: { total_tokens: 30, prompt_tokens: 10, completion_tokens: 20 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetchWithCache.mockResolvedValue(mockResponse);
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
+      const result = await provider.callApi(
+        JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
+      );
+
+      expect(result.output).toBe('First response');
+      expect(result.metadata?.choices).toBeDefined();
+      expect(result.metadata?.choices).toHaveLength(3);
+      expect(result.metadata?.choices).toEqual(mockChoices);
+    });
+
+    it('should not include choices in metadata when n = 1', async () => {
+      const mockResponse = {
+        data: {
+          choices: [{ message: { content: 'Single response' }, index: 0 }],
+          usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetchWithCache.mockResolvedValue(mockResponse);
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
+      const result = await provider.callApi(
+        JSON.stringify([{ role: 'user', content: 'Test prompt' }]),
+      );
+
+      expect(result.output).toBe('Single response');
+      expect(result.metadata?.choices).toBeUndefined();
+    });
+
     it('should include HTTP metadata in error response', async () => {
       const mockResponse = {
         data: { error: { message: 'Rate limit exceeded' } },


### PR DESCRIPTION
## Summary

- Expose all OpenAI completion choices in response metadata when `n > 1`
- Previously only the first choice was accessible; additional choices were discarded
- Enables evaluation test harnesses to access all generated responses

## Changes

- Add conditional spread to include `choices` array in metadata when `data.choices.length > 1`
- Add tests verifying choices are included for `n > 1` and absent for `n = 1`
- Document the `n` parameter usage and `metadata.choices` in provider docs

## Test plan

- [x] Unit tests for `n > 1` case (verify `metadata.choices` populated)
- [x] Unit tests for `n = 1` case (verify `metadata.choices` absent)
- [x] Manual test with `n: 2` configuration
- [x] Manual test with `n: 1` configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)