### PR TITLE
test(webui): use shared frontend timer helpers

### DIFF
--- a/src/app/src/pages/eval-creator/components/PromptsSection.test.tsx
+++ b/src/app/src/pages/eval-creator/components/PromptsSection.test.tsx
@@ -1,5 +1,6 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { useStore } from '@app/stores/evalConfig';
+import { restoreTestTimers, useTestTimers } from '@app/tests/timers';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PromptsSection from './PromptsSection';
@@ -13,12 +14,11 @@ describe('PromptsSection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+    useTestTimers();
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
+    restoreTestTimers({ runPending: true });
   });
 
   const setupStore = (prompts: string[]) => {

--- a/src/app/src/pages/eval/components/Eval.test.tsx
+++ b/src/app/src/pages/eval/components/Eval.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { restoreTestTimers, useTestTimers } from '@app/tests/timers';
 import { callApi } from '@app/utils/api';
 import { act, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -128,7 +129,7 @@ describe('Eval', () => {
     baseMockResultsViewSettings.setComparisonEvalIds.mockClear();
     mockShowToast.mockClear();
 
-    vi.useFakeTimers();
+    useTestTimers();
 
     // Use stable mock to prevent infinite loops
     vi.mocked(useResultsViewSettingsStore).mockReturnValue(baseMockResultsViewSettings);
@@ -139,8 +140,7 @@ describe('Eval', () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
+    restoreTestTimers({ runPending: true });
   });
 
   it('should call resetFilters when mounted with a new fetchId', async () => {

--- a/src/app/src/pages/eval/components/EvalOutputCell.duplicateImages.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.duplicateImages.test.tsx
@@ -1,7 +1,8 @@
+import { useTestTimers } from '@app/tests/timers';
 import { renderWithProviders as baseRender } from '@app/utils/testutils';
 import { type EvaluateTableOutput, ResultFailureReason } from '@promptfoo/types';
 import { screen } from '@testing-library/react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
 import EvalOutputCell from './EvalOutputCell';
 
@@ -34,10 +35,6 @@ vi.mock('./store', () => ({
 vi.mock('../../../hooks/useShiftKey', () => ({
   useShiftKey: () => false,
 }));
-
-beforeAll(() => {
-  vi.useFakeTimers({ shouldAdvanceTime: true });
-});
 
 interface MockEvalOutputCellProps extends EvalOutputCellProps {
   firstOutput: EvaluateTableOutput;
@@ -92,6 +89,7 @@ describe('EvalOutputCell duplicate image prevention', () => {
   });
 
   beforeEach(() => {
+    useTestTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
   });
 

--- a/src/app/src/pages/eval/components/EvalOutputCell.duplicateImages.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.duplicateImages.test.tsx
@@ -1,8 +1,8 @@
-import { useTestTimers } from '@app/tests/timers';
+import { type TestTimers, useTestTimers } from '@app/tests/timers';
 import { renderWithProviders as baseRender } from '@app/utils/testutils';
 import { type EvaluateTableOutput, ResultFailureReason } from '@promptfoo/types';
 import { screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
 import EvalOutputCell from './EvalOutputCell';
 
@@ -50,6 +50,7 @@ interface MockEvalOutputCellProps extends EvalOutputCellProps {
  */
 describe('EvalOutputCell duplicate image prevention', () => {
   const mockOnRating = vi.fn();
+  let timers: TestTimers | undefined;
 
   const createBaseProps = (overrides?: Partial<EvaluateTableOutput>): MockEvalOutputCellProps => ({
     firstOutput: {
@@ -89,8 +90,13 @@ describe('EvalOutputCell duplicate image prevention', () => {
   });
 
   beforeEach(() => {
-    useTestTimers({ shouldAdvanceTime: true });
+    timers = useTestTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    timers?.restore();
+    timers = undefined;
   });
 
   describe('primaryRenderedAsImage detection', () => {

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -1,4 +1,5 @@
 import { mockClipboard } from '@app/tests/browserMocks';
+import { useTestTimers } from '@app/tests/timers';
 import { renderWithProviders as baseRender } from '@app/utils/testutils';
 import {
   type AssertionType,
@@ -704,57 +705,49 @@ describe('EvalOutputCell', () => {
   });
 
   it('shows checkmark after copying link', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     const clipboard = mockClipboardWriteText();
 
-    try {
-      renderWithProviders(<EvalOutputCell {...defaultProps} />);
+    renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-      const shareButton = screen.getByRole('button', { name: /Copy link to output/i });
-      expect(shareButton).toBeInTheDocument();
+    const shareButton = screen.getByRole('button', { name: /Copy link to output/i });
+    expect(shareButton).toBeInTheDocument();
 
-      await act(async () => {
-        fireEvent.click(shareButton);
-        await clipboard.writeText.mock.results[0]?.value;
-      });
+    await act(async () => {
+      fireEvent.click(shareButton);
+      await clipboard.writeText.mock.results[0]?.value;
+    });
 
-      expect(clipboard.writeText).toHaveBeenCalled();
-      expect(shareButton.querySelector('.lucide-check')).toBeInTheDocument();
+    expect(clipboard.writeText).toHaveBeenCalled();
+    expect(shareButton.querySelector('.lucide-check')).toBeInTheDocument();
 
-      act(() => {
-        vi.advanceTimersByTime(3000);
-      });
+    act(() => {
+      timers.advanceBy(3000);
+    });
 
-      expect(shareButton.querySelector('.lucide-link')).toBeInTheDocument();
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(shareButton.querySelector('.lucide-link')).toBeInTheDocument();
   });
 
   it('clears the link feedback timer on unmount after copying link', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     const clipboard = mockClipboardWriteText();
 
-    try {
-      const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
+    const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /Copy link to output/i }));
-        await clipboard.writeText.mock.results[0]?.value;
-      });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Copy link to output/i }));
+      await clipboard.writeText.mock.results[0]?.value;
+    });
 
-      expect(vi.getTimerCount()).toBe(1);
+    expect(timers.getTimerCount()).toBe(1);
 
-      unmount();
+    unmount();
 
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(timers.getTimerCount()).toBe(0);
   });
 
   it('does not schedule link feedback after unmount if clipboard resolves late', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     let resolveClipboardWrite: () => void = () => {};
     const writeTextPromise = new Promise<void>((resolve) => {
       resolveClipboardWrite = resolve;
@@ -765,23 +758,19 @@ describe('EvalOutputCell', () => {
 
     mockClipboard({ writeText: clipboard.writeText as Clipboard['writeText'] });
 
-    try {
-      const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
+    const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
 
-      fireEvent.click(screen.getByRole('button', { name: /Copy link to output/i }));
-      expect(clipboard.writeText).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /Copy link to output/i }));
+    expect(clipboard.writeText).toHaveBeenCalled();
 
-      unmount();
+    unmount();
 
-      await act(async () => {
-        resolveClipboardWrite();
-        await writeTextPromise;
-      });
+    await act(async () => {
+      resolveClipboardWrite();
+      await writeTextPromise;
+    });
 
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(timers.getTimerCount()).toBe(0);
   });
 
   it('displays the token usage tooltip with reasoning tokens', () => {

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -1,5 +1,5 @@
 import { mockClipboard } from '@app/tests/browserMocks';
-import { useTestTimers } from '@app/tests/timers';
+import { type TestTimers, useTestTimers } from '@app/tests/timers';
 import { renderWithProviders as baseRender } from '@app/utils/testutils';
 import {
   type AssertionType,
@@ -8,7 +8,7 @@ import {
 } from '@promptfoo/types';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
 import EvalOutputCell, { isImageProvider, isVideoProvider } from './EvalOutputCell';
 
@@ -81,6 +81,7 @@ interface MockEvalOutputCellProps extends EvalOutputCellProps {
 
 describe('EvalOutputCell', () => {
   const mockOnRating = vi.fn();
+  let timers: TestTimers | undefined;
 
   const defaultProps: MockEvalOutputCellProps = {
     firstOutput: {
@@ -150,6 +151,11 @@ describe('EvalOutputCell', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMockStoreState();
+  });
+
+  afterEach(() => {
+    timers?.restore();
+    timers = undefined;
   });
 
   it('handles outputs without text without throwing', () => {
@@ -705,7 +711,7 @@ describe('EvalOutputCell', () => {
   });
 
   it('shows checkmark after copying link', async () => {
-    const timers = useTestTimers();
+    timers = useTestTimers();
     const clipboard = mockClipboardWriteText();
 
     renderWithProviders(<EvalOutputCell {...defaultProps} />);
@@ -722,14 +728,14 @@ describe('EvalOutputCell', () => {
     expect(shareButton.querySelector('.lucide-check')).toBeInTheDocument();
 
     act(() => {
-      timers.advanceBy(3000);
+      timers?.advanceBy(3000);
     });
 
     expect(shareButton.querySelector('.lucide-link')).toBeInTheDocument();
   });
 
   it('clears the link feedback timer on unmount after copying link', async () => {
-    const timers = useTestTimers();
+    timers = useTestTimers();
     const clipboard = mockClipboardWriteText();
 
     const { unmount } = renderWithProviders(<EvalOutputCell {...defaultProps} />);
@@ -747,7 +753,7 @@ describe('EvalOutputCell', () => {
   });
 
   it('does not schedule link feedback after unmount if clipboard resolves late', async () => {
-    const timers = useTestTimers();
+    timers = useTestTimers();
     let resolveClipboardWrite: () => void = () => {};
     const writeTextPromise = new Promise<void>((resolve) => {
       resolveClipboardWrite = resolve;

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -354,23 +354,34 @@ describe('EvalOutputPromptDialog', () => {
     const transitionDuration = { enter: 320, exit: 250 };
 
     const root = ReactDOM.createRoot(container);
-    root.render(<EvalOutputPromptDialog {...defaultProps} />);
+    let isUnmounted = false;
 
-    await act(async () => {
-      await timers.advanceByAsync(50);
-    });
+    try {
+      root.render(<EvalOutputPromptDialog {...defaultProps} />);
 
-    act(() => {
-      root.unmount();
-    });
+      await act(async () => {
+        await timers.advanceByAsync(50);
+      });
 
-    await act(async () => {
-      await timers.advanceByAsync(transitionDuration.enter);
-    });
+      act(() => {
+        root.unmount();
+        isUnmounted = true;
+      });
 
-    expect(true).toBe(true);
+      await act(async () => {
+        await timers.advanceByAsync(transitionDuration.enter);
+      });
 
-    document.body.removeChild(container);
+      expect(true).toBe(true);
+    } finally {
+      if (!isUnmounted) {
+        act(() => {
+          root.unmount();
+        });
+      }
+      container.remove();
+      timers.restore({ runPending: true });
+    }
   });
 
   it('passes the promptIndex prop to DebuggingPanel when provided', async () => {

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -1,6 +1,7 @@
 import * as ReactDOM from 'react-dom/client';
 
 import { mockClipboard } from '@app/tests/browserMocks';
+import { useTestTimers } from '@app/tests/timers';
 import { renderWithProviders } from '@app/utils/testutils';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -345,7 +346,7 @@ describe('EvalOutputPromptDialog', () => {
 
   it('handles unmounting during drawer transition', async () => {
     // This test needs fake timers to control transition timing
-    vi.useFakeTimers();
+    const timers = useTestTimers();
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -356,7 +357,7 @@ describe('EvalOutputPromptDialog', () => {
     root.render(<EvalOutputPromptDialog {...defaultProps} />);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(50);
+      await timers.advanceByAsync(50);
     });
 
     act(() => {
@@ -364,13 +365,12 @@ describe('EvalOutputPromptDialog', () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(transitionDuration.enter);
+      await timers.advanceByAsync(transitionDuration.enter);
     });
 
     expect(true).toBe(true);
 
     document.body.removeChild(container);
-    vi.useRealTimers();
   });
 
   it('passes the promptIndex prop to DebuggingPanel when provided', async () => {

--- a/src/app/src/pages/eval/components/ProviderDisplay.test.tsx
+++ b/src/app/src/pages/eval/components/ProviderDisplay.test.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { restoreTestTimers, useTestTimers } from '@app/tests/timers';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { filterConfigForDisplay, ProviderDisplay } from './ProviderDisplay';
@@ -307,11 +308,11 @@ describe('filterConfigForDisplay', () => {
 
 describe('ProviderDisplay', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    useTestTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    restoreTestTimers();
   });
 
   const renderWithProviders = (

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1,5 +1,6 @@
 import { act } from 'react';
 
+import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
 import { renderWithProviders } from '@app/utils/testutils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -3491,9 +3492,10 @@ describe('ResultsTable minimal scroll room detection', () => {
   // Use mutable values with getters so they can be changed during tests
   let scrollHeightValue = 1000;
   let innerHeightValue = 700;
+  let timers: TestTimers;
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    timers = useTestTimers();
 
     // Reset to default values (plenty of scroll room)
     scrollHeightValue = 1000;
@@ -3531,7 +3533,7 @@ describe('ResultsTable minimal scroll room detection', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    restoreTestTimers();
   });
 
   it('adds minimal-scroll-room class when scroll room is less than 150px', async () => {
@@ -3543,7 +3545,7 @@ describe('ResultsTable minimal scroll room detection', () => {
 
     // Run all timers to trigger the setTimeout in useEffect
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');
@@ -3559,7 +3561,7 @@ describe('ResultsTable minimal scroll room detection', () => {
 
     // Run all timers to trigger the setTimeout in useEffect
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');
@@ -3575,7 +3577,7 @@ describe('ResultsTable minimal scroll room detection', () => {
 
     // Run initial timers
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     // Verify no class initially
@@ -3601,7 +3603,7 @@ describe('ResultsTable minimal scroll room detection', () => {
     renderWithProviders(<ResultsTable {...defaultProps} />);
 
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');
@@ -3617,7 +3619,7 @@ describe('ResultsTable minimal scroll room detection', () => {
     renderWithProviders(<ResultsTable {...defaultProps} />);
 
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');
@@ -3634,7 +3636,7 @@ describe('ResultsTable minimal scroll room detection', () => {
     renderWithProviders(<ResultsTable {...defaultProps} />);
 
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');
@@ -3652,7 +3654,7 @@ describe('ResultsTable minimal scroll room detection', () => {
     const { unmount } = renderWithProviders(<ResultsTable {...defaultProps} />);
 
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     unmount();
@@ -3670,7 +3672,7 @@ describe('ResultsTable minimal scroll room detection', () => {
     renderWithProviders(<ResultsTable {...defaultProps} />);
 
     await act(async () => {
-      vi.runAllTimers();
+      timers.runAll();
     });
 
     const stickyContainer = screen.getByTestId('results-table-header');

--- a/src/app/src/pages/eval/components/store.test.ts
+++ b/src/app/src/pages/eval/components/store.test.ts
@@ -2582,36 +2582,40 @@ describe('useTableStore', () => {
 
     it('should abort the request after 30 seconds if fetchMetadataKeys API call does not complete', async () => {
       const timers = useTestTimers();
-      const mockEvalId = 'test-eval-id';
+      try {
+        const mockEvalId = 'test-eval-id';
 
-      vi.mocked(callApi).mockImplementation((_url: string, options?: any) => {
-        return new Promise((_resolve, reject) => {
-          options?.signal?.addEventListener('abort', () => {
-            const abortError = new Error('The operation was aborted');
-            abortError.name = 'AbortError';
-            reject(abortError);
+        vi.mocked(callApi).mockImplementation((_url: string, options?: any) => {
+          return new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              const abortError = new Error('The operation was aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
           });
         });
-      });
 
-      act(() => {
-        useTableStore.setState({ currentMetadataKeysRequest: null });
-      });
+        act(() => {
+          useTableStore.setState({ currentMetadataKeysRequest: null });
+        });
 
-      act(() => {
-        useTableStore.getState().fetchMetadataKeys(mockEvalId);
-      });
+        act(() => {
+          useTableStore.getState().fetchMetadataKeys(mockEvalId);
+        });
 
-      expect(useTableStore.getState().metadataKeysLoading).toBe(true);
+        expect(useTableStore.getState().metadataKeysLoading).toBe(true);
 
-      await act(async () => {
-        await timers.runAllAsync();
-      });
+        await act(async () => {
+          await timers.runAllAsync();
+        });
 
-      const state = useTableStore.getState();
-      expect(state.metadataKeysLoading).toBe(false);
-      expect(state.metadataKeysError).toBe(false);
-      expect(state.currentMetadataKeysRequest).toBeNull();
+        const state = useTableStore.getState();
+        expect(state.metadataKeysLoading).toBe(false);
+        expect(state.metadataKeysError).toBe(false);
+        expect(state.currentMetadataKeysRequest).toBeNull();
+      } finally {
+        timers.restore({ runPending: true });
+      }
     });
   });
 });

--- a/src/app/src/pages/eval/components/store.test.ts
+++ b/src/app/src/pages/eval/components/store.test.ts
@@ -1,4 +1,5 @@
 import { HIDDEN_METADATA_KEYS } from '@app/constants';
+import { useTestTimers } from '@app/tests/timers';
 import { callApi } from '@app/utils/api';
 import { Severity } from '@promptfoo/redteam/constants';
 import { act } from '@testing-library/react';
@@ -2580,7 +2581,7 @@ describe('useTableStore', () => {
     });
 
     it('should abort the request after 30 seconds if fetchMetadataKeys API call does not complete', async () => {
-      vi.useFakeTimers();
+      const timers = useTestTimers();
       const mockEvalId = 'test-eval-id';
 
       vi.mocked(callApi).mockImplementation((_url: string, options?: any) => {
@@ -2604,15 +2605,13 @@ describe('useTableStore', () => {
       expect(useTableStore.getState().metadataKeysLoading).toBe(true);
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await timers.runAllAsync();
       });
 
       const state = useTableStore.getState();
       expect(state.metadataKeysLoading).toBe(false);
       expect(state.metadataKeysError).toBe(false);
       expect(state.currentMetadataKeysRequest).toBeNull();
-
-      vi.useRealTimers();
     });
   });
 });

--- a/src/app/src/pages/media/hooks/useVideoThumbnail.test.ts
+++ b/src/app/src/pages/media/hooks/useVideoThumbnail.test.ts
@@ -1,3 +1,4 @@
+import { useTestTimers } from '@app/tests/timers';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useVideoThumbnail } from './useVideoThumbnail';
@@ -216,7 +217,7 @@ describe('useVideoThumbnail', () => {
   });
 
   it('times out after 10 seconds', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
 
     const { result } = renderHook(() => useVideoThumbnail('/slow.mp4', 'hash-timeout'));
 
@@ -225,7 +226,7 @@ describe('useVideoThumbnail', () => {
     // 10s setTimeout is registered. Wrap in act so React processes
     // any state updates triggered during flushing.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+      await timers.advanceByAsync(100);
     });
 
     // Video element should now be created and waiting for events
@@ -233,13 +234,11 @@ describe('useVideoThumbnail', () => {
 
     // Advance past the 10s timeout without firing any video events
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
+      await timers.advanceByAsync(10_000);
     });
 
     expect(result.current.error).toBe('Thumbnail generation timed out');
     expect(result.current.isLoading).toBe(false);
-
-    vi.useRealTimers();
   });
 
   it('does not generate when enabled is false', () => {

--- a/src/app/src/pages/media/hooks/useVideoThumbnail.test.ts
+++ b/src/app/src/pages/media/hooks/useVideoThumbnail.test.ts
@@ -1,4 +1,4 @@
-import { useTestTimers } from '@app/tests/timers';
+import { type TestTimers, useTestTimers } from '@app/tests/timers';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useVideoThumbnail } from './useVideoThumbnail';
@@ -68,6 +68,7 @@ describe('useVideoThumbnail', () => {
   let mockVideo: ReturnType<typeof createMockVideo>;
   let mockCanvas: ReturnType<typeof createMockCanvas>;
   let originalCreateElement: typeof document.createElement;
+  let timers: TestTimers | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -92,6 +93,8 @@ describe('useVideoThumbnail', () => {
   });
 
   afterEach(() => {
+    timers?.restore({ runPending: true });
+    timers = undefined;
     document.createElement = originalCreateElement;
     vi.restoreAllMocks();
   });
@@ -217,7 +220,8 @@ describe('useVideoThumbnail', () => {
   });
 
   it('times out after 10 seconds', async () => {
-    const timers = useTestTimers();
+    const testTimers = useTestTimers();
+    timers = testTimers;
 
     const { result } = renderHook(() => useVideoThumbnail('/slow.mp4', 'hash-timeout'));
 
@@ -226,7 +230,7 @@ describe('useVideoThumbnail', () => {
     // 10s setTimeout is registered. Wrap in act so React processes
     // any state updates triggered during flushing.
     await act(async () => {
-      await timers.advanceByAsync(100);
+      await testTimers.advanceByAsync(100);
     });
 
     // Video element should now be created and waiting for events
@@ -234,7 +238,7 @@ describe('useVideoThumbnail', () => {
 
     // Advance past the 10s timeout without firing any video events
     await act(async () => {
-      await timers.advanceByAsync(10_000);
+      await testTimers.advanceByAsync(10_000);
     });
 
     expect(result.current.error).toBe('Thumbnail generation timed out');

--- a/src/app/src/pages/prompts/PromptDialog.test.tsx
+++ b/src/app/src/pages/prompts/PromptDialog.test.tsx
@@ -1,4 +1,5 @@
 import { mockClipboard } from '@app/tests/browserMocks';
+import { restoreTestTimers, useTestTimers } from '@app/tests/timers';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -133,12 +134,11 @@ const mockSelectedPromptThreeEvals: ServerPromptWithMetadata = {
 
 describe('PromptDialog', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    useTestTimers();
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
+    restoreTestTimers({ runPending: true });
   });
 
   it('should render the dialog with prompt details, prompt text, and eval history when openDialog is true and a valid selectedPrompt is provided', () => {

--- a/src/app/src/pages/redteam/setup/components/DefaultTestVariables.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/DefaultTestVariables.test.tsx
@@ -1,3 +1,4 @@
+import { type TestTimers, useTestTimers } from '@app/tests/timers';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DefaultTestVariables from './DefaultTestVariables';
@@ -11,6 +12,8 @@ vi.mock('../hooks/useRedTeamConfig', () => ({
 }));
 
 describe('DefaultTestVariables Component', () => {
+  let timers: TestTimers;
+
   const defaultConfig = {
     description: 'Test Configuration',
     plugins: [],
@@ -35,7 +38,7 @@ describe('DefaultTestVariables Component', () => {
   };
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    timers = useTestTimers();
     vi.clearAllMocks();
     mockUseRedTeamConfig.mockReturnValue({
       config: defaultConfig,
@@ -44,12 +47,12 @@ describe('DefaultTestVariables Component', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    timers.restore();
   });
 
   async function flushDebouncedUpdate() {
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(300);
+      await timers.advanceByAsync(300);
     });
   }
 
@@ -460,37 +463,33 @@ describe('DefaultTestVariables Component', () => {
   describe('ID Generation', () => {
     it('generates unique IDs even when multiple variables are created in the same millisecond', async () => {
       const timestamp = Date.now();
-      const originalDateNow = Date.now;
-      Date.now = vi.fn(() => timestamp);
-      try {
-        mockUseRedTeamConfig.mockReturnValue({
-          config: {
-            ...defaultConfig,
-            defaultTest: { vars: {} },
-          },
-          updateConfig: mockUpdateConfig,
-        });
+      timers.setSystemTime(timestamp);
 
-        render(<DefaultTestVariables />);
+      mockUseRedTeamConfig.mockReturnValue({
+        config: {
+          ...defaultConfig,
+          defaultTest: { vars: {} },
+        },
+        updateConfig: mockUpdateConfig,
+      });
 
-        const addButton = screen.getByText('Add Variable');
-        fireEvent.click(addButton);
-        fireEvent.click(addButton);
-        fireEvent.click(addButton);
+      render(<DefaultTestVariables />);
 
-        await flushDebouncedUpdate();
+      const addButton = screen.getByText('Add Variable');
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
 
-        expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
+      await flushDebouncedUpdate();
 
-        const vars = mockUpdateConfig.mock.calls[0][1].vars;
-        const ids = Object.keys(vars);
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
 
-        expect(ids[0]).not.toBe(ids[1]);
-        expect(ids[0]).not.toBe(ids[2]);
-        expect(ids[1]).not.toBe(ids[2]);
-      } finally {
-        Date.now = originalDateNow;
-      }
+      const vars = mockUpdateConfig.mock.calls[0][1].vars;
+      const ids = Object.keys(vars);
+
+      expect(ids[0]).not.toBe(ids[1]);
+      expect(ids[0]).not.toBe(ids[2]);
+      expect(ids[1]).not.toBe(ids[2]);
     });
   });
 

--- a/src/app/src/pages/redteam/setup/components/EstimatedProbesDisplay.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/EstimatedProbesDisplay.test.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import EstimatedProbesDisplay from './EstimatedProbesDisplay';
@@ -19,6 +20,7 @@ vi.mock('./strategies/utils', () => ({
 import { getEstimatedProbes } from './strategies/utils';
 
 const mockGetEstimatedProbes = vi.mocked(getEstimatedProbes);
+let timers: TestTimers;
 
 const mockConfig: Config = {
   description: 'Test Configuration',
@@ -40,14 +42,14 @@ const mockConfig: Config = {
 
 describe('EstimatedProbesDisplay', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    timers = useTestTimers();
     vi.clearAllMocks();
     // Default mock return value
     mockGetEstimatedProbes.mockReturnValue(150);
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    restoreTestTimers();
   });
 
   const showTooltip = () => {
@@ -56,7 +58,7 @@ describe('EstimatedProbesDisplay', () => {
 
     fireEvent.pointerMove(infoIcon!, { pointerType: 'mouse' });
     act(() => {
-      vi.advanceTimersByTime(700);
+      timers.advanceBy(700);
     });
 
     return screen.getByRole('tooltip');

--- a/src/app/src/pages/redteam/setup/components/Review.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.test.tsx
@@ -3,6 +3,7 @@ import { EvalHistoryProvider } from '@app/contexts/EvalHistoryContext';
 import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
 import { useEmailVerification } from '@app/hooks/useEmailVerification';
 import { useRedteamJobStore } from '@app/stores/redteamJobStore';
+import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
 import { callApi } from '@app/utils/api';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -224,6 +225,8 @@ vi.mock('../hooks/useRedTeamConfig', () => ({
 }));
 
 describe('Review Component', () => {
+  let timers: TestTimers;
+
   const defaultConfig = {
     description: 'Test Configuration',
     plugins: [],
@@ -240,7 +243,7 @@ describe('Review Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+    timers = useTestTimers();
 
     // Reset the mock to return a connected state by default
     vi.mocked(useApiHealth).mockReturnValue({
@@ -275,14 +278,7 @@ describe('Review Component', () => {
   });
 
   afterEach(() => {
-    // Only run pending timers if fake timers are active
-    // This prevents errors when child describe blocks use real timers
-    try {
-      vi.runOnlyPendingTimers();
-    } catch {
-      // Ignore error if timers are not mocked
-    }
-    vi.useRealTimers();
+    restoreTestTimers({ runPending: true });
   });
 
   describe('Component Integration', () => {
@@ -437,7 +433,7 @@ describe('Review Component', () => {
 
     // Advance timers for any animations/transitions
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
+      await timers.advanceByAsync(100);
     });
 
     const defaultTestVariables = screen.getByTestId('default-test-variables');

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -107,7 +107,7 @@ const directTimerMockPatterns = [
     message: 'use @app/tests/timers useTestTimers()',
   },
   {
-    pattern: /\bDate\.now\s*=/,
+    pattern: /\bDate\.now\s*=(?!=)/,
     message: 'mock time with vi.setSystemTime() or @app/tests/timers helpers',
   },
 ];
@@ -310,6 +310,15 @@ describe('test hygiene', () => {
       source.trim().startsWith('//') || source.includes('useTestTimers')
         ? []
         : directTimerMockPatterns.filter(({ pattern }) => pattern.test(source));
+
+    expect(matches).toEqual([]);
+  });
+
+  it.each([
+    'Date.now === originalDateNow',
+    'Date.now == originalDateNow',
+  ])('does not flag Date.now comparison source in %s', (source) => {
+    const matches = directTimerMockPatterns.filter(({ pattern }) => pattern.test(source));
 
     expect(matches).toEqual([]);
   });

--- a/src/app/src/tests/test-hygiene.test.ts
+++ b/src/app/src/tests/test-hygiene.test.ts
@@ -101,6 +101,16 @@ const directCallApiMockPatterns = [
     message: 'mock callApi with @app/tests/apiMocks helpers instead of casting callApi',
   },
 ];
+const directTimerMockPatterns = [
+  {
+    pattern: /\bvi\.useFakeTimers\s*\(/,
+    message: 'use @app/tests/timers useTestTimers()',
+  },
+  {
+    pattern: /\bDate\.now\s*=/,
+    message: 'mock time with vi.setSystemTime() or @app/tests/timers helpers',
+  },
+];
 const legacyDirectCallApiMockFiles = new Set([
   'hooks/useEvalOperations.test.ts',
   'pages/eval/components/Eval.test.tsx',
@@ -166,6 +176,25 @@ function findPatternViolations(
     toPosixRelativePath(file),
     patterns,
   );
+}
+
+function findLinePatternViolations(
+  file: string,
+  patterns: { pattern: RegExp; message: string }[],
+): string[] {
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .flatMap((line, index) => {
+      if (line.trim().startsWith('//')) {
+        return [];
+      }
+
+      return patterns.flatMap(({ pattern, message }) =>
+        pattern.test(line)
+          ? [`${toPosixRelativePath(file)}:${index + 1}: ${message}: ${line.trim()}`]
+          : [],
+      );
+    });
 }
 
 describe('test hygiene', () => {
@@ -264,6 +293,28 @@ describe('test hygiene', () => {
   });
 
   it.each([
+    'vi.useFakeTimers()',
+    'Date.now = vi.fn(() => timestamp)',
+  ])('detects direct timer mock source in %s', (source) => {
+    const matches = directTimerMockPatterns.filter(({ pattern }) => pattern.test(source));
+
+    expect(matches).toHaveLength(1);
+  });
+
+  it.each([
+    'useTestTimers()',
+    'vi.setSystemTime(timestamp)',
+    '// Note: Do NOT use vi.useFakeTimers() here - it breaks waitFor',
+  ])('ignores shared timer helper source in %s', (source) => {
+    const matches =
+      source.trim().startsWith('//') || source.includes('useTestTimers')
+        ? []
+        : directTimerMockPatterns.filter(({ pattern }) => pattern.test(source));
+
+    expect(matches).toEqual([]);
+  });
+
+  it.each([
     'mockCallApiResponse({ ok: true })',
     'mockCallApiResponseOnce({ step: 1 })',
     'rejectCallApi(new Error("network"))',
@@ -309,6 +360,18 @@ describe('test hygiene', () => {
       }
 
       return findPatternViolations(file, directCallApiMockPatterns);
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('uses shared timer helpers for frontend fake timers', () => {
+    const violations = findTestFiles(srcDir).flatMap((file) => {
+      if (file === thisFile) {
+        return [];
+      }
+
+      return findLinePatternViolations(file, directTimerMockPatterns);
     });
 
     expect(violations).toEqual([]);

--- a/src/app/src/tests/timers.ts
+++ b/src/app/src/tests/timers.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 type FakeTimerOptions = Parameters<typeof vi.useFakeTimers>[0];
+type SystemTime = Parameters<typeof vi.setSystemTime>[0];
 
 type RestoreTestTimersOptions = {
   runPending?: boolean;
@@ -51,7 +52,10 @@ export function useTestTimers(options?: FakeTimerOptions) {
     advanceByAsync: (milliseconds: number) => vi.advanceTimersByTimeAsync(milliseconds),
     getTimerCount: () => vi.getTimerCount(),
     restore: restoreTestTimers,
+    runAll: () => vi.runAllTimers(),
+    runAllAsync: () => vi.runAllTimersAsync(),
     runPending: () => vi.runOnlyPendingTimers(),
+    setSystemTime: (time: SystemTime) => vi.setSystemTime(time),
     useFakeTimers: (nextOptions: FakeTimerOptions = options) => vi.useFakeTimers(nextOptions),
     useRealTimers: () => vi.useRealTimers(),
   };


### PR DESCRIPTION
## Summary
- extend the frontend timer test helper with `runAll`, `runAllAsync`, and `setSystemTime`
- migrate remaining frontend tests away from direct `vi.useFakeTimers()` and `Date.now` assignment
- add a hygiene check that keeps new frontend tests on the shared timer helper path

## Test plan
- npm run test:app -- -- src/tests/test-hygiene.test.ts src/pages/media/hooks/useVideoThumbnail.test.ts src/pages/eval/components/EvalOutputPromptDialog.test.tsx src/pages/eval/components/EvalOutputCell.duplicateImages.test.tsx src/pages/eval/components/store.test.ts src/pages/eval/components/ResultsTable.test.tsx src/pages/redteam/setup/components/EstimatedProbesDisplay.test.tsx src/pages/eval/components/EvalOutputCell.test.tsx src/pages/redteam/setup/components/Review.test.tsx src/pages/redteam/setup/components/DefaultTestVariables.test.tsx src/pages/prompts/PromptDialog.test.tsx src/pages/eval/components/ProviderDisplay.test.tsx src/pages/eval/components/Eval.test.tsx src/pages/eval-creator/components/PromptsSection.test.tsx --run
- npm run lint:src
- npm run tsc