### PR TITLE
chore(code-scan): address SAST findings

### DIFF
--- a/.github/promptfoo-code-scan.yaml
+++ b/.github/promptfoo-code-scan.yaml
@@ -1,0 +1,2 @@
+minimumSeverity: medium
+diffsOnly: true

--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -42,4 +42,5 @@ jobs:
           NPM_CONFIG_USERCONFIG: '/dev/null'
         with:
           min-severity: medium
+          config-path: .github/promptfoo-code-scan.yaml
           enable-fork-prs: true

--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Run Promptfoo Code Scan
         uses: promptfoo/code-scan-action@v0
         env:
-          # promptfoo@0.121.3 is compatible, but newer @asamuzakjp/css-color releases
-          # currently break jsdom's CommonJS import path during the global CLI install.
-          NPM_CONFIG_BEFORE: '2026-03-29T00:00:00.000Z'
+          # Keep the global CLI install on the first promptfoo release that retries
+          # transient repository MCP timeouts, while avoiding future dependency drift.
+          NPM_CONFIG_BEFORE: '2026-04-11T00:40:00.000Z'
           # Avoid combining the workflow's before pin with this repo's project .npmrc
           # min-release-age setting when the published action invokes nested npx commands.
           NPM_CONFIG_LOCATION: 'global'

--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -38,8 +38,8 @@ jobs:
           # transient repository MCP timeouts, while avoiding future dependency drift.
           NPM_CONFIG_BEFORE: '2026-04-11T00:40:00.000Z'
           # Avoid combining the workflow's before pin with this repo's project .npmrc
-          # min-release-age setting when the published action invokes nested npx commands.
-          NPM_CONFIG_LOCATION: 'global'
+          # min-release-age setting without changing nested npx package layout.
+          NPM_CONFIG_USERCONFIG: '/dev/null'
         with:
           min-severity: medium
           enable-fork-prs: true

--- a/src/app/src/tests/browserMocks.test.ts
+++ b/src/app/src/tests/browserMocks.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   mockBrowserProperty,
   mockIndexedDB,
