### PR TITLE
fix(evaluator): detect standalone conversation templates

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -83,6 +83,13 @@ import { type TransformContext, TransformInputType, transform } from './util/tra
 import type { SingleBar } from 'cli-progress';
 import type winston from 'winston';
 
+const CONVERSATION_TEMPLATE_VAR_REGEX =
+  /\{\{[\s\S]*?\b_conversation\b[\s\S]*?\}\}|\{%[\s\S]*?\b_conversation\b[\s\S]*?%\}/m;
+
+export function usesConversationTemplateVar(rawPrompt: string): boolean {
+  return CONVERSATION_TEMPLATE_VAR_REGEX.test(rawPrompt);
+}
+
 import type Eval from './models/eval';
 import type EvalResult from './models/evalResult';
 import type {
@@ -461,7 +468,7 @@ export async function runEval({
   const fileMetadata = collectFileMetadata(test.vars || vars);
 
   const conversationKey = `${provider.label || provider.id()}:${prompt.id}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
-  const usesConversation = prompt.raw.includes('_conversation');
+  const usesConversation = usesConversationTemplateVar(prompt.raw);
   if (
     !getEnvBool('PROMPTFOO_DISABLE_CONVERSATION_VAR') &&
     !test.options?.disableConversationVar &&
@@ -1607,7 +1614,7 @@ class Evaluator {
     // Determine run parameters
 
     if (concurrency > 1) {
-      const usesConversation = prompts.some((p) => p.raw.includes('_conversation'));
+      const usesConversation = prompts.some((p) => usesConversationTemplateVar(p.raw));
       const usesStoreOutputAs = tests.some((t) => t.options?.storeOutputAs);
       if (usesConversation) {
         logger.info(
@@ -2435,7 +2442,7 @@ class Evaluator {
       this.evalRecord.results.length > 0 ? totalLatencyMs / this.evalRecord.results.length : 0;
 
     // Detect key feature usage patterns
-    const usesConversationVar = prompts.some((p) => p.raw.includes('_conversation'));
+    const usesConversationVar = prompts.some((p) => usesConversationTemplateVar(p.raw));
     const usesTransforms = Boolean(
       tests.some((t) => t.options?.transform || t.options?.postprocess) ||
         testSuite.providers.some((p) => Boolean(p.transform)),

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -11,6 +11,7 @@ import {
   generateVarCombinations,
   isAllowedPrompt,
   runEval,
+  usesConversationTemplateVar,
 } from '../src/evaluator';
 import { runExtensionHook } from '../src/evaluatorHelpers';
 import logger from '../src/logger';
@@ -2230,6 +2231,60 @@ describe('evaluator', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.results[0].response?.output).toBe('First run ');
     expect(summary.results[1].response?.output).toBe('Second run First run ');
+  });
+
+  it('forces concurrency to 1 when _conversation is used as a standalone template variable', async () => {
+    const loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    const mockApiProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('test-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'ok',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('{{ _conversation[0].output }} {{ input }}')],
+      tests: [{ vars: { input: 'test input' } }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 10 });
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Setting concurrency to 1 because the'),
+    );
+  });
+
+  it('does not force concurrency to 1 when _conversation appears only as a substring', async () => {
+    const loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    const mockApiProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('test-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'ok',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Summarize the pre_conversation_context for {{ input }}')],
+      tests: [{ vars: { input: 'test input' } }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 10 });
+
+    expect(loggerInfoSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Setting concurrency to 1 because the'),
+    );
+  });
+
+  it('detects _conversation inside object-literal template expressions', () => {
+    const prompt = '{{ {"nested": {"value": 1}, "history": _conversation}["history"][0].output }}';
+
+    expect(usesConversationTemplateVar(prompt)).toBe(true);
   });
 
   it('evaluate with labeled and unlabeled providers and providerPromptMap', async () => {


### PR DESCRIPTION
## Summary

- broaden `_conversation` template detection so valid Nunjucks expressions with object literals still trigger the concurrency safeguard
- add focused regression coverage for object-literal template expressions while preserving the substring-only non-match behavior
- keep the standalone-template detection intent intact without regressing the original false-positive fix

## Testing

- `npx vitest run test/evaluator.test.ts -t \"_conversation is used as a standalone template variable|_conversation appears only as a substring|object-literal template expressions\"`
- `npm run tsc -- --pretty false`
- `npm run l`