### PR TITLE
fix: replace undeclared tiny-invariant imports in app

### DIFF
--- a/src/app/src/hooks/useSearchParamState.ts
+++ b/src/app/src/hooks/useSearchParamState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import invariant from '@promptfoo/util/invariant';
 import { useSearchParams } from 'react-router-dom';
-import invariant from 'tiny-invariant';
 import type { ZodSchema } from 'zod';
 
 /**

--- a/src/app/src/pages/eval/components/ChatMessages.tsx
+++ b/src/app/src/pages/eval/components/ChatMessages.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 
 import { cn } from '@app/lib/utils';
 import { resolveAudioSource, resolveImageSource } from '@app/utils/media';
+import invariant from '@promptfoo/util/invariant';
 import { Crosshair, Swords } from 'lucide-react';
-import invariant from 'tiny-invariant';
 
 interface BaseMessage {
   role: 'user' | 'assistant' | 'system';


### PR DESCRIPTION
## Summary

This fixes a frontend workspace dependency issue that broke the app dev server.  Users would see import resolution errors for `tiny-invariant` while running the app locally.

## Root Cause

The `src/app` workspace imported `tiny-invariant` directly in two files, but `src/app/package.json` does not declare `tiny-invariant` as a dependency.

That import could appear to work on some machines because `tiny-invariant` exists in the lockfiles as a transitive dependency of other packages and may be hoisted into a shared `node_modules` layout. In the current install layout, it was not available as a direct import from the app workspace, so Vite correctly failed module resolution.