### PR TITLE
fix(assertions): resolve search-rubric web providers

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -2018,13 +2018,28 @@ export async function matchesSearchRubric(
 
   // Search rubric assertion is like llm-rubric but with web search capabilities
   const defaultProviders = await getDefaultProviders();
+  const defaultSearchProviders = [
+    defaultProviders.webSearchProvider,
+    defaultProviders.llmRubricProvider,
+    defaultProviders.gradingProvider,
+  ];
+  const configuredProvider = grading.provider
+    ? await getGradingProvider('text', grading.provider, null)
+    : null;
 
   // Get a provider with web search capabilities
   let searchProvider =
-    grading.provider ||
-    defaultProviders.webSearchProvider ||
-    defaultProviders.llmRubricProvider ||
-    defaultProviders.gradingProvider;
+    configuredProvider || defaultSearchProviders.find((provider) => Boolean(provider));
+
+  // Prefer a known web-search default over a configured/default text grader that lacks search.
+  if (!hasWebSearchCapability(searchProvider)) {
+    const webSearchDefault = defaultSearchProviders.find((provider) =>
+      hasWebSearchCapability(provider),
+    );
+    if (webSearchDefault) {
+      searchProvider = webSearchDefault;
+    }
+  }
 
   // Check if current provider has web search, if not try to load one
   if (!hasWebSearchCapability(searchProvider)) {

--- a/src/providers/webSearchUtils.ts
+++ b/src/providers/webSearchUtils.ts
@@ -12,18 +12,7 @@ function hasTool(
 
 function isOpenAiResponsesProvider(provider: ApiProvider, id: string): boolean {
   return (
-    id.includes('openai:responses') ||
-    provider.constructor?.name === 'OpenAiResponsesProvider' ||
-    (id.startsWith('openai:') &&
-      !id.startsWith('openai:chat:') &&
-      !id.startsWith('openai:completion:') &&
-      !id.startsWith('openai:assistant:') &&
-      !id.startsWith('openai:embedding:') &&
-      !id.startsWith('openai:image:') &&
-      !id.startsWith('openai:moderation:') &&
-      !id.startsWith('openai:realtime:') &&
-      !id.startsWith('openai:transcription:') &&
-      !id.startsWith('openai:video:'))
+    id.includes('openai:responses') || provider.constructor?.name === 'OpenAiResponsesProvider'
   );
 }
 

--- a/src/providers/webSearchUtils.ts
+++ b/src/providers/webSearchUtils.ts
@@ -10,6 +10,19 @@ function hasTool(
   return Array.isArray(provider.config?.tools) && provider.config.tools.some(predicate);
 }
 
+function getProviderId(provider: ApiProvider): string | null {
+  if (typeof provider.id !== 'function') {
+    return null;
+  }
+
+  try {
+    return provider.id();
+  } catch (err) {
+    logger.debug(`Failed to read provider id: ${err}`);
+    return null;
+  }
+}
+
 function isOpenAiResponsesProvider(provider: ApiProvider, id: string): boolean {
   return (
     id.includes('openai:responses') || provider.constructor?.name === 'OpenAiResponsesProvider'
@@ -26,11 +39,10 @@ export function hasWebSearchCapability(provider: ApiProvider | null | undefined)
     return false;
   }
 
-  if (typeof provider.id !== 'function') {
+  const id = getProviderId(provider);
+  if (!id) {
     return false;
   }
-
-  const id = provider.id();
 
   // Perplexity has built-in web search
   if (id.includes('perplexity')) {
@@ -197,11 +209,13 @@ export async function loadWebSearchProvider(
   for (const getProvider of providers) {
     const provider = await getProvider();
     if (provider && hasWebSearchCapability(provider)) {
-      logger.info(`Using ${provider.id()} as web search provider`);
+      logger.info(`Using ${getProviderId(provider) ?? 'loaded provider'} as web search provider`);
       return provider;
     }
     if (provider) {
-      logger.debug(`Loaded provider ${provider.id()} does not support web search`);
+      logger.debug(
+        `Loaded provider ${getProviderId(provider) ?? 'unknown'} does not support web search`,
+      );
     }
   }
 

--- a/src/providers/webSearchUtils.ts
+++ b/src/providers/webSearchUtils.ts
@@ -3,6 +3,30 @@ import { loadApiProvider } from '../providers/index';
 
 import type { ApiProvider } from '../types/index';
 
+function hasTool(
+  provider: ApiProvider,
+  predicate: (tool: Record<string, unknown>) => boolean,
+): boolean {
+  return Array.isArray(provider.config?.tools) && provider.config.tools.some(predicate);
+}
+
+function isOpenAiResponsesProvider(provider: ApiProvider, id: string): boolean {
+  return (
+    id.includes('openai:responses') ||
+    provider.constructor?.name === 'OpenAiResponsesProvider' ||
+    (id.startsWith('openai:') &&
+      !id.startsWith('openai:chat:') &&
+      !id.startsWith('openai:completion:') &&
+      !id.startsWith('openai:assistant:') &&
+      !id.startsWith('openai:embedding:') &&
+      !id.startsWith('openai:image:') &&
+      !id.startsWith('openai:moderation:') &&
+      !id.startsWith('openai:realtime:') &&
+      !id.startsWith('openai:transcription:') &&
+      !id.startsWith('openai:video:'))
+  );
+}
+
 /**
  * Check if a provider has web search capabilities
  * @param provider The provider to check
@@ -12,6 +36,11 @@ export function hasWebSearchCapability(provider: ApiProvider | null | undefined)
   if (!provider) {
     return false;
   }
+
+  if (typeof provider.id !== 'function') {
+    return false;
+  }
+
   const id = provider.id();
 
   // Perplexity has built-in web search
@@ -22,7 +51,7 @@ export function hasWebSearchCapability(provider: ApiProvider | null | undefined)
   // Check for Google/Gemini with search tools
   if (
     (id.includes('google') || id.includes('gemini') || id.includes('vertex')) &&
-    provider.config?.tools?.some((t: any) => t.googleSearch !== undefined)
+    hasTool(provider, (t) => t.googleSearch !== undefined)
   ) {
     return true;
   }
@@ -34,8 +63,8 @@ export function hasWebSearchCapability(provider: ApiProvider | null | undefined)
 
   // Check for OpenAI responses API with web_search_preview tool
   if (
-    id.includes('openai:responses') &&
-    provider.config?.tools?.some((t: any) => t.type === 'web_search_preview')
+    isOpenAiResponsesProvider(provider, id) &&
+    hasTool(provider, (t) => t.type === 'web_search_preview')
   ) {
     return true;
   }
@@ -51,10 +80,7 @@ export function hasWebSearchCapability(provider: ApiProvider | null | undefined)
   }
 
   // Check for Anthropic with web_search tool
-  if (
-    id.includes('anthropic') &&
-    provider.config?.tools?.some((t: any) => t.type === 'web_search_20250305')
-  ) {
+  if (id.includes('anthropic') && hasTool(provider, (t) => t.type === 'web_search_20250305')) {
     return true;
   }
 
@@ -181,9 +207,12 @@ export async function loadWebSearchProvider(
 
   for (const getProvider of providers) {
     const provider = await getProvider();
-    if (provider) {
+    if (provider && hasWebSearchCapability(provider)) {
       logger.info(`Using ${provider.id()} as web search provider`);
       return provider;
+    }
+    if (provider) {
+      logger.debug(`Loaded provider ${provider.id()} does not support web search`);
     }
   }
 

--- a/test/matchers/search-rubric.test.ts
+++ b/test/matchers/search-rubric.test.ts
@@ -56,9 +56,8 @@ describe('matchesSearchRubric', () => {
       provider: 'openai:responses:gpt-5.4-2026-03-05',
     });
 
-    expect(mocks.loadApiProvider).toHaveBeenCalledWith('openai:responses:gpt-5.4-2026-03-05', {
-      basePath: undefined,
-    });
+    expect(mocks.loadApiProvider).toHaveBeenCalled();
+    expect(mocks.loadApiProvider.mock.calls[0][0]).toBe('openai:responses:gpt-5.4-2026-03-05');
     expect(mocks.configuredProvider.callApi).not.toHaveBeenCalled();
     expect(mocks.webSearchProvider.callApi).toHaveBeenCalledTimes(1);
     expect(result).toEqual(

--- a/test/matchers/search-rubric.test.ts
+++ b/test/matchers/search-rubric.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiProvider, ProviderResponse } from '../../src/types/index';
+
+const mocks = vi.hoisted(() => {
+  const configuredProvider: ApiProvider = {
+    id: () => 'openai:gpt-4o',
+    config: {},
+    callApi: vi.fn(async (): Promise<ProviderResponse> => ({ output: 'should not be used' })),
+  };
+  const webSearchProvider = {
+    id: () => 'openai:gpt-5.4-2026-03-05',
+    constructor: { name: 'OpenAiResponsesProvider' },
+    config: {
+      tools: [{ type: 'web_search_preview' }],
+    },
+    callApi: vi.fn(
+      async (): Promise<ProviderResponse> => ({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'web search ok' }),
+        tokenUsage: { total: 5, prompt: 3, completion: 2 },
+      }),
+    ),
+  } as unknown as ApiProvider;
+
+  return {
+    configuredProvider,
+    loadApiProvider: vi.fn(),
+    getDefaultProviders: vi.fn(),
+    webSearchProvider,
+  };
+});
+
+vi.mock('../../src/providers/index', () => ({
+  loadApiProvider: mocks.loadApiProvider,
+}));
+
+vi.mock('../../src/providers/defaults', () => ({
+  getDefaultProviders: mocks.getDefaultProviders,
+}));
+
+describe('matchesSearchRubric', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.loadApiProvider.mockResolvedValue(mocks.configuredProvider);
+    mocks.getDefaultProviders.mockResolvedValue({
+      webSearchProvider: mocks.webSearchProvider,
+      llmRubricProvider: null,
+      gradingProvider: null,
+    });
+  });
+
+  it('resolves string grading providers before checking web search capability', async () => {
+    const { matchesSearchRubric } = await import('../../src/matchers');
+
+    const result = await matchesSearchRubric('Confirm current facts', 'output', {
+      provider: 'openai:responses:gpt-5.4-2026-03-05',
+    });
+
+    expect(mocks.loadApiProvider).toHaveBeenCalledWith('openai:responses:gpt-5.4-2026-03-05', {
+      basePath: undefined,
+    });
+    expect(mocks.configuredProvider.callApi).not.toHaveBeenCalled();
+    expect(mocks.webSearchProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        pass: true,
+        score: 1,
+        reason: 'web search ok',
+      }),
+    );
+  });
+});

--- a/test/providers/webSearchUtils.test.ts
+++ b/test/providers/webSearchUtils.test.ts
@@ -135,6 +135,17 @@ describe('webSearchUtils', () => {
       expect(hasWebSearchCapability(provider)).toBe(true);
     });
 
+    it('should return false for a generic OpenAI provider whose id omits the responses prefix', () => {
+      const provider: Partial<ApiProvider> = {
+        id: () => 'openai:gpt-4.1',
+        config: {
+          tools: [{ type: 'web_search_preview' }],
+        },
+      };
+
+      expect(hasWebSearchCapability(provider as ApiProvider)).toBe(false);
+    });
+
     it('should return true for Codex SDK with live web search enabled', () => {
       const provider: Partial<ApiProvider> = {
         id: () => 'openai:codex-sdk',

--- a/test/providers/webSearchUtils.test.ts
+++ b/test/providers/webSearchUtils.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadApiProvider } from '../../src/providers/index';
+import { OpenAiResponsesProvider } from '../../src/providers/openai/responses';
 import { hasWebSearchCapability, loadWebSearchProvider } from '../../src/providers/webSearchUtils';
 
 import type { ApiProvider } from '../../src/types/index';
@@ -32,6 +33,13 @@ describe('webSearchUtils', () => {
 
     it('should return false for undefined provider', () => {
       expect(hasWebSearchCapability(undefined)).toBe(false);
+    });
+
+    it('should return false for provider-like values without an id function', () => {
+      expect(hasWebSearchCapability('openai:responses:gpt-5.4-2026-03-05' as any)).toBe(false);
+      expect(hasWebSearchCapability({ id: 'openai:responses:gpt-5.4-2026-03-05' } as any)).toBe(
+        false,
+      );
     });
 
     it('should return true for Perplexity provider', () => {
@@ -114,6 +122,17 @@ describe('webSearchUtils', () => {
         },
       };
       expect(hasWebSearchCapability(provider as ApiProvider)).toBe(true);
+    });
+
+    it('should return true for a real OpenAI Responses provider whose id omits the responses prefix', () => {
+      const provider = new OpenAiResponsesProvider('gpt-5.4-2026-03-05', {
+        config: {
+          tools: [{ type: 'web_search_preview' }],
+        },
+      });
+
+      expect(provider.id()).toBe('openai:gpt-5.4-2026-03-05');
+      expect(hasWebSearchCapability(provider)).toBe(true);
     });
 
     it('should return true for Codex SDK with live web search enabled', () => {
@@ -232,6 +251,20 @@ describe('webSearchUtils', () => {
 
   describe('loadWebSearchProvider', () => {
     const mockLoadApiProvider = vi.mocked(loadApiProvider);
+    const mockAnthropicWebSearchProvider = (): Partial<ApiProvider> => ({
+      id: () => 'anthropic:messages:claude-opus-4-6',
+      config: {
+        tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }],
+      },
+    });
+    const mockOpenAiWebSearchProvider = (): Partial<ApiProvider> =>
+      ({
+        id: () => 'openai:gpt-5.4-2026-03-05',
+        constructor: { name: 'OpenAiResponsesProvider' },
+        config: {
+          tools: [{ type: 'web_search_preview' }],
+        },
+      }) as any;
 
     it('should return null when no providers can be loaded', async () => {
       mockLoadApiProvider.mockRejectedValue(new Error('API key not found'));
@@ -242,9 +275,7 @@ describe('webSearchUtils', () => {
     });
 
     it('should load Anthropic provider first when preferAnthropic is true', async () => {
-      const mockProvider: Partial<ApiProvider> = {
-        id: () => 'anthropic:messages:claude-opus-4-6',
-      };
+      const mockProvider = mockAnthropicWebSearchProvider();
       mockLoadApiProvider.mockResolvedValueOnce(mockProvider as ApiProvider);
 
       const result = await loadWebSearchProvider(true);
@@ -265,9 +296,7 @@ describe('webSearchUtils', () => {
     });
 
     it('should load OpenAI provider first when preferAnthropic is false', async () => {
-      const mockProvider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.4-2026-03-05',
-      };
+      const mockProvider = mockOpenAiWebSearchProvider();
       mockLoadApiProvider.mockResolvedValueOnce(mockProvider as ApiProvider);
 
       const result = await loadWebSearchProvider(false);
@@ -288,9 +317,7 @@ describe('webSearchUtils', () => {
     });
 
     it('should fallback to next provider when first fails', async () => {
-      const mockProvider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.4-2026-03-05',
-      };
+      const mockProvider = mockOpenAiWebSearchProvider();
       mockLoadApiProvider
         .mockRejectedValueOnce(new Error('Anthropic API key not found'))
         .mockResolvedValueOnce(mockProvider as ApiProvider);
@@ -381,9 +408,7 @@ describe('webSearchUtils', () => {
     });
 
     it('should use default value (false) for preferAnthropic parameter', async () => {
-      const mockProvider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.4-2026-03-05',
-      };
+      const mockProvider = mockOpenAiWebSearchProvider();
       mockLoadApiProvider.mockResolvedValueOnce(mockProvider as ApiProvider);
 
       await loadWebSearchProvider();

--- a/test/providers/webSearchUtils.test.ts
+++ b/test/providers/webSearchUtils.test.ts
@@ -42,6 +42,19 @@ describe('webSearchUtils', () => {
       );
     });
 
+    it('should return false when a provider id function throws', () => {
+      const provider: Partial<ApiProvider> = {
+        id: () => {
+          throw new Error('bad provider id');
+        },
+        config: {
+          tools: [{ type: 'web_search_preview' }],
+        },
+      };
+
+      expect(hasWebSearchCapability(provider as ApiProvider)).toBe(false);
+    });
+
     it('should return true for Perplexity provider', () => {
       const provider: Partial<ApiProvider> = {
         id: () => 'perplexity:sonar-pro',
@@ -281,6 +294,24 @@ describe('webSearchUtils', () => {
       mockLoadApiProvider.mockRejectedValue(new Error('API key not found'));
 
       const result = await loadWebSearchProvider();
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip loaded providers whose id function throws', async () => {
+      const malformedProvider: Partial<ApiProvider> = {
+        id: () => {
+          throw new Error('bad provider id');
+        },
+        config: {
+          tools: [{ type: 'web_search_preview' }],
+        },
+      };
+      mockLoadApiProvider
+        .mockResolvedValueOnce(malformedProvider as ApiProvider)
+        .mockRejectedValue(new Error('API key not found'));
+
+      const result = await loadWebSearchProvider(false);
 
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Summary

Fix `search-rubric` web-search provider selection so OpenAI Responses providers loaded through `openai:responses:*` are recognized after construction, even when their runtime provider id is `openai:<model>`.

Also resolve configured grader provider strings before checking web-search capability, preventing raw strings in `test.options.provider` / `defaultTest.options.provider` from reaching `hasWebSearchCapability()` and throwing `provider.id is not a function`.

## Root Cause

`loadApiProvider('openai:responses:gpt-5.4-2026-03-05')` returns an `OpenAiResponsesProvider` whose public id is `openai:gpt-5.4-2026-03-05`. The prior capability check required `id.includes('openai:responses')`, so the default OpenAI web-search grader was skipped and `search-rubric` could fall through to another provider such as Anthropic.

## Validation

- `npx vitest run test/providers/webSearchUtils.test.ts test/matchers/search-rubric.test.ts test/assertions/searchRubric.test.ts`
- `npx vitest run test/providers/webSearchUtils.test.ts test/matchers/search-rubric.test.ts test/assertions/searchRubric.test.ts test/providers/openai/responses.test.ts test/providers/openai/defaults.test.ts test/providers/defaults.test.ts`
- `npm run tsc`
- `npm run build`
- Real eval: `PROMPTFOO_DISABLE_SHARING=true npm run local -- eval -c /tmp/promptfoo-release-audit-search-rubric.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache --no-share --max-concurrency 1 -o /tmp/promptfoo-release-audit-search-rubric-fixed.json`
- Real eval: `PROMPTFOO_DISABLE_SHARING=true npm run local -- eval -c /tmp/promptfoo-release-audit-search-rubric-openai-explicit.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache --no-share --max-concurrency 1 -o /tmp/promptfoo-release-audit-search-rubric-openai-explicit-fixed.json`
