### PR TITLE
fix(providers): preserve explicit zero max_tokens for mistral

### DIFF
--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -323,7 +323,7 @@ export class MistralChatCompletionProvider implements ApiProvider {
       messages,
       temperature: config?.temperature,
       top_p: config?.top_p || 1,
-      max_tokens: config?.max_tokens || 1024,
+      max_tokens: config?.max_tokens ?? 1024,
       safe_prompt: config?.safe_prompt || false,
       random_seed: config?.random_seed || null,
       ...(hasTools ? { tools: loadedTools } : {}),

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -198,6 +198,29 @@ describe('Mistral', () => {
       });
     });
 
+    it('should preserve an explicit max_tokens value of 0', async () => {
+      const zeroProvider = new MistralChatCompletionProvider('mistral-medium', {
+        config: { max_tokens: 0 },
+      });
+      vi.spyOn(zeroProvider, 'getApiKey').mockReturnValue('fake-api-key');
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: {
+          choices: [{ message: { content: 'Zero token response' } }],
+          usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await zeroProvider.callApi('Test prompt');
+
+      const requestInit = vi.mocked(fetchWithCache).mock.calls[0]?.[1];
+      expect(requestInit).toBeDefined();
+      const requestBody = JSON.parse((requestInit as RequestInit).body as string);
+      expect(requestBody.max_tokens).toBe(0);
+    });
+
     it('should calculate cost correctly for Magistral models', async () => {
       const magistralSmallProvider = new MistralChatCompletionProvider('magistral-small-2506');
       vi.spyOn(magistralSmallProvider, 'getApiKey').mockReturnValue('fake-api-key');


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `max_tokens: 0` for Mistral requests instead of falling back to the default `1024`
- add a focused provider regression test to prove the request body keeps `max_tokens` at `0`

## Testing

- `npx vitest run test/providers/mistral.test.ts`
- `npm run tsc -- --pretty false`