### PR TITLE
feat(redteam): enforce max chars per message

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -46,6 +46,7 @@ redteam:
   plugins: Array<string | { id: string, numTests?: number, config?: Record<string, any> }>
   strategies: Array<string | { id: string }>
   numTests: number
+  maxCharsPerMessage: number
   injectVar: string
   provider: string | ProviderOptions
   purpose: string
@@ -63,6 +64,7 @@ redteam:
 | ---------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `injectVar`                  | `string`                  | Variable to inject adversarial inputs into                                                              | Inferred from prompts                            |
 | `numTests`                   | `number`                  | Default number of tests to generate per plugin                                                          | 5                                                |
+| `maxCharsPerMessage`         | `number`                  | Maximum characters allowed in each generated user message                                               | None                                             |
 | `plugins`                    | `Array<string\|object>`   | Plugins to use for red team generation                                                                  | `default`                                        |
 | `provider` or `targets`      | `string\|ProviderOptions` | Endpoint or AI model provider for generating adversarial inputs                                         | `openai:gpt-5`                                   |
 | `purpose`                    | `string`                  | Description of prompt templates' purpose to guide adversarial generation                                | Inferred from prompts                            |
@@ -114,6 +116,7 @@ plugins:
     config:
       examples: Array<string> # Custom examples to guide test generation
       language: string # Language for generated tests (overrides global setting)
+      maxCharsPerMessage: number # Per-plugin user message length cap when no global cap is set
       modifiers: Record<string, string> # Additional requirements for test generation
       graderGuidance: string # Custom grading instructions (prioritized in conflicts)
       graderExamples: Array<object> # Example outputs with pass/fail scores
