### PR TITLE
feat(openai): enable chatgpt login via codex

### DIFF
--- a/examples/openai-codex-sdk/README.md
+++ b/examples/openai-codex-sdk/README.md
@@ -31,6 +31,8 @@ codex
 
 ```bash
 export OPENAI_API_KEY=your_api_key_here
+# or
+export CODEX_API_KEY=your_api_key_here
 ```
 
 When no `apiKey`, `OPENAI_API_KEY`, or `CODEX_API_KEY` is set, promptfoo will let the Codex SDK reuse an existing Codex login.

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -151,29 +151,29 @@ Skipping the Git check removes a safety guard. Use with caution and consider ver
 
 ## Supported Parameters
 
-| Parameter                | Type     | Description                                               | Default               |
-| ------------------------ | -------- | --------------------------------------------------------- | --------------------- |
-| `apiKey`                 | string   | OpenAI API key. Optional when Codex is already signed in. | Environment variable  |
-| `base_url`               | string   | Custom base URL for API requests (for proxies)            | None                  |
-| `working_dir`            | string   | Directory for Codex to operate in                         | Current directory     |
-| `additional_directories` | string[] | Additional directories the agent can access               | None                  |
-| `model`                  | string   | Model to use                                              | SDK default           |
-| `sandbox_mode`           | string   | Sandbox access level (see below)                          | `workspace-write`     |
-| `model_reasoning_effort` | string   | Reasoning intensity (see below)                           | SDK default           |
-| `network_access_enabled` | boolean  | Allow network requests                                    | false                 |
-| `web_search_enabled`     | boolean  | Allow web search                                          | false                 |
-| `approval_policy`        | string   | When to require approval (see below)                      | SDK default           |
-| `collaboration_mode`     | string   | Multi-agent mode: `coding` or `plan` (beta)               | None                  |
-| `skip_git_repo_check`    | boolean  | Skip Git repository validation                            | false                 |
-| `codex_path_override`    | string   | Custom path to codex binary                               | None                  |
-| `thread_id`              | string   | Resume existing thread from ~/.codex/sessions             | None (creates new)    |
-| `persist_threads`        | boolean  | Keep threads alive between calls                          | false                 |
-| `thread_pool_size`       | number   | Max concurrent threads (when persist_threads)             | 1                     |
-| `output_schema`          | object   | JSON schema for structured responses                      | None                  |
-| `cli_env`                | object   | Custom environment variables for Codex CLI                | Inherits from process |
-| `inherit_process_env`    | boolean  | Merge process env when `cli_env` is set                   | false                 |
-| `enable_streaming`       | boolean  | Enable streaming events                                   | false                 |
-| `deep_tracing`           | boolean  | Enable OpenTelemetry tracing of CLI internals             | false                 |
+| Parameter                | Type     | Description                                               | Default                |
+| ------------------------ | -------- | --------------------------------------------------------- | ---------------------- |
+| `apiKey`                 | string   | OpenAI API key. Optional when Codex is already signed in. | Environment variable   |
+| `base_url`               | string   | Custom base URL for API requests (for proxies)            | None                   |
+| `working_dir`            | string   | Directory for Codex to operate in                         | Current directory      |
+| `additional_directories` | string[] | Additional directories the agent can access               | None                   |
+| `model`                  | string   | Model to use                                              | SDK default            |
+| `sandbox_mode`           | string   | Sandbox access level (see below)                          | `workspace-write`      |
+| `model_reasoning_effort` | string   | Reasoning intensity (see below)                           | SDK default            |
+| `network_access_enabled` | boolean  | Allow network requests                                    | false                  |
+| `web_search_enabled`     | boolean  | Allow web search                                          | false                  |
+| `approval_policy`        | string   | When to require approval (see below)                      | SDK default            |
+| `cli_config`             | object   | Additional Codex CLI config overrides                     | None                   |
+| `skip_git_repo_check`    | boolean  | Skip Git repository validation                            | false                  |
+| `codex_path_override`    | string   | Custom path to codex binary                               | None                   |
+| `thread_id`              | string   | Resume existing thread from ~/.codex/sessions             | None (creates new)     |
+| `persist_threads`        | boolean  | Keep threads alive between calls                          | false                  |
+| `thread_pool_size`       | number   | Max concurrent threads (when persist_threads)             | 1                      |
+| `output_schema`          | object   | JSON schema for structured responses                      | None                   |
+| `cli_env`                | object   | Custom environment variables for Codex CLI                | Inherits from process  |
+| `inherit_process_env`    | boolean  | Merge process env when `cli_env` is set                   | `false` with `cli_env` |
+| `enable_streaming`       | boolean  | Enable streaming events                                   | false                  |
+| `deep_tracing`           | boolean  | Enable OpenTelemetry tracing of CLI internals             | false                  |
 
 ### Sandbox Modes
 

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -357,8 +357,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
 
   private providerId = 'openai:codex-sdk';
   private codexModule?: any;
