### PR TITLE
docs: clarify database security guidance for agents

### DIFF
--- a/docs/agents/database-security.md
+++ b/docs/agents/database-security.md
@@ -12,30 +12,47 @@ This codebase uses Drizzle ORM with SQLite. All database queries must use parame
 
 ## Required Pattern: Use `sql` Template Strings
 
+Use parameterized queries for single values:
+
 ```typescript
 import { sql } from 'drizzle-orm';
 
-// CORRECT: Parameterized query - values are safely escaped
 const query = sql`SELECT * FROM eval_results WHERE eval_id = ${evalId}`;
+```
 
-// CORRECT: Multiple parameters
+Use parameterized queries for multiple values:
+
+```typescript
+import { sql } from 'drizzle-orm';
+
 const query = sql`
   SELECT * FROM eval_results
   WHERE eval_id = ${evalId} AND success = ${1}
 `;
+```
 
-// CORRECT: Using sql.join() for IN clauses
+Use `sql.join()` for dynamic `IN (...)` lists:
+
+```typescript
+import { sql } from 'drizzle-orm';
+
 const ids = ['id1', 'id2', 'id3'];
 const query = sql`SELECT * FROM evals WHERE id IN (${sql.join(ids, sql`, `)})`;
 ```
 
 ## Forbidden Pattern: Raw SQL with Dynamic Content
 
-```typescript
-// WRONG: SQL injection vulnerability
-const query = sql.raw(`SELECT * FROM eval_results WHERE eval_id = '${evalId}'`);
+Do not interpolate user-controlled values into raw SQL:
 
-// WRONG: String concatenation
+```typescript
+const query = sql.raw(`SELECT * FROM eval_results WHERE eval_id = '${evalId}'`);
+```
+
+Do not build SQL conditions with string concatenation:
+
+```typescript
+import { sql } from 'drizzle-orm';
+
 const whereClause = `eval_id = '${evalId}'`;
 const query = sql.raw(`SELECT * FROM eval_results WHERE ${whereClause}`);
 ```
@@ -47,10 +64,11 @@ SQLite's `json_extract()` requires the JSON path to be a string literal, so this
 - Backslashes and double quotes for JSON path syntax
 - Single quotes before embedding the path in a SQL string literal
 
+Reuse `buildSafeJsonPath` from `src/models/eval.ts`:
+
 ```typescript
 import { sql } from 'drizzle-orm';
 
-// Reuse the audited helper defined in src/models/eval.ts
 const jsonPath = buildSafeJsonPath(userField);
 const query = sql`
   SELECT * FROM eval_results


### PR DESCRIPTION
## Summary
- restore the structured database security guidance used by agents
- keep copyable examples for parameterized queries, `sql.join()`, and `SQL<unknown>` fragments
- document the audited `buildSafeJsonPath` exception for SQLite `json_extract()` paths, including single-quote escaping

## Testing
- `npx prettier --write docs/agents/database-security.md`
- `git diff --check`

## Notes
- this is an internal agent-instructions doc, so the update favors imperative rules, concrete examples, and references to the shared vetted helper over narrative prose
