### PR TITLE
fix: narrow _conversation detection

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -67,6 +67,7 @@ import {
   isProviderAllowed,
 } from './util/provider';
 import { promptYesNo } from './util/readline';
+import { templateUsesVariable } from './util/templates';
 import { sleep } from './util/time';
 import { TokenUsageTracker } from './util/tokenUsage';
 import {
@@ -92,6 +93,12 @@ import type {
   VarValue,
 } from './types/index';
 import type { CallApiContextParams } from './types/providers';
+
+const CONVERSATION_VAR_NAME = '_conversation';
+
+function promptUsesConversationVariable(prompt: Prompt): boolean {
+  return templateUsesVariable(prompt.raw, CONVERSATION_VAR_NAME);
+}
 
 /**
  * Manages a single progress bar for the evaluation
@@ -326,7 +333,7 @@ export async function runEval({
   const fileMetadata = collectFileMetadata(test.vars || vars);
 
   const conversationKey = `${provider.label || provider.id()}:${prompt.id}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
-  const usesConversation = prompt.raw.includes('_conversation');
+  const usesConversation = promptUsesConversationVariable(prompt);
   if (
     !getEnvBool('PROMPTFOO_DISABLE_CONVERSATION_VAR') &&
     !test.options?.disableConversationVar &&
@@ -1461,11 +1468,11 @@ class Evaluator {
     // Determine run parameters
 
     if (concurrency > 1) {
-      const usesConversation = prompts.some((p) => p.raw.includes('_conversation'));
+      const usesConversation = prompts.some(promptUsesConversationVariable);
       const usesStoreOutputAs = tests.some((t) => t.options?.storeOutputAs);
       if (usesConversation) {
         logger.info(
-          `Setting concurrency to 1 because the ${chalk.cyan('_conversation')} variable is used.`,
+          `Setting concurrency to 1 because the ${chalk.cyan(CONVERSATION_VAR_NAME)} variable is used.`,
         );
         concurrency = 1;
       } else if (usesStoreOutputAs) {
@@ -2284,7 +2291,7 @@ class Evaluator {
       this.evalRecord.results.length > 0 ? totalLatencyMs / this.evalRecord.results.length : 0;
 
     // Detect key feature usage patterns
-    const usesConversationVar = prompts.some((p) => p.raw.includes('_conversation'));
+    const usesConversationVar = prompts.some(promptUsesConversationVariable);
     const usesTransforms = Boolean(
       tests.some((t) => t.options?.transform || t.options?.postprocess) ||
         testSuite.providers.some((p) => Boolean(p.transform)),

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -4,6 +4,8 @@ import { getEnvBool } from '../envars';
 
 import type { NunjucksFilterMap } from '../types/index';
 
+const TEMPLATE_COMMENT_REGEX = /\{#[\s\S]*?#\}/g;
+
 /**
  * Get a Nunjucks engine instance with optional filters and configuration.
  * @param filters - Optional map of custom Nunjucks filters.
@@ -63,10 +65,9 @@ export function extractVariablesFromTemplate(template: string): string[] {
   const variableSet = new Set<string>();
   const regex =
     /\{\{[\s]*([^{}\s|]+)[\s]*(?:\|[^}]+)?\}\}|\{%[\s]*(?:if|for)[\s]+([^{}\s]+)[\s]*.*?%\}/g;
-  const commentRegex = /\{#[\s\S]*?#\}/g;
 
   // Remove comments
-  template = template.replace(commentRegex, '');
+  template = template.replace(TEMPLATE_COMMENT_REGEX, '');
 
   let match;
   while ((match = regex.exec(template)) !== null) {
@@ -85,6 +86,23 @@ export function extractVariablesFromTemplate(template: string): string[] {
   }
 
   return Array.from(variableSet);
+}
+
+/**
+ * Check whether a Nunjucks template references a variable as an actual template identifier.
+ * This ignores plain text and property access on other variables.
+ */
+export function templateUsesVariable(template: string, variableName: string): boolean {
+  if (!variableName) {
+    return false;
+  }
+
+  return extractVariablesFromTemplate(template).some(
+    (variable) =>
+      variable === variableName ||
+      variable.startsWith(`${variableName}[`) ||
+      variable.startsWith(`${variableName}.`),
+  );
 }
 
 /**

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -2152,6 +2152,31 @@ describe('evaluator', () => {
     expect(summary.results[1].response?.output).toBe('Second run First run ');
   });
 
+  it('does not force concurrency to 1 for _conversation substrings', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    let forcedConversationConcurrency = false;
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Summarize the pre_conversation_context for the user: {{ question }}')],
+      tests: [{ vars: { question: 'What changed?' } }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    try {
+      await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+      forcedConversationConcurrency = infoSpy.mock.calls.some(
+        ([message]) =>
+          typeof message === 'string' &&
+          message.includes('Setting concurrency to 1 because the') &&
+          message.includes('_conversation'),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+
+    expect(forcedConversationConcurrency).toBe(false);
+  });
+
   it('evaluate with labeled and unlabeled providers and providerPromptMap', async () => {
     const mockLabeledProvider: ApiProvider = {
       id: () => 'labeled-provider-id',

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -5,6 +5,7 @@ import {
   extractVariablesFromTemplate,
   extractVariablesFromTemplates,
   getNunjucksEngine,
+  templateUsesVariable,
 } from '../../src/util/templates';
 
 describe('extractVariablesFromTemplate', () => {
@@ -96,6 +97,29 @@ describe('extractVariablesFromTemplates', () => {
     const result = extractVariablesFromTemplates(templates);
 
     expect(result).toEqual(['name', 'age']);
+  });
+});
+
+describe('templateUsesVariable', () => {
+  it('should detect direct variable references and for loops', () => {
+    expect(templateUsesVariable('{{ _conversation[0].output }}', '_conversation')).toBe(true);
+    expect(
+      templateUsesVariable(
+        '{% for completion in _conversation %}{{ completion.output }}{% endfor %}',
+        '_conversation',
+      ),
+    ).toBe(true);
+  });
+
+  it('should ignore substring matches, comments, strings, and nested property names', () => {
+    const template = [
+      'Summarize the pre_conversation_context for {{ question }}',
+      '{# _conversation #}',
+      '{{ "_conversation" }}',
+      '{{ foo._conversation }}',
+    ].join(' ');
+
+    expect(templateUsesVariable(template, '_conversation')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Linear: [ENG-1976](https://linear.app/promptfooo/issue/ENG-1976/conversation-variable-detection-uses-naive-substring-match-causing)

This fixes the OSS false positive where `_conversation` detection was using a raw substring match and could force concurrency to `1` for prompts that only contained text like `pre_conversation_context`.

The tradeoff here is deliberate: this uses the existing template variable extraction path instead of adding more parsing machinery. That covers direct `_conversation` template references and loop usage while keeping the fix small and low-risk. It does not try to detect every possible control-flow-only reference such as a complex `{% if _conversation %}` expression.

Validation:
- `npx vitest run test/util/templates.test.ts`
- `npx vitest run test/evaluator.test.ts -t "_conversation"`
- `npx @biomejs/biome check src/util/templates.ts src/evaluator.ts test/util/templates.test.ts test/evaluator.test.ts` (warnings only from existing complexity rules)


Fixes https://github.com/promptfoo/promptfoo/issues/7845