### PR TITLE
fix(redteam): avoid router dependency in risk category drawer

### DIFF
--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.test.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.test.tsx
@@ -1,15 +1,10 @@
 import { renderWithProviders } from '@app/utils/testutils';
 import { fireEvent, screen } from '@testing-library/react';
-import { useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import RiskCategoryDrawer from './RiskCategoryDrawer';
 import type { AtomicTestCase, EvaluateResult, ResultFailureReason } from '@promptfoo/types';
 
 // Mock dependencies
-vi.mock('react-router-dom', () => ({
-  useNavigate: vi.fn(),
-}));
-
 vi.mock('../../../eval/components/EvalOutputPromptDialog', () => ({
   default: () => null,
 }));
@@ -23,8 +18,6 @@ vi.mock('./SuggestionsDialog', () => ({
 }));
 
 describe('RiskCategoryDrawer Component Navigation', () => {
-  const mockNavigate = vi.fn();
-
   // Create a mock test case
   const mockTestCase: AtomicTestCase = {
     vars: {},
@@ -79,47 +72,32 @@ describe('RiskCategoryDrawer Component Navigation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
-
-    // Mock window.open
-    global.window.open = vi.fn();
   });
 
-  it('should navigate to eval page when clicking View All Logs button', () => {
+  it('renders outside a router provider and links to filtered eval logs', () => {
     renderWithProviders(<RiskCategoryDrawer {...defaultProps} />);
 
-    const viewAllLogsButton = screen.getByText('View All Logs');
-
-    // Test normal click - should use navigate
-    fireEvent.click(viewAllLogsButton);
-
+    const viewAllLogsLink = screen.getByRole('link', { name: 'View All Logs' });
     const expectedUrl =
       '/eval/test-eval-123?filter=%5B%7B%22type%22%3A%22plugin%22%2C%22operator%22%3A%22equals%22%2C%22value%22%3A%22bola%22%7D%5D';
-    expect(mockNavigate).toHaveBeenCalledWith(expectedUrl);
-    expect(window.open).not.toHaveBeenCalled();
+    expect(viewAllLogsLink).toHaveAttribute('href', expectedUrl);
   });
 
-  it('should open in new tab when ctrl/cmd clicking View All Logs button', () => {
-    renderWithProviders(<RiskCategoryDrawer {...defaultProps} />);
+  it('falls back to the eval page when no plugin filter is available', () => {
+    const propsWithoutPluginId = {
+      ...defaultProps,
+      failures: [
+        {
+          ...defaultProps.failures[0],
+          result: createMockEvaluateResult({}),
+        },
+      ],
+    };
 
-    const viewAllLogsButton = screen.getByText('View All Logs');
+    renderWithProviders(<RiskCategoryDrawer {...propsWithoutPluginId} />);
 
-    // Test Ctrl+click - should open new tab
-    fireEvent.click(viewAllLogsButton, { ctrlKey: true });
-
-    const expectedUrl =
-      '/eval/test-eval-123?filter=%5B%7B%22type%22%3A%22plugin%22%2C%22operator%22%3A%22equals%22%2C%22value%22%3A%22bola%22%7D%5D';
-    expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
-    expect(mockNavigate).not.toHaveBeenCalled();
-
-    // Reset mocks
-    vi.clearAllMocks();
-
-    // Test Cmd+click (Mac) - should also open new tab
-    fireEvent.click(viewAllLogsButton, { metaKey: true });
-
-    expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
-    expect(mockNavigate).not.toHaveBeenCalled();
+    const viewAllLogsLink = screen.getByRole('link', { name: 'View All Logs' });
+    expect(viewAllLogsLink).toHaveAttribute('href', '/eval/test-eval-123');
   });
 
   it('should close drawer when close button is clicked', () => {

--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
@@ -13,7 +13,6 @@ import { cn } from '@app/lib/utils';
 import { getActualPrompt } from '@app/utils/providerResponse';
 import { categoryAliases, displayNameOverrides } from '@promptfoo/redteam/constants';
 import { ChevronDown, Lightbulb } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 import ChatMessages, { type Message } from '../../../eval/components/ChatMessages';
 import EvalOutputPromptDialog from '../../../eval/components/EvalOutputPromptDialog';
 import PluginStrategyFlow from './PluginStrategyFlow';
@@ -151,7 +150,6 @@ const RiskCategoryDrawer = ({
   }
 
   // All hooks must be called unconditionally after early returns
-  const navigate = useNavigate();
   const [suggestionsDialogOpen, setSuggestionsDialogOpen] = React.useState(false);
   const [currentGradingResult, setCurrentGradingResult] = React.useState<GradingResult | undefined>(
     undefined,
@@ -169,6 +167,21 @@ const RiskCategoryDrawer = ({
 
   const totalTests = numPassed + numFailed;
   const passPercentage = totalTests > 0 ? Math.round((numPassed / totalTests) * 100) : 0;
+  const firstFailure = failures[0];
+  const firstPass = passes[0];
+  const pluginId = (firstFailure || firstPass)?.result?.metadata?.pluginId;
+  const filterParam = pluginId
+    ? encodeURIComponent(
+        JSON.stringify([
+          {
+            type: 'plugin',
+            operator: 'equals',
+            value: pluginId,
+          },
+        ]),
+      )
+    : null;
+  const viewAllLogsUrl = filterParam ? `/eval/${evalId}?filter=${filterParam}` : `/eval/${evalId}`;
 
   if (totalTests === 0) {
     return (
@@ -304,34 +317,8 @@ const RiskCategoryDrawer = ({
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={(event) => {
-              const firstFailure = failures.length > 0 ? failures[0] : null;
-              const firstPass = passes.length > 0 ? passes[0] : null;
-              const testWithPluginId = firstFailure || firstPass;
-              const pluginId = testWithPluginId?.result?.metadata?.pluginId;
-
-              const filterParam = encodeURIComponent(
-                JSON.stringify([
-                  {
-                    type: 'plugin',
-                    operator: 'equals',
-                    value: pluginId,
-                  },
-                ]),
-              );
-
-              const url = pluginId ? `/eval/${evalId}?filter=${filterParam}` : `/eval/${evalId}`;
-              if (event.ctrlKey || event.metaKey) {
-                window.open(url, '_blank');
-              } else {
-                navigate(url);
-              }
-            }}
-          >
-            View All Logs
+          <Button variant="outline" className="w-full" asChild>
+            <a href={viewAllLogsUrl}>View All Logs</a>
           </Button>
 
           <Tabs


### PR DESCRIPTION
This fixes the redteam report crash when the risk category drawer renders without a compatible router context.

It changes the View All Logs action to a normal link and adds a regression test that renders the drawer outside a router provider.