### PR TITLE
docs(site): clarify openclaw artifact risk

### DIFF
--- a/site/blog/openclaw-at-work.md
+++ b/site/blog/openclaw-at-work.md
@@ -25,7 +25,7 @@ In a controlled lab, we tested a local OpenClaw deployment with browser access, 
 
 <!-- truncate -->
 
-This post documents one exploit chain in a permissive OpenClaw deployment where browsing, local file access, and outbound actions shared a trust boundary, leading to capability disclosure, local document access, secret aggregation into new files, and unauthorized messages to loopback sinks.
+This post documents one exploit chain in a permissive OpenClaw deployment where browsing, local file access, and outbound actions shared a trust boundary. That led to capability disclosure, local document access, secret aggregation into new files, and unauthorized messages to loopback sinks.
 
 Indirect prompt injection from websites and files is already a known agent risk. This case study looks at what happens when that risk is combined with a local agent that can browse attacker-controlled pages, read and write local files, and send messages through connected channels. It focuses on one exploit chain rather than behavior across OpenClaw versions, model providers, or approval modes.
 


### PR DESCRIPTION
## Summary
- merge `main` into this branch so the already-published OpenClaw article drops out of the PR diff
- clarify the remaining OpenClaw copy to describe sensitive data aggregation into durable local artifacts
- keep the change scoped to the article text in `site/blog/openclaw-at-work.md`

## Testing
- npm run l
- npm run f
- cd site && SKIP_OG_GENERATION=true npm run build