### PR TITLE
fix(assertions): preserve nested metric weights

### DIFF
--- a/src/assertions/assertionsResult.ts
+++ b/src/assertions/assertionsResult.ts
@@ -112,8 +112,12 @@ export class AssertionsResult {
     if (result.namedScores) {
       Object.entries(result.namedScores).forEach(([metricName, score]) => {
         if (metricName !== metric) {
-          this.namedScores[metricName] = (this.namedScores[metricName] || 0) + score * weight;
-          this.namedScoreWeights[metricName] = (this.namedScoreWeights[metricName] || 0) + weight;
+          const incomingWeight = result.namedScoreWeights?.[metricName] ?? 1;
+          const weightedIncomingWeight = incomingWeight * weight;
+          this.namedScores[metricName] =
+            (this.namedScores[metricName] || 0) + score * weightedIncomingWeight;
+          this.namedScoreWeights[metricName] =
+            (this.namedScoreWeights[metricName] || 0) + weightedIncomingWeight;
         }
       });
     }

--- a/test/assertions/assertionsResult.test.ts
+++ b/test/assertions/assertionsResult.test.ts
@@ -365,6 +365,61 @@ describe('AssertionsResult', () => {
         safety: 0,
       });
     });
+
+    it('should preserve nested namedScoreWeights when merging child named scores', async () => {
+      const assertionsResult = new AssertionsResult({});
+
+      assertionsResult.addResult({
+        index: 0,
+        result: {
+          pass: false,
+          score: 0.75,
+          reason: 'Nested assertion set partially failed',
+          tokensUsed: DEFAULT_TOKENS_USED,
+          namedScores: {
+            accuracy: 0.75,
+          },
+          namedScoreWeights: {
+            accuracy: 4,
+          },
+        },
+      });
+
+      const result = await assertionsResult.testResult();
+
+      expect(result.namedScores!['accuracy']).toBeCloseTo(0.75);
+      expect(result.namedScoreWeights).toEqual({
+        accuracy: 4,
+      });
+    });
+
+    it('should scale nested namedScoreWeights by parent assertion weight', async () => {
+      const assertionsResult = new AssertionsResult({});
+
+      assertionsResult.addResult({
+        index: 0,
+        result: {
+          pass: true,
+          score: 0.75,
+          reason: 'Nested assertion set passed',
+          tokensUsed: DEFAULT_TOKENS_USED,
+          namedScores: {
+            accuracy: 0.75,
+          },
+          namedScoreWeights: {
+            accuracy: 4,
+          },
+        },
+        weight: 2,
+      });
+
+      const result = await assertionsResult.testResult();
+
+      expect(result.namedScores!['accuracy']).toBeCloseTo(0.75);
+      expect(result.namedScoreWeights).toEqual({
+        accuracy: 8,
+      });
+    });
   });
 
   describe('parentAssertionSet', () => {

--- a/test/assertions/runAssertions.test.ts
+++ b/test/assertions/runAssertions.test.ts
@@ -376,6 +376,45 @@ describe('runAssertions', () => {
       });
     });
 
+    it('preserves child metric weights inside assert-set', async () => {
+      const output = 'Expected output';
+      const test: AtomicTestCase = {
+        assert: [
+          {
+            type: 'assert-set',
+            assert: [
+              {
+                type: 'equals',
+                value: 'Expected output',
+                metric: 'Accuracy',
+                weight: 3,
+              },
+              {
+                type: 'equals',
+                value: 'Nope',
+                metric: 'Accuracy',
+                weight: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result: GradingResult = await runAssertions({
+        prompt,
+        provider,
+        test,
+        providerResponse: { output },
+      });
+
+      expect(result.namedScores).toEqual({
+        Accuracy: 0.75,
+      });
+      expect(result.namedScoreWeights).toEqual({
+        Accuracy: 4,
+      });
+    });
+
     it('uses assert-set weight', async () => {
       const output = 'Expected';
       const test: AtomicTestCase = {


### PR DESCRIPTION
## Summary

- Preserve child `namedScoreWeights` when an assertion result with named scores is merged into a parent `AssertionsResult`
- Scale nested metric denominators by the parent assertion weight, matching how nested named-score numerators are aggregated
- Add regression coverage for both direct `AssertionsResult` merging and real `assert-set` execution

## Why

The release audit found that weighted named metrics inside an `assert-set` could report an incorrect named metric score. A child assertion set with metric weights like 3 and 1 produced the correct child score of 0.75, but the parent merge treated the child named metric denominator as weight 1. This could inflate or deflate named metric summaries used for release gates.

## QA

- `npx vitest run test/assertions/assertionsResult.test.ts test/assertions/runAssertions.test.ts test/evaluator.test.ts`
- `PROMPTFOO_DISABLE_SHARING=true npm run local -- eval -c /tmp/promptfoo-release-audit-weighted-assert-set.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache --no-share -o /tmp/promptfoo-release-audit-weighted-assert-set-fixed.json`
  - Expected exit code `100` because the eval intentionally contains one failing assertion
  - Verified output JSON reports `gradingResult.namedScores.Accuracy = 0.75`
  - Verified output JSON reports `gradingResult.namedScoreWeights.Accuracy = 4`
- `npm run tsc`
- `npx vitest run test/util/namedMetrics.test.ts test/assertions/assertionsResult.test.ts test/assertions/runAssertions.test.ts test/evaluator.test.ts`
- `npm run build`
- `npm run l && npm run f`

