### PR TITLE
feat(assertions): add temperature field to llm-rubric and grading config

### DIFF
--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 import Clone from 'rfdc';
 import cliState from '../cliState';
 import { importModule } from '../esm';
-import { type Assertion, type TestCase } from '../types/index';
+import { type Assertion, type ProviderOptions, type TestCase } from '../types/index';
 
 const clone = Clone();
 
@@ -31,7 +31,37 @@ export function getFinalTest(test: TestCase, assertion: Assertion) {
   if (test.provider) {
     ret.provider = test.provider;
   }
-  ret.options.provider = assertion.provider || test?.options?.provider;
+
+  const provider = assertion.provider || test?.options?.provider;
+  const temperature = assertion.temperature ?? test?.options?.temperature;
+
+  // If temperature is specified, inject it into the provider options
+  if (temperature !== undefined && provider !== undefined) {
+    if (typeof provider === 'string') {
+      // Convert string provider to ProviderOptions so temperature can be set
+      ret.options.provider = { id: provider, config: { temperature } } as ProviderOptions;
+    } else if (
+      typeof provider === 'object' &&
+      !Array.isArray(provider) &&
+      'id' in (provider as object)
+    ) {
+      // ProviderOptions — assertion temperature is the default; explicit config.temperature wins
+      const po = provider as ProviderOptions;
+      ret.options.provider = {
+        ...po,
+        config: { temperature, ...(po.config || {}) },
+      } as ProviderOptions;
+    } else {
+      ret.options.provider = provider;
+    }
+  } else {
+    ret.options.provider = provider;
+  }
+
+  if (temperature !== undefined) {
+    ret.options.temperature = temperature;
+  }
+
   ret.options.rubricPrompt = assertion.rubricPrompt || ret.options.rubricPrompt;
   return Object.freeze(ret);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,6 +147,7 @@ export const GradingConfigSchema = z.object({
       differButFactual: z.number().optional(),
     })
     .optional(),
+  temperature: z.number().optional(),
 });
 
 export type GradingConfig = z.infer<typeof GradingConfigSchema>;
@@ -653,6 +654,10 @@ export const AssertionSchema = z.object({
 
   // Override the grading rubric
   rubricPrompt: z.custom<GradingConfig['rubricPrompt']>().optional(),
+
+  // Override the temperature for LLM-based assertions (llm-rubric, g-eval, etc.)
+  // Defaults to 0 for deterministic grading when provider is a string or ProviderOptions
+  temperature: z.number().optional(),
 
   // Tag this assertion result as a named metric
   metric: z.string().optional(),

--- a/test/assertions/utils.test.ts
+++ b/test/assertions/utils.test.ts
@@ -220,6 +220,85 @@ describe('getFinalTest', () => {
     expect(result.provider).toBe(directProvider);
     expect(result.options?.provider).toBe(assertionProvider);
   });
+
+  it('should convert string provider to ProviderOptions when temperature is set on assertion', () => {
+    const testCase: TestCase = { vars: {} };
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+      provider: 'openai:gpt-4o-mini',
+      temperature: 0.5,
+    };
+
+    const result = getFinalTest(testCase, assertion);
+    const provider = result.options?.provider as { id: string; config: { temperature: number } };
+    expect(provider).toEqual({ id: 'openai:gpt-4o-mini', config: { temperature: 0.5 } });
+    expect(result.options?.temperature).toBe(0.5);
+  });
+
+  it('should merge assertion temperature into ProviderOptions without overriding explicit config.temperature', () => {
+    const testCase: TestCase = { vars: {} };
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+      provider: { id: 'openai:gpt-4o-mini', config: { temperature: 0.9 } },
+      temperature: 0.1,
+    };
+
+    const result = getFinalTest(testCase, assertion);
+    const provider = result.options?.provider as { id: string; config: { temperature: number } };
+    // Explicit config.temperature (0.9) takes precedence over assertion.temperature (0.1)
+    expect(provider.config.temperature).toBe(0.9);
+    expect(result.options?.temperature).toBe(0.1);
+  });
+
+  it('should apply assertion temperature as default when ProviderOptions has no explicit temperature', () => {
+    const testCase: TestCase = { vars: {} };
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+      provider: { id: 'openai:gpt-4o-mini', config: { max_tokens: 100 } },
+      temperature: 0,
+    };
+
+    const result = getFinalTest(testCase, assertion);
+    const provider = result.options?.provider as {
+      id: string;
+      config: { temperature: number; max_tokens: number };
+    };
+    expect(provider.config.temperature).toBe(0);
+    expect(provider.config.max_tokens).toBe(100);
+  });
+
+  it('should inherit temperature from test options when assertion does not specify one', () => {
+    const testCase: TestCase = {
+      vars: {},
+      options: { temperature: 0, provider: 'openai:gpt-4o-mini' },
+    };
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+    };
+
+    const result = getFinalTest(testCase, assertion);
+    const provider = result.options?.provider as { id: string; config: { temperature: number } };
+    expect(provider.config.temperature).toBe(0);
+    expect(result.options?.temperature).toBe(0);
+  });
+
+  it('should not modify provider when temperature is undefined', () => {
+    const testCase: TestCase = { vars: {} };
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+      provider: 'openai:gpt-4o-mini',
+    };
+
+    const result = getFinalTest(testCase, assertion);
+    // Without temperature, string provider stays as string
+    expect(result.options?.provider).toBe('openai:gpt-4o-mini');
+    expect(result.options?.temperature).toBeUndefined();
+  });
 });
 
 describe('loadFromJavaScriptFile', () => {


### PR DESCRIPTION
Fixes #8175

## Problem

Users who want deterministic grading with LLM-judge assertions need to wrap their provider in a full config object just to set temperature. This is verbose and easy to forget.

## Solution

Add a `temperature` field directly to `AssertionSchema` and `GradingConfig`, so users can write:

```yaml
assert:
  - type: llm-rubric
    value: Is not apologetic
    provider: openai:gpt-4o-mini
    temperature: 0
```

When `temperature` is set on an assertion, `getFinalTest` injects it into the provider options. For string providers it converts them to ProviderOptions; for existing ProviderOptions it acts as a default (explicit config.temperature still wins).

## Testing

Added 5 new unit tests covering all provider-merging cases.