### PR TITLE
docs(site): add announcement bar for OpenAI blog post

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -81,7 +81,7 @@ const config: Config = {
     announcementBar: {
       id: 'joining-openai',
       content:
-        '<strong>Promptfoo is joining OpenAI.</strong> <a href="/blog/promptfoo-joining-openai">Read the announcement →</a>',
+        '<strong>Promptfoo will be joining OpenAI.</strong> <a href="/blog/promptfoo-joining-openai">Read the announcement →</a>',
       backgroundColor: '#dc2626',
       textColor: '#ffffff',
       isCloseable: false,

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -412,3 +412,18 @@ html:not(.docs-wrapper) .DocSearch {
 
 /* Import custom pagination styles */
 @import url('./custom-pagination.css');
+
+/* Announcement bar link styling */
+div[class*='announcementBar'] a {
+  color: #ffffff;
+  text-decoration: none;
+  text-underline-offset: 2px;
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+
+div[class*='announcementBar'] a:hover {
+  color: #ffffff;
+  text-decoration: underline;
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- Add a site-wide announcement bar linking to the OpenAI blog post

## Test plan
- [ ] Verify banner renders on all pages
- [ ] Verify link navigates to blog post