### PR TITLE
fix: render rubric value with vars before grading

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -633,9 +633,17 @@ export async function matchesLlmRubric(
   }
 
   const rubricPrompt = await loadRubricPrompt(grading?.rubricPrompt, DEFAULT_GRADING_PROMPT);
+
+  // Render the rubric value with vars so that template variables like {{myVar}}
+  // are expanded before being passed to the grading LLM.
+  const renderedRubric =
+    typeof rubric === 'string'
+      ? nunjucks.renderString(rubric, vars || {})
+      : JSON.stringify(rubric);
+
   const prompt = await renderLlmRubricPrompt(rubricPrompt, {
     output: tryParse(llmOutput),
-    rubric,
+    rubric: renderedRubric,
     ...(vars || {}),
   });
 
@@ -654,7 +662,7 @@ export async function matchesLlmRubric(
     'llm-rubric',
     {
       output: tryParse(llmOutput),
-      rubric,
+      rubric: renderedRubric,
       ...(vars || {}),
     },
     providerCallContext,


### PR DESCRIPTION
When llm-rubric assertion is defined in defaultTest, template variables like {{myVar}} were not being resolved - the rubric received the literal string {{myVar}} instead of the test case's variable value.

This fix renders the rubric value with nunjucks using the vars before passing it to the grading LLM context.

Fixes #7861