### PR TITLE
fix(redteam): clarify remote generation guidance

### DIFF
--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -163,7 +163,7 @@ export class HydraProvider implements ApiProvider {
     // Hydra strategy requires remote generation
     if (!shouldGenerateRemote()) {
       throw new Error(
-        'jailbreak:hydra strategy requires remote generation, which is currently disabled (commonly because OPENAI_API_KEY is set). To fix, unset OPENAI_API_KEY, set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
+        'jailbreak:hydra strategy requires remote generation, which is currently disabled for this configuration. To fix, enable remote generation (for example by unsetting OPENAI_API_KEY), set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
       );
     }
 

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -653,7 +653,7 @@ class RedteamIterativeMetaProvider implements ApiProvider {
     // Meta-agent strategy requires remote generation
     if (!shouldGenerateRemote()) {
       throw new Error(
-        'jailbreak:meta strategy requires remote generation, which is currently disabled (commonly because OPENAI_API_KEY is set). To fix, unset OPENAI_API_KEY, set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
+        'jailbreak:meta strategy requires remote generation, which is currently disabled for this configuration. To fix, enable remote generation (for example by unsetting OPENAI_API_KEY), set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
       );
     }
 

--- a/test/redteam/providers/hydra/index.test.ts
+++ b/test/redteam/providers/hydra/index.test.ts
@@ -206,7 +206,7 @@ describe('HydraProvider', () => {
       expect(() => {
         new HydraProvider({ injectVar: 'input' });
       }).toThrow(
-        'jailbreak:hydra strategy requires remote generation, which is currently disabled (commonly because OPENAI_API_KEY is set). To fix, unset OPENAI_API_KEY, set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
+        'jailbreak:hydra strategy requires remote generation, which is currently disabled for this configuration. To fix, enable remote generation (for example by unsetting OPENAI_API_KEY), set PROMPTFOO_REMOTE_GENERATION_URL, or log into Promptfoo Cloud.',
       );
     });
 


### PR DESCRIPTION
## Summary
- update the Hydra and Iterative Meta remote-generation error message so it says remote generation is disabled for the current configuration instead of implying `OPENAI_API_KEY` is always the reason
- keep the actual remote-generation gating logic unchanged and scope this follow-up to clearer user guidance only
- update the Hydra constructor test to match the new wording

## Validation
- `npx vitest run test/redteam/providers/hydra/index.test.ts test/redteam/providers/iterativeMeta.test.ts`
- `npx @biomejs/biome check src/redteam/providers/hydra/index.ts src/redteam/providers/iterativeMeta.ts test/redteam/providers/hydra/index.test.ts`