### PR TITLE
fix(providers): add gpt-5.4 mini and nano support

### DIFF
--- a/examples/openai-responses/README.md
+++ b/examples/openai-responses/README.md
@@ -13,7 +13,7 @@ cd openai-responses
 
 ### Basic Responses API (`promptfooconfig.yaml`)
 
-Basic example showing how to use the Responses API with different models and configurations.
+Basic example showing how to use the Responses API with current GPT-5.4 family models and configurations.
 
 ### External Response Format (`promptfooconfig.external-format.yaml`)
 

--- a/examples/openai-responses/promptfooconfig.yaml
+++ b/examples/openai-responses/promptfooconfig.yaml
@@ -33,8 +33,8 @@ providers:
           required: ['event_name', 'date', 'location', 'participants']
           additionalProperties: false
 
-  - id: openai:responses:gpt-5-nano
-    label: gpt-5-nano-json-object
+  - id: openai:responses:gpt-5.4-nano
+    label: gpt-5.4-nano-json-object
     config:
       temperature: 0.7
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
@@ -62,8 +62,8 @@ providers:
           additionalProperties: false
       store: true
 
-  - id: openai:responses:gpt-5-mini
-    label: gpt-5-mini-json-schema
+  - id: openai:responses:gpt-5.4-mini
+    label: gpt-5.4-mini-json-schema
     config:
       temperature: 0.7
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -481,20 +481,24 @@ GPT-5.4 is a GPT-5 family model for complex professional work, combining advance
 
 #### Available Models
 
-| Model                  | Description                   | Pricing (Input / Output)    |
-| ---------------------- | ----------------------------- | --------------------------- |
-| gpt-5.4                | Standard GPT-5.4 model        | $2.50 / $15 per 1M tokens   |
-| gpt-5.4-2026-03-05     | Dated snapshot of gpt-5.4     | $2.50 / $15 per 1M tokens   |
-| gpt-5.4-pro            | Premium GPT-5.4 pro model     | $30.00 / $180 per 1M tokens |
-| gpt-5.4-pro-2026-03-05 | Dated snapshot of gpt-5.4-pro | $30.00 / $180 per 1M tokens |
+| Model                   | Description                    | Pricing (Input / Output)    |
+| ----------------------- | ------------------------------ | --------------------------- |
+| gpt-5.4                 | Standard GPT-5.4 model         | $2.50 / $15 per 1M tokens   |
+| gpt-5.4-2026-03-05      | Dated snapshot of gpt-5.4      | $2.50 / $15 per 1M tokens   |
+| gpt-5.4-mini            | Smaller GPT-5.4 model          | $0.75 / $4.50 per 1M tokens |
+| gpt-5.4-mini-2026-03-17 | Dated snapshot of gpt-5.4-mini | $0.75 / $4.50 per 1M tokens |
+| gpt-5.4-nano            | Lowest-cost GPT-5.4 model      | $0.20 / $1.25 per 1M tokens |
+| gpt-5.4-nano-2026-03-17 | Dated snapshot of gpt-5.4-nano | $0.20 / $1.25 per 1M tokens |
+| gpt-5.4-pro             | Premium GPT-5.4 pro model      | $30.00 / $180 per 1M tokens |
+| gpt-5.4-pro-2026-03-05  | Dated snapshot of gpt-5.4-pro  | $30.00 / $180 per 1M tokens |
 
 #### Key Specifications
 
-- **Context window**: 1,050,000 tokens
+- **Context window**: `gpt-5.4` and `gpt-5.4-pro` support 1,050,000 tokens. `gpt-5.4-mini` and `gpt-5.4-nano` support 400,000 tokens.
 - **Max output tokens**: 128,000 tokens
-- **Reasoning effort**: `gpt-5.4` supports `none`, `low`, `medium`, `high`, `xhigh`. `gpt-5.4-pro` supports `medium`, `high`, `xhigh`.
-- **Endpoint support**: Chat Completions API, Responses API, and Codex SDK
-- **Cached input**: `gpt-5.4` cached input tokens $0.25 per 1M. `gpt-5.4-pro` has no cached-input discount.
+- **Reasoning effort**: `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` support `none`, `low`, `medium`, `high`, `xhigh`. `gpt-5.4-pro` supports `medium`, `high`, `xhigh`.
+- **Endpoint support**: Chat Completions API and Responses API across the GPT-5.4 family. Promptfoo's Codex SDK provider currently supports `gpt-5.4` and `gpt-5.4-pro`.
+- **Cached input**: `gpt-5.4` cached input tokens $0.25 per 1M, `gpt-5.4-mini` $0.075 per 1M, and `gpt-5.4-nano` $0.02 per 1M. `gpt-5.4-pro` has no cached-input discount.
 
 #### Usage Examples
 
