### PR TITLE
fix: preserve configured plugin config in strategy preview

### DIFF
--- a/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts
+++ b/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
+import { useTestCaseGeneration } from '../TestCaseGenerationProvider';
+import { useStrategyTestGeneration } from './useStrategyTestGeneration';
+
+vi.mock('../../hooks/useRedTeamConfig', () => ({
+  useRedTeamConfig: vi.fn(),
+}));
+
+vi.mock('../TestCaseGenerationProvider', () => ({
+  useTestCaseGeneration: vi.fn(),
+}));
+
+describe('useStrategyTestGeneration', () => {
+  const generateTestCase = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useTestCaseGeneration).mockReturnValue({
+      generateTestCase,
+      isGenerating: false,
+      strategy: null,
+      continueGeneration: vi.fn(),
+      plugin: null,
+    });
+  });
+
+  it('passes through configured plugin payloads when generating a strategy preview', async () => {
+    vi.mocked(useRedTeamConfig).mockReturnValue({
+      config: {
+        plugins: [
+          {
+            id: 'policy',
+            config: {
+              policy: 'Never disclose another customer account details.',
+            },
+          },
+        ],
+        strategies: [
+          {
+            id: 'jailbreak:meta',
+            config: {
+              numTests: 5,
+            },
+          },
+        ],
+      },
+    } as ReturnType<typeof useRedTeamConfig>);
+
+    const { result } = renderHook(() =>
+      useStrategyTestGeneration({
+        strategyId: 'jailbreak:meta',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleTestCaseGeneration();
+    });
+
+    expect(result.current.testGenerationPlugin).toBe('policy');
+    expect(generateTestCase).toHaveBeenCalledWith(
+      {
+        id: 'policy',
+        config: {
+          policy: 'Never disclose another customer account details.',
+        },
+        isStatic: true,
+      },
+      {
+        id: 'jailbreak:meta',
+        config: {
+          numTests: 5,
+        },
+        isStatic: false,
+      },
+    );
+  });
+
+  it('falls back to the default preview plugin when no plugins are configured', async () => {
+    vi.mocked(useRedTeamConfig).mockReturnValue({
+      config: {
+        plugins: [],
+        strategies: [],
+      },
+    } as ReturnType<typeof useRedTeamConfig>);
+
+    const { result } = renderHook(() =>
+      useStrategyTestGeneration({
+        strategyId: 'jailbreak:meta',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleTestCaseGeneration();
+    });
+
+    expect(result.current.testGenerationPlugin).toBe('harmful:hate');
+    expect(generateTestCase).toHaveBeenCalledWith(
+      {
+        id: 'harmful:hate',
+        config: {},
+        isStatic: true,
+      },
+      {
+        id: 'jailbreak:meta',
+        config: {},
+        isStatic: false,
+      },
+    );
+  });
+});

--- a/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.ts
+++ b/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.ts
@@ -5,6 +5,8 @@ import { type RedteamStrategyObject, type StrategyConfig } from '@promptfoo/redt
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import { useTestCaseGeneration } from '../TestCaseGenerationProvider';
 
+import type { TargetPlugin } from '../testCaseGenerationTypes';
+
 const DEFAULT_TEST_GENERATION_PLUGIN: Plugin = 'harmful:hate';
 
 interface UseStrategyTestGenerationOptions {
@@ -36,25 +38,44 @@ export function useStrategyTestGeneration({
     return (found?.config ?? {}) as StrategyConfig;
   }, [config.strategies, strategyId]);
 
-  // Select a random plugin from the user's configured plugins, or fall back to default
-  const testGenerationPlugin = useMemo(() => {
-    const plugins = config.plugins?.map((p) => (typeof p === 'string' ? p : p.id)) ?? [];
+  // Select a random plugin from the user's configured plugins, preserving any plugin config.
+  const testGenerationTargetPlugin = useMemo<TargetPlugin>(() => {
+    const plugins = config.plugins ?? [];
     if (plugins.length === 0) {
-      return DEFAULT_TEST_GENERATION_PLUGIN;
+      return {
+        id: DEFAULT_TEST_GENERATION_PLUGIN,
+        config: {},
+        isStatic: true,
+      };
     }
-    return plugins[Math.floor(Math.random() * plugins.length)] as Plugin;
+
+    const selectedPlugin = plugins[Math.floor(Math.random() * plugins.length)];
+    if (typeof selectedPlugin === 'string') {
+      return {
+        id: selectedPlugin as Plugin,
+        config: {},
+        isStatic: true,
+      };
+    }
+
+    return {
+      id: selectedPlugin.id as Plugin,
+      config: selectedPlugin.config ?? {},
+      isStatic: true,
+    };
   }, [config.plugins]);
 
   const handleTestCaseGeneration = useCallback(async () => {
-    await generateTestCase(
-      { id: testGenerationPlugin, config: {}, isStatic: true },
-      { id: strategyId, config: strategyConfig, isStatic: false },
-    );
-  }, [strategyConfig, generateTestCase, strategyId, testGenerationPlugin]);
+    await generateTestCase(testGenerationTargetPlugin, {
+      id: strategyId,
+      config: strategyConfig,
+      isStatic: false,
+    });
+  }, [strategyConfig, generateTestCase, strategyId, testGenerationTargetPlugin]);
 
   return {
     strategyConfig,
-    testGenerationPlugin,
+    testGenerationPlugin: testGenerationTargetPlugin.id,
     handleTestCaseGeneration,
     isGenerating,
     isCurrentStrategy: currentStrategy === strategyId,


### PR DESCRIPTION
This fixes a strategy preview failure in the red team setup UI. Users could click generate on a strategy such as Meta Agent and receive a generic `Failed to generate test case` error even when the underlying plugin was already configured.

The user-facing effect was most obvious with configurable plugins like `policy`. The strategy preview hook chose a random plugin from the configured plugin list, but it reduced object plugins down to their `id` and always called the preview API with `config: {}`. That meant the request dropped required plugin configuration before it left the browser. On the server side, the request still passed route validation, then failed later when the selected plugin attempted to generate a test case without the required config.

The root cause was in `useStrategyTestGeneration`: it treated the configured plugin list as a list of ids rather than preserving the selected plugin object. This change keeps a full `TargetPlugin` in the hook, including any existing plugin config, and passes that object through to `generateTestCase`. The UI still exposes the selected plugin id for display, but the request payload now matches the selected plugin's actual configuration.

I also added a regression test for the broken case. The new test verifies that a configured `policy` plugin keeps its `policy` payload when generating a strategy preview, and a second test verifies the existing fallback behavior when no plugins are configured.

Validation for this change was run locally in this worktree after installing dependencies under the repo's supported Node version. `npm run f` passed, `npm run l` passed, and `npm run test:app -- src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts` passed with 1 test file and 2 tests passing.
