### PR TITLE
fix: respect review language in example test generation

### DIFF
--- a/src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.test.tsx
@@ -13,6 +13,7 @@ import { within } from '@testing-library/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestCaseGenerationProvider, useTestCaseGeneration } from './TestCaseGenerationProvider';
+import type { PluginConfig } from '@promptfoo/redteam/types';
 
 // ===================================================================
 // Mocks
@@ -125,11 +126,13 @@ callApiMock.mockImplementation((path, options) => {
  */
 const TestConsumer = ({
   testPlugin,
+  pluginConfig = {},
   testStrategy,
   isPluginStatic = false,
   isStrategyStatic = false,
 }: {
   testPlugin: Plugin;
+  pluginConfig?: PluginConfig;
   testStrategy: Strategy;
   isPluginStatic?: boolean;
   isStrategyStatic?: boolean;
@@ -138,7 +141,7 @@ const TestConsumer = ({
 
   async function handleGenerateTestCase() {
     await generateTestCase(
-      { id: testPlugin, config: {}, isStatic: isPluginStatic },
+      { id: testPlugin, config: pluginConfig, isStatic: isPluginStatic },
       { id: testStrategy, config: {}, isStatic: isStrategyStatic },
     );
   }
@@ -248,6 +251,64 @@ describe('TestCaseGenerationProvider', () => {
             redTeamConfig={{
               ...MOCK_CONFIG,
               language: 'Japanese',
+            }}
+          >
+            <TestConsumer testPlugin="harmful:hate" testStrategy="basic" />
+          </TestCaseGenerationProvider>
+        </ToastProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId('test-case-generation-btn'));
+
+      await waitFor(() => expect(callApi).toHaveBeenCalledTimes(1));
+
+      const generateCall = callApiMock.mock.calls.find(
+        (call) => call[0] === '/redteam/generate-test',
+      );
+      expect(generateCall).toBeDefined();
+
+      const requestBody = JSON.parse(generateCall![1]?.body as string);
+      expect(requestBody.plugin.config.language).toBe('Japanese');
+    });
+
+    it('should preserve plugin-specific language when review language is configured', async () => {
+      render(
+        <ToastProvider>
+          <TestCaseGenerationProvider
+            redTeamConfig={{
+              ...MOCK_CONFIG,
+              language: 'Japanese',
+            }}
+          >
+            <TestConsumer
+              testPlugin="harmful:hate"
+              pluginConfig={{ language: 'Spanish' }}
+              testStrategy="basic"
+            />
+          </TestCaseGenerationProvider>
+        </ToastProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId('test-case-generation-btn'));
+
+      await waitFor(() => expect(callApi).toHaveBeenCalledTimes(1));
+
+      const generateCall = callApiMock.mock.calls.find(
+        (call) => call[0] === '/redteam/generate-test',
+      );
+      expect(generateCall).toBeDefined();
+
+      const requestBody = JSON.parse(generateCall![1]?.body as string);
+      expect(requestBody.plugin.config.language).toBe('Spanish');
+    });
+
+    it('should use the first configured review language for generated example tests', async () => {
+      render(
+        <ToastProvider>
+          <TestCaseGenerationProvider
+            redTeamConfig={{
+              ...MOCK_CONFIG,
+              language: ['Japanese', 'Spanish'],
             }}
           >
             <TestConsumer testPlugin="harmful:hate" testStrategy="basic" />

--- a/src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.tsx
@@ -121,8 +121,9 @@ async function callTestGenerationApi(
   count: number = 1,
 ) {
   const previewLanguage = getPreviewLanguage(language);
+  const pluginLanguage = getPreviewLanguage(plugin.config.language);
   const pluginWithLanguage =
-    previewLanguage && !plugin.config.language
+    previewLanguage && !pluginLanguage
       ? {
           ...plugin,
           config: {


### PR DESCRIPTION
Example test previews in the redteam setup UI ignored the review tab's global language setting because the shared `/redteam/generate-test` preview path only forwarded `plugin.config.language`, so users selecting languages like Japanese still saw previews generated without that preference; this change makes preview generation inherit `config.language` whenever a plugin-specific language is not already set.

It adds a regression test covering a Japanese preview request and was validated with `npm run test:app -- src/pages/redteam/setup/components/TestCaseGenerationProvider.test.tsx` plus `npx @biomejs/biome check src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.tsx src/app/src/pages/redteam/setup/components/TestCaseGenerationProvider.test.tsx` under the repo's `.nvmrc` Node version.
