### PR TITLE
docs(site): fix dark mode code highlights

### DIFF
--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -59,7 +59,6 @@
   --ifm-color-primary-lighter: #ffc6c6;
   --ifm-color-primary-lightest: #ffd9d9;
   --ifm-button-color: #fff;
-  /* Use a more specific selector so the light-mode :root value cannot override this in the built CSS. */
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
 
   /* Update background colors */


### PR DESCRIPTION
Fix the docs code-block highlighted-line styling in dark mode.

Use a more specific dark-theme selector so Docusaurus' later `:root` fallback does not override the dark highlight color.


Fixes this:

<img width="1040" height="906" alt="image" src="https://github.com/user-attachments/assets/d3cd90e4-8ebb-4f47-8e46-d794de4642b3" />

