### PR TITLE
fix(openai): avoid invalid realtime zero output tokens

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -1700,9 +1700,11 @@ The Realtime API configuration supports these parameters in addition to standard
 | `input_audio_format`         | Format of audio input                               | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
 | `output_audio_format`        | Format of audio output                              | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
 | `websocketTimeout`           | Timeout for WebSocket connection (milliseconds)     | 30000                  | Any number                              |
-| `max_response_output_tokens` | Maximum tokens in model response                    | 'inf'                  | Number or 'inf'                         |
-| `tools`                      | Array of tool definitions for function calling      | []                     | Array of tool objects                   |
-| `tool_choice`                | Controls how tools are selected                     | 'auto'                 | 'none', 'auto', 'required', or object   |
+| `max_response_output_tokens` | Maximum tokens in model response                    | 'inf'                  | Positive integer or 'inf'               |
+
+For Realtime models, `0` is treated as invalid and falls back to the default `'inf'` value instead of being sent to the API.
+| `tools` | Array of tool definitions for function calling | [] | Array of tool objects |
+| `tool_choice` | Controls how tools are selected | 'auto' | 'none', 'auto', 'required', or object |
 
 #### Custom endpoints and proxies (Realtime)
 

--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -136,6 +136,14 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
   private isProcessingAudio: boolean = false;
   private audioTimeout: NodeJS.Timeout | null = null;
 
