### PR TITLE
fix(providers): preserve explicit zero values in Mistral, AI21, and Azure Assistant config

### DIFF
--- a/src/providers/ai21.ts
+++ b/src/providers/ai21.ts
@@ -143,7 +143,7 @@ export class AI21ChatCompletionProvider implements ApiProvider {
       model: this.modelName,
       messages,
       temperature: config?.temperature ?? 0.1,
-      top_p: config?.top_p || 1,
+      top_p: config?.top_p ?? 1,
       max_tokens: config?.max_tokens ?? 1024,
       n: 1,
       stop: [],

--- a/src/providers/azure/assistant.ts
+++ b/src/providers/azure/assistant.ts
@@ -366,7 +366,7 @@ export class AzureAssistantProvider extends AzureGenericProvider {
    */
   private async makeRequest<T>(url: string, options: RequestInit): Promise<T> {
     const timeoutMs = this.assistantConfig.timeoutMs || REQUEST_TIMEOUT_MS;
-    const retries = this.assistantConfig.retryOptions?.maxRetries || 4;
+    const retries = this.assistantConfig.retryOptions?.maxRetries ?? 4;
 
     // These operations should never be cached
     const shouldBustCache =

--- a/src/providers/azure/assistant.ts
+++ b/src/providers/azure/assistant.ts
@@ -365,7 +365,7 @@ export class AzureAssistantProvider extends AzureGenericProvider {
    * Helper method to make HTTP requests using fetchWithCache
    */
   private async makeRequest<T>(url: string, options: RequestInit): Promise<T> {
-    const timeoutMs = this.assistantConfig.timeoutMs || REQUEST_TIMEOUT_MS;
+    const timeoutMs = this.assistantConfig.timeoutMs ?? REQUEST_TIMEOUT_MS;
     const retries = this.assistantConfig.retryOptions?.maxRetries ?? 4;
 
     // These operations should never be cached

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -322,10 +322,10 @@ export class MistralChatCompletionProvider implements ApiProvider {
       model: this.modelName,
       messages,
       temperature: config?.temperature,
-      top_p: config?.top_p || 1,
-      max_tokens: config?.max_tokens || 1024,
+      top_p: config?.top_p ?? 1,
+      max_tokens: config?.max_tokens ?? 1024,
       safe_prompt: config?.safe_prompt || false,
-      random_seed: config?.random_seed || null,
+      random_seed: config?.random_seed ?? null,
       ...(hasTools ? { tools: loadedTools } : {}),
       ...(config?.tool_choice ? { tool_choice: config.tool_choice } : {}),
       ...('parallel_tool_calls' in config

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -324,7 +324,7 @@ export class MistralChatCompletionProvider implements ApiProvider {
       temperature: config?.temperature,
       top_p: config?.top_p ?? 1,
       max_tokens: config?.max_tokens ?? 1024,
-      safe_prompt: config?.safe_prompt || false,
+      safe_prompt: config?.safe_prompt ?? false,
       random_seed: config?.random_seed ?? null,
       ...(hasTools ? { tools: loadedTools } : {}),
       ...(config?.tool_choice ? { tool_choice: config.tool_choice } : {}),

--- a/test/providers/ai21.test.ts
+++ b/test/providers/ai21.test.ts
@@ -118,6 +118,30 @@ describe('AI21ChatCompletionProvider', () => {
     });
   });
 
+  it('should preserve explicit zero for top_p', async () => {
+    const mockResponse = {
+      data: {
+        choices: [{ message: { content: 'test response' } }],
+        usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    };
+
+    vi.mocked(fetchWithCache).mockResolvedValue(mockResponse);
+
+    const provider = new AI21ChatCompletionProvider('jamba-1.5-mini', {
+      config: { apiKey: 'test-key', top_p: 0 },
+    });
+
+    await provider.callApi('test prompt');
+
+    const callArgs = vi.mocked(fetchWithCache).mock.calls[0]!;
+    const body = JSON.parse((callArgs[1] as RequestInit).body as string);
+    expect(body.top_p).toBe(0);
+  });
+
   it('should handle API error response', async () => {
     const mockResponse = {
       data: {

--- a/test/providers/azure/assistant.test.ts
+++ b/test/providers/azure/assistant.test.ts
@@ -1130,6 +1130,42 @@ describe('Azure Assistant Provider', () => {
       );
     });
 
+    it('should preserve explicit zero for maxRetries and timeoutMs', async () => {
+      const zeroRetryProvider = new AzureAssistantProvider('test-deployment', {
+        config: {
+          apiKey: 'test-key',
+          apiHost: 'test.azure.com',
+          timeoutMs: 0,
+          retryOptions: { maxRetries: 0 },
+        },
+      });
+      (zeroRetryProvider as any).authHeaders = { 'api-key': 'test-key' };
+      (zeroRetryProvider as any).makeRequest = AzureAssistantProvider.prototype['makeRequest'];
+      vi.spyOn(zeroRetryProvider as any, 'getHeaders').mockResolvedValue({
+        'Content-Type': 'application/json',
+        'api-key': 'test-key',
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: { success: true },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      });
+
+      await (zeroRetryProvider as any).makeRequest('https://test.url', {
+        method: 'POST',
+      });
+
+      const callArgs = vi.mocked(fetchWithCache).mock.calls[0];
+      // fetchWithCache(url, options, timeoutMs, 'json', shouldBustCache, retries)
+      const timeoutMs = callArgs[2];
+      const retries = callArgs[5];
+      expect(timeoutMs).toBe(0);
+      expect(retries).toBe(0);
+    });
+
     it('should handle JSON parsing errors', async () => {
       vi.mocked(fetchWithCache).mockRejectedValueOnce(
         new Error('Failed to parse response as JSON: Invalid JSON'),

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -149,9 +149,9 @@ describe('Mistral', () => {
       });
     });
 
-    it('should preserve explicit zero for top_p and random_seed', async () => {
+    it('should preserve explicit zero for top_p, random_seed, and max_tokens', async () => {
       const zeroProvider = new MistralChatCompletionProvider('mistral-tiny', {
-        config: { top_p: 0, random_seed: 0 },
+        config: { top_p: 0, random_seed: 0, max_tokens: 0 },
       });
       vi.spyOn(zeroProvider, 'getApiKey').mockReturnValue('fake-api-key');
 
@@ -172,6 +172,7 @@ describe('Mistral', () => {
       const body = JSON.parse((callArgs[1] as RequestInit).body as string);
       expect(body.top_p).toBe(0);
       expect(body.random_seed).toBe(0);
+      expect(body.max_tokens).toBe(0);
     });
 
     it('should include tools configuration in the request body', async () => {

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -149,6 +149,31 @@ describe('Mistral', () => {
       });
     });
 
+    it('should preserve explicit zero for top_p and random_seed', async () => {
+      const zeroProvider = new MistralChatCompletionProvider('mistral-tiny', {
+        config: { top_p: 0, random_seed: 0 },
+      });
+      vi.spyOn(zeroProvider, 'getApiKey').mockReturnValue('fake-api-key');
+
+      const mockResponse = {
+        choices: [{ message: { content: 'Test output' } }],
+        usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+      };
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: mockResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await zeroProvider.callApi('Test prompt');
+
+      const callArgs = vi.mocked(fetchWithCache).mock.calls[0];
+      const body = JSON.parse((callArgs[1] as RequestInit).body as string);
+      expect(body.top_p).toBe(0);
+      expect(body.random_seed).toBe(0);
+    });
+
     it('should include tools configuration in the request body', async () => {
       const tools = [
         {


### PR DESCRIPTION
Fixes the same class of bug addressed in #8358 (ElevenLabs), #8128 (Replicate), and #8163 (Anthropic/LocalAI) — but in three providers that were missed.

## Problem

Several numeric configuration parameters use `||` instead of `??`, which silently replaces explicit zero values with defaults:

- **Mistral**: `top_p: 0`, `random_seed: 0`, `max_tokens: 0` all get overridden
- **AI21**: `top_p: 0` gets overridden (notably, `temperature` on the adjacent line already uses `??` correctly)
- **Azure Assistant**: `maxRetries: 0` gets overridden to 4, so users can't disable retries

For example, setting `random_seed: 0` for reproducible generation silently becomes `random_seed: null`. Setting `maxRetries: 0` to disable retries silently becomes 4 retries.

## Fix

Replace `||` with `??` (nullish coalescing) so zero values are preserved. `??` only falls back when the value is `null` or `undefined`, not when it's `0` or `false`.

## What was checked

- `npm run tsc` — clean
- `npx vitest run test/providers/mistral.test.ts` — 24 passed
- `npx vitest run test/providers/ai21.test.ts` — 14 passed
- `npx biome check` on changed files — only pre-existing complexity warnings