### PR TITLE
fix(redteam): preserve voice crescendo zero delay

### DIFF
--- a/src/redteam/providers/voiceCrescendo/index.ts
+++ b/src/redteam/providers/voiceCrescendo/index.ts
@@ -250,7 +250,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
     this.nunjucks = getNunjucksEngine();
     this.memory = new VoiceMemorySystem();
     this.conversationId = crypto.randomUUID();
-    this.delayBetweenTurns = config.delayBetweenTurns || 500;
+    this.delayBetweenTurns = config.delayBetweenTurns ?? 500;
 
     logger.debug('[VoiceCrescendo] Provider initialized', { config });
   }

--- a/test/redteam/providers/voiceCrescendo/index.test.ts
+++ b/test/redteam/providers/voiceCrescendo/index.test.ts
@@ -326,4 +326,30 @@ describe('VoiceCrescendoProvider', () => {
     expect(result.metadata?.voiceCrescendoTurnsCompleted).toBeLessThanOrEqual(3);
     expect(result.metadata?.stopReason).toBeDefined();
   });
+
+  it('should preserve an explicit delayBetweenTurns value of 0', async () => {
+    const { sleep } = await import('../../../../src/util/time');
+
+    vi.mocked(redteamProviderManager.getProvider).mockResolvedValue(mockRedteamProvider);
+    vi.mocked(getTargetResponse).mockResolvedValue({
+      output: 'Target response',
+      tokenUsage: { prompt: 20, completion: 10, total: 30, numRequests: 1 },
+    });
+
+    const provider = new VoiceCrescendoProvider({
+      injectVar: 'goal',
+      maxTurns: 2,
+      delayBetweenTurns: 0,
+    });
+
+    const context: CallApiContextParams = {
+      originalProvider: mockTargetProvider,
+      vars: { goal: 'test goal' },
+      prompt: { raw: 'test prompt', label: 'test' },
+    };
+
+    await provider.callApi('Test objective', context);
+
+    expect(vi.mocked(sleep)).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- preserve an explicit `delayBetweenTurns: 0` in the Voice Crescendo redteam provider instead of defaulting it back to 500ms
- add a focused regression test proving zero delay does not call `sleep()` between turns

## Testing
- npx vitest run test/redteam/providers/voiceCrescendo/index.test.ts
- npm run build
- npm run l
- npx @biomejs/biome check --write src/redteam/providers/voiceCrescendo/index.ts test/redteam/providers/voiceCrescendo/index.test.ts