### PR TITLE
docs(site): document frontend TypeScript providers

### DIFF
--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -251,7 +251,7 @@ export default class TypedProvider implements ApiProvider {
 
 ### TypeScript Providers in Frontend Projects
 
-promptfoo loads TypeScript providers in Node.js, not through your frontend bundler. If your provider imports app code from a Vite, Next.js, or Webpack project, make sure the imports are also valid from Node.
+Promptfoo loads TypeScript providers in Node.js, not through your frontend bundler. If your provider imports app code from a Vite, Next.js, or Webpack project, make sure the imports are also valid from Node.
 
 For path aliases such as `@/utils`, define the alias in `tsconfig.json`:
 

--- a/site/docs/providers/custom-api.md
+++ b/site/docs/providers/custom-api.md
@@ -249,6 +249,32 @@ export default class TypedProvider implements ApiProvider {
 }
 ```
 
+### TypeScript Providers in Frontend Projects
+
+promptfoo loads TypeScript providers in Node.js, not through your frontend bundler. If your provider imports app code from a Vite, Next.js, or Webpack project, make sure the imports are also valid from Node.
+
+For path aliases such as `@/utils`, define the alias in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}
+```
+
+Run `promptfoo eval` from the project root so the TypeScript loader can find that `tsconfig.json`.
+
+If your provider depends on bundler-only aliases, browser-only globals, CSS imports, or frontend plugins, compile or bundle the provider to JavaScript first and reference the built file:
+
+```yaml
+providers:
+  - file://dist/promptfoo-provider.js
+```
+
 ## Additional Capabilities
 
 ### Embeddings API

--- a/test/smoke/fixtures/frontend-ts-provider/promptfooconfig.yaml
+++ b/test/smoke/fixtures/frontend-ts-provider/promptfooconfig.yaml
@@ -1,0 +1,9 @@
+description: 'Smoke test - TypeScript provider with frontend project syntax'
+prompts:
+  - hello frontend
+providers:
+  - file://provider.ts
+tests:
+  - assert:
+      - type: contains
+        value: 'frontend enum: hello frontend'

--- a/test/smoke/fixtures/frontend-ts-provider/promptfooconfig.yaml
+++ b/test/smoke/fixtures/frontend-ts-provider/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: 'Smoke test - TypeScript provider with frontend project syntax'
 prompts:
   - hello frontend

--- a/test/smoke/fixtures/frontend-ts-provider/provider.ts
+++ b/test/smoke/fixtures/frontend-ts-provider/provider.ts
@@ -1,6 +1,18 @@
 // @ts-expect-error The fixture tsconfig supplies this alias at smoke-test runtime.
 import { formatOutput } from '@/utils';
-import type { ApiProvider, ProviderOptions, ProviderResponse } from 'promptfoo';
+
+interface ProviderOptions {
+  id?: string;
+}
+
+interface ProviderResponse {
+  output: string;
+}
+
+interface ApiProvider {
+  id(): string;
+  callApi(prompt: string): Promise<ProviderResponse>;
+}
 
 // biome-ignore lint/style/noEnum: This fixture verifies TypeScript enums load in custom providers.
 enum Mode {

--- a/test/smoke/fixtures/frontend-ts-provider/provider.ts
+++ b/test/smoke/fixtures/frontend-ts-provider/provider.ts
@@ -1,0 +1,26 @@
+// @ts-expect-error The fixture tsconfig supplies this alias at smoke-test runtime.
+import { formatOutput } from '@/utils';
+import type { ApiProvider, ProviderOptions, ProviderResponse } from 'promptfoo';
+
+// biome-ignore lint/style/noEnum: This fixture verifies TypeScript enums load in custom providers.
+enum Mode {
+  Frontend = 'frontend enum',
+}
+
+export default class FrontendTsProvider implements ApiProvider {
+  private providerId: string;
+
+  constructor(options: ProviderOptions) {
+    this.providerId = options?.id || 'frontend-ts-provider';
+  }
+
+  id(): string {
+    return this.providerId;
+  }
+
+  async callApi(prompt: string): Promise<ProviderResponse> {
+    return {
+      output: `${Mode.Frontend}: ${formatOutput(prompt)}`,
+    };
+  }
+}

--- a/test/smoke/fixtures/frontend-ts-provider/src/utils.ts
+++ b/test/smoke/fixtures/frontend-ts-provider/src/utils.ts
@@ -1,0 +1,3 @@
+export function formatOutput(prompt: string): string {
+  return prompt;
+}

--- a/test/smoke/fixtures/frontend-ts-provider/tsconfig.json
+++ b/test/smoke/fixtures/frontend-ts-provider/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/test/smoke/js-ts-and-data.test.ts
+++ b/test/smoke/js-ts-and-data.test.ts
@@ -17,6 +17,7 @@ const CLI_PATH = path.resolve(__dirname, '../../dist/src/main.js');
 const ROOT_DIR = path.resolve(__dirname, '../..');
 const FIXTURES_DIR = path.resolve(__dirname, 'fixtures');
 const CONFIGS_DIR = path.resolve(FIXTURES_DIR, 'configs');
+const FRONTEND_TS_PROJECT_DIR = path.resolve(FIXTURES_DIR, 'frontend-ts-provider');
 const OUTPUT_DIR = path.resolve(__dirname, '.temp-output-jsts');
 
 /**
@@ -216,6 +217,29 @@ describe('JavaScript/TypeScript Provider Smoke Tests', () => {
       const parsed = JSON.parse(content);
       expect(parsed.results.results[0].success).toBe(true);
       expect(parsed.results.results[0].response.output).toContain('TypeScript Transitive Echo:');
+    });
+
+    it('3.3.3 - TypeScript provider with enum and tsconfig path alias', () => {
+      const configPath = path.join(FRONTEND_TS_PROJECT_DIR, 'promptfooconfig.yaml');
+      const outputPath = path.join(OUTPUT_DIR, 'ts-provider-frontend-output.json');
+
+      const { exitCode, stderr } = runCli(
+        ['eval', '-c', configPath, '-o', outputPath, '--no-cache'],
+        {
+          cwd: FRONTEND_TS_PROJECT_DIR,
+          env: {
+            PROMPTFOO_CONFIG_DIR: path.join(OUTPUT_DIR, 'frontend-ts-config'),
+            PROMPTFOO_LOG_DIR: path.join(OUTPUT_DIR, 'frontend-ts-logs'),
+          },
+        },
+      );
+
+      expect(exitCode, stderr).toBe(0);
+
+      const content = fs.readFileSync(outputPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed.results.results[0].success).toBe(true);
+      expect(parsed.results.results[0].response.output).toContain('frontend enum: hello frontend');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add a smoke fixture that mirrors #8116 with a TypeScript custom provider using an enum and a `@/utils` tsconfig path alias.
- Cover that fixture in the JS/TS provider smoke tests so future loader regressions catch frontend-style TypeScript providers.
- Document how to use custom TypeScript providers from frontend projects, including tsconfig path aliases and when to bundle to JavaScript.

## Validation
- `npm run f`
- `npm run l`
- `npm run tsc`
- `node --import tsx ../../../../src/main.ts eval -c promptfooconfig.yaml -o /tmp/promptfoo-8116-source-output.json --no-cache` from `test/smoke/fixtures/frontend-ts-provider`
- `NODE_OPTIONS='--experimental-specifier-resolution=node' npx vitest run test/smoke/js-ts-and-data.test.ts --config vitest.smoke.config.ts -t "3.3.3"`

## Notes
- Local `npm run build` completed `tsc`, `tsdown`, and the app build, then failed in the postbuild lifecycle because the `tsx` CLI could not create its local IPC pipe (`listen EPERM .../tsx-501/...pipe`). I reran the same postbuild script as `node --import tsx scripts/postbuild.ts` before the smoke check.

Refs #8116