### PR TITLE
docs(site): clarify security policy scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Some features intentionally execute user-provided code (custom assertions, provi
 
 The local web server (`promptfoo view`) is a **single-user development tool** intended for use on your local machine. The web API executes evaluations with the same privileges as the CLI — inputs to the API (including provider configurations, transforms, and assertions) are treated as **trusted code**, equivalent to a local config file. The server is not designed to be exposed to untrusted networks or users.
 
-The server includes **CSRF/origin checks** that use browser-provided `Sec-Fetch-Site` and `Origin` headers to reduce accidental cross-origin requests from modern browsers. These checks are **best-effort hardening** for a local development tool, not a supported security boundary. Non-browser clients and requests without browser headers are allowed through to avoid breaking curl, scripts, and SDKs. Known localhost aliases (`localhost`, `127.0.0.1`, `[::1]`, `local.promptfoo.app`) are treated as equivalent origins.
+The server includes **CSRF/origin checks** that use browser-provided `Sec-Fetch-Site` and `Origin` headers to reduce accidental cross-origin requests from modern browsers. These checks are **best-effort hardening** for a local development tool, not a supported security boundary. Non-browser clients and requests without browser headers are allowed through to avoid breaking `curl`, scripts, and SDKs. Known localhost aliases (`localhost`, `127.0.0.1`, `[::1]`, `local.promptfoo.app`) are treated as equivalent origins.
 
 ### Trust Boundaries
 

--- a/site/src/pages/responsible-disclosure-policy.md
+++ b/site/src/pages/responsible-disclosure-policy.md
@@ -22,7 +22,7 @@ The OSS CLI runs in your environment with your user permissions. It is **permiss
 
 **In scope for OSS:** vulnerabilities where untrusted data inputs (prompts, test cases, model outputs) can trigger code execution, file access, or network access without explicit configuration.
 
-**Out of scope for OSS:** code execution from explicitly configured custom code, and direct local API or browser access to the OSS local server (`promptfoo view`), since these are part of the documented local trust model for the open source tool.
+**Out of scope for OSS:** code execution from explicitly configured custom code, and direct local API or browser access to the OSS local server (`promptfoo view`), since these are part of the documented local trust model for the open-source tool.
 
 ### Cloud Services
 
@@ -54,7 +54,7 @@ To speed triage, also include:
 
 - Whether you reproduced on the latest supported release (or `main`)
 - The affected file/function/code path, if known
-- A real browser-based PoC for browser-origin claims; spoofed browser headers from `curl` are not sufficient
+- A real browser-based PoC for browser-origin claims; spoofed `Origin` or `Sec-Fetch-Site` headers from `curl` or other non-browser clients are not sufficient
 - Why the issue exceeds the OSS trust model described in [SECURITY.md](https://github.com/promptfoo/promptfoo/blob/main/SECURITY.md)
 
 ## Response Time


### PR DESCRIPTION
## Summary
- clarify that the OSS local server shares the CLI trust model and treat browser access to `promptfoo view` as out of scope
- add small triage guidance for latest-version reproduction, code paths, and browser-header claims
- align the site responsible disclosure page with the repository security policy

## Testing
- git diff --check
