### PR TITLE
test(webui): enforce strict callApi mock helpers

### DIFF
--- a/src/app/src/hooks/useCloudConfig.test.ts
+++ b/src/app/src/hooks/useCloudConfig.test.ts
@@ -1,9 +1,18 @@
+import {
+  createMockResponse,
+  getCallApiMock,
+  mockCallApiResponse,
+  mockCallApiResponseOnce,
+  rejectCallApi,
+  rejectCallApiOnce,
+  resetCallApiMock,
+} from '@app/tests/apiMocks';
+import { callApi } from '@app/utils/api';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { callApi } from '../utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import useCloudConfig from './useCloudConfig';
 
-vi.mock('../utils/api', () => ({
+vi.mock('@app/utils/api', () => ({
   callApi: vi.fn(),
   fetchUserEmail: vi.fn(() => Promise.resolve('test@example.com')),
   fetchUserId: vi.fn(() => Promise.resolve('test-user-id')),
@@ -12,20 +21,13 @@ vi.mock('../utils/api', () => ({
 
 describe('useCloudConfig', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetCallApiMock();
     // Note: Do NOT use vi.useFakeTimers() here - it breaks waitFor
     // Only use fake timers in specific tests that need timer control
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should initialize with isLoading=true, data=null, and error=null', () => {
-    (callApi as Mock).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ appUrl: 'https://app.promptfoo.com', isEnabled: true }),
-    });
+    mockCallApiResponse({ appUrl: 'https://app.promptfoo.com', isEnabled: true });
 
     const { result } = renderHook(() => useCloudConfig());
 
@@ -40,10 +42,7 @@ describe('useCloudConfig', () => {
       isEnabled: true,
     };
 
-    (callApi as Mock).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue(mockCloudConfig),
-    });
+    mockCallApiResponse(mockCloudConfig);
 
     const { result } = renderHook(() => useCloudConfig());
 
@@ -58,10 +57,7 @@ describe('useCloudConfig', () => {
   });
 
   it('should set error and isLoading=false when API returns ok=false', async () => {
-    (callApi as Mock).mockResolvedValue({
-      ok: false,
-      json: vi.fn().mockResolvedValue({}),
-    });
+    mockCallApiResponse({}, { ok: false });
 
     const { result } = renderHook(() => useCloudConfig());
 
@@ -77,7 +73,7 @@ describe('useCloudConfig', () => {
 
   it('should handle network errors gracefully', async () => {
     const networkError = new Error('Network error');
-    (callApi as Mock).mockRejectedValue(networkError);
+    rejectCallApi(networkError);
 
     const { result } = renderHook(() => useCloudConfig());
 
@@ -92,7 +88,7 @@ describe('useCloudConfig', () => {
   });
 
   it('should handle non-Error exceptions', async () => {
-    (callApi as Mock).mockRejectedValue('String error');
+    rejectCallApi('String error');
 
     const { result } = renderHook(() => useCloudConfig());
 
@@ -111,10 +107,7 @@ describe('useCloudConfig', () => {
       isEnabled: false,
     };
 
-    (callApi as Mock).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue(mockCloudConfig),
-    });
+    mockCallApiResponse(mockCloudConfig);
 
     renderHook(() => useCloudConfig());
 
@@ -137,10 +130,7 @@ describe('useCloudConfig', () => {
         isEnabled: false,
       };
 
-      (callApi as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue(initialConfig),
-      });
+      mockCallApiResponseOnce(initialConfig);
 
       const { result } = renderHook(() => useCloudConfig());
 
@@ -152,10 +142,7 @@ describe('useCloudConfig', () => {
       expect(callApi).toHaveBeenCalledTimes(1);
 
       // Setup mock for refetch
-      (callApi as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue(updatedConfig),
-      });
+      mockCallApiResponseOnce(updatedConfig);
 
       // Call refetch
       await act(async () => {
@@ -177,16 +164,13 @@ describe('useCloudConfig', () => {
         isEnabled: true,
       };
 
-      let resolveFetch: any;
-      const delayedPromise = new Promise((resolve) => {
+      let resolveFetch!: (response: Response) => void;
+      const delayedPromise = new Promise<Response>((resolve) => {
         resolveFetch = resolve;
       });
 
       // First call resolves immediately
-      (callApi as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockCloudConfig),
-      });
+      mockCallApiResponseOnce(mockCloudConfig);
 
       const { result } = renderHook(() => useCloudConfig());
 
@@ -196,7 +180,7 @@ describe('useCloudConfig', () => {
       });
 
       // Second call will be delayed so we can check loading state
-      (callApi as Mock).mockImplementationOnce(() => delayedPromise);
+      getCallApiMock().mockImplementationOnce(() => delayedPromise);
 
       // Start refetch
       act(() => {
@@ -207,10 +191,7 @@ describe('useCloudConfig', () => {
       expect(result.current.isLoading).toBe(true);
 
       // Resolve the delayed promise
-      resolveFetch({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockCloudConfig),
-      });
+      resolveFetch(createMockResponse(mockCloudConfig));
 
       // Wait for loading to become false
       await waitFor(() => {
@@ -225,10 +206,7 @@ describe('useCloudConfig', () => {
       };
 
       // Initial successful fetch
-      (callApi as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockCloudConfig),
-      });
+      mockCallApiResponseOnce(mockCloudConfig);
 
       const { result } = renderHook(() => useCloudConfig());
 
@@ -240,7 +218,7 @@ describe('useCloudConfig', () => {
       expect(result.current.error).toBeNull();
 
       // Setup error for refetch
-      (callApi as Mock).mockRejectedValueOnce(new Error('Refetch failed'));
+      rejectCallApiOnce(new Error('Refetch failed'));
 
       // Call refetch
       await act(async () => {
@@ -259,7 +237,7 @@ describe('useCloudConfig', () => {
 
     it('should clear previous error on successful refetch', async () => {
       // Initial failed fetch
-      (callApi as Mock).mockRejectedValueOnce(new Error('Initial fetch failed'));
+      rejectCallApiOnce(new Error('Initial fetch failed'));
 
       const { result } = renderHook(() => useCloudConfig());
 
@@ -276,10 +254,7 @@ describe('useCloudConfig', () => {
       };
 
       // Setup successful refetch
-      (callApi as Mock).mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockCloudConfig),
-      });
+      mockCallApiResponseOnce(mockCloudConfig);
 
       // Call refetch
       await act(async () => {
@@ -302,10 +277,7 @@ describe('useCloudConfig', () => {
       isEnabled: true,
     };
 
-    (callApi as Mock).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue(mockCloudConfig),
-    });
+    mockCallApiResponseOnce(mockCloudConfig);
 
     const { result, rerender } = renderHook(() => useCloudConfig());
 

--- a/src/app/src/tests/apiMocks.test.ts
+++ b/src/app/src/tests/apiMocks.test.ts
@@ -2,6 +2,7 @@ import { callApi } from '@app/utils/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMockResponse,
+  getCallApiMock,
   mockCallApiResponse,
   mockCallApiResponseOnce,
   mockCallApiRoutes,
@@ -60,6 +61,23 @@ describe('apiMocks', () => {
     await expect(callApi('/third')).rejects.toThrow(
       'Unhandled GET callApi request in test: /third',
     );
+  });
+
+  it('queues one-time responses with a fail-fast default when used before reset', async () => {
+    const mockCallApi = vi.mocked(callApi);
+    mockCallApi.mockReset();
+    void callApi('/before-helper');
+
+    mockCallApiResponseOnce({ step: 1 });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+    await expect(callApi('/first').then((response) => response.json())).resolves.toEqual({
+      step: 1,
+    });
+    await expect(callApi('/second')).rejects.toThrow(
+      'Unhandled GET callApi request in test: /second',
+    );
+    expect(mockCallApi).toHaveBeenCalledTimes(3);
   });
 
   it('queues one-time rejections while preserving the fail-fast default', async () => {

--- a/src/app/src/tests/apiMocks.test.ts
+++ b/src/app/src/tests/apiMocks.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMockResponse,
   mockCallApiResponse,
+  mockCallApiResponseOnce,
   mockCallApiRoutes,
   rejectCallApi,
+  rejectCallApiOnce,
   resetCallApiMock,
 } from './apiMocks';
 
@@ -43,6 +45,30 @@ describe('apiMocks', () => {
     await expect(callApi('/anything').then((response) => response.json())).resolves.toEqual({
       ok: true,
     });
+  });
+
+  it('queues one-time responses while preserving the fail-fast default', async () => {
+    mockCallApiResponseOnce({ step: 1 });
+    mockCallApiResponseOnce({ step: 2 });
+
+    await expect(callApi('/first').then((response) => response.json())).resolves.toEqual({
+      step: 1,
+    });
+    await expect(callApi('/second').then((response) => response.json())).resolves.toEqual({
+      step: 2,
+    });
+    await expect(callApi('/third')).rejects.toThrow(
+      'Unhandled GET callApi request in test: /third',
+    );
+  });
+
+  it('queues one-time rejections while preserving the fail-fast default', async () => {
+    rejectCallApiOnce(new Error('once'));
+
+    await expect(callApi('/error')).rejects.toThrow('once');
+    await expect(callApi('/error-again')).rejects.toThrow(
+      'Unhandled GET callApi request in test: /error-again',
+    );
   });
 
   it('matches route paths and methods in order', async () => {

--- a/src/app/src/tests/apiMocks.ts
+++ b/src/app/src/tests/apiMocks.ts
@@ -99,9 +99,21 @@ export function rejectCallApi(error: unknown) {
   return mockCallApi;
 }
 
+export function rejectCallApiOnce(error: unknown) {
+  const mockCallApi = getCallApiMock();
+  mockCallApi.mockRejectedValueOnce(error);
+  return mockCallApi;
+}
+
 export function mockCallApiResponse(body: unknown, init: MockApiResponseInit = {}) {
   const mockCallApi = resetCallApiMock();
   mockCallApi.mockResolvedValue(createMockResponse(body, init));
+  return mockCallApi;
+}
+
+export function mockCallApiResponseOnce(body: unknown, init: MockApiResponseInit = {}) {
+  const mockCallApi = getCallApiMock();
+  mockCallApi.mockResolvedValueOnce(createMockResponse(body, init));
   return mockCallApi;
 }
 

--- a/src/app/src/tests/apiMocks.ts
+++ b/src/app/src/tests/apiMocks.ts
@@ -32,6 +32,24 @@ function getRequestMethod(options: RequestInit | undefined) {
   return (options?.method ?? 'GET').toUpperCase();
 }
 
+function assertCallApiMock(): CallApiMock {
+  if (!vi.isMockFunction(callApi)) {
+    throw new Error(
+      'callApi must be mocked with vi.fn() before using apiMocks helpers. Use vi.mock("@app/utils/api", () => ({ callApi: vi.fn() })) in the test file.',
+    );
+  }
+
+  return vi.mocked(callApi);
+}
+
+function ensureDefaultUnhandledCallApi(mockCallApi: CallApiMock) {
+  if (!mockCallApi.getMockImplementation()) {
+    mockCallApi.mockImplementation(defaultUnhandledCallApi);
+  }
+
+  return mockCallApi;
+}
+
 function matchesRoute(route: MockApiRoute, path: string, options: RequestInit | undefined) {
   if ((route.method ?? 'GET').toUpperCase() !== getRequestMethod(options)) {
     return false;
@@ -81,13 +99,7 @@ export function createMockResponse(body: unknown, init: MockApiResponseInit = {}
 }
 
 export function resetCallApiMock() {
-  if (!vi.isMockFunction(callApi)) {
-    throw new Error(
-      'callApi must be mocked with vi.fn() before using apiMocks helpers. Use vi.mock("@app/utils/api", () => ({ callApi: vi.fn() })) in the test file.',
-    );
-  }
-
-  const mockCallApi = vi.mocked(callApi);
+  const mockCallApi = assertCallApiMock();
   mockCallApi.mockReset();
   mockCallApi.mockImplementation(defaultUnhandledCallApi);
   return mockCallApi;
@@ -164,5 +176,5 @@ export function mockCallApiRoutes(routes: MockApiRoute[]) {
 }
 
 export function getCallApiMock(): CallApiMock {
-  return vi.mocked(callApi);
+  return ensureDefaultUnhandledCallApi(assertCallApiMock());
 }

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -92,12 +92,12 @@ const directBrowserMockPatterns = [
 const directCallApiMockPatterns = [
   {
     pattern:
-      /\bvi\.mocked\(\s*(?:api\.)?callApi\s*\)\.mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
+      /\bvi\.mocked\(\s*(?:api\.)?callApi\s*\)\s*\.\s*mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
     message: 'mock callApi with @app/tests/apiMocks helpers',
   },
   {
     pattern:
-      /\(\s*callApi\s+as\s+Mock\s*\)\.mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
+      /\(\s*callApi\s+as\s+Mock\s*\)\s*\.\s*mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
     message: 'mock callApi with @app/tests/apiMocks helpers instead of casting callApi',
   },
 ];
@@ -130,19 +130,42 @@ function findTestFiles(dir: string): string[] {
   });
 }
 
+function toPosixPath(filePath: string) {
+  return filePath.replace(/\\/g, '/');
+}
+
+function toPosixRelativePath(file: string) {
+  return toPosixPath(path.relative(srcDir, file));
+}
+
+function findPatternViolationsInSource(
+  source: string,
+  relativePath: string,
+  patterns: { pattern: RegExp; message: string }[],
+): string[] {
+  return patterns.flatMap(({ pattern, message }) => {
+    const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+    const globalPattern = new RegExp(pattern.source, flags);
+
+    return Array.from(source.matchAll(globalPattern), (match) => {
+      const index = match.index ?? 0;
+      const lineNumber = source.slice(0, index).split('\n').length;
+      const sourceSnippet = match[0].replace(/\s+/g, ' ').trim();
+
+      return `${relativePath}:${lineNumber}: ${message}: ${sourceSnippet}`;
+    });
+  });
+}
+
 function findPatternViolations(
   file: string,
   patterns: { pattern: RegExp; message: string }[],
 ): string[] {
-  return readFileSync(file, 'utf8')
-    .split('\n')
-    .flatMap((line, index) =>
-      patterns.flatMap(({ pattern, message }) =>
-        pattern.test(line)
-          ? [`${path.relative(srcDir, file)}:${index + 1}: ${message}: ${line.trim()}`]
-          : [],
-      ),
-    );
+  return findPatternViolationsInSource(
+    readFileSync(file, 'utf8'),
+    toPosixRelativePath(file),
+    patterns,
+  );
 }
 
 describe('test hygiene', () => {
@@ -177,7 +200,7 @@ describe('test hygiene', () => {
         .split('\n')
         .flatMap((line, index) =>
           focusedOrSkippedTestPattern.test(line)
-            ? [`${path.relative(srcDir, file)}:${index + 1}: ${line.trim()}`]
+            ? [`${toPosixRelativePath(file)}:${index + 1}: ${line.trim()}`]
             : [],
         );
     });
@@ -196,7 +219,7 @@ describe('test hygiene', () => {
         .flatMap((line, index) =>
           directBrowserMockPatterns.flatMap(({ pattern, message }) =>
             pattern.test(line)
-              ? [`${path.relative(srcDir, file)}:${index + 1}: ${message}: ${line.trim()}`]
+              ? [`${toPosixRelativePath(file)}:${index + 1}: ${message}: ${line.trim()}`]
               : [],
           ),
         );
@@ -232,6 +255,8 @@ describe('test hygiene', () => {
     'vi.mocked(api.callApi).mockRejectedValue(error)',
     '(callApi as Mock).mockImplementation(() => response)',
     '(callApi as Mock).mockReturnValue(response)',
+    'vi.mocked(callApi)\n  .mockResolvedValue(response)',
+    '(callApi as Mock)\n  .mockReturnValue(response)',
   ])('detects direct callApi mock source in %s', (source) => {
     const matches = directCallApiMockPatterns.filter(({ pattern }) => pattern.test(source));
 
@@ -249,13 +274,36 @@ describe('test hygiene', () => {
     expect(matches).toEqual([]);
   });
 
+  it('detects multiline direct callApi mock violations in source files', () => {
+    const violations = findPatternViolationsInSource(
+      [
+        'import { callApi } from "@app/utils/api";',
+        'vi.mocked(callApi)',
+        '  .mockResolvedValue(response);',
+        '(callApi as Mock)',
+        '  .mockReturnValue(response);',
+      ].join('\n'),
+      'hooks/example.test.ts',
+      directCallApiMockPatterns,
+    );
+
+    expect(violations).toEqual([
+      'hooks/example.test.ts:2: mock callApi with @app/tests/apiMocks helpers: vi.mocked(callApi) .mockResolvedValue',
+      'hooks/example.test.ts:4: mock callApi with @app/tests/apiMocks helpers instead of casting callApi: (callApi as Mock) .mockReturnValue',
+    ]);
+  });
+
+  it('normalizes Windows path separators before comparing allowlist entries', () => {
+    expect(toPosixPath('pages\\media\\Media.test.tsx')).toBe('pages/media/Media.test.tsx');
+  });
+
   it('keeps new frontend tests on strict callApi mock helpers', () => {
     const violations = findTestFiles(srcDir).flatMap((file) => {
       if (file === thisFile) {
         return [];
       }
 
-      const relativePath = path.relative(srcDir, file);
+      const relativePath = toPosixRelativePath(file);
       if (legacyDirectCallApiMockFiles.has(relativePath)) {
         return [];
       }
@@ -267,7 +315,7 @@ describe('test hygiene', () => {
   });
 
   it('keeps the legacy direct callApi mock allowlist scoped to active violations', () => {
-    const testFiles = new Set(findTestFiles(srcDir).map((file) => path.relative(srcDir, file)));
+    const testFiles = new Set(findTestFiles(srcDir).map((file) => toPosixRelativePath(file)));
     const missingAllowlistFiles = Array.from(legacyDirectCallApiMockFiles).filter(
       (file) => !testFiles.has(file),
     );

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -89,6 +89,33 @@ const directBrowserMockPatterns = [
     message: 'mock document.execCommand with mockDocumentExecCommand()',
   },
 ];
+const directCallApiMockPatterns = [
+  {
+    pattern:
+      /\bvi\.mocked\(\s*(?:api\.)?callApi\s*\)\.mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
+    message: 'mock callApi with @app/tests/apiMocks helpers',
+  },
+  {
+    pattern:
+      /\(\s*callApi\s+as\s+Mock\s*\)\.mock(?:ResolvedValue|RejectedValue|Implementation|ReturnValue)/,
+    message: 'mock callApi with @app/tests/apiMocks helpers instead of casting callApi',
+  },
+];
+const legacyDirectCallApiMockFiles = new Set([
+  'hooks/useEvalOperations.test.ts',
+  'pages/eval/components/Eval.test.tsx',
+  'pages/eval/components/ResultsView.delete.test.tsx',
+  'pages/eval/components/ResultsView.test.tsx',
+  'pages/eval/components/store.test.ts',
+  'pages/eval-creator/components/EvaluateTestSuiteCreator.test.tsx',
+  'pages/evals/components/EvalsTable.test.tsx',
+  'pages/media/Media.test.tsx',
+  'pages/media/hooks/useMediaItems.test.ts',
+  'pages/redteam/setup/components/Purpose.test.tsx',
+  'pages/redteam/setup/components/Review.test.tsx',
+  'pages/redteam/setup/components/Targets/tabs/SessionsTab.test.tsx',
+  'utils/api/downloads.test.ts',
+]);
 
 function findTestFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -101,6 +128,21 @@ function findTestFiles(dir: string): string[] {
 
     return testFilePattern.test(fullPath) ? [fullPath] : [];
   });
+}
+
+function findPatternViolations(
+  file: string,
+  patterns: { pattern: RegExp; message: string }[],
+): string[] {
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .flatMap((line, index) =>
+      patterns.flatMap(({ pattern, message }) =>
+        pattern.test(line)
+          ? [`${path.relative(srcDir, file)}:${index + 1}: ${message}: ${line.trim()}`]
+          : [],
+      ),
+    );
 }
 
 describe('test hygiene', () => {
@@ -183,5 +225,62 @@ describe('test hygiene', () => {
     const matches = directBrowserMockPatterns.filter(({ pattern }) => pattern.test(source));
 
     expect(matches).toHaveLength(1);
+  });
+
+  it.each([
+    'vi.mocked(callApi).mockResolvedValue(response)',
+    'vi.mocked(api.callApi).mockRejectedValue(error)',
+    '(callApi as Mock).mockImplementation(() => response)',
+    '(callApi as Mock).mockReturnValue(response)',
+  ])('detects direct callApi mock source in %s', (source) => {
+    const matches = directCallApiMockPatterns.filter(({ pattern }) => pattern.test(source));
+
+    expect(matches).toHaveLength(1);
+  });
+
+  it.each([
+    'mockCallApiResponse({ ok: true })',
+    'mockCallApiResponseOnce({ step: 1 })',
+    'rejectCallApi(new Error("network"))',
+    'expect(callApi).toHaveBeenCalledTimes(1)',
+  ])('ignores strict callApi helper source in %s', (source) => {
+    const matches = directCallApiMockPatterns.filter(({ pattern }) => pattern.test(source));
+
+    expect(matches).toEqual([]);
+  });
+
+  it('keeps new frontend tests on strict callApi mock helpers', () => {
+    const violations = findTestFiles(srcDir).flatMap((file) => {
+      if (file === thisFile) {
+        return [];
+      }
+
+      const relativePath = path.relative(srcDir, file);
+      if (legacyDirectCallApiMockFiles.has(relativePath)) {
+        return [];
+      }
+
+      return findPatternViolations(file, directCallApiMockPatterns);
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the legacy direct callApi mock allowlist scoped to active violations', () => {
+    const testFiles = new Set(findTestFiles(srcDir).map((file) => path.relative(srcDir, file)));
+    const missingAllowlistFiles = Array.from(legacyDirectCallApiMockFiles).filter(
+      (file) => !testFiles.has(file),
+    );
+    const staleAllowlistFiles = Array.from(legacyDirectCallApiMockFiles).filter((file) => {
+      if (!testFiles.has(file)) {
+        return false;
+      }
+
+      const violations = findPatternViolations(path.join(srcDir, file), directCallApiMockPatterns);
+      return violations.length === 0;
+    });
+
+    expect(missingAllowlistFiles).toEqual([]);
+    expect(staleAllowlistFiles).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add one-time `callApi` response/rejection helpers that keep the default unhandled-request failure in place after queued calls are consumed.
- Migrate `useCloudConfig` tests from direct `(callApi as Mock)` setup to the shared strict `apiMocks` helpers.
- Add a frontend hygiene ratchet so new tests avoid direct `vi.mocked(callApi).mock*` / `(callApi as Mock).mock*` setup, while keeping a checked legacy allowlist for existing files.

## Test plan
- `npm run test:app -- -- src/tests/apiMocks.test.ts src/tests/test-hygiene.test.ts src/hooks/useCloudConfig.test.ts --run`
- `npm run f && npm run l`
- `npm run tsc`