+  private getMaxResponseOutputTokens(): number | 'inf' {
+    const value = this.config.max_response_output_tokens;
+    if (typeof value === 'number' && value > 0) {
+      return value;
+    }
+    return 'inf';
+  }
+
   constructor(
     modelName: string,
     options: { config?: OpenAiRealtimeOptions; id?: string; env?: EnvOverrides } = {},
@@ -199,7 +207,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
     const inputAudioFormat = this.config.input_audio_format || 'pcm16';
     const outputAudioFormat = this.config.output_audio_format || 'pcm16';
     const temperature = this.config.temperature ?? 0.8;
-    const maxResponseOutputTokens = this.config.max_response_output_tokens ?? 'inf';
+    const maxResponseOutputTokens = this.getMaxResponseOutputTokens();
 
     const body: any = {
       model: this.modelName,
@@ -980,7 +988,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
             input_audio_format: this.config.input_audio_format || 'pcm16',
             output_audio_format: this.config.output_audio_format || 'pcm16',
             temperature: this.config.temperature ?? 0.8,
-            max_response_output_tokens: this.config.max_response_output_tokens ?? 'inf',
+            max_response_output_tokens: this.getMaxResponseOutputTokens(),
             ...(this.config.input_audio_transcription !== undefined && {
               input_audio_transcription: this.config.input_audio_transcription,
             }),

--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -199,7 +199,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
     const inputAudioFormat = this.config.input_audio_format || 'pcm16';
     const outputAudioFormat = this.config.output_audio_format || 'pcm16';
     const temperature = this.config.temperature ?? 0.8;
-    const maxResponseOutputTokens = this.config.max_response_output_tokens || 'inf';
+    const maxResponseOutputTokens = this.config.max_response_output_tokens ?? 'inf';
 
     const body: any = {
       model: this.modelName,
@@ -980,7 +980,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
             input_audio_format: this.config.input_audio_format || 'pcm16',
             output_audio_format: this.config.output_audio_format || 'pcm16',
             temperature: this.config.temperature ?? 0.8,
-            max_response_output_tokens: this.config.max_response_output_tokens || 'inf',
+            max_response_output_tokens: this.config.max_response_output_tokens ?? 'inf',
             ...(this.config.input_audio_transcription !== undefined && {
               input_audio_transcription: this.config.input_audio_transcription,
             }),

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -207,7 +207,7 @@ describe('OpenAI Realtime Provider', () => {
       });
     });
 
-    it('should preserve an explicit max_response_output_tokens value of 0 in the session body', async () => {
+    it('should fall back to inf when max_response_output_tokens is 0 in the session body', async () => {
       const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
         config: {
           modalities: ['text'],
@@ -217,7 +217,7 @@ describe('OpenAI Realtime Provider', () => {
 
       const body = await provider.getRealtimeSessionBody();
 
-      expect(body.max_response_output_tokens).toBe(0);
+      expect(body.max_response_output_tokens).toBe('inf');
     });
 
     it('should handle basic text response with persistent connection', async () => {
@@ -771,7 +771,7 @@ describe('OpenAI Realtime Provider', () => {
       );
     });
 
-    it('preserves an explicit max_response_output_tokens value of 0 in session.update', async () => {
+    it('falls back to inf when max_response_output_tokens is 0 in session.update', async () => {
       const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
         config: { max_response_output_tokens: 0 },
       });
@@ -781,7 +781,7 @@ describe('OpenAI Realtime Provider', () => {
 
       expect(mockWs.send).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('"max_response_output_tokens":0'),
+        expect.stringContaining('"max_response_output_tokens":"inf"'),
       );
 
       const messageHandlers = mockHandlers.message;

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -27,11 +27,15 @@ describe('OpenAI Realtime Provider', () => {
   let mockHandlers: { [key: string]: Function[] };
   const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
   const originalCustomRealtimeApiKey = process.env.CUSTOM_REALTIME_API_KEY;
+  const originalOpenAiApiBaseUrl = process.env.OPENAI_API_BASE_URL;
+  const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
 
   beforeEach(() => {
     vi.resetAllMocks();
     disableCache();
     process.env.OPENAI_API_KEY = 'test-api-key';
+    delete process.env.OPENAI_API_BASE_URL;
+    delete process.env.OPENAI_BASE_URL;
     mockHandlers = {
       open: [],
       message: [],
@@ -61,6 +65,8 @@ describe('OpenAI Realtime Provider', () => {
     enableCache();
     restoreEnvVar('OPENAI_API_KEY', originalOpenAiApiKey);
     restoreEnvVar('CUSTOM_REALTIME_API_KEY', originalCustomRealtimeApiKey);
+    restoreEnvVar('OPENAI_API_BASE_URL', originalOpenAiApiBaseUrl);
+    restoreEnvVar('OPENAI_BASE_URL', originalOpenAiBaseUrl);
   });
 
   describe('Basic Functionality', () => {
@@ -199,6 +205,19 @@ describe('OpenAI Realtime Provider', () => {
         temperature: 0.8,
         max_response_output_tokens: 'inf',
       });
+    });
+
+    it('should preserve an explicit max_response_output_tokens value of 0 in the session body', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
+        config: {
+          modalities: ['text'],
+          max_response_output_tokens: 0,
+        },
+      });
+
+      const body = await provider.getRealtimeSessionBody();
+
+      expect(body.max_response_output_tokens).toBe(0);
     });
 
     it('should handle basic text response with persistent connection', async () => {
@@ -750,6 +769,45 @@ describe('OpenAI Realtime Provider', () => {
       expect(constructedUrl).toBe(
         'wss://api.openai.com/v1/realtime?model=' + encodeURIComponent('gpt-4o-realtime-preview'),
       );
+    });
+
+    it('preserves an explicit max_response_output_tokens value of 0 in session.update', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
+        config: { max_response_output_tokens: 0 },
+      });
+      const promise = provider.directWebSocketRequest('hi');
+
+      mockHandlers.open.forEach((h) => h());
+
+      expect(mockWs.send).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('"max_response_output_tokens":0'),
+      );
+
+      const messageHandlers = mockHandlers.message;
+      const lastHandler = messageHandlers[messageHandlers.length - 1];
+      lastHandler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'conversation.item.created',
+            item: { id: 'msg_zero', role: 'user' },
+          }),
+        ),
+      );
+      lastHandler(
+        Buffer.from(JSON.stringify({ type: 'response.created', response: { id: 'resp_zero' } })),
+      );
+      lastHandler(Buffer.from(JSON.stringify({ type: 'response.text.done', text: 'ok' })));
+      lastHandler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.done',
+            response: { usage: { total_tokens: 1, input_tokens: 1, output_tokens: 0 } },
+          }),
+        ),
+      );
+
+      await promise;
     });
 
     it('converts custom https apiBaseUrl to wss for direct WebSocket', async () => {

--- a/test/util/redteamProbeLimit.test.ts
+++ b/test/util/redteamProbeLimit.test.ts
@@ -165,10 +165,8 @@ describe('redteamProbeLimit', () => {
     });
 
     it('should not count evals from previous months', () => {
-      const lastMonth = new Date();
-      lastMonth.setMonth(lastMonth.getMonth() - 1);
       insertRedteamEval({
-        createdAt: lastMonth.getTime(),
+        createdAt: getMonthStartTimestamp() - 1,
         numResults: 5,
         numRequestsPerResult: 1,
       });


### PR DESCRIPTION
## Summary

- avoid sending `max_response_output_tokens: 0` to the OpenAI Realtime API
- fall back invalid zero values to the documented default `'inf'`
- document the accepted realtime token behavior and update the provider regression tests

## Testing

- `npx vitest run test/providers/openai/realtime.test.ts`
- `npm run tsc -- --pretty false`