@@ -509,6 +513,12 @@ providers:
     config:
       reasoning:
         effort: 'high'
+      max_output_tokens: 4096
+
+  - id: openai:responses:gpt-5.4-mini
+    config:
+      reasoning:
+        effort: 'medium'
       max_output_tokens: 4096
 
   - id: openai:responses:gpt-5.4-pro
@@ -1761,6 +1771,10 @@ The Responses API supports a wide range of models, including:
 
 - `gpt-5.4` - GPT-5.4 model ($2.50/$15 per 1M tokens)
 - `gpt-5.4-2026-03-05` - Dated snapshot of gpt-5.4
+- `gpt-5.4-mini` - Smaller GPT-5.4 model ($0.75/$4.50 per 1M tokens)
+- `gpt-5.4-mini-2026-03-17` - Dated snapshot of gpt-5.4-mini
+- `gpt-5.4-nano` - Lowest-cost GPT-5.4 model ($0.20/$1.25 per 1M tokens)
+- `gpt-5.4-nano-2026-03-17` - Dated snapshot of gpt-5.4-nano
 - `gpt-5.4-pro` - Premium GPT-5.4 model ($30/$180 per 1M tokens)
 - `gpt-5.4-pro-2026-03-05` - Dated snapshot of gpt-5.4-pro
 - `gpt-5` - OpenAI's most capable vision model

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -82,6 +82,10 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     // GPT-5.4 models
     'gpt-5.4',
     'gpt-5.4-2026-03-05',
+    'gpt-5.4-mini',
+    'gpt-5.4-mini-2026-03-17',
+    'gpt-5.4-nano',
+    'gpt-5.4-nano-2026-03-17',
     'gpt-5.4-pro',
     'gpt-5.4-pro-2026-03-05',
     // Audio models

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -346,6 +346,20 @@ export const OPENAI_CHAT_MODELS = [
       output: 15 / 1e6,
     },
   })),
