### PR TITLE
feat(examples): add RAG failure checklist eval starter

### DIFF
--- a/examples/rag-failure-checklist/README.md
+++ b/examples/rag-failure-checklist/README.md
@@ -4,11 +4,13 @@
 npx promptfoo@latest init --example rag-failure-checklist
 ````
 
-This example shows how to model a small set of common RAG and agent failure patterns as reproducible promptfoo evaluations.
+This example shows how to model a small set of common RAG and agent failure
+patterns as reproducible promptfoo evaluations.
 
 The goal is not to define a full benchmarking framework.
 
-Instead, this starter gives users a practical way to test a few high-signal failure modes that often show up in real pipelines:
+Instead, this starter gives users a practical way to test a few high-signal
+failure modes that often show up in real pipelines:
 
 * retrieval mismatch
 * weak grounding
@@ -20,7 +22,8 @@ Instead, this starter gives users a practical way to test a few high-signal fail
 
 In many RAG and agent workflows, failures do not look like obvious crashes.
 
-The system may return a fluent answer, but the answer can still be wrong because:
+The system may return a fluent answer, but the answer can still be wrong
+because:
 
 * retrieved context does not match the question
 * the answer is not grounded in the provided evidence
@@ -53,15 +56,18 @@ This example is not:
 * a complete benchmark for every RAG failure mode
 * tied to any specific vector database or retrieval framework
 * a replacement for end-to-end system tracing
-* a claim that one prompt or one assertion type is sufficient for production evaluation
+* a claim that one prompt or one assertion type is sufficient for production
+  evaluation
 
-It is intentionally small so that the integration path is easy to review and extend.
+It is intentionally small so that the integration path is easy to review and
+extend.
 
 ## Starter failure patterns
 
 ### 1. Retrieval mismatch
 
-The question is reasonable, but the retrieved context does not actually support the expected answer.
+The question is reasonable, but the retrieved context does not actually support
+the expected answer.
 
 Typical symptom:
 
@@ -71,7 +77,8 @@ Typical symptom:
 
 ### 2. Weak grounding
 
-The answer sounds plausible, but the retrieved context does not justify the claim.
+The answer sounds plausible, but the retrieved context does not justify the
+claim.
 
 Typical symptom:
 
@@ -81,7 +88,8 @@ Typical symptom:
 
 ### 3. Context drift across steps
 
-A later step in the workflow slowly moves away from the original task or instruction.
+A later step in the workflow slowly moves away from the original task or
+instruction.
 
 Typical symptom:
 
@@ -91,7 +99,8 @@ Typical symptom:
 
 ### 4. Overconfident unsupported answers
 
-The model responds with high confidence even when the context is incomplete or ambiguous.
+The model responds with high confidence even when the context is incomplete or
+ambiguous.
 
 Typical symptom:
 
@@ -132,14 +141,16 @@ Questions to ask:
 
 ## How to adapt this example
 
-The easiest way to extend this starter is to replace the sample cases with your own:
+The easiest way to extend this starter is to replace the sample cases with your
+own:
 
 * swap in your own retrieved passages
 * use your real prompts or system instructions
 * add assertions that match your reliability requirements
 * duplicate the existing pattern structure for new failure cases
 
-A good next step is to turn your most common support or QA complaints into eval cases.
+A good next step is to turn your most common support or QA complaints into eval
+cases.
 
 ## Suggested extension path
 
@@ -161,4 +172,5 @@ The intended integration path is:
 * make failure patterns concrete
 * let users replace the sample cases with their own RAG or agent workflows
 
-If the shape is useful, it can be extended into a broader set of reusable eval templates later.
+If the shape is useful, it can be extended into a broader set of reusable eval
+templates later.

