### PR TITLE
test: add xlsx parser validation coverage

### DIFF
--- a/test/util/xlsx.test.ts
+++ b/test/util/xlsx.test.ts
@@ -73,6 +73,42 @@ describe('parseXlsxFile', () => {
     );
   });
 
+  it('should throw error when Excel file has no sheets', async () => {
+    mockReadXlsxFile.mockResolvedValue([]);
+
+    await expect(parseXlsxFile('test.xlsx')).rejects.toThrow('Excel file has no sheets');
+  });
+
+  it('should throw error when sheet has no valid column headers', async () => {
+    mockReadXlsxFile.mockResolvedValue([createMockSheet('Sheet1', [['', '', '']])]);
+
+    await expect(parseXlsxFile('test.xlsx')).rejects.toThrow(
+      'Sheet "Sheet1" has no valid column headers',
+    );
+  });
+
+  it('should throw error when sheet has headers but no data rows', async () => {
+    mockReadXlsxFile.mockResolvedValue([createMockSheet('Sheet1', [['col1', 'col2']])]);
+
+    await expect(parseXlsxFile('test.xlsx')).rejects.toThrow(
+      'Sheet "Sheet1" is empty or contains no valid data rows',
+    );
+  });
+
+  it('should throw error when sheet has headers but only empty data rows', async () => {
+    mockReadXlsxFile.mockResolvedValue([
+      createMockSheet('Sheet1', [
+        ['col1', 'col2'],
+        ['', ''],
+        [null, undefined],
+      ]),
+    ]);
+
+    await expect(parseXlsxFile('test.xlsx')).rejects.toThrow(
+      'Sheet "Sheet1" contains only empty data. Please ensure the sheet has both headers and data rows.',
+    );
+  });
+
   it('should use first sheet by default', async () => {
     const mockRows = [
       ['col1', 'col2'],


### PR DESCRIPTION
## Summary

Add focused negative-path coverage for `parseXlsxFile` workbook and sheet validation failures:

- no sheets in workbook
- no valid column headers in the first row
- headers with no data rows
- headers with only empty data rows

These cases map directly to existing validation branches in `src/util/xlsx.ts` and only update tests.

## Validation

- `source ~/.nvm/nvm.sh && nvm use && npm ci && npx vitest run test/util/xlsx.test.ts`
- 1 file passed, 19 tests passed
