### PR TITLE
feat(web): add env-controlled results table defaults

### DIFF
--- a/src/app/src/pages/eval/components/store.defaults.test.ts
+++ b/src/app/src/pages/eval/components/store.defaults.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getResultsViewSettingsDefaults } from './store';
+
+describe('getResultsViewSettingsDefaults', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the existing defaults when no env vars are set', () => {
+    expect(getResultsViewSettingsDefaults()).toEqual({
+      prettifyJson: false,
+      showPassFail: true,
+    });
+  });
+
+  it('overrides defaults from env vars', () => {
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON', 'true');
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL', 'false');
+
+    expect(getResultsViewSettingsDefaults()).toEqual({
+      prettifyJson: true,
+      showPassFail: false,
+    });
+  });
+
+  it('accepts common truthy and falsey env values', () => {
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON', '1');
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL', 'off');
+
+    expect(getResultsViewSettingsDefaults()).toEqual({
+      prettifyJson: true,
+      showPassFail: false,
+    });
+  });
+
+  it('falls back to defaults for invalid env values', () => {
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON', 'maybe');
+    vi.stubEnv('VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL', 'sometimes');
+
+    expect(getResultsViewSettingsDefaults()).toEqual({
+      prettifyJson: false,
+      showPassFail: true,
+    });
+  });
+});

--- a/src/app/src/pages/eval/components/store.ts
+++ b/src/app/src/pages/eval/components/store.ts
@@ -26,6 +26,35 @@ import type {
 } from '@promptfoo/types';
 import type { VisibilityState } from '@tanstack/table-core';
 
