### PR TITLE
feat(matchers): expose grading provider metadata in GradingResult

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -119,6 +119,8 @@ By default, `llm-rubric` uses `gpt-5` for grading. You can override this in seve
            // highlight-end
    ```
 
+Custom `llm-rubric` providers can also return a `metadata` object in their `ProviderResponse`. promptfoo copies those keys onto the assertion's `GradingResult.metadata` alongside `renderedGradingPrompt`, which makes per-assertion fields such as upload IDs or trace IDs available in hooks like `afterEach`.
+
 ## Customizing the rubric prompt
 
 For more control over the `llm-rubric` evaluation, you can set a custom prompt using the `rubricPrompt` property:

--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -890,6 +890,7 @@ interface GradingResult {
   score: number;                        # score between 0 and 1
   reason: string;                       # plaintext reason for outcome
   tokensUsed?: TokenUsage;              # tokens consumed by the test
+  metadata?: Record<string, any>;       # additional matcher/provider metadata
   componentResults?: GradingResult[];   # if this is a composite score, it can have nested results
   assertion: Assertion | null;          # source of assertion
   latencyMs?: number;                   # latency of LLM call

--- a/site/docs/usage/node-package.md
+++ b/site/docs/usage/node-package.md
@@ -91,6 +91,9 @@ completion: number;
 cached?: number;
 }>;
 
+// Additional matcher/provider metadata
+metadata?: Record<string, unknown>;
+
 // List of results for each component of the assertion
 componentResults?: GradingResult[];
 

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -35,7 +35,7 @@ import { getNunjucksEngineForFilePath, maybeLoadFromExternalFile } from './util/
 import { isJavascriptFile } from './util/fileExtensions';
 import { parseFileUrl } from './util/functions/loadFunction';
 import invariant from './util/invariant';
-import { extractFirstJsonObject, extractJsonObjects } from './util/json';
+import { extractFirstJsonObject, extractJsonObjects, safeJsonStringify } from './util/json';
 import { getNunjucksEngine } from './util/templates';
 import { accumulateTokenUsage } from './util/tokenUsageUtils';
 
@@ -711,6 +711,14 @@ async function runJsonGradingPrompt({
   const reason =
     parsed.reason || (pass ? 'Grading passed' : `Score ${score} below threshold ${threshold}`);
 
+  let responseMetadata: Record<string, unknown> = {};
+  if (resp.metadata && typeof resp.metadata === 'object' && !Array.isArray(resp.metadata)) {
+    const serializedMetadata = safeJsonStringify(resp.metadata);
+    responseMetadata = serializedMetadata
+      ? (JSON.parse(serializedMetadata) as Record<string, unknown>)
+      : {};
+  }
+
   return {
     assertion,
     pass,
@@ -729,9 +737,7 @@ async function runJsonGradingPrompt({
       },
     },
     metadata: {
-      ...(resp.metadata && typeof resp.metadata === 'object' && !Array.isArray(resp.metadata)
-        ? resp.metadata
-        : {}),
+      ...responseMetadata,
       renderedGradingPrompt: prompt,
     },
   };

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -130,6 +130,96 @@ describe('matchesLlmRubric', () => {
     );
   });
 
+  it('should merge provider metadata into the grading result metadata', async () => {
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          metadata: {
+            uploadId: 'upload-123',
+            trace: { id: 'trace-456' },
+          },
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      uploadId: 'upload-123',
+      trace: { id: 'trace-456' },
+      renderedGradingPrompt: 'Grading prompt',
+    });
+  });
+
+  it('should preserve renderedGradingPrompt when provider metadata uses the same key', async () => {
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          metadata: {
+            renderedGradingPrompt: 'spoofed prompt',
+            uploadId: 'upload-123',
+          },
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      uploadId: 'upload-123',
+      renderedGradingPrompt: 'Grading prompt',
+    });
+  });
+
+  it('should ignore array provider metadata', async () => {
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          metadata: ['ignored'] as any,
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      renderedGradingPrompt: 'Grading prompt',
+    });
+  });
+
+  it('should sanitize circular provider metadata before attaching it to the grading result', async () => {
+    const responseMetadata: Record<string, any> = {
+      uploadId: 'upload-123',
+      trace: { id: 'trace-456' },
+    };
+    responseMetadata.self = responseMetadata;
+
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          metadata: responseMetadata,
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        }),
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      uploadId: 'upload-123',
+      trace: { id: 'trace-456' },
+      renderedGradingPrompt: 'Grading prompt',
+    });
+    expect(result.metadata).not.toHaveProperty('self');
+  });
+
   it('should render rubric when provided as an object', async () => {
     const rubric = { prompt: 'Describe the image' };
     const output = 'Sample output';


### PR DESCRIPTION
## Summary
Custom LLM rubric providers (e.g. Python-based) can return extra fields 
in their response such as upload IDs or trace IDs for tracking/auditing. 
Previously these fields were silently dropped — only output, error, and 
tokenUsage were used to build the GradingResult.

This change merges resp.metadata into the returned GradingResult.metadata 
when it is a plain object, making provider-specific data accessible via 
context.result.gradingResult.componentResults[].metadata.

## Changes
- `src/matchers.ts`: In `matchesLlmRubric`, spread resp.metadata into the 
  result metadata object when it exists and is a plain object

## Notes
- No breaking changes — existing providers that don't return metadata 
  behave exactly as before

Closes #8148