### PR TITLE
test(redteam): remove tautological test guards

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -3290,15 +3290,9 @@ describe('ResultsTable handleRating - Toggle off (null isPass) behavior', () => 
 
     // When score is provided explicitly, it should be used instead of defaulting to 0/1
     const customScore = 0.75;
-    const isPass = true;
 
-    // Verify logic: if score is provided, use it; if only isPass, use 0/1
-    let finalScore: number = 0;
-    if (typeof customScore !== 'undefined') {
-      finalScore = customScore;
-    } else if (typeof isPass !== 'undefined' && isPass !== null) {
-      finalScore = isPass ? 1 : 0;
-    }
+    // Verify logic: an explicit score takes precedence over pass/fail-derived scores.
+    const finalScore = customScore;
 
     expect(finalScore).toBe(0.75);
   });

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -478,13 +478,8 @@ describe('ProviderConfigEditor', () => {
 
       // Test case 1: value is undefined -> should delete inputs field
       const updatedTarget: any = { id: 'test', config: {}, inputs: { old: 'value' } };
-      const value = undefined;
 
-      if (value === undefined) {
-        delete updatedTarget.inputs;
-      } else {
-        updatedTarget.inputs = value;
-      }
+      delete updatedTarget.inputs;
 
       expect(updatedTarget.inputs).toBeUndefined();
       expect('inputs' in updatedTarget).toBe(false);
@@ -495,11 +490,7 @@ describe('ProviderConfigEditor', () => {
       const updatedTarget = { id: 'test', config: {} } as any;
       const value = { user_id: 'A user ID', role: 'A role' };
 
-      if (value === undefined) {
-        delete updatedTarget.inputs;
-      } else {
-        updatedTarget.inputs = value;
-      }
+      updatedTarget.inputs = value;
 
       expect(updatedTarget.inputs).toEqual({ user_id: 'A user ID', role: 'A role' });
     });


### PR DESCRIPTION
## Summary

Remove test-local tautological guards flagged as unneeded defensive code in `ResultsTable.test.tsx` and `ProviderConfigEditor.test.tsx`.

## Details

The corresponding production branches remain valid: `handleRating` still needs to handle undefined scores and nullable pass states, and `updateCustomTarget` still needs to delete `inputs` when the editor emits `undefined`. The CodeQL findings were against copied test snippets where each test pins the branch selector to a constant, so one side of each defensive conditional is unreachable in that test body.

This PR simplifies those tests to directly execute the intended branch and removes the now-unused selector locals. No production logic is changed.

## Validation

- `npm run f`
- `npm run l`
- `npm run test:app -- -- src/pages/eval/components/ResultsTable.test.tsx --run`
- `npm run test:app -- -- src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx --run`
