### PR TITLE
fix: refresh prompt listings after prompt metadata updates

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -1242,6 +1242,9 @@ export default class Eval {
     if (this.persisted) {
       const db = getDb();
       db.update(evalsTable).set({ prompts }).where(eq(evalsTable.id, this.id)).run();
+      // Notify the view server after prompt metadata changes so cached /api/prompts
+      // responses and socket listeners can pick up prompts added after eval creation.
+      updateSignalFile(this.id);
     }
   }
 

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../src/database/index';
+import { updateSignalFile } from '../../src/database/signal';
 import { getUserEmail } from '../../src/globalConfig/accounts';
 import { runDbMigrations } from '../../src/migrate';
 import Eval, {
@@ -22,12 +23,22 @@ vi.mock('../../src/globalConfig/accounts', async () => {
   };
 });
 
+vi.mock('../../src/database/signal', async () => {
+  const actual = await vi.importActual('../../src/database/signal');
+  return {
+    ...actual,
+    updateSignalFile: vi.fn(),
+  };
+});
+
 describe('evaluator', () => {
   beforeAll(async () => {
     await runDbMigrations();
   });
 
   beforeEach(async () => {
+    vi.mocked(updateSignalFile).mockClear();
+
     // Clear all tables before each test
     const db = getDb();
     // Delete related tables first
@@ -37,6 +48,46 @@ describe('evaluator', () => {
     await db.run('DELETE FROM evals_to_tags');
     // Then delete from main table
     await db.run('DELETE FROM evals');
+  });
+
+  describe('addPrompts', () => {
+    it('should notify watchers when persisted prompt metadata changes', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 0 });
+      vi.mocked(updateSignalFile).mockClear();
+
+      await eval_.addPrompts([
+        {
+          raw: 'Summarize the latest changelog entry',
+          label: 'Summarize the latest changelog entry',
+          provider: 'test-provider',
+        },
+      ]);
+
+      expect(updateSignalFile).toHaveBeenCalledWith(eval_.id);
+
+      const reloaded = await Eval.findById(eval_.id);
+      expect(reloaded?.prompts).toEqual([
+        expect.objectContaining({
+          raw: 'Summarize the latest changelog entry',
+          label: 'Summarize the latest changelog entry',
+          provider: 'test-provider',
+        }),
+      ]);
+    });
+
+    it('should not notify watchers for in-memory evals', async () => {
+      const eval_ = new Eval({});
+
+      await eval_.addPrompts([
+        {
+          raw: 'In-memory prompt',
+          label: 'In-memory prompt',
+          provider: 'test-provider',
+        },
+      ]);
+
+      expect(updateSignalFile).not.toHaveBeenCalled();
+    });
   });
 
   describe('summaryResults', () => {


### PR DESCRIPTION
## Summary
- notify the view server when persisted eval prompt metadata changes
- keep `/api/prompts` caches and prompt-list listeners in sync after prompts are written post-creation
- add regression coverage for persisted vs in-memory `addPrompts` updates

## Testing
- `npx vitest run test/models/eval.test.ts`

Closes #2471