+function parseBooleanSetting(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+export function getResultsViewSettingsDefaults() {
+  return {
+    prettifyJson: parseBooleanSetting(
+      import.meta.env.VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON,
+      false,
+    ),
+    showPassFail: parseBooleanSetting(
+      import.meta.env.VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL,
+      true,
+    ),
+  };
+}
+
 function computeHighlightCount(table: EvaluateTable | null): number {
   if (!table) {
     return 0;
@@ -444,55 +473,59 @@ interface SettingsState {
 
 export const useResultsViewSettingsStore = create<SettingsState>()(
   persist(
-    (set, _get) => ({
-      maxTextLength: 250,
-      setMaxTextLength: (maxTextLength: number) => set(() => ({ maxTextLength })),
-      wordBreak: 'break-word',
-      setWordBreak: (wordBreak: 'break-word' | 'break-all') => set(() => ({ wordBreak })),
-      showInferenceDetails: true,
-      setShowInferenceDetails: (showInferenceDetails: boolean) =>
-        set(() => ({ showInferenceDetails })),
-      renderMarkdown: false,
-      setRenderMarkdown: (renderMarkdown: boolean) => set(() => ({ renderMarkdown })),
-      prettifyJson: false,
-      setPrettifyJson: (prettifyJson: boolean) => set(() => ({ prettifyJson })),
-      showPrompts: false,
-      setShowPrompts: (showPrompts: boolean) => set(() => ({ showPrompts })),
-      showPassFail: true,
-      setShowPassFail: (showPassFail: boolean) => set(() => ({ showPassFail })),
-      showPassReasons: false,
-      setShowPassReasons: (showPassReasons: boolean) => set(() => ({ showPassReasons })),
+    (set, _get) => {
+      const defaults = getResultsViewSettingsDefaults();
 
-      inComparisonMode: false,
-      setInComparisonMode: (inComparisonMode: boolean) => set(() => ({ inComparisonMode })),
-      comparisonEvalIds: [],
-      setComparisonEvalIds: (comparisonEvalIds: string[]) => set(() => ({ comparisonEvalIds })),
-      stickyHeader: true,
-      setStickyHeader: (stickyHeader: boolean) => set(() => ({ stickyHeader })),
+      return {
+        maxTextLength: 250,
+        setMaxTextLength: (maxTextLength: number) => set(() => ({ maxTextLength })),
+        wordBreak: 'break-word',
+        setWordBreak: (wordBreak: 'break-word' | 'break-all') => set(() => ({ wordBreak })),
+        showInferenceDetails: true,
+        setShowInferenceDetails: (showInferenceDetails: boolean) =>
+          set(() => ({ showInferenceDetails })),
+        renderMarkdown: false,
+        setRenderMarkdown: (renderMarkdown: boolean) => set(() => ({ renderMarkdown })),
+        prettifyJson: defaults.prettifyJson,
+        setPrettifyJson: (prettifyJson: boolean) => set(() => ({ prettifyJson })),
+        showPrompts: false,
+        setShowPrompts: (showPrompts: boolean) => set(() => ({ showPrompts })),
+        showPassFail: defaults.showPassFail,
+        setShowPassFail: (showPassFail: boolean) => set(() => ({ showPassFail })),
+        showPassReasons: false,
+        setShowPassReasons: (showPassReasons: boolean) => set(() => ({ showPassReasons })),
 
-      columnStates: {},
-      setColumnState: (evalId: string, state: ColumnState) =>
-        set((prevState) => ({
-          columnStates: {
-            ...prevState.columnStates,
-            [evalId]: state,
-          },
-        })),
+        inComparisonMode: false,
+        setInComparisonMode: (inComparisonMode: boolean) => set(() => ({ inComparisonMode })),
+        comparisonEvalIds: [],
+        setComparisonEvalIds: (comparisonEvalIds: string[]) => set(() => ({ comparisonEvalIds })),
+        stickyHeader: true,
+        setStickyHeader: (stickyHeader: boolean) => set(() => ({ stickyHeader })),
 
-      hiddenVarNamesBySchema: {},
-      setHiddenVarNamesForSchema: (schemaHash: string, hiddenVarNames: string[]) =>
-        set((prevState) => ({
-          hiddenVarNamesBySchema: {
-            ...prevState.hiddenVarNamesBySchema,
-            [schemaHash]: hiddenVarNames,
-          },
-        })),
+        columnStates: {},
+        setColumnState: (evalId: string, state: ColumnState) =>
+          set((prevState) => ({
+            columnStates: {
+              ...prevState.columnStates,
+              [evalId]: state,
+            },
+          })),
 
-      maxImageWidth: 256,
-      setMaxImageWidth: (maxImageWidth: number) => set(() => ({ maxImageWidth })),
-      maxImageHeight: 256,
-      setMaxImageHeight: (maxImageHeight: number) => set(() => ({ maxImageHeight })),
-    }),
+        hiddenVarNamesBySchema: {},
+        setHiddenVarNamesForSchema: (schemaHash: string, hiddenVarNames: string[]) =>
+          set((prevState) => ({
+            hiddenVarNamesBySchema: {
+              ...prevState.hiddenVarNamesBySchema,
+              [schemaHash]: hiddenVarNames,
+            },
+          })),
+
+        maxImageWidth: 256,
+        setMaxImageWidth: (maxImageWidth: number) => set(() => ({ maxImageWidth })),
+        maxImageHeight: 256,
+        setMaxImageHeight: (maxImageHeight: number) => set(() => ({ maxImageHeight })),
+      };
+    },
     {
       name: 'eval-settings',
       version: 2,

--- a/src/app/src/vite-env.d.ts
+++ b/src/app/src/vite-env.d.ts
@@ -10,6 +10,8 @@ interface ImportMetaEnv {
   readonly VITE_PROMPTFOO_LAUNCHER?: string;
   readonly VITE_IS_HOSTED?: string;
   readonly VITE_PROMPTFOO_NO_CHAT?: string;
+  readonly VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON?: string;
+  readonly VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL?: string;
 }
 
 interface ImportMeta {

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -220,5 +220,11 @@ export default defineConfig({
       process.env.PROMPTFOO_POSTHOG_HOST || 'https://a.promptfoo.app',
     ),
     'import.meta.env.VITE_PUBLIC_BASENAME': JSON.stringify(process.env.VITE_PUBLIC_BASENAME || ''),
+    'import.meta.env.VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON': JSON.stringify(
+      process.env.PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON || '',
+    ),
+    'import.meta.env.VITE_PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL': JSON.stringify(
+      process.env.PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL || '',
+    ),
   },
 });


### PR DESCRIPTION
## Summary
- allow the web viewer results table defaults to be overridden via env vars
- wire `PROMPTFOO_WEB_VIEWER_TABLE_SETTING_PRETTIFY_JSON` and `PROMPTFOO_WEB_VIEWER_TABLE_SETTING_SHOW_PASS_FAIL` through the Vite app config
- add a small frontend test for the default-setting parser

## Testing
- `npm exec vitest -- --config vite.config.ts run src/pages/eval/components/store.defaults.test.ts`
- `npx @biomejs/biome check src/app/src/pages/eval/components/store.ts src/app/src/pages/eval/components/store.defaults.test.ts src/app/src/vite-env.d.ts src/app/vite.config.ts`

Closes #6187.