@@ -304,6 +307,22 @@ testGenerationInstructions: |
   Use realistic employee scenarios and corporate terminology.
   Focus on role-based access control bypasses and information disclosure.
 ```
+
+### Message Length Limits
+
+Use `redteam.maxCharsPerMessage` to cap each generated user message before it is sent to your target. Promptfoo adds this limit to generation prompts, retries plugin outputs that exceed it, drops oversized strategy outputs, and fails a red team eval before calling the target if the rendered user message is still too long.
+
+```yaml
+redteam:
+  maxCharsPerMessage: 280
+  plugins:
+    - harmful:hate
+    - id: 'contracts'
+      config:
+        maxCharsPerMessage: 180
+```
+
+If `redteam.maxCharsPerMessage` is set, it applies to every plugin and strategy in the scan. Use `plugins[].config.maxCharsPerMessage` only when you want a plugin-specific cap and have not set a global limit.
 
 ## Core Concepts
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -2684,6 +2684,12 @@
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
         },
+        "maxCharsPerMessage": {
+          "description": "Maximum number of characters allowed per generated user message",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
         "delay": {
           "description": "Delay in milliseconds between plugin API calls",
           "type": "integer",

--- a/src/app/src/pages/redteam/setup/components/Review.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.test.tsx
@@ -230,6 +230,7 @@ describe('Review Component', () => {
     strategies: [],
     purpose: 'Test purpose',
     numTests: 10,
+    maxCharsPerMessage: 250,
     maxConcurrency: 4,
     target: { id: 'test-target', config: {} },
     applicationDefinition: {},
@@ -313,6 +314,25 @@ describe('Review Component', () => {
       const descriptionField = screen.getByLabelText('Description');
       expect(descriptionField).toBeInTheDocument();
       expect(descriptionField).toHaveValue('Test Configuration');
+    });
+
+    it('renders the max chars per message field in Run Options and persists changes', () => {
+      renderWithProviders(
+        <Review
+          navigateToPlugins={vi.fn()}
+          navigateToStrategies={vi.fn()}
+          navigateToPurpose={vi.fn()}
+        />,
+      );
+
+      const maxCharsPerMessageInput = screen.getByLabelText('Max chars per message');
+      expect(maxCharsPerMessageInput).toBeInTheDocument();
+      expect(maxCharsPerMessageInput).toHaveValue(250);
+
+      fireEvent.change(maxCharsPerMessageInput, { target: { value: '180' } });
+      fireEvent.blur(maxCharsPerMessageInput);
+
+      expect(mockUpdateConfig).toHaveBeenCalledWith('maxCharsPerMessage', 180);
     });
 
     it('renders DefaultTestVariables component inside CollapsibleContent when expanded', () => {

--- a/src/app/src/pages/redteam/setup/components/Review.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.tsx
@@ -1051,6 +1051,7 @@ export default function Review({
               <div className="p-4 pt-0">
                 <RunOptionsContent
                   numTests={config.numTests}
+                  maxCharsPerMessage={config.maxCharsPerMessage}
                   runOptions={{
                     maxConcurrency: config.maxConcurrency,
                     delay: config.target.config.delay,

--- a/src/app/src/pages/redteam/setup/components/RunOptions.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/RunOptions.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Config } from '../types';
 import {
   DelayBetweenAPICallsInput,
+  MaxCharsPerMessageInput,
   MaxNumberOfConcurrentRequestsInput,
   NumberOfTestCasesInput,
   RUNOPTIONS_TEXT,
@@ -31,6 +32,10 @@ describe('RUNOPTIONS_TEXT', () => {
     expect(RUNOPTIONS_TEXT.maxConcurrentRequests).toBeDefined();
     expect(RUNOPTIONS_TEXT.maxConcurrentRequests.helper).toBeDefined();
     expect(RUNOPTIONS_TEXT.maxConcurrentRequests.error).toBeDefined();
+
+    expect(RUNOPTIONS_TEXT.maxCharsPerMessage).toBeDefined();
+    expect(RUNOPTIONS_TEXT.maxCharsPerMessage.helper).toBeDefined();
+    expect(RUNOPTIONS_TEXT.maxCharsPerMessage.error).toBeDefined();
   });
 });
 
@@ -40,6 +45,7 @@ describe('RunOptionsContent', () => {
 
   const defaultProps = {
     numTests: 10,
+    maxCharsPerMessage: 250,
     runOptions: {
       delay: 0,
       maxConcurrency: 1,
@@ -70,6 +76,10 @@ describe('RunOptionsContent', () => {
       expect(maxConcurrencyInput).toBeInTheDocument();
       expect(maxConcurrencyInput).toHaveValue(defaultProps.runOptions.maxConcurrency);
       expect(maxConcurrencyInput).not.toBeDisabled();
+
+      const maxCharsPerMessageInput = screen.getByLabelText('Max chars per message');
+      expect(maxCharsPerMessageInput).toBeInTheDocument();
+      expect(maxCharsPerMessageInput).toHaveValue(defaultProps.maxCharsPerMessage);
 
       const debugSwitch = screen.getByRole('switch', { name: /Debug mode/i });
       expect(debugSwitch).toBeInTheDocument();
@@ -124,6 +134,7 @@ describe('RunOptionsContent', () => {
         const props = {
           ...defaultProps,
           numTests: largeValue,
+          maxCharsPerMessage: largeValue,
           runOptions: {
             delay: largeValue,
             maxConcurrency: largeValue,
@@ -146,6 +157,12 @@ describe('RunOptionsContent', () => {
         ) as HTMLInputElement;
         expect(maxConcurrencyInput).toBeInTheDocument();
         expect(Number(maxConcurrencyInput.value)).toBe(largeValue);
+
+        const maxCharsPerMessageInput = screen.getByLabelText(
+          'Max chars per message',
+        ) as HTMLInputElement;
+        expect(maxCharsPerMessageInput).toBeInTheDocument();
+        expect(Number(maxCharsPerMessageInput.value)).toBe(largeValue);
       });
     });
   });
@@ -168,6 +185,28 @@ describe('RunOptionsContent', () => {
       fireEvent.blur(numTestsInput);
       expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
       expect(mockUpdateConfig).toHaveBeenCalledWith('numTests', REDTEAM_DEFAULTS.NUM_TESTS);
+    });
+
+    it('should call updateConfig with maxCharsPerMessage when that field is set to a valid value', () => {
+      renderWithTooltipProvider(
+        <RunOptionsContent {...defaultProps} maxCharsPerMessage={undefined} />,
+      );
+      const maxCharsPerMessageInput = screen.getByLabelText('Max chars per message');
+
+      fireEvent.change(maxCharsPerMessageInput, { target: { value: '120' } });
+      fireEvent.blur(maxCharsPerMessageInput);
+
+      expect(mockUpdateConfig).toHaveBeenCalledWith('maxCharsPerMessage', 120);
+    });
+
+    it('should clear maxCharsPerMessage when the field is emptied', () => {
+      renderWithTooltipProvider(<RunOptionsContent {...defaultProps} />);
+      const maxCharsPerMessageInput = screen.getByLabelText('Max chars per message');
+
+      fireEvent.change(maxCharsPerMessageInput, { target: { value: '' } });
+      fireEvent.blur(maxCharsPerMessageInput);
+
+      expect(mockUpdateConfig).toHaveBeenCalledWith('maxCharsPerMessage', undefined);
     });
   });
 
@@ -591,5 +630,76 @@ describe('NumberOfTestCasesInput', () => {
 
     // @ts-ignore - Restoring the original object
     RUNOPTIONS_TEXT.missingProperty = originalRunOptionsText.missingProperty;
+  });
+});
+
+describe('MaxCharsPerMessageInput', () => {
+  const setValue = vi.fn();
+  const updateConfig = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should persist a valid positive integer on blur', () => {
+    renderWithTooltipProvider(
+      <MaxCharsPerMessageInput value="42" setValue={setValue} updateConfig={updateConfig} />,
+    );
+
+    const input = screen.getByLabelText('Max chars per message');
+    fireEvent.blur(input);
+
+    expect(updateConfig).toHaveBeenCalledWith('maxCharsPerMessage', 42);
+    expect(setValue).toHaveBeenCalledWith('42');
+  });
+
+  it('should clear the config value when the field is blank', () => {
+    renderWithTooltipProvider(
+      <MaxCharsPerMessageInput value="" setValue={setValue} updateConfig={updateConfig} />,
+    );
+
+    const input = screen.getByLabelText('Max chars per message');
+    fireEvent.blur(input);
+
+    expect(updateConfig).toHaveBeenCalledWith('maxCharsPerMessage', undefined);
+    expect(setValue).toHaveBeenCalledWith('');
+  });
+
+  it('should clear invalid values on blur', () => {
+    renderWithTooltipProvider(
+      <MaxCharsPerMessageInput value="0" setValue={setValue} updateConfig={updateConfig} />,
+    );
+
+    const input = screen.getByLabelText('Max chars per message');
+    fireEvent.blur(input);
+
+    expect(updateConfig).toHaveBeenCalledWith('maxCharsPerMessage', undefined);
+    expect(setValue).toHaveBeenCalledWith('');
+  });
+
+  it('should show validation helper text when the value is below 1', () => {
+    renderWithTooltipProvider(
+      <MaxCharsPerMessageInput value="0" setValue={setValue} updateConfig={updateConfig} />,
+    );
+
+    const input = screen.getByLabelText('Max chars per message');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText(RUNOPTIONS_TEXT.maxCharsPerMessage.error)).toBeInTheDocument();
+  });
+
+  it('should not persist changes when readOnly is true', () => {
+    renderWithTooltipProvider(
+      <MaxCharsPerMessageInput
+        value="100"
+        setValue={setValue}
+        updateConfig={updateConfig}
+        readOnly
+      />,
+    );
+
+    const input = screen.getByLabelText('Max chars per message');
+    fireEvent.blur(input);
+
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/app/src/pages/redteam/setup/components/RunOptions.tsx
+++ b/src/app/src/pages/redteam/setup/components/RunOptions.tsx
@@ -15,6 +15,11 @@ export const RUNOPTIONS_TEXT = {
     helper: 'Number of test cases to generate for each plugin',
     error: 'Number of test cases must be greater than 0',
   },
+  maxCharsPerMessage: {
+    helper:
+      'Optional character cap for each generated user message and final prompt sent to the target. Leave blank for no limit.',
+    error: 'Max chars per message must be greater than 0',
+  },
   delayBetweenApiCalls: {
     helper:
       'Add a delay between API calls to avoid rate limits. This will not override a delay set on the target.',
@@ -34,6 +39,7 @@ export const RUNOPTIONS_TEXT = {
 
 interface RunOptionsProps {
   numTests: number | undefined;
+  maxCharsPerMessage?: number;
   runOptions?: Partial<RedteamRunOptions>;
   updateConfig: (section: keyof Config, value: Config[keyof Config]) => void;
   updateRunOption: (
@@ -115,6 +121,55 @@ export interface DelayBetweenAPICallsInputProps {
   canSetDelay?: boolean;
   setMaxConcurrencyValue: (value: string) => void;
 }
+
+export interface MaxCharsPerMessageInputProps {
+  value: string;
+  setValue: (value: string) => void;
+  updateConfig: (section: keyof Config, value: Config[keyof Config]) => void;
+  readOnly?: boolean;
+}
+
+export const MaxCharsPerMessageInput = ({
+  value,
+  setValue,
+  updateConfig,
+  readOnly,
+}: MaxCharsPerMessageInputProps) => {
+  const error = isBelowMin(value, 1) ? RUNOPTIONS_TEXT.maxCharsPerMessage.error : undefined;
+
+  return (
+    <NumberInput
+      fullWidth
+      label="Max chars per message"
+      value={value}
+      min={1}
+      onChange={(v) => {
+        setValue(v?.toString() || '');
+      }}
+      onBlur={() => {
+        if (readOnly) {
+          return;
+        }
+        if (value.trim() === '') {
+          updateConfig('maxCharsPerMessage', undefined);
+          setValue('');
+          return;
+        }
+        const parsed = Number(value);
+        if (Number.isNaN(parsed) || parsed < 1) {
+          updateConfig('maxCharsPerMessage', undefined);
+          setValue('');
+          return;
+        }
+        updateConfig('maxCharsPerMessage', parsed);
+        setValue(String(parsed));
+      }}
+      readOnly={readOnly}
+      helperText={error ? error : RUNOPTIONS_TEXT.maxCharsPerMessage.helper}
+      error={Boolean(error)}
+    />
+  );
+};
 
 /**
  * Delay between API calls (ms)
@@ -252,6 +307,7 @@ export const MaxNumberOfConcurrentRequestsInput = ({
 
 export const RunOptionsContent = ({
   numTests,
+  maxCharsPerMessage,
   runOptions,
   updateConfig,
   updateRunOption,
@@ -264,6 +320,9 @@ export const RunOptionsContent = ({
 
   const [numTestsInput, setNumTestsInput] = useState<string>(
     numTests === undefined ? '0' : String(numTests),
+  );
+  const [maxCharsPerMessageInput, setMaxCharsPerMessageInput] = useState<string>(
+    maxCharsPerMessage === undefined ? '' : String(maxCharsPerMessage),
   );
   const [delayInput, setDelayInput] = useState<string>(
     runOptions?.delay === undefined ? '0' : String(runOptions.delay),
@@ -290,6 +349,12 @@ export const RunOptionsContent = ({
       <NumberOfTestCasesInput
         value={numTestsInput}
         setValue={setNumTestsInput}
+        updateConfig={updateConfig}
+      />
+
+      <MaxCharsPerMessageInput
+        value={maxCharsPerMessageInput}
+        setValue={setMaxCharsPerMessageInput}
         updateConfig={updateConfig}
       />
 

--- a/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
+++ b/src/app/src/pages/redteam/setup/hooks/useRedTeamConfig.ts
@@ -63,6 +63,7 @@ const defaultConfig: Config = {
   purpose: '',
   entities: [],
   numTests: REDTEAM_DEFAULTS.NUM_TESTS,
+  maxCharsPerMessage: undefined,
   maxConcurrency: REDTEAM_DEFAULTS.MAX_CONCURRENCY,
   applicationDefinition: {
     purpose: '',
@@ -253,6 +254,7 @@ export const EXAMPLE_CONFIG: Config = {
   purpose: applicationDefinitionToPurpose(CUSTOMER_SERVICE_BOT_EXAMPLE_APPLICATION_DEFINITION),
   entities: [],
   numTests: REDTEAM_DEFAULTS.NUM_TESTS,
+  maxCharsPerMessage: undefined,
   maxConcurrency: 5,
   applicationDefinition: CUSTOMER_SERVICE_BOT_EXAMPLE_APPLICATION_DEFINITION,
 };

--- a/src/app/src/pages/redteam/setup/types.ts
+++ b/src/app/src/pages/redteam/setup/types.ts
@@ -72,6 +72,7 @@ export interface Config {
   strategies: RedteamStrategy[];
   purpose?: string;
   numTests?: number;
+  maxCharsPerMessage?: number;
   maxConcurrency?: number;
   applicationDefinition: ApplicationDefinition;
   entities: string[];

--- a/src/app/src/pages/redteam/setup/utils/yamlHelpers.test.ts
+++ b/src/app/src/pages/redteam/setup/utils/yamlHelpers.test.ts
@@ -179,6 +179,8 @@ describe('yamlHelpers', () => {
         description: 'Ordered config',
         redteam: {
           numTests: 3,
+          maxCharsPerMessage: 120,
+          maxConcurrency: 4,
           sharing: true,
           strategies: ['strategy-1'],
           plugins: [{ id: 'plugin-1' }],
@@ -216,6 +218,8 @@ describe('yamlHelpers', () => {
         'strategies',
         'language',
         'numTests',
+        'maxCharsPerMessage',
+        'maxConcurrency',
         'sharing',
       ]);
       expect((dumpedConfig.redteam as Record<string, unknown>).purpose).toBe('Security testing');

--- a/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
+++ b/src/app/src/pages/redteam/setup/utils/yamlHelpers.ts
@@ -17,6 +17,7 @@ const orderRedTeam = (redteam: Partial<RedteamFileConfig>): Record<string, unkno
     'strategies',
     'language',
     'numTests',
+    'maxCharsPerMessage',
     'maxConcurrency',
   ] as const;
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -26,6 +26,7 @@ import { maybeEmitAzureOpenAiWarning } from './providers/azure/warnings';
 import { providerRegistry } from './providers/providerRegistry';
 import { isPromptfooSampleTarget } from './providers/shared';
 import { redteamProviderManager } from './redteam/providers/shared';
+import { throwIfTargetPromptExceedsMaxChars } from './redteam/shared/promptLength';
 import { getSessionId } from './redteam/util';
 import {
   createProviderRateLimitOptions,
@@ -613,6 +614,7 @@ async function renderRunEvalPrompt({
     provider,
     skipRenderVars,
   );
+  throwIfTargetPromptExceedsMaxChars(renderedPrompt, testSuite?.redteam?.maxCharsPerMessage);
   const promptConfig = {
     ...(promptForRender.config ?? {}),
     ...(test.options ?? {}),

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -614,7 +614,9 @@ async function renderRunEvalPrompt({
     provider,
     skipRenderVars,
   );
-  throwIfTargetPromptExceedsMaxChars(renderedPrompt, testSuite?.redteam?.maxCharsPerMessage);
+  if (isRedteam) {
+    throwIfTargetPromptExceedsMaxChars(renderedPrompt, testSuite?.redteam?.maxCharsPerMessage);
+  }
   const promptConfig = {
     ...(promptForRender.config ?? {}),
     ...(test.options ?? {}),

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -41,7 +41,11 @@ import { Plugins } from './plugins/index';
 import { isValidPolicyObject, makeInlinePolicyIdSync } from './plugins/policy/utils';
 import { redteamProviderManager } from './providers/shared';
 import { getRemoteHealthUrl, shouldGenerateRemote } from './remoteGeneration';
-import { getGeneratedPromptOverLimit } from './shared/promptLength';
+import {
+  getGeneratedPromptOverLimit,
+  getMaxCharsPerMessageModifierValue,
+  MAX_CHARS_PER_MESSAGE_MODIFIER_KEY,
+} from './shared/promptLength';
 import { validateSharpDependency } from './sharpAvailability';
 import { loadStrategy, Strategies, validateStrategies } from './strategies/index';
 import { pluginMatchesStrategyTargets } from './strategies/util';
@@ -246,6 +250,38 @@ export function resolvePluginConfig(config: Record<string, any> | undefined): Re
   return config;
 }
 
+function resolvePluginConfigWithMaxChars(
+  config: Record<string, any> | undefined,
+  maxCharsPerMessage?: number,
+): Record<string, any> {
+  return {
+    ...resolvePluginConfig(config),
+    ...(maxCharsPerMessage ? { maxCharsPerMessage } : {}),
+  };
+}
+
+function buildRedteamModifiers({
+  maxCharsPerMessage,
+  pluginConfig,
+  testGenerationInstructions,
+}: {
+  maxCharsPerMessage?: number;
+  pluginConfig?: Record<string, any>;
+  testGenerationInstructions?: string;
+}): Record<string, string> {
+  const modifiers: Record<string, string> = {
+    ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
+    ...((pluginConfig?.modifiers as Record<string, string> | undefined) ?? {}),
+  };
+  const maxCharsPerMessageModifier = getMaxCharsPerMessageModifierValue(
+    maxCharsPerMessage ?? pluginConfig?.maxCharsPerMessage,
+  );
+  if (maxCharsPerMessageModifier) {
+    modifiers[MAX_CHARS_PER_MESSAGE_MODIFIER_KEY] = maxCharsPerMessageModifier;
+  }
+  return modifiers;
+}
+
 const categories = {
   foundation: FOUNDATION_PLUGINS,
   harmful: Object.keys(HARM_PLUGINS),
@@ -288,9 +324,19 @@ function filterOversizedTestCases<T extends TestCase>(
   testCases: T[],
   injectVar: string,
   sourceLabel: string,
+  maxCharsPerMessage?: number,
 ): T[] {
   return testCases.filter((testCase) => {
-    const violation = getGeneratedPromptOverLimit(String(testCase.vars?.[injectVar] ?? ''));
+    const testCaseMaxCharsPerMessage =
+      maxCharsPerMessage ??
+      (testCase.metadata?.strategyConfig as { maxCharsPerMessage?: number } | undefined)
+        ?.maxCharsPerMessage ??
+      (testCase.metadata?.pluginConfig as { maxCharsPerMessage?: number } | undefined)
+        ?.maxCharsPerMessage;
+    const violation = getGeneratedPromptOverLimit(
+      String(testCase.vars?.[injectVar] ?? ''),
+      testCaseMaxCharsPerMessage,
+    );
     if (!violation) {
       return true;
     }
@@ -314,32 +360,46 @@ function addLanguageToPluginMetadata(
   test: TestCase,
   lang: string | undefined,
   plugin: RedteamPluginObject,
+  maxCharsPerMessage?: number,
   testGenerationInstructions?: string,
 ): TestCase {
   const existingLanguage = getLanguageForTestCase(test);
   const languageToAdd = lang && !existingLanguage ? { language: lang } : {};
+  const includePluginConfig = !(
+    test.metadata &&
+    Object.hasOwn(test.metadata, 'pluginConfig') &&
+    test.metadata.pluginConfig === undefined
+  );
 
   // Use modifiers from the test's pluginConfig first (which may have been computed by appendModifiers),
   // then fall back to the original plugin.config?.modifiers
-  const pluginModifiers =
-    (test.metadata?.pluginConfig?.modifiers as Record<string, string> | undefined) ||
-    (plugin.config?.modifiers as Record<string, string> | undefined) ||
-    {};
+  const pluginModifiers = buildRedteamModifiers({
+    maxCharsPerMessage,
+    pluginConfig:
+      (test.metadata?.pluginConfig as Record<string, any> | undefined) ||
+      plugin.config ||
+      undefined,
+    testGenerationInstructions,
+  });
 
   return {
     ...test,
     metadata: {
+      ...test.metadata,
       pluginId: plugin.id,
-      pluginConfig: resolvePluginConfig(plugin.config),
+      ...(includePluginConfig && {
+        pluginConfig: {
+          ...resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
+          ...((test.metadata?.pluginConfig as Record<string, any> | undefined) ?? {}),
+        },
+      }),
       severity: plugin.severity ?? getPluginSeverity(plugin.id, resolvePluginConfig(plugin.config)),
       modifiers: {
-        ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
         ...pluginModifiers,
         ...test.metadata?.modifiers,
         // Add language to modifiers if not already present (respect existing)
         ...languageToAdd,
       },
-      ...test.metadata,
       // Hoist language to top-level metadata for backward compatibility and easier access
       ...languageToAdd,
     },
@@ -375,6 +435,7 @@ async function applyStrategies(
   strategies: RedteamStrategyObject[],
   injectVar: string,
   excludeTargetOutputFromAgenticAttackGeneration?: boolean,
+  maxCharsPerMessage?: number,
 ): Promise<{
   testCases: TestCaseWithPlugin[];
   strategyResults: Record<string, { requested: number; generated: number }>;
@@ -450,6 +511,7 @@ async function applyStrategies(
       injectVar,
       {
         ...(strategy.config || {}),
+        ...(maxCharsPerMessage ? { maxCharsPerMessage } : {}),
         // Pass redteam provider from config so agentic strategies (iterative, crescendo, etc.) can use it
         redteamProvider: cliState.config?.redteam?.provider,
         excludeTargetOutputFromAgenticAttackGeneration,
@@ -476,6 +538,7 @@ async function applyStrategies(
       resultTestCases,
       injectVar,
       `Strategy ${strategy.id}`,
+      maxCharsPerMessage,
     );
 
     newTestCases.push(
@@ -492,6 +555,12 @@ async function applyStrategies(
             // If parsing fails, keep original vars
           }
         }
+        const strategyConfig = {
+          ...(strategy.config || {}),
+          ...(maxCharsPerMessage ? { maxCharsPerMessage } : {}),
+          ...(t?.metadata?.strategyConfig || {}),
+        };
+
         return {
           ...t,
           vars: updatedVars,
@@ -505,11 +574,8 @@ async function applyStrategies(
             ...(t?.metadata?.pluginConfig && {
               pluginConfig: t.metadata.pluginConfig,
             }),
-            ...(strategy.config && {
-              strategyConfig: {
-                ...strategy.config,
-                ...(t?.metadata?.strategyConfig || {}),
-              },
+            ...(Object.keys(strategyConfig).length > 0 && {
+              strategyConfig,
             }),
           },
         };
@@ -733,6 +799,7 @@ export async function synthesize({
   injectVar,
   inputs,
   language,
+  maxCharsPerMessage,
   maxConcurrency = 1,
   plugins,
   prompts,
@@ -1019,13 +1086,18 @@ export async function synthesize({
       }
     } else if (registeredPlugin.validate) {
       try {
+        const resolvedPluginConfig = resolvePluginConfigWithMaxChars(
+          plugin.config,
+          maxCharsPerMessage,
+        );
         registeredPlugin.validate({
           language,
-          modifiers: {
-            ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
-            ...(plugin.config?.modifiers || {}),
-          },
-          ...resolvePluginConfig(plugin.config),
+          ...resolvedPluginConfig,
+          modifiers: buildRedteamModifiers({
+            maxCharsPerMessage,
+            pluginConfig: resolvedPluginConfig,
+            testGenerationInstructions,
+          }),
         });
       } catch (error) {
         logger.warn(`Validation failed for plugin ${plugin.id}: ${error}, skipping plugin.`);
@@ -1136,14 +1208,15 @@ export async function synthesize({
           n: plugin.numTests,
           delayMs: delay || 0,
           config: {
-            ...resolvePluginConfig(plugin.config),
+            ...resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
             ...(lang ? { language: lang } : {}),
             // Pass inputs to plugin for multi-variable test case generation
             ...(hasMultipleInputs ? { inputs } : {}),
-            modifiers: {
-              ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
-              ...(plugin.config?.modifiers || {}),
-            },
+            modifiers: buildRedteamModifiers({
+              maxCharsPerMessage,
+              pluginConfig: plugin.config,
+              testGenerationInstructions,
+            }),
           },
         });
         {
@@ -1152,12 +1225,19 @@ export async function synthesize({
           if (Array.isArray(pluginTests) && pluginTests.length > 0) {
             // Add all metadata (language + plugin info) so strategies can access it
             const testsWithMetadata = pluginTests.map((test) =>
-              addLanguageToPluginMetadata(test, lang, plugin, testGenerationInstructions),
+              addLanguageToPluginMetadata(
+                test,
+                lang,
+                plugin,
+                maxCharsPerMessage,
+                testGenerationInstructions,
+              ),
             );
             const constrainedTests = filterOversizedTestCases(
               testsWithMetadata,
               injectVar,
               `Plugin ${plugin.id}`,
+              maxCharsPerMessage,
             );
 
             return {
@@ -1260,27 +1340,54 @@ export async function synthesize({
       }
     } else if (plugin.id.startsWith('file://')) {
       try {
-        const customPlugin = new CustomPlugin(redteamProvider, purpose, injectVar, plugin.id);
+        const customPlugin = new CustomPlugin(
+          redteamProvider,
+          purpose,
+          injectVar,
+          plugin.id,
+          resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
+        );
         const customTests = await customPlugin.generateTests(plugin.numTests, delay);
 
         // Add metadata to each test case
         const testCasesWithMetadata = filterOversizedTestCases(
-          customTests.map((t) => ({
-            ...t,
-            metadata: {
-              pluginId: plugin.id,
-              pluginConfig: resolvePluginConfig(plugin.config),
-              severity:
-                plugin.severity || getPluginSeverity(plugin.id, resolvePluginConfig(plugin.config)),
-              modifiers: {
-                ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
-                ...(plugin.config?.modifiers || {}),
+          customTests.map((t) => {
+            const includePluginConfig = !(
+              t.metadata &&
+              Object.hasOwn(t.metadata, 'pluginConfig') &&
+              t.metadata.pluginConfig === undefined
+            );
+            const pluginConfigWithMaxChars = {
+              ...resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
+              ...((t.metadata?.pluginConfig as Record<string, any> | undefined) ?? {}),
+            };
+            const modifiers = {
+              ...buildRedteamModifiers({
+                maxCharsPerMessage,
+                pluginConfig: pluginConfigWithMaxChars,
+                testGenerationInstructions,
+              }),
+              ...t.metadata?.modifiers,
+            };
+
+            return {
+              ...t,
+              metadata: {
+                ...(t.metadata || {}),
+                pluginId: plugin.id,
+                ...(includePluginConfig && {
+                  pluginConfig: pluginConfigWithMaxChars,
+                }),
+                severity:
+                  plugin.severity ||
+                  getPluginSeverity(plugin.id, resolvePluginConfig(plugin.config)),
+                modifiers,
               },
-              ...(t.metadata || {}),
-            },
-          })),
+            };
+          }),
           injectVar,
           `Custom plugin ${plugin.id}`,
+          maxCharsPerMessage,
         );
 
         // Extract goal for custom plugin's tests (only needed for agentic strategies)
@@ -1342,6 +1449,8 @@ export async function synthesize({
       pluginTestCases,
       [retryStrategy],
       injectVar,
+      undefined,
+      maxCharsPerMessage,
     );
     pluginTestCases.push(...retryTestCases);
     Object.assign(strategyResults, retryResults);
@@ -1363,6 +1472,7 @@ export async function synthesize({
       nonBasicStrategies,
       injectVar,
       excludeTargetOutputFromAgenticAttackGeneration,
+      maxCharsPerMessage,
     );
 
   Object.assign(strategyResults, otherStrategyResults);

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -41,6 +41,7 @@ import { Plugins } from './plugins/index';
 import { isValidPolicyObject, makeInlinePolicyIdSync } from './plugins/policy/utils';
 import { redteamProviderManager } from './providers/shared';
 import { getRemoteHealthUrl, shouldGenerateRemote } from './remoteGeneration';
+import { getGeneratedPromptOverLimit } from './shared/promptLength';
 import { validateSharpDependency } from './sharpAvailability';
 import { loadStrategy, Strategies, validateStrategies } from './strategies/index';
 import { pluginMatchesStrategyTargets } from './strategies/util';
@@ -283,6 +284,24 @@ function getLanguageForTestCase(test: TestCase | undefined): string | undefined 
   return test.metadata?.language || test.metadata?.modifiers?.language;
 }
 
+function filterOversizedTestCases<T extends TestCase>(
+  testCases: T[],
+  injectVar: string,
+  sourceLabel: string,
+): T[] {
+  return testCases.filter((testCase) => {
+    const violation = getGeneratedPromptOverLimit(String(testCase.vars?.[injectVar] ?? ''));
+    if (!violation) {
+      return true;
+    }
+
+    logger.warn(
+      `[${sourceLabel}] Dropping generated test case that exceeds maxCharsPerMessage=${violation.limit} (${violation.length} chars)`,
+    );
+    return false;
+  });
+}
+
 /**
  * Adds comprehensive metadata to plugin test cases including language, plugin info, and severity.
  * @param test - The test case to add metadata to.
@@ -452,6 +471,12 @@ async function applyStrategies(
         resultTestCases = resultTestCases.slice(0, numTestsLimit);
       }
     }
+
+    resultTestCases = filterOversizedTestCases(
+      resultTestCases,
+      injectVar,
+      `Strategy ${strategy.id}`,
+    );
 
     newTestCases.push(
       ...resultTestCases.map((t) => {
@@ -1129,12 +1154,17 @@ export async function synthesize({
             const testsWithMetadata = pluginTests.map((test) =>
               addLanguageToPluginMetadata(test, lang, plugin, testGenerationInstructions),
             );
+            const constrainedTests = filterOversizedTestCases(
+              testsWithMetadata,
+              injectVar,
+              `Plugin ${plugin.id}`,
+            );
 
             return {
               lang: langKey,
-              tests: testsWithMetadata,
+              tests: constrainedTests,
               requested: plugin.numTests,
-              generated: pluginTests.length,
+              generated: constrainedTests.length,
             };
           }
 
@@ -1234,20 +1264,24 @@ export async function synthesize({
         const customTests = await customPlugin.generateTests(plugin.numTests, delay);
 
         // Add metadata to each test case
-        const testCasesWithMetadata = customTests.map((t) => ({
-          ...t,
-          metadata: {
-            pluginId: plugin.id,
-            pluginConfig: resolvePluginConfig(plugin.config),
-            severity:
-              plugin.severity || getPluginSeverity(plugin.id, resolvePluginConfig(plugin.config)),
-            modifiers: {
-              ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
-              ...(plugin.config?.modifiers || {}),
+        const testCasesWithMetadata = filterOversizedTestCases(
+          customTests.map((t) => ({
+            ...t,
+            metadata: {
+              pluginId: plugin.id,
+              pluginConfig: resolvePluginConfig(plugin.config),
+              severity:
+                plugin.severity || getPluginSeverity(plugin.id, resolvePluginConfig(plugin.config)),
+              modifiers: {
+                ...(testGenerationInstructions ? { testGenerationInstructions } : {}),
+                ...(plugin.config?.modifiers || {}),
+              },
+              ...(t.metadata || {}),
             },
-            ...(t.metadata || {}),
-          },
-        }));
+          })),
+          injectVar,
+          `Custom plugin ${plugin.id}`,
+        );
 
         // Extract goal for custom plugin's tests (only needed for agentic strategies)
         if (needsGoalExtraction) {
@@ -1272,7 +1306,7 @@ export async function synthesize({
         const displayId = getPluginDisplayId(plugin);
         pluginResults[displayId] = {
           requested: plugin.numTests,
-          generated: customTests.length,
+          generated: testCasesWithMetadata.length,
         };
       } catch (e) {
         logger.error(`Error generating tests for custom plugin ${plugin.id}: ${e}`);

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -201,7 +201,7 @@ export abstract class RedteamPluginBase {
 
       for (const prompt of parsedPrompts) {
         const promptText = '__prompt' in prompt ? String(prompt.__prompt) : JSON.stringify(prompt);
-        const violation = getGeneratedPromptOverLimit(promptText);
+        const violation = getGeneratedPromptOverLimit(promptText, this.config.maxCharsPerMessage);
         if (violation) {
           rejectedPromptLengths.push(violation.length);
           rejectedPromptLimit = violation.limit;
@@ -297,6 +297,13 @@ export abstract class RedteamPluginBase {
       modifiers.__outputFormat = `multi-input-mode: ${inputKeys.join(', ')}`;
     }
 
+    const maxCharsPerMessageModifier = getMaxCharsPerMessageModifierValue(
+      config.maxCharsPerMessage,
+    );
+    if (maxCharsPerMessageModifier) {
+      modifiers[MAX_CHARS_PER_MESSAGE_MODIFIER_KEY] = maxCharsPerMessageModifier;
+    }
+
     // Store the computed modifiers back into config so they get passed to strategies
     if (Object.keys(modifiers).length > 0) {
       config.modifiers = modifiers;
@@ -306,10 +313,6 @@ export abstract class RedteamPluginBase {
     const promptModifiers = {
       ...modifiers,
     };
-    const maxCharsPerMessageModifier = getMaxCharsPerMessageModifierValue();
-    if (maxCharsPerMessageModifier) {
-      promptModifiers[MAX_CHARS_PER_MESSAGE_MODIFIER_KEY] = maxCharsPerMessageModifier;
-    }
 
     const regularModifiers = Object.entries(promptModifiers)
       .filter(

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -8,6 +8,11 @@ import { extractVariablesFromTemplate, getNunjucksEngine } from '../../util/temp
 import { sleep } from '../../util/time';
 import { redteamProviderManager } from '../providers/shared';
 import {
+  getGeneratedPromptOverLimit,
+  getMaxCharsPerMessageModifierValue,
+  MAX_CHARS_PER_MESSAGE_MODIFIER_KEY,
+} from '../shared/promptLength';
+import {
   extractInputVarsFromPrompt,
   getShortPluginId,
   isBasicRefusal,
@@ -117,6 +122,7 @@ export abstract class RedteamPluginBase {
      * In single-input mode, returns { __prompt: string }[]
      * In multi-input mode, returns Record<string, string>[]
      */
+    let retryInstructions: string | undefined;
     const generatePrompts = async (
       currentPrompts: { __prompt: string }[] | Record<string, string>[],
     ): Promise<{ __prompt: string }[] | Record<string, string>[]> => {
@@ -133,7 +139,12 @@ export abstract class RedteamPluginBase {
         hasCustomOutputFormat: !!this.config.inputs && Object.keys(this.config.inputs).length > 0,
       });
 
-      const finalTemplate = RedteamPluginBase.appendModifiers(renderedTemplate, this.config);
+      const finalTemplate = [
+        RedteamPluginBase.appendModifiers(renderedTemplate, this.config),
+        retryInstructions,
+      ]
+        .filter(Boolean)
+        .join('\n\n');
       const { output: generatedPrompts, error } = await this.provider.callApi(finalTemplate);
       if (delayMs > 0) {
         logger.debug(`Delaying for ${delayMs}ms`);
@@ -183,7 +194,35 @@ export abstract class RedteamPluginBase {
 
       // Use formatter to parse output
       const formatter = getPromptOutputFormatter(this.config);
-      return formatter.parse(generatedPrompts, this.config);
+      const parsedPrompts = formatter.parse(generatedPrompts, this.config);
+      const acceptedPrompts: ({ __prompt: string } | Record<string, string>)[] = [];
+      const rejectedPromptLengths: number[] = [];
+      let rejectedPromptLimit: number | undefined;
+
+      for (const prompt of parsedPrompts) {
+        const promptText = '__prompt' in prompt ? String(prompt.__prompt) : JSON.stringify(prompt);
+        const violation = getGeneratedPromptOverLimit(promptText);
+        if (violation) {
+          rejectedPromptLengths.push(violation.length);
+          rejectedPromptLimit = violation.limit;
+        } else {
+          acceptedPrompts.push(prompt);
+        }
+      }
+
+      if (rejectedPromptLengths.length > 0) {
+        retryInstructions = dedent`
+          Your previous response included ${rejectedPromptLengths.length} generated prompt${
+            rejectedPromptLengths.length === 1 ? '' : 's'
+          } that exceeded the ${rejectedPromptLimit ?? 'configured'}-character limit.
+          The longest rejected prompt was ${Math.max(...rejectedPromptLengths)} characters.
+          Generate replacement prompts only, and keep every user message within the character limit.
+        `.trim();
+      } else {
+        retryInstructions = undefined;
+      }
+
+      return acceptedPrompts as { __prompt: string }[] | Record<string, string>[];
     };
 
     const allPrompts = await retryWithDeduplication(
@@ -243,7 +282,9 @@ export abstract class RedteamPluginBase {
    */
   static appendModifiers(template: string, config: PluginConfig): string {
     // Take everything under "modifiers" config key
-    const modifiers: Record<string, string> = (config.modifiers as Record<string, string>) ?? {};
+    const modifiers: Record<string, string> = {
+      ...((config.modifiers as Record<string, string> | undefined) ?? {}),
+    };
 
     if (config.language) {
       invariant(typeof config.language === 'string', 'language must be a string');
@@ -262,7 +303,15 @@ export abstract class RedteamPluginBase {
     }
 
     // Filter out __outputFormat from regular modifiers section (templates handle it directly)
-    const regularModifiers = Object.entries(modifiers)
+    const promptModifiers = {
+      ...modifiers,
+    };
+    const maxCharsPerMessageModifier = getMaxCharsPerMessageModifierValue();
+    if (maxCharsPerMessageModifier) {
+      promptModifiers[MAX_CHARS_PER_MESSAGE_MODIFIER_KEY] = maxCharsPerMessageModifier;
+    }
+
+    const regularModifiers = Object.entries(promptModifiers)
       .filter(
         ([key, value]) => key !== '__outputFormat' && typeof value !== 'undefined' && value !== '',
       )

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -201,6 +201,8 @@ export abstract class RedteamPluginBase {
 
       for (const prompt of parsedPrompts) {
         const promptText = '__prompt' in prompt ? String(prompt.__prompt) : JSON.stringify(prompt);
+        // TODO(ian): In multi-input mode, validate the generated user-facing field values rather
+        // than the serialized JSON envelope stored in __prompt, which overcounts keys/braces.
         const violation = getGeneratedPromptOverLimit(promptText, this.config.maxCharsPerMessage);
         if (violation) {
           rejectedPromptLengths.push(violation.length);

--- a/src/redteam/plugins/custom.ts
+++ b/src/redteam/plugins/custom.ts
@@ -5,7 +5,7 @@ import { maybeLoadFromExternalFile } from '../../util/file';
 import { getNunjucksEngine } from '../../util/templates';
 import { RedteamPluginBase } from './base';
 
-import type { ApiProvider, Assertion, TestCase } from '../../types/index';
+import type { ApiProvider, Assertion, PluginConfig, TestCase } from '../../types/index';
 
 const CustomPluginDefinitionSchema = z.strictObject({
   generator: z.string().min(1, 'Generator must not be empty').trim(),
@@ -45,8 +45,14 @@ export class CustomPlugin extends RedteamPluginBase {
     return this.definition.id || `promptfoo:redteam:custom`;
   }
 
-  constructor(provider: ApiProvider, purpose: string, injectVar: string, filePath: string) {
-    super(provider, purpose, injectVar);
+  constructor(
+    provider: ApiProvider,
+    purpose: string,
+    injectVar: string,
+    filePath: string,
+    config: PluginConfig = {},
+  ) {
+    super(provider, purpose, injectVar, config);
     this.definition = loadCustomPluginDefinition(filePath);
   }
 

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { fetchWithCache } from '../../cache';
 import { VERSION } from '../../constants';
 import { getEnvBool } from '../../envars';
@@ -5,6 +6,7 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
 import { checkRemoteHealth } from '../../util/apiHealth';
+import { retryWithDeduplication } from '../../util/generation';
 import invariant from '../../util/invariant';
 import {
   BIAS_PLUGINS,
@@ -21,6 +23,7 @@ import {
   shouldGenerateRemote,
 } from '../remoteGeneration';
 import {
+  getGeneratedPromptOverLimit,
   getMaxCharsPerMessageModifierValue,
   MAX_CHARS_PER_MESSAGE_MODIFIER_KEY,
 } from '../shared/promptLength';
@@ -81,6 +84,8 @@ type PluginClass<T extends PluginConfig> = new (
   config: T,
 ) => RedteamPluginBase;
 
+const MAX_CHARS_RETRY_MODIFIER_KEY = '__maxCharsPerMessageRetry';
+
 /**
  * Computes modifiers from config (same logic as appendModifiers in base.ts).
  * Used to ensure modifiers are available for strategies when using remote generation.
@@ -139,6 +144,179 @@ function applyDefaultRemotePluginConfig(
         ...(configWithDefaultExamples?.excludeStrategies ?? []),
       ]),
     ],
+  };
+}
+
+function isValidMaxCharsPerMessage(limit: unknown): limit is number {
+  return typeof limit === 'number' && Number.isInteger(limit) && limit > 0;
+}
+
+function getMaxCharsPerMessageFromConfig(config: PluginConfig | undefined): number | undefined {
+  if (isValidMaxCharsPerMessage(config?.maxCharsPerMessage)) {
+    return config.maxCharsPerMessage;
+  }
+
+  const maxCharsModifier = (config?.modifiers as Record<string, string> | undefined)?.[
+    MAX_CHARS_PER_MESSAGE_MODIFIER_KEY
+  ];
+  if (typeof maxCharsModifier !== 'string') {
+    return undefined;
+  }
+
+  const match = /must be (\d+) characters or fewer\./.exec(maxCharsModifier);
+  if (!match) {
+    return undefined;
+  }
+
+  const maxCharsPerMessage = Number(match[1]);
+  return isValidMaxCharsPerMessage(maxCharsPerMessage) ? maxCharsPerMessage : undefined;
+}
+
+function clonePluginConfig(config: PluginConfig | undefined): PluginConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  return {
+    ...config,
+    modifiers: {
+      ...((config.modifiers as Record<string, string> | undefined) ?? {}),
+    },
+  };
+}
+
+function buildRetryConfig(
+  config: PluginConfig | undefined,
+  retryInstructions: string | undefined,
+): PluginConfig | undefined {
+  const retryConfig = clonePluginConfig(config);
+  if (!retryConfig || !retryInstructions) {
+    return retryConfig;
+  }
+
+  retryConfig.modifiers = {
+    ...((retryConfig.modifiers as Record<string, string> | undefined) ?? {}),
+    [MAX_CHARS_RETRY_MODIFIER_KEY]: retryInstructions,
+  };
+
+  return retryConfig;
+}
+
+function stripRetryModifier(testCase: TestCase): TestCase {
+  const pluginConfig = testCase.metadata?.pluginConfig;
+  const modifiers = pluginConfig?.modifiers as Record<string, string> | undefined;
+  if (!modifiers || !(MAX_CHARS_RETRY_MODIFIER_KEY in modifiers)) {
+    return testCase;
+  }
+
+  const { [MAX_CHARS_RETRY_MODIFIER_KEY]: _retryInstructions, ...remainingModifiers } = modifiers;
+
+  return {
+    ...testCase,
+    metadata: {
+      ...testCase.metadata,
+      pluginConfig: {
+        ...pluginConfig,
+        modifiers: remainingModifiers,
+      },
+    },
+  };
+}
+
+function dedupeTestCases(testCases: TestCase[]): TestCase[] {
+  const deduped: TestCase[] = [];
+  const seen = new Set<string>();
+
+  for (const testCase of testCases) {
+    const normalizedTestCase = stripRetryModifier(testCase);
+    const provider =
+      typeof normalizedTestCase.provider === 'string'
+        ? normalizedTestCase.provider
+        : normalizedTestCase.provider && typeof normalizedTestCase.provider === 'object'
+          ? (normalizedTestCase.provider as { id?: unknown }).id
+          : undefined;
+    const dedupKey = JSON.stringify({
+      vars: normalizedTestCase.vars,
+      assert: normalizedTestCase.assert,
+      options: normalizedTestCase.options,
+      metadata: normalizedTestCase.metadata,
+      provider,
+    });
+
+    if (seen.has(dedupKey)) {
+      continue;
+    }
+
+    seen.add(dedupKey);
+    deduped.push(normalizedTestCase);
+  }
+
+  return deduped;
+}
+
+function buildMaxCharsRetryInstructions(rejectedPromptLengths: number[], limit?: number): string {
+  return dedent`
+    Your previous response included ${rejectedPromptLengths.length} generated prompt${
+      rejectedPromptLengths.length === 1 ? '' : 's'
+    } that exceeded the ${limit ?? 'configured'}-character limit.
+    The longest rejected prompt was ${Math.max(...rejectedPromptLengths)} characters.
+    Generate replacement prompts only, and keep every user message within the character limit.
+  `.trim();
+}
+
+function withMaxCharsRetries(pluginFactory: PluginFactory): PluginFactory {
+  return {
+    ...pluginFactory,
+    action: async (params: PluginActionParams) => {
+      const maxCharsPerMessage = getMaxCharsPerMessageFromConfig(params.config);
+      if (!maxCharsPerMessage) {
+        return pluginFactory.action(params);
+      }
+
+      let retryInstructions: string | undefined;
+      const generateValidTestCases = async (currentTestCases: TestCase[]): Promise<TestCase[]> => {
+        const retryConfig = buildRetryConfig(params.config, retryInstructions);
+        const generatedTestCases = await pluginFactory.action({
+          ...params,
+          n: Math.max(params.n - currentTestCases.length, 0),
+          config: retryConfig,
+        });
+
+        const validTestCases: TestCase[] = [];
+        const rejectedPromptLengths: number[] = [];
+        let rejectedPromptLimit: number | undefined;
+
+        for (const testCase of generatedTestCases) {
+          const violation = getGeneratedPromptOverLimit(
+            String(testCase.vars?.[params.injectVar] ?? ''),
+            maxCharsPerMessage,
+          );
+          if (violation) {
+            rejectedPromptLengths.push(violation.length);
+            rejectedPromptLimit = violation.limit;
+            continue;
+          }
+
+          validTestCases.push(stripRetryModifier(testCase));
+        }
+
+        retryInstructions =
+          rejectedPromptLengths.length > 0
+            ? buildMaxCharsRetryInstructions(rejectedPromptLengths, rejectedPromptLimit)
+            : undefined;
+
+        return validTestCases;
+      };
+
+      const testCases = await retryWithDeduplication(
+        generateValidTestCases,
+        params.n,
+        2,
+        dedupeTestCases,
+      );
+
+      return testCases.map(stripRetryModifier);
+    },
   };
 }
 
@@ -494,4 +672,4 @@ export const Plugins: PluginFactory[] = [
   ...piiPlugins,
   ...biasPlugins,
   ...remotePlugins,
-];
+].map(withMaxCharsRetries);

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -98,6 +98,10 @@ function computeModifiersFromConfig(config: PluginConfig | undefined): Record<st
       .join(', ');
     modifiers.__outputFormat = `Output each test case as JSON wrapped in <Prompt> tags: <Prompt>{${schema}}</Prompt>`;
   }
+  const maxCharsModifier = getMaxCharsPerMessageModifierValue(config?.maxCharsPerMessage);
+  if (maxCharsModifier) {
+    modifiers[MAX_CHARS_PER_MESSAGE_MODIFIER_KEY] = maxCharsModifier;
+  }
   return modifiers;
 }
 
@@ -163,7 +167,7 @@ async function fetchRemoteTestCases(
   // Strip graderExamples before sending - they're not used during generation,
   // only during grading. The CLI re-attaches the full config to test case metadata after.
   const { graderExamples, ...configForRemote } = config ?? {};
-  const maxCharsModifier = getMaxCharsPerMessageModifierValue();
+  const maxCharsModifier = getMaxCharsPerMessageModifierValue(config?.maxCharsPerMessage);
   if (maxCharsModifier) {
     configForRemote.modifiers = {
       ...((configForRemote.modifiers as Record<string, string> | undefined) ?? {}),

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -20,6 +20,10 @@ import {
   neverGenerateRemote,
   shouldGenerateRemote,
 } from '../remoteGeneration';
+import {
+  getMaxCharsPerMessageModifierValue,
+  MAX_CHARS_PER_MESSAGE_MODIFIER_KEY,
+} from '../shared/promptLength';
 import { getShortPluginId } from '../util';
 import { AegisPlugin } from './aegis';
 import { type RedteamPluginBase } from './base';
@@ -159,6 +163,13 @@ async function fetchRemoteTestCases(
   // Strip graderExamples before sending - they're not used during generation,
   // only during grading. The CLI re-attaches the full config to test case metadata after.
   const { graderExamples, ...configForRemote } = config ?? {};
+  const maxCharsModifier = getMaxCharsPerMessageModifierValue();
+  if (maxCharsModifier) {
+    configForRemote.modifiers = {
+      ...((configForRemote.modifiers as Record<string, string> | undefined) ?? {}),
+      [MAX_CHARS_PER_MESSAGE_MODIFIER_KEY]: maxCharsModifier,
+    };
+  }
   const body = JSON.stringify({
     config: configForRemote,
     injectVar,

--- a/src/redteam/providers/agentic/memoryPoisoning.ts
+++ b/src/redteam/providers/agentic/memoryPoisoning.ts
@@ -6,6 +6,7 @@ import invariant from '../../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { REDTEAM_MEMORY_POISONING_PLUGIN_ID } from '../../plugins/agentic/constants';
 import { getRemoteGenerationUrl } from '../../remoteGeneration';
+import { throwIfTargetPromptExceedsMaxChars } from '../../shared/promptLength';
 import { messagesToRedteamHistory } from '../shared';
 
 import type {
@@ -77,14 +78,17 @@ export class MemoryPoisoningProvider implements ApiProvider {
       const totalTokenUsage = createEmptyTokenUsage();
 
       // Send the memory message to the provider.
+      throwIfTargetPromptExceedsMaxChars(scenario.memory);
       const memoryResponse = await targetProvider.callApi(scenario.memory, context, options);
       accumulateResponseTokenUsage(totalTokenUsage, memoryResponse);
 
       // Send the test case to the provider; the test case should poison the memory created in the previous step.
+      throwIfTargetPromptExceedsMaxChars(prompt);
       const testResponse = await targetProvider.callApi(prompt, context, options);
       accumulateResponseTokenUsage(totalTokenUsage, testResponse);
 
       // Send the follow up question to the provider.
+      throwIfTargetPromptExceedsMaxChars(scenario.followUp);
       const response = await targetProvider.callApi(scenario.followUp, context, options);
       accumulateResponseTokenUsage(totalTokenUsage, response);
 

--- a/src/redteam/providers/authoritativeMarkupInjection.ts
+++ b/src/redteam/providers/authoritativeMarkupInjection.ts
@@ -7,6 +7,7 @@ import invariant from '../../util/invariant';
 import { safeJsonStringify } from '../../util/json';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
+import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 
 import type {
   ApiProvider,
@@ -116,6 +117,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
     const totalTokenUsage = createEmptyTokenUsage();
 
     // Call the target provider with the injected attack
+    throwIfTargetPromptExceedsMaxChars(renderedAttackerPrompt);
     const targetResponse = await targetProvider.callApi(renderedAttackerPrompt, context, options);
     accumulateResponseTokenUsage(totalTokenUsage, targetResponse);
 

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -9,6 +9,7 @@ import { fetchWithProxy } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
+import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import { getSessionId } from '../util';
 
 import type {
@@ -128,6 +129,7 @@ export default class BestOfNProvider implements ApiProvider {
           );
 
           try {
+            throwIfTargetPromptExceedsMaxChars(renderedPrompt);
             const response = await targetProvider.callApi(renderedPrompt, context, options);
             const sessionId = getSessionId(response, context);
             if (sessionId) {
@@ -148,6 +150,7 @@ export default class BestOfNProvider implements ApiProvider {
             }
           } catch (err) {
             logger.debug(`[Best-of-N] Candidate failed: ${err}`);
+            lastResponse = { error: String(err) };
             currentStep++;
           }
         },

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -129,6 +129,8 @@ export default class BestOfNProvider implements ApiProvider {
           );
 
           try {
+            // TODO(ian): Pass the strategy/plugin metadata maxCharsPerMessage limit here so
+            // plugin-scoped caps are enforced even when no top-level redteam cap is configured.
             throwIfTargetPromptExceedsMaxChars(renderedPrompt);
             const response = await targetProvider.callApi(renderedPrompt, context, options);
             const sessionId = getSessionId(response, context);

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -80,6 +80,7 @@ export interface ExtractAttackFailureResponse {
 
 interface GoatConfig {
   injectVar: string;
+  maxCharsPerMessage?: number;
   maxTurns: number;
   excludeTargetOutputFromAgenticAttackGeneration: boolean;
   stateful: boolean;
@@ -121,6 +122,7 @@ export default class GoatProvider implements ApiProvider {
   constructor(
     options: ProviderOptions & {
       maxTurns?: number;
+      maxCharsPerMessage?: number;
       injectVar?: string;
       stateful?: boolean;
       excludeTargetOutputFromAgenticAttackGeneration?: boolean;
@@ -141,6 +143,7 @@ export default class GoatProvider implements ApiProvider {
     }
     this.config = {
       maxTurns,
+      ...(options.maxCharsPerMessage ? { maxCharsPerMessage: options.maxCharsPerMessage } : {}),
       injectVar: options.injectVar,
       stateful: options.stateful ?? false,
       excludeTargetOutputFromAgenticAttackGeneration:
@@ -155,6 +158,7 @@ export default class GoatProvider implements ApiProvider {
     logger.debug('[GOAT] Constructor options', {
       injectVar: options.injectVar,
       maxTurns: options.maxTurns,
+      maxCharsPerMessage: options.maxCharsPerMessage,
       stateful: options.stateful,
       continueAfterSuccess: options.continueAfterSuccess,
       perTurnLayers: this.perTurnLayers.map((l) => (typeof l === 'string' ? l : l.id)),
@@ -186,6 +190,12 @@ export default class GoatProvider implements ApiProvider {
 
     const targetProvider: ApiProvider | undefined = context?.originalProvider;
     invariant(targetProvider, 'Expected originalProvider to be set');
+    const maxCharsPerMessage =
+      this.config.maxCharsPerMessage ??
+      (context?.test?.metadata?.strategyConfig as { maxCharsPerMessage?: number } | undefined)
+        ?.maxCharsPerMessage ??
+      (context?.test?.metadata?.pluginConfig as { maxCharsPerMessage?: number } | undefined)
+        ?.maxCharsPerMessage;
 
     const messages: Message[] = [];
     const totalTokenUsage: TokenUsage = createEmptyTokenUsage();
@@ -283,7 +293,7 @@ export default class GoatProvider implements ApiProvider {
               unblockingTargetPrompt = transformResult.prompt;
             }
 
-            throwIfTargetPromptExceedsMaxChars(unblockingTargetPrompt);
+            throwIfTargetPromptExceedsMaxChars(unblockingTargetPrompt, maxCharsPerMessage);
             const unblockingResponse = await targetProvider.callApi(
               unblockingTargetPrompt,
               context,
@@ -524,7 +534,7 @@ export default class GoatProvider implements ApiProvider {
         }
 
         const iterationStart = Date.now();
-        throwIfTargetPromptExceedsMaxChars(targetPrompt);
+        throwIfTargetPromptExceedsMaxChars(targetPrompt, maxCharsPerMessage);
         const targetResponse = (await targetProvider.callApi(
           targetPrompt,
           context,

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -16,6 +16,7 @@ import { getNunjucksEngine } from '../../util/templates';
 import { sleep } from '../../util/time';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
+import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import {
   applyRuntimeTransforms,
   type LayerConfig,
@@ -282,6 +283,7 @@ export default class GoatProvider implements ApiProvider {
               unblockingTargetPrompt = transformResult.prompt;
             }
 
+            throwIfTargetPromptExceedsMaxChars(unblockingTargetPrompt);
             const unblockingResponse = await targetProvider.callApi(
               unblockingTargetPrompt,
               context,
@@ -522,6 +524,7 @@ export default class GoatProvider implements ApiProvider {
         }
 
         const iterationStart = Date.now();
+        throwIfTargetPromptExceedsMaxChars(targetPrompt);
         const targetResponse = (await targetProvider.callApi(
           targetPrompt,
           context,

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -28,6 +28,7 @@ import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { TokenUsageTracker } from '../../util/tokenUsage';
 import { type TransformContext, TransformInputType, transform } from '../../util/transform';
+import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
 
 import type { TraceContextData } from '../../tracing/traceContext';
@@ -273,13 +274,21 @@ export async function getTargetResponse(
   let targetRespRaw;
 
   try {
+    throwIfTargetPromptExceedsMaxChars(targetPrompt);
     targetRespRaw = await targetProvider.callApi(targetPrompt, context, options);
   } catch (error) {
     // Re-throw abort errors to properly cancel the operation
     if (error instanceof Error && error.name === 'AbortError') {
       throw error;
     }
-    return { output: '', error: (error as Error).message, tokenUsage: { numRequests: 1 } };
+    return {
+      output: '',
+      error: (error as Error).message,
+      tokenUsage: {
+        numRequests:
+          error instanceof Error && error.message.includes('maxCharsPerMessage=') ? 0 : 1,
+      },
+    };
   }
   if (!targetRespRaw.cached && targetProvider.delay && targetProvider.delay > 0) {
     logger.debug(`Sleeping for ${targetProvider.delay}ms`);

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -259,6 +259,24 @@ export function isConversationEndedResponse(
   return Boolean(response?.conversationEnded);
 }
 
+function getTargetPromptMaxCharsPerMessage(context?: CallApiContextParams): number | undefined {
+  const configuredLimit =
+    (context?.test?.metadata?.strategyConfig as { maxCharsPerMessage?: unknown } | undefined)
+      ?.maxCharsPerMessage ??
+    (context?.test?.metadata?.pluginConfig as { maxCharsPerMessage?: unknown } | undefined)
+      ?.maxCharsPerMessage;
+
+  if (
+    typeof configuredLimit !== 'number' ||
+    !Number.isInteger(configuredLimit) ||
+    configuredLimit <= 0
+  ) {
+    return undefined;
+  }
+
+  return configuredLimit;
+}
+
 /**
  * Gets the response from the target provider for a given prompt.
  * @param targetProvider - The API provider to get the response from.
@@ -274,7 +292,7 @@ export async function getTargetResponse(
   let targetRespRaw;
 
   try {
-    throwIfTargetPromptExceedsMaxChars(targetPrompt);
+    throwIfTargetPromptExceedsMaxChars(targetPrompt, getTargetPromptMaxCharsPerMessage(context));
     targetRespRaw = await targetProvider.callApi(targetPrompt, context, options);
   } catch (error) {
     // Re-throw abort errors to properly cancel the operation

--- a/src/redteam/shared/promptLength.ts
+++ b/src/redteam/shared/promptLength.ts
@@ -1,0 +1,115 @@
+import cliState from '../../cliState';
+
+export const MAX_CHARS_PER_MESSAGE_MODIFIER_KEY = 'maxCharsPerMessage';
+
+type ChatMessage = {
+  content: string;
+  role: string;
+};
+
+function getMaxCharsPerMessage(limit?: number): number | undefined {
+  const maxCharsPerMessage = limit ?? cliState.config?.redteam?.maxCharsPerMessage;
+
+  if (
+    typeof maxCharsPerMessage !== 'number' ||
+    !Number.isInteger(maxCharsPerMessage) ||
+    maxCharsPerMessage <= 0
+  ) {
+    return undefined;
+  }
+
+  return maxCharsPerMessage;
+}
+
+function parseChatMessages(prompt: string): ChatMessage[] | undefined {
+  try {
+    const parsed = JSON.parse(prompt);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every(
+        (item) =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as ChatMessage).role === 'string' &&
+          typeof (item as ChatMessage).content === 'string',
+      )
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Plain-string prompts are checked as-is.
+  }
+
+  return undefined;
+}
+
+function getPromptLengthViolation(
+  prompt: string,
+  limit?: number,
+): { length: number; limit: number; path: string } | undefined {
+  const maxCharsPerMessage = getMaxCharsPerMessage(limit);
+  if (!maxCharsPerMessage) {
+    return undefined;
+  }
+
+  const messages = parseChatMessages(prompt);
+  if (messages) {
+    const oversizedMessage = messages
+      .map((message, index) => ({ index, message }))
+      .find(
+        ({ message }) => message.role === 'user' && message.content.length > maxCharsPerMessage,
+      );
+
+    return oversizedMessage
+      ? {
+          length: oversizedMessage.message.content.length,
+          limit: maxCharsPerMessage,
+          path: `[${oversizedMessage.index}].content`,
+        }
+      : undefined;
+  }
+
+  if (prompt.length <= maxCharsPerMessage) {
+    return undefined;
+  }
+
+  return {
+    length: prompt.length,
+    limit: maxCharsPerMessage,
+    path: 'prompt',
+  };
+}
+
+export function getMaxCharsPerMessageModifierValue(limit?: number): string | undefined {
+  const maxCharsPerMessage = getMaxCharsPerMessage(limit);
+  if (!maxCharsPerMessage) {
+    return undefined;
+  }
+
+  return `Each generated user message must be ${maxCharsPerMessage} characters or fewer.`;
+}
+
+export function getGeneratedPromptOverLimit(
+  prompt: string,
+): { length: number; limit: number } | undefined {
+  const violation = getPromptLengthViolation(prompt);
+  if (!violation) {
+    return undefined;
+  }
+
+  return {
+    length: violation.length,
+    limit: violation.limit,
+  };
+}
+
+export function throwIfTargetPromptExceedsMaxChars(prompt: string, limit?: number): void {
+  const violation = getPromptLengthViolation(prompt, limit);
+  if (!violation) {
+    return;
+  }
+
+  throw new Error(
+    `Target prompt message at ${violation.path} exceeds maxCharsPerMessage=${violation.limit}: ${violation.length} characters.`,
+  );
+}

--- a/src/redteam/shared/promptLength.ts
+++ b/src/redteam/shared/promptLength.ts
@@ -4,8 +4,13 @@ export const MAX_CHARS_PER_MESSAGE_MODIFIER_KEY = 'maxCharsPerMessage';
 
 type ChatMessage = {
   content: string;
+  path: string;
   role: string;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 function getMaxCharsPerMessage(limit?: number): number | undefined {
   const maxCharsPerMessage = limit ?? cliState.config?.redteam?.maxCharsPerMessage;
@@ -24,17 +29,48 @@ function getMaxCharsPerMessage(limit?: number): number | undefined {
 function parseChatMessages(prompt: string): ChatMessage[] | undefined {
   try {
     const parsed = JSON.parse(prompt);
+
     if (
       Array.isArray(parsed) &&
       parsed.every(
         (item) =>
-          typeof item === 'object' &&
-          item !== null &&
-          typeof (item as ChatMessage).role === 'string' &&
-          typeof (item as ChatMessage).content === 'string',
+          isRecord(item) && typeof item.role === 'string' && typeof item.content === 'string',
       )
     ) {
-      return parsed;
+      return parsed.map((message, index) => ({
+        content: message.content,
+        path: `[${index}].content`,
+        role: message.role,
+      }));
+    }
+
+    if (
+      isRecord(parsed) &&
+      parsed._promptfoo_audio_hybrid === true &&
+      (parsed.history === undefined || Array.isArray(parsed.history)) &&
+      isRecord(parsed.currentTurn) &&
+      typeof parsed.currentTurn.role === 'string' &&
+      typeof parsed.currentTurn.transcript === 'string' &&
+      (parsed.history === undefined ||
+        parsed.history.every(
+          (item) =>
+            isRecord(item) && typeof item.role === 'string' && typeof item.content === 'string',
+        ))
+    ) {
+      return [
+        ...((parsed.history as Array<{ content: string; role: string }> | undefined) ?? []).map(
+          (message, index) => ({
+            content: message.content,
+            path: `history[${index}].content`,
+            role: message.role,
+          }),
+        ),
+        {
+          content: parsed.currentTurn.transcript,
+          path: 'currentTurn.transcript',
+          role: parsed.currentTurn.role,
+        },
+      ];
     }
   } catch {
     // Plain-string prompts are checked as-is.
@@ -54,17 +90,15 @@ function getPromptLengthViolation(
 
   const messages = parseChatMessages(prompt);
   if (messages) {
-    const oversizedMessage = messages
-      .map((message, index) => ({ index, message }))
-      .find(
-        ({ message }) => message.role === 'user' && message.content.length > maxCharsPerMessage,
-      );
+    const oversizedMessage = messages.find(
+      (message) => message.role === 'user' && message.content.length > maxCharsPerMessage,
+    );
 
     return oversizedMessage
       ? {
-          length: oversizedMessage.message.content.length,
+          length: oversizedMessage.content.length,
           limit: maxCharsPerMessage,
-          path: `[${oversizedMessage.index}].content`,
+          path: oversizedMessage.path,
         }
       : undefined;
   }
@@ -91,8 +125,9 @@ export function getMaxCharsPerMessageModifierValue(limit?: number): string | und
 
 export function getGeneratedPromptOverLimit(
   prompt: string,
+  limit?: number,
 ): { length: number; limit: number } | undefined {
-  const violation = getPromptLengthViolation(prompt);
+  const violation = getPromptLengthViolation(prompt, limit);
   if (!violation) {
     return undefined;
   }

--- a/src/redteam/shared/promptLength.ts
+++ b/src/redteam/shared/promptLength.ts
@@ -33,6 +33,8 @@ function parseChatMessages(prompt: string): ChatMessage[] | undefined {
     if (
       Array.isArray(parsed) &&
       parsed.every(
+        // TODO(ian): Support multimodal chat content arrays and count only text parts instead of
+        // falling back to the full serialized JSON payload, which can include base64 media blobs.
         (item) =>
           isRecord(item) && typeof item.role === 'string' && typeof item.content === 'string',
       )

--- a/src/redteam/sharedFrontend.ts
+++ b/src/redteam/sharedFrontend.ts
@@ -64,6 +64,9 @@ export function getUnifiedConfig(
     redteam: {
       purpose: config.purpose,
       numTests: config.numTests,
+      ...(config.maxCharsPerMessage && {
+        maxCharsPerMessage: config.maxCharsPerMessage,
+      }),
       ...(config.provider && { provider: config.provider }),
       ...(config.maxConcurrency && { maxConcurrency: config.maxConcurrency }),
       ...(config.language && { language: config.language }),

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -153,6 +153,7 @@ export const PluginConfigSchema = z.object({
   // Multi-variable inputs - allows generating test cases with multiple variables
   // Keys are variable names, values are descriptions of what each variable should contain
   inputs: InputsSchema.optional(),
+  maxCharsPerMessage: z.number().int().positive().optional(),
 
   // Allow for the inclusion of a nonce to prevent caching of test cases.
   __nonce: z.number().optional(),

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -243,6 +243,7 @@ type CommonOptions = {
   sharing?: boolean;
   excludeTargetOutputFromAgenticAttackGeneration?: boolean;
   testGenerationInstructions?: string;
+  maxCharsPerMessage?: number;
   maxConcurrency?: number;
   tracing?: TracingConfig;
 };
@@ -338,6 +339,7 @@ export interface SavedRedteamConfig {
   frameworks?: FrameworkComplianceId[];
   extensions?: string[];
   numTests?: number;
+  maxCharsPerMessage?: number;
   maxConcurrency?: number;
   language?: string | string[];
   provider?: string | ProviderOptions;

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -895,6 +895,7 @@ export async function resolveConfigs(
       fileConfig.nunjucksFilters || defaultConfig.nunjucksFilters || {},
       basePath,
     ),
+    redteam: config.redteam,
     extensions: config.extensions,
     tracing: config.tracing,
   };

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -228,6 +228,11 @@ export const RedteamGenerateOptionsSchema = z.object({
       'Subset of compliance frameworks to include when generating, reporting, and filtering results',
     ),
   maxConcurrency: z.int().positive().optional().describe('Maximum number of concurrent API calls'),
+  maxCharsPerMessage: z
+    .int()
+    .positive()
+    .optional()
+    .describe('Maximum number of characters allowed per generated user message'),
   numTests: z.int().positive().optional().describe('Number of tests to generate'),
   output: z.string().optional().describe('Output file path'),
   plugins: z.array(RedteamPluginObjectSchema).optional().describe('Plugins to use'),
@@ -303,6 +308,11 @@ export const RedteamConfigSchema = z
       .positive()
       .optional()
       .describe('Maximum number of concurrent API calls'),
+    maxCharsPerMessage: z
+      .int()
+      .positive()
+      .optional()
+      .describe('Maximum number of characters allowed per generated user message'),
     delay: z
       .int()
       .nonnegative()
@@ -544,6 +554,7 @@ export const RedteamConfigSchema = z
 
     return {
       numTests: data.numTests,
+      ...(data.maxCharsPerMessage ? { maxCharsPerMessage: data.maxCharsPerMessage } : {}),
       plugins: uniquePlugins,
       strategies,
       ...(frameworks ? { frameworks } : {}),

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -5985,6 +5985,37 @@ describe('runEval', () => {
     expect(results[0].prompt.raw).toContain('{{purpose | trim}}');
   });
 
+  it('should fail before calling the provider when redteam maxCharsPerMessage is exceeded', async () => {
+    const callApi = vi.fn().mockResolvedValue({ output: 'should not be called' });
+
+    const results = await runEval({
+      ...defaultOptions,
+      provider: {
+        id: () => 'test-provider',
+        callApi,
+      },
+      prompt: { raw: 'User said: {{prompt}}', label: 'test-label' },
+      test: {
+        vars: {
+          prompt: 'this is too long',
+        },
+      },
+      testSuite: {
+        providers: [],
+        prompts: [],
+        redteam: {
+          maxCharsPerMessage: 10,
+        },
+      } as unknown as TestSuite,
+      conversations: {},
+      registers: {},
+      isRedteam: true,
+    });
+
+    expect(callApi).not.toHaveBeenCalled();
+    expect(results[0].error).toContain('maxCharsPerMessage=10');
+  });
+
   it('should use default injectVar "prompt" when not explicitly set in redteam config', async () => {
     // Tests the fallback to default 'prompt' injectVar when redteam config exists but injectVar is undefined
     const results = await runEval({

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -6016,6 +6016,34 @@ describe('runEval', () => {
     expect(results[0].error).toContain('maxCharsPerMessage=10');
   });
 
+  it('should not enforce redteam maxCharsPerMessage for non-redteam evals', async () => {
+    const callApi = vi.fn().mockResolvedValue({ output: 'success' });
+
+    const results = await runEval({
+      ...defaultOptions,
+      provider: {
+        id: () => 'test-provider',
+        callApi,
+      },
+      prompt: { raw: 'this prompt is longer than ten chars', label: 'test-label' },
+      test: {},
+      testSuite: {
+        providers: [],
+        prompts: [],
+        redteam: {
+          maxCharsPerMessage: 10,
+        },
+      } as unknown as TestSuite,
+      conversations: {},
+      registers: {},
+      isRedteam: false,
+    });
+
+    expect(callApi).toHaveBeenCalledTimes(1);
+    expect(results[0].success).toBe(true);
+    expect(results[0].response?.output).toBe('success');
+  });
+
   it('should use default injectVar "prompt" when not explicitly set in redteam config', async () => {
     // Tests the fallback to default 'prompt' injectVar when redteam config exists but injectVar is undefined
     const results = await runEval({

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -245,6 +245,75 @@ describe('synthesize', () => {
       ]);
     });
 
+    it('should pass maxCharsPerMessage through synthesize into plugin metadata and strategy config', async () => {
+      const mockPluginAction = vi.fn().mockResolvedValue([{ vars: { query: 'short' } }]);
+      vi.spyOn(Plugins, 'find').mockReturnValue({ action: mockPluginAction, key: 'mockPlugin' });
+
+      const mockStrategyAction = vi.fn().mockImplementation((testCases) =>
+        testCases.map((testCase: any) => ({
+          ...testCase,
+          metadata: {
+            ...testCase.metadata,
+            strategyId: 'goat',
+          },
+        })),
+      );
+      vi.spyOn(Strategies, 'find').mockReturnValue({
+        action: mockStrategyAction,
+        id: 'goat',
+      });
+
+      const result = await synthesize({
+        maxCharsPerMessage: 12,
+        numTests: 1,
+        plugins: [{ id: 'test-plugin', numTests: 1 }],
+        prompts: ['Test prompt'],
+        strategies: [{ id: 'goat' }],
+        targetIds: ['test-provider'],
+      });
+
+      expect(mockPluginAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            maxCharsPerMessage: 12,
+            modifiers: expect.objectContaining({
+              maxCharsPerMessage: 'Each generated user message must be 12 characters or fewer.',
+            }),
+          }),
+        }),
+      );
+      expect(mockStrategyAction).toHaveBeenCalledWith(
+        expect.any(Array),
+        'query',
+        expect.objectContaining({
+          maxCharsPerMessage: 12,
+        }),
+        'goat',
+      );
+      expect(result.testCases).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              pluginId: 'test-plugin',
+              pluginConfig: expect.objectContaining({
+                maxCharsPerMessage: 12,
+              }),
+              modifiers: expect.objectContaining({
+                maxCharsPerMessage: 'Each generated user message must be 12 characters or fewer.',
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              strategyConfig: expect.objectContaining({
+                maxCharsPerMessage: 12,
+              }),
+            }),
+          }),
+        ]),
+      );
+    });
+
     it('should warn about unregistered plugins', async () => {
       vi.spyOn(Plugins, 'find').mockReturnValue(undefined);
 

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } from 'vitest';
+import cliState from '../../../src/cliState';
 import { matchesLlmRubric } from '../../../src/matchers';
 import { MULTI_INPUT_VAR } from '../../../src/redteam/constants';
 import { RedteamGraderBase, RedteamPluginBase } from '../../../src/redteam/plugins/base';
@@ -55,6 +56,7 @@ describe('RedteamPluginBase', () => {
   let plugin: RedteamPluginBase;
 
   beforeEach(() => {
+    cliState.config = {};
     provider = {
       callApi: vi.fn().mockResolvedValue({
         output: 'Prompt: test prompt\nPrompt: another prompt\nirrelevant line',
@@ -65,6 +67,7 @@ describe('RedteamPluginBase', () => {
   });
 
   afterEach(() => {
+    cliState.config = {};
     vi.clearAllMocks();
   });
 
@@ -235,6 +238,38 @@ describe('RedteamPluginBase', () => {
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(5);
     expect(new Set(result.map((r) => r.vars?.testVar)).size).toBe(5);
+  });
+
+  it('should append max chars guidance from top-level redteam config and retry oversized prompts', async () => {
+    cliState.config = {
+      redteam: {
+        maxCharsPerMessage: 10,
+      },
+    };
+
+    vi.spyOn(provider, 'callApi')
+      .mockResolvedValueOnce({
+        output: 'Prompt: this one is too long\nPrompt: short',
+      })
+      .mockResolvedValueOnce({
+        output: 'Prompt: tiny',
+      });
+
+    const result = await plugin.generateTests(2);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((test) => test.vars?.testVar).sort()).toEqual(['short', 'tiny']);
+    expect(provider.callApi).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(
+        'maxCharsPerMessage: Each generated user message must be 10 characters or fewer.',
+      ),
+    );
+    expect(provider.callApi).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('The longest rejected prompt was 20 characters.'),
+    );
+    expect(result[0].metadata?.pluginConfig?.modifiers).toEqual({ language: 'German' });
   });
 
   describe('false positive refusal detection', () => {

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -269,7 +269,35 @@ describe('RedteamPluginBase', () => {
       2,
       expect.stringContaining('The longest rejected prompt was 20 characters.'),
     );
-    expect(result[0].metadata?.pluginConfig?.modifiers).toEqual({ language: 'German' });
+    expect(result[0].metadata?.pluginConfig?.modifiers).toEqual({
+      language: 'German',
+      maxCharsPerMessage: 'Each generated user message must be 10 characters or fewer.',
+    });
+  });
+
+  it('should honor maxCharsPerMessage from plugin config without cliState', async () => {
+    plugin = new TestPlugin(provider, 'test purpose', 'testVar', {
+      language: 'German',
+      maxCharsPerMessage: 8,
+    });
+
+    vi.spyOn(provider, 'callApi').mockResolvedValue({
+      output: 'Prompt: tiny',
+    });
+
+    const result = await plugin.generateTests(1);
+
+    expect(result).toHaveLength(1);
+    expect(provider.callApi).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'maxCharsPerMessage: Each generated user message must be 8 characters or fewer.',
+      ),
+    );
+    expect(result[0].metadata?.pluginConfig?.maxCharsPerMessage).toBe(8);
+    expect(result[0].metadata?.pluginConfig?.modifiers).toEqual({
+      language: 'German',
+      maxCharsPerMessage: 'Each generated user message must be 8 characters or fewer.',
+    });
   });
 
   describe('false positive refusal detection', () => {

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -167,6 +167,101 @@ describe('Plugins', () => {
     });
   });
 
+  describe('max chars retries', () => {
+    it('should retry oversized local PII generations', async () => {
+      vi.mocked(shouldGenerateRemote).mockImplementation(function () {
+        return false;
+      });
+
+      vi.spyOn(mockProvider, 'callApi')
+        .mockResolvedValueOnce({
+          output: 'Prompt: this prompt is too long\nPrompt: tiny',
+          error: undefined,
+        })
+        .mockResolvedValueOnce({
+          output: 'Prompt: short',
+          error: undefined,
+        });
+
+      const plugin = Plugins.find((p) => p.key === 'pii:direct');
+      const result = await plugin?.action({
+        provider: mockProvider,
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 2,
+        config: { maxCharsPerMessage: 10 },
+        delayMs: 0,
+      });
+
+      expect(mockProvider.callApi).toHaveBeenCalledTimes(2);
+      expect(mockProvider.callApi).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('Generate replacement prompts only'),
+      );
+      expect(result?.map((testCase) => testCase.vars?.testVar).sort()).toEqual(['short', 'tiny']);
+    });
+
+    it('should retry oversized remote generations and strip retry modifiers from metadata', async () => {
+      vi.mocked(shouldGenerateRemote).mockImplementation(function () {
+        return true;
+      });
+      vi.mocked(neverGenerateRemote).mockImplementation(function () {
+        return false;
+      });
+
+      vi.mocked(fetchWithCache)
+        .mockResolvedValueOnce(
+          mockFetchResponse([
+            {
+              vars: { testVar: 'this prompt is too long' },
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse([
+            {
+              vars: { testVar: 'short' },
+            },
+          ]),
+        );
+
+      const plugin = Plugins.find((p) => p.key === 'ssrf');
+      const result = await plugin?.action({
+        provider: mockProvider,
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        config: {
+          modifiers: {
+            maxCharsPerMessage: 'Each generated user message must be 10 characters or fewer.',
+          },
+        },
+        delayMs: 0,
+      });
+
+      expect(fetchWithCache).toHaveBeenCalledTimes(2);
+
+      const retryRequestBody = JSON.parse((vi.mocked(fetchWithCache).mock.calls[1][1] as any).body);
+      expect(retryRequestBody.config.modifiers.__maxCharsPerMessageRetry).toContain(
+        'Generate replacement prompts only',
+      );
+
+      expect(result).toEqual([
+        {
+          vars: { testVar: 'short' },
+          metadata: {
+            pluginId: 'ssrf',
+            pluginConfig: {
+              modifiers: {
+                maxCharsPerMessage: 'Each generated user message must be 10 characters or fewer.',
+              },
+            },
+          },
+        },
+      ]);
+    });
+  });
+
   describe('remote generation', () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/test/redteam/providers/goat.test.ts
+++ b/test/redteam/providers/goat.test.ts
@@ -123,6 +123,21 @@ describe('RedteamGoatProvider', () => {
     });
   });
 
+  it('should enforce maxCharsPerMessage from provider config without cliState', async () => {
+    const provider = new RedteamGoatProvider({
+      injectVar: 'goal',
+      maxCharsPerMessage: 5,
+      maxTurns: 1,
+      stateful: true,
+    });
+    const targetProvider = createMockTargetProvider();
+    const context = createMockContext(targetProvider);
+
+    await provider.callApi('test prompt', context);
+
+    expect(targetProvider.callApi).not.toHaveBeenCalled();
+  });
+
   it('should preserve an explicit maxTurns value of 0', async () => {
     const provider = new RedteamGoatProvider({
       injectVar: 'goal',

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -497,6 +497,115 @@ describe('shared redteam provider utilities', () => {
       expect(result.output).toBe('ok');
     });
 
+    it('uses maxCharsPerMessage from test metadata when cliState is unset', async () => {
+      const mockProvider: ApiProvider = {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: 'test response',
+          tokenUsage: { numRequests: 1 },
+        }),
+      };
+      const context = {
+        prompt: { raw: '', label: '' },
+        vars: {},
+        test: {
+          metadata: {
+            pluginConfig: {
+              maxCharsPerMessage: 5,
+            },
+          },
+        },
+      } as CallApiContextParams;
+
+      const result = await getTargetResponse(mockProvider, 'too long', context);
+
+      expect(mockProvider.callApi).not.toHaveBeenCalled();
+      expect(result.error).toBe(
+        'Target prompt message at prompt exceeds maxCharsPerMessage=5: 8 characters.',
+      );
+    });
+
+    it('checks GOAT audio/image hybrid payload transcript text without counting base64 blobs', async () => {
+      const mockProvider: ApiProvider = {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: 'ok',
+          tokenUsage: { numRequests: 1 },
+        }),
+      };
+      const context = {
+        prompt: { raw: '', label: '' },
+        vars: {},
+        test: {
+          metadata: {
+            pluginConfig: {
+              maxCharsPerMessage: 5,
+            },
+          },
+        },
+      } as CallApiContextParams;
+      const prompt = JSON.stringify({
+        _promptfoo_audio_hybrid: true,
+        history: [
+          { role: 'user', content: 'tiny' },
+          { role: 'assistant', content: 'this assistant response is long and should be ignored' },
+        ],
+        currentTurn: {
+          role: 'user',
+          transcript: 'short',
+          image: {
+            data: 'a'.repeat(500),
+            format: 'png',
+          },
+        },
+      });
+
+      const result = await getTargetResponse(mockProvider, prompt, context);
+
+      expect(mockProvider.callApi).toHaveBeenCalledWith(prompt, context, undefined);
+      expect(result.output).toBe('ok');
+    });
+
+    it('rejects GOAT audio/image hybrid payloads when currentTurn transcript exceeds maxCharsPerMessage', async () => {
+      const mockProvider: ApiProvider = {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: 'ok',
+          tokenUsage: { numRequests: 1 },
+        }),
+      };
+      const context = {
+        prompt: { raw: '', label: '' },
+        vars: {},
+        test: {
+          metadata: {
+            pluginConfig: {
+              maxCharsPerMessage: 5,
+            },
+          },
+        },
+      } as CallApiContextParams;
+      const prompt = JSON.stringify({
+        _promptfoo_audio_hybrid: true,
+        history: [],
+        currentTurn: {
+          role: 'user',
+          transcript: 'too long',
+          audio: {
+            data: 'a'.repeat(500),
+            format: 'mp3',
+          },
+        },
+      });
+
+      const result = await getTargetResponse(mockProvider, prompt, context);
+
+      expect(mockProvider.callApi).not.toHaveBeenCalled();
+      expect(result.error).toBe(
+        'Target prompt message at currentTurn.transcript exceeds maxCharsPerMessage=5: 8 characters.',
+      );
+    });
+
     it('returns successful response with string output', async () => {
       const mockProvider: ApiProvider = {
         id: () => 'test-provider',

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -449,6 +449,54 @@ describe('shared redteam provider utilities', () => {
   });
 
   describe('getTargetResponse', () => {
+    it('returns an error before calling the target when the prompt exceeds maxCharsPerMessage', async () => {
+      cliState.config = {
+        redteam: {
+          maxCharsPerMessage: 5,
+        },
+      };
+      const mockProvider: ApiProvider = {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: 'test response',
+          tokenUsage: { numRequests: 1 },
+        }),
+      };
+
+      const result = await getTargetResponse(mockProvider, 'too long');
+
+      expect(mockProvider.callApi).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        output: '',
+        error: 'Target prompt message at prompt exceeds maxCharsPerMessage=5: 8 characters.',
+        tokenUsage: { numRequests: 0 },
+      });
+    });
+
+    it('only enforces maxCharsPerMessage for user messages in chat arrays', async () => {
+      cliState.config = {
+        redteam: {
+          maxCharsPerMessage: 5,
+        },
+      };
+      const mockProvider: ApiProvider = {
+        id: () => 'test-provider',
+        callApi: vi.fn().mockResolvedValue({
+          output: 'ok',
+          tokenUsage: { numRequests: 1 },
+        }),
+      };
+      const prompt = JSON.stringify([
+        { role: 'system', content: 'this system message is long' },
+        { role: 'user', content: 'short' },
+      ]);
+
+      const result = await getTargetResponse(mockProvider, prompt);
+
+      expect(mockProvider.callApi).toHaveBeenCalledWith(prompt, undefined, undefined);
+      expect(result.output).toBe('ok');
+    });
+
     it('returns successful response with string output', async () => {
       const mockProvider: ApiProvider = {
         id: () => 'test-provider',

--- a/test/redteam/sharedFrontend.test.ts
+++ b/test/redteam/sharedFrontend.test.ts
@@ -218,6 +218,17 @@ describe('getUnifiedConfig', () => {
     expect(result.redteam.testGenerationInstructions).toBe('Generate more tests');
   });
 
+  it('should include maxCharsPerMessage if provided', () => {
+    const configWithMaxChars: SavedRedteamConfig = {
+      ...baseConfig,
+      maxCharsPerMessage: 125,
+    };
+
+    const result = getUnifiedConfig(configWithMaxChars);
+
+    expect(result.redteam.maxCharsPerMessage).toBe(125);
+  });
+
   it('should omit plugin config if empty', () => {
     const configWithEmptyPluginConfig: SavedRedteamConfig = {
       ...baseConfig,

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -120,6 +120,7 @@ describe('redteamGenerateOptionsSchema', () => {
       plugins: [{ id: 'pii:direct', numTests: 5 }],
       strategies: ['basic'],
       maxConcurrency: 5,
+      maxCharsPerMessage: 125,
       delay: 1000,
     };
 
@@ -139,6 +140,16 @@ describe('redteamGenerateOptionsSchema', () => {
     const input = {
       numTests: -5,
       plugins: ['harmful:hate'],
+    };
+    expect(RedteamGenerateOptionsSchema.safeParse(input).success).toBe(false);
+  });
+
+  it('should require maxCharsPerMessage to be a positive integer', () => {
+    const input = {
+      cache: true,
+      defaultConfig: {},
+      write: true,
+      maxCharsPerMessage: 0,
     };
     expect(RedteamGenerateOptionsSchema.safeParse(input).success).toBe(false);
   });
@@ -227,6 +238,7 @@ describe('redteamConfigSchema', () => {
     const input = {
       purpose: 'You are a travel agent',
       numTests: 3,
+      maxCharsPerMessage: 125,
       plugins: [
         { id: 'harmful:non-violent-crime', numTests: 5 },
         { id: 'hijacking', numTests: 3 },
@@ -238,6 +250,7 @@ describe('redteamConfigSchema', () => {
       data: {
         purpose: 'You are a travel agent',
         numTests: 3,
+        maxCharsPerMessage: 125,
         plugins: [
           { id: 'harmful:non-violent-crime', numTests: 5 },
           { id: 'hijacking', numTests: 3 },
@@ -322,6 +335,13 @@ describe('redteamConfigSchema', () => {
   it('should reject negative numTests', () => {
     const input = {
       numTests: -1,
+    };
+    expect(RedteamConfigSchema.safeParse(input).success).toBe(false);
+  });
+
+  it('should reject invalid maxCharsPerMessage values', () => {
+    const input = {
+      maxCharsPerMessage: 0,
     };
     expect(RedteamConfigSchema.safeParse(input).success).toBe(false);
   });


### PR DESCRIPTION
Adds a scan-level maxCharsPerMessage limit that guides generation, retries oversized plugin outputs, and blocks over-limit target sends.