### PR TITLE
fix(anthropic): preserve zero max_tokens_to_sample

### DIFF
--- a/src/providers/anthropic/completion.ts
+++ b/src/providers/anthropic/completion.ts
@@ -51,7 +51,7 @@ export class AnthropicCompletionProvider extends AnthropicGenericProvider {
       model: this.modelName,
       prompt: `${Anthropic.HUMAN_PROMPT} ${prompt} ${Anthropic.AI_PROMPT}`,
       max_tokens_to_sample:
-        this.config?.max_tokens_to_sample || getEnvInt('ANTHROPIC_MAX_TOKENS', 1024),
+        this.config?.max_tokens_to_sample ?? getEnvInt('ANTHROPIC_MAX_TOKENS', 1024),
       temperature: this.config.temperature ?? getEnvFloat('ANTHROPIC_TEMPERATURE', 0),
       stop_sequences: stop,
     };

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -115,5 +115,26 @@ describe('AnthropicCompletionProvider', () => {
         error: 'API call error: Error: API call failed',
       });
     });
+
+    it('should preserve an explicit max_tokens_to_sample value of 0', async () => {
+      process.env.ANTHROPIC_MAX_TOKENS = '1024';
+
+      const provider = new AnthropicCompletionProvider('claude-2.1', {
+        config: { max_tokens_to_sample: 0 },
+      });
+      vi.spyOn(provider.anthropic.completions, 'create').mockResolvedValue({
+        id: 'test-id',
+        model: 'claude-2.1',
+        stop_reason: 'stop_sequence',
+        type: 'completion',
+        completion: 'Test output',
+      });
+
+      await provider.callApi('Test prompt');
+
+      expect(provider.anthropic.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ max_tokens_to_sample: 0 }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- preserve an explicit `max_tokens_to_sample: 0` in Anthropic completion requests instead of falling back to the env/default limit
- add a focused regression test proving the zero value reaches `anthropic.completions.create`

## Testing
- npx vitest run test/providers/anthropic/completion.test.ts
- npm run build
- npm run lint:src -- src/providers/anthropic/completion.ts
- npm run lint:tests -- test/providers/anthropic/completion.test.ts