### PR TITLE
fix: add updatedAt to EvaluateResult interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -343,6 +343,7 @@ export interface EvaluateResult {
   cost?: number;
   metadata?: Record<string, any>;
   tokenUsage?: Required<TokenUsage>;
+  updatedAt?: string;
 }
 
 export interface EvaluateTableOutput {


### PR DESCRIPTION
## Summary
- Adds optional `updatedAt?: string` field to the `EvaluateResult` interface
- Enables promptfoo-cloud to return `updatedAt` from the `/results` endpoint without needing an ad-hoc intersection type (`EvaluateResult & { updatedAt: string }`)

## Test plan
- [ ] Verify existing tests pass (no breaking change — field is optional)
- [ ] Confirm promptfoo-cloud can use `EvaluateResult` directly after submodule bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)