### PR TITLE
fix(providers): support separate input/output cost overrides

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -276,8 +276,10 @@ export function calculateAnthropicCost(
     // Tiered pricing for Claude Sonnet 4.5+:
     // - If prompt > 200k tokens: $6/MTok input, $22.50/MTok output
     // - Otherwise: $3/MTok input, $15/MTok output
-    const inputCost = config.cost ?? (promptTokens > 200_000 ? 6 / 1e6 : 3 / 1e6);
-    const outputCost = config.cost ?? (promptTokens > 200_000 ? 22.5 / 1e6 : 15 / 1e6);
+    const inputCost =
+      config.inputCost ?? config.cost ?? (promptTokens > 200_000 ? 6 / 1e6 : 3 / 1e6);
+    const outputCost =
+      config.outputCost ?? config.cost ?? (promptTokens > 200_000 ? 22.5 / 1e6 : 15 / 1e6);
 
     return inputCost * promptTokens + outputCost * completionTokens;
   }

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -53,8 +53,8 @@ export function calculateDeepSeekCost(
   }
 
   const uncachedPromptTokens = cachedTokens ? promptTokens - cachedTokens : promptTokens;
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   const cacheReadCost = config.cacheReadCost ?? model.cost.cache_read;
 
   const inputCostTotal = inputCost * uncachedPromptTokens;

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -59,15 +59,15 @@ export function calculateGoogleCost(
   // Check for tiered pricing (higher rates above token threshold)
   if (promptTokens != null && completionTokens != null) {
     if (model?.tieredCost && promptTokens > model.tieredCost.threshold) {
-      const inputCost = config.cost ?? model.tieredCost.above.input;
-      const outputCost = config.cost ?? model.tieredCost.above.output;
+      const inputCost = config.inputCost ?? config.cost ?? model.tieredCost.above.input;
+      const outputCost = config.outputCost ?? config.cost ?? model.tieredCost.above.output;
       return inputCost * promptTokens + outputCost * completionTokens;
     }
 
     // Use Vertex-specific pricing when available
     if (isVertexMode && model?.vertexCost) {
-      const inputCost = config.cost ?? model.vertexCost.input;
-      const outputCost = config.cost ?? model.vertexCost.output;
+      const inputCost = config.inputCost ?? config.cost ?? model.vertexCost.input;
+      const outputCost = config.outputCost ?? config.cost ?? model.vertexCost.output;
       return inputCost * promptTokens + outputCost * completionTokens;
     }
   }

--- a/src/providers/hyperbolic/chat.ts
+++ b/src/providers/hyperbolic/chat.ts
@@ -217,8 +217,8 @@ export function calculateHyperbolicCost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
 
   const inputCostTotal = inputCost * promptTokens;
   const outputCostTotal = outputCost * completionTokens;

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -593,13 +593,13 @@ export function calculateOpenAICost(
 
   let totalCost = 0;
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   totalCost += inputCost * promptTokens + outputCost * completionTokens;
 
   if ('audioInput' in model.cost || 'audioOutput' in model.cost) {
-    const audioInputCost = config.audioCost ?? (model.cost as any).audioInput ?? 0;
-    const audioOutputCost = config.audioCost ?? (model.cost as any).audioOutput ?? 0;
+    const audioInputCost = config.audioInputCost ?? config.audioCost ?? (model.cost as any).audioInput ?? 0;
+    const audioOutputCost = config.audioOutputCost ?? config.audioCost ?? (model.cost as any).audioOutput ?? 0;
     totalCost += audioInputCost * audioPromptTokens + audioOutputCost * audioCompletionTokens;
   }
 

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -598,8 +598,10 @@ export function calculateOpenAICost(
   totalCost += inputCost * promptTokens + outputCost * completionTokens;
 
   if ('audioInput' in model.cost || 'audioOutput' in model.cost) {
-    const audioInputCost = config.audioInputCost ?? config.audioCost ?? (model.cost as any).audioInput ?? 0;
-    const audioOutputCost = config.audioOutputCost ?? config.audioCost ?? (model.cost as any).audioOutput ?? 0;
+    const audioInputCost =
+      config.audioInputCost ?? config.audioCost ?? (model.cost as any).audioInput ?? 0;
+    const audioOutputCost =
+      config.audioOutputCost ?? config.audioCost ?? (model.cost as any).audioOutput ?? 0;
     totalCost += audioInputCost * audioPromptTokens + audioOutputCost * audioCompletionTokens;
   }
 

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -28,7 +28,11 @@ interface ProviderModel {
 
 export interface ProviderConfig {
   cost?: number;
+  inputCost?: number;
+  outputCost?: number;
   audioCost?: number;
+  audioInputCost?: number;
+  audioOutputCost?: number;
 }
 
 /**
@@ -62,8 +66,8 @@ export function calculateCost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
   return inputCost * promptTokens + outputCost * completionTokens;
 }
 

--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -306,8 +306,8 @@ export function calculateXAICost(
     return undefined;
   }
 
-  const inputCost = config.cost ?? model.cost.input;
-  const outputCost = config.cost ?? model.cost.output;
+  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
+  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
 
   const inputCostTotal = inputCost * promptTokens;
   const outputCostTotal = outputCost * completionTokens;

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -172,6 +172,16 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(5200); // (0.02 * 250,000) + (0.02 * 10,000) = 5000 + 200 = 5200
     });
 
+    it('should respect separate inputCost and outputCost overrides for tiered Sonnet models', () => {
+      const cost = calculateAnthropicCost(
+        'claude-sonnet-4-5-20250929',
+        { inputCost: 0.01, outputCost: 0.03 },
+        250_000,
+        10_000,
+      );
+      expect(cost).toBe(2800); // (0.01 * 250,000) + (0.03 * 10,000) = 2500 + 300 = 2800
+    });
+
     it('should return undefined for missing model', () => {
       const cost = calculateAnthropicCost('non-existent-model', { cost: 0.015 });
 


### PR DESCRIPTION
## Summary
- cherry-pick the original provider cost override commit from #8195 onto a clean branch from `main`
- complete Anthropic tiered Sonnet pricing so `inputCost` and `outputCost` overrides are both honored
- add regression coverage for Anthropic tiered pricing and keep the OpenAI audio override formatting aligned with Biome
- exclude the unrelated redteam concurrency change that was bundled into the original PR branch

## Context
This supersedes #8195 with the same core provider-config change on a clean branch so the original contributor still receives commit authorship credit without carrying the unrelated fork-`main` branch history.

## Testing
- `npx vitest run test/providers/anthropic/util.test.ts test/providers/openai/util.test.ts test/providers/google/util.test.ts test/providers/hyperbolic.test.ts test/providers/xai/chat.test.ts test/providers/deepseek.test.ts`
- `npx -y @biomejs/biome@2.4.8 check src/providers/anthropic/util.ts src/providers/openai/util.ts test/providers/anthropic/util.test.ts`