### PR TITLE
fix: parse rate-limit reset headers

### DIFF
--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -9,6 +9,7 @@ import { DEFAULT_MAX_CONCURRENCY, VERSION } from '../../constants';
 import { getEnvBool, getEnvInt, getEnvString } from '../../envars';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { parseRateLimitHeaders, parseRetryAfter } from '../../scheduler/headerParser';
 import invariant from '../../util/invariant';
 import { sleep } from '../../util/time';
 import { sanitizeUrl } from '../sanitizer';
@@ -291,13 +292,16 @@ export async function handleRateLimit(response: Response): Promise<void> {
   let waitTime = 60_000; // Default wait time of 60 seconds
 
   if (openaiReset) {
-    waitTime = Math.max(Number.parseInt(openaiReset) * 1000, 0);
+    const parsedHeaders = parseRateLimitHeaders(Object.fromEntries(response.headers.entries()));
+    if (parsedHeaders.resetAt !== undefined) {
+      waitTime = Math.max(parsedHeaders.resetAt - Date.now(), 0);
+    }
   } else if (rateLimitReset) {
     const resetTime = new Date(Number.parseInt(rateLimitReset) * 1000);
     const now = new Date();
     waitTime = Math.max(resetTime.getTime() - now.getTime() + 1000, 0);
   } else if (retryAfter) {
-    waitTime = Number.parseInt(retryAfter) * 1000;
+    waitTime = parseRetryAfter(retryAfter) ?? waitTime;
   }
 
   logger.debug(`Rate limited, waiting ${waitTime}ms before retry`);

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -871,7 +871,7 @@ describe('isRateLimited', () => {
 describe('handleRateLimit', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.mocked(sleep).mockClear();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -890,6 +890,30 @@ describe('handleRateLimit', () => {
     await promise;
 
     expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
+  });
+
+  it('should handle OpenAI reset headers with millisecond durations', async () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'x-ratelimit-reset-requests': '500ms',
+      }),
+    });
+
+    await handleRateLimit(response);
+
+    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 500ms before retry');
+  });
+
+  it('should handle OpenAI reset headers with compound durations', async () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'x-ratelimit-reset-requests': '1m30s',
+      }),
+    });
+
+    await handleRateLimit(response);
+
+    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 90000ms before retry');
   });
 
   it('should handle standard rate limit reset headers', async () => {
@@ -920,6 +944,31 @@ describe('handleRateLimit', () => {
     await promise;
 
     expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
+  });
+
+  it('should handle Retry-After HTTP-date headers', async () => {
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    const response = createMockResponse({
+      headers: new Headers({
+        'Retry-After': 'Mon, 01 Jan 2024 00:00:05 GMT',
+      }),
+    });
+
+    await handleRateLimit(response);
+
+    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 5000ms before retry');
+  });
+
+  it('should use default wait time for invalid Retry-After headers', async () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'Retry-After': 'invalid',
+      }),
+    });
+
+    await handleRateLimit(response);
+
+    expect(logger.debug).toHaveBeenCalledWith('Rate limited, waiting 60000ms before retry');
   });
 
   it('should use default wait time when no headers present', async () => {


### PR DESCRIPTION
## Summary

`handleRateLimit` currently parses OpenAI reset headers and `Retry-After` with `Number.parseInt()`, which can turn values like `500ms` into the wrong delay and fail to handle HTTP-date retry values. The expected behavior is to wait for the delay represented by those headers and fall back to the default wait time when a retry header is invalid.

This reuses the existing scheduler rate-limit header parser for OpenAI reset headers and `Retry-After`, and adds coverage for millisecond durations, compound durations, HTTP-date values, and invalid retry headers.

## Validation

Ran `npx vitest run test/fetch.test.ts`, `npm run tsc`, and `npm run l && npm run f`.
