### PR TITLE
chore(code-scan): resolve useless conditional findings

### DIFF
--- a/site/blog/unicode-threats/components/VSCodeSimulator.tsx
+++ b/site/blog/unicode-threats/components/VSCodeSimulator.tsx
@@ -869,15 +869,11 @@ module.exports = { validateUser, validatePasswordStrength };`;
               <div className={styles.editorHeader}>
                 <span className={styles.tabTitle}>{selectedFile.name}</span>
               </div>
-              <pre
-                className={`${styles.codeArea} ${isEditing && selectedFile ? styles.editing : ''}`}
-              >
+              <pre className={`${styles.codeArea} ${isEditing ? styles.editing : ''}`}>
                 <code
-                  dangerouslySetInnerHTML={
-                    selectedFile
-                      ? formatCodeWithHighlightedInstructions(selectedFile.content)
-                      : { __html: '' }
-                  }
+                  dangerouslySetInnerHTML={formatCodeWithHighlightedInstructions(
+                    selectedFile.content,
+                  )}
                 />
               </pre>
               {useHiddenChars && selectedFile?.isMalicious && showMaliciousCode && (

--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -414,15 +414,15 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
     typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id;
 
   React.useEffect(() => {
-    if (!isSelectFilter) {
-      setTextValue(typeof value === 'string' ? value : '');
-    } else if (isSelectFilter) {
+    if (isSelectFilter) {
       setSelectValue(
         Array.isArray(value) ? (value[0] ?? '') : typeof value === 'string' ? value : '',
       );
       setMultiSelectValues(
         Array.isArray(value) ? value : typeof value === 'string' && value ? [value] : [],
       );
+    } else {
+      setTextValue(typeof value === 'string' ? value : '');
     }
   }, [isSelectFilter, value]);
 

--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -13,6 +13,7 @@ import { Input } from '@app/components/ui/input';
 import { Spinner } from '@app/components/ui/spinner';
 import { callApi } from '@app/utils/api';
 import { Check, Copy } from 'lucide-react';
+import logger from '../../../../../logger';
 
 interface ShareModalProps {
   open: boolean;
@@ -64,7 +65,7 @@ const ShareModal = ({ open, onClose, evalId, onShare }: ShareModalProps) => {
             const url = await onShare(evalId);
             setShareUrl(url);
           } catch (error) {
-            console.error('Failed to generate share URL:', error);
+            logger.error('Failed to generate share URL', { error, evalId });
             setError('Failed to generate share URL');
           } finally {
             setIsLoading(false);

--- a/src/app/src/pages/eval/components/ShareModal.tsx
+++ b/src/app/src/pages/eval/components/ShareModal.tsx
@@ -40,7 +40,7 @@ const ShareModal = ({ open, onClose, evalId, onShare }: ShareModalProps) => {
 
   useEffect(() => {
     const handleShare = async () => {
-      if (!open || !evalId || shareUrl) {
+      if (!open || !evalId || shareUrl || error) {
         return;
       }
 
@@ -59,18 +59,15 @@ const ShareModal = ({ open, onClose, evalId, onShare }: ShareModalProps) => {
             return;
           }
 
-          // If it's not a public domain or we already have a URL, no need to generate
-          if (!shareUrl && !error) {
-            setIsLoading(true);
-            try {
-              const url = await onShare(evalId);
-              setShareUrl(url);
-            } catch (error) {
-              console.error('Failed to generate share URL:', error);
-              setError('Failed to generate share URL');
-            } finally {
-              setIsLoading(false);
-            }
+          setIsLoading(true);
+          try {
+            const url = await onShare(evalId);
+            setShareUrl(url);
+          } catch (error) {
+            console.error('Failed to generate share URL:', error);
+            setError('Failed to generate share URL');
+          } finally {
+            setIsLoading(false);
           }
         } else {
           setError(data.error || 'Failed to check share domain');

--- a/src/app/src/pages/login.tsx
+++ b/src/app/src/pages/login.tsx
@@ -113,7 +113,7 @@ export default function LoginPage() {
     }
   }, [isLoading, email, handleRedirect]);
 
-  if (isLoading || (!isLoading && email)) {
+  if (isLoading || email) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner size="lg" />

--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -717,7 +717,7 @@ const App = ({ evalId: evalIdProp, embedded, onActionsReady }: ReportProps = {})
 
       <div className="mx-auto max-w-7xl px-4 pb-8 pt-4 print:max-w-none print:px-0 print:pt-0 print:pb-0">
         <div className="flex flex-col gap-6">
-          {!embedded && evalData.config.redteam && <EnterpriseBanner evalId={evalId || ''} />}
+          {!embedded && <EnterpriseBanner evalId={evalId} />}
 
           {!embedded && (
             <>

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -345,9 +345,14 @@ export async function renderPrompt(
       }
     } else if (isPackagePath(value)) {
       const basePath = cliState.basePath || '';
-      const javascriptOutput = (await (
-        await loadFromPackage(value, basePath)
-      )(varName, basePrompt, vars, provider)) as {
+      const requiredModule = await loadFromPackage(value, basePath);
+      if (typeof requiredModule !== 'function') {
+        throw new Error(
+          `Variable source malformed: ${value} must export a function. Received: ${typeof requiredModule}`,
+        );
+      }
+
+      const javascriptOutput = (await requiredModule(varName, basePrompt, vars, provider)) as {
         output?: string;
         error?: string;
       };

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -672,7 +672,7 @@ export async function loadRubricPrompt(
 ): Promise<string> {
   if (
     !rubricPrompt ||
-    (typeof rubricPrompt === 'object' && Object.keys(rubricPrompt ?? {}).length === 0)
+    (typeof rubricPrompt === 'object' && Object.keys(rubricPrompt).length === 0)
   ) {
     return defaultPrompt;
   }

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -304,9 +304,14 @@ function convertToolChoiceToConverseFormat(
   if (toolChoice === 'any') {
     return { any: {} };
   }
-  if (typeof toolChoice === 'object' && toolChoice && 'tool' in toolChoice) {
-    const tc = toolChoice as { tool: { name: string } };
-    return { tool: { name: tc.tool.name } };
+  if (typeof toolChoice === 'object' && toolChoice !== null) {
+    const tool = (toolChoice as { tool?: unknown }).tool;
+    if (typeof tool === 'object' && tool !== null) {
+      const name = (tool as { name?: unknown }).name;
+      if (typeof name === 'string') {
+        return { tool: { name } };
+      }
+    }
   }
   return { auto: {} };
 }

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -304,9 +304,9 @@ function convertToolChoiceToConverseFormat(
   if (toolChoice === 'any') {
     return { any: {} };
   }
-  if (typeof toolChoice === 'object' && toolChoice !== null) {
+  if (toolChoice && typeof toolChoice === 'object') {
     const tool = (toolChoice as { tool?: unknown }).tool;
-    if (typeof tool === 'object' && tool !== null) {
+    if (tool && typeof tool === 'object') {
       const name = (tool as { name?: unknown }).name;
       if (typeof name === 'string') {
         return { tool: { name } };

--- a/src/providers/google/live.ts
+++ b/src/providers/google/live.ts
@@ -650,7 +650,7 @@ export class GoogleLiveProvider implements ApiProvider {
                 'Unknown message with transcription enabled - marking audio as complete',
               );
               hasAudioStreamEnded = true;
-              if (hasTextStreamEnded && hasAudioStreamEnded) {
+              if (hasTextStreamEnded) {
                 try {
                   await finalizeResponse();
                 } catch (err) {

--- a/src/providers/packageParser.ts
+++ b/src/providers/packageParser.ts
@@ -38,9 +38,9 @@ export async function loadFromPackage(packageInstancePath: string, basePath: str
     throw new Error(`Failed to import module: ${packageName}. Error: ${error}`);
   }
 
-  const entity = getValue(module, entityName ?? 'default');
+  const entity = getValue(module, entityName);
 
-  if (!entity) {
+  if (entity === undefined) {
     throw new Error(
       `Could not find entity: ${entityName} in module: ${filePath}. ` +
         `Make sure the entity is exported from the package.`,

--- a/src/providers/packageParser.ts
+++ b/src/providers/packageParser.ts
@@ -56,6 +56,11 @@ export async function parsePackageProvider(
   options: ProviderOptions,
 ): Promise<ApiProvider> {
   const Provider = await loadFromPackage(providerPath, basePath);
+  if (typeof Provider !== 'function') {
+    throw new Error(
+      `Provider malformed: ${providerPath} must export a provider constructor. Received: ${typeof Provider}`,
+    );
+  }
 
   return new Provider(options);
 }

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -31,6 +31,7 @@ import {
 } from '../../util';
 import { getGoalRubric } from '../prompts';
 import {
+  buildGraderResultAssertion,
   externalizeResponseForRedteamHistory,
   formatRedteamHistoryAsTranscript,
   getLastMessageContent,
@@ -628,7 +629,7 @@ export class CrescendoProvider implements ApiProvider {
               lastResponse.output,
               test,
               provider,
-              assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+              'value' in assertToUse ? assertToUse.value : undefined,
               additionalRubric,
               undefined,
               gradingContext,
@@ -637,11 +638,7 @@ export class CrescendoProvider implements ApiProvider {
             graderPassed = grade.pass;
             storedGraderResult = {
               ...grade,
-              assertion: grade.assertion
-                ? { ...grade.assertion, value: rubric }
-                : assertToUse && 'type' in assertToUse && assertToUse.type !== 'assert-set'
-                  ? { ...assertToUse, value: rubric }
-                  : undefined,
+              assertion: buildGraderResultAssertion(grade.assertion, assertToUse, rubric),
             };
           }
         }

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -546,7 +546,7 @@ export class CustomProvider implements ApiProvider {
               lastResponse.output,
               test,
               provider,
-              assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+              'value' in assertToUse ? assertToUse.value : undefined,
               additionalRubric,
             );
             graderPassed = grade.pass;

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -27,7 +27,7 @@ import { Strategies } from '../strategies';
 import { checkExfilTracking } from '../strategies/indirectWebPwn';
 import { extractInputVarsFromPrompt, extractPromptFromTags, getSessionId } from '../util';
 import { getGoalRubric } from './prompts';
-import { getLastMessageContent, tryUnblocking } from './shared';
+import { buildGraderResultAssertion, getLastMessageContent, tryUnblocking } from './shared';
 import { formatTraceForMetadata, formatTraceSummary } from './traceFormatting';
 import { type RawTracingConfig, resolveTracingOptions } from './tracingOptions';
 
@@ -670,7 +670,7 @@ export default class GoatProvider implements ApiProvider {
         lastTargetResponse = finalResponse;
 
         const grader = assertToUse ? getGraderById(assertToUse.type) : undefined;
-        if (test && grader && finalOutput) {
+        if (test && assertToUse && grader && finalOutput) {
           // Build grading context with tracing and exfil tracking data
           let gradingContext:
             | {
@@ -738,7 +738,7 @@ export default class GoatProvider implements ApiProvider {
             finalOutput,
             test,
             targetProvider,
-            assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+            'value' in assertToUse ? assertToUse.value : undefined,
             additionalRubric,
             undefined,
             gradingContext,
@@ -746,11 +746,7 @@ export default class GoatProvider implements ApiProvider {
           graderPassed = grade.pass;
           storedGraderResult = {
             ...grade,
-            assertion: grade.assertion
-              ? { ...grade.assertion, value: rubric }
-              : assertToUse && 'type' in assertToUse && assertToUse.type !== 'assert-set'
-                ? { ...assertToUse, value: rubric }
-                : undefined,
+            assertion: buildGraderResultAssertion(grade.assertion, assertToUse, rubric),
           };
         }
 

--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -806,7 +806,7 @@ export class HydraProvider implements ApiProvider {
             targetResponse.output,
             test,
             targetProvider,
-            assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+            'value' in assertToUse ? assertToUse.value : undefined,
             undefined, // additionalRubric
             undefined, // skipRefusalCheck
             gradingContext,

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -553,7 +553,7 @@ export async function runRedteamConversation({
           targetResponse.output,
           iterationTest,
           gradingProvider,
-          assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+          'value' in assertToUse ? assertToUse.value : undefined,
           additionalRubric,
           undefined,
           gradingContext,

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -23,6 +23,7 @@ import { Strategies } from '../strategies';
 import { checkExfilTracking } from '../strategies/indirectWebPwn';
 import { extractInputVarsFromPrompt, extractPromptFromTags } from '../util';
 import {
+  buildGraderResultAssertion,
   createIterationContext,
   externalizeResponseForRedteamHistory,
   getTargetResponse,
@@ -520,18 +521,14 @@ export async function runMetaAgentRedteam({
           targetResponse.output,
           iterationTest,
           gradingProvider,
-          assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+          'value' in assertToUse ? assertToUse.value : undefined,
           additionalRubric,
           undefined, // skipRefusalCheck
           gradingContext,
         );
         graderResult = {
           ...grade,
-          assertion: grade.assertion
-            ? { ...grade.assertion, value: rubric }
-            : assertToUse && 'type' in assertToUse && assertToUse.type !== 'assert-set'
-              ? { ...assertToUse, value: rubric }
-              : undefined,
+          assertion: buildGraderResultAssertion(grade.assertion, assertToUse, rubric),
         };
         storedGraderResult = graderResult;
 

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -40,6 +40,7 @@ import {
   JUDGE_SYSTEM_PROMPT,
 } from './prompts';
 import {
+  buildGraderResultAssertion,
   checkPenalizedPhrases,
   createIterationContext,
   externalizeResponseForRedteamHistory,
@@ -778,12 +779,10 @@ async function runRedteamConversation({
           const grader = getGraderById(assertToUse.type);
           if (grader) {
             // Create test object with iteration-specific vars
-            const iterationTest = test
-              ? {
-                  ...test,
-                  vars: iterationVars,
-                }
-              : { vars: iterationVars };
+            const iterationTest = {
+              ...test,
+              vars: iterationVars,
+            };
 
             // Build grading context with exfil tracking data
             let gradingContext:
@@ -850,18 +849,14 @@ async function runRedteamConversation({
               targetResponse.output,
               iterationTest,
               gradingProvider,
-              assertToUse && 'value' in assertToUse ? assertToUse.value : undefined,
+              'value' in assertToUse ? assertToUse.value : undefined,
               additionalRubric,
               undefined, // skipRefusalCheck
               gradingContext,
             );
             storedGraderResult = {
               ...grade,
-              assertion: grade.assertion
-                ? { ...grade.assertion, value: rubric }
-                : assertToUse && 'type' in assertToUse && assertToUse.type !== 'assert-set'
-                  ? { ...assertToUse, value: rubric }
-                  : undefined,
+              assertion: buildGraderResultAssertion(grade.assertion, assertToUse, rubric),
             };
             graderPassed = grade.pass;
           }

--- a/src/table.ts
+++ b/src/table.ts
@@ -31,7 +31,7 @@ export function generateTable(
         text = ellipsize(text, tableCellMaxLength);
         if (pass) {
           return chalk.green('[PASS] ') + text;
-        } else if (!pass) {
+        } else {
           // color everything red up until '---'
           return (
             chalk.red(failureType === ResultFailureReason.ASSERT ? '[FAIL] ' : '[ERROR] ') +
@@ -41,7 +41,6 @@ export function generateTable(
               .join('---')
           );
         }
-        return text;
       }),
     ]);
   }

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -333,6 +333,21 @@ describe('evaluatorHelpers', () => {
       expect(renderedPrompt).toBe('Test prompt with Dynamic value for var1');
     });
 
+    it('should throw a clear error when a package variable does not export a function', async () => {
+      const prompt = toPrompt('Test prompt with {{ var1 }}');
+      const vars = {
+        var1: 'package:@promptfoo/fake:testFunction',
+      };
+
+      mockDynamicModule('/node_modules/@promptfoo/fake/index.js', {
+        testFunction: false,
+      });
+
+      await expect(renderPrompt(prompt, vars, {})).rejects.toThrow(
+        'Variable source malformed: package:@promptfoo/fake:testFunction must export a function. Received: boolean',
+      );
+    });
+
     it('should load external json files in renderPrompt and parse the JSON content', async () => {
       const prompt = toPrompt('Test prompt with {{ var1 }}');
       const vars = { var1: 'file:///path/to/testData.json' };

--- a/test/providers/packageParser.test.ts
+++ b/test/providers/packageParser.test.ts
@@ -159,6 +159,16 @@ describe('parsePackageProvider', () => {
     );
   });
 
+  it('should throw a clear error if provider export is not constructable', async () => {
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    vi.mocked(resolvePackageEntryPoint).mockReturnValue(mockPackagePath);
+    vi.mocked(importModule).mockResolvedValue({ Provider: false });
+
+    await expect(parsePackageProvider(mockProviderPath, mockBasePath, mockOptions)).rejects.toThrow(
+      `Provider malformed: ${mockProviderPath} must export a provider constructor. Received: boolean`,
+    );
+  });
+
   it('should handle nested provider names', async () => {
     const mockModule = {
       nested: {

--- a/test/providers/packageParser.test.ts
+++ b/test/providers/packageParser.test.ts
@@ -62,6 +62,14 @@ describe('loadFromPackage', () => {
     expect(importModule).toHaveBeenCalledWith(mockPackagePath);
   });
 
+  it('should distinguish missing exports from falsy exported values', async () => {
+    const mockPackagePath = path.join(mockBasePath, 'node_modules', mockPackageName, 'index.js');
+    vi.mocked(resolvePackageEntryPoint).mockReturnValue(mockPackagePath);
+    vi.mocked(importModule).mockResolvedValue({ getVariable: false });
+
+    await expect(loadFromPackage(mockProviderPath, mockBasePath)).resolves.toBe(false);
+  });
+
   it('should throw an error for invalid provider format', async () => {
     await expect(loadFromPackage('invalid:format', mockBasePath)).rejects.toThrow(
       'Invalid package format: invalid:format. Expected format: package:packageName:exportedClassOrFunction',

--- a/test/smoke/mcp.test.ts
+++ b/test/smoke/mcp.test.ts
@@ -9,7 +9,6 @@ const CLI_PATH = path.resolve(__dirname, '../../dist/src/main.js');
 describe('MCP Stdio Server', () => {
   let child: ChildProcess | undefined;
   let timeoutId: NodeJS.Timeout | undefined;
-  let killTimeoutId: NodeJS.Timeout | undefined;
 
   beforeAll(() => {
     if (!fs.existsSync(CLI_PATH)) {
@@ -21,10 +20,6 @@ describe('MCP Stdio Server', () => {
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = undefined;
-    }
-    if (killTimeoutId) {
-      clearTimeout(killTimeoutId);
-      killTimeoutId = undefined;
     }
     if (child) {
       child.removeAllListeners();


### PR DESCRIPTION
## Summary
- Simplify SAST-reported useless conditionals across UI, provider, redteam, table, matcher, site, and smoke-test code paths.
- Reuse the shared redteam grader assertion builder where duplicated ternaries had redundant guards.
- Tighten Bedrock native tool-choice parsing and package export lookup so missing values are distinguished from malformed or falsy values.

## SAST Review
- Treated redundant conditions inside already-narrowed branches as true positives and removed them.
- Kept optional guards where they are still semantically necessary, such as shared helpers that can be called with undefined assertions and login redirect logic that depends on loading state.

## Tests
- npm run f
- npm run l
- npx vitest run test/providers/packageParser.test.ts test/table.test.ts
- npm run test:app -- --run src/pages/eval/components/ShareModal.test.tsx src/pages/login.test.tsx src/pages/redteam/report/components/Report.test.tsx
- npx vitest run test/redteam/providers/iterative.test.ts test/redteam/providers/iterativeMeta.test.ts test/redteam/providers/iterativeTree.test.ts test/redteam/providers/crescendo/index.test.ts test/redteam/providers/custom/index.test.ts test/redteam/providers/hydra/index.test.ts test/redteam/providers/goat.test.ts
- npx vitest run test/redteam/providers/goat.test.ts
- npm run tsc

Note: npm run f/l and the pre-commit hook report existing noExcessiveCognitiveComplexity warnings in touched large functions, but exit successfully.