### PR TITLE
fix(redteam): preserve zero-valued custom config

### DIFF
--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -186,8 +186,8 @@ export class CustomProvider implements ApiProvider {
 
     // Create a copy of config to avoid mutating the original
     this.config = { ...config };
-    this.maxTurns = config.maxTurns || DEFAULT_MAX_TURNS;
-    this.maxBacktracks = config.maxBacktracks || DEFAULT_MAX_BACKTRACKS;
+    this.maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
+    this.maxBacktracks = config.maxBacktracks ?? DEFAULT_MAX_BACKTRACKS;
 
     // Cap turns for unauthenticated users
     if (!isLoggedIntoCloud()) {

--- a/test/redteam/providers/custom/index.test.ts
+++ b/test/redteam/providers/custom/index.test.ts
@@ -227,6 +227,20 @@ describe('CustomProvider', () => {
     expect(provider.config.continueAfterSuccess).toBe(false); // Default false
   });
 
+  it('should preserve explicit zero values for maxTurns and maxBacktracks', () => {
+    const provider = new CustomProvider({
+      injectVar: 'objective',
+      strategyText: 'Custom strategy',
+      maxTurns: 0,
+      maxBacktracks: 0,
+      redteamProvider: mockRedTeamProvider,
+      stateful: false,
+    });
+
+    expect((provider as any).maxTurns).toBe(0);
+    expect((provider as any).maxBacktracks).toBe(0);
+  });
+
   it('should include sessionId from context vars when response is missing it', async () => {
     const provider = new CustomProvider({
       injectVar: 'objective',


### PR DESCRIPTION
## Summary
- preserve explicit `0` values for the Custom redteam provider's `maxTurns` and `maxBacktracks`
- add constructor-level regression coverage proving zero-valued config is not replaced by defaults

## Testing
- `npx vitest run test/redteam/providers/custom/index.test.ts`
- `npm run build`
- `npm run lint:src -- src/redteam/providers/custom/index.ts`
- `npm run lint:tests -- test/redteam/providers/custom/index.test.ts`