### PR TITLE
fix(browser): make stealth plugin install explicit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -200,7 +200,6 @@
         "pdf-parse": "^2.4.5",
         "playwright": "^1.58.2",
         "playwright-extra": "^4.3.6",
-        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "read-excel-file": "^8.0.0",
         "sharp": "^0.34.5"
       }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,6 @@
     "pdf-parse": "^2.4.5",
     "playwright": "^1.58.2",
     "playwright-extra": "^4.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-excel-file": "^8.0.0",
     "sharp": "^0.34.5"
   },

--- a/site/docs/providers/browser.md
+++ b/site/docs/providers/browser.md
@@ -36,7 +36,7 @@ When using browser automation:
 
 ## Prerequisites
 
-The browser provider requires Playwright and related packages. These are optional dependencies, so you'll need to install them:
+The browser provider requires Playwright and the stealth plugin. Install these packages in the project where you run promptfoo:
 
 ```bash
 npm install playwright @playwright/browser-chromium playwright-extra puppeteer-extra-plugin-stealth


### PR DESCRIPTION
Stop shipping puppeteer-extra-plugin-stealth as an optional dependency so regular installs no longer pull the inflight transitive chain; browser users still install the stealth plugin explicitly.