--- a/examples/rag-failure-checklist/README.md
+++ b/examples/rag-failure-checklist/README.md
@@ -1,4 +1,8 @@
-# RAG Failure Checklist Eval Starter
+# rag-failure-checklist (RAG Failure Checklist Eval Starter)
+
+```bash
+npx promptfoo@latest init --example rag-failure-checklist
+````
 
 This example shows how to model a small set of common RAG and agent failure patterns as reproducible promptfoo evaluations.
 
@@ -6,11 +10,11 @@ The goal is not to define a full benchmarking framework.
 
 Instead, this starter gives users a practical way to test a few high-signal failure modes that often show up in real pipelines:
 
-- retrieval mismatch
-- weak grounding
-- context drift across steps
-- overconfident unsupported answers
-- stale context carryover
+* retrieval mismatch
+* weak grounding
+* context drift across steps
+* overconfident unsupported answers
+* stale context carryover
 
 ## Why this example exists
 
@@ -18,11 +22,11 @@ In many RAG and agent workflows, failures do not look like obvious crashes.
 
 The system may return a fluent answer, but the answer can still be wrong because:
 
-- retrieved context does not match the question
-- the answer is not grounded in the provided evidence
-- later steps drift away from the original task
-- the model sounds confident without support
-- old context leaks into the current turn
+* retrieved context does not match the question
+* the answer is not grounded in the provided evidence
+* later steps drift away from the original task
+* the model sounds confident without support
+* old context leaks into the current turn
 
 This example provides a small eval starter for those patterns.
 
@@ -30,26 +34,26 @@ This example provides a small eval starter for those patterns.
 
 This folder contains:
 
-- `promptfooconfig.yaml` with a small set of starter test cases
-- this README with usage notes and expected interpretation
+* `promptfooconfig.yaml` with a small set of starter test cases
+* this README with usage notes and expected interpretation
 
 ## What this example is for
 
 Use this example if you want to:
 
-- create a lightweight RAG reliability smoke test
-- evaluate common failure patterns before shipping changes
-- adapt a few starter scenarios to your own prompts, tools, or retrieval stack
-- turn vague quality complaints into reproducible eval cases
+* create a lightweight RAG reliability smoke test
+* evaluate common failure patterns before shipping changes
+* adapt a few starter scenarios to your own prompts, tools, or retrieval stack
+* turn vague quality complaints into reproducible eval cases
 
 ## What this example is not
 
 This example is not:
 
-- a complete benchmark for every RAG failure mode
-- tied to any specific vector database or retrieval framework
-- a replacement for end-to-end system tracing
-- a claim that one prompt or one assertion type is sufficient for production evaluation
+* a complete benchmark for every RAG failure mode
+* tied to any specific vector database or retrieval framework
+* a replacement for end-to-end system tracing
+* a claim that one prompt or one assertion type is sufficient for production evaluation
 
 It is intentionally small so that the integration path is easy to review and extend.
 
@@ -61,9 +65,9 @@ The question is reasonable, but the retrieved context does not actually support 
 
 Typical symptom:
 
-- the model answers from the wrong passage
-- the answer follows nearby but irrelevant content
-- the system appears to have "retrieved something" but not the right thing
+* the model answers from the wrong passage
+* the answer follows nearby but irrelevant content
+* the system appears to have "retrieved something" but not the right thing
 
 ### 2. Weak grounding
 
@@ -71,9 +75,9 @@ The answer sounds plausible, but the retrieved context does not justify the clai
 
 Typical symptom:
 
-- correct tone, weak evidence
-- unsupported specifics
-- answer contains details not present in the context
+* correct tone, weak evidence
+* unsupported specifics
+* answer contains details not present in the context
 
 ### 3. Context drift across steps
 
@@ -81,9 +85,9 @@ A later step in the workflow slowly moves away from the original task or instruc
 
 Typical symptom:
 
-- the first response is acceptable
-- follow-up behavior becomes less aligned
-- summaries or intermediate rewrites introduce drift
+* the first response is acceptable
+* follow-up behavior becomes less aligned
+* summaries or intermediate rewrites introduce drift
 
 ### 4. Overconfident unsupported answers
 
@@ -91,9 +95,9 @@ The model responds with high confidence even when the context is incomplete or a
 
 Typical symptom:
 
-- no hedging where uncertainty should exist
-- direct answer when the evidence is missing
-- strong claims without support
+* no hedging where uncertainty should exist
+* direct answer when the evidence is missing
+* strong claims without support
 
 ### 5. Stale context carryover
 
@@ -101,9 +105,9 @@ Context from a previous turn or task leaks into the current response.
 
 Typical symptom:
 
-- old facts appear in a new answer
-- current question is answered using outdated assumptions
-- prior state contaminates an otherwise independent task
+* old facts appear in a new answer
+* current question is answered using outdated assumptions
+* prior state contaminates an otherwise independent task
 
 ## How to run
 
@@ -112,7 +116,7 @@ From the repository root:
 ```bash
 npm install
 npm run local -- eval --config examples/rag-failure-checklist/promptfooconfig.yaml
