### PR TITLE
fix(elevenlabs): preserve explicit zero retries

### DIFF
--- a/src/providers/elevenlabs/agents/index.ts
+++ b/src/providers/elevenlabs/agents/index.ts
@@ -343,7 +343,7 @@ export class ElevenLabsAgentsProvider implements ApiProvider {
       timeout: config?.timeout || 180000,
       cache: config?.cache,
       cacheTTL: config?.cacheTTL,
-      retries: config?.retries || 3,
+      retries: config?.retries ?? 3,
 
       // Agent-specific config
       agentId: config?.agentId,

--- a/src/providers/elevenlabs/client.ts
+++ b/src/providers/elevenlabs/client.ts
@@ -9,6 +9,10 @@ export interface ElevenLabsClientConfig {
   retries?: number;
 }
 
+interface ElevenLabsPostOptions extends RequestInit {
+  allowRetriesForNonIdempotent?: boolean;
+}
+
 /**
  * HTTP client for ElevenLabs API with automatic retries, rate limiting, and error handling
  */
@@ -22,13 +26,13 @@ export class ElevenLabsClient {
     this.apiKey = config.apiKey;
     this.baseUrl = config.baseUrl || 'https://api.elevenlabs.io/v1';
     this.timeout = config.timeout || 120000; // 2 minutes default
-    this.retries = config.retries || 3;
+    this.retries = config.retries ?? 3;
   }
 
   /**
    * Make a POST request to the ElevenLabs API
    */
-  async post<T>(endpoint: string, body: any, options?: RequestInit): Promise<T> {
+  async post<T>(endpoint: string, body: any, options?: ElevenLabsPostOptions): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     logger.debug('[ElevenLabs Client] POST request', {
@@ -40,23 +44,25 @@ export class ElevenLabsClient {
 
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt < this.retries; attempt++) {
+    const { headers: optionsHeaders, allowRetriesForNonIdempotent, ...restOptions } = options || {};
+    const headers = new Headers(optionsHeaders || {});
+    const hasIdempotencyKey = headers.has('Idempotency-Key') || headers.has('idempotency-key');
+    const effectiveRetries = allowRetriesForNonIdempotent || hasIdempotencyKey ? this.retries : 0;
+
+    for (let attempt = 0; attempt <= effectiveRetries; attempt++) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
-        const { headers: optionsHeaders, ...restOptions } = options || {};
-
         // Handle FormData for multipart uploads
         const isFormData = body instanceof FormData;
-        const headers: HeadersInit = {
-          'xi-api-key': this.apiKey,
-          ...(optionsHeaders || {}),
-        };
+        headers.set('xi-api-key', this.apiKey);
 
         // Don't set Content-Type for FormData (fetch sets it automatically with boundary)
-        if (!isFormData) {
-          (headers as Record<string, string>)['Content-Type'] = 'application/json';
+        if (isFormData) {
+          headers.delete('Content-Type');
+        } else {
+          headers.set('Content-Type', 'application/json');
         }
 
         const response = await fetchWithProxy(url, {
@@ -70,7 +76,7 @@ export class ElevenLabsClient {
         clearTimeout(timeoutId);
 
         if (!response.ok) {
-          await this.handleErrorResponse(response, attempt);
+          await this.handleErrorResponse(response, attempt, effectiveRetries);
           continue;
         }
 
@@ -99,10 +105,10 @@ export class ElevenLabsClient {
           throw error;
         }
 
-        if (attempt < this.retries - 1) {
+        if (attempt < effectiveRetries) {
           const backoffMs = Math.pow(2, attempt) * 1000;
           logger.debug(
-            `[ElevenLabs Client] Retry ${attempt + 1}/${this.retries} after ${backoffMs}ms`,
+            `[ElevenLabs Client] Retry ${attempt + 1}/${effectiveRetries} after ${backoffMs}ms`,
           );
           await new Promise((resolve) => setTimeout(resolve, backoffMs));
         }
@@ -137,7 +143,7 @@ export class ElevenLabsClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        await this.handleErrorResponse(response, 0);
+        await this.handleErrorResponse(response, 0, 0);
       }
 
       return (await response.json()) as T;
@@ -172,7 +178,7 @@ export class ElevenLabsClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        await this.handleErrorResponse(response, 0);
+        await this.handleErrorResponse(response, 0, 0);
       }
     } catch (error) {
       clearTimeout(timeoutId);
@@ -227,7 +233,7 @@ export class ElevenLabsClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        await this.handleErrorResponse(response, 0);
+        await this.handleErrorResponse(response, 0, 0);
       }
 
       // Check if response is JSON or binary
@@ -275,7 +281,11 @@ export class ElevenLabsClient {
   /**
    * Handle error responses from the API
    */
-  private async handleErrorResponse(response: Response, attempt: number): Promise<void> {
+  private async handleErrorResponse(
+    response: Response,
+    attempt: number,
+    retries: number,
+  ): Promise<void> {
     const errorText = await response.text();
     let errorData: any;
 
@@ -301,7 +311,7 @@ export class ElevenLabsClient {
     // Handle rate limiting
     if (response.status === 429) {
       const retryAfter = response.headers.get('Retry-After');
-      if (retryAfter && attempt < this.retries - 1) {
+      if (retryAfter && attempt < retries) {
         const waitMs = parseInt(retryAfter) * 1000;
         logger.debug(`[ElevenLabs Client] Rate limited, waiting ${waitMs}ms`);
         await new Promise((resolve) => setTimeout(resolve, waitMs));

--- a/src/providers/elevenlabs/client.ts
+++ b/src/providers/elevenlabs/client.ts
@@ -9,6 +9,23 @@ export interface ElevenLabsClientConfig {
   retries?: number;
 }
 
+function toPlainHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  const entries =
+    headers instanceof Headers
+      ? headers.entries()
+      : Array.isArray(headers)
+        ? headers
+        : Object.entries(headers);
+
+  return Object.fromEntries(
+    Array.from(entries, ([key, value]) => [key.toLowerCase(), value]),
+  ) as Record<string, string>;
+}
+
 /**
  * HTTP client for ElevenLabs API with automatic retries, rate limiting, and error handling
  */
@@ -41,7 +58,7 @@ export class ElevenLabsClient {
     let lastError: Error | null = null;
 
     const { headers: optionsHeaders, ...restOptions } = options || {};
-    const headers = new Headers(optionsHeaders || {});
+    const headers = toPlainHeaders(optionsHeaders);
 
     for (let attempt = 0; attempt <= this.retries; attempt++) {
       try {
@@ -50,13 +67,13 @@ export class ElevenLabsClient {
 
         // Handle FormData for multipart uploads
         const isFormData = body instanceof FormData;
-        headers.set('xi-api-key', this.apiKey);
+        headers['xi-api-key'] = this.apiKey;
 
         // Don't set Content-Type for FormData (fetch sets it automatically with boundary)
         if (isFormData) {
-          headers.delete('Content-Type');
+          delete headers['content-type'];
         } else {
-          headers.set('Content-Type', 'application/json');
+          headers['content-type'] = 'application/json';
         }
 
         const response = await fetchWithProxy(url, {
@@ -127,8 +144,8 @@ export class ElevenLabsClient {
       const response = await fetchWithProxy(url, {
         method: 'GET',
         headers: {
+          ...toPlainHeaders(options?.headers),
           'xi-api-key': this.apiKey,
-          ...options?.headers,
         },
         signal: controller.signal,
         ...options,
@@ -162,8 +179,8 @@ export class ElevenLabsClient {
       const response = await fetchWithProxy(url, {
         method: 'DELETE',
         headers: {
+          ...toPlainHeaders(options?.headers),
           'xi-api-key': this.apiKey,
-          ...options?.headers,
         },
         signal: controller.signal,
         ...options,

--- a/src/providers/elevenlabs/client.ts
+++ b/src/providers/elevenlabs/client.ts
@@ -9,10 +9,6 @@ export interface ElevenLabsClientConfig {
   retries?: number;
 }
 
-interface ElevenLabsPostOptions extends RequestInit {
-  allowRetriesForNonIdempotent?: boolean;
-}
-
 /**
  * HTTP client for ElevenLabs API with automatic retries, rate limiting, and error handling
  */
@@ -32,7 +28,7 @@ export class ElevenLabsClient {
   /**
    * Make a POST request to the ElevenLabs API
    */
-  async post<T>(endpoint: string, body: any, options?: ElevenLabsPostOptions): Promise<T> {
+  async post<T>(endpoint: string, body: any, options?: RequestInit): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     logger.debug('[ElevenLabs Client] POST request', {
@@ -44,12 +40,10 @@ export class ElevenLabsClient {
 
     let lastError: Error | null = null;
 
-    const { headers: optionsHeaders, allowRetriesForNonIdempotent, ...restOptions } = options || {};
+    const { headers: optionsHeaders, ...restOptions } = options || {};
     const headers = new Headers(optionsHeaders || {});
-    const hasIdempotencyKey = headers.has('Idempotency-Key') || headers.has('idempotency-key');
-    const effectiveRetries = allowRetriesForNonIdempotent || hasIdempotencyKey ? this.retries : 0;
 
-    for (let attempt = 0; attempt <= effectiveRetries; attempt++) {
+    for (let attempt = 0; attempt <= this.retries; attempt++) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeout);
@@ -76,7 +70,7 @@ export class ElevenLabsClient {
         clearTimeout(timeoutId);
 
         if (!response.ok) {
-          await this.handleErrorResponse(response, attempt, effectiveRetries);
+          await this.handleErrorResponse(response, attempt, this.retries);
           continue;
         }
 
@@ -105,10 +99,10 @@ export class ElevenLabsClient {
           throw error;
         }
 
-        if (attempt < effectiveRetries) {
+        if (attempt < this.retries) {
           const backoffMs = Math.pow(2, attempt) * 1000;
           logger.debug(
-            `[ElevenLabs Client] Retry ${attempt + 1}/${effectiveRetries} after ${backoffMs}ms`,
+            `[ElevenLabs Client] Retry ${attempt + 1}/${this.retries} after ${backoffMs}ms`,
           );
           await new Promise((resolve) => setTimeout(resolve, backoffMs));
         }

--- a/src/providers/elevenlabs/stt/index.ts
+++ b/src/providers/elevenlabs/stt/index.ts
@@ -60,7 +60,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
       calculateWER: config?.calculateWER || false,
       baseUrl: config?.baseUrl || 'https://api.elevenlabs.io/v1',
       timeout: config?.timeout || 120000,
-      retries: config?.retries || 3,
+      retries: config?.retries ?? 3,
       label: options.label || config?.label,
       apiKey: config?.apiKey,
       apiKeyEnvar: config?.apiKeyEnvar,

--- a/src/providers/elevenlabs/tts/index.ts
+++ b/src/providers/elevenlabs/tts/index.ts
@@ -349,7 +349,7 @@ export class ElevenLabsTTSProvider implements ApiProvider {
       timeout: config?.timeout || 120000, // 2 minutes
       cache: config?.cache,
       cacheTTL: config?.cacheTTL,
-      retries: config?.retries || 3,
+      retries: config?.retries ?? 3,
 
       // TTS-specific config
       voiceId: config?.voiceId || voiceNameFromId || '21m00Tcm4TlvDq8ikWAM', // Rachel (default)

--- a/test/providers/elevenlabs/agents/index.test.ts
+++ b/test/providers/elevenlabs/agents/index.test.ts
@@ -80,6 +80,16 @@ describe('ElevenLabsAgentsProvider', () => {
       expect(provider.config.maxTurns).toBe(0);
     });
 
+    it('should preserve explicit zero retries', () => {
+      const provider = new ElevenLabsAgentsProvider('elevenlabs:agent', {
+        config: {
+          retries: 0,
+        },
+      });
+
+      expect(provider.config.retries).toBe(0);
+    });
+
     it('should use custom label if provided', () => {
       const provider = new ElevenLabsAgentsProvider('elevenlabs:agent', {
         label: 'Custom Agent Label',

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -74,14 +74,36 @@ describe('ElevenLabsClient', () => {
 
       expect(result).toEqual(mockResponse);
       const [url, options] = mockFetch.mock.calls[0];
-      const headers =
-        options?.headers instanceof Headers ? options.headers : new Headers(options?.headers);
+      const headers = new Headers(options?.headers);
 
       expect(url).toBe('https://api.elevenlabs.io/v1/test');
       expect(options?.method).toBe('POST');
       expect(options?.body).toBe(JSON.stringify({ foo: 'bar' }));
+      expect(options?.headers).not.toBeInstanceOf(Headers);
       expect(headers.get('xi-api-key')).toBe('test-api-key');
       expect(headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('should normalize caller Headers to a plain object before fetchWithProxy', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ success: true }),
+      } as Response);
+
+      await client.post<{ success: boolean }>(
+        '/test',
+        { foo: 'bar' },
+        { headers: new Headers({ 'Idempotency-Key': 'request-123' }) },
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options?.headers).toEqual({
+        'idempotency-key': 'request-123',
+        'xi-api-key': 'test-api-key',
+        'content-type': 'application/json',
+      });
     });
 
     it('should handle binary response', async () => {

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -123,14 +123,26 @@ describe('ElevenLabsClient', () => {
       await vi.runAllTimersAsync();
       const error = await promise;
       expect(error).toBeInstanceOf(ElevenLabsRateLimitError);
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
-    it('should make one attempt by default on network error', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    it('should retry on network error', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ success: true }),
+        } as Response);
 
-      await expect(client.post<{ success: boolean }>('/test', {})).rejects.toThrow('Network error');
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const promise = client.post<{ success: boolean }>('/test', {});
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it('should make one attempt when retries is set to 0', async () => {
@@ -145,31 +157,8 @@ describe('ElevenLabsClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('should retry non-idempotent POSTs only when explicitly allowed', async () => {
-      mockFetch
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          headers: new Headers({ 'content-type': 'application/json' }),
-          json: async () => ({ success: true }),
-        } as Response);
-
-      const promise = client.post<{ success: boolean }>(
-        '/test',
-        {},
-        { allowRetriesForNonIdempotent: true },
-      );
-      await vi.runAllTimersAsync();
-      const result = await promise;
-
-      expect(result).toEqual({ success: true });
-      expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
-
     it('should throw ElevenLabsAPIError on 500', async () => {
-      // Mock all retry attempts (retries: 2 means 2 total attempts)
+      // Mock all retry attempts (retries: 2 means 3 total attempts)
       const errorResponse = {
         ok: false,
         status: 500,
@@ -182,6 +171,7 @@ describe('ElevenLabsClient', () => {
       await vi.runAllTimersAsync();
       const error = await promise;
       expect(error).toBeInstanceOf(ElevenLabsAPIError);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -49,6 +49,12 @@ describe('ElevenLabsClient', () => {
       });
       expect(customClient).toBeDefined();
     });
+
+    it('should preserve explicit zero retries', () => {
+      const zeroRetryClient = new ElevenLabsClient({ apiKey: 'test-key', retries: 0 });
+
+      expect((zeroRetryClient as any).retries).toBe(0);
+    });
   });
 
   describe('post', () => {
@@ -67,17 +73,15 @@ describe('ElevenLabsClient', () => {
       });
 
       expect(result).toEqual(mockResponse);
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.elevenlabs.io/v1/test',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'xi-api-key': 'test-api-key',
-            'Content-Type': 'application/json',
-          }),
-          body: JSON.stringify({ foo: 'bar' }),
-        }),
-      );
+      const [url, options] = mockFetch.mock.calls[0];
+      const headers =
+        options?.headers instanceof Headers ? options.headers : new Headers(options?.headers);
+
+      expect(url).toBe('https://api.elevenlabs.io/v1/test');
+      expect(options?.method).toBe('POST');
+      expect(options?.body).toBe(JSON.stringify({ foo: 'bar' }));
+      expect(headers.get('xi-api-key')).toBe('test-api-key');
+      expect(headers.get('Content-Type')).toBe('application/json');
     });
 
     it('should handle binary response', async () => {
@@ -107,7 +111,6 @@ describe('ElevenLabsClient', () => {
     });
 
     it('should throw ElevenLabsRateLimitError on 429', async () => {
-      // Mock all retry attempts - client retries on 429 without Retry-After
       const rateLimitResponse = {
         ok: false,
         status: 429,
@@ -120,22 +123,49 @@ describe('ElevenLabsClient', () => {
       await vi.runAllTimersAsync();
       const error = await promise;
       expect(error).toBeInstanceOf(ElevenLabsRateLimitError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('should retry on network error', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({ 'content-type': 'application/json' }),
-        json: async () => ({ success: true }),
-      } as Response);
+    it('should make one attempt by default on network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
-      const promise = client.post<{ success: boolean }>('/test', {});
+      await expect(client.post<{ success: boolean }>('/test', {})).rejects.toThrow('Network error');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should make one attempt when retries is set to 0', async () => {
+      const zeroRetryClient = new ElevenLabsClient({
+        apiKey: 'test-api-key',
+        timeout: 5000,
+        retries: 0,
+      });
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(zeroRetryClient.post('/test', {})).rejects.toThrow('Network error');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry non-idempotent POSTs only when explicitly allowed', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ success: true }),
+        } as Response);
+
+      const promise = client.post<{ success: boolean }>(
+        '/test',
+        {},
+        { allowRetriesForNonIdempotent: true },
+      );
       await vi.runAllTimersAsync();
       const result = await promise;
 
       expect(result).toEqual({ success: true });
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it('should throw ElevenLabsAPIError on 500', async () => {

--- a/test/providers/elevenlabs/stt/index.test.ts
+++ b/test/providers/elevenlabs/stt/index.test.ts
@@ -48,6 +48,16 @@ describe('ElevenLabsSTTProvider', () => {
       expect(provider.config.language).toBe('es');
     });
 
+    it('should preserve explicit zero retries', () => {
+      const provider = new ElevenLabsSTTProvider('elevenlabs:stt', {
+        config: {
+          retries: 0,
+        },
+      });
+
+      expect(provider.config.retries).toBe(0);
+    });
+
     it('should use custom label if provided', () => {
       const provider = new ElevenLabsSTTProvider('elevenlabs:stt', {
         label: 'Custom STT Label',

--- a/test/providers/elevenlabs/tts/index.test.ts
+++ b/test/providers/elevenlabs/tts/index.test.ts
@@ -52,6 +52,16 @@ describe('ElevenLabsTTSProvider', () => {
       expect(provider.config.outputFormat).toBe('mp3_22050_32');
     });
 
+    it('should preserve explicit zero retries', () => {
+      const provider = new ElevenLabsTTSProvider('elevenlabs:tts', {
+        config: {
+          retries: 0,
+        },
+      });
+
+      expect(provider.config.retries).toBe(0);
+    });
+
     it('should use custom label if provided', () => {
       const provider = new ElevenLabsTTSProvider('elevenlabs:tts', {
         label: 'Custom TTS Label',


### PR DESCRIPTION
## Summary
- preserve explicit `retries: 0` across the ElevenLabs client, agents, TTS, and STT providers
- treat `retries` as retry attempts so `0` still performs the first request without scheduling any retries
- add focused regression coverage for the client and provider config parsers

## Testing
- `npx vitest run test/providers/elevenlabs/client.test.ts test/providers/elevenlabs/agents/index.test.ts test/providers/elevenlabs/tts/index.test.ts test/providers/elevenlabs/stt/index.test.ts`
- `npm run l`
- `npm run build`