### PR TITLE
docs(site): add rag and agent getting started examples

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Getting started
 
-By the end of this guide, you'll have a working eval that tests prompts across multiple models and a web view for comparing outputs.
+This guide will walk you through creating a working eval that tests prompts across multiple models and opens a web view for comparing outputs.
 
 After [installing](/docs/installation) promptfoo, you can set up your first config file in a few ways:
 
@@ -233,6 +233,8 @@ See the [Configuration docs](/docs/configuration/guide) for a detailed guide.
 :::
 
 ## Examples
+
+The examples below cover a few common eval patterns: prompt quality, model quality, RAG quality, and agent quality.
 
 ### Prompt quality
 
@@ -463,6 +465,58 @@ A similar approach can be used to run other model comparisons. For example, you 
 - Compare open-source models (see [Comparing Open-Source Models](/docs/guides/compare-open-source-models))
 - Compare Retrieval-Augmented Generation (RAG) with LangChain vs. regular GPT-4 (see [LangChain example](/docs/configuration/testing-llm-chains))
 
+### RAG quality
+
+In [this example](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-rag), we evaluate whether RAG outputs are factual, relevant, and grounded in the retrieved context.
+
+You can quickly set up this example by running:
+
+<Tabs groupId="promptfoo-command">
+  <TabItem value="npx" label="npx" default>
+    ```bash
+    npx promptfoo@latest init --example eval-rag
+    ```
+  </TabItem>
+  <TabItem value="npm" label="npm">
+    ```bash
+    promptfoo init --example eval-rag
+    ```
+  </TabItem>
+  <TabItem value="brew" label="brew">
+    ```bash
+    promptfoo init --example eval-rag
+    ```
+  </TabItem>
+</Tabs>
+
+From the newly created directory, run `npx promptfoo@latest eval` or `promptfoo eval` to grade outputs on factuality, answer relevance, context recall, context relevance, and context faithfulness. For a deeper walkthrough, see the [RAG evaluation guide](/docs/guides/evaluate-rag).
+
+### Agent quality
+
+In [this example](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-agents-basic), we evaluate an OpenAI Agents SDK workflow that uses tools for dice rolls, inventory checks, scene descriptions, and character stats.
+
+You can quickly set up this example by running:
+
+<Tabs groupId="promptfoo-command">
+  <TabItem value="npx" label="npx" default>
+    ```bash
+    npx promptfoo@latest init --example openai-agents-basic
+    ```
+  </TabItem>
+  <TabItem value="npm" label="npm">
+    ```bash
+    promptfoo init --example openai-agents-basic
+    ```
+  </TabItem>
+  <TabItem value="brew" label="brew">
+    ```bash
+    promptfoo init --example openai-agents-basic
+    ```
+  </TabItem>
+</Tabs>
+
+From the newly created directory, run `npm install`, then `npx promptfoo@latest eval` or `promptfoo eval` to test tool use and response quality across multi-turn scenarios. For task completion and trajectory checks, see the [agent evaluation guide](/docs/guides/evaluate-coding-agents) and [tracing docs](/docs/tracing).
+
 ## Next steps
 
 Now that you've run your first eval, here are some ways to go deeper:
@@ -475,6 +529,7 @@ Now that you've run your first eval, here are some ways to go deeper:
 
 **Explore use cases:**
 
+- [Agent evaluation](/docs/guides/evaluate-coding-agents) - Test whether agents complete tasks and follow expected trajectories
 - [RAG evaluation](/docs/guides/evaluate-rag) - Test retrieval-augmented generation pipelines
 - [Red teaming quickstart](/docs/red-team/quickstart) - Scan your LLM app for security vulnerabilities
 - [CI/CD integration](/docs/integrations/github-action) - Run evals automatically on every PR


### PR DESCRIPTION
Adds RAG and agent examples to Getting started so first-time users see common eval workflows beyond prompt and model comparison.  Also smooth out some of the intro