### PR TITLE
fix(cost): support inputCost/outputCost overrides

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -276,8 +276,11 @@ export function calculateAnthropicCost(
     // Tiered pricing for Claude Sonnet 4.5+:
     // - If prompt > 200k tokens: $6/MTok input, $22.50/MTok output
     // - Otherwise: $3/MTok input, $15/MTok output
-    const inputCost = config.cost ?? (promptTokens > 200_000 ? 6 / 1e6 : 3 / 1e6);
-    const outputCost = config.cost ?? (promptTokens > 200_000 ? 22.5 / 1e6 : 15 / 1e6);
+    const defaultInputCost = promptTokens > 200_000 ? 6 / 1e6 : 3 / 1e6;
+    const defaultOutputCost = promptTokens > 200_000 ? 22.5 / 1e6 : 15 / 1e6;
+
+    const inputCost = config.inputCost ?? config.cost ?? defaultInputCost;
+    const outputCost = config.outputCost ?? config.cost ?? defaultOutputCost;
 
     return inputCost * promptTokens + outputCost * completionTokens;
   }

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -53,8 +53,8 @@ export function calculateDeepSeekCost(
   }
 
   const uncachedPromptTokens = cachedTokens ? promptTokens - cachedTokens : promptTokens;
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   const cacheReadCost = config.cacheReadCost ?? model.cost.cache_read;
 
   const inputCostTotal = inputCost * uncachedPromptTokens;

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -59,15 +59,15 @@ export function calculateGoogleCost(
   // Check for tiered pricing (higher rates above token threshold)
   if (promptTokens != null && completionTokens != null) {
     if (model?.tieredCost && promptTokens > model.tieredCost.threshold) {
-      const inputCost = config.cost ?? model.tieredCost.above.input;
-      const outputCost = config.cost ?? model.tieredCost.above.output;
+      const inputCost = config.inputCost ?? config.cost ?? model.tieredCost.above.input;
+      const outputCost = config.outputCost ?? config.cost ?? model.tieredCost.above.output;
       return inputCost * promptTokens + outputCost * completionTokens;
     }
 
     // Use Vertex-specific pricing when available
     if (isVertexMode && model?.vertexCost) {
-      const inputCost = config.cost ?? model.vertexCost.input;
-      const outputCost = config.cost ?? model.vertexCost.output;
+      const inputCost = config.inputCost ?? config.cost ?? model.vertexCost.input;
+      const outputCost = config.outputCost ?? config.cost ?? model.vertexCost.output;
       return inputCost * promptTokens + outputCost * completionTokens;
     }
   }

--- a/src/providers/hyperbolic/chat.ts
+++ b/src/providers/hyperbolic/chat.ts
@@ -217,8 +217,8 @@ export function calculateHyperbolicCost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
 
   const inputCostTotal = inputCost * promptTokens;
   const outputCostTotal = outputCost * completionTokens;

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -593,13 +593,15 @@ export function calculateOpenAICost(
 
   let totalCost = 0;
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   totalCost += inputCost * promptTokens + outputCost * completionTokens;
 
   if ('audioInput' in model.cost || 'audioOutput' in model.cost) {
-    const audioInputCost = config.audioCost ?? (model.cost as any).audioInput ?? 0;
-    const audioOutputCost = config.audioCost ?? (model.cost as any).audioOutput ?? 0;
+    const audioInputCost =
+      config.audioInputCost ?? config.audioCost ?? (model.cost as any).audioInput ?? 0;
+    const audioOutputCost =
+      config.audioOutputCost ?? config.audioCost ?? (model.cost as any).audioOutput ?? 0;
     totalCost += audioInputCost * audioPromptTokens + audioOutputCost * audioCompletionTokens;
   }
 

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -27,8 +27,21 @@ interface ProviderModel {
 }
 
 export interface ProviderConfig {
+  /**
+   * Legacy single override applied to BOTH input + output token cost.
+   * Prefer `inputCost` / `outputCost` for asymmetric pricing.
+   */
   cost?: number;
+  inputCost?: number;
+  outputCost?: number;
+
+  /**
+   * Legacy single override applied to BOTH audio input + audio output token cost.
+   * Prefer `audioInputCost` / `audioOutputCost` for asymmetric pricing.
+   */
   audioCost?: number;
+  audioInputCost?: number;
+  audioOutputCost?: number;
 }
 
 /**
@@ -62,8 +75,8 @@ export function calculateCost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   return inputCost * promptTokens + outputCost * completionTokens;
 }
 

--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -306,8 +306,8 @@ export function calculateXAICost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
 
   const inputCostTotal = inputCost * promptTokens;
   const outputCostTotal = outputCost * completionTokens;

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -300,6 +300,11 @@ describe('calculateOpenAICost', () => {
     expect(cost).toBe(184.5);
   });
 
+  it('should use custom inputCost/outputCost from config when provided', () => {
+    const cost = calculateOpenAICost('gpt-4', { inputCost: 0.1, outputCost: 0.2 }, 1000, 500);
+    expect(cost).toBe(1000 * 0.1 + 500 * 0.2);
+  });
+
   it('should calculate cost correctly with custom audioCost', () => {
     const cost = calculateOpenAICost(
       'gpt-4o-audio-preview',
@@ -310,6 +315,32 @@ describe('calculateOpenAICost', () => {
       100,
     );
     expect(cost).toBe(15.0075);
+  });
+
+  it('should use custom audioInputCost/audioOutputCost when provided', () => {
+    const promptTokens = 1000;
+    const completionTokens = 500;
+    const audioPromptTokens = 200;
+    const audioCompletionTokens = 100;
+
+    const model = OPENAI_CHAT_MODELS.find((m) => m.id === 'gpt-4o-audio-preview');
+    if (!model || !model.cost) {
+      return;
+    }
+
+    const base = model.cost.input * promptTokens + model.cost.output * completionTokens;
+    const expected = base + 0.01 * audioPromptTokens + 0.02 * audioCompletionTokens;
+
+    const cost = calculateOpenAICost(
+      'gpt-4o-audio-preview',
+      { audioInputCost: 0.01, audioOutputCost: 0.02 },
+      promptTokens,
+      completionTokens,
+      audioPromptTokens,
+      audioCompletionTokens,
+    );
+
+    expect(cost).toBeCloseTo(expected, 8);
   });
 
   it('should handle a model with no cost property', () => {

--- a/test/providers/shared.test.ts
+++ b/test/providers/shared.test.ts
@@ -151,6 +151,25 @@ describe('Shared Provider Functions', () => {
       expect(cost).toBe(7.5);
     });
 
+    it('should prefer inputCost/outputCost over cost when provided', () => {
+      const cost = calculateCost(
+        'model1',
+        { inputCost: 0.01, outputCost: 0.02, cost: 0.005 },
+        1000,
+        500,
+        models,
+      );
+      expect(cost).toBe(1000 * 0.01 + 500 * 0.02);
+    });
+
+    it('should allow overriding only inputCost or outputCost', () => {
+      const inputOnly = calculateCost('model1', { inputCost: 0.01 }, 1000, 500, models);
+      expect(inputOnly).toBe(1000 * 0.01 + 500 * 0.002);
+
+      const outputOnly = calculateCost('model1', { outputCost: 0.02 }, 1000, 500, models);
+      expect(outputOnly).toBe(1000 * 0.001 + 500 * 0.02);
+    });
+
     it('should return undefined if model not found', () => {
       const cost = calculateCost('nonexistent', {}, 1000, 500, models);
       expect(cost).toBeUndefined();


### PR DESCRIPTION
Fixes #8184.

### What changed
- Added `inputCost` / `outputCost` (and `audioInputCost` / `audioOutputCost`) as optional overrides in provider cost config.
- Updated shared and provider-specific cost calculations to prefer the new fields, while keeping `cost` / `audioCost` as backwards-compatible fallbacks.
- Added unit tests covering override precedence and partial overrides.

### Notes
- Existing configs using `cost` or `audioCost` continue to behave the same.
- New fields allow modeling asymmetric pricing (common for most LLM APIs).