-  private codexInstance?: any;
-  private codexInstanceEnvHash?: string; // Track env hash to detect changes
+  private codexInstances: Map<string, any> = new Map();
   private threads: Map<string, any> = new Map();
   private deepTracingWarningShown = false; // Show warning once per instance
 
@@ -394,6 +393,10 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     );
   }
 
+  requiresApiKey(): boolean {
+    return false;
+  }
+
   toString(): string {
     return '[OpenAI Codex SDK Provider]';
   }
@@ -416,16 +419,15 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     // Clean up threads
     this.threads.clear();
 
-    // Clean up Codex instance to release resources (child processes, file handles)
-    if (this.codexInstance) {
+    // Clean up Codex instances to release resources (child processes, file handles)
+    for (const instance of this.codexInstances.values()) {
       try {
-        await this.destroyInstance(this.codexInstance);
+        await this.destroyInstance(instance);
       } catch (error) {
         logger.warn('[CodexSDK] Error during cleanup', { error });
       }
-      this.codexInstance = undefined;
-      this.codexInstanceEnvHash = undefined;
     }
+    this.codexInstances.clear();
   }
 
   private prepareEnvironment(
@@ -723,6 +725,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
   private async getOrCreateThread(
     config: OpenAICodexSDKConfig,
     cacheKey: string | undefined,
+    instanceKey: string,
     instance: any,
   ): Promise<any> {
     const threadOptions = this.buildThreadOptions(config);
@@ -735,14 +738,15 @@ export class OpenAICodexSDKProvider implements ApiProvider {
 
     // Resume specific thread
     if (config.thread_id) {
-      const cached = this.threads.get(config.thread_id);
+      const threadIdCacheKey = `${instanceKey}:${config.thread_id}`;
+      const cached = this.threads.get(threadIdCacheKey);
       if (cached) {
         return cached;
       }
 
       const thread = instance.resumeThread(config.thread_id, threadOptions);
       if (config.persist_threads) {
-        this.threads.set(config.thread_id, thread);
+        this.threads.set(threadIdCacheKey, thread);
       }
       return thread;
     }
@@ -1274,8 +1278,25 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     return attrs;
   }
 
-  private generateCacheKey(config: OpenAICodexSDKConfig, prompt: string): string {
+  private generateInstanceKey(env: Record<string, string>, config: OpenAICodexSDKConfig): string {
     const keyData = {
+      env,
+      base_url: config.base_url,
+      cli_config: config.cli_config,
+      codex_path_override: config.codex_path_override,
+    };
+
+    const hash = crypto.createHash('sha256').update(JSON.stringify(keyData)).digest('hex');
+    return `openai:codex-sdk:instance:${hash}`;
+  }
+
+  private generateCacheKey(
+    config: OpenAICodexSDKConfig,
+    prompt: string,
+    instanceKey: string,
+  ): string {
+    const keyData = {
+      instanceKey,
       working_dir: config.working_dir,
       additional_directories: config.additional_directories,
       model: config.model,
@@ -1443,10 +1464,16 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       this.codexModule = await loadCodexSDK();
     }
 
+    // Exclude TRACEPARENT from cache keys to preserve thread persistence across traces.
+    const stableEnv = { ...env };
+    delete stableEnv.TRACEPARENT;
+    const instanceKey = this.generateInstanceKey(stableEnv, config);
+
     // Deep tracing requires per-call instances (each call has unique TRACEPARENT)
     // This avoids race conditions where concurrent calls destroy shared instances
     let localInstance: any = undefined;
     const useLocalInstance = config.deep_tracing;
+    let activeInstance: any = undefined;
 
     if (useLocalInstance) {
       // Warn about ignored thread options (only once)
@@ -1463,38 +1490,17 @@ export class OpenAICodexSDKProvider implements ApiProvider {
 
       // Create a fresh instance for this call only (not cached)
       localInstance = new this.codexModule.Codex(this.buildCodexOptions(env, config, apiKey));
+      activeInstance = localInstance;
     } else {
-      // Standard caching path for non-deep-tracing mode
-      // Exclude TRACEPARENT from hash to preserve thread persistence across traces
-      const stableEnv = { ...env };
-      delete stableEnv.TRACEPARENT;
-
-      const envHash = crypto.createHash('sha256').update(JSON.stringify(stableEnv)).digest('hex');
-      const envChanged = this.codexInstanceEnvHash !== envHash;
-
-      // Initialize Codex instance - recreate only if stable config changed
-      if (!this.codexInstance || envChanged) {
-        if (envChanged && this.codexInstance) {
-          logger.debug('[CodexSDK] Recreating instance due to configuration change');
-          // Clean up old instance to prevent resource leaks
-          try {
-            await this.destroyInstance(this.codexInstance);
-          } catch (cleanupError) {
-            logger.warn('[CodexSDK] Error cleaning up old instance', { error: cleanupError });
-          }
-          // Clear thread pool when instance is recreated
-          this.threads.clear();
-        }
-        // Create new instance with full environment
-        this.codexInstance = new this.codexModule.Codex(
-          this.buildCodexOptions(env, config, apiKey),
-        );
-        this.codexInstanceEnvHash = envHash;
+      // Standard caching path for non-deep-tracing mode.
+      // Cache one Codex instance per stable constructor config so concurrent calls
+      // with different prompt-level credentials/config do not tear each other down.
+      activeInstance = this.codexInstances.get(instanceKey);
+      if (!activeInstance) {
+        activeInstance = new this.codexModule.Codex(this.buildCodexOptions(env, config, apiKey));
+        this.codexInstances.set(instanceKey, activeInstance);
       }
     }
-
-    // Use local instance for deep_tracing, otherwise shared cached instance
-    const activeInstance = useLocalInstance ? localInstance : this.codexInstance;
 
     // Guard against undefined instance (shouldn't happen, but defensive coding)
     if (!activeInstance) {
@@ -1502,8 +1508,8 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     }
 
     // Get or create thread (pass instance to avoid using stale this.codexInstance)
-    const cacheKey = this.generateCacheKey(config, prompt);
-    const thread = await this.getOrCreateThread(config, cacheKey, activeInstance);
+    const cacheKey = this.generateCacheKey(config, prompt, instanceKey);
+    const thread = await this.getOrCreateThread(config, cacheKey, instanceKey, activeInstance);
 
     // Prepare run options
     const runOptions: any = {};

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -6,6 +6,7 @@ import cliState from '../../src/cliState';
 import { importModule, resolvePackageEntryPoint } from '../../src/esm';
 import logger from '../../src/logger';
 import { OpenAICodexSDKProvider } from '../../src/providers/openai/codex-sdk';
+import { checkProviderApiKeys } from '../../src/util/provider';
 
 import type { CallApiContextParams } from '../../src/types/index';
 
@@ -73,6 +74,17 @@ function restoreEnvVar(name: 'OPENAI_API_KEY' | 'CODEX_API_KEY', value: string |
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('OpenAICodexSDKProvider', () => {
   let statSyncSpy: MockInstance;
   let existsSyncSpy: MockInstance;
@@ -90,6 +102,12 @@ describe('OpenAICodexSDKProvider', () => {
     originalCodexApiKey = process.env.CODEX_API_KEY;
 
     // Reset mock implementations
+    MockCodex.mockImplementation(function () {
+      return {
+        startThread: mockStartThread.mockReturnValue(mockThread),
+        resumeThread: mockResumeThread.mockReturnValue(mockThread),
+      };
+    });
     mockStartThread.mockReturnValue(mockThread);
     mockResumeThread.mockReturnValue(mockThread);
 
@@ -242,6 +260,16 @@ describe('OpenAICodexSDKProvider', () => {
         expect(codexOptions.apiKey).toBeUndefined();
         expect(codexOptions.env.OPENAI_API_KEY).toBeUndefined();
         expect(codexOptions.env.CODEX_API_KEY).toBeUndefined();
+      });
+
+      it('should skip missing API key preflight for SDK-managed auth', () => {
+        delete process.env.OPENAI_API_KEY;
+        delete process.env.CODEX_API_KEY;
+
+        const provider = new OpenAICodexSDKProvider();
+        const result = checkProviderApiKeys([provider]);
+
+        expect(result.size).toBe(0);
       });
 
       it('should fall back to process.cwd() when resolving the SDK from an external config base path', async () => {
@@ -693,6 +721,73 @@ describe('OpenAICodexSDKProvider', () => {
         expect(mockStartThread).toHaveBeenCalledTimes(2);
       });
 
+      it('should isolate concurrent calls with different prompt-level apiKeys', async () => {
+        const firstRun = createDeferred<ReturnType<typeof createMockResponse>>();
+        const secondRun = createDeferred<ReturnType<typeof createMockResponse>>();
+        const firstDestroy = vi.fn();
+        const secondDestroy = vi.fn();
+        const firstThread = {
+          id: 'thread-1',
+          run: vi.fn().mockReturnValue(firstRun.promise),
+          runStreamed: mockRunStreamed,
+        };
+        const secondThread = {
+          id: 'thread-2',
+          run: vi.fn().mockReturnValue(secondRun.promise),
+          runStreamed: mockRunStreamed,
+        };
+
+        MockCodex.mockImplementationOnce(function () {
+          return {
+            startThread: vi.fn().mockReturnValue(firstThread),
+            resumeThread: vi.fn().mockReturnValue(firstThread),
+            destroy: firstDestroy,
+          };
+        }).mockImplementationOnce(function () {
+          return {
+            startThread: vi.fn().mockReturnValue(secondThread),
+            resumeThread: vi.fn().mockReturnValue(secondThread),
+            destroy: secondDestroy,
+          };
+        });
+
+        const provider = new OpenAICodexSDKProvider();
+
+        const firstCall = provider.callApi('Test prompt', {
+          prompt: {
+            config: { apiKey: 'prompt-key-1' },
+          },
+        } as any);
+
+        await vi.waitFor(() => {
+          expect(firstThread.run).toHaveBeenCalledTimes(1);
+        });
+
+        const secondCall = provider.callApi('Test prompt', {
+          prompt: {
+            config: { apiKey: 'prompt-key-2' },
+          },
+        } as any);
+
+        await vi.waitFor(() => {
+          expect(secondThread.run).toHaveBeenCalledTimes(1);
+        });
+
+        expect(firstDestroy).not.toHaveBeenCalled();
+        expect(secondDestroy).not.toHaveBeenCalled();
+
+        firstRun.resolve(createMockResponse('First response'));
+        secondRun.resolve(createMockResponse('Second response'));
+
+        await expect(firstCall).resolves.toEqual(
+          expect.objectContaining({ output: 'First response', sessionId: 'thread-1' }),
+        );
+        await expect(secondCall).resolves.toEqual(
+          expect.objectContaining({ output: 'Second response', sessionId: 'thread-2' }),
+        );
+        expect(MockCodex).toHaveBeenCalledTimes(2);
+      });
+
       it('should reuse threads when persist_threads is true', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
 
@@ -1121,6 +1216,41 @@ describe('OpenAICodexSDKProvider', () => {
           workingDirectory: '/prompt/dir',
           skipGitRepoCheck: false,
         });
+      });
+
+      it('should create separate Codex instances for prompt-level base_url overrides', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt', {
+          prompt: {
+            raw: 'Test prompt',
+            label: 'test-1',
+            config: { base_url: 'https://proxy-one.example.com' },
+          },
+          vars: {},
+        });
+        await provider.callApi('Test prompt', {
+          prompt: {
+            raw: 'Test prompt',
+            label: 'test-2',
+            config: { base_url: 'https://proxy-two.example.com' },
+          },
+          vars: {},
+        });
+
+        expect(MockCodex).toHaveBeenCalledTimes(2);
+        expect(MockCodex).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ baseUrl: 'https://proxy-one.example.com' }),
+        );
+        expect(MockCodex).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ baseUrl: 'https://proxy-two.example.com' }),
+        );
       });
     });
 


### PR DESCRIPTION
This change enables ChatGPT-backed Codex authentication for promptfoo's `openai:codex-sdk` provider without changing the standard OpenAI API providers.