### PR TITLE
fix(assertions): handle inverse flag in finish-reason handler

### DIFF
--- a/src/assertions/finishReason.ts
+++ b/src/assertions/finishReason.ts
@@ -4,6 +4,7 @@ import type { AssertionParams, GradingResult } from '../types/index';
 
 export function handleFinishReason({
   assertion,
+  inverse = false,
   renderedValue,
   providerResponse,
 }: AssertionParams): GradingResult {
@@ -11,10 +12,11 @@ export function handleFinishReason({
   invariant(typeof value === 'string', '"finish-reason" assertion type must have a string value');
 
   if (!providerResponse.finishReason) {
+    const pass = !!inverse;
     return {
-      pass: false,
-      score: 0,
-      reason: 'Provider did not supply stop/finish reason',
+      pass,
+      score: pass ? 1 : 0,
+      reason: pass ? 'Assertion passed' : 'Provider did not supply stop/finish reason',
       assertion,
     };
   }
@@ -22,14 +24,14 @@ export function handleFinishReason({
   // Case-insensitive comparison to be more user-friendly
   const normalizedValue = value.toLowerCase();
   const normalizedFinishReason = providerResponse.finishReason.toLowerCase();
-  const pass = normalizedValue === normalizedFinishReason;
+  const pass = (normalizedValue === normalizedFinishReason) !== inverse;
 
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Expected finish reason "${value}" but got "${providerResponse.finishReason}"`,
+      : `Expected finish reason ${inverse ? 'not ' : ''}"${value}" but got "${providerResponse.finishReason}"`,
     assertion,
   };
 }

--- a/test/assertions/finishReason.test.ts
+++ b/test/assertions/finishReason.test.ts
@@ -120,4 +120,40 @@ describe('finishReason assertion', () => {
     expect(result.pass).toBe(true);
     expect(result.score).toBe(1);
   });
+
+  it('should invert result when inverse is true (not-finish-reason)', () => {
+    const params: Partial<AssertionParams> = {
+      assertion: { type: 'not-finish-reason' as any, value: 'stop' },
+      inverse: true,
+      providerResponse: { finishReason: 'stop' },
+    };
+
+    const result = handleFinishReason(params as AssertionParams);
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('should pass when inverse is true and finish reason does not match', () => {
+    const params: Partial<AssertionParams> = {
+      assertion: { type: 'not-finish-reason' as any, value: 'stop' },
+      inverse: true,
+      providerResponse: { finishReason: 'length' },
+    };
+
+    const result = handleFinishReason(params as AssertionParams);
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1);
+  });
+
+  it('should pass when inverse is true and provider has no finish reason', () => {
+    const params: Partial<AssertionParams> = {
+      assertion: { type: 'not-finish-reason' as any, value: 'stop' },
+      inverse: true,
+      providerResponse: {},
+    };
+
+    const result = handleFinishReason(params as AssertionParams);
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1);
+  });
 });


### PR DESCRIPTION
\`handleFinishReason\` did not destructure or use the \`inverse\` parameter from \`AssertionParams\`, so \`not-finish-reason\` assertions always produced the same result as \`finish-reason\` — the negation was silently dropped.

Same bug class as #8238 (crossSessionLeak) and #8485 (not-javascript), both recently merged.

**Before:** \`not-finish-reason: stop\` with actual finish reason \`"stop"\` → incorrectly passes (should fail)
**After:** correctly fails, because the match is inverted

**Changes:**
- Destructure \`inverse\` with default \`false\` in \`handleFinishReason\`
- Apply \`!== inverse\` to the comparison result (same pattern as \`handleRegex\`, \`handleIsSql\`, etc.)
- Handle the missing-finishReason early return with \`inverse\` awareness
- Adjust failure message to include "not" when inverted

**Validation:**
- \`npx vitest run test/assertions/finishReason.test.ts\` — 13/13 passed
- \`npx @biomejs/biome check src/assertions/finishReason.ts test/assertions/finishReason.test.ts\` — clean