### PR TITLE
test(webui): scope frontend browser mocks

### DIFF
--- a/src/app/src/components/Navigation.test.tsx
+++ b/src/app/src/components/Navigation.test.tsx
@@ -5,13 +5,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Navigation from './Navigation';
 
-// Mock ResizeObserver for Radix NavigationMenu
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
-
 // Helper function to render Navigation with all required providers
 const renderNavigation = (
   props: { onToggleDarkMode?: () => void } = {},

--- a/src/app/src/components/PageShell.test.tsx
+++ b/src/app/src/components/PageShell.test.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { mockMatchMedia } from '@app/tests/browserMocks';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -69,20 +70,7 @@ describe('PageShell', () => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
 
-    // Mock matchMedia
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
+    mockMatchMedia();
   });
 
   afterEach(() => {
@@ -118,19 +106,7 @@ describe('PageShell', () => {
   });
 
   it('should start in dark mode when system preference is dark', async () => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query.includes('dark'),
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
+    mockMatchMedia({ matches: (query) => query.includes('dark') });
 
     renderPageShell();
     await waitFor(() => {

--- a/src/app/src/components/PostHogPageViewTracker.test.tsx
+++ b/src/app/src/components/PostHogPageViewTracker.test.tsx
@@ -1,6 +1,7 @@
+import { mockWindowLocation } from '@app/tests/browserMocks';
 import { render } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePostHog } from './PostHogContext';
 import { PostHogPageViewTracker } from './PostHogPageViewTracker';
 
@@ -24,26 +25,13 @@ describe('PostHogPageViewTracker', () => {
     capture: vi.fn(),
   };
 
-  const originalWindowLocation = window.location;
-
   beforeEach(() => {
     vi.clearAllMocks();
-
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...originalWindowLocation, href: '' },
-    });
+    mockWindowLocation({ href: '' });
 
     mockedUsePostHog.mockReturnValue({
       posthog: mockPostHog as any,
       isInitialized: true,
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: originalWindowLocation,
     });
   });
 

--- a/src/app/src/components/ui/copy-button.test.tsx
+++ b/src/app/src/components/ui/copy-button.test.tsx
@@ -1,3 +1,4 @@
+import { mockClipboard } from '@app/tests/browserMocks';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -5,18 +6,10 @@ import { CopyButton } from './copy-button';
 
 describe('CopyButton', () => {
   beforeEach(() => {
-    // Set up a working clipboard API for most tests
-    Object.defineProperty(navigator, 'clipboard', {
-      value: {
-        writeText: vi.fn().mockResolvedValue(undefined),
-      },
-      writable: true,
-      configurable: true,
-    });
+    mockClipboard();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/src/app/src/hooks/useDownloadEval.test.ts
+++ b/src/app/src/hooks/useDownloadEval.test.ts
@@ -1,3 +1,4 @@
+import { mockBrowserProperty } from '@app/tests/browserMocks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadBlob } from './useDownloadEval';
 
@@ -11,8 +12,8 @@ describe('downloadBlob', () => {
     revokeObjectURLMock.mockClear();
     clickMock.mockClear();
 
-    global.URL.createObjectURL = createObjectURLMock;
-    global.URL.revokeObjectURL = revokeObjectURLMock;
+    mockBrowserProperty(URL, 'createObjectURL', createObjectURLMock as typeof URL.createObjectURL);
+    mockBrowserProperty(URL, 'revokeObjectURL', revokeObjectURLMock as typeof URL.revokeObjectURL);
 
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickMock);
 

--- a/src/app/src/hooks/useIsPrinting.spec.ts
+++ b/src/app/src/hooks/useIsPrinting.spec.ts
@@ -1,3 +1,4 @@
+import { mockBrowserProperty } from '@app/tests/browserMocks';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useIsPrinting } from './useIsPrinting';
@@ -17,17 +18,20 @@ describe('useIsPrinting', () => {
       removeEventListener: vi.fn(),
     };
 
-    // Mock window.matchMedia
-    window.matchMedia = vi.fn().mockImplementation((query: string) => {
-      if (query === 'print') {
-        return mockMediaQueryList;
-      }
-      return {
-        matches: false,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      };
-    });
+    mockBrowserProperty(
+      window,
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => {
+        if (query === 'print') {
+          return mockMediaQueryList;
+        }
+        return {
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        };
+      }) as typeof window.matchMedia,
+    );
   });
 
   it('should return false when not in print mode', () => {

--- a/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
+++ b/src/app/src/pages/eval-creator/components/YamlEditor.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { mockClipboard, mockObjectUrl } from '@app/tests/browserMocks';
 import { fireEvent, render, screen } from '@testing-library/react';
 import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -35,13 +36,6 @@ vi.mock('@app/stores/evalConfig', () => ({
   })),
 }));
 
-Object.defineProperty(navigator, 'clipboard', {
-  value: {
-    writeText: vi.fn().mockResolvedValue(undefined),
-  },
-  configurable: true,
-});
-
 // Mock the editor component to avoid prism.js issues
 vi.mock('react-simple-code-editor', () => ({
   default: ({ value, onValueChange, disabled }: any) => (
@@ -73,8 +67,8 @@ vi.mock('@mui/icons-material/Upload', () => ({
 describe('YamlEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.URL.createObjectURL = vi.fn(() => 'blob:yaml-editor-test');
-    global.URL.revokeObjectURL = vi.fn();
+    mockClipboard();
+    mockObjectUrl('blob:yaml-editor-test');
 
     // Reset mock to default return value
     mockGetTestSuite.mockReturnValue({

--- a/src/app/src/pages/eval/components/ConfigModal.test.tsx
+++ b/src/app/src/pages/eval/components/ConfigModal.test.tsx
@@ -1,3 +1,4 @@
+import { mockDocumentExecCommand, mockObjectUrl } from '@app/tests/browserMocks';
 import { renderWithProviders } from '@app/utils/testutils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import yaml from 'js-yaml';
@@ -25,12 +26,8 @@ describe('ConfigModal', () => {
       config: sampleConfig,
     } as ReturnType<typeof useTableStore>);
 
-    // Mock document.execCommand
-    document.execCommand = vi.fn();
-
-    // Mock URL.createObjectURL and URL.revokeObjectURL
-    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
-    global.URL.revokeObjectURL = vi.fn();
+    mockDocumentExecCommand();
+    mockObjectUrl('blob:mock-url');
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
   });
 

--- a/src/app/src/pages/eval/components/DownloadMenu.test.tsx
+++ b/src/app/src/pages/eval/components/DownloadMenu.test.tsx
@@ -1,3 +1,4 @@
+import { mockBrowserProperty, mockClipboard, mockObjectUrl } from '@app/tests/browserMocks';
 import { renderWithProviders } from '@app/utils/testutils';
 import { screen } from '@testing-library/dom';
 import { waitFor } from '@testing-library/react';
@@ -15,13 +16,6 @@ function renderDownloadDialog() {
 
 // Get a reference to the mock
 const showToastMock = vi.fn();
-
-// Mock clipboard API
-Object.assign(navigator, {
-  clipboard: {
-    writeText: vi.fn().mockImplementation(() => Promise.resolve()),
-  },
-});
 
 vi.mock('./store', () => ({
   useTableStore: vi.fn(),
@@ -71,14 +65,6 @@ vi.mock('js-yaml', () => ({
   dump: yamlDumpMock,
 }));
 
-global.URL.createObjectURL = vi.fn(() => 'mocked-blob-url');
-global.URL.revokeObjectURL = vi.fn();
-
-Object.defineProperty(global.navigator, 'msSaveOrOpenBlob', {
-  value: vi.fn(),
-  writable: true,
-});
-
 describe('DownloadMenu', () => {
   const mockTable = {
     head: {
@@ -113,6 +99,9 @@ describe('DownloadMenu', () => {
     jsonIsLoading = false;
     csvHookOptions = undefined;
     jsonHookOptions = undefined;
+    mockClipboard();
+    mockObjectUrl('mocked-blob-url');
+    mockBrowserProperty(global.navigator, 'msSaveOrOpenBlob', vi.fn());
 
     yamlDumpMock.mockClear();
     yamlDumpMock.mockReturnValue('mocked yaml');

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -1,3 +1,4 @@
+import { mockClipboard } from '@app/tests/browserMocks';
 import { renderWithProviders as baseRender } from '@app/utils/testutils';
 import {
   type AssertionType,
@@ -53,27 +54,13 @@ const resetMockStoreState = () => {
 };
 
 const mockClipboardWriteText = () => {
-  const originalClipboard = navigator.clipboard;
-  const mockClipboard = {
+  const clipboard = {
     writeText: vi.fn().mockResolvedValue(undefined),
   };
 
-  Object.defineProperty(navigator, 'clipboard', {
-    value: mockClipboard,
-    configurable: true,
-    writable: true,
-  });
+  mockClipboard({ writeText: clipboard.writeText as Clipboard['writeText'] });
 
-  return {
-    mockClipboard,
-    restore: () => {
-      Object.defineProperty(navigator, 'clipboard', {
-        value: originalClipboard,
-        configurable: true,
-        writable: true,
-      });
-    },
-  };
+  return clipboard;
 };
 
 vi.mock('./store', () => ({
@@ -700,29 +687,25 @@ describe('EvalOutputCell', () => {
   });
 
   it('allows copying row link to clipboard', async () => {
-    const { mockClipboard, restore } = mockClipboardWriteText();
+    const mockClipboard = mockClipboardWriteText();
     const expectedUrl = new URL(window.location.href);
     expectedUrl.searchParams.set('rowId', '1');
 
-    try {
-      renderWithProviders(<EvalOutputCell {...defaultProps} />);
+    renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-      const shareButton = screen.getByLabelText('Copy link to output');
-      expect(shareButton).toBeInTheDocument();
+    const shareButton = screen.getByLabelText('Copy link to output');
+    expect(shareButton).toBeInTheDocument();
 
-      fireEvent.click(shareButton);
+    fireEvent.click(shareButton);
 
-      await waitFor(() => {
-        expect(mockClipboard.writeText).toHaveBeenCalledWith(expectedUrl.toString());
-      });
-    } finally {
-      restore();
-    }
+    await waitFor(() => {
+      expect(mockClipboard.writeText).toHaveBeenCalledWith(expectedUrl.toString());
+    });
   });
 
   it('shows checkmark after copying link', async () => {
     vi.useFakeTimers();
-    const { mockClipboard, restore } = mockClipboardWriteText();
+    const mockClipboard = mockClipboardWriteText();
 
     try {
       renderWithProviders(<EvalOutputCell {...defaultProps} />);
@@ -744,14 +727,13 @@ describe('EvalOutputCell', () => {
 
       expect(shareButton.querySelector('.lucide-link')).toBeInTheDocument();
     } finally {
-      restore();
       vi.useRealTimers();
     }
   });
 
   it('clears the link feedback timer on unmount after copying link', async () => {
     vi.useFakeTimers();
-    const { mockClipboard, restore } = mockClipboardWriteText();
+    const mockClipboard = mockClipboardWriteText();
 
     try {
       const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
@@ -767,33 +749,27 @@ describe('EvalOutputCell', () => {
 
       expect(vi.getTimerCount()).toBe(0);
     } finally {
-      restore();
       vi.useRealTimers();
     }
   });
 
   it('does not schedule link feedback after unmount if clipboard resolves late', async () => {
     vi.useFakeTimers();
-    const originalClipboard = navigator.clipboard;
     let resolveClipboardWrite: () => void = () => {};
     const writeTextPromise = new Promise<void>((resolve) => {
       resolveClipboardWrite = resolve;
     });
-    const mockClipboard = {
+    const clipboard = {
       writeText: vi.fn().mockReturnValue(writeTextPromise),
     };
 
-    Object.defineProperty(navigator, 'clipboard', {
-      value: mockClipboard,
-      configurable: true,
-      writable: true,
-    });
+    mockClipboard({ writeText: clipboard.writeText as Clipboard['writeText'] });
 
     try {
       const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
       fireEvent.click(screen.getByRole('button', { name: /Copy link to output/i }));
-      expect(mockClipboard.writeText).toHaveBeenCalled();
+      expect(clipboard.writeText).toHaveBeenCalled();
 
       unmount();
 
@@ -804,11 +780,6 @@ describe('EvalOutputCell', () => {
 
       expect(vi.getTimerCount()).toBe(0);
     } finally {
-      Object.defineProperty(navigator, 'clipboard', {
-        value: originalClipboard,
-        configurable: true,
-        writable: true,
-      });
       vi.useRealTimers();
     }
   });

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -1,5 +1,6 @@
 import * as ReactDOM from 'react-dom/client';
 
+import { mockClipboard } from '@app/tests/browserMocks';
 import { renderWithProviders } from '@app/utils/testutils';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -77,20 +78,12 @@ const defaultProps = {
 };
 
 describe('EvalOutputPromptDialog', () => {
-  let originalClipboardDescriptor: PropertyDescriptor | undefined;
-
   beforeEach(() => {
-    originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
     vi.clearAllMocks();
     // Note: Do NOT use vi.useFakeTimers() here - it breaks component rendering
   });
 
   afterEach(() => {
-    if (originalClipboardDescriptor) {
-      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
-    } else {
-      Reflect.deleteProperty(navigator, 'clipboard');
-    }
     vi.clearAllMocks();
   });
 
@@ -165,13 +158,10 @@ describe('EvalOutputPromptDialog', () => {
   });
 
   it('copies prompt to clipboard when copy button is clicked', async () => {
-    const mockClipboard = {
+    const clipboard = {
       writeText: vi.fn().mockResolvedValue(undefined),
     };
-    Object.defineProperty(navigator, 'clipboard', {
-      value: mockClipboard,
-      configurable: true,
-    });
+    mockClipboard({ writeText: clipboard.writeText as Clipboard['writeText'] });
 
     renderWithProviders(<EvalOutputPromptDialog {...defaultProps} />);
 
@@ -188,7 +178,7 @@ describe('EvalOutputPromptDialog', () => {
     expect(copyButton).toBeInTheDocument();
     await userEvent.click(copyButton);
 
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('Test prompt');
+    expect(clipboard.writeText).toHaveBeenCalledWith('Test prompt');
     // Wait for Check icon to appear after state update (use document.body because Sheet uses portals)
     await waitFor(() => {
       expect(document.body.querySelector('svg.lucide-check')).toBeInTheDocument();
@@ -196,13 +186,10 @@ describe('EvalOutputPromptDialog', () => {
   });
 
   it('copies assertion value to clipboard when copy button is clicked', async () => {
-    const mockClipboard = {
+    const clipboard = {
       writeText: vi.fn().mockResolvedValue(undefined),
     };
-    Object.defineProperty(navigator, 'clipboard', {
-      value: mockClipboard,
-      configurable: true,
-    });
+    mockClipboard({ writeText: clipboard.writeText as Clipboard['writeText'] });
 
     renderWithProviders(<EvalOutputPromptDialog {...defaultProps} />);
 
@@ -220,7 +207,7 @@ describe('EvalOutputPromptDialog', () => {
     const copyButton = screen.getByLabelText('Copy assertion value 0');
     await userEvent.click(copyButton);
 
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('expected value');
+    expect(clipboard.writeText).toHaveBeenCalledWith('expected value');
     // Wait for Check icon to appear after state update (use document.body because Sheet uses portals)
     await waitFor(() => {
       expect(document.body.querySelector('svg.lucide-check')).toBeInTheDocument();

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -2005,6 +2005,34 @@ describe('ResultsTable Non-Numeric Input Handling', () => {
 });
 
 describe('ResultsTable Zoom and Scroll Position', () => {
+  const mockTable = {
+    body: [
+      {
+        outputs: [
+          {
+            pass: true,
+            score: 1,
+            text: 'test output',
+          },
+        ],
+        test: {},
+        vars: [],
+      },
+    ],
+    head: {
+      prompts: [
+        {
+          metrics: {
+            testPassCount: 1,
+            testFailCount: 0,
+          },
+          provider: 'test-provider',
+        },
+      ],
+      vars: [],
+    },
+  };
+
   const defaultProps = {
     columnVisibility: {},
     failureFilter: {},
@@ -2020,6 +2048,28 @@ describe('ResultsTable Zoom and Scroll Position', () => {
     onResultsContainerScroll: vi.fn(),
     atInitialVerticalScrollPosition: true,
   };
+
+  beforeEach(() => {
+    vi.mocked(useTableStore).mockImplementation(() => ({
+      config: {},
+      evalId: '123',
+      inComparisonMode: false,
+      setTable: vi.fn(),
+      table: mockTable,
+      version: 4,
+      renderMarkdown: true,
+      fetchEvalData: vi.fn(),
+      isFetching: false,
+      filteredResultsCount: 1,
+      filters: {
+        values: {},
+        appliedCount: 0,
+        options: {
+          metric: [],
+        },
+      },
+    }));
+  });
 
   it('should maintain scroll position and focused element when zoom changes', () => {
     const { container, rerender } = renderWithProviders(<ResultsTable {...defaultProps} />);

--- a/src/app/src/pages/eval/components/ShareModal.test.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.test.tsx
@@ -1,3 +1,4 @@
+import { mockClipboard, mockDocumentExecCommand, mockWindowOpen } from '@app/tests/browserMocks';
 import { callApi } from '@app/utils/api';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,15 +9,6 @@ import ShareModal from './ShareModal';
 vi.mock('@app/utils/api', () => ({
   callApi: vi.fn(),
 }));
-
-// Mock document.execCommand for copy functionality
-Object.assign(navigator, {
-  clipboard: {
-    writeText: vi.fn(),
-  },
-});
-
-global.document.execCommand = vi.fn();
 
 describe('ShareModal', () => {
   const mockOnClose = vi.fn();
@@ -32,6 +24,8 @@ describe('ShareModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClipboard();
+    mockDocumentExecCommand();
     // Mock successful domain check by default
     mockCallApi.mockResolvedValue(
       Response.json({
@@ -158,9 +152,7 @@ describe('ShareModal', () => {
       }),
     );
 
-    // Mock window.open
-    const mockOpen = vi.fn();
-    vi.stubGlobal('open', mockOpen);
+    const mockOpen = mockWindowOpen();
 
     render(<ShareModal {...defaultProps} />);
 

--- a/src/app/src/pages/eval/components/hooks.test.ts
+++ b/src/app/src/pages/eval/components/hooks.test.ts
@@ -3,7 +3,7 @@ import {
   isPolicyMetric,
 } from '@promptfoo/redteam/plugins/policy/utils';
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   useApplyFilterFromMetric,
   useMetricsGetter,
@@ -1546,6 +1546,12 @@ describe('useMetricsGetter', () => {
 });
 
 describe('useApplyFilterFromMetric', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedIsPolicyMetric.mockReturnValue(false);
+    mockedDeserializePolicyIdFromMetric.mockReturnValue('');
+  });
+
   it('should not call addFilter if an identical filter is already present in filters.values', () => {
     const mockAddFilter = vi.fn();
     const metricName = 'latency';

--- a/src/app/src/pages/launcher/page.test.tsx
+++ b/src/app/src/pages/launcher/page.test.tsx
@@ -1,4 +1,5 @@
 import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
+import { mockMatchMedia as installMatchMedia, mockBrowserProperty } from '@app/tests/browserMocks';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -8,32 +9,13 @@ import type { DefinedUseQueryResult } from '@tanstack/react-query';
 import type { Mock } from 'vitest';
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
 
 const mockLocalStorage = {
   getItem: vi.fn(),
   setItem: vi.fn(),
 };
-Object.defineProperty(window, 'localStorage', {
-  value: mockLocalStorage,
-});
 
-const mockMatchMedia = vi.fn();
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: mockMatchMedia,
-});
-
-mockMatchMedia.mockImplementation((query) => ({
-  matches: false,
-  media: query,
-  onchange: null,
-  addListener: vi.fn(),
-  removeListener: vi.fn(),
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  dispatchEvent: vi.fn(),
-}));
+let mockMatchMedia: ReturnType<typeof installMatchMedia>;
 
 const renderLauncher = () => {
   return render(
@@ -56,17 +38,9 @@ describe('LauncherPage', () => {
     mockFetch.mockReset();
     mockLocalStorage.getItem.mockReset();
     mockLocalStorage.setItem.mockReset();
-    mockMatchMedia.mockReset();
-    mockMatchMedia.mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
+    mockBrowserProperty(globalThis, 'fetch', mockFetch as typeof fetch);
+    mockBrowserProperty(window, 'localStorage', mockLocalStorage as unknown as Storage);
+    mockMatchMedia = installMatchMedia();
   });
 
   afterEach(() => {

--- a/src/app/src/pages/media/Media.test.tsx
+++ b/src/app/src/pages/media/Media.test.tsx
@@ -1,8 +1,9 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { mockIntersectionObserver } from '@app/tests/browserMocks';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MediaItem } from './types';
 
@@ -118,19 +119,7 @@ function mockApiResponses(items: MediaItem[] = mockItems) {
 describe('Media page URL state machine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock IntersectionObserver as a proper class
-    vi.stubGlobal(
-      'IntersectionObserver',
-      class {
-        observe = vi.fn();
-        unobserve = vi.fn();
-        disconnect = vi.fn();
-      },
-    );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
+    mockIntersectionObserver();
   });
 
   it('renders the media grid with items', async () => {

--- a/src/app/src/pages/media/components/MediaCard.test.tsx
+++ b/src/app/src/pages/media/components/MediaCard.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { mockIntersectionObserver, mockMatchMedia } from '@app/tests/browserMocks';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,29 +22,6 @@ vi.mock('@app/utils/media', () => ({
   getKindLabel: (kind: string) => kind.charAt(0).toUpperCase() + kind.slice(1),
   hashToNumber: () => 0,
 }));
-
-// Mock matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(hover: hover)',
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
-
-// Mock IntersectionObserver
-class MockIntersectionObserver {
-  observe = vi.fn();
-  unobserve = vi.fn();
-  disconnect = vi.fn();
-}
-window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
 
 // Wrapper component with providers
 const Wrapper = ({ children }: { children: ReactNode }) => (
@@ -73,6 +51,8 @@ const createMockMediaItem = (overrides: Partial<MediaItem> = {}): MediaItem => (
 describe('MediaCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMatchMedia({ matches: (query) => query === '(hover: hover)' });
+    mockIntersectionObserver();
   });
 
   describe('rendering', () => {

--- a/src/app/src/pages/media/components/MediaGrid.test.tsx
+++ b/src/app/src/pages/media/components/MediaGrid.test.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from 'react';
 
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import {
+  mockBrowserProperty,
+  mockIntersectionObserver,
+  mockMatchMedia,
+} from '@app/tests/browserMocks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -23,41 +28,9 @@ vi.mock('@app/utils/media', () => ({
   MEDIA_INFINITE_SCROLL_MARGIN: 100,
 }));
 
-// Mock matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(hover: hover)',
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
-
-// Mock IntersectionObserver
 const mockObserve = vi.fn();
 const mockDisconnect = vi.fn();
 let intersectionCallback: IntersectionObserverCallback | null = null;
-
-class MockIntersectionObserver {
-  constructor(callback: IntersectionObserverCallback) {
-    intersectionCallback = callback;
-  }
-  observe = mockObserve;
-  unobserve = vi.fn();
-  disconnect = mockDisconnect;
-}
-window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
-
-// Mock window dimensions for getItemsPerRow
-Object.defineProperty(window, 'innerWidth', {
-  writable: true,
-  value: 1280, // xl breakpoint
-});
 
 // Wrapper component with providers
 const Wrapper = ({ children }: { children: ReactNode }) => (
@@ -98,6 +71,15 @@ describe('MediaGrid', () => {
     mockObserve.mockClear();
     mockDisconnect.mockClear();
     intersectionCallback = null;
+    mockMatchMedia({ matches: (query) => query === '(hover: hover)' });
+    mockIntersectionObserver({
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+      onCreate: (callback) => {
+        intersectionCallback = callback;
+      },
+    });
+    mockBrowserProperty(window, 'innerWidth', 1280);
   });
 
   describe('rendering', () => {

--- a/src/app/src/pages/media/components/MediaModal.test.tsx
+++ b/src/app/src/pages/media/components/MediaModal.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { mockMatchMedia } from '@app/tests/browserMocks';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -32,21 +33,6 @@ vi.mock('@app/utils/media', () => ({
 vi.mock('./AudioWaveform', () => ({
   AudioWaveform: () => <div data-testid="audio-waveform" />,
 }));
-
-// Mock matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: query === '(prefers-reduced-motion: reduce)' ? false : query === '(hover: hover)',
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
 
 // Wrapper with router context (required for Link components)
 const Wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
@@ -88,6 +74,10 @@ const createMockItems = (count: number): MediaItem[] =>
 describe('MediaModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMatchMedia({
+      matches: (query) =>
+        query === '(prefers-reduced-motion: reduce)' ? false : query === '(hover: hover)',
+    });
   });
 
   describe('rendering', () => {

--- a/src/app/src/pages/media/hooks/useHoverIntent.test.ts
+++ b/src/app/src/pages/media/hooks/useHoverIntent.test.ts
@@ -1,3 +1,4 @@
+import { mockMatchMedia } from '@app/tests/browserMocks';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHoverIntent } from './useHoverIntent';
@@ -6,20 +7,7 @@ describe('useHoverIntent', () => {
   beforeEach(() => {
     vi.useFakeTimers();
 
-    // Mock matchMedia for hover capability detection
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === '(hover: hover)',
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
+    mockMatchMedia({ matches: (query) => query === '(hover: hover)' });
   });
 
   afterEach(() => {
@@ -177,19 +165,9 @@ describe('useHoverIntent', () => {
 
   describe('prefers-reduced-motion', () => {
     it('should not activate when user prefers reduced motion and respectReducedMotion is true', () => {
-      // Mock reduced motion preference
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        value: vi.fn().mockImplementation((query: string) => ({
-          matches: query === '(prefers-reduced-motion: reduce)' || query === '(hover: hover)',
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
+      mockMatchMedia({
+        matches: (query) =>
+          query === '(prefers-reduced-motion: reduce)' || query === '(hover: hover)',
       });
 
       const { result } = renderHook(() => useHoverIntent({ respectReducedMotion: true }));
@@ -203,19 +181,9 @@ describe('useHoverIntent', () => {
     });
 
     it('should activate when respectReducedMotion is false even with reduced motion preference', () => {
-      // Mock reduced motion preference
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        value: vi.fn().mockImplementation((query: string) => ({
-          matches: query === '(prefers-reduced-motion: reduce)' || query === '(hover: hover)',
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
+      mockMatchMedia({
+        matches: (query) =>
+          query === '(prefers-reduced-motion: reduce)' || query === '(hover: hover)',
       });
 
       const { result } = renderHook(() => useHoverIntent({ respectReducedMotion: false }));
@@ -231,20 +199,7 @@ describe('useHoverIntent', () => {
 
   describe('touch devices', () => {
     it('should not activate on touch-only devices', () => {
-      // Mock no hover capability (touch device)
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        value: vi.fn().mockImplementation((query: string) => ({
-          matches: false, // No hover capability
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
-      });
+      mockMatchMedia();
 
       const { result } = renderHook(() => useHoverIntent());
 

--- a/src/app/src/pages/prompts/PromptDialog.test.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.test.tsx
@@ -1,3 +1,4 @@
+import { mockClipboard } from '@app/tests/browserMocks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -460,7 +461,7 @@ describe('PromptDialog', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const mockWriteText = vi.fn().mockRejectedValue(new Error('Failed to copy'));
-    Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
+    mockClipboard({ writeText: mockWriteText as Clipboard['writeText'] });
 
     render(
       <MemoryRouter>

--- a/src/app/src/pages/redteam/report/components/Report.test.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.test.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { mockWindowLocation } from '@app/tests/browserMocks';
 import { callApi } from '@app/utils/api';
 import { ResultFailureReason } from '@promptfoo/types';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import App from './Report';
 import type { EvaluateResult, GradingResult, ResultsFile } from '@promptfoo/types';
 
@@ -594,25 +595,10 @@ const createComponentMockEvalData = (numPrompts: number, results: EvaluateResult
 
 describe('App component target selection', () => {
   const mockCallApi = callApi as Mock;
-  let originalWindowLocation: Location;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalWindowLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        ...originalWindowLocation,
-        search: '?evalId=test-eval-id',
-      },
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: originalWindowLocation,
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-id' });
   });
 
   it('should handle evalData with empty prompts array and non-zero selectedPromptIndex gracefully', async () => {
@@ -676,25 +662,10 @@ describe('App component target selection', () => {
 
 describe('App component target selector rendering', () => {
   const mockCallApi = callApi as Mock;
-  let originalWindowLocation: Location;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalWindowLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        ...originalWindowLocation,
-        search: '?evalId=test-eval-id',
-      },
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: originalWindowLocation,
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-id' });
   });
 
   it('should render the target selector dropdown when there are multiple prompts', async () => {
@@ -732,25 +703,10 @@ describe('App component target selector rendering', () => {
 
 describe('App component categoryStats calculation with moderation', () => {
   const mockCallApi = callApi as Mock;
-  let originalWindowLocation: Location;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalWindowLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        ...originalWindowLocation,
-        search: '?evalId=test-eval-id',
-      },
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: originalWindowLocation,
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-id' });
   });
 
   it('should correctly increment passWithFilter but not pass when moderation tests fail but other tests pass', async () => {
@@ -795,25 +751,10 @@ describe('App component categoryStats calculation with moderation', () => {
 
 describe('Filter panel regression tests', () => {
   const mockCallApi = callApi as Mock;
-  let originalWindowLocation: Location;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    originalWindowLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        ...originalWindowLocation,
-        search: '?evalId=test-eval-id',
-      },
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: originalWindowLocation,
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-id' });
   });
 
   it('should open filter panel without errors when filter button is clicked', async () => {

--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.test.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { mockWindowOpen } from '@app/tests/browserMocks';
 import { renderWithProviders } from '@app/utils/testutils';
 import { fireEvent, screen } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
@@ -81,8 +82,7 @@ describe('RiskCategoryDrawer Component Navigation', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    // Mock window.open
-    global.window.open = vi.fn();
+    mockWindowOpen();
   });
 
   it('should navigate to eval page when clicking View All Logs button', () => {

--- a/src/app/src/pages/redteam/report/components/SuggestionsDialog.test.tsx
+++ b/src/app/src/pages/redteam/report/components/SuggestionsDialog.test.tsx
@@ -1,3 +1,4 @@
+import { mockClipboard } from '@app/tests/browserMocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import SuggestionsDialog from './SuggestionsDialog';
@@ -115,12 +116,7 @@ describe('SuggestionsDialog', () => {
   it('should show copy button when suggestion is expanded', async () => {
     const mockWriteText = vi.fn().mockResolvedValue(undefined);
 
-    Object.defineProperty(global.navigator, 'clipboard', {
-      value: {
-        writeText: mockWriteText,
-      },
-      writable: true,
-    });
+    mockClipboard({ writeText: mockWriteText as Clipboard['writeText'] });
 
     const mockGradingResult: GradingResult = {
       score: 1,
@@ -160,12 +156,7 @@ describe('SuggestionsDialog', () => {
   it('should handle navigator.clipboard.writeText failure gracefully', async () => {
     const mockWriteText = vi.fn().mockRejectedValue(new Error('Clipboard write failed'));
 
-    Object.defineProperty(global.navigator, 'clipboard', {
-      value: {
-        writeText: mockWriteText,
-      },
-      writable: true,
-    });
+    mockClipboard({ writeText: mockWriteText as Clipboard['writeText'] });
 
     const gradingResult: GradingResult = {
       score: 0,

--- a/src/app/src/pages/redteam/report/components/TestSuites.test.tsx
+++ b/src/app/src/pages/redteam/report/components/TestSuites.test.tsx
@@ -1,3 +1,4 @@
+import { mockObjectUrl, mockWindowLocation } from '@app/tests/browserMocks';
 import { renderWithProviders } from '@app/utils/testutils';
 import { fireEvent, screen } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
@@ -15,7 +16,7 @@ vi.mock('@app/hooks/useTelemetry', () => ({
 }));
 
 function mockCsvDownloadApis() {
-  global.URL.createObjectURL = vi.fn(() => 'blob:test');
+  mockObjectUrl('blob:test');
   vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 }
 
@@ -43,10 +44,7 @@ describe('TestSuites Component', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should render empty state message when categoryStats is empty', () => {
@@ -162,10 +160,7 @@ describe('TestSuites Component Navigation', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should navigate to eval page with correct search params when clicking View logs', () => {
@@ -271,10 +266,7 @@ describe('TestSuites Component Navigation with Missing EvalId', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '' },
-    });
+    mockWindowLocation({ search: '' });
   });
 
   it('should navigate to eval page without evalId when evalId is missing from URL parameters', () => {
@@ -330,10 +322,7 @@ describe('TestSuites Component Filtering', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should filter out subcategories with zero total tests', () => {
@@ -415,10 +404,7 @@ describe('TestSuites Component - Zero Attack Success Rate', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should correctly display 0.00% attack success rate', () => {
@@ -507,10 +493,7 @@ describe('TestSuites Component - Large Filter Object', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should navigate with a large filter object without exceeding URL length limits', () => {
@@ -586,10 +569,7 @@ describe('TestSuites Component Navigation with Special Characters in Plugin ID',
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should navigate to eval page with correctly encoded search params when pluginId contains special characters', () => {
@@ -641,10 +621,7 @@ describe('TestSuites Component - Zero Attack Success Rate Navigation', () => {
     vi.clearAllMocks();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
 
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { search: '?evalId=test-eval-123' },
-    });
+    mockWindowLocation({ search: '?evalId=test-eval-123' });
   });
 
   it('should navigate to eval page with mode=passes when attackSuccessRate is 0', () => {

--- a/src/app/src/pages/redteam/setup/components/CustomIntentPluginSection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/CustomIntentPluginSection.test.tsx
@@ -1,3 +1,4 @@
+import { mockBrowserProperty } from '@app/tests/browserMocks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CustomIntentPluginSection from './CustomIntentPluginSection';
@@ -17,10 +18,6 @@ vi.mock('../hooks/useRedTeamConfig', () => ({
 
 // Mock file reading
 const mockReadAsText = vi.fn();
-Object.defineProperty(global.File.prototype, 'text', {
-  value: mockReadAsText,
-  writable: true,
-});
 
 describe('CustomIntentPluginSection', () => {
   const defaultConfig = {
@@ -42,6 +39,7 @@ describe('CustomIntentPluginSection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBrowserProperty(global.File.prototype, 'text', mockReadAsText);
     mockUseRedTeamConfig.mockReturnValue({
       config: defaultConfig,
       updatePlugins: mockUpdatePlugins,

--- a/src/app/src/pages/redteam/setup/components/LogViewer.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/LogViewer.test.tsx
@@ -1,5 +1,6 @@
+import { mockClipboard } from '@app/tests/browserMocks';
 import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LogViewer } from './LogViewer';
 
 vi.mock('@app/hooks/useToast', () => ({
@@ -8,21 +9,11 @@ vi.mock('@app/hooks/useToast', () => ({
   }),
 }));
 
-Object.defineProperty(navigator, 'clipboard', {
-  value: {
-    writeText: vi.fn().mockResolvedValue(undefined),
-  },
-  configurable: true,
-});
-
-// Mock ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
-
 describe('LogViewer', () => {
+  beforeEach(() => {
+    mockClipboard();
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/src/app/src/pages/redteam/setup/components/PageWrapper.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/PageWrapper.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PageWrapper from './PageWrapper';
 
-vi.spyOn(React, 'useEffect').mockImplementation((f) => f());
-
 describe('PageWrapper', () => {
+  beforeEach(() => {
+    vi.spyOn(React, 'useEffect').mockImplementation((f) => f());
+  });
+
   describe('Header Content', () => {
     it('should render the provided title and description in the header when given appropriate props', () => {
       const testTitle = 'My Test Page';

--- a/src/app/src/pages/redteam/setup/utils/crypto.test.ts
+++ b/src/app/src/pages/redteam/setup/utils/crypto.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { convertStringKeyToPem, validatePrivateKey } from './crypto';
 
 const mockAtob = vi.fn();
+const nativeAtob = globalThis.atob;
 
 describe('crypto utils', () => {
   beforeEach(() => {

--- a/src/app/src/pages/redteam/setup/utils/crypto.test.ts
+++ b/src/app/src/pages/redteam/setup/utils/crypto.test.ts
@@ -1,12 +1,12 @@
+import { mockBrowserProperty } from '@app/tests/browserMocks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { convertStringKeyToPem, validatePrivateKey } from './crypto';
 
 const mockAtob = vi.fn();
-const nativeAtob = globalThis.atob;
 
 describe('crypto utils', () => {
   beforeEach(() => {
-    vi.stubGlobal('atob', mockAtob);
+    mockBrowserProperty(globalThis, 'atob', mockAtob as typeof atob);
     vi.clearAllMocks();
     // Default atob behavior: decode base64
     mockAtob.mockImplementation((str: string) => {
@@ -20,7 +20,7 @@ describe('crypto utils', () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
   describe('convertStringKeyToPem', () => {

--- a/src/app/src/setupTests.ts
+++ b/src/app/src/setupTests.ts
@@ -4,6 +4,7 @@ import { webcrypto } from 'node:crypto';
 
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { afterEach, expect, vi } from 'vitest';
+import { restoreBrowserMocks } from './tests/browserMocks';
 
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();
@@ -204,6 +205,11 @@ afterEach(() => {
   // This is safe to call regardless of timer state
   vi.useRealTimers();
 
-  // Clear all mocks to prevent state leakage between tests
+  // Restore explicit browser mocks and spies so local test doubles cannot leak
+  // across shuffled tests in the same file.
+  restoreBrowserMocks();
+  vi.restoreAllMocks();
+
+  // Clear all mocks to prevent call state leakage between tests.
   vi.clearAllMocks();
 });

--- a/src/app/src/setupTests.ts
+++ b/src/app/src/setupTests.ts
@@ -205,10 +205,11 @@ afterEach(() => {
   // This is safe to call regardless of timer state
   vi.useRealTimers();
 
-  // Restore explicit browser mocks and spies so local test doubles cannot leak
-  // across shuffled tests in the same file.
-  restoreBrowserMocks();
+  // Restore spies before browser property descriptors. If a spy wraps a
+  // mockBrowserProperty value, restoring descriptors first lets the spy put the
+  // mocked value back.
   vi.restoreAllMocks();
+  restoreBrowserMocks();
 
   // Clear all mocks to prevent call state leakage between tests.
   vi.clearAllMocks();

--- a/src/app/src/tests/browserMocks.test.ts
+++ b/src/app/src/tests/browserMocks.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mockBrowserProperty, restoreBrowserMocks } from './browserMocks';
+
+describe('browserMocks', () => {
+  it('restores original properties after spies wrap mocked values', () => {
+    const target = {
+      open: () => 'original',
+    };
+
+    mockBrowserProperty(
+      target,
+      'open',
+      vi.fn(() => 'mocked'),
+    );
+    vi.spyOn(target, 'open').mockImplementation(() => 'spied');
+
+    vi.restoreAllMocks();
+    restoreBrowserMocks();
+
+    expect(target.open()).toBe('original');
+  });
+});

--- a/src/app/src/tests/browserMocks.ts
+++ b/src/app/src/tests/browserMocks.ts
@@ -1,0 +1,143 @@
+import { vi } from 'vitest';
+
+type RestoreBrowserMock = () => void;
+
+const restoreCallbacks: RestoreBrowserMock[] = [];
+
+export function restoreBrowserMocks() {
+  while (restoreCallbacks.length > 0) {
+    restoreCallbacks.pop()?.();
+  }
+}
+
+export function mockBrowserProperty<T extends object, V>(
+  target: T,
+  property: PropertyKey,
+  value: V,
+) {
+  const descriptor = Object.getOwnPropertyDescriptor(target, property);
+
+  Object.defineProperty(target, property, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+
+  const restore = () => {
+    if (descriptor) {
+      Object.defineProperty(target, property, descriptor);
+    } else {
+      Reflect.deleteProperty(target, property);
+    }
+  };
+
+  restoreCallbacks.push(restore);
+
+  return value;
+}
+
+export function mockClipboard(overrides: Partial<Clipboard> = {}) {
+  return mockBrowserProperty(navigator, 'clipboard', {
+    writeText: vi.fn().mockResolvedValue(undefined),
+    readText: vi.fn().mockResolvedValue(''),
+    ...overrides,
+  } as Clipboard);
+}
+
+export function mockDocumentExecCommand() {
+  return mockBrowserProperty(document, 'execCommand', vi.fn());
+}
+
+type MatchMediaOptions = {
+  matches?: boolean | ((query: string) => boolean);
+};
+
+export function mockMatchMedia(options: MatchMediaOptions = {}) {
+  const { matches = false } = options;
+  const getMatches = typeof matches === 'function' ? matches : () => matches;
+  const matchMedia = vi.fn((query: string): MediaQueryList => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    return {
+      matches: getMatches(query),
+      media: query,
+      onchange: null,
+      addListener: vi.fn((listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      }),
+      removeListener: vi.fn((listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      }),
+      addEventListener: vi.fn((_event: string, listener: EventListenerOrEventListenerObject) => {
+        if (typeof listener === 'function') {
+          listeners.add(listener as (event: MediaQueryListEvent) => void);
+        }
+      }),
+      removeEventListener: vi.fn((_event: string, listener: EventListenerOrEventListenerObject) => {
+        if (typeof listener === 'function') {
+          listeners.delete(listener as (event: MediaQueryListEvent) => void);
+        }
+      }),
+      dispatchEvent: vi.fn((event: Event) => {
+        listeners.forEach((listener) => listener(event as MediaQueryListEvent));
+        return true;
+      }),
+    };
+  });
+
+  return mockBrowserProperty(window, 'matchMedia', matchMedia);
+}
+
+type IntersectionObserverMockOptions = {
+  observe?: IntersectionObserver['observe'];
+  unobserve?: IntersectionObserver['unobserve'];
+  disconnect?: IntersectionObserver['disconnect'];
+  onCreate?: (callback: IntersectionObserverCallback) => void;
+};
+
+export function mockIntersectionObserver(options: IntersectionObserverMockOptions = {}) {
+  const MockIntersectionObserver = vi.fn(function (callback: IntersectionObserverCallback) {
+    options.onCreate?.(callback);
+
+    return {
+      root: null,
+      rootMargin: '',
+      thresholds: [],
+      observe: options.observe ?? vi.fn(),
+      unobserve: options.unobserve ?? vi.fn(),
+      disconnect: options.disconnect ?? vi.fn(),
+      takeRecords: vi.fn(() => []),
+    } satisfies IntersectionObserver;
+  });
+
+  return mockBrowserProperty(
+    window,
+    'IntersectionObserver',
+    MockIntersectionObserver as unknown as typeof IntersectionObserver,
+  );
+}
+
+export function mockObjectUrl(url = 'blob:test') {
+  const createObjectURL = vi.fn(() => url);
+  const revokeObjectURL = vi.fn();
+
+  mockBrowserProperty(URL, 'createObjectURL', createObjectURL as typeof URL.createObjectURL);
+  mockBrowserProperty(URL, 'revokeObjectURL', revokeObjectURL as typeof URL.revokeObjectURL);
+
+  return { createObjectURL, revokeObjectURL };
+}
+
+export function mockWindowLocation(value: Partial<Location>) {
+  return mockBrowserProperty(window, 'location', {
+    ...window.location,
+    ...value,
+  } as Location);
+}
+
+export function mockWindowOpen() {
+  return mockBrowserProperty(
+    window,
+    'open',
+    vi.fn(() => null),
+  );
+}

--- a/src/app/src/tests/browserMocks.ts
+++ b/src/app/src/tests/browserMocks.ts
@@ -102,6 +102,7 @@ export function mockIntersectionObserver(options: IntersectionObserverMockOption
     return {
       root: null,
       rootMargin: '',
+      scrollMargin: '',
       thresholds: [],
       observe: options.observe ?? vi.fn(),
       unobserve: options.unobserve ?? vi.fn(),

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -9,6 +9,44 @@ const thisFile = fileURLToPath(import.meta.url);
 const testFilePattern = /\.(?:test|spec)\.(?:ts|tsx)$/;
 const focusedOrSkippedTestPattern =
   /\b(?:describe|it|test|suite)\s*(?:\.\s*\w+\s*)*\.\s*(?:only|skip)\b/;
+const directBrowserMockPatterns = [
+  {
+    pattern: /\bvi\.unstubAllGlobals\s*\(/,
+    message: 'vi.unstubAllGlobals() can remove shared setup globals; use browserMocks helpers',
+  },
+  {
+    pattern: /\bglobal(?:This)?\.fetch\s*=/,
+    message: 'mock fetch with mockBrowserProperty(globalThis, "fetch", ...)',
+  },
+  {
+    pattern: /\bglobal\.window\.open\s*=/,
+    message: 'mock window.open with mockWindowOpen()',
+  },
+  {
+    pattern: /\bwindow\.IntersectionObserver\s*=/,
+    message: 'mock IntersectionObserver with mockIntersectionObserver()',
+  },
+  {
+    pattern: /\bObject\.defineProperty\(\s*window\s*,\s*['"](matchMedia|location)['"]/,
+    message: 'mock window browser APIs with browserMocks helpers',
+  },
+  {
+    pattern: /\bObject\.defineProperty\(\s*(?:global\.)?navigator\s*,\s*['"]clipboard['"]/,
+    message: 'mock clipboard with mockClipboard()',
+  },
+  {
+    pattern: /\bObject\.assign\(\s*navigator\s*,\s*\{\s*clipboard\b/,
+    message: 'mock clipboard with mockClipboard()',
+  },
+  {
+    pattern: /\bglobal\.URL\.(createObjectURL|revokeObjectURL)\s*=/,
+    message: 'mock object URLs with mockObjectUrl() or mockBrowserProperty()',
+  },
+  {
+    pattern: /\bdocument\.execCommand\s*=/,
+    message: 'mock document.execCommand with mockDocumentExecCommand()',
+  },
+];
 
 function findTestFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -57,6 +95,26 @@ describe('test hygiene', () => {
           focusedOrSkippedTestPattern.test(line)
             ? [`${path.relative(srcDir, file)}:${index + 1}: ${line.trim()}`]
             : [],
+        );
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('uses scoped browser mock helpers for global browser APIs', () => {
+    const violations = findTestFiles(srcDir).flatMap((file) => {
+      if (file === thisFile) {
+        return [];
+      }
+
+      return readFileSync(file, 'utf8')
+        .split('\n')
+        .flatMap((line, index) =>
+          directBrowserMockPatterns.flatMap(({ pattern, message }) =>
+            pattern.test(line)
+              ? [`${path.relative(srcDir, file)}:${index + 1}: ${message}: ${line.trim()}`]
+              : [],
+          ),
         );
     });
 

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -19,16 +19,29 @@ const directBrowserMockPatterns = [
     message: 'mock fetch with mockBrowserProperty(globalThis, "fetch", ...)',
   },
   {
-    pattern: /\bglobal\.window\.open\s*=/,
+    pattern: /\bglobalThis\.atob\s*=/,
+    message: 'mock atob with mockBrowserProperty(globalThis, "atob", ...)',
+  },
+  {
+    pattern: /\b(?:global\.)?window\.open\s*=/,
     message: 'mock window.open with mockWindowOpen()',
+  },
+  {
+    pattern: /\bwindow\.matchMedia\s*=/,
+    message: 'mock matchMedia with mockMatchMedia() or mockBrowserProperty()',
   },
   {
     pattern: /\bwindow\.IntersectionObserver\s*=/,
     message: 'mock IntersectionObserver with mockIntersectionObserver()',
   },
   {
-    pattern: /\bObject\.defineProperty\(\s*window\s*,\s*['"](matchMedia|location)['"]/,
+    pattern:
+      /\bObject\.defineProperty\(\s*window\s*,\s*['"](matchMedia|location|open|IntersectionObserver)['"]/,
     message: 'mock window browser APIs with browserMocks helpers',
+  },
+  {
+    pattern: /\bObject\.defineProperty\(\s*globalThis\s*,\s*['"](fetch|atob)['"]/,
+    message: 'mock global browser APIs with mockBrowserProperty()',
   },
   {
     pattern: /\bObject\.defineProperty\(\s*(?:global\.)?navigator\s*,\s*['"]clipboard['"]/,
@@ -39,11 +52,23 @@ const directBrowserMockPatterns = [
     message: 'mock clipboard with mockClipboard()',
   },
   {
-    pattern: /\bglobal\.URL\.(createObjectURL|revokeObjectURL)\s*=/,
+    pattern: /\b(?:global|globalThis)\.URL\.(createObjectURL|revokeObjectURL)\s*=/,
+    message: 'mock object URLs with mockObjectUrl() or mockBrowserProperty()',
+  },
+  {
+    pattern: /\bURL\.(createObjectURL|revokeObjectURL)\s*=/,
+    message: 'mock object URLs with mockObjectUrl() or mockBrowserProperty()',
+  },
+  {
+    pattern: /\bObject\.defineProperty\(\s*URL\s*,\s*['"](createObjectURL|revokeObjectURL)['"]/,
     message: 'mock object URLs with mockObjectUrl() or mockBrowserProperty()',
   },
   {
     pattern: /\bdocument\.execCommand\s*=/,
+    message: 'mock document.execCommand with mockDocumentExecCommand()',
+  },
+  {
+    pattern: /\bObject\.defineProperty\(\s*document\s*,\s*['"]execCommand['"]/,
     message: 'mock document.execCommand with mockDocumentExecCommand()',
   },
 ];

--- a/src/app/src/utils/api.test.ts
+++ b/src/app/src/utils/api.test.ts
@@ -1,3 +1,4 @@
+import { mockBrowserProperty } from '@app/tests/browserMocks';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { callApi, fetchUserEmail, fetchUserId, getApiBaseUrl, updateEvalAuthor } from './api';
 
@@ -12,7 +13,10 @@ import useApiConfig from '@app/stores/apiConfig';
 
 // Mock global fetch
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockBrowserProperty(globalThis, 'fetch', mockFetch as typeof fetch);
+});
 
 // Helper to create mock state with only apiBaseUrl (other fields unused by getApiBaseUrl)
 const mockState = (apiBaseUrl: string) =>


### PR DESCRIPTION
## Summary

This PR stacks on top of #8565 and tightens the next layer of frontend Vitest isolation. It adds shared browser mock helpers for APIs that jsdom does not fully implement or that tests need to override locally, then migrates existing direct global mutations to those scoped helpers.

The main goal is to keep global setup strict: tests can still mock browser APIs such as clipboard, matchMedia, IntersectionObserver, window.location, object URLs, document.execCommand, and window.open, but those mocks now restore through shared cleanup instead of leaking through worker-local globals.

## Changes

- Add `src/app/src/tests/browserMocks.ts` with scoped helpers for common browser API mocks.
- Restore Vitest spies before helper-managed browser descriptors in the frontend global `afterEach`, so spies around helper-installed mocks cannot reapply mocked descriptors during cleanup.
- Add regression coverage for the spy + browser mock cleanup ordering.
- Extend the frontend hygiene test to reject direct global browser mutation patterns that previously made shuffled tests easier to weaken.
- Migrate existing tests from direct `global`, `window`, `navigator`, URL, clipboard, and matchMedia mutations to the helpers.
- Fix two hidden random-order assumptions exposed by stricter cleanup:
  - `ResultsTable` zoom test now provides its own table store fixture.
  - `useApplyFilterFromMetric` tests reset policy metric mocks per test.

## Validation

- `cd src/app && npm run test -- --run src/pages/eval/components/ResultsTable.test.tsx --sequence.shuffle=true --sequence.seed=231020`
- `cd src/app && npm run test -- --run src/pages/eval/components/hooks.test.ts --sequence.shuffle=true --sequence.seed=999999`
- `cd src/app && npm run test -- --run --sequence.shuffle=true --sequence.seed=231020`
- `cd src/app && npm run test -- --run --sequence.shuffle=true --sequence.seed=999999`
- `npm run test --prefix src/app -- --run src/hooks/useIsPrinting.spec.ts src/tests/test-hygiene.test.ts --sequence.shuffle=true --sequence.seed=8567`
- `npm run test --prefix src/app -- --run src/tests/browserMocks.test.ts src/tests/test-hygiene.test.ts src/hooks/useIsPrinting.spec.ts --sequence.shuffle=true --sequence.seed=8567`
- `npm run f`
- `npm run l`
- `npm run tsc --prefix src/app`
- `git diff --check`

`npm run f` and `npm run l` still report the existing non-fatal `ProviderTypeSelector.tsx` cognitive complexity warning from the earlier stack.
