### PR TITLE
feat(http): support structured multipart requests

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -109,7 +109,7 @@ providers:
 ```
 
 The `generated` source creates a deterministic document suitable for transport
-tests. Supported formats are `pdf`, `png`, and `jpeg`.
+tests. Supported formats are `pdf`, `png`, `jpeg`, and `jpg` (alias for `jpeg`).
 
 ### Uploading local files
 

--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -73,6 +73,74 @@ providers:
       body: 'model={{model}}&translate={{language}}'
 ```
 
+## Sending multipart/form-data
+
+Use `multipart.parts` when the target API expects form fields or file uploads.
+Promptfoo builds a fresh `FormData` body for every request and automatically sets the
+multipart boundary. Do not set `Content-Type: multipart/form-data` yourself unless
+you are using [raw HTTP request mode](#sending-a-raw-http-request).
+
+### Text fields and generated documents
+
+This example sends the prompt as a `documentQuery` text field and sends a simple
+generated PDF as the `files` upload field:
+
+```yaml
+providers:
+  - id: http
+    config:
+      url: 'http://localhost:8080/api/genai/analyze-file'
+      method: POST
+      headers:
+        X-API-Key: '{{api_key}}'
+      multipart:
+        parts:
+          - kind: file
+            name: files
+            filename: promptfoo-document.pdf
+            source:
+              type: generated
+              format: pdf
+              text: 'Promptfoo generated document for multipart testing.'
+          - kind: field
+            name: documentQuery
+            value: '{{prompt}}'
+      transformResponse: json.summary
+```
+
+The `generated` source creates a deterministic document suitable for transport
+tests. Supported formats are `pdf`, `png`, and `jpeg`.
+
+### Uploading local files
+
+Use a `path` source to upload a file from the machine running promptfoo. Relative
+paths resolve from the promptfoo config directory.
+
+```yaml
+providers:
+  - id: http
+    config:
+      url: 'http://localhost:8080/api/genai/analyze-file'
+      method: POST
+      multipart:
+        parts:
+          - kind: file
+            name: files
+            filename: sample-report45.pdf
+            contentType: application/pdf
+            source:
+              type: path
+              path: file://fixtures/sample-report45.pdf
+          - kind: field
+            name: documentQuery
+            value: '{{prompt}}'
+      transformResponse: json.summary
+```
+
+Structured multipart requests bypass the HTTP response cache by default.
+`multipart` is mutually exclusive with `request` and `body`, and it cannot be
+used with `GET` or `HEAD`.
+
 ## Sending a raw HTTP request
 
 You can also send a raw HTTP request by specifying the `request` property in the provider configuration. This allows you to have full control over the request, including headers and body.
@@ -1702,6 +1770,7 @@ Supported config options:
 | method            | string                  | HTTP method (GET, POST, etc). Defaults to POST if body is provided, GET otherwise.                                                                                                  |
 | headers           | Record\<string, string> | Key-value pairs of HTTP headers to include in the request.                                                                                                                          |
 | body              | object \| string        | The request body. For POST requests, objects are automatically stringified as JSON.                                                                                                 |
+| multipart         | object                  | Multipart form configuration with ordered `parts`. Supports text fields, local file uploads, and generated PDF/PNG/JPEG documents.                                                  |
 | queryParams       | Record\<string, string> | Key-value pairs of query parameters to append to the URL.                                                                                                                           |
 | transformRequest  | string \| Function      | A function, string template, or file path to transform the prompt before sending it to the API.                                                                                     |
 | transformResponse | string \| Function      | Transforms the API response using a JavaScript expression (e.g., 'json.result'), function, or file path (e.g., 'file://parser.js'). Replaces the deprecated `responseParser` field. |

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -945,8 +945,7 @@ function sanitizeMultipartFields(fields: RenderedHttpMultipartBody['fields']) {
 function sanitizeMultipartFiles(files: RenderedHttpMultipartBody['files']) {
   return files.map((file) => ({
     field: isSecretField(file.field) ? REDACTED : file.field,
-    filename:
-      isSecretField(file.filename) || looksLikeSecret(file.filename) ? REDACTED : file.filename,
+    filename: looksLikeSecret(file.filename) ? REDACTED : file.filename,
     contentType: file.contentType,
     sizeBytes: file.sizeBytes,
     source: file.source,

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -21,9 +21,20 @@ import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { TOKEN_REFRESH_BUFFER_MS, type TokenRefreshLock } from '../util/oauth';
 import { safeResolve } from '../util/pathUtils';
-import { sanitizeObject, sanitizeUrl } from '../util/sanitizer';
+import {
+  isSecretField,
+  looksLikeSecret,
+  REDACTED,
+  sanitizeObject,
+  sanitizeUrl,
+} from '../util/sanitizer';
 import { getNunjucksEngine } from '../util/templates';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
+import {
+  HttpMultipartConfigSchema,
+  type RenderedHttpMultipartBody,
+  renderHttpMultipartBody,
+} from './httpMultipart';
 import {
   createTransformRequest,
   createTransformResponse,
@@ -843,6 +854,7 @@ export const HttpProviderConfigSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   maxRetries: z.number().min(0).optional(),
   method: z.string().optional(),
+  multipart: HttpMultipartConfigSchema.optional(),
   queryParams: z.record(z.string(), z.string()).optional(),
   request: z.string().optional(),
   /**
@@ -913,6 +925,44 @@ function contentTypeIsJson(headers: Record<string, string> | undefined) {
     }
     return false;
   });
+}
+
+function removeMultipartContentType(headers: Record<string, string>): void {
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'content-type') {
+      delete headers[key];
+    }
+  }
+}
+
+function sanitizeMultipartFields(fields: RenderedHttpMultipartBody['fields']) {
+  return fields.map((field) => ({
+    ...field,
+    value: isSecretField(field.field) || looksLikeSecret(field.value) ? REDACTED : field.value,
+  }));
+}
+
+function sanitizeMultipartFiles(files: RenderedHttpMultipartBody['files']) {
+  return files.map((file) => ({
+    field: isSecretField(file.field) ? REDACTED : file.field,
+    filename:
+      isSecretField(file.filename) || looksLikeSecret(file.filename) ? REDACTED : file.filename,
+    contentType: file.contentType,
+    sizeBytes: file.sizeBytes,
+    source: file.source,
+  }));
+}
+
+function validateMultipartConfig(config: HttpProviderConfig): void {
+  if (!config.multipart) {
+    return;
+  }
+  if (config.request) {
+    throw new Error('HTTP provider config cannot include both request and multipart');
+  }
+  if (config.body != null) {
+    throw new Error('HTTP provider config cannot include both body and multipart');
+  }
 }
 
 interface SessionParserData {
@@ -1491,6 +1541,7 @@ export class HttpProvider implements ApiProvider {
 
   constructor(url: string, options: ProviderOptions) {
     this.config = HttpProviderConfigSchema.parse(options.config);
+    validateMultipartConfig(this.config);
     if (!this.config.tokenEstimation && cliState.config?.redteam) {
       this.config.tokenEstimation = { enabled: true, multiplier: 1.3 };
     }
@@ -1524,7 +1575,7 @@ export class HttpProvider implements ApiProvider {
       this.config.request = maybeLoadFromExternalFile(this.config.request) as string;
     } else {
       invariant(
-        this.config.body || this.config.method === 'GET',
+        this.config.body || this.config.multipart || this.config.method === 'GET',
         `Expected HTTP provider ${this.url} to have a config containing {body}, but instead got ${safeJsonStringify(
           this.config,
         )}`,
@@ -2020,6 +2071,9 @@ export class HttpProvider implements ApiProvider {
     if (this.config.method === 'GET') {
       return {};
     }
+    if (this.config.multipart) {
+      return {};
+    }
     if (typeof body === 'object' && body !== null) {
       return { 'content-type': 'application/json' };
     } else if (typeof body === 'string') {
@@ -2252,7 +2306,11 @@ export class HttpProvider implements ApiProvider {
       headers.tracestate = context.tracestate;
     }
 
-    this.validateContentTypeAndBody(headers, this.config.body);
+    if (this.config.multipart) {
+      removeMultipartContentType(headers);
+    } else {
+      this.validateContentTypeAndBody(headers, this.config.body);
+    }
 
     // Transform prompt using request transform
     const transformedPrompt = await (await this.transformRequest)(prompt, vars, context);
@@ -2262,14 +2320,19 @@ export class HttpProvider implements ApiProvider {
 
     const renderedConfig: Partial<HttpProviderConfig> = {
       url: getNunjucksEngine().renderString(this.url, vars),
-      method: getNunjucksEngine().renderString(this.config.method || 'GET', vars),
-      headers,
-      body: determineRequestBody(
-        contentTypeIsJson(headers),
-        transformedPrompt,
-        this.config.body,
+      method: getNunjucksEngine().renderString(
+        this.config.method || (this.config.multipart ? 'POST' : 'GET'),
         vars,
       ),
+      headers,
+      body: this.config.multipart
+        ? undefined
+        : determineRequestBody(
+            contentTypeIsJson(headers),
+            transformedPrompt,
+            this.config.body,
+            vars,
+          ),
       queryParams: (() => {
         const baseQueryParams = this.config.queryParams
           ? Object.fromEntries(
@@ -2296,6 +2359,9 @@ export class HttpProvider implements ApiProvider {
 
     invariant(typeof method === 'string', 'Expected method to be a string');
     invariant(typeof headers === 'object', 'Expected headers to be an object');
+    if (this.config.multipart && ['GET', 'HEAD'].includes(method.toUpperCase())) {
+      throw new Error(`HTTP provider ${method} requests cannot use multipart`);
+    }
 
     // Template the base URL first, then construct URL with query parameters
     let url = renderedConfig.url as string;
@@ -2319,6 +2385,17 @@ export class HttpProvider implements ApiProvider {
       config: renderedConfig,
     });
 
+    const multipartBody: RenderedHttpMultipartBody | undefined = this.config.multipart
+      ? await renderHttpMultipartBody(
+          this.config.multipart,
+          {
+            ...vars,
+            prompt: transformedPrompt,
+          },
+          options?.abortSignal,
+        )
+      : undefined;
+
     // Prepare fetch options with dispatcher if HTTPS agent is configured
     const httpsAgent = await this.getHttpsAgent();
     const fetchOptions: any = {
@@ -2326,6 +2403,11 @@ export class HttpProvider implements ApiProvider {
       headers: renderedConfig.headers,
       ...(options?.abortSignal && { signal: options.abortSignal }),
       ...(method !== 'GET' &&
+        multipartBody && {
+          body: multipartBody.body,
+        }),
+      ...(method !== 'GET' &&
+        !multipartBody &&
         renderedConfig.body != null && {
           body: contentTypeIsJson(headers)
             ? typeof renderedConfig.body === 'string'
@@ -2362,7 +2444,7 @@ export class HttpProvider implements ApiProvider {
         fetchOptions,
         REQUEST_TIMEOUT_MS,
         'text',
-        context?.bustCache ?? context?.debug,
+        multipartBody ? true : (context?.bustCache ?? context?.debug),
         this.config.maxRetries,
       ));
     } catch (err) {
@@ -2393,7 +2475,14 @@ export class HttpProvider implements ApiProvider {
     };
     if (context?.debug) {
       ret.metadata.transformedRequest = transformedPrompt;
-      ret.metadata.finalRequestBody = renderedConfig.body;
+      if (multipartBody) {
+        ret.metadata.multipart = {
+          fields: sanitizeMultipartFields(multipartBody.fields),
+          files: sanitizeMultipartFiles(multipartBody.files),
+        };
+      } else {
+        ret.metadata.finalRequestBody = renderedConfig.body;
+      }
     }
 
     const rawText = data as string;

--- a/src/providers/httpMultipart.ts
+++ b/src/providers/httpMultipart.ts
@@ -1,0 +1,236 @@
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { z } from 'zod';
+import cliState from '../cliState';
+import { getNunjucksEngine } from '../util/templates';
+
+const GeneratedDocumentSourceSchema = z.object({
+  type: z.literal('generated'),
+  generator: z.literal('basic-document').optional().default('basic-document'),
+  format: z.enum(['pdf', 'png', 'jpeg', 'jpg']).optional().default('pdf'),
+  text: z.string().optional(),
+});
+
+const PathFileSourceSchema = z.object({
+  type: z.literal('path'),
+  path: z.string(),
+});
+
+const MultipartFieldPartSchema = z.object({
+  kind: z.literal('field'),
+  name: z.string(),
+  value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+const MultipartFilePartSchema = z.object({
+  kind: z.literal('file'),
+  name: z.string(),
+  filename: z.string().optional(),
+  filenameTemplate: z.string().optional(),
+  contentType: z.string().optional(),
+  source: z.union([GeneratedDocumentSourceSchema, PathFileSourceSchema]),
+});
+
+export const HttpMultipartConfigSchema = z.object({
+  parts: z.array(z.union([MultipartFieldPartSchema, MultipartFilePartSchema])).min(1),
+});
+
+export type HttpMultipartConfig = z.infer<typeof HttpMultipartConfigSchema>;
+
+export interface MultipartFileDescriptor {
+  field: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+  source: 'generated' | 'path';
+}
+
+export interface MultipartFieldDescriptor {
+  field: string;
+  value: string;
+}
+
+export interface RenderedHttpMultipartBody {
+  body: FormData;
+  fields: MultipartFieldDescriptor[];
+  files: MultipartFileDescriptor[];
+}
+
+function renderTemplate(value: string, vars: Record<string, unknown>): string {
+  return getNunjucksEngine().renderString(value, vars);
+}
+
+function getMimeTypeForGeneratedFormat(
+  format: z.infer<typeof GeneratedDocumentSourceSchema>['format'],
+) {
+  switch (format) {
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'pdf':
+    default:
+      return 'application/pdf';
+  }
+}
+
+function escapePdfText(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function createBasicPdf(text: string): Buffer {
+  const displayText = escapePdfText(text.replace(/\s+/g, ' ').trim().slice(0, 800));
+  const content = `BT
+/F1 16 Tf
+72 720 Td
+(${displayText}) Tj
+ET`;
+
+  const objects = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n',
+    '4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n',
+    `5 0 obj\n<< /Length ${Buffer.byteLength(content)} >>\nstream\n${content}\nendstream\nendobj\n`,
+  ];
+
+  let pdf = '%PDF-1.4\n';
+  const offsets = [0];
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += object;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf);
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (const offset of offsets.slice(1)) {
+    pdf += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(pdf, 'utf8');
+}
+
+function createGeneratedImage(format: 'png' | 'jpeg' | 'jpg'): Buffer {
+  if (format === 'png') {
+    // 1x1 transparent PNG.
+    return Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+      'base64',
+    );
+  }
+
+  // 1x1 white JPEG.
+  return Buffer.from(
+    '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/ASP/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/ASP/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Al//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/IV//2gAMAwEAAgADAAAAEP/EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EABQQAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z',
+    'base64',
+  );
+}
+
+function createGeneratedFile(
+  source: z.infer<typeof GeneratedDocumentSourceSchema>,
+  vars: Record<string, unknown>,
+): { buffer: Buffer; contentType: string; extension: string } {
+  const format = source.format || 'pdf';
+  const contentType = getMimeTypeForGeneratedFormat(format);
+  const text = renderTemplate(
+    source.text || 'Promptfoo generated document for multipart HTTP target testing.',
+    vars,
+  );
+
+  if (format === 'pdf') {
+    return { buffer: createBasicPdf(text), contentType, extension: 'pdf' };
+  }
+
+  return {
+    buffer: createGeneratedImage(format),
+    contentType,
+    extension: format === 'jpg' ? 'jpg' : format,
+  };
+}
+
+function resolvePath(filePath: string): string {
+  const withoutFileScheme = filePath.startsWith('file://')
+    ? filePath.slice('file://'.length)
+    : filePath;
+  if (path.isAbsolute(withoutFileScheme)) {
+    return withoutFileScheme;
+  }
+  return path.resolve(cliState.basePath || process.cwd(), withoutFileScheme);
+}
+
+async function loadFilePart(
+  source: z.infer<typeof PathFileSourceSchema>,
+  vars: Record<string, unknown>,
+  abortSignal?: AbortSignal,
+): Promise<{ buffer: Buffer; filename: string; contentType: string }> {
+  const resolvedPath = resolvePath(renderTemplate(source.path, vars));
+  const buffer = await fs.readFile(resolvedPath, { signal: abortSignal });
+  return {
+    buffer,
+    filename: path.basename(resolvedPath),
+    contentType: 'application/octet-stream',
+  };
+}
+
+function hash(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+export async function renderHttpMultipartBody(
+  config: HttpMultipartConfig,
+  vars: Record<string, unknown>,
+  abortSignal?: AbortSignal,
+): Promise<RenderedHttpMultipartBody> {
+  const formData = new FormData();
+  const fields: MultipartFieldDescriptor[] = [];
+  const files: MultipartFileDescriptor[] = [];
+
+  for (const part of config.parts) {
+    abortSignal?.throwIfAborted();
+    const field = renderTemplate(part.name, vars);
+
+    if (part.kind === 'field') {
+      const value = renderTemplate(String(part.value), vars);
+      formData.append(field, value);
+      fields.push({ field, value });
+      continue;
+    }
+
+    let loaded: { buffer: Buffer; contentType: string };
+    let defaultFilename: string;
+
+    if (part.source.type === 'path') {
+      const file = await loadFilePart(part.source, vars, abortSignal);
+      loaded = file;
+      defaultFilename = file.filename;
+    } else {
+      const generated = createGeneratedFile(part.source, vars);
+      loaded = generated;
+      defaultFilename = `promptfoo-document.${generated.extension}`;
+    }
+
+    const filenameTemplate = part.filenameTemplate || part.filename || defaultFilename;
+    const filename = renderTemplate(filenameTemplate, vars);
+    const contentType = part.contentType || loaded.contentType;
+    const blob = new Blob([loaded.buffer as unknown as BlobPart], { type: contentType });
+
+    formData.append(field, blob, filename);
+    files.push({
+      field,
+      filename,
+      contentType,
+      sizeBytes: loaded.buffer.length,
+      sha256: hash(loaded.buffer),
+      source: part.source.type,
+    });
+  }
+
+  return { body: formData, fields, files };
+}

--- a/src/providers/httpMultipart.ts
+++ b/src/providers/httpMultipart.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { z } from 'zod';
 import cliState from '../cliState';
@@ -44,7 +44,6 @@ export interface MultipartFileDescriptor {
   filename: string;
   contentType: string;
   sizeBytes: number;
-  sha256: string;
   source: 'generated' | 'path';
 }
 
@@ -155,14 +154,52 @@ function createGeneratedFile(
   };
 }
 
+function normalizeFilePath(filePath: string): string {
+  if (!filePath.startsWith('file://')) {
+    return filePath;
+  }
+
+  try {
+    return fileURLToPath(filePath);
+  } catch {
+    // Preserve promptfoo's long-standing shorthand: file://relative/path.ext
+    return filePath.slice('file://'.length);
+  }
+}
+
 function resolvePath(filePath: string): string {
-  const withoutFileScheme = filePath.startsWith('file://')
-    ? filePath.slice('file://'.length)
-    : filePath;
+  const withoutFileScheme = normalizeFilePath(filePath);
   if (path.isAbsolute(withoutFileScheme)) {
     return withoutFileScheme;
   }
   return path.resolve(cliState.basePath || process.cwd(), withoutFileScheme);
+}
+
+function getContentTypeFromFilename(filename: string): string {
+  switch (path.extname(filename).toLowerCase()) {
+    case '.pdf':
+      return 'application/pdf';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.gif':
+      return 'image/gif';
+    case '.bmp':
+      return 'image/bmp';
+    case '.tif':
+    case '.tiff':
+      return 'image/tiff';
+    case '.webp':
+      return 'image/webp';
+    case '.txt':
+      return 'text/plain';
+    case '.json':
+      return 'application/json';
+    default:
+      return 'application/octet-stream';
+  }
 }
 
 async function loadFilePart(
@@ -175,12 +212,8 @@ async function loadFilePart(
   return {
     buffer,
     filename: path.basename(resolvedPath),
-    contentType: 'application/octet-stream',
+    contentType: getContentTypeFromFilename(resolvedPath),
   };
-}
-
-function hash(buffer: Buffer): string {
-  return crypto.createHash('sha256').update(buffer).digest('hex');
 }
 
 export async function renderHttpMultipartBody(
@@ -227,7 +260,6 @@ export async function renderHttpMultipartBody(
       filename,
       contentType,
       sizeBytes: loaded.buffer.length,
-      sha256: hash(loaded.buffer),
       source: part.source.type,
     });
   }

--- a/test/providers/http-multipart.test.ts
+++ b/test/providers/http-multipart.test.ts
@@ -185,6 +185,7 @@ describe('HttpProvider structured multipart requests', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-multipart-'));
     tempDirs.push(tempDir);
     const reportPath = path.join(tempDir, 'report-a.txt');
+    const standardFileUrl = new URL(`file://${reportPath}`).toString();
     fs.writeFileSync(reportPath, 'report-a contents');
 
     const mockServer = await createMultipartDocumentSummarizerServer();
@@ -199,7 +200,7 @@ describe('HttpProvider structured multipart requests', () => {
               name: 'files',
               source: {
                 type: 'path',
-                path: '{{documentPath}}',
+                path: 'file://{{documentPath}}',
               },
             },
             {
@@ -225,9 +226,21 @@ describe('HttpProvider structured multipart requests', () => {
       files: [
         expect.objectContaining({
           filename: 'report-a.txt',
+          contentType: 'text/plain',
           sizeBytes: Buffer.byteLength('report-a contents'),
         }),
       ],
+    });
+
+    await provider.callApi('Summarize local fixture', {
+      prompt: { raw: 'Summarize local fixture', label: 'query' },
+      vars: {
+        documentPath: standardFileUrl.slice('file://'.length),
+      },
+    });
+    expect(mockServer.getLastRequest()?.files[0]).toMatchObject({
+      filename: 'report-a.txt',
+      contentType: 'text/plain',
     });
   });
 

--- a/test/providers/http-multipart.test.ts
+++ b/test/providers/http-multipart.test.ts
@@ -103,9 +103,9 @@ async function createMultipartDocumentSummarizerServer() {
           documentQuery,
         }),
       );
-    } catch (error) {
+    } catch {
       res.writeHead(500, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+      res.end(JSON.stringify({ error: 'mock server failed to parse multipart request' }));
     }
   });
 

--- a/test/providers/http-multipart.test.ts
+++ b/test/providers/http-multipart.test.ts
@@ -1,0 +1,429 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { HttpProvider } from '../../src/providers/http';
+
+interface MockFileSummary {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+  prefix: string;
+}
+
+interface MockRequestSummary {
+  apiKey: string | null;
+  contentType: string | null;
+  documentQuery: string | null;
+  files: MockFileSummary[];
+  method: string | undefined;
+  url: string | undefined;
+}
+
+const servers: Server[] = [];
+const tempDirs: string[] = [];
+
+async function createMultipartDocumentSummarizerServer() {
+  let lastRequest: MockRequestSummary | undefined;
+
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method !== 'POST' || req.url !== '/api/genai/analyze-file') {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+        return;
+      }
+
+      const apiKey = req.headers['x-api-key'];
+      if (apiKey !== 'test-api-key') {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid api key' }));
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks);
+      const contentType = String(req.headers['content-type'] || '');
+      const request = new Request(`http://localhost${req.url}`, {
+        body,
+        headers: { 'content-type': contentType },
+        method: req.method,
+      });
+      const formData = await request.formData();
+      const documentQuery = formData.get('documentQuery');
+      const files = formData.getAll('files');
+
+      if (typeof documentQuery !== 'string' || documentQuery.trim() === '') {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'missing documentQuery' }));
+        return;
+      }
+
+      if (files.length === 0 || !files.every((file) => file instanceof File)) {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'missing files' }));
+        return;
+      }
+
+      const summaries: MockFileSummary[] = [];
+      for (const file of files as File[]) {
+        const buffer = Buffer.from(await file.arrayBuffer());
+        summaries.push({
+          filename: file.name,
+          contentType: file.type,
+          sizeBytes: buffer.length,
+          sha256: crypto.createHash('sha256').update(buffer).digest('hex'),
+          prefix: buffer.subarray(0, 8).toString('utf8'),
+        });
+      }
+
+      lastRequest = {
+        apiKey: String(apiKey),
+        contentType,
+        documentQuery,
+        files: summaries,
+        method: req.method,
+        url: req.url,
+      };
+
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          summary: `mock summary for ${summaries.length} file(s): ${documentQuery}`,
+          fileCount: summaries.length,
+          files: summaries,
+          documentQuery,
+        }),
+      );
+    } catch (error) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  servers.push(server);
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}/api/genai/analyze-file`,
+    getLastRequest: () => lastRequest,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('HttpProvider structured multipart requests', () => {
+  it('executes the generated-document config emitted by the Cloud HTTP editor defaults', async () => {
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        method: 'POST',
+        headers: {
+          'X-API-Key': 'test-api-key',
+        },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              filename: 'promptfoo-document.pdf',
+              source: {
+                type: 'generated',
+                generator: 'basic-document',
+                format: 'pdf',
+              },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    const result = await provider.callApi('Summarize this upload');
+
+    expect(result.output).toBe('mock summary for 1 file(s): Summarize this upload');
+    expect(mockServer.getLastRequest()).toMatchObject({
+      documentQuery: 'Summarize this upload',
+      files: [
+        expect.objectContaining({
+          filename: 'promptfoo-document.pdf',
+          contentType: 'application/pdf',
+          prefix: '%PDF-1.4',
+        }),
+      ],
+    });
+  });
+
+  it('renders path sources with per-test variables before reading local files', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-multipart-'));
+    tempDirs.push(tempDir);
+    const reportPath = path.join(tempDir, 'report-a.txt');
+    fs.writeFileSync(reportPath, 'report-a contents');
+
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        headers: { 'X-API-Key': 'test-api-key' },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              source: {
+                type: 'path',
+                path: '{{documentPath}}',
+              },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    await provider.callApi('Summarize local fixture', {
+      prompt: { raw: 'Summarize local fixture', label: 'query' },
+      vars: {
+        documentPath: reportPath,
+      },
+    });
+
+    expect(mockServer.getLastRequest()).toMatchObject({
+      documentQuery: 'Summarize local fixture',
+      files: [
+        expect.objectContaining({
+          filename: 'report-a.txt',
+          sizeBytes: Buffer.byteLength('report-a contents'),
+        }),
+      ],
+    });
+  });
+
+  it('redacts secret-like multipart text fields from debug metadata', async () => {
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        headers: { 'X-API-Key': 'test-api-key' },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              source: { type: 'generated', format: 'pdf' },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+            {
+              kind: 'field',
+              name: 'api_key',
+              value: 'sk-secret-key-that-should-not-appear-anywhere',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    const result = await provider.callApi('Query', {
+      debug: true,
+      prompt: { raw: 'Query', label: 'query' },
+      vars: {},
+    });
+
+    expect(result.metadata?.multipart.fields).toContainEqual({
+      field: 'api_key',
+      value: '[REDACTED]',
+    });
+    expect(result.metadata?.multipart.files[0]).not.toHaveProperty('sha256');
+    expect(JSON.stringify(result.metadata)).not.toContain('sk-secret-key');
+  });
+
+  it('redacts secret-like multipart filenames from debug metadata', async () => {
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        headers: { 'X-API-Key': 'test-api-key' },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              filename: 'sk-secret-filename-that-should-not-appear',
+              source: { type: 'generated', format: 'pdf' },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    const result = await provider.callApi('Query', {
+      debug: true,
+      prompt: { raw: 'Query', label: 'query' },
+      vars: {},
+    });
+
+    expect(result.metadata?.multipart.files[0]).toMatchObject({
+      field: 'files',
+      filename: '[REDACTED]',
+      contentType: 'application/pdf',
+    });
+    expect(result.metadata?.multipart.files[0]).not.toHaveProperty('sha256');
+    expect(JSON.stringify(result.metadata)).not.toContain('sk-secret-filename');
+  });
+
+  it('rejects incompatible multipart HTTP provider modes before sending requests', () => {
+    expect(
+      () =>
+        new HttpProvider('http', {
+          config: {
+            request: 'POST / HTTP/1.1\nHost: example.com\n\n{{prompt}}',
+            multipart: { parts: [{ kind: 'field', name: 'documentQuery', value: '{{prompt}}' }] },
+          },
+        }),
+    ).toThrow(/cannot include both request and multipart/);
+
+    expect(
+      () =>
+        new HttpProvider('http', {
+          config: {
+            body: { prompt: '{{prompt}}' },
+            multipart: { parts: [{ kind: 'field', name: 'documentQuery', value: '{{prompt}}' }] },
+          },
+        }),
+    ).toThrow(/cannot include both body and multipart/);
+  });
+
+  it('rejects multipart GET requests before rendering the multipart body', async () => {
+    const provider = new HttpProvider('http://example.com/upload', {
+      config: {
+        method: 'GET',
+        multipart: {
+          parts: [
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(provider.callApi('Query')).rejects.toThrow(/GET requests cannot use multipart/);
+  });
+
+  it('uploads a generated PDF file with a templated document query', async () => {
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        headers: {
+          'X-API-Key': 'test-api-key',
+          // The provider must remove this stale value and let fetch set a boundary.
+          'Content-Type': 'multipart/form-data',
+        },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              filename: 'sample-report45.pdf',
+              source: {
+                type: 'generated',
+                format: 'pdf',
+                text: 'Benign generated report used to test multipart transport.',
+              },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    const result = await provider.callApi('Give summary of the file', {
+      debug: true,
+      prompt: { raw: 'Give summary of the file', label: 'query' },
+      vars: {},
+    });
+
+    expect(result.output).toBe('mock summary for 1 file(s): Give summary of the file');
+
+    const request = mockServer.getLastRequest();
+    expect(request).toMatchObject({
+      apiKey: 'test-api-key',
+      documentQuery: 'Give summary of the file',
+      method: 'POST',
+      url: '/api/genai/analyze-file',
+    });
+    expect(request?.contentType).toMatch(/^multipart\/form-data; boundary=/);
+    expect(request?.files).toHaveLength(1);
+    expect(request?.files[0]).toMatchObject({
+      filename: 'sample-report45.pdf',
+      contentType: 'application/pdf',
+      prefix: '%PDF-1.4',
+    });
+    expect(request?.files[0].sizeBytes).toBeGreaterThan(100);
+
+    expect(result.metadata?.multipart).toMatchObject({
+      fields: [{ field: 'documentQuery', value: 'Give summary of the file' }],
+      files: [
+        {
+          field: 'files',
+          filename: 'sample-report45.pdf',
+          contentType: 'application/pdf',
+          source: 'generated',
+        },
+      ],
+    });
+    expect(result.metadata?.multipart.files[0]).not.toHaveProperty('sha256');
+    expect(JSON.stringify(result.metadata)).not.toContain('Benign generated report');
+  });
+});

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1857,6 +1857,43 @@ describe('HttpProvider', () => {
     );
   });
 
+  it('should bypass fetch cache when sending structured multipart requests', async () => {
+    const provider = new HttpProvider(mockUrl, {
+      config: {
+        multipart: {
+          parts: [
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+      },
+    });
+    const mockResponse = {
+      data: JSON.stringify({ result: 'success' }),
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    };
+    vi.mocked(fetchWithCache).mockResolvedValueOnce(mockResponse);
+
+    await provider.callApi('test prompt');
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      mockUrl,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+      }),
+      expect.any(Number),
+      'text',
+      true,
+      undefined,
+    );
+  });
+
   it('should default to application/x-www-form-urlencoded for content-type if body is not an object', async () => {
     const provider = new HttpProvider(mockUrl, {
       config: {


### PR DESCRIPTION
## Summary
- add structured `multipart.parts` support to the HTTP provider
- support multipart text fields, local file uploads, and deterministic generated PDF/PNG/JPEG document parts
- document multipart HTTP config and add real multipart mock-server coverage

## Validation
- `npx vitest run test/providers/http-multipart.test.ts test/providers/http.test.ts --sequence.shuffle=false`
- `npm run l` (passes; existing `src/providers/http.ts` complexity warnings remain)
- `npx prettier --check site/docs/providers/http.md`
- targeted `httpMultipart.ts` TS6 check passed

## Notes
- Structured multipart requests intentionally bypass HTTP response cache for now.
- Full repo `tsc` was not authoritative in my temporary worktree because it used symlinked deps from an older promptfoo checkout; unrelated provider/SDK/XLSX type errors appear before this change.