### PR TITLE
chore(deps): update claude-agent-sdk to 0.2.89

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "promptfoo": "dist/src/entrypoint.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.89",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1018.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1018.0",
         "@aws-sdk/client-s3": "^3.1003.0",
@@ -166,7 +166,7 @@
         "node": "^20.20.0 || >=22.22.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.89",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1018.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1018.0",
         "@aws-sdk/client-s3": "^3.1003.0",
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.87",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.87.tgz",
-      "integrity": "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==",
+      "version": "0.2.89",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.89.tgz",
+      "integrity": "sha512-/9W0lyBGuGHw1uu7pQafsp6BLpxfqCv1QYE0Z/eZTX6lGHht4j4Q+O3UImzjsiyEE9cGkOAwZBGAEHDEqt+QUA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     }
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.89",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1018.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1018.0",
     "@aws-sdk/client-s3": "^3.1003.0",
@@ -176,7 +176,7 @@
     "winston-transport": "^4.9.0"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.89",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1018.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1018.0",
     "@aws-sdk/client-s3": "^3.1003.0",


### PR DESCRIPTION
# Summary

Update @anthropic-ai/claude-agent-sdk from ^0.2.87 to ^0.2.89 in both package.json dependency sections and refresh package-lock.json to pin the 0.2.89 tarball.

# Why

Several worktrees/branches had package-lock.json entries pointing at claude-agent-sdk-0.2.88.tgz, but that tarball now returns E404 from npm. That blocks npm ci before Vitest can run. The package registry currently publishes 0.2.89, so this PR moves the dependency range and lockfile pin to a version that resolves successfully.

# Root Cause

The dependency range was broad enough to admit 0.2.88, and lockfiles generated while that version was briefly available could capture a tarball URL that no longer exists. npm ci then fails because it installs exactly what the lockfile requests.

# Validation

- npm ci
- npm run l
- npm run f
- npx vitest test/providers/claude-agent-sdk.test.ts --run