-````
+```
 
 ## What to look for in results
 

--- a/examples/rag-failure-checklist/README.md
+++ b/examples/rag-failure-checklist/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 npx promptfoo@latest init --example rag-failure-checklist
-````
+```
 
 This example shows how to model a small set of common RAG and agent failure
 patterns as reproducible promptfoo evaluations.
@@ -12,11 +12,11 @@ The goal is not to define a full benchmarking framework.
 Instead, this starter gives users a practical way to test a few high-signal
 failure modes that often show up in real pipelines:
 
-* retrieval mismatch
-* weak grounding
-* context drift across steps
-* overconfident unsupported answers
-* stale context carryover
+- retrieval mismatch
+- weak grounding
+- context drift across steps
+- overconfident unsupported answers
+- stale context carryover
 
 ## Why this example exists
 
@@ -25,11 +25,11 @@ In many RAG and agent workflows, failures do not look like obvious crashes.
 The system may return a fluent answer, but the answer can still be wrong
 because:
 
-* retrieved context does not match the question
-* the answer is not grounded in the provided evidence
-* later steps drift away from the original task
-* the model sounds confident without support
-* old context leaks into the current turn
+- retrieved context does not match the question
+- the answer is not grounded in the provided evidence
+- later steps drift away from the original task
+- the model sounds confident without support
+- old context leaks into the current turn
 
 This example provides a small eval starter for those patterns.
 
@@ -37,26 +37,26 @@ This example provides a small eval starter for those patterns.
 
 This folder contains:
 
-* `promptfooconfig.yaml` with a small set of starter test cases
-* this README with usage notes and expected interpretation
+- `promptfooconfig.yaml` with a small set of starter test cases
+- this README with usage notes and expected interpretation
 
 ## What this example is for
 
 Use this example if you want to:
 
-* create a lightweight RAG reliability smoke test
-* evaluate common failure patterns before shipping changes
-* adapt a few starter scenarios to your own prompts, tools, or retrieval stack
-* turn vague quality complaints into reproducible eval cases
+- create a lightweight RAG reliability smoke test
+- evaluate common failure patterns before shipping changes
+- adapt a few starter scenarios to your own prompts, tools, or retrieval stack
+- turn vague quality complaints into reproducible eval cases
 
 ## What this example is not
 
 This example is not:
 
-* a complete benchmark for every RAG failure mode
-* tied to any specific vector database or retrieval framework
-* a replacement for end-to-end system tracing
-* a claim that one prompt or one assertion type is sufficient for production
+- a complete benchmark for every RAG failure mode
+- tied to any specific vector database or retrieval framework
+- a replacement for end-to-end system tracing
+- a claim that one prompt or one assertion type is sufficient for production
   evaluation
 
 It is intentionally small so that the integration path is easy to review and
@@ -71,9 +71,9 @@ the expected answer.
 
 Typical symptom:
 
