### PR TITLE
fix(openai): avoid invalid realtime zero output tokens

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -1692,17 +1692,17 @@ providers:
 
 The Realtime API configuration supports these parameters in addition to standard OpenAI parameters:
 
-| Parameter                    | Description                                         | Default                | Options                                 |
-| ---------------------------- | --------------------------------------------------- | ---------------------- | --------------------------------------- |
-| `modalities`                 | Types of content the model can process and generate | ['text', 'audio']      | 'text', 'audio'                         |
-| `voice`                      | Voice for audio generation                          | 'alloy'                | alloy, echo, fable, onyx, nova, shimmer |
-| `instructions`               | System instructions for the model                   | 'You are a helpful...' | Any text string                         |
-| `input_audio_format`         | Format of audio input                               | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
-| `output_audio_format`        | Format of audio output                              | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
-| `websocketTimeout`           | Timeout for WebSocket connection (milliseconds)     | 30000                  | Any number                              |
-| `max_response_output_tokens` | Maximum tokens in model response                    | 'inf'                  | Number or 'inf'                         |
-| `tools`                      | Array of tool definitions for function calling      | []                     | Array of tool objects                   |
-| `tool_choice`                | Controls how tools are selected                     | 'auto'                 | 'none', 'auto', 'required', or object   |
+| Parameter                    | Description                                                                                                 | Default                | Options                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------- |
+| `modalities`                 | Types of content the model can process and generate                                                         | ['text', 'audio']      | 'text', 'audio'                         |
+| `voice`                      | Voice for audio generation                                                                                  | 'alloy'                | alloy, echo, fable, onyx, nova, shimmer |
+| `instructions`               | System instructions for the model                                                                           | 'You are a helpful...' | Any text string                         |
+| `input_audio_format`         | Format of audio input                                                                                       | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
+| `output_audio_format`        | Format of audio output                                                                                      | 'pcm16'                | 'pcm16', 'g711_ulaw', 'g711_alaw'       |
+| `websocketTimeout`           | Timeout for WebSocket connection (milliseconds)                                                             | 30000                  | Any number                              |
+| `max_response_output_tokens` | Maximum tokens in model response. For Realtime models, `0` is treated as invalid and falls back to `'inf'`. | 'inf'                  | Positive integer or 'inf'               |
+| `tools`                      | Array of tool definitions for function calling                                                              | []                     | Array of tool objects                   |
+| `tool_choice`                | Controls how tools are selected                                                                             | 'auto'                 | 'none', 'auto', 'required', or object   |
 
 #### Custom endpoints and proxies (Realtime)
 

--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -136,6 +136,14 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
   private isProcessingAudio: boolean = false;
   private audioTimeout: NodeJS.Timeout | null = null;
 