+  ...['gpt-5.4-mini', 'gpt-5.4-mini-2026-03-17'].map((model) => ({
+    id: model,
+    cost: {
+      input: 0.75 / 1e6,
+      output: 4.5 / 1e6,
+    },
+  })),
+  ...['gpt-5.4-nano', 'gpt-5.4-nano-2026-03-17'].map((model) => ({
+    id: model,
+    cost: {
+      input: 0.2 / 1e6,
+      output: 1.25 / 1e6,
+    },
+  })),
   ...['gpt-5.4-pro', 'gpt-5.4-pro-2026-03-05'].map((model) => ({
     id: model,
     cost: {

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -1587,11 +1587,15 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
     it('should identify GPT-5 models correctly including prefixed names', async () => {
       // Direct model names
       const gpt5Provider = new OpenAiChatCompletionProvider('gpt-5');
+      const gpt54MiniProvider = new OpenAiChatCompletionProvider('gpt-5.4-mini');
+      const gpt54NanoProvider = new OpenAiChatCompletionProvider('gpt-5.4-nano');
       const gpt5MiniProvider = new OpenAiChatCompletionProvider('gpt-5-mini');
       const gpt5NanoProvider = new OpenAiChatCompletionProvider('gpt-5-nano');
 
       // Prefixed model names (used by GitHub Models)
       const prefixedGpt5Provider = new OpenAiChatCompletionProvider('openai/gpt-5');
+      const prefixedGpt54MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-mini');
+      const prefixedGpt54NanoProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-nano');
       const prefixedGpt5MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5-mini');
       const prefixedGpt5NanoProvider = new OpenAiChatCompletionProvider('openai/gpt-5-nano');
 
@@ -1600,9 +1604,13 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const gpt4oProvider = new OpenAiChatCompletionProvider('openai/gpt-4o');
 
       expect(gpt5Provider['isGPT5Model']()).toBe(true);
+      expect(gpt54MiniProvider['isGPT5Model']()).toBe(true);
+      expect(gpt54NanoProvider['isGPT5Model']()).toBe(true);
       expect(gpt5MiniProvider['isGPT5Model']()).toBe(true);
       expect(gpt5NanoProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt5Provider['isGPT5Model']()).toBe(true);
+      expect(prefixedGpt54MiniProvider['isGPT5Model']()).toBe(true);
+      expect(prefixedGpt54NanoProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt5MiniProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt5NanoProvider['isGPT5Model']()).toBe(true);
       expect(gpt4Provider['isGPT5Model']()).toBe(false);
@@ -1615,6 +1623,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const prefixedO3Provider = new OpenAiChatCompletionProvider('openai/o3-mini');
       const prefixedO4Provider = new OpenAiChatCompletionProvider('openai/o4-mini');
       const prefixedGpt5Provider = new OpenAiChatCompletionProvider('openai/gpt-5');
+      const prefixedGpt54MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-mini');
       const prefixedGpt5MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5-mini');
 
       // Non-reasoning prefixed models
@@ -1624,6 +1633,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(prefixedO3Provider['isReasoningModel']()).toBe(true);
       expect(prefixedO4Provider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt5Provider['isReasoningModel']()).toBe(true);
+      expect(prefixedGpt54MiniProvider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt5MiniProvider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt4oProvider['isReasoningModel']()).toBe(false);
     });

--- a/test/providers/openai/responses.test.ts
+++ b/test/providers/openai/responses.test.ts
@@ -52,6 +52,14 @@ describe('OpenAiResponsesProvider', () => {
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.3-chat-latest');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-2026-03-05');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-mini');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.4-mini-2026-03-17',
+    );
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-nano');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.4-nano-2026-03-17',
+    );
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-pro');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
       'gpt-5.4-pro-2026-03-05',
@@ -2681,6 +2689,14 @@ describe('OpenAiResponsesProvider', () => {
     // GPT-5.4 models
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-2026-03-05');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-mini');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.4-mini-2026-03-17',
+    );
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-nano');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.4-nano-2026-03-17',
+    );
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-pro');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
       'gpt-5.4-pro-2026-03-05',

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -235,6 +235,26 @@ describe('calculateOpenAICost', () => {
     expect(cost).toBeCloseTo((1000 * 2.5 + 500 * 15) / 1e6, 6);
   });
 
+  it('should calculate cost correctly for gpt-5.4-mini', () => {
+    const cost = calculateOpenAICost('gpt-5.4-mini', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 0.75 + 500 * 4.5) / 1e6, 6);
+  });
+
+  it('should calculate cost correctly for gpt-5.4-mini-2026-03-17', () => {
+    const cost = calculateOpenAICost('gpt-5.4-mini-2026-03-17', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 0.75 + 500 * 4.5) / 1e6, 6);
+  });
+
+  it('should calculate cost correctly for gpt-5.4-nano', () => {
+    const cost = calculateOpenAICost('gpt-5.4-nano', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 0.2 + 500 * 1.25) / 1e6, 6);
+  });
+
+  it('should calculate cost correctly for gpt-5.4-nano-2026-03-17', () => {
+    const cost = calculateOpenAICost('gpt-5.4-nano-2026-03-17', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 0.2 + 500 * 1.25) / 1e6, 6);
+  });
+
   it('should calculate cost correctly for gpt-5.2-codex', () => {
     const cost = calculateOpenAICost('gpt-5.2-codex', {}, 1000, 500);
     expect(cost).toBeCloseTo((1000 * 1.75 + 500 * 14) / 1e6, 6);


### PR DESCRIPTION
## Summary
- add the latest GPT-5.4 mini and nano model IDs and dated snapshots to the OpenAI Responses model registry
- add pricing coverage for the GPT-5.4 mini and nano family and extend provider tests for recognition and cost calculation
- update the OpenAI provider docs and Responses example config to use the current GPT-5.4 family

## Testing
- npm ci
- npx vitest run test/providers/openai/responses.test.ts test/providers/openai/util.test.ts test/providers/openai/chat.test.ts
- npm run tsc
