### PR TITLE
refactor(webui): simplify data table header rendering

### DIFF
--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -605,8 +605,7 @@ export function DataTable<TData, TValue = unknown>({
                       {row.getVisibleCells().map((cell) => {
                         const cellAlign = cell.column.columnDef.meta?.align ?? 'left';
                         const cellSize = `${cell.column.getSize()}px`;
-                        const isUtilityColumn =
-                          cell.column.id === 'select' || cell.column.id === 'expand';
+                        const isUtilityColumn = UTILITY_COLUMN_IDS.has(cell.column.id);
 
                         return (
                           <td


### PR DESCRIPTION
## Summary
- extract data-table header rendering into small pure render helpers
- move the empty-state predicate into a named helper
- keep the table DOM, event handlers, and public props behavior unchanged

## Notes
- this removes the `lint/complexity/noExcessiveCognitiveComplexity` warnings from `src/app/src/components/data-table/data-table.tsx`
- helpers are plain render functions, not child components, so TanStack header handlers are recomputed every parent render and row-selection behavior stays intact

## Validation
- `npm run lint:src`
- `npm run tsc`
- `npm run test:app -- -- src/components/data-table/data-table.test.tsx --run`
- repo-wide Biome scan confirms `data-table.tsx` no longer emits complexity warnings
