### PR TITLE
test: add root env and global mock helpers

### DIFF
--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockProcessEnv } from '../util/utils';
 
 const mocks = vi.hoisted(() => {
   const core = {
@@ -204,15 +205,20 @@ function expectSanitizedExecEnv(options: PromptfooExecCall['options'] | NpmExecC
 }
 
 describe('code-scan-action main', () => {
+  let restoreEnv: () => void;
+
   beforeEach(() => {
     vi.resetAllMocks();
     vi.resetModules();
-    process.env = { ...originalEnv, GITHUB_WORKSPACE: '/test/workspace' };
+    restoreEnv = mockProcessEnv(
+      { ...originalEnv, GITHUB_WORKSPACE: '/test/workspace' },
+      { clear: true },
+    );
     setupMocks();
   });
 
   afterEach(() => {
-    process.env = { ...originalEnv };
+    restoreEnv();
     vi.clearAllMocks();
   });
 

--- a/test/codeScans/mcp/filesystem.test.ts
+++ b/test/codeScans/mcp/filesystem.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import type { ChildProcess } from 'child_process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockProcessEnv } from '../../util/utils';
 
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
@@ -35,15 +36,16 @@ function createFakeProcess(): ChildProcess & { stderr: EventEmitter } {
 
 describe('filesystem MCP server management', () => {
   const originalEnv = { ...process.env };
+  let restoreEnv: () => void;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.resetAllMocks();
-    process.env = { ...originalEnv };
+    restoreEnv = mockProcessEnv(originalEnv, { clear: true });
   });
 
   afterEach(() => {
-    process.env = { ...originalEnv };
+    restoreEnv();
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/test/commands/auth.test.ts
+++ b/test/commands/auth.test.ts
@@ -1,6 +1,6 @@
 import select from '@inquirer/select';
 import { Command } from 'commander';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authCommand } from '../../src/commands/auth';
 import { isNonInteractive } from '../../src/envars';
 import { getUserEmail, setUserEmail } from '../../src/globalConfig/accounts';
@@ -9,7 +9,7 @@ import logger from '../../src/logger';
 import { getDefaultTeam, getUserTeams } from '../../src/util/cloud';
 import { fetchWithProxy } from '../../src/util/fetch/index';
 import { openAuthBrowser } from '../../src/util/server';
-import { createMockResponse, stripAnsi } from '../util/utils';
+import { createMockResponse, mockGlobal, stripAnsi } from '../util/utils';
 
 vi.mock('@inquirer/select');
 
@@ -45,7 +45,11 @@ vi.mock('../../src/util/fetch/index.ts');
 vi.mock('../../src/util/server');
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const restoreFetch = mockGlobal('fetch', mockFetch);
+
+afterAll(() => {
+  restoreFetch();
+});
 
 describe('auth command', () => {
   let program: Command;

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -23,6 +23,7 @@ describe('constants', () => {
 
   afterEach(() => {
     restoreEnv();
+    vi.clearAllMocks();
   });
 
   it('should export VERSION from package.json', () => {

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CLOUD_PROVIDER_PREFIX,
   DEFAULT_API_BASE_URL,
@@ -11,17 +11,18 @@ import {
   VERSION,
 } from '../src/constants';
 import { REDTEAM_DEFAULTS } from '../src/redteam/constants';
+import { mockProcessEnv } from './util/utils';
 
 describe('constants', () => {
-  const originalEnv = process.env;
+  let restoreEnv: () => void;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = {};
+    restoreEnv = mockProcessEnv({}, { clear: true });
   });
 
-  afterAll(() => {
-    process.env = originalEnv;
+  afterEach(() => {
+    restoreEnv();
   });
 
   it('should export VERSION from package.json', () => {

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -1,9 +1,10 @@
 import { rm } from 'fs/promises';
 
 import yaml from 'js-yaml';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createDummyFiles, reportProviderAPIKeyWarnings } from '../src/onboarding';
 import { TestSuiteConfigSchema } from '../src/types/index';
+import { mockProcessEnv } from './util/utils';
 
 // Create hoisted mocks for inquirer modules
 const mockSelect = vi.hoisted(() => vi.fn());
@@ -72,17 +73,19 @@ vi.mock('../src/envars', () => ({
 describe('reportProviderAPIKeyWarnings', () => {
   const openaiID = 'openai:gpt-4o';
   const anthropicID = 'anthropic:messages:claude-3-5-sonnet-20241022';
-  let oldEnv: any = {};
-  beforeAll(() => {
-    oldEnv = { ...process.env };
-  });
+  let restoreEnv: () => void;
+
   beforeEach(() => {
-    process.env.OPENAI_API_KEY = '';
-    process.env.ANTHROPIC_API_KEY = '';
+    restoreEnv = mockProcessEnv({
+      ANTHROPIC_API_KEY: '',
+      OPENAI_API_KEY: '',
+    });
   });
-  afterAll(() => {
-    process.env = { ...oldEnv };
+
+  afterEach(() => {
+    restoreEnv();
   });
+
   it('should produce a warning for openai if env key is not set', () => {
     expect(reportProviderAPIKeyWarnings([openaiID])).toEqual(
       expect.arrayContaining([

--- a/test/providers/openai/transcription.test.ts
+++ b/test/providers/openai/transcription.test.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { OpenAiTranscriptionProvider } from '../../../src/providers/openai/transcription';
+import { mockGlobal } from '../../util/utils';
 import { getOpenAiMissingApiKeyMessage, restoreEnvVar } from './shared';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
@@ -21,17 +22,15 @@ vi.mock('../../../src/logger', () => ({
 }));
 vi.mock('fs');
 
-// Mock native File API
-global.File = class MockFile {
+class MockFile {
   constructor(
     public parts: any[],
     public name: string,
     public options?: FilePropertyBag,
   ) {}
-} as any;
+}
 
-// Mock native FormData
-global.FormData = class MockFormData {
+class MockFormData {
   private data: Map<string, any> = new Map();
 
   append(key: string, value: any) {
@@ -45,7 +44,15 @@ global.FormData = class MockFormData {
   has(key: string) {
     return this.data.has(key);
   }
-} as any;
+}
+
+const restoreFile = mockGlobal('File', MockFile as unknown as typeof File);
+const restoreFormData = mockGlobal('FormData', MockFormData as unknown as typeof FormData);
+
+afterAll(() => {
+  restoreFormData();
+  restoreFile();
+});
 
 describe('OpenAiTranscriptionProvider', () => {
   const mockTranscriptionResponse = {

--- a/test/providers/testProvider.test.ts
+++ b/test/providers/testProvider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, Mock, Mocked, MockedClass, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, Mock, Mocked, MockedClass, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import logger from '../../src/logger';
 import Eval from '../../src/models/eval';
@@ -7,6 +7,7 @@ import { doRemoteGrading } from '../../src/remoteGrading';
 import { ResultFailureReason } from '../../src/types/index';
 import { fetchWithProxy } from '../../src/util/fetch/index';
 import { testProviderConnectivity, testProviderSession } from '../../src/validators/testProvider';
+import { mockGlobal } from '../util/utils';
 
 import type { EvaluateResult, EvaluateSummaryV3 } from '../../src/types/index';
 import type { ApiProvider } from '../../src/types/providers';
@@ -29,9 +30,13 @@ vi.mock('../../src/globalConfig/cloud', async (importOriginal) => {
     },
   };
 });
-vi.stubGlobal('crypto', {
+const restoreCrypto = mockGlobal('crypto', {
   ...crypto,
   randomUUID: vi.fn(() => 'test-uuid-1234'),
+} as Crypto);
+
+afterAll(() => {
+  restoreCrypto();
 });
 
 describe('Provider Test Functions', () => {

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithRetries } from '../src/util/fetch/index';
+import { mockGlobal } from './util/utils';
 
 const mockedFetchResponse = (ok: boolean, response: object, headers: object = {}) => {
   const responseText = JSON.stringify(response);
@@ -28,16 +29,18 @@ const mockedSetTimeout = (reqTimeout: number) =>
 const mockFetch = vi.fn();
 
 describe('fetchWithRetries', () => {
+  let restoreFetch: (() => void) | undefined;
+
   beforeEach(() => {
     vi.useFakeTimers();
-    // Use stubGlobal which properly replaces the global fetch for all modules
-    vi.stubGlobal('fetch', mockFetch);
+    restoreFetch = mockGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
     mockFetch.mockReset();
     vi.useRealTimers();
-    vi.unstubAllGlobals();
+    restoreFetch?.();
+    restoreFetch = undefined;
   });
 
   it('should fetch data', async () => {

--- a/test/tracing/store.test.ts
+++ b/test/tracing/store.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockGlobal } from '../util/utils';
 
-// Mock crypto.randomUUID using vi.stubGlobal
 const mockRandomUUID = vi.fn(() => 'test-uuid');
-vi.stubGlobal('crypto', {
+const restoreCrypto = mockGlobal('crypto', {
   ...crypto,
   randomUUID: mockRandomUUID,
+} as Crypto);
+
+afterAll(() => {
+  restoreCrypto();
 });
 
 // Mock logger

--- a/test/ui/render.test.ts
+++ b/test/ui/render.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockGlobal } from '../util/utils';
 
 // Mock process properties before importing the module
 const mockProcess: {
@@ -20,16 +21,18 @@ const mockProcess: {
 };
 
 describe('render utilities', () => {
+  let restoreProcess: (() => void) | undefined;
+
   beforeAll(() => {
-    vi.stubGlobal('process', {
+    restoreProcess = mockGlobal('process', {
       ...process,
       stdout: mockProcess.stdout,
       env: mockProcess.env,
-    });
+    } as NodeJS.Process);
   });
 
   afterAll(() => {
-    vi.unstubAllGlobals();
+    restoreProcess?.();
   });
 
   afterEach(() => {

--- a/test/util/utils.test.ts
+++ b/test/util/utils.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mockGlobal, mockProcessEnv } from './utils';
+
+const envKeys = [
+  'PROMPTFOO_TEST_UTIL_ORIGINAL',
+  'PROMPTFOO_TEST_UTIL_OVERRIDE',
+  'PROMPTFOO_TEST_UTIL_CREATED',
+];
+
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const testGlobalName = '__PROMPTFOO_TEST_UTIL_GLOBAL__';
+
+function restoreTestEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+afterEach(() => {
+  restoreTestEnv();
+  Reflect.deleteProperty(globalThis, testGlobalName);
+});
+
+describe('mockProcessEnv', () => {
+  it('applies overrides and restores the previous environment snapshot', () => {
+    process.env.PROMPTFOO_TEST_UTIL_ORIGINAL = 'original';
+
+    const restoreEnv = mockProcessEnv({
+      PROMPTFOO_TEST_UTIL_ORIGINAL: 'override',
+      PROMPTFOO_TEST_UTIL_OVERRIDE: 'set',
+    });
+
+    process.env.PROMPTFOO_TEST_UTIL_CREATED = 'created-by-test';
+
+    expect(process.env.PROMPTFOO_TEST_UTIL_ORIGINAL).toBe('override');
+    expect(process.env.PROMPTFOO_TEST_UTIL_OVERRIDE).toBe('set');
+
+    restoreEnv();
+
+    expect(process.env.PROMPTFOO_TEST_UTIL_ORIGINAL).toBe('original');
+    expect(process.env.PROMPTFOO_TEST_UTIL_OVERRIDE).toBeUndefined();
+    expect(process.env.PROMPTFOO_TEST_UTIL_CREATED).toBeUndefined();
+  });
+
+  it('can start from an empty environment without replacing the process.env object', () => {
+    process.env.PROMPTFOO_TEST_UTIL_ORIGINAL = 'original';
+    const envReference = process.env;
+
+    const restoreEnv = mockProcessEnv(
+      {
+        PROMPTFOO_TEST_UTIL_OVERRIDE: 'only-value',
+      },
+      { clear: true },
+    );
+
+    expect(process.env).toBe(envReference);
+    expect(process.env.PROMPTFOO_TEST_UTIL_ORIGINAL).toBeUndefined();
+    expect(process.env.PROMPTFOO_TEST_UTIL_OVERRIDE).toBe('only-value');
+
+    restoreEnv();
+
+    expect(process.env).toBe(envReference);
+    expect(process.env.PROMPTFOO_TEST_UTIL_ORIGINAL).toBe('original');
+    expect(process.env.PROMPTFOO_TEST_UTIL_OVERRIDE).toBeUndefined();
+  });
+});
+
+describe('mockGlobal', () => {
+  it('restores globals that did not previously exist', () => {
+    const restoreGlobal = mockGlobal(testGlobalName, { value: 'mocked' });
+
+    expect((globalThis as Record<string, unknown>)[testGlobalName]).toEqual({ value: 'mocked' });
+
+    restoreGlobal();
+
+    expect(testGlobalName in globalThis).toBe(false);
+  });
+
+  it('restores the previous global descriptor', () => {
+    Object.defineProperty(globalThis, testGlobalName, {
+      configurable: true,
+      get: () => 'original',
+    });
+
+    const restoreGlobal = mockGlobal(testGlobalName, 'mocked');
+
+    expect((globalThis as Record<string, unknown>)[testGlobalName]).toBe('mocked');
+
+    restoreGlobal();
+
+    expect((globalThis as Record<string, unknown>)[testGlobalName]).toBe('original');
+  });
+});

--- a/test/util/utils.test.ts
+++ b/test/util/utils.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mockGlobal, mockProcessEnv } from './utils';
 
 const envKeys = [
@@ -24,6 +24,7 @@ function restoreTestEnv(): void {
 afterEach(() => {
   restoreTestEnv();
   Reflect.deleteProperty(globalThis, testGlobalName);
+  vi.clearAllMocks();
 });
 
 describe('mockProcessEnv', () => {

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -85,6 +85,54 @@ export function mockConsole(
   return vi.spyOn(console, method).mockImplementation(implementation);
 }
 
+function replaceProcessEnv(nextEnv: Record<string, string | undefined>): void {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, nextEnv);
+}
+
+export function mockProcessEnv(
+  overrides: Record<string, string | undefined> = {},
+  options: { clear?: boolean } = {},
+): () => void {
+  const originalEnv = { ...process.env };
+
+  if (options.clear) {
+    replaceProcessEnv({});
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return () => {
+    replaceProcessEnv(originalEnv);
+  };
+}
+
+export function mockGlobal<T>(name: string, value: T): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
 export function createTempDir(prefix = 'promptfoo-test-'): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }


### PR DESCRIPTION
## Summary
- add root test helpers for restoring process.env snapshots and patched globals without replacing process.env object identity
- cover the helpers with focused Vitest tests
- migrate high-risk root tests that replaced process.env wholesale or patched process-level globals directly

## Test plan
- source ~/.nvm/nvm.sh && nvm use && npx vitest test/util/utils.test.ts test/ui/render.test.ts test/rateLimit.test.ts test/tracing/store.test.ts test/providers/testProvider.test.ts test/commands/auth.test.ts test/providers/openai/transcription.test.ts test/onboarding.test.ts test/constants.test.ts test/codeScans/mcp/filesystem.test.ts test/code-scan-action/main.test.ts --run
- source ~/.nvm/nvm.sh && nvm use && npx @biomejs/biome check --write test/util/utils.ts test/util/utils.test.ts test/ui/render.test.ts test/rateLimit.test.ts test/tracing/store.test.ts test/providers/testProvider.test.ts test/commands/auth.test.ts test/providers/openai/transcription.test.ts test/onboarding.test.ts test/constants.test.ts test/codeScans/mcp/filesystem.test.ts test/code-scan-action/main.test.ts
- source ~/.nvm/nvm.sh && nvm use && npm run tsc
- source ~/.nvm/nvm.sh && nvm use && npm run lint:tests

Note: lint:tests exits 0 with two existing unrelated complexity warnings in test/assertions/meteor.test.ts and test/providers/google/gemini-mcp-integration.test.ts.