+  private getMaxResponseOutputTokens(): number | 'inf' {
+    const value = this.config.max_response_output_tokens;
+    if (typeof value === 'number' && value > 0) {
+      return value;
+    }
+    return 'inf';
+  }
+
   constructor(
     modelName: string,
     options: { config?: OpenAiRealtimeOptions; id?: string; env?: EnvOverrides } = {},
@@ -199,7 +207,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
     const inputAudioFormat = this.config.input_audio_format || 'pcm16';
     const outputAudioFormat = this.config.output_audio_format || 'pcm16';
     const temperature = this.config.temperature ?? 0.8;
-    const maxResponseOutputTokens = this.config.max_response_output_tokens || 'inf';
+    const maxResponseOutputTokens = this.getMaxResponseOutputTokens();
 
     const body: any = {
       model: this.modelName,
@@ -980,7 +988,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
             input_audio_format: this.config.input_audio_format || 'pcm16',
             output_audio_format: this.config.output_audio_format || 'pcm16',
             temperature: this.config.temperature ?? 0.8,
-            max_response_output_tokens: this.config.max_response_output_tokens || 'inf',
+            max_response_output_tokens: this.getMaxResponseOutputTokens(),
             ...(this.config.input_audio_transcription !== undefined && {
               input_audio_transcription: this.config.input_audio_transcription,
             }),

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -27,11 +27,15 @@ describe('OpenAI Realtime Provider', () => {
   let mockHandlers: { [key: string]: Function[] };
   const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
   const originalCustomRealtimeApiKey = process.env.CUSTOM_REALTIME_API_KEY;
+  const originalOpenAiApiBaseUrl = process.env.OPENAI_API_BASE_URL;
+  const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
 
   beforeEach(() => {
     vi.resetAllMocks();
     disableCache();
     process.env.OPENAI_API_KEY = 'test-api-key';
+    delete process.env.OPENAI_API_BASE_URL;
+    delete process.env.OPENAI_BASE_URL;
     mockHandlers = {
       open: [],
       message: [],
@@ -61,6 +65,8 @@ describe('OpenAI Realtime Provider', () => {
     enableCache();
     restoreEnvVar('OPENAI_API_KEY', originalOpenAiApiKey);
     restoreEnvVar('CUSTOM_REALTIME_API_KEY', originalCustomRealtimeApiKey);
+    restoreEnvVar('OPENAI_API_BASE_URL', originalOpenAiApiBaseUrl);
+    restoreEnvVar('OPENAI_BASE_URL', originalOpenAiBaseUrl);
   });
 
   describe('Basic Functionality', () => {
@@ -199,6 +205,19 @@ describe('OpenAI Realtime Provider', () => {
         temperature: 0.8,
         max_response_output_tokens: 'inf',
       });
+    });
+
+    it('should fall back to inf when max_response_output_tokens is 0 in the session body', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
+        config: {
+          modalities: ['text'],
+          max_response_output_tokens: 0,
+        },
+      });
+
+      const body = await provider.getRealtimeSessionBody();
+
+      expect(body.max_response_output_tokens).toBe('inf');
     });
 
     it('should handle basic text response with persistent connection', async () => {
@@ -750,6 +769,45 @@ describe('OpenAI Realtime Provider', () => {
       expect(constructedUrl).toBe(
         'wss://api.openai.com/v1/realtime?model=' + encodeURIComponent('gpt-4o-realtime-preview'),
       );
+    });
+
+    it('falls back to inf when max_response_output_tokens is 0 in session.update', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
+        config: { max_response_output_tokens: 0 },
+      });
+      const promise = provider.directWebSocketRequest('hi');
+
+      mockHandlers.open.forEach((h) => h());
+
+      expect(mockWs.send).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('"max_response_output_tokens":"inf"'),
+      );
+
+      const messageHandlers = mockHandlers.message;
+      const lastHandler = messageHandlers[messageHandlers.length - 1];
+      lastHandler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'conversation.item.created',
+            item: { id: 'msg_zero', role: 'user' },
+          }),
+        ),
+      );
+      lastHandler(
+        Buffer.from(JSON.stringify({ type: 'response.created', response: { id: 'resp_zero' } })),
+      );
+      lastHandler(Buffer.from(JSON.stringify({ type: 'response.text.done', text: 'ok' })));
+      lastHandler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.done',
+            response: { usage: { total_tokens: 1, input_tokens: 1, output_tokens: 0 } },
+          }),
+        ),
+      );
+
+      await promise;
     });
 
     it('converts custom https apiBaseUrl to wss for direct WebSocket', async () => {

--- a/test/util/redteamProbeLimit.test.ts
+++ b/test/util/redteamProbeLimit.test.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'crypto';
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../src/database/index';
 import { evalResultsTable, evalsTable } from '../../src/database/tables';
-import { getUserEmail, isLoggedIntoCloud } from '../../src/globalConfig/accounts';
 import { runDbMigrations } from '../../src/migrate';
 import {
   checkRedteamProbeLimit,
@@ -130,16 +129,6 @@ describe('redteamProbeLimit', () => {
     await db.run('DELETE FROM evals_to_datasets');
     await db.run('DELETE FROM evals_to_prompts');
     await db.run('DELETE FROM evals');
-
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-15T12:00:00.000Z'));
-    vi.mocked(isLoggedIntoCloud).mockReturnValue(false);
-    vi.mocked(getUserEmail).mockReturnValue('test@example.com');
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.resetAllMocks();
   });
 
   describe('getMonthStartTimestamp', () => {
@@ -176,11 +165,8 @@ describe('redteamProbeLimit', () => {
     });
 
     it('should not count evals from previous months', () => {
-      const lastMonth = new Date();
-      lastMonth.setDate(1);
-      lastMonth.setMonth(lastMonth.getMonth() - 1);
       insertRedteamEval({
-        createdAt: lastMonth.getTime(),
+        createdAt: getMonthStartTimestamp() - 1,
         numResults: 5,
         numRequestsPerResult: 1,
       });
@@ -304,6 +290,7 @@ describe('redteamProbeLimit', () => {
     });
 
     it('should exempt cloud-authenticated users', async () => {
+      const { isLoggedIntoCloud } = await import('../../src/globalConfig/accounts');
       vi.mocked(isLoggedIntoCloud).mockReturnValue(true);
 
       // Even with probes, cloud users should be exempt
@@ -313,6 +300,9 @@ describe('redteamProbeLimit', () => {
       expect(result.withinLimit).toBe(true);
       expect(result.remaining).toBe(Number.POSITIVE_INFINITY);
       expect(result.limit).toBe(Number.POSITIVE_INFINITY);
+
+      // Reset mock
+      vi.mocked(isLoggedIntoCloud).mockReturnValue(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- treat `max_response_output_tokens: 0` as invalid for OpenAI Realtime and fall back to the documented default `inf`
- keep the direct session body and websocket `session.update` payloads aligned so the invalid zero value is never sent to the API
- carry over the focused realtime test coverage and the follow-up docs / shared redteam test stabilization from the previously closed branch

## End-user benefit
When a user explicitly configures `max_response_output_tokens: 0` today, the Realtime provider can send an invalid payload to the API instead of falling back to the provider default. This fix preserves the expected fallback behavior and avoids request rejection on otherwise valid realtime runs.

## Testing
- `npx vitest run test/providers/openai/realtime.test.ts`