### PR TITLE
test(webui): fix window location browser mock

### DIFF
--- a/src/app/src/components/PostHogPageViewTracker.test.tsx
+++ b/src/app/src/components/PostHogPageViewTracker.test.tsx
@@ -27,7 +27,7 @@ describe('PostHogPageViewTracker', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockWindowLocation({ href: '' });
+    mockWindowLocation({ pathname: '/', search: '', hash: '' });
 
     mockedUsePostHog.mockReturnValue({
       posthog: mockPostHog as any,
@@ -45,13 +45,17 @@ describe('PostHogPageViewTracker', () => {
       unstable_mask: undefined,
     };
     mockedUseLocation.mockReturnValue(initialLocation);
-    window.location.href = `http://localhost${initialLocation.pathname}${initialLocation.search}${initialLocation.hash}`;
+    mockWindowLocation({
+      pathname: initialLocation.pathname,
+      search: initialLocation.search,
+      hash: initialLocation.hash,
+    });
 
     const { rerender } = render(<PostHogPageViewTracker />, { wrapper: MemoryRouter });
 
     expect(mockPostHog.capture).toHaveBeenCalledTimes(1);
     expect(mockPostHog.capture).toHaveBeenCalledWith('$pageview', {
-      $current_url: 'http://localhost/dashboard?filter=active#overview',
+      $current_url: `${window.location.origin}/dashboard?filter=active#overview`,
       pathname: '/dashboard',
       search: '?filter=active',
       hash: '#overview',
@@ -66,13 +70,17 @@ describe('PostHogPageViewTracker', () => {
       unstable_mask: undefined,
     };
     mockedUseLocation.mockReturnValue(newLocation);
-    window.location.href = `http://localhost${newLocation.pathname}`;
+    mockWindowLocation({
+      pathname: newLocation.pathname,
+      search: newLocation.search,
+      hash: newLocation.hash,
+    });
 
     rerender(<PostHogPageViewTracker />);
 
     expect(mockPostHog.capture).toHaveBeenCalledTimes(2);
     expect(mockPostHog.capture).toHaveBeenLastCalledWith('$pageview', {
-      $current_url: 'http://localhost/settings',
+      $current_url: `${window.location.origin}/settings`,
       pathname: '/settings',
       search: '',
       hash: '',

--- a/src/app/src/tests/browserMocks.test.ts
+++ b/src/app/src/tests/browserMocks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mockBrowserProperty, mockIndexedDB, restoreBrowserMocks } from './browserMocks';
+import {
+  mockBrowserProperty,
+  mockIndexedDB,
+  mockWindowLocation,
+  restoreBrowserMocks,
+} from './browserMocks';
 
 describe('browserMocks', () => {
   it('restores original properties after spies wrap mocked values', () => {
@@ -29,5 +34,47 @@ describe('browserMocks', () => {
 
     restoreBrowserMocks();
     expect(globalThis.indexedDB).toBe(originalIndexedDB);
+  });
+
+  it('updates and restores window.location through history state', () => {
+    const originalHref = window.location.href;
+
+    const location = mockWindowLocation({
+      pathname: '/reports',
+      search: '?evalId=test-eval-id',
+      hash: '#overview',
+    });
+
+    expect(location).toBe(window.location);
+    expect(window.location.href).toBe(
+      `${window.location.origin}/reports?evalId=test-eval-id#overview`,
+    );
+    expect(window.location.pathname).toBe('/reports');
+    expect(window.location.search).toBe('?evalId=test-eval-id');
+    expect(window.location.hash).toBe('#overview');
+
+    restoreBrowserMocks();
+    expect(window.location.href).toBe(originalHref);
+  });
+
+  it('supports same-origin href values without redefining window.location', () => {
+    const locationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+    const nextHref = `${window.location.origin}/evals?filter=failed`;
+
+    expect(() => mockWindowLocation({ href: nextHref })).not.toThrow();
+    expect(window.location.href).toBe(nextHref);
+    expect(Object.getOwnPropertyDescriptor(window, 'location')).toEqual(locationDescriptor);
+  });
+
+  it('rejects cross-origin href values', () => {
+    expect(() => mockWindowLocation({ href: 'https://example.com/report' })).toThrow(
+      /same-origin URLs/,
+    );
+  });
+
+  it('rejects unsupported location fields', () => {
+    expect(() => mockWindowLocation({ assign: vi.fn() } as Partial<Location>)).toThrow(
+      /unsupported fields: assign/,
+    );
   });
 });

--- a/src/app/src/tests/browserMocks.test.ts
+++ b/src/app/src/tests/browserMocks.test.ts
@@ -72,6 +72,12 @@ describe('browserMocks', () => {
     );
   });
 
+  it('rejects mixed href and location field overrides', () => {
+    expect(() => mockWindowLocation({ href: '/reports', search: '?evalId=test-eval-id' })).toThrow(
+      /mixing href with URL field overrides: search/,
+    );
+  });
+
   it('rejects unsupported location fields', () => {
     expect(() => mockWindowLocation({ assign: vi.fn() } as Partial<Location>)).toThrow(
       /unsupported fields: assign/,

--- a/src/app/src/tests/browserMocks.ts
+++ b/src/app/src/tests/browserMocks.ts
@@ -1,8 +1,27 @@
 import { vi } from 'vitest';
 
 type RestoreBrowserMock = () => void;
+type MockWindowLocationValue =
+  | string
+  | URL
+  | Partial<
+      Pick<
+        Location,
+        'hash' | 'host' | 'hostname' | 'href' | 'pathname' | 'port' | 'protocol' | 'search'
+      >
+    >;
 
 const restoreCallbacks: RestoreBrowserMock[] = [];
+const mockWindowLocationUrlKeys = new Set([
+  'hash',
+  'host',
+  'hostname',
+  'href',
+  'pathname',
+  'port',
+  'protocol',
+  'search',
+]);
 
 export function restoreBrowserMocks() {
   while (restoreCallbacks.length > 0) {
@@ -132,11 +151,67 @@ export function mockObjectUrl(url = 'blob:test') {
   return { createObjectURL, revokeObjectURL };
 }
 
-export function mockWindowLocation(value: Partial<Location>) {
-  return mockBrowserProperty(window, 'location', {
-    ...window.location,
-    ...value,
-  } as Location);
+function createMockWindowLocationUrl(value: MockWindowLocationValue) {
+  if (typeof value === 'string' || value instanceof URL) {
+    return new URL(value.toString(), window.location.href);
+  }
+
+  const unsupportedKeys = Object.keys(value).filter((key) => !mockWindowLocationUrlKeys.has(key));
+  if (unsupportedKeys.length > 0) {
+    throw new Error(
+      `mockWindowLocation only supports URL fields (${Array.from(mockWindowLocationUrlKeys).join(
+        ', ',
+      )}); unsupported fields: ${unsupportedKeys.join(', ')}`,
+    );
+  }
+
+  if (value.href !== undefined) {
+    return new URL(value.href, window.location.href);
+  }
+
+  const nextUrl = new URL(window.location.href);
+  if (value.protocol !== undefined) {
+    nextUrl.protocol = value.protocol;
+  }
+  if (value.host !== undefined) {
+    nextUrl.host = value.host;
+  }
+  if (value.hostname !== undefined) {
+    nextUrl.hostname = value.hostname;
+  }
+  if (value.port !== undefined) {
+    nextUrl.port = value.port;
+  }
+  if (value.pathname !== undefined) {
+    nextUrl.pathname = value.pathname;
+  }
+  if (value.search !== undefined) {
+    nextUrl.search = value.search;
+  }
+  if (value.hash !== undefined) {
+    nextUrl.hash = value.hash;
+  }
+
+  return nextUrl;
+}
+
+export function mockWindowLocation(value: MockWindowLocationValue) {
+  const originalUrl = window.location.href;
+  const nextUrl = createMockWindowLocationUrl(value);
+
+  if (nextUrl.origin !== window.location.origin) {
+    throw new Error(
+      `mockWindowLocation only supports same-origin URLs; received ${nextUrl.href} from ${originalUrl}`,
+    );
+  }
+
+  window.history.replaceState(window.history.state, '', nextUrl);
+
+  restoreCallbacks.push(() => {
+    window.history.replaceState(window.history.state, '', originalUrl);
+  });
+
+  return window.location;
 }
 
 export function mockWindowOpen() {

--- a/src/app/src/tests/browserMocks.ts
+++ b/src/app/src/tests/browserMocks.ts
@@ -1,18 +1,7 @@
 import { vi } from 'vitest';
 
 type RestoreBrowserMock = () => void;
-type MockWindowLocationValue =
-  | string
-  | URL
-  | Partial<
-      Pick<
-        Location,
-        'hash' | 'host' | 'hostname' | 'href' | 'pathname' | 'port' | 'protocol' | 'search'
-      >
-    >;
-
-const restoreCallbacks: RestoreBrowserMock[] = [];
-const mockWindowLocationUrlKeys = new Set([
+const mockWindowLocationUrlKeys = [
   'hash',
   'host',
   'hostname',
@@ -21,7 +10,12 @@ const mockWindowLocationUrlKeys = new Set([
   'port',
   'protocol',
   'search',
-]);
+] as const;
+type MockWindowLocationUrlKey = (typeof mockWindowLocationUrlKeys)[number];
+type MockWindowLocationValue = string | URL | Partial<Pick<Location, MockWindowLocationUrlKey>>;
+
+const restoreCallbacks: RestoreBrowserMock[] = [];
+const mockWindowLocationUrlKeySet = new Set<MockWindowLocationUrlKey>(mockWindowLocationUrlKeys);
 
 export function restoreBrowserMocks() {
   while (restoreCallbacks.length > 0) {
@@ -156,16 +150,25 @@ function createMockWindowLocationUrl(value: MockWindowLocationValue) {
     return new URL(value.toString(), window.location.href);
   }
 
-  const unsupportedKeys = Object.keys(value).filter((key) => !mockWindowLocationUrlKeys.has(key));
+  const unsupportedKeys = Object.keys(value).filter(
+    (key) => !mockWindowLocationUrlKeySet.has(key as MockWindowLocationUrlKey),
+  );
   if (unsupportedKeys.length > 0) {
     throw new Error(
-      `mockWindowLocation only supports URL fields (${Array.from(mockWindowLocationUrlKeys).join(
-        ', ',
-      )}); unsupported fields: ${unsupportedKeys.join(', ')}`,
+      `mockWindowLocation only supports URL fields (${mockWindowLocationUrlKeys.join(', ')}); unsupported fields: ${unsupportedKeys.join(', ')}`,
     );
   }
 
   if (value.href !== undefined) {
+    const mixedOverrideKeys = mockWindowLocationUrlKeys.filter(
+      (key) => key !== 'href' && value[key] !== undefined,
+    );
+    if (mixedOverrideKeys.length > 0) {
+      throw new Error(
+        `mockWindowLocation does not support mixing href with URL field overrides: ${mixedOverrideKeys.join(', ')}`,
+      );
+    }
+
     return new URL(value.href, window.location.href);
   }
 


### PR DESCRIPTION
## Summary
- Replace `mockWindowLocation` descriptor replacement with same-origin `history.replaceState` URL mutation so it works with jsdom 29 non-configurable `window.location`.
- Add helper coverage for URL mutation, restore behavior, descriptor preservation, and clear unsupported/cross-origin errors.
- Update PostHog page view tracker tests to avoid direct `window.location.href` assignment.

## Test plan
- `npm run test:app -- -- src/tests/browserMocks.test.ts src/components/PostHogPageViewTracker.test.tsx src/pages/redteam/report/components/TestSuites.test.tsx src/pages/redteam/report/components/Report.test.tsx --run`
- `npm run f && npm run l`
- `npm run tsc`