### PR TITLE
feat(redteam): add action buttons to target type selector description

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -202,6 +202,61 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
         {showTargetTypeSection && (
           <section className="space-y-4">
             <Label className="text-sm font-semibold">Select Target Type</Label>
+            <p className="text-sm text-muted-foreground">
+              Select the type that best matches your target. You can also create your own using{' '}
+              <button
+                type="button"
+                className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground hover:bg-primary hover:text-primary-foreground transition-colors"
+                onClick={() =>
+                  handleProviderChange(
+                    { id: 'file:///path/to/custom_provider.py', config: {}, label: selectedTarget.label },
+                    'python',
+                  )
+                }
+              >
+                Python
+              </button>
+              ,{' '}
+              <button
+                type="button"
+                className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground hover:bg-primary hover:text-primary-foreground transition-colors"
+                onClick={() =>
+                  handleProviderChange(
+                    { id: 'file:///path/to/custom_provider.js', config: {}, label: selectedTarget.label },
+                    'javascript',
+                  )
+                }
+              >
+                JavaScript
+              </button>
+              , or{' '}
+              <button
+                type="button"
+                className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground hover:bg-primary hover:text-primary-foreground transition-colors"
+                onClick={() =>
+                  handleProviderChange(
+                    { id: 'exec', config: { command: '' }, label: selectedTarget.label },
+                    'exec',
+                  )
+                }
+              >
+                Shell Scripts
+              </button>
+              . Don&apos;t see what you need? Try{' '}
+              <button
+                type="button"
+                className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground hover:bg-primary hover:text-primary-foreground transition-colors"
+                onClick={() =>
+                  handleProviderChange(
+                    { id: '', config: {}, label: selectedTarget.label },
+                    'custom',
+                  )
+                }
+              >
+                Custom Provider
+              </button>
+              .
+            </p>
 
             <ProviderTypeSelector
               provider={selectedTarget}


### PR DESCRIPTION
## Summary
- Added a descriptive text below "Select Target Type" with inline action buttons for **Python**, **JavaScript**, **Shell Scripts**, and **Custom Provider**
- Clicking any button directly selects that provider type, improving discoverability for users who don't want to scroll through the full list
- Buttons use consistent styling with hover states matching the primary theme

Closes #6730

## Test plan
- [ ] Navigate to Red Team setup → Target Setup → enter a name → Continue
- [ ] Verify the description text appears below "Select Target Type"
- [ ] Click "Python" button → verify Python provider is selected
- [ ] Click "JavaScript" button → verify JavaScript provider is selected
- [ ] Click "Shell Scripts" button → verify Shell Command provider is selected
- [ ] Click "Custom Provider" button → verify Custom Provider is selected
- [ ] Verify buttons have proper hover states