### PR TITLE
test(app): cover string plugin path in strategy preview hook

### DIFF
--- a/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts
+++ b/src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts
@@ -110,4 +110,37 @@ describe('useStrategyTestGeneration', () => {
       },
     );
   });
+
+  it('uses an empty config for string plugin entries', async () => {
+    vi.mocked(useRedTeamConfig).mockReturnValue({
+      config: {
+        plugins: ['policy'],
+        strategies: [],
+      },
+    } as ReturnType<typeof useRedTeamConfig>);
+
+    const { result } = renderHook(() =>
+      useStrategyTestGeneration({
+        strategyId: 'jailbreak:meta',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleTestCaseGeneration();
+    });
+
+    expect(result.current.testGenerationPlugin).toBe('policy');
+    expect(generateTestCase).toHaveBeenCalledWith(
+      {
+        id: 'policy',
+        config: {},
+        isStatic: true,
+      },
+      {
+        id: 'jailbreak:meta',
+        config: {},
+        isStatic: false,
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add targeted coverage for useStrategyTestGeneration when configured plugins use string entries
- verify preview generation passes { id, config: {}, isStatic: true } for string plugins
- keep scope limited to the recent strategy preview config-preservation fix area

## Testing
- npm run test:app -- -- src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts --run (fails in this environment: vitest command not found in src/app workspace)
- npx vitest src/app/src/pages/redteam/setup/components/strategies/useStrategyTestGeneration.test.ts --run (fails in this environment: local vitest package missing)
