### PR TITLE
test: add root test hygiene guard

### DIFF
--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -1,0 +1,272 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+type TestControlKind = 'only' | 'skip' | 'skipIf';
+
+type TestControlUsage = {
+  column: number;
+  expression: string;
+  file: string;
+  kind: TestControlKind;
+  line: number;
+  lineText: string;
+};
+
+type AllowedSkip = {
+  file: string;
+  kind: Exclude<TestControlKind, 'only'>;
+  linePattern: RegExp;
+  reason: string;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const testDir = path.join(repoRoot, 'test');
+const testFilePattern = /\.(?:test|spec)\.(?:ts|tsx)$/;
+const testApiNames = new Set(['describe', 'it', 'suite', 'test']);
+
+const allowedSkippedTests: AllowedSkip[] = [
+  {
+    file: 'integration/library-exports.integration.test.ts',
+    kind: 'skip',
+    linePattern: /buildExists \? describe : describe\.skip/,
+    reason: 'requires built dist artifacts when this integration file runs outside build jobs',
+  },
+  {
+    file: 'prompts/processors/executable.test.ts',
+    kind: 'skip',
+    linePattern: /process\.platform === 'win32' \? describe\.skip : describe/,
+    reason: 'Unix executable-path coverage is intentionally disabled on Windows',
+  },
+  {
+    file: 'blobs/extractor.test.ts',
+    kind: 'skip',
+    linePattern: /isBlobStorageEnabled\(\) \? it : it\.skip/,
+    reason: 'Blob storage integration coverage requires opt-in storage credentials',
+  },
+  {
+    file: 'python/worker.test.ts',
+    kind: 'skip',
+    linePattern: /process\.platform === 'win32' && process\.env\.CI \? describe\.skip : describe/,
+    reason: 'Python temp-file IPC is unreliable under Windows CI security policy',
+  },
+  {
+    file: 'python/workerPool.test.ts',
+    kind: 'skip',
+    linePattern: /process\.platform === 'win32' && process\.env\.CI \? describe\.skip : describe/,
+    reason: 'Python temp-file IPC is unreliable under Windows CI security policy',
+  },
+  {
+    file: 'providers/pythonCompletion.unicode.test.ts',
+    kind: 'skip',
+    linePattern: /process\.platform === 'win32' && process\.env\.CI \? describe\.skip : describe/,
+    reason: 'Python provider temp-file IPC is unreliable under Windows CI security policy',
+  },
+  {
+    file: 'providers/openai-codex-sdk.e2e.test.ts',
+    kind: 'skip',
+    linePattern: /hasApiKey && hasSdk \? describe : describe\.skip/,
+    reason: 'E2E coverage requires an API key and optional Codex SDK dependency',
+  },
+  {
+    file: 'commands/mcp/lib/security.test.ts',
+    kind: 'skipIf',
+    linePattern:
+      /^it\.skipIf\(process\.platform === 'win32'\)\('should reject paths to system directories'/,
+    reason: 'Unix system-directory assertions are platform-specific',
+  },
+  {
+    file: 'commands/mcp/lib/security.test.ts',
+    kind: 'skipIf',
+    linePattern:
+      /^it\.skipIf\(process\.platform !== 'win32'\)\('should reject Windows system directories'/,
+    reason: 'Windows system-directory assertions are platform-specific',
+  },
+  {
+    file: 'commands/mcp/lib/security.test.ts',
+    kind: 'skipIf',
+    linePattern: /^it\.skipIf\(process\.platform === 'win32'\)\($/,
+    reason: 'Unix absolute-path assertions are platform-specific',
+  },
+  {
+    file: 'smoke/regression-0120.test.ts',
+    kind: 'skipIf',
+    linePattern: /^it\.skipIf\(!isGoAvailable\(\)\)\('loads and executes Go provider'/,
+    reason: 'Go smoke coverage requires the Go toolchain',
+  },
+  {
+    file: 'smoke/regression-0120.test.ts',
+    kind: 'skipIf',
+    linePattern: /^it\.skipIf\(!isRubyAvailable\(\)\)\('loads and executes Ruby provider'/,
+    reason: 'Ruby smoke coverage requires the Ruby toolchain',
+  },
+  {
+    file: 'redteam/plugins/codingAgent.test.ts',
+    kind: 'skipIf',
+    linePattern: /^it\.skipIf\(process\.platform === 'win32'\)\($/,
+    reason: 'Host-side unreadable-file sandbox coverage depends on Unix permissions',
+  },
+];
+
+function findTestFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const fullPath = path.join(dir, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      return findTestFiles(fullPath);
+    }
+
+    return testFilePattern.test(fullPath) ? [fullPath] : [];
+  });
+}
+
+function toPosixRelativePath(file: string) {
+  return path.relative(testDir, file).replace(/\\/g, '/');
+}
+
+function isTestControlKind(name: string): name is TestControlKind {
+  return name === 'only' || name === 'skip' || name === 'skipIf';
+}
+
+function hasTestApiBase(expression: ts.Expression): boolean {
+  let current = expression;
+
+  while (true) {
+    if (ts.isIdentifier(current)) {
+      return testApiNames.has(current.text);
+    }
+
+    if (ts.isPropertyAccessExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+
+    if (ts.isCallExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+
+    if (ts.isParenthesizedExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+
+    return false;
+  }
+}
+
+function findTestControlUsages(file: string, source: string): TestControlUsage[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+  const sourceLines = source.split(/\r?\n/);
+  const usages: TestControlUsage[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      isTestControlKind(node.name.text) &&
+      hasTestApiBase(node.expression)
+    ) {
+      const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      const lineText = sourceLines[position.line]?.trim() ?? '';
+
+      usages.push({
+        column: position.character + 1,
+        expression: node.getText(sourceFile).replace(/\s+/g, ' '),
+        file,
+        kind: node.name.text,
+        line: position.line + 1,
+        lineText,
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return usages;
+}
+
+function findRootTestControlUsages(): TestControlUsage[] {
+  return findTestFiles(testDir).flatMap((file) =>
+    findTestControlUsages(toPosixRelativePath(file), readFileSync(file, 'utf8')),
+  );
+}
+
+function formatUsage(usage: TestControlUsage) {
+  return `${usage.file}:${usage.line}:${usage.column}: ${usage.kind} is not allowed: ${usage.lineText || usage.expression}`;
+}
+
+function isAllowedSkip(usage: TestControlUsage) {
+  return allowedSkippedTests.some(
+    (allowed) =>
+      allowed.file === usage.file &&
+      allowed.kind === usage.kind &&
+      allowed.linePattern.test(usage.lineText),
+  );
+}
+
+describe('root test hygiene', () => {
+  it.each([
+    ['describe.only("suite", () => {})', 'only', 'describe.only'],
+    ['test.concurrent.only("case", () => {})', 'only', 'test.concurrent.only'],
+    ['test.each([1]).only("case", () => {})', 'only', 'test.each([1]).only'],
+    ['it.skip("case", () => {})', 'skip', 'it.skip'],
+    ['const maybeIt = condition ? it : it.skip;', 'skip', 'it.skip'],
+    ['it.skipIf(process.platform === "win32")("case", () => {})', 'skipIf', 'it.skipIf'],
+  ])('detects committed test control source in %s', (source, kind, expression) => {
+    expect(findTestControlUsages('fixture.test.ts', source)).toMatchObject([
+      {
+        expression,
+        kind,
+      },
+    ]);
+  });
+
+  it('ignores test control text inside verifier fixtures and comments', () => {
+    const source = [
+      '// describe.only("not executable", () => {})',
+      'const patch = `test.skip("auth validation", () => {})`;',
+      'fs.writeFileSync(path, "it.skip(\\\"case\\\", () => {})");',
+    ].join('\n');
+
+    expect(findTestControlUsages('fixture.test.ts', source)).toEqual([]);
+  });
+
+  it('does not commit focused root tests', () => {
+    const focusedUsages = findRootTestControlUsages()
+      .filter((usage) => usage.kind === 'only')
+      .map(formatUsage);
+
+    expect(focusedUsages).toEqual([]);
+  });
+
+  it('keeps root skipped tests explicit and allowlisted', () => {
+    const unapprovedSkips = findRootTestControlUsages()
+      .filter((usage) => usage.kind !== 'only')
+      .filter((usage) => !isAllowedSkip(usage))
+      .map(formatUsage);
+
+    expect(unapprovedSkips).toEqual([]);
+  });
+
+  it('keeps the root skip allowlist scoped to active skips', () => {
+    const skippedUsages = findRootTestControlUsages().filter((usage) => usage.kind !== 'only');
+    const staleAllowlistEntries = allowedSkippedTests
+      .filter(
+        (allowed) =>
+          !skippedUsages.some(
+            (usage) =>
+              usage.file === allowed.file &&
+              usage.kind === allowed.kind &&
+              allowed.linePattern.test(usage.lineText),
+          ),
+      )
+      .map((allowed) => `${allowed.file}: ${allowed.kind} allowlist is stale: ${allowed.reason}`);
+
+    expect(staleAllowlistEntries).toEqual([]);
+  });
+});

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -210,6 +210,8 @@ function isAllowedSkip(usage: TestControlUsage) {
 }
 
 describe('root test hygiene', () => {
+  const rootUsages = findRootTestControlUsages();
+
   it.each([
     ['describe.only("suite", () => {})', 'only', 'describe.only'],
     ['test.concurrent.only("case", () => {})', 'only', 'test.concurrent.only'],
@@ -237,15 +239,13 @@ describe('root test hygiene', () => {
   });
 
   it('does not commit focused root tests', () => {
-    const focusedUsages = findRootTestControlUsages()
-      .filter((usage) => usage.kind === 'only')
-      .map(formatUsage);
+    const focusedUsages = rootUsages.filter((usage) => usage.kind === 'only').map(formatUsage);
 
     expect(focusedUsages).toEqual([]);
   });
 
   it('keeps root skipped tests explicit and allowlisted', () => {
-    const unapprovedSkips = findRootTestControlUsages()
+    const unapprovedSkips = rootUsages
       .filter((usage) => usage.kind !== 'only')
       .filter((usage) => !isAllowedSkip(usage))
       .map(formatUsage);
@@ -254,7 +254,7 @@ describe('root test hygiene', () => {
   });
 
   it('keeps the root skip allowlist scoped to active skips', () => {
-    const skippedUsages = findRootTestControlUsages().filter((usage) => usage.kind !== 'only');
+    const skippedUsages = rootUsages.filter((usage) => usage.kind !== 'only');
     const staleAllowlistEntries = allowedSkippedTests
       .filter(
         (allowed) =>


### PR DESCRIPTION
## Summary
- add a root Vitest hygiene test that parses test files with the TypeScript AST to catch committed `.only`, `.skip`, and `.skipIf` usage
- keep intentional root-suite skips explicit with a scoped allowlist for platform, smoke, integration, and e2e prerequisites
- add regression fixtures proving string/comment examples such as verifier-sabotage `test.skip` snippets are ignored

## Test plan
- `npx vitest test/test-hygiene.test.ts --run`
- `npx @biomejs/biome check --write test/test-hygiene.test.ts`
- `npm run tsc`
- `npm run lint:tests` (passes with existing unrelated complexity warnings in `test/assertions/meteor.test.ts` and `test/providers/google/gemini-mcp-integration.test.ts`)