### PR TITLE
fix(mcp): preserve falsy values and bound truncation

### DIFF
--- a/src/commands/mcp/lib/resultFormatter.ts
+++ b/src/commands/mcp/lib/resultFormatter.ts
@@ -1,4 +1,5 @@
 import { ResultFailureReason as ResultFailureReasonEnum } from '../../../types/index';
+import { truncateText } from './utils';
 
 import type {
   EvaluateResult,
@@ -81,16 +82,6 @@ export interface PaginationInfo {
   offset: number;
   hasMore: boolean;
   returnedCount: number;
-}
-
-/**
- * Truncate text to specified length with ellipsis
- */
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-  return text.slice(0, maxLength) + '...';
 }
 
 /**

--- a/src/commands/mcp/lib/utils.ts
+++ b/src/commands/mcp/lib/utils.ts
@@ -201,16 +201,18 @@ export function formatDuration(ms: number): string {
 }
 
 /**
- * Truncate text to specified length with ellipsis
+ * Truncate text to specified length with ellipsis.
+ * The returned string is guaranteed to be at most maxLength characters.
  */
 export function truncateText(text: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return '';
+  }
   if (text.length <= maxLength) {
     return text;
   }
-
-  if (maxLength < 3) {
-    return text.slice(0, Math.max(0, maxLength));
+  if (maxLength <= 3) {
+    return text.slice(0, maxLength);
   }
-
   return text.slice(0, maxLength - 3) + '...';
 }

--- a/test/commands/mcp/lib/utils.test.ts
+++ b/test/commands/mcp/lib/utils.test.ts
@@ -434,18 +434,16 @@ describe('MCP Utility Functions', () => {
       expect(result).toHaveLength(20);
     });
 
-    it('should handle max length less than ellipsis length', () => {
-      const text = 'Hello';
-      const result = truncateText(text, 2);
-
-      // Truncate without ellipsis so the result never exceeds maxLength.
-      expect(result).toBe('He');
+    it('should truncate without ellipsis when max length is 3 or less', () => {
+      expect(truncateText('Hello', 3)).toBe('Hel');
+      expect(truncateText('Hello', 2)).toBe('He');
+      expect(truncateText('Hello', 1)).toBe('H');
     });
 
-    it('should return ellipsis when max length equals ellipsis length', () => {
-      const result = truncateText('Hello', 3);
-
-      expect(result).toBe('...');
+    it('should use ellipsis starting at max length 4', () => {
+      const result = truncateText('Hello World', 4);
+      expect(result).toBe('H...');
+      expect(result).toHaveLength(4);
     });
 
     it('should return empty string when max length is zero', () => {


### PR DESCRIPTION
## Summary

Fix two edge-case bugs in the MCP utility helpers and align the unit tests with the intended contracts.

`filterNonNull` was documented as removing only `null` and `undefined`, but the implementation used `Boolean(item)`, which also dropped valid falsy values such as `0`, `false`, and `''`. That could silently strip legitimate data from MCP tool payloads and downstream processing. The helper now uses a nullish check so falsy values are preserved.

`truncateText` appended an ellipsis after slicing with `maxLength - 3`, which produced oversized results when `maxLength` was less than 3. That broke the function's length contract and could return strings longer than callers requested. The helper now truncates without an ellipsis for very small limits and clamps non-positive limits to an empty string.

## Tests

- `npx vitest run test/commands/mcp/lib/utils.test.ts`
- `npm run l`
- `npm run f`
