### PR TITLE
fix(redteam): preserve zero-valued crescendo config

### DIFF
--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -165,8 +165,8 @@ export class CrescendoProvider implements ApiProvider {
     // Create a copy of config to avoid mutating the original
     this.config = { ...config };
     // Support backwards compatibility: use maxRounds if maxTurns is not provided
-    this.maxTurns = config.maxTurns || config.maxRounds || DEFAULT_MAX_TURNS;
-    this.maxBacktracks = config.maxBacktracks || DEFAULT_MAX_BACKTRACKS;
+    this.maxTurns = config.maxTurns ?? config.maxRounds ?? DEFAULT_MAX_TURNS;
+    this.maxBacktracks = config.maxBacktracks ?? DEFAULT_MAX_BACKTRACKS;
 
     // Cap turns for unauthenticated users
     if (!isLoggedIntoCloud()) {

--- a/test/redteam/providers/crescendo/index.test.ts
+++ b/test/redteam/providers/crescendo/index.test.ts
@@ -242,6 +242,30 @@ describe('CrescendoProvider', () => {
     expect(provider['maxTurns']).toBe(12);
   });
 
+  it('should preserve explicit zero values for maxTurns and maxBacktracks', () => {
+    const provider = new CrescendoProvider({
+      injectVar: 'objective',
+      maxTurns: 0,
+      maxBacktracks: 0,
+      redteamProvider: mockRedTeamProvider,
+      stateful: false,
+    });
+
+    expect(provider['maxTurns']).toBe(0);
+    expect(provider['maxBacktracks']).toBe(0);
+  });
+
+  it('should preserve maxRounds when it is explicitly set to zero', () => {
+    const provider = new CrescendoProvider({
+      injectVar: 'objective',
+      maxRounds: 0,
+      redteamProvider: mockRedTeamProvider,
+      stateful: false,
+    });
+
+    expect(provider['maxTurns']).toBe(0);
+  });
+
   it('should return correct provider id', () => {
     expect(crescendoProvider.id()).toBe('promptfoo:redteam:crescendo');
   });


### PR DESCRIPTION
## Summary
- preserve explicit `0` values for Crescendo `maxTurns`, deprecated `maxRounds`, and `maxBacktracks`
- add constructor-level regression coverage proving zero-valued config is not replaced by defaults

## Testing
- `npx vitest run test/redteam/providers/crescendo/index.test.ts`
- `npm run build`
- `npm run lint:src -- src/redteam/providers/crescendo/index.ts`
- `npm run lint:tests -- test/redteam/providers/crescendo/index.test.ts`