### PR TITLE
fix: remove unnecessary string length limit for env var rendering

### DIFF
--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -38,16 +38,6 @@ export function renderEnvOnlyInObject<T>(
   }
 
   if (typeof obj === 'string') {
-    // Prevent ReDoS: Skip regex matching on extremely long strings
-    // The regex pattern has nested quantifiers that can cause exponential backtracking
-    const MAX_STRING_LENGTH = 50000; // Reasonable limit for config strings
-    if (obj.length > MAX_STRING_LENGTH) {
-      logger.warn(
-        `String too long (${obj.length} chars) for template matching. Skipping env var rendering.`,
-      );
-      return obj as unknown as T;
-    }
-
     const nunjucks = getNunjucksEngine();
     // process.env values are always strings or undefined, never numbers or booleans
     const baseEnvGlobals = nunjucks.getGlobal('env') as Record<string, string | undefined>;

--- a/test/util/render.test.ts
+++ b/test/util/render.test.ts
@@ -513,6 +513,34 @@ Line 2: {{ vars.test }}`),
 Line 2: {{ vars.test }}`);
     });
 
+    it('should render env vars in strings longer than 50000 chars', async () => {
+      process.env.TEST_ENV_VAR = 'env_value';
+      const padding = 'x'.repeat(60000);
+      const template = `${padding} {{ env.TEST_ENV_VAR }} ${padding}`;
+      expect(template.length).toBeGreaterThan(50000);
+      expect(renderEnvOnlyInObject(template)).toBe(`${padding} env_value ${padding}`);
+    });
+
+    it('should preserve non-env templates in long strings', async () => {
+      const padding = 'x'.repeat(60000);
+      const template = `${padding} {{ vars.myVar }} ${padding}`;
+      expect(renderEnvOnlyInObject(template)).toBe(template);
+    });
+
+    it('should handle long strings with mixed env and non-env templates', async () => {
+      process.env.HOST = 'example.com';
+      const padding = 'x'.repeat(60000);
+      const template = `${padding} {{ env.HOST }} {{ vars.test }} ${padding}`;
+      expect(renderEnvOnlyInObject(template)).toBe(
+        `${padding} example.com {{ vars.test }} ${padding}`,
+      );
+    });
+
+    it('should handle long strings with no templates at all', async () => {
+      const longString = 'a'.repeat(100000);
+      expect(renderEnvOnlyInObject(longString)).toBe(longString);
+    });
+
     it('should not confuse env in other contexts', async () => {
       process.env.TEST = 'value';
       // Should not match "environment" or other words containing "env"


### PR DESCRIPTION
## Summary

- Remove the 50,000 character `MAX_STRING_LENGTH` guard in `renderEnvOnlyInObject` that was silently skipping env var rendering for large config strings
- The guard was added to prevent ReDoS, but the regex (`/\{\{(?:[^}]|\}(?!\}))*\}\}/g`) has mutually exclusive alternation branches (`[^}]` vs `\}(?!\})`), making it O(N) on all inputs — no exponential backtracking is possible
- Add test coverage for strings >50k characters

## Test plan

- [x] Existing render tests pass (51 tests)
- [x] New tests for long strings (4 tests): env rendering, non-env preservation, mixed templates, no templates
- [x] Biome lint clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)