### PR TITLE
docs(site): update OpenAI join messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
   <a href="https://discord.gg/promptfoo">Discord</a>
 </p>
 
+> Update (March 16, 2026): Promptfoo has joined OpenAI. Promptfoo remains open source and MIT licensed. Read the [company update](https://www.promptfoo.dev/blog/promptfoo-joining-openai/).
+
 ## Quick Start
 
 ```sh

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -79,9 +79,9 @@ const config: Config = {
 
   themeConfig: {
     announcementBar: {
-      id: 'joining-openai',
+      id: 'joined-openai',
       content:
-        '<strong>Promptfoo will be joining OpenAI.</strong> <a href="/blog/promptfoo-joining-openai">Read the announcement →</a>',
+        '<strong>Promptfoo has joined OpenAI.</strong> <a href="/blog/promptfoo-joining-openai">Read the update →</a>',
       backgroundColor: '#dc2626',
       textColor: '#ffffff',
       isCloseable: false,

--- a/site/src/pages/about.tsx
+++ b/site/src/pages/about.tsx
@@ -53,8 +53,9 @@ const AboutPageContent = () => {
                 when we were on the front lines.
               </Typography>
               <Typography variant="body1" paragraph>
-                Based in San Mateo, California, we're backed by Insight Partners, Andreessen
-                Horowitz, and top leaders in the technology and security industries.
+                Based in San Mateo, California, Promptfoo joined OpenAI on March 16, 2026. Promptfoo
+                remains open source, and we continue to build tools for secure, reliable AI
+                applications.
               </Typography>
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
@@ -131,11 +132,11 @@ const AboutPageContent = () => {
 
         <Box mb={8}>
           <Typography variant="h4" component="h3" align="center" fontWeight="medium" mb={4}>
-            Backed by Industry Leaders
+            Early Supporters
           </Typography>
           <Typography variant="body1" align="center" paragraph mb={8}>
-            We're honored to have the support of top investors and industry experts who share our
-            vision for open-source, application-focused AI security.
+            We're grateful to the investors and operators who backed Promptfoo early and helped us
+            build open-source, application-focused AI security.
           </Typography>
           <Grid container spacing={4} justifyContent="center">
             {[

--- a/site/src/pages/press/_data.ts
+++ b/site/src/pages/press/_data.ts
@@ -205,6 +205,7 @@ export const FOUNDERS: Founder[] = [
 export const COMPANY_INFO = {
   founded: '2024',
   headquarters: 'San Francisco, California',
-  investors: 'Insight Partners, Andreessen Horowitz, and industry leaders',
+  affiliation: 'OpenAI',
+  earlySupporters: 'Insight Partners, Andreessen Horowitz, and industry leaders',
   contactEmail: 'inquiries@promptfoo.dev',
 };

--- a/site/src/pages/press/index.tsx
+++ b/site/src/pages/press/index.tsx
@@ -171,7 +171,8 @@ const PressContent = () => {
           <Typography variant="body1" paragraph>
             Promptfoo is a leading provider of AI security solutions, helping developers and
             enterprises build secure, reliable AI applications. Based in {COMPANY_INFO.headquarters}
-            , Promptfoo is backed by {COMPANY_INFO.investors}.
+            , Promptfoo joined OpenAI on March 16, 2026 and continues as an open-source AI security
+            project.
           </Typography>
           <Typography variant="body1" paragraph>
             Our core product is an open-source pentesting and evaluation framework used by{' '}
@@ -339,10 +340,16 @@ const PressContent = () => {
                 ))}
               </Typography>
               <Typography variant="h6" component="h4" gutterBottom>
-                Investors
+                Part of
               </Typography>
               <Typography variant="body1" paragraph>
-                {COMPANY_INFO.investors}
+                {COMPANY_INFO.affiliation}
+              </Typography>
+              <Typography variant="h6" component="h4" gutterBottom>
+                Early supporters
+              </Typography>
+              <Typography variant="body1" paragraph>
+                {COMPANY_INFO.earlySupporters}
               </Typography>
             </Grid>
           </Grid>


### PR DESCRIPTION
## Summary
- update the README and site announcement bar to reflect that Promptfoo has joined OpenAI
- refresh About and Press copy so current company messaging describes Promptfoo as part of OpenAI
- keep the original announcement blog post unchanged as historical content

## Testing
- pre-commit Biome + Prettier checks
- npx @biomejs/biome lint site/docusaurus.config.ts site/src/pages/about.tsx site/src/pages/press/_data.ts site/src/pages/press/index.tsx
