### PR TITLE
docs(site): document provider pricing overrides

### DIFF
--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -618,6 +618,11 @@ type ProviderFunction = (
 
 ProviderOptions is an object that includes the `id` of the provider and an optional `config` object that can be used to pass provider-specific configurations.
 
+For providers with built-in cost estimation, `config` can also include pricing overrides such
+as `cost`, `inputCost`, and `outputCost`. When supported, `inputCost` and `outputCost` take
+precedence over the legacy shared `cost` value. OpenAI audio-capable models also support
+`audioCost`, `audioInputCost`, and `audioOutputCost`.
+
 ```typescript
 interface ProviderOptions {
   id?: ProviderId;

--- a/site/docs/providers/ai21.md
+++ b/site/docs/providers/ai21.md
@@ -58,7 +58,8 @@ providers:
       response_format: { type: 'json_object' }
 ```
 
-This configuration uses the `jamba-1.5-mini` model with a temperature of 0.1, top-p sampling with a value of 1, a maximum output length of 1024 tokens, JSON-formatted output, and a custom cost of $0.2 per 1M input tokens.
+This configuration uses the `jamba-1.5-mini` model with a temperature of 0.1, top-p sampling
+with a value of 1, a maximum output length of 1024 tokens, and JSON-formatted output.
 
 ## Cost
 
@@ -67,7 +68,9 @@ The cost of using AI21 models depends on the model and the number of input and o
 - `jamba-1.5-mini`: $0.2 per 1M input tokens, $0.4 per 1M output tokens
 - `jamba-1.5-large`: $2 per 1M input tokens, $8 per 1M output tokens
 
-You can set the `cost` option in the provider configuration to specify a custom cost for the model.
+You can override promptfoo's built-in pricing with `inputCost` and `outputCost` in the
+provider configuration. The legacy `cost` option still works as a shared fallback when you
+want the same rate for both directions.
 
 ## Supported environment variables
 

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -74,6 +74,9 @@ Claude models are available across multiple platforms. Here's how the model name
 | apiBaseUrl      | ANTHROPIC_BASE_URL    | The base URL for requests to the Anthropic API                                      |
 | temperature     | ANTHROPIC_TEMPERATURE | Controls the randomness of the output (default: 0)                                  |
 | max_tokens      | ANTHROPIC_MAX_TOKENS  | The maximum length of the generated text (default: 1024)                            |
+| cost            | -                     | Legacy per-token override applied to both input and output pricing                  |
+| inputCost       | -                     | Override input token pricing in promptfoo cost estimates                            |
+| outputCost      | -                     | Override output token pricing in promptfoo cost estimates                           |
 | top_p           | -                     | Controls nucleus sampling, affecting the randomness of the output                   |
 | top_k           | -                     | Only sample from the top K options for each subsequent token                        |
 | tools           | -                     | An array of tool or function definitions for the model to call                      |

--- a/site/docs/providers/deepseek.md
+++ b/site/docs/providers/deepseek.md
@@ -33,6 +33,7 @@ providers:
 
 - `temperature`
 - `max_tokens`
+- `cost`, `inputCost`, `outputCost` - Override promptfoo's pricing estimates (`inputCost` and `outputCost` take precedence over `cost`)
 - `top_p`, `presence_penalty`, `frequency_penalty`
 - `stream`
 - `showThinking` - Control whether reasoning content is included in the output (default: `true`, applies to deepseek-reasoner model)

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -100,6 +100,10 @@ providers:
       apiBaseUrl: https://custom.googleapis.com
 ```
 
+For promptfoo's built-in cost estimates, Google providers also support `config.cost`,
+`config.inputCost`, and `config.outputCost`. Use `inputCost` and `outputCost` for separate
+prompt and completion pricing. The legacy `cost` option remains the shared fallback.
+
 ## Quick Start
 
 ### 1. Basic Evaluation

--- a/site/docs/providers/hyperbolic.md
+++ b/site/docs/providers/hyperbolic.md
@@ -107,19 +107,20 @@ providers:
 
 #### Text Generation Options
 
-| Parameter            | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| `apiKey`             | Your Hyperbolic API key                                                   |
-| `temperature`        | Controls the randomness of the output (0.0 to 2.0)                        |
-| `max_tokens`         | The maximum number of tokens to generate                                  |
-| `top_p`              | Controls nucleus sampling (0.0 to 1.0)                                    |
-| `top_k`              | Controls the number of top tokens to consider (-1 to consider all tokens) |
-| `min_p`              | Minimum probability for a token to be considered (0.0 to 1.0)             |
-| `presence_penalty`   | Penalty for new tokens (0.0 to 1.0)                                       |
-| `frequency_penalty`  | Penalty for frequent tokens (0.0 to 1.0)                                  |
-| `repetition_penalty` | Prevents token repetition (default: 1.0)                                  |
-| `stop`               | Array of strings that will stop generation when encountered               |
-| `seed`               | Random seed for reproducible results                                      |
+| Parameter                         | Description                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `apiKey`                          | Your Hyperbolic API key                                                                                                              |
+| `cost`, `inputCost`, `outputCost` | Override promptfoo's pricing estimates. Use `inputCost` and `outputCost` for asymmetric pricing; `cost` remains the shared fallback. |
+| `temperature`                     | Controls the randomness of the output (0.0 to 2.0)                                                                                   |
+| `max_tokens`                      | The maximum number of tokens to generate                                                                                             |
+| `top_p`                           | Controls nucleus sampling (0.0 to 1.0)                                                                                               |
+| `top_k`                           | Controls the number of top tokens to consider (-1 to consider all tokens)                                                            |
+| `min_p`                           | Minimum probability for a token to be considered (0.0 to 1.0)                                                                        |
+| `presence_penalty`                | Penalty for new tokens (0.0 to 1.0)                                                                                                  |
+| `frequency_penalty`               | Penalty for frequent tokens (0.0 to 1.0)                                                                                             |
+| `repetition_penalty`              | Prevents token repetition (default: 1.0)                                                                                             |
+| `stop`                            | Array of strings that will stop generation when encountered                                                                          |
+| `seed`                            | Random seed for reproducible results                                                                                                 |
 
 #### Image Generation Options
 

--- a/site/docs/providers/index.md
+++ b/site/docs/providers/index.md
@@ -175,6 +175,24 @@ providers:
       apiKey: your_api_key_here
 ```
 
+### Overriding Pricing
+
+For providers with built-in token pricing, you can override promptfoo's cost estimates in
+`config`:
+
+```yaml
+providers:
+  - id: openai:gpt-4o
+    config:
+      inputCost: 0.0000025
+      outputCost: 0.00001
+```
+
+Use `inputCost` and `outputCost` when a provider charges different prompt and completion
+rates. The legacy `cost` option remains a shared fallback that applies the same value to
+both directions. OpenAI audio-capable models also support `audioInputCost` and
+`audioOutputCost`, with `audioCost` as the shared fallback.
+
 ## Custom Integrations
 
 promptfoo supports several types of custom integrations:

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -101,6 +101,12 @@ Supported parameters include:
 | `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                                                                                                                                                                 |
 | `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                                                                                                                              |
 | `headers`               | Additional headers to include in the request.                                                                                                                                                                                                                                                     |
+| `cost`                  | Legacy per-token override applied to both input and output pricing in promptfoo cost estimates.                                                                                                                                                                                                   |
+| `inputCost`             | Override input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                         |
+| `outputCost`            | Override output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                        |
+| `audioCost`             | Legacy per-token override applied to both audio input and audio output pricing in promptfoo cost estimates.                                                                                                                                                                                       |
+| `audioInputCost`        | Override audio input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                   |
+| `audioOutputCost`       | Override audio output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                  |
 | `max_tokens`            | Controls maximum output length for non-reasoning requests. Not used by reasoning-capable models (o-series, `codex-mini-latest`, and GPT-5 family). Use `max_completion_tokens` (Chat Completions) or `max_output_tokens` (Responses API) instead.                                                 |
 | `maxRetries`            | Maximum number of retry attempts for failed API requests. Defaults to 4. Set to 0 to disable retries.                                                                                                                                                                                             |
 | `metadata`              | Key-value pairs for request tagging and organization.                                                                                                                                                                                                                                             |
@@ -118,6 +124,10 @@ Supported parameters include:
 | `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                                                                                                                                                     |
 | `user`                  | A unique identifier representing your end-user, for tracking and abuse prevention.                                                                                                                                                                                                                |
 | `max_completion_tokens` | Maximum number of tokens for reasoning-capable Chat Completions models (o-series and GPT-5 family). For Responses API, use `max_output_tokens` instead.                                                                                                                                           |
+
+Use `inputCost` and `outputCost` when a model has different prompt and completion rates.
+The legacy `cost` option remains a shared fallback. For audio-capable models,
+`audioInputCost` and `audioOutputCost` take precedence over `audioCost`.
 
 Here are the type declarations of `config` parameters:
 
@@ -159,6 +169,12 @@ interface OpenAiConfig {
   apiHost?: string;
   apiBaseUrl?: string;
   organization?: string;
+  cost?: number;
+  inputCost?: number;
+  outputCost?: number;
+  audioCost?: number;
+  audioInputCost?: number;
+  audioOutputCost?: number;
   headers?: { [key: string]: string };
   maxRetries?: number;
 }

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -626,28 +626,31 @@ defaultTest:
 
 ### Configuration Reference
 
-| Option                             | Description                                            | Default                              |
-| ---------------------------------- | ------------------------------------------------------ | ------------------------------------ |
-| `apiKey`                           | GCloud API token                                       | None                                 |
-| `apiHost`                          | API host override                                      | `{region}-aiplatform.googleapis.com` |
-| `apiVersion`                       | API version                                            | `v1`                                 |
-| `credentials`                      | Service account credentials (JSON or file path)        | None                                 |
-| `projectId`                        | GCloud project ID                                      | `GOOGLE_CLOUD_PROJECT` env var       |
-| `region`                           | GCloud region                                          | `us-central1`                        |
-| `publisher`                        | Model publisher                                        | `google`                             |
-| `context`                          | Model context                                          | None                                 |
-| `examples`                         | Few-shot examples                                      | None                                 |
-| `safetySettings`                   | Content filtering                                      | None                                 |
-| `generationConfig.temperature`     | Randomness control                                     | None                                 |
-| `generationConfig.maxOutputTokens` | Max tokens to generate                                 | None                                 |
-| `generationConfig.topP`            | Nucleus sampling                                       | None                                 |
-| `generationConfig.topK`            | Sampling diversity                                     | None                                 |
-| `generationConfig.stopSequences`   | Generation stop triggers                               | `[]`                                 |
-| `responseSchema`                   | JSON schema for structured output (supports `file://`) | None                                 |
-| `toolConfig`                       | Tool/function calling config                           | None                                 |
-| `systemInstruction`                | System prompt (supports `{{var}}` and `file://`)       | None                                 |
-| `expressMode`                      | Set to `false` to force OAuth/ADC even with API key    | auto (API key → `true`)              |
-| `streaming`                        | Use streaming API (`streamGenerateContent`)            | `false`                              |
+| Option                             | Description                                                        | Default                              |
+| ---------------------------------- | ------------------------------------------------------------------ | ------------------------------------ |
+| `apiKey`                           | GCloud API token                                                   | None                                 |
+| `apiHost`                          | API host override                                                  | `{region}-aiplatform.googleapis.com` |
+| `apiVersion`                       | API version                                                        | `v1`                                 |
+| `credentials`                      | Service account credentials (JSON or file path)                    | None                                 |
+| `projectId`                        | GCloud project ID                                                  | `GOOGLE_CLOUD_PROJECT` env var       |
+| `region`                           | GCloud region                                                      | `us-central1`                        |
+| `publisher`                        | Model publisher                                                    | `google`                             |
+| `context`                          | Model context                                                      | None                                 |
+| `cost`                             | Legacy per-token override applied to both input and output pricing | None                                 |
+| `inputCost`                        | Override input token pricing in promptfoo cost estimates           | None                                 |
+| `outputCost`                       | Override output token pricing in promptfoo cost estimates          | None                                 |
+| `examples`                         | Few-shot examples                                                  | None                                 |
+| `safetySettings`                   | Content filtering                                                  | None                                 |
+| `generationConfig.temperature`     | Randomness control                                                 | None                                 |
+| `generationConfig.maxOutputTokens` | Max tokens to generate                                             | None                                 |
+| `generationConfig.topP`            | Nucleus sampling                                                   | None                                 |
+| `generationConfig.topK`            | Sampling diversity                                                 | None                                 |
+| `generationConfig.stopSequences`   | Generation stop triggers                                           | `[]`                                 |
+| `responseSchema`                   | JSON schema for structured output (supports `file://`)             | None                                 |
+| `toolConfig`                       | Tool/function calling config                                       | None                                 |
+| `systemInstruction`                | System prompt (supports `{{var}}` and `file://`)                   | None                                 |
+| `expressMode`                      | Set to `false` to force OAuth/ADC even with API key                | auto (API key → `true`)              |
+| `streaming`                        | Use streaming API (`streamGenerateContent`)                        | `false`                              |
 
 :::note
 Not all models support all parameters. See [Google's documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/overview) for model-specific details.


### PR DESCRIPTION
Land after #8222 since I can't push to that PR directly for some reason