### PR TITLE
fix(elevenlabs): Disable implicit retries for POST calls

### DIFF
--- a/src/providers/elevenlabs/client.ts
+++ b/src/providers/elevenlabs/client.ts
@@ -63,7 +63,7 @@ export class ElevenLabsClient {
 
     const { headers: optionsHeaders, allowRetriesForNonIdempotent, ...restOptions } = options || {};
     const headers = toPlainHeaders(optionsHeaders);
-    const hasIdempotencyKey = Object.hasOwn(headers, 'idempotency-key');
+    const hasIdempotencyKey = 'idempotency-key' in headers;
     const effectiveRetries = allowRetriesForNonIdempotent || hasIdempotencyKey ? this.retries : 0;
 
     for (let attempt = 0; attempt <= effectiveRetries; attempt++) {

--- a/src/providers/elevenlabs/client.ts
+++ b/src/providers/elevenlabs/client.ts
@@ -26,6 +26,10 @@ function toPlainHeaders(headers?: HeadersInit): Record<string, string> {
   ) as Record<string, string>;
 }
 
+interface ElevenLabsPostOptions extends RequestInit {
+  allowRetriesForNonIdempotent?: boolean;
+}
+
 /**
  * HTTP client for ElevenLabs API with automatic retries, rate limiting, and error handling
  */
@@ -45,7 +49,7 @@ export class ElevenLabsClient {
   /**
    * Make a POST request to the ElevenLabs API
    */
-  async post<T>(endpoint: string, body: any, options?: RequestInit): Promise<T> {
+  async post<T>(endpoint: string, body: any, options?: ElevenLabsPostOptions): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     logger.debug('[ElevenLabs Client] POST request', {
@@ -57,10 +61,12 @@ export class ElevenLabsClient {
 
     let lastError: Error | null = null;
 
-    const { headers: optionsHeaders, ...restOptions } = options || {};
+    const { headers: optionsHeaders, allowRetriesForNonIdempotent, ...restOptions } = options || {};
     const headers = toPlainHeaders(optionsHeaders);
+    const hasIdempotencyKey = Object.hasOwn(headers, 'idempotency-key');
+    const effectiveRetries = allowRetriesForNonIdempotent || hasIdempotencyKey ? this.retries : 0;
 
-    for (let attempt = 0; attempt <= this.retries; attempt++) {
+    for (let attempt = 0; attempt <= effectiveRetries; attempt++) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeout);
@@ -87,7 +93,7 @@ export class ElevenLabsClient {
         clearTimeout(timeoutId);
 
         if (!response.ok) {
-          await this.handleErrorResponse(response, attempt, this.retries);
+          await this.handleErrorResponse(response, attempt, effectiveRetries);
           continue;
         }
 
@@ -116,10 +122,10 @@ export class ElevenLabsClient {
           throw error;
         }
 
-        if (attempt < this.retries) {
+        if (attempt < effectiveRetries) {
           const backoffMs = Math.pow(2, attempt) * 1000;
           logger.debug(
-            `[ElevenLabs Client] Retry ${attempt + 1}/${this.retries} after ${backoffMs}ms`,
+            `[ElevenLabs Client] Retry ${attempt + 1}/${effectiveRetries} after ${backoffMs}ms`,
           );
           await new Promise((resolve) => setTimeout(resolve, backoffMs));
         }

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -145,26 +145,14 @@ describe('ElevenLabsClient', () => {
       await vi.runAllTimersAsync();
       const error = await promise;
       expect(error).toBeInstanceOf(ElevenLabsRateLimitError);
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('should retry on network error', async () => {
-      mockFetch
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          headers: new Headers({ 'content-type': 'application/json' }),
-          json: async () => ({ success: true }),
-        } as Response);
+    it('should make one attempt by default on network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
-      const promise = client.post<{ success: boolean }>('/test', {});
-      await vi.runAllTimersAsync();
-      const result = await promise;
-
-      expect(result).toEqual({ success: true });
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      await expect(client.post<{ success: boolean }>('/test', {})).rejects.toThrow('Network error');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('should make one attempt when retries is set to 0', async () => {
@@ -177,6 +165,29 @@ describe('ElevenLabsClient', () => {
 
       await expect(zeroRetryClient.post('/test', {})).rejects.toThrow('Network error');
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry non-idempotent POSTs only when explicitly allowed', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({ success: true }),
+        } as Response);
+
+      const promise = client.post<{ success: boolean }>(
+        '/test',
+        {},
+        { allowRetriesForNonIdempotent: true },
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it('should throw ElevenLabsAPIError on 500', async () => {

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -190,6 +190,26 @@ describe('ElevenLabsClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
+    it('should retry POSTs when an idempotency-key header is present', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ success: true }),
+      } as Response);
+
+      const promise = client.post<{ success: boolean }>(
+        '/test',
+        {},
+        { headers: { 'Idempotency-Key': 'req-123' } },
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('should throw ElevenLabsAPIError on 500 without retrying', async () => {
       const errorResponse = {
         ok: false,

--- a/test/providers/elevenlabs/client.test.ts
+++ b/test/providers/elevenlabs/client.test.ts
@@ -190,8 +190,7 @@ describe('ElevenLabsClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
-    it('should throw ElevenLabsAPIError on 500', async () => {
-      // Mock all retry attempts (retries: 2 means 3 total attempts)
+    it('should throw ElevenLabsAPIError on 500 without retrying', async () => {
       const errorResponse = {
         ok: false,
         status: 500,
@@ -204,7 +203,7 @@ describe('ElevenLabsClient', () => {
       await vi.runAllTimersAsync();
       const error = await promise;
       expect(error).toBeInstanceOf(ElevenLabsAPIError);
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- stop the shared ElevenLabs client from silently retrying POST calls that can create duplicate side effects
- preserve the explicit zero-retry behavior across agents, STT, and TTS providers
- keep the redteam probe limit fixture aligned with the refreshed branch base

## Verification
- `npx vitest run test/providers/elevenlabs/client.test.ts test/providers/elevenlabs/agents/index.test.ts test/providers/elevenlabs/stt/index.test.ts test/providers/elevenlabs/tts/index.test.ts test/util/redteamProbeLimit.test.ts`
