### PR TITLE
fix(assertions): stabilize trajectory eval assertions

### DIFF
--- a/src/assertions/trajectory.ts
+++ b/src/assertions/trajectory.ts
@@ -380,7 +380,7 @@ export const handleTrajectoryGoalSuccess = async (
     trajectory,
     params.outputString,
     params.test.options,
-    params.test.vars,
+    params.assertionValueContext.vars,
     params.assertion,
     params.providerCallContext,
   );

--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -213,20 +213,22 @@ function isMessageSpan(span: TraceSpan): boolean {
 
 export function extractTrajectorySteps(trace: TraceData): TrajectoryStep[] {
   return [...(trace.spans || [])]
-    .sort((a, b) => {
-      const timeDiff = a.startTime - b.startTime;
+    .map((span, index) => ({ span, index }))
+    .sort((left, right) => {
+      const timeDiff = left.span.startTime - right.span.startTime;
       if (timeDiff !== 0) {
         return timeDiff;
       }
 
-      const endDiff = (a.endTime ?? a.startTime) - (b.endTime ?? b.startTime);
+      const endDiff =
+        (left.span.endTime ?? left.span.startTime) - (right.span.endTime ?? right.span.startTime);
       if (endDiff !== 0) {
         return endDiff;
       }
 
-      return a.name.localeCompare(b.name);
+      return left.index - right.index;
     })
-    .map((span) => {
+    .map(({ span }) => {
       const toolName = extractToolName(span);
       const command = extractCommand(span);
       const searchQuery = extractSearchQuery(span);

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -148,6 +148,43 @@ describe('trajectory utilities', () => {
     ]);
   });
 
+  it('preserves original span order when timestamps are tied', () => {
+    const steps = extractTrajectorySteps({
+      ...mockTraceData,
+      spans: [
+        {
+          spanId: 'tied-1',
+          name: 'tool.call',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: {
+            'tool.name': 'compose_reply',
+          },
+        },
+        {
+          spanId: 'tied-2',
+          name: 'tool.call',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: {
+            'tool.name': 'search_orders',
+          },
+        },
+        {
+          spanId: 'tied-3',
+          name: 'tool.call',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: {
+            'tool.name': 'finalize',
+          },
+        },
+      ],
+    });
+
+    expect(steps.map((step) => step.name)).toEqual(['compose_reply', 'search_orders', 'finalize']);
+  });
+
   it('compacts repeated steps and truncates long judge summaries', () => {
     const trace = {
       ...mockTraceData,

--- a/test/assertions/trajectoryGoalSuccess.test.ts
+++ b/test/assertions/trajectoryGoalSuccess.test.ts
@@ -98,6 +98,10 @@ describe('handleTrajectoryGoalSuccess', () => {
 
     const params: AssertionParams = {
       ...defaultParams,
+      assertionValueContext: {
+        ...defaultParams.assertionValueContext,
+        vars: { orderId: '123' },
+      },
       providerCallContext,
       test: {
         vars: { orderId: '123' },
@@ -148,7 +152,38 @@ describe('handleTrajectoryGoalSuccess', () => {
       expect.any(String),
       'test output',
       undefined,
+      {},
+      params.assertion,
       undefined,
+    );
+  });
+
+  it('passes resolved assertion vars instead of the raw test vars', async () => {
+    vi.mocked(matchesTrajectoryGoalSuccess).mockResolvedValue({
+      pass: true,
+      score: 1,
+      reason: 'Goal achieved',
+    });
+
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertionValueContext: {
+        ...defaultParams.assertionValueContext,
+        vars: { orderId: 'resolved-123' },
+      },
+      test: {
+        vars: { orderId: '{{ order_id }}' },
+      },
+    };
+
+    await handleTrajectoryGoalSuccess(params);
+
+    expect(matchesTrajectoryGoalSuccess).toHaveBeenCalledWith(
+      'Resolve the order lookup task',
+      expect.any(String),
+      'test output',
+      undefined,
+      { orderId: 'resolved-123' },
       params.assertion,
       undefined,
     );


### PR DESCRIPTION
Fix two trajectory assertion regressions.

- Preserve original span order when timestamps tie.
- Use resolved assertion vars for `trajectory:goal-success` grading.
- Add focused regression coverage for both cases.
