### PR TITLE
fix(redteam): preserve zero prompt injection sample

### DIFF
--- a/src/redteam/strategies/promptInjections/index.ts
+++ b/src/redteam/strategies/promptInjections/index.ts
@@ -7,7 +7,7 @@ export async function addInjections(
   injectVar: string,
   config: Record<string, any>,
 ): Promise<TestCase[]> {
-  const sampleSize = config.sample || 1;
+  const sampleSize = config.sample ?? 1;
   const harmfulOnly = config.harmfulOnly || false;
   const injections =
     sampleSize === 1

--- a/test/redteam/strategies/promptInjections.test.ts
+++ b/test/redteam/strategies/promptInjections.test.ts
@@ -51,6 +51,19 @@ describe('addInjections', () => {
     });
   });
 
+  it('should preserve an explicit sample size of 0', async () => {
+    const testCases: TestCase[] = [
+      {
+        vars: { prompt: 'Hello world' },
+        metadata: {},
+      },
+    ];
+
+    const result = await addInjections(testCases, 'prompt', { sample: 0 });
+
+    expect(result).toEqual([]);
+  });
+
   it('should filter harmful only when configured', async () => {
     const testCases: TestCase[] = [
       {


### PR DESCRIPTION
## Summary
- preserve an explicit `sample: 0` in the prompt injection strategy instead of defaulting it back to 1
- add a focused regression test proving zero sample produces no injected cases

## Testing
- npx vitest run test/redteam/strategies/promptInjections.test.ts
- npm run build
- npm run lint:src -- src/redteam/strategies/promptInjections/index.ts
- npm run lint:tests -- test/redteam/strategies/promptInjections.test.ts
- npm run l