### PR TITLE
fix: avoid false _conversation detection

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -67,6 +67,7 @@ import {
   isProviderAllowed,
 } from './util/provider';
 import { promptYesNo } from './util/readline';
+import { templateReferencesVariable } from './util/templates';
 import { sleep } from './util/time';
 import { TokenUsageTracker } from './util/tokenUsage';
 import {
@@ -326,7 +327,7 @@ export async function runEval({
   const fileMetadata = collectFileMetadata(test.vars || vars);
 
   const conversationKey = `${provider.label || provider.id()}:${prompt.id}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
-  const usesConversation = prompt.raw.includes('_conversation');
+  const usesConversation = templateReferencesVariable(prompt.raw, '_conversation');
   if (
     !getEnvBool('PROMPTFOO_DISABLE_CONVERSATION_VAR') &&
     !test.options?.disableConversationVar &&
@@ -1461,7 +1462,9 @@ class Evaluator {
     // Determine run parameters
 
     if (concurrency > 1) {
-      const usesConversation = prompts.some((p) => p.raw.includes('_conversation'));
+      const usesConversation = prompts.some((p) =>
+        templateReferencesVariable(p.raw, '_conversation'),
+      );
       const usesStoreOutputAs = tests.some((t) => t.options?.storeOutputAs);
       if (usesConversation) {
         logger.info(
@@ -2284,7 +2287,9 @@ class Evaluator {
       this.evalRecord.results.length > 0 ? totalLatencyMs / this.evalRecord.results.length : 0;
 
     // Detect key feature usage patterns
-    const usesConversationVar = prompts.some((p) => p.raw.includes('_conversation'));
+    const usesConversationVar = prompts.some((p) =>
+      templateReferencesVariable(p.raw, '_conversation'),
+    );
     const usesTransforms = Boolean(
       tests.some((t) => t.options?.transform || t.options?.postprocess) ||
         testSuite.providers.some((p) => Boolean(p.transform)),

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -100,3 +100,19 @@ export function extractVariablesFromTemplates(templates: string[]): string[] {
   }
   return Array.from(variableSet);
 }
+
+function getRootVariableName(variable: string): string | null {
+  const match = variable.match(/^[A-Za-z_][A-Za-z0-9_]*/);
+  return match?.[0] ?? null;
+}
+
+/**
+ * Check whether a Nunjucks template references a specific root variable name.
+ * This avoids false positives from similarly named variables such as
+ * `pre_conversation_context` when checking for `_conversation`.
+ */
+export function templateReferencesVariable(template: string, variableName: string): boolean {
+  return extractVariablesFromTemplate(template).some(
+    (variable) => getRootVariableName(variable) === variableName,
+  );
+}

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -2152,6 +2152,41 @@ describe('evaluator', () => {
     expect(summary.results[1].response?.output).toBe('Second run First run ');
   });
 
+  it('does not force concurrency to 1 for similarly named variables', async () => {
+    let activeCalls = 0;
+    let maxActiveCalls = 0;
+
+    const concurrentProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('concurrent-provider'),
+      callApi: vi.fn().mockImplementation(async (prompt) => {
+        activeCalls += 1;
+        maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        activeCalls -= 1;
+
+        return {
+          output: prompt,
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+        };
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [concurrentProvider],
+      prompts: [toPrompt('{{ pre_conversation_context }}')],
+      tests: [
+        { vars: { pre_conversation_context: 'first' } },
+        { vars: { pre_conversation_context: 'second' } },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 2 });
+
+    expect(concurrentProvider.callApi).toHaveBeenCalledTimes(2);
+    expect(maxActiveCalls).toBe(2);
+  });
+
   it('evaluate with labeled and unlabeled providers and providerPromptMap', async () => {
     const mockLabeledProvider: ApiProvider = {
       id: () => 'labeled-provider-id',

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -5,6 +5,7 @@ import {
   extractVariablesFromTemplate,
   extractVariablesFromTemplates,
   getNunjucksEngine,
+  templateReferencesVariable,
 } from '../../src/util/templates';
 
 describe('extractVariablesFromTemplate', () => {
@@ -96,6 +97,27 @@ describe('extractVariablesFromTemplates', () => {
     const result = extractVariablesFromTemplates(templates);
 
     expect(result).toEqual(['name', 'age']);
+  });
+});
+
+describe('templateReferencesVariable', () => {
+  it('matches direct and indexed references to a variable', () => {
+    expect(templateReferencesVariable('{{ _conversation[0].output }}', '_conversation')).toBe(true);
+    expect(
+      templateReferencesVariable(
+        '{% for turn in _conversation %}{{ turn.output }}{% endfor %}',
+        '_conversation',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not false-positive on similarly named variables', () => {
+    expect(templateReferencesVariable('{{ pre_conversation_context }}', '_conversation')).toBe(
+      false,
+    );
+    expect(templateReferencesVariable('{{ user._conversation_label }}', '_conversation')).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- fix `_conversation` detection so only real `_conversation` template references trigger the special-case behavior
- avoid false positives for similarly named variables such as `pre_conversation_context`
- add regression coverage for both the template helper and evaluator concurrency behavior

## Problem

`promptfoo` currently checks for `_conversation` using a plain substring match.

That means prompts like:

```nunjucks
{{ pre_conversation_context }}
```

can be treated as if they were using the special `_conversation` runtime variable.

The visible effect is that evaluation concurrency can be forced down to `1` even though the prompt does not actually depend on `_conversation`.

## Reproduction

1. Create an eval that uses a normal variable with `_conversation` as part of its name, such as `pre_conversation_context`
2. Run the eval with `maxConcurrency > 1`
3. Observe that promptfoo incorrectly treats the prompt as using `_conversation` and serializes execution

## Fix

- added `templateReferencesVariable()` in `src/util/templates.ts`
- detect `_conversation` by checking the root template variable name instead of using `String.includes('_conversation')`
- updated all evaluator call sites that use `_conversation` detection:
  - runtime conversation var injection
  - concurrency forcing logic
  - telemetry feature detection

This keeps valid references like `{{ _conversation[0].output }}` working while preventing false positives from similarly named variables.

## Testing

Passed:

```bash
npx vitest run test/util/templates.test.ts
npx vitest run test/evaluator.test.ts
npm run build
```

Additional note:

- I also attempted `npm test` for the full suite.
- In this environment, unrelated existing test failures appeared in server route suites, and the run later blocked on an interactive `Work email:` prompt.
- Those failures/blockers were not caused by this change; the targeted regression tests above and the full build both passed.

## Files changed

- `src/util/templates.ts`
- `src/evaluator.ts`
- `test/util/templates.test.ts`
- `test/evaluator.test.ts`

Fixes #7845
