### PR TITLE
fix(deps): pin claude-agent-sdk lockfile to 0.2.87

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.88",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.88.tgz",
-      "integrity": "sha512-hm9AYD8UGpGouOlmWB6kMRjIUCMtO13N3HDsviu7/htOXJZ/KKypgEd5yW04Ro6421SwX4KfQNrwayJ6R227+g==",
+      "version": "0.2.87",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.87.tgz",
+      "integrity": "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "dependencies": {


### PR DESCRIPTION
## Summary

This fixes a fresh install failure caused by `package-lock.json` pointing at `@anthropic-ai/claude-agent-sdk@0.2.88`, which is not currently published on npm. The package manifest already requests `^0.2.87`, and `0.2.87` is the latest published version available from the registry.

The lockfile entry is updated to the published `0.2.87` tarball and integrity so `npm ci` works in a clean checkout again.

## Validation

- `npm ci`
- `npx prettier --check package-lock.json`

