### PR TITLE
fix(providers): support gpt-5.4 in codex provider

### DIFF
--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -16,10 +16,10 @@ The OpenAI Codex SDK is a proprietary package and is not installed by default. Y
 
 ## Provider IDs
 
-You can reference this provider using either:
+You can reference this provider using either base ID, and you can inline the model in the provider path:
 
-- `openai:codex-sdk` (full name)
-- `openai:codex` (alias)
+- `openai:codex-sdk` or `openai:codex-sdk:<model name>` (full name)
+- `openai:codex` or `openai:codex:<model name>` (alias)
 
 ## Installation
 
@@ -75,12 +75,19 @@ Specify which OpenAI model to use for code generation:
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:codex-sdk
-    config:
-      model: codex # Or any supported model
+  - openai:codex:gpt-5.4
 
 prompts:
   - 'Write a TypeScript function that validates email addresses'
+```
+
+If you need additional Codex settings, you can still set the model via `config.model`:
+
+```yaml
+providers:
+  - id: openai:codex-sdk
+    config:
+      model: gpt-5.4
 ```
 
 ### With Working Directory

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -32,7 +32,7 @@ The OpenAI provider supports the following model formats:
 - `openai:video:<model name>` - uses Sora video generation models
 - `openai:agents:<agent name>` - runs agentic workflows via OpenAI Agents SDK
 - `openai:chatkit:<workflow_id>` - runs ChatKit workflows
-- `openai:codex-sdk` - runs agentic coding workflows via OpenAI Codex SDK
+- `openai:codex-sdk` / `openai:codex` - runs agentic coding workflows via OpenAI Codex SDK, with optional inline model selection like `openai:codex:gpt-5.4`
 
 The `openai:<endpoint>:<model name>` construction is useful if OpenAI releases a new model,
 or if you have a custom model.
@@ -2300,7 +2300,7 @@ See the [OpenAI Agents documentation](/docs/providers/openai-agents) for full co
 
 ### Codex SDK
 
-For agentic coding tasks with working directory access and structured JSON output, use the [OpenAI Codex SDK provider](/docs/providers/openai-codex-sdk). This provider supports GPT-5.4 and Codex-optimized GPT-5 models for code generation:
+For agentic coding tasks with working directory access and structured JSON output, use the [OpenAI Codex SDK provider](/docs/providers/openai-codex-sdk). This provider supports GPT-5.4 and Codex-optimized GPT-5 models for code generation. You can select a model inline with `openai:codex:gpt-5.4` or via `config.model` when you need additional options:
 
 ```yaml
 providers:

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -893,8 +893,10 @@ export const providerMap: ProviderFactory[] = [
       if (modelType === 'codex-sdk' || modelType === 'codex') {
         const { OpenAICodexSDKProvider } = await import('./openai/codex-sdk');
         const codexModel = modelName || configuredModel;
+        const codexProviderId = providerOptions.id ?? providerPath;
         return new OpenAICodexSDKProvider({
           ...providerOptions,
+          id: codexProviderId,
           config: codexModel
             ? {
                 ...providerOptions.config,

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -474,6 +474,7 @@ describe('loadApiProvider', () => {
     const provider = await loadApiProvider('openai:codex:gpt-5.4');
 
     expect(provider).toBeInstanceOf(OpenAICodexSDKProvider);
+    expect(provider.id()).toBe('openai:codex:gpt-5.4');
     expect((provider as OpenAICodexSDKProvider).config.model).toBe('gpt-5.4');
   });
 
@@ -481,6 +482,7 @@ describe('loadApiProvider', () => {
     const provider = await loadApiProvider('openai:codex-sdk:gpt-5.4-pro');
 
     expect(provider).toBeInstanceOf(OpenAICodexSDKProvider);
+    expect(provider.id()).toBe('openai:codex-sdk:gpt-5.4-pro');
     expect((provider as OpenAICodexSDKProvider).config.model).toBe('gpt-5.4-pro');
   });
 
@@ -494,6 +496,7 @@ describe('loadApiProvider', () => {
     });
 
     expect(provider).toBeInstanceOf(OpenAICodexSDKProvider);
+    expect(provider.id()).toBe('openai:codex');
     expect((provider as OpenAICodexSDKProvider).config.model).toBe('gpt-5.4');
   });
 


### PR DESCRIPTION
## Summary
- preserve model suffixes for `openai:codex` and `openai:codex-sdk` provider IDs so explicit Codex model selection reaches the SDK provider
- add loader coverage for `openai:codex:gpt-5.4`, `openai:codex-sdk:gpt-5.4-pro`, and the config-model fallback
- merge latest `origin/main` into the branch and resolve unrelated upstream conflicts

## Testing
- `npx vitest run test/providers.test.ts test/providers/openai-codex-sdk.test.ts`
- `npm run tsc -- --pretty false`