### PR TITLE
fix(util): preserve shared references in safeJsonStringify

### DIFF
--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -77,6 +77,7 @@ function safeJsonStringifyTruncated<T>(value: T, prettyPrint: boolean = false): 
         truncated[k] = truncateValue(v);
         count++;
       }
+      cache.delete(val);
       return truncated;
     }
 
@@ -98,19 +99,22 @@ function safeJsonStringifyTruncated<T>(value: T, prettyPrint: boolean = false): 
  * @returns JSON string representation, or undefined if serialization fails
  */
 export function safeJsonStringify<T>(value: T, prettyPrint: boolean = false): string | undefined {
-  const cache = new Set();
+  const ancestors: any[] = [];
   const space = prettyPrint ? 2 : undefined;
 
   try {
     return (
       JSON.stringify(
         value,
-        (_key, val) => {
+        function (this: any, _key, val) {
           if (typeof val === 'object' && val !== null) {
-            if (cache.has(val)) {
+            while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+              ancestors.pop();
+            }
+            if (ancestors.includes(val)) {
               return;
             }
-            cache.add(val);
+            ancestors.push(val);
           }
           return val;
         },

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -173,6 +173,13 @@ describe('json utilities', () => {
       expect(safeJsonStringify(obj)).toBe('{"a":{"b":{}}}');
     });
 
+    it('preserves shared non-circular references', () => {
+      const shared = { value: 'shared' };
+      expect(safeJsonStringify({ a: shared, b: shared, c: [shared] })).toBe(
+        '{"a":{"value":"shared"},"b":{"value":"shared"},"c":[{"value":"shared"}]}',
+      );
+    });
+
     it('preserves non-circular nested structures', () => {
       const nested = { a: { b: { c: 1 } }, d: [1, 2, { e: 3 }] };
       expect(JSON.parse(safeJsonStringify(nested) as string)).toEqual(nested);


### PR DESCRIPTION
safeJsonStringify now tracks only the current ancestor chain so repeated non-circular references are preserved while circular references are still omitted. Added a regression test and verified with vitest, tsc, and Biome lint.