-* the model answers from the wrong passage
-* the answer follows nearby but irrelevant content
-* the system appears to have "retrieved something" but not the right thing
+- the model answers from the wrong passage
+- the answer follows nearby but irrelevant content
+- the system appears to have "retrieved something" but not the right thing
 
 ### 2. Weak grounding
 
@@ -82,9 +82,9 @@ claim.
 
 Typical symptom:
 
-* correct tone, weak evidence
-* unsupported specifics
-* answer contains details not present in the context
+- correct tone, weak evidence
+- unsupported specifics
+- answer contains details not present in the context
 
 ### 3. Context drift across steps
 
@@ -93,9 +93,9 @@ instruction.
 
 Typical symptom:
 
-* the first response is acceptable
-* follow-up behavior becomes less aligned
-* summaries or intermediate rewrites introduce drift
+- the first response is acceptable
+- follow-up behavior becomes less aligned
+- summaries or intermediate rewrites introduce drift
 
 ### 4. Overconfident unsupported answers
 
@@ -104,9 +104,9 @@ ambiguous.
 
 Typical symptom:
 
-* no hedging where uncertainty should exist
-* direct answer when the evidence is missing
-* strong claims without support
+- no hedging where uncertainty should exist
+- direct answer when the evidence is missing
+- strong claims without support
 
 ### 5. Stale context carryover
 
@@ -114,9 +114,9 @@ Context from a previous turn or task leaks into the current response.
 
 Typical symptom:
 
-* old facts appear in a new answer
-* current question is answered using outdated assumptions
-* prior state contaminates an otherwise independent task
+- old facts appear in a new answer
+- current question is answered using outdated assumptions
+- prior state contaminates an otherwise independent task
 
 ## How to run
 
@@ -133,21 +133,21 @@ This starter is most useful when you inspect results pattern by pattern.
 
 Questions to ask:
 
-* Did the model stay grounded in the supplied context?
-* Did it avoid inventing details that were not provided?
-* Did it preserve the correct task boundary across steps?
-* Did it express uncertainty when support was weak?
-* Did prior context leak into the current response?
+- Did the model stay grounded in the supplied context?
+- Did it avoid inventing details that were not provided?
+- Did it preserve the correct task boundary across steps?
+- Did it express uncertainty when support was weak?
+- Did prior context leak into the current response?
 
 ## How to adapt this example
 
 The easiest way to extend this starter is to replace the sample cases with your
 own:
 
-* swap in your own retrieved passages
-* use your real prompts or system instructions
-* add assertions that match your reliability requirements
-* duplicate the existing pattern structure for new failure cases
+- swap in your own retrieved passages
+- use your real prompts or system instructions
+- add assertions that match your reliability requirements
+- duplicate the existing pattern structure for new failure cases
 
 A good next step is to turn your most common support or QA complaints into eval
 cases.
@@ -168,9 +168,9 @@ This example is intentionally small and example-first.
 
 The intended integration path is:
 
-* keep the starter easy to run
-* make failure patterns concrete
-* let users replace the sample cases with their own RAG or agent workflows
+- keep the starter easy to run
+- make failure patterns concrete
+- let users replace the sample cases with their own RAG or agent workflows
 
 If the shape is useful, it can be extended into a broader set of reusable eval
 templates later.

