### PR TITLE
fix(helm): disable ingress by default

### DIFF
--- a/helm/chart/promptfoo/templates/ingress.yaml
+++ b/helm/chart/promptfoo/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,3 +25,4 @@ spec:
   - hosts:
     - {{ $.Values.domainName }}
     secretName: {{ $.Release.Name }}-certificate-tls
+{{- end }}

--- a/helm/chart/promptfoo/values.yaml
+++ b/helm/chart/promptfoo/values.yaml
@@ -42,6 +42,8 @@ service:
   port: 3000
 
 domainName: 'promptfoo.example.com'
+ingress:
+  enabled: false
 
 resources:
   limits:


### PR DESCRIPTION
### Motivation

- The chart previously created an `Ingress` unconditionally which could expose the unauthenticated promptfoo HTTP API publicly by default, increasing risk of remote arbitrary evaluation execution.

### Description

- Gate the Ingress template behind a new chart value `ingress.enabled` by wrapping the manifest with `{{- if .Values.ingress.enabled }} ... {{- end }}` so the resource is only created when explicitly enabled.
- Add a new `ingress.enabled: false` default to `helm/chart/promptfoo/values.yaml` so installs are not exposed externally unless operators opt in.

### Testing

- Attempted `helm template test-release helm/chart/promptfoo` to validate rendering, but the command failed in this environment because `helm` is not installed and could not be executed.
- Ran the repository lint command via `npm run l`, but it failed in this environment due to missing `origin/main` ref and blocked npm registry access, so lint could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be944730a08327aef2afb60a08c22f)