+  mockIntersectionObserver,
+  mockObjectUrl,
   mockWindowLocation,
   restoreBrowserMocks,
 } from './browserMocks';
 
 describe('browserMocks', () => {
+  afterEach(() => {
+    restoreBrowserMocks();
+  });
+
   it('restores original properties after spies wrap mocked values', () => {
     const target = {
       open: () => 'original',
@@ -34,6 +40,37 @@ describe('browserMocks', () => {
 
     restoreBrowserMocks();
     expect(globalThis.indexedDB).toBe(originalIndexedDB);
+  });
+
+  it('mocks IntersectionObserver without nonportable properties', () => {
+    const onCreate = vi.fn();
+    const callback: IntersectionObserverCallback = vi.fn();
+
+    mockIntersectionObserver({ onCreate });
+
+    const observer = new window.IntersectionObserver(callback);
+
+    expect(onCreate).toHaveBeenCalledWith(callback);
+    expect(observer.root).toBeNull();
+    expect(observer.rootMargin).toBe('');
+    expect(observer.thresholds).toEqual([]);
+    expect('scrollMargin' in observer).toBe(false);
+  });
+
+  it('allows object URL mocks to be restored individually or together', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    const objectUrl = mockObjectUrl('blob:browser-mock-test');
+
+    expect(URL.createObjectURL(new Blob())).toBe('blob:browser-mock-test');
+
+    objectUrl.restoreCreateObjectURL();
+    expect(URL.createObjectURL).toBe(originalCreateObjectURL);
+    expect(URL.revokeObjectURL).toBe(objectUrl.revokeObjectURL);
+
+    objectUrl.restore();
+    expect(URL.revokeObjectURL).toBe(originalRevokeObjectURL);
   });
 
   it('updates and restores window.location through history state', () => {

--- a/src/app/src/tests/browserMocks.ts
+++ b/src/app/src/tests/browserMocks.ts
@@ -1,6 +1,10 @@
 import { vi } from 'vitest';
 
 type RestoreBrowserMock = () => void;
+type MockedBrowserProperty<V> = {
+  value: V;
+  restore: RestoreBrowserMock;
+};
 const mockWindowLocationUrlKeys = [
   'hash',
   'host',
@@ -23,11 +27,11 @@ export function restoreBrowserMocks() {
   }
 }
 
-export function mockBrowserProperty<T extends object, V>(
+function mockBrowserPropertyWithRestore<T extends object, V>(
   target: T,
   property: PropertyKey,
   value: V,
-) {
+): MockedBrowserProperty<V> {
   const descriptor = Object.getOwnPropertyDescriptor(target, property);
 
   Object.defineProperty(target, property, {
@@ -36,18 +40,42 @@ export function mockBrowserProperty<T extends object, V>(
     value,
   });
 
+  let restored = false;
   const restore = () => {
+    if (restored) {
+      return;
+    }
+    restored = true;
+
     if (descriptor) {
       Object.defineProperty(target, property, descriptor);
     } else {
       Reflect.deleteProperty(target, property);
     }
+
+    const restoreIndex = restoreCallbacks.lastIndexOf(restore);
+    if (restoreIndex !== -1) {
+      restoreCallbacks.splice(restoreIndex, 1);
+    }
   };
 
   restoreCallbacks.push(restore);
 
-  return value;
+  return { value, restore };
 }
+
+export function mockBrowserProperty<T extends object, V>(
+  target: T,
+  property: PropertyKey,
+  value: V,
+) {
+  return mockBrowserPropertyWithRestore(target, property, value).value;
+}
+
+type MockIntersectionObserverInstance = Pick<
+  IntersectionObserver,
+  'root' | 'rootMargin' | 'thresholds' | 'observe' | 'unobserve' | 'disconnect' | 'takeRecords'
+>;
 
 export function mockClipboard(overrides: Partial<Clipboard> = {}) {
   return mockBrowserProperty(navigator, 'clipboard', {
@@ -115,13 +143,12 @@ export function mockIntersectionObserver(options: IntersectionObserverMockOption
     return {
       root: null,
       rootMargin: '',
-      scrollMargin: '',
       thresholds: [],
       observe: options.observe ?? vi.fn(),
       unobserve: options.unobserve ?? vi.fn(),
       disconnect: options.disconnect ?? vi.fn(),
       takeRecords: vi.fn(() => []),
-    } satisfies IntersectionObserver;
+    } satisfies MockIntersectionObserverInstance;
   });
 
   return mockBrowserProperty(
@@ -139,10 +166,29 @@ export function mockObjectUrl(url = 'blob:test') {
   const createObjectURL = vi.fn(() => url);
   const revokeObjectURL = vi.fn();
 
-  mockBrowserProperty(URL, 'createObjectURL', createObjectURL as typeof URL.createObjectURL);
-  mockBrowserProperty(URL, 'revokeObjectURL', revokeObjectURL as typeof URL.revokeObjectURL);
+  const { restore: restoreCreateObjectURL } = mockBrowserPropertyWithRestore(
+    URL,
+    'createObjectURL',
+    createObjectURL as typeof URL.createObjectURL,
+  );
+  const { restore: restoreRevokeObjectURL } = mockBrowserPropertyWithRestore(
+    URL,
+    'revokeObjectURL',
+    revokeObjectURL as typeof URL.revokeObjectURL,
+  );
 
-  return { createObjectURL, revokeObjectURL };
+  const restore = () => {
+    restoreRevokeObjectURL();
+    restoreCreateObjectURL();
+  };
+
+  return {
+    createObjectURL,
+    revokeObjectURL,
+    restoreCreateObjectURL,
+    restoreRevokeObjectURL,
+    restore,
+  };
 }
 
 function createMockWindowLocationUrl(value: MockWindowLocationValue) {

--- a/src/app/vite.react-compiler.test.ts
+++ b/src/app/vite.react-compiler.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BabelFileResult } from '@babel/core';
 
+const mockReactCompilerPreset = vi.hoisted(() => vi.fn());
+
 vi.mock('@babel/core', () => ({
   transformAsync: vi.fn(),
 }));
 
 vi.mock('@vitejs/plugin-react', () => ({
-  reactCompilerPreset: vi.fn(() => ({
-    preset: () => ({ plugins: [['babel-plugin-react-compiler', {}]] }),
-  })),
+  reactCompilerPreset: mockReactCompilerPreset,
 }));
 
 function createMockBabelResult(code: string, map: BabelFileResult['map'] | null): BabelFileResult {
@@ -24,6 +24,10 @@ describe('reactCompilerPlugin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockReactCompilerPreset.mockReset();
+    mockReactCompilerPreset.mockReturnValue({
+      preset: () => ({ plugins: [['babel-plugin-react-compiler', {}]] }),
+    });
   });
 
   it('skips files from node_modules', async () => {
@@ -91,5 +95,47 @@ describe('reactCompilerPlugin', () => {
       code: transformedCode,
       map: null,
     });
+  });
+
+  it('disables the compiler when preset creation fails', async () => {
+    mockReactCompilerPreset.mockImplementation(() => {
+      throw new Error('plugin-react preset changed');
+    });
+
+    const { reactCompilerPlugin } = await import('./vite.shared');
+    const { transformAsync } = await import('@babel/core');
+    const plugin = reactCompilerPlugin();
+    const warn = vi.fn();
+
+    if (typeof plugin.buildStart === 'function') {
+      plugin.buildStart.call({ warn } as never, {} as never);
+    }
+    const result = await plugin.transform?.(
+      'const Component = () => <div>Hello</div>;',
+      '/project/src/Component.tsx',
+    );
+
+    expect(result).toBeNull();
+    expect(transformAsync).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('React Compiler will be disabled'));
+  });
+
+  it('disables the compiler when preset extraction fails', async () => {
+    mockReactCompilerPreset.mockReturnValue({
+      preset: () => {
+        throw new Error('preset extraction changed');
+      },
+    });
+
+    const { reactCompilerPlugin } = await import('./vite.shared');
+    const { transformAsync } = await import('@babel/core');
+
+    const result = await reactCompilerPlugin().transform?.(
+      'const Component = () => <div>Hello</div>;',
+      '/project/src/Component.tsx',
+    );
+
+    expect(result).toBeNull();
+    expect(transformAsync).not.toHaveBeenCalled();
   });
 });

--- a/src/app/vite.shared.ts
+++ b/src/app/vite.shared.ts
@@ -51,7 +51,15 @@ const nodeModulesPathPattern = /[\\/]node_modules[\\/]/;
 // Extract React Compiler Babel plugins from @vitejs/plugin-react's preset.
 // Validate the runtime shape defensively so plugin-react API changes disable
 // only this optimization instead of failing config evaluation.
-const reactCompilerPresetValue: unknown = reactCompilerPreset();
+function getReactCompilerPresetValue(): unknown {
+  try {
+    return reactCompilerPreset();
+  } catch {
+    return undefined;
+  }
+}
+
+const reactCompilerPresetValue: unknown = getReactCompilerPresetValue();
 const reactCompilerPlugins: TransformOptions['plugins'] | undefined = (() => {
   if (!reactCompilerPresetValue || typeof reactCompilerPresetValue !== 'object') {
     return undefined;
@@ -62,10 +70,14 @@ const reactCompilerPlugins: TransformOptions['plugins'] | undefined = (() => {
     return undefined;
   }
 
-  const presetResult = presetCandidate() as { plugins?: unknown } | null | undefined;
-  return Array.isArray(presetResult?.plugins)
-    ? (presetResult.plugins as TransformOptions['plugins'])
-    : undefined;
+  try {
+    const presetResult = presetCandidate() as { plugins?: unknown } | null | undefined;
+    return Array.isArray(presetResult?.plugins)
+      ? (presetResult.plugins as TransformOptions['plugins'])
+      : undefined;
+  } catch {
+    return undefined;
+  }
 })();
 const reactCompilerCodeFilter: RegExp | undefined = (() => {
   if (!reactCompilerPresetValue || typeof reactCompilerPresetValue !== 'object') {

--- a/src/app/vite.shared.ts
+++ b/src/app/vite.shared.ts
@@ -49,29 +49,43 @@ const browserModuleImportFilter = /(?:^|[\\/])(?:logger|createHash)(?:\.ts)?$/;
 const nodeModulesPathPattern = /[\\/]node_modules[\\/]/;
 
 // Extract React Compiler Babel plugins from @vitejs/plugin-react's preset.
-// The type assertion mirrors the shape returned by reactCompilerPreset() —
-// if a future version of plugin-react changes this, the optional chaining
-// below will keep the build working (compiler just won't run) and the
-// warning will surface the issue.
-const reactCompilerConfig = reactCompilerPreset() as {
-  preset: () => { plugins: TransformOptions['plugins'] };
-  rolldown?: { filter?: { code?: RegExp } };
-};
-const reactCompilerPlugins = reactCompilerConfig.preset().plugins;
-const reactCompilerCodeFilter = reactCompilerConfig.rolldown?.filter?.code;
+// Validate the runtime shape defensively so plugin-react API changes disable
+// only this optimization instead of failing config evaluation.
+const reactCompilerPresetValue: unknown = reactCompilerPreset();
+const reactCompilerPlugins: TransformOptions['plugins'] | undefined = (() => {
+  if (!reactCompilerPresetValue || typeof reactCompilerPresetValue !== 'object') {
+    return undefined;
+  }
+
+  const presetCandidate = (reactCompilerPresetValue as { preset?: unknown }).preset;
+  if (typeof presetCandidate !== 'function') {
+    return undefined;
+  }
+
+  const presetResult = presetCandidate() as { plugins?: unknown } | null | undefined;
+  return Array.isArray(presetResult?.plugins)
+    ? (presetResult.plugins as TransformOptions['plugins'])
+    : undefined;
+})();
+const reactCompilerCodeFilter: RegExp | undefined = (() => {
+  if (!reactCompilerPresetValue || typeof reactCompilerPresetValue !== 'object') {
+    return undefined;
+  }
+
+  const codeCandidate = (
+    reactCompilerPresetValue as {
+      rolldown?: { filter?: { code?: unknown } };
+    }
+  ).rolldown?.filter?.code;
+
+  return codeCandidate instanceof RegExp ? codeCandidate : undefined;
+})();
 const reactCompilerFileFilter = /\.[jt]sx?$/;
 const reactCompilerFileExcludes = [
   // Keep this table out of React Compiler centrally. Source-level compiler
   // opt-out directives are flagged by GitHub code scanning as unknown JS directives.
   /[\\/]src[\\/]app[\\/]src[\\/]pages[\\/]eval[\\/]components[\\/]ResultsTable\.tsx$/,
 ];
-
-if (!reactCompilerPlugins?.length) {
-  console.warn(
-    '[react-compiler] Failed to extract Babel plugins from @vitejs/plugin-react. ' +
-      'The React Compiler will be disabled for this build.',
-  );
-}
 
 export function browserModulesPlugin(): Plugin {
   return {
@@ -120,8 +134,17 @@ export function reactCompilerPlugin(): Plugin {
   return {
     name: 'react-compiler',
     enforce: 'pre',
-    async transform(code, id) {
+    buildStart() {
       if (!reactCompilerPlugins?.length) {
+        this.warn(
+          '[react-compiler] Failed to extract Babel plugins from @vitejs/plugin-react. ' +
+            'The React Compiler will be disabled for this build.',
+        );
+      }
+    },
+    async transform(code, id) {
+      const compilerPlugins = reactCompilerPlugins;
+      if (!compilerPlugins?.length) {
         return null;
       }
 
@@ -145,7 +168,7 @@ export function reactCompilerPlugin(): Plugin {
         parserOpts: {
           plugins: ['jsx', 'typescript'],
         },
-        plugins: reactCompilerPlugins,
+        plugins: compilerPlugins,
       });
 
       return result?.code ? { code: result.code, map: result.map } : null;

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -288,6 +288,10 @@ function convertToolsToConverseFormat(tools: BedrockConverseToolConfig[]): Tool[
   });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 /**
  * Convert tool choice to Converse API format.
  * Supports OpenAI tool choice format and native Bedrock format.
@@ -304,14 +308,12 @@ function convertToolChoiceToConverseFormat(
   if (toolChoice === 'any') {
     return { any: {} };
   }
-  if (toolChoice && typeof toolChoice === 'object') {
-    const tool = (toolChoice as { tool?: unknown }).tool;
-    if (tool && typeof tool === 'object') {
-      const name = (tool as { name?: unknown }).name;
-      if (typeof name === 'string') {
-        return { tool: { name } };
-      }
-    }
+  if (
+    isRecord(toolChoice) &&
+    isRecord(toolChoice.tool) &&
+    typeof toolChoice.tool.name === 'string'
+  ) {
+    return { tool: { name: toolChoice.tool.name } };
   }
   return { auto: {} };
 }

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -255,11 +255,16 @@ function dedupeTestCases(testCases: TestCase[]): TestCase[] {
 }
 
 function buildMaxCharsRetryInstructions(rejectedPromptLengths: number[], limit?: number): string {
+  const longestRejectedPromptText =
+    rejectedPromptLengths.length > 0
+      ? `${Math.max(...rejectedPromptLengths)} characters`
+      : 'unknown length';
+
   return dedent`
     Your previous response included ${rejectedPromptLengths.length} generated prompt${
       rejectedPromptLengths.length === 1 ? '' : 's'
     } that exceeded the ${limit ?? 'configured'}-character limit.
-    The longest rejected prompt was ${Math.max(...rejectedPromptLengths)} characters.
+    The longest rejected prompt was ${longestRejectedPromptText}.
     Generate replacement prompts only, and keep every user message within the character limit.
   `.trim();
 }

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -34,6 +34,8 @@ import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
 import type { TraceContextData } from '../../tracing/traceContext';
 import type { RedteamHistoryEntry } from '../types';
 
+export const BLOCKING_QUESTION_ANALYSIS_FEATURE_FLAG_TIMESTAMP = '2025-06-16T14:49:11-07:00';
+
 async function loadRedteamProvider({
   provider,
   jsonOnly = false,
@@ -595,7 +597,7 @@ export async function tryUnblocking({
     const { checkServerFeatureSupport } = await import('../../util/server');
     const supportsUnblocking = await checkServerFeatureSupport(
       'blocking-question-analysis',
-      '2025-06-16T14:49:11-07:00',
+      BLOCKING_QUESTION_ANALYSIS_FEATURE_FLAG_TIMESTAMP,
     );
 
     if (!supportsUnblocking) {

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -627,15 +627,10 @@ describe('Plugins', () => {
         ...ADDITIONAL_PLUGINS,
       ];
 
-      // Check that each expected plugin is registered
-      expectedPlugins.forEach((pluginKey) => {
-        const plugin = Plugins.find((p) => p.key === pluginKey);
-        expect(plugin).toBeDefined();
-      });
-
-      // Check the actual count matches the expected count
+      // Verify all expected plugin keys are present in the registry
       // Note: We don't expect exact equality because some plugins like collections may not be in the expected list
-      expect(Plugins.length).toBeGreaterThanOrEqual(expectedPlugins.length);
+      const registeredPluginKeys = Plugins.map((p) => p.key);
+      expect(registeredPluginKeys).toEqual(expect.arrayContaining(expectedPlugins));
     });
 
     it('should have unique plugin keys', () => {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -6,6 +6,7 @@ import {
   TEMPERATURE,
 } from '../../../src/redteam/providers/constants';
 import {
+  BLOCKING_QUESTION_ANALYSIS_FEATURE_FLAG_TIMESTAMP,
   formatRedteamHistoryAsTranscript,
   getTargetResponse,
   type Message,
@@ -993,7 +994,7 @@ describe('shared redteam provider utilities', () => {
       expect(result.success).toBe(false);
       expect(mockedCheckServerFeatureSupport).toHaveBeenCalledWith(
         'blocking-question-analysis',
-        '2025-06-16T14:49:11-07:00',
+        BLOCKING_QUESTION_ANALYSIS_FEATURE_FLAG_TIMESTAMP,
       );
     });
   });


### PR DESCRIPTION
## Summary
- Extract the blocking-question-analysis feature flag timestamp into a named constant and reuse it in the test.
- Harden React Compiler preset extraction in the Vite shared config, including thrown preset creation/evaluation failures, and move the disabled-compiler warning into plugin execution.
- Tighten redteam max-chars retry messaging, plugin registry coverage checks, browser test mocks, and Bedrock toolChoice object validation.
- Stabilize the Promptfoo Code Scan workflow by pinning the scanner CLI cutoff, isolating npm user config for nested npx calls, and scanning PR diffs via `.github/promptfoo-code-scan.yaml` to avoid flaky filesystem MCP startup.

## Validation
- `npm run f` (passes; reports existing complexity warnings in `src/providers/bedrock/converse.ts`)
- `npm run l` (passes; reports the same existing complexity warnings)
- `npm run test:app -- -- vite.react-compiler.test.ts src/tests/browserMocks.test.ts --run`
- `npx vitest run test/codeScans/mcp/filesystem.test.ts test/redteam/plugins/index.test.ts test/redteam/providers/shared.test.ts test/providers/bedrock/converse.test.ts`
- `npm run tsc`
- `npm run tsc --prefix src/app`
- Promptfoo Code Scan workflow dispatch `24276046250` passed

## Review notes
- No actionable inline review threads were present.
- Copilot and CodeRabbit generated no actionable comments; Promptfoo scanner returned all clear after the workflow update.
- Left `src/evaluator.ts` and `site/blog/unicode-threats/components/VSCodeSimulator.tsx` findings unchanged because the flagged values are read in the current code and appear to be false positives.