### PR TITLE
fix(envars): use explicit undefined check in getEnvInt and getEnvFloat

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -487,15 +487,13 @@ export function getEnvBool(key: EnvVarKey, defaultValue?: boolean): boolean {
 export function getEnvInt(key: EnvVarKey): number | undefined;
 export function getEnvInt(key: EnvVarKey, defaultValue: number): number;
 export function getEnvInt(key: EnvVarKey, defaultValue?: number): number | undefined {
-  const value = getEnvString(key) || defaultValue;
-  if (typeof value === 'number') {
-    return Math.floor(value);
+  const str = getEnvString(key);
+  if (str === undefined || str === '') {
+    return defaultValue;
   }
-  if (typeof value === 'string') {
-    const parsedValue = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsedValue)) {
-      return parsedValue;
-    }
+  const parsedValue = Number.parseInt(str, 10);
+  if (!Number.isNaN(parsedValue)) {
+    return parsedValue;
   }
   return defaultValue;
 }
@@ -509,15 +507,13 @@ export function getEnvInt(key: EnvVarKey, defaultValue?: number): number | undef
 export function getEnvFloat(key: EnvVarKey): number | undefined;
 export function getEnvFloat(key: EnvVarKey, defaultValue: number): number;
 export function getEnvFloat(key: EnvVarKey, defaultValue?: number): number | undefined {
-  const value = getEnvString(key) || defaultValue;
-  if (typeof value === 'number') {
-    return value;
+  const str = getEnvString(key);
+  if (str === undefined || str === '') {
+    return defaultValue;
   }
-  if (typeof value === 'string') {
-    const parsedValue = Number.parseFloat(value);
-    if (!Number.isNaN(parsedValue)) {
-      return parsedValue;
-    }
+  const parsedValue = Number.parseFloat(str);
+  if (!Number.isNaN(parsedValue)) {
+    return parsedValue;
   }
   return defaultValue;
 }

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -230,6 +230,16 @@ describe('envars', () => {
       process.env.CUSTOM_INT_VAR = '123';
       expect(getEnvInt('CUSTOM_INT_VAR' as EnvVarKey)).toBe(123);
     });
+
+    it('should return 0 when environment variable is set to "0"', () => {
+      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '0';
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(0);
+    });
+
+    it('should return 0 instead of default when environment variable is "0"', () => {
+      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '0';
+      expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT', 100)).toBe(0);
+    });
   });
 
   describe('getEnvFloat', () => {
@@ -270,6 +280,16 @@ describe('envars', () => {
     it('should return undefined when no default value is provided and the environment variable is not set', () => {
       delete process.env.OPENAI_TEMPERATURE;
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
+    });
+
+    it('should return 0 when environment variable is set to "0"', () => {
+      process.env.OPENAI_TEMPERATURE = '0';
+      expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(0);
+    });
+
+    it('should return 0 instead of default when environment variable is "0"', () => {
+      process.env.OPENAI_TEMPERATURE = '0';
+      expect(getEnvFloat('OPENAI_TEMPERATURE', 0.7)).toBe(0);
     });
 
     it('should prioritize cliState.config.env over process.env for float values', () => {


### PR DESCRIPTION
## Summary

`getEnvInt()` and `getEnvFloat()` in `src/envars.ts` use the `||` operator to fall back to a default value. In JavaScript, the string `"0"` is falsy, so setting any numeric environment variable to `0` is silently ignored and the default value is used instead.

Closes #8181

## Root cause

```typescript
// Before — "0" || defaultValue → defaultValue
const value = getEnvString(key) || defaultValue;
```

This affects all numeric env vars where `0` is a valid value, including `OPENAI_TEMPERATURE`, `PROMPTFOO_DELAY_MS`, `OPENAI_FREQUENCY_PENALTY`, etc.

## Fix

Adopted the pattern from `src/python/pythonUtils.ts` — explicit `undefined`/empty-string check instead of `||`:

```typescript
const str = getEnvString(key);
if (str === undefined || str === '') {
  return defaultValue;
}
const parsedValue = Number.parseInt(str, 10);
if (!Number.isNaN(parsedValue)) {
  return parsedValue;
}
return defaultValue;
```

A simple `||` → `??` swap would not work here because `getEnvString` returns `""` for `export VAR=`, and `parseInt("")` returns `NaN`.

## Relationship to #8163

This is an independent root cause. Even after #8163 fixed provider-level `||` → `??` for `config.temperature`, the env var path remained broken because `getEnvFloat` itself discards `"0"`.

## Test plan

Added 4 test cases:
- `getEnvInt` returns `0` when env var is `"0"`
- `getEnvInt` returns `0` instead of default `100` when env var is `"0"`
- `getEnvFloat` returns `0` when env var is `"0"`
- `getEnvFloat` returns `0` instead of default `0.7` when env var is `"0"`

All existing tests pass unchanged.