### PR TITLE
fix(cli): serialize source-map support initialization

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -49,6 +49,7 @@ export interface SanitizedLogContext {
 
 // Lazy source map support - only loaded when debug is enabled
 export let sourceMapSupportInitialized = false;
+let sourceMapSupportInitializationPromise: Promise<void> | null = null;
 
 // Shutdown state tracking - prevents writes once logger closure begins
 let isLoggerShuttingDown = false;
@@ -64,15 +65,23 @@ export function getLoggerShuttingDown(): boolean {
 }
 
 export async function initializeSourceMapSupport(): Promise<void> {
-  if (!sourceMapSupportInitialized) {
+  if (sourceMapSupportInitialized) {
+    return;
+  }
+
+  sourceMapSupportInitializationPromise ??= (async () => {
     try {
       const sourceMapSupport = await import('source-map-support');
       sourceMapSupport.install();
       sourceMapSupportInitialized = true;
     } catch {
       // Ignore errors. This happens in the production build, because source-map-support is a dev dependency.
+    } finally {
+      sourceMapSupportInitializationPromise = null;
     }
-  }
+  })();
+
+  await sourceMapSupportInitializationPromise;
 }
 
 /**

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -143,9 +143,12 @@ describe('logger', () => {
     mockLogger.transports[0].level = 'info';
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     mockStdout.mockRestore();
     global.Error = originalError;
+    vi.restoreAllMocks();
+    vi.doUnmock('source-map-support');
+    await vi.dynamicImportSettled();
     vi.resetModules();
   });
 
@@ -564,7 +567,7 @@ describe('logger', () => {
   });
 
   describe('initializeSourceMapSupport', () => {
-    it('should only call install once across multiple invocations', async () => {
+    it('should only call install once across concurrent and repeated invocations', async () => {
       // Save and clear LOG_LEVEL to prevent auto-initialization during import
       const originalLogLevel = process.env.LOG_LEVEL;
       delete process.env.LOG_LEVEL;
@@ -578,25 +581,17 @@ describe('logger', () => {
           install: mockInstall,
         }));
 
-        // Import fresh logger with our mock (import needed for side effect)
-        await import('../src/logger');
-
-        // Clear any calls that happened during import
-        mockInstall.mockClear();
-
-        // Reset the initialized flag by reimporting with clean state
-        vi.resetModules();
-        vi.doMock('source-map-support', () => ({
-          install: mockInstall,
-        }));
         const cleanLogger = await import('../src/logger');
         mockInstall.mockClear();
 
-        // First explicit call should trigger install
-        await cleanLogger.initializeSourceMapSupport();
+        // Concurrent explicit calls should share one in-flight initialization.
+        await Promise.all([
+          cleanLogger.initializeSourceMapSupport(),
+          cleanLogger.initializeSourceMapSupport(),
+        ]);
         expect(mockInstall).toHaveBeenCalledTimes(1);
 
-        // Second call should NOT trigger install again (flag is set)
+        // A later call should not trigger install again once initialized.
         mockInstall.mockClear();
         await cleanLogger.initializeSourceMapSupport();
         expect(mockInstall).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- serialize source-map-support initialization with a shared in-flight promise
- drain async dynamic imports and restore global spies in logger tests

## Test Plan
- npx vitest run test/logger.test.ts --sequence.seed=1
- npx vitest run test/logger.test.ts --sequence.seed=2
- npx vitest run test/logger.test.ts --sequence.seed=3
- npx vitest run test/logger.test.ts --sequence.shuffle=false
- npm run f
- npm run l
- npm run tsc
