### PR TITLE
fix(replicate): preserve zero-valued config

### DIFF
--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -105,7 +105,7 @@ export class ReplicateProvider implements ApiProvider {
       providerId: this.id(),
       temperature: this.config.temperature,
       topP: this.config.top_p,
-      maxTokens: this.config.max_tokens || this.config.max_length || this.config.max_new_tokens,
+      maxTokens: this.config.max_tokens ?? this.config.max_length ?? this.config.max_new_tokens,
       testIndex: context?.test?.vars?.__testIdx as number | undefined,
       promptLabel: context?.prompt?.label,
       // W3C Trace Context for linking to evaluation trace
@@ -168,15 +168,15 @@ export class ReplicateProvider implements ApiProvider {
     let response;
     try {
       const inputOptions = {
-        max_length: this.config.max_length || getEnvInt('REPLICATE_MAX_LENGTH'),
-        max_new_tokens: this.config.max_new_tokens || getEnvInt('REPLICATE_MAX_NEW_TOKENS'),
-        temperature: this.config.temperature || getEnvFloat('REPLICATE_TEMPERATURE'),
-        top_p: this.config.top_p || getEnvFloat('REPLICATE_TOP_P'),
-        top_k: this.config.top_k || getEnvInt('REPLICATE_TOP_K'),
+        max_length: this.config.max_length ?? getEnvInt('REPLICATE_MAX_LENGTH'),
+        max_new_tokens: this.config.max_new_tokens ?? getEnvInt('REPLICATE_MAX_NEW_TOKENS'),
+        temperature: this.config.temperature ?? getEnvFloat('REPLICATE_TEMPERATURE'),
+        top_p: this.config.top_p ?? getEnvFloat('REPLICATE_TOP_P'),
+        top_k: this.config.top_k ?? getEnvInt('REPLICATE_TOP_K'),
         repetition_penalty:
-          this.config.repetition_penalty || getEnvFloat('REPLICATE_REPETITION_PENALTY'),
-        stop_sequences: this.config.stop_sequences || getEnvString('REPLICATE_STOP_SEQUENCES'),
-        seed: this.config.seed || getEnvInt('REPLICATE_SEED'),
+          this.config.repetition_penalty ?? getEnvFloat('REPLICATE_REPETITION_PENALTY'),
+        stop_sequences: this.config.stop_sequences ?? getEnvString('REPLICATE_STOP_SEQUENCES'),
+        seed: this.config.seed ?? getEnvInt('REPLICATE_SEED'),
         system_prompt: systemPrompt,
         prompt: userPrompt,
       };

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -62,6 +62,54 @@ describe('ReplicateProvider', () => {
     );
   });
 
+  it('should preserve explicit zero-valued config instead of replacing it with env defaults', async () => {
+    const originalTemperature = process.env.REPLICATE_TEMPERATURE;
+    const originalSeed = process.env.REPLICATE_SEED;
+    process.env.REPLICATE_TEMPERATURE = '0.9';
+    process.env.REPLICATE_SEED = '123';
+
+    mockedFetchWithCache.mockResolvedValue({
+      data: {
+        id: 'test-id',
+        status: 'succeeded',
+        output: 'test response',
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    try {
+      const provider = new ReplicateProvider('test-model', {
+        config: {
+          apiKey: mockApiKey,
+          temperature: 0,
+          seed: 0,
+        },
+      });
+
+      await provider.callApi('test prompt');
+
+      const request = mockedFetchWithCache.mock.calls[0] as [string, { body: string }];
+      const body = JSON.parse(request[1].body);
+
+      expect(body.input.temperature).toBe(0);
+      expect(body.input.seed).toBe(0);
+    } finally {
+      if (originalTemperature === undefined) {
+        delete process.env.REPLICATE_TEMPERATURE;
+      } else {
+        process.env.REPLICATE_TEMPERATURE = originalTemperature;
+      }
+
+      if (originalSeed === undefined) {
+        delete process.env.REPLICATE_SEED;
+      } else {
+        process.env.REPLICATE_SEED = originalSeed;
+      }
+    }
+  });
+
   it('should handle API errors', async () => {
     mockedFetchWithCache.mockRejectedValue(new Error('API Error'));
 


### PR DESCRIPTION
Preserve explicit zero-valued Replicate config such as `temperature: 0` and `seed: 0` instead of letting environment defaults override them.

Add a regression test covering the zero-value merge path.