--- a/examples/rag-failure-checklist/README.md
+++ b/examples/rag-failure-checklist/README.md
@@ -1,0 +1,160 @@
+# RAG Failure Checklist Eval Starter
+
+This example shows how to model a small set of common RAG and agent failure patterns as reproducible promptfoo evaluations.
+
+The goal is not to define a full benchmarking framework.
+
+Instead, this starter gives users a practical way to test a few high-signal failure modes that often show up in real pipelines:
+
+- retrieval mismatch
+- weak grounding
+- context drift across steps
+- overconfident unsupported answers
+- stale context carryover
+
+## Why this example exists
+
+In many RAG and agent workflows, failures do not look like obvious crashes.
+
+The system may return a fluent answer, but the answer can still be wrong because:
+
+- retrieved context does not match the question
+- the answer is not grounded in the provided evidence
+- later steps drift away from the original task
+- the model sounds confident without support
+- old context leaks into the current turn
+
+This example provides a small eval starter for those patterns.
+
+## What is included
+
+This folder contains:
+
+- `promptfooconfig.yaml` with a small set of starter test cases
+- this README with usage notes and expected interpretation
+
+## What this example is for
+
+Use this example if you want to:
+
+- create a lightweight RAG reliability smoke test
+- evaluate common failure patterns before shipping changes
+- adapt a few starter scenarios to your own prompts, tools, or retrieval stack
+- turn vague quality complaints into reproducible eval cases
+
+## What this example is not
+
+This example is not:
+
+- a complete benchmark for every RAG failure mode
+- tied to any specific vector database or retrieval framework
+- a replacement for end-to-end system tracing
+- a claim that one prompt or one assertion type is sufficient for production evaluation
+
+It is intentionally small so that the integration path is easy to review and extend.
+
+## Starter failure patterns
+
+### 1. Retrieval mismatch
+
+The question is reasonable, but the retrieved context does not actually support the expected answer.
+
+Typical symptom:
+
+- the model answers from the wrong passage
+- the answer follows nearby but irrelevant content
+- the system appears to have "retrieved something" but not the right thing
+
+### 2. Weak grounding
+
+The answer sounds plausible, but the retrieved context does not justify the claim.
+
+Typical symptom:
+
+- correct tone, weak evidence
+- unsupported specifics
+- answer contains details not present in the context
+
+### 3. Context drift across steps
+
+A later step in the workflow slowly moves away from the original task or instruction.
+
+Typical symptom:
+
+- the first response is acceptable
+- follow-up behavior becomes less aligned
+- summaries or intermediate rewrites introduce drift
+
+### 4. Overconfident unsupported answers
+
+The model responds with high confidence even when the context is incomplete or ambiguous.
+
+Typical symptom:
+
+- no hedging where uncertainty should exist
+- direct answer when the evidence is missing
+- strong claims without support
+
+### 5. Stale context carryover
+
+Context from a previous turn or task leaks into the current response.
+
+Typical symptom:
+
+- old facts appear in a new answer
+- current question is answered using outdated assumptions
+- prior state contaminates an otherwise independent task
+
+## How to run
+
+From the repository root:
+
+```bash
+npm install
+npm run local -- eval --config examples/rag-failure-checklist/promptfooconfig.yaml
+````
+
+## What to look for in results
+
+This starter is most useful when you inspect results pattern by pattern.
+
+Questions to ask:
+
+* Did the model stay grounded in the supplied context?
+* Did it avoid inventing details that were not provided?
+* Did it preserve the correct task boundary across steps?
+* Did it express uncertainty when support was weak?
+* Did prior context leak into the current response?
+
+## How to adapt this example
+
+The easiest way to extend this starter is to replace the sample cases with your own:
+
+* swap in your own retrieved passages
+* use your real prompts or system instructions
+* add assertions that match your reliability requirements
+* duplicate the existing pattern structure for new failure cases
+
+A good next step is to turn your most common support or QA complaints into eval cases.
+
+## Suggested extension path
+
+If you want to expand this starter later, a practical order is:
+
+1. add more retrieval mismatch cases
+2. add harder grounding tests with partial evidence
+3. add multi-turn drift scenarios
+4. add tool-augmented or agent routing failures
+5. add regressions from real incidents
+
+## Verification note
+
+This example is intentionally small and example-first.
+
+The intended integration path is:
+
+* keep the starter easy to run
+* make failure patterns concrete
+* let users replace the sample cases with their own RAG or agent workflows
+
+If the shape is useful, it can be extended into a broader set of reusable eval templates later.

--- a/examples/rag-failure-checklist/promptfooconfig.yaml
+++ b/examples/rag-failure-checklist/promptfooconfig.yaml
@@ -1,30 +1,33 @@
-description: RAG failure checklist eval starter for common retrieval, grounding, and context hygiene failures
+description:
+  RAG failure checklist eval starter for common retrieval, grounding, and
+  context hygiene failures
 
 providers:
   - openai:gpt-5-mini
 
 prompts:
   - |
-      You are evaluating a retrieval-augmented or agentic workflow.
+    You are evaluating a retrieval-augmented or agentic workflow.
 
-      Follow these rules exactly:
-      1. Answer only from CURRENT_CONTEXT.
-      2. If CURRENT_CONTEXT does not support the answer, reply exactly: INSUFFICIENT_CONTEXT
-      3. Do not use PRIOR_CONTEXT unless the user explicitly asks about it.
-      4. Keep the answer short, at most two sentences.
-      5. Do not invent names, numbers, owners, or versions that are not supported by CURRENT_CONTEXT.
+    Follow these rules exactly:
+    1. Answer only from CURRENT_CONTEXT.
+    2. If CURRENT_CONTEXT does not support the answer, reply exactly: INSUFFICIENT_CONTEXT
+    3. Do not use PRIOR_CONTEXT unless the user explicitly asks about it.
+    4. Keep the answer short, at most two sentences.
+    5. Do not invent names, numbers, owners, or versions that are not supported by CURRENT_CONTEXT.
 
-      User question:
-      {{question}}
+    User question:
+    {{question}}
 
-      PRIOR_CONTEXT:
-      {{prior_context}}
+    PRIOR_CONTEXT:
+    {{prior_context}}
 
-      CURRENT_CONTEXT:
-      {{current_context}}
+    CURRENT_CONTEXT:
+    {{current_context}}
 
 tests:
-  - description: retrieval mismatch should fail closed when retrieved context is irrelevant
+  - description:
+      retrieval mismatch should fail closed when retrieved context is irrelevant
     metadata:
       failure_pattern: retrieval-mismatch
       starter_group: rag-failure-checklist
@@ -42,14 +45,16 @@ tests:
       - type: not-icontains
         value: 3 to 5 business days
 
-  - description: weak grounding should return the supported owner, not a guessed team
+  - description:
+      weak grounding should return the supported owner, not a guessed team
     metadata:
       failure_pattern: weak-grounding
       starter_group: rag-failure-checklist
     vars:
       question: Which team owns the incident paging policy?
       prior_context: |
-        Earlier brainstorming notes mentioned several possible owners, including Security and Developer Experience.
+        Earlier brainstorming notes mentioned several possible owners,
+        including Security and Developer Experience.
       current_context: |
         The current on-call runbook states:
         "The incident paging policy is maintained by the Platform Reliability team."
@@ -59,12 +64,16 @@ tests:
       - type: not-icontains
         value: security
 
-  - description: later-step context should follow the final approved requirement, not older draft notes
+  - description:
+      later-step context should follow the final approved requirement, not older
+      draft notes
     metadata:
       failure_pattern: context-drift
       starter_group: rag-failure-checklist
     vars:
-      question: Based on the final approved requirement, what should the release note emphasize?
+      question:
+        Based on the final approved requirement, what should the release note
+        emphasize?
       prior_context: |
         Earlier draft:
         emphasize speed improvements and performance gains in the next release note.
@@ -80,7 +89,8 @@ tests:
       - type: not-icontains
         value: speed
 
-  - description: unsupported specifics should not be answered with confidence
+  - description:
+      unsupported specifics should not be answered with confidence
     metadata:
       failure_pattern: overconfident-unsupported-answer
       starter_group: rag-failure-checklist
@@ -97,7 +107,8 @@ tests:
       - type: not-icontains
         value: postgresql 16
 
-  - description: stale context carryover should not leak a previous customer's support tier
+  - description:
+      stale context carryover should not leak a previous customer's support tier
     metadata:
       failure_pattern: stale-context-carryover
       starter_group: rag-failure-checklist

--- a/examples/rag-failure-checklist/promptfooconfig.yaml
+++ b/examples/rag-failure-checklist/promptfooconfig.yaml
@@ -1,0 +1,118 @@
+description: RAG failure checklist eval starter for common retrieval, grounding, and context hygiene failures
+
+providers:
+  - openai:gpt-5-mini
+
+prompts:
+  - |
+      You are evaluating a retrieval-augmented or agentic workflow.
+
+      Follow these rules exactly:
+      1. Answer only from CURRENT_CONTEXT.
+      2. If CURRENT_CONTEXT does not support the answer, reply exactly: INSUFFICIENT_CONTEXT
+      3. Do not use PRIOR_CONTEXT unless the user explicitly asks about it.
+      4. Keep the answer short, at most two sentences.
+      5. Do not invent names, numbers, owners, or versions that are not supported by CURRENT_CONTEXT.
+
+      User question:
+      {{question}}
+
+      PRIOR_CONTEXT:
+      {{prior_context}}
+
+      CURRENT_CONTEXT:
+      {{current_context}}
+
+tests:
+  - description: retrieval mismatch should fail closed when retrieved context is irrelevant
+    metadata:
+      failure_pattern: retrieval-mismatch
+      starter_group: rag-failure-checklist
+    vars:
+      question: What is the enterprise refund window?
+      prior_context: ""
+      current_context: |
+        Shipping policy:
+        Standard delivery takes 3 to 5 business days.
+        Express delivery is available in selected regions.
+        Delivery fees are calculated at checkout.
+    assert:
+      - type: equals
+        value: INSUFFICIENT_CONTEXT
+      - type: not-icontains
+        value: 3 to 5 business days
+
+  - description: weak grounding should return the supported owner, not a guessed team
+    metadata:
+      failure_pattern: weak-grounding
+      starter_group: rag-failure-checklist
+    vars:
+      question: Which team owns the incident paging policy?
+      prior_context: |
+        Earlier brainstorming notes mentioned several possible owners, including Security and Developer Experience.
+      current_context: |
+        The current on-call runbook states:
+        "The incident paging policy is maintained by the Platform Reliability team."
+    assert:
+      - type: icontains
+        value: platform reliability
+      - type: not-icontains
+        value: security
+
+  - description: later-step context should follow the final approved requirement, not older draft notes
+    metadata:
+      failure_pattern: context-drift
+      starter_group: rag-failure-checklist
+    vars:
+      question: Based on the final approved requirement, what should the release note emphasize?
+      prior_context: |
+        Earlier draft:
+        emphasize speed improvements and performance gains in the next release note.
+      current_context: |
+        Final approved requirement:
+        emphasize stability improvements and rollback safety.
+        Avoid performance claims until benchmark validation is complete.
+    assert:
+      - type: contains-all
+        value:
+          - stability
+          - rollback
+      - type: not-icontains
+        value: speed
+
+  - description: unsupported specifics should not be answered with confidence
+    metadata:
+      failure_pattern: overconfident-unsupported-answer
+      starter_group: rag-failure-checklist
+    vars:
+      question: What database version is currently running in production?
+      prior_context: ""
+      current_context: |
+        Migration planning notes:
+        the team proposes moving to PostgreSQL 16 next quarter.
+        The current production database version is not specified in the provided materials.
+    assert:
+      - type: equals
+        value: INSUFFICIENT_CONTEXT
+      - type: not-icontains
+        value: postgresql 16
+
+  - description: stale context carryover should not leak a previous customer's support tier
+    metadata:
+      failure_pattern: stale-context-carryover
+      starter_group: rag-failure-checklist
+    vars:
+      question: What support tier applies to the current ticket?
+      prior_context: |
+        Previous ticket:
+        Acme Corp has premium support with 24/7 response coverage.
+      current_context: |
+        Current ticket:
+        Northwind Traders is on the standard support tier with business-hours response coverage.
+    assert:
+      - type: contains-all
+        value:
+          - standard
+          - support
+      - type: not-icontains
+        value: premium

--- a/examples/rag-failure-checklist/promptfooconfig.yaml
+++ b/examples/rag-failure-checklist/promptfooconfig.yaml
@@ -1,5 +1,4 @@
-description:
-  RAG failure checklist eval starter for common retrieval, grounding, and
+description: RAG failure checklist eval starter for common retrieval, grounding, and
   context hygiene failures
 
 providers:
@@ -26,14 +25,13 @@ prompts:
     {{current_context}}
 
 tests:
-  - description:
-      retrieval mismatch should fail closed when retrieved context is irrelevant
+  - description: retrieval mismatch should fail closed when retrieved context is irrelevant
     metadata:
       failure_pattern: retrieval-mismatch
       starter_group: rag-failure-checklist
     vars:
       question: What is the enterprise refund window?
-      prior_context: ""
+      prior_context: ''
       current_context: |
         Shipping policy:
         Standard delivery takes 3 to 5 business days.
@@ -45,8 +43,7 @@ tests:
       - type: not-icontains
         value: 3 to 5 business days
 
-  - description:
-      weak grounding should return the supported owner, not a guessed team
+  - description: weak grounding should return the supported owner, not a guessed team
     metadata:
       failure_pattern: weak-grounding
       starter_group: rag-failure-checklist
@@ -64,15 +61,13 @@ tests:
       - type: not-icontains
         value: security
 
-  - description:
-      later-step context should follow the final approved requirement, not older
+  - description: later-step context should follow the final approved requirement, not older
       draft notes
     metadata:
       failure_pattern: context-drift
       starter_group: rag-failure-checklist
     vars:
-      question:
-        Based on the final approved requirement, what should the release note
+      question: Based on the final approved requirement, what should the release note
         emphasize?
       prior_context: |
         Earlier draft:
@@ -89,14 +84,13 @@ tests:
       - type: not-icontains
         value: speed
 
-  - description:
-      unsupported specifics should not be answered with confidence
+  - description: unsupported specifics should not be answered with confidence
     metadata:
       failure_pattern: overconfident-unsupported-answer
       starter_group: rag-failure-checklist
     vars:
       question: What database version is currently running in production?
-      prior_context: ""
+      prior_context: ''
       current_context: |
         Migration planning notes:
         the team proposes moving to PostgreSQL 16 next quarter.
@@ -107,8 +101,7 @@ tests:
       - type: not-icontains
         value: postgresql 16
 
-  - description:
-      stale context carryover should not leak a previous customer's support tier
+  - description: stale context carryover should not leak a previous customer's support tier
     metadata:
       failure_pattern: stale-context-carryover
       starter_group: rag-failure-checklist


### PR DESCRIPTION
## Summary

This PR adds a small example-first integration path for evaluating common RAG failure patterns with promptfoo.

It introduces a lightweight starter in `examples/rag-failure-checklist/` with:
- a short README
- a `promptfooconfig.yaml` covering a few high-signal failure patterns

The starter focuses on practical scenarios such as:
- retrieval mismatch
- weak grounding
- context drift across steps
- overconfident unsupported answers
- stale context carryover

## Why this shape

I kept this intentionally small and example-first so the integration path is easy to review and extend.

Rather than introducing a large framework all at once, this PR aims to provide a minimal, reusable starter that users can adapt to their own RAG or agent workflows.

## Files added

- `examples/rag-failure-checklist/README.md`
- `examples/rag-failure-checklist/promptfooconfig.yaml`

## Verification

From the repository root:

```bash
npm install
npm run local -- eval --config examples/rag-failure-checklist/promptfooconfig.yaml