### PR TITLE
test(fetch): isolate proxy environment

### DIFF
--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -158,6 +158,7 @@ describe('fetchWithProxy', () => {
     clearAgentCache();
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response());
     vi.mocked(ProxyAgent).mockClear();
+    cliState.basePath = undefined;
     cliState.maxConcurrency = undefined;
   });
 
@@ -165,6 +166,8 @@ describe('fetchWithProxy', () => {
     vi.resetAllMocks();
     restoreFetchTestEnv();
     restoreFetchTestEnv = () => {};
+    cliState.basePath = undefined;
+    cliState.maxConcurrency = undefined;
   });
 
   it('should add version header to all requests', async () => {
@@ -560,6 +563,8 @@ describe('fetchWithProxy', () => {
       https_proxy: 'http://https-proxy-lower.example.com',
       HTTP_PROXY: 'http://http-proxy.example.com',
       http_proxy: 'http://http-proxy-lower.example.com',
+      ALL_PROXY: 'http://all-proxy.example.com',
+      all_proxy: 'http://all-proxy-lower.example.com',
     } as const;
 
     const httpTestCases = [
@@ -570,6 +575,14 @@ describe('fetchWithProxy', () => {
       {
         env: { http_proxy: mockProxyUrls.http_proxy },
         expected: { url: mockProxyUrls.http_proxy },
+      },
+      {
+        env: { ALL_PROXY: mockProxyUrls.ALL_PROXY },
+        expected: { url: mockProxyUrls.ALL_PROXY },
+      },
+      {
+        env: { all_proxy: mockProxyUrls.all_proxy },
+        expected: { url: mockProxyUrls.all_proxy },
       },
     ];
 
@@ -582,10 +595,19 @@ describe('fetchWithProxy', () => {
         env: { https_proxy: mockProxyUrls.https_proxy },
         expected: { url: mockProxyUrls.https_proxy },
       },
+      {
+        env: { ALL_PROXY: mockProxyUrls.ALL_PROXY },
+        expected: { url: mockProxyUrls.ALL_PROXY },
+      },
+      {
+        env: { all_proxy: mockProxyUrls.all_proxy },
+        expected: { url: mockProxyUrls.all_proxy },
+      },
     ];
 
     for (const testCase of httpTestCases) {
       vi.clearAllMocks();
+      clearAgentCache();
 
       clearProxyEnv();
 
@@ -625,6 +647,7 @@ describe('fetchWithProxy', () => {
 
     for (const testCase of httpsTestCases) {
       vi.clearAllMocks();
+      clearAgentCache();
 
       clearProxyEnv();
 
@@ -1279,12 +1302,16 @@ describe('fetchWithProxy with NO_PROXY', () => {
     clearAgentCache();
     vi.spyOn(global, 'fetch').mockImplementation(() => Promise.resolve(new Response()));
     vi.mocked(ProxyAgent).mockClear();
+    cliState.basePath = undefined;
+    cliState.maxConcurrency = undefined;
   });
 
   afterEach(() => {
     vi.resetAllMocks();
     restoreFetchTestEnv();
     restoreFetchTestEnv = () => {};
+    cliState.basePath = undefined;
+    cliState.maxConcurrency = undefined;
   });
 
   it('should respect NO_PROXY for localhost URLs', async () => {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -18,7 +18,24 @@ import {
   isTransientError,
 } from '../src/util/fetch/index';
 import { sleep } from '../src/util/time';
-import { createMockResponse } from './util/utils';
+import { clearProxyEnv, createMockResponse, mockProcessEnv, PROXY_ENV_KEYS } from './util/utils';
+
+const FETCH_TEST_ENV_KEYS = [
+  ...PROXY_ENV_KEYS,
+  'PROMPTFOO_INSECURE_SSL',
+  'PROMPTFOO_CA_CERT_PATH',
+] as const;
+
+function mockFetchTestEnv(): () => void {
+  return mockProcessEnv(
+    Object.fromEntries(FETCH_TEST_ENV_KEYS.map((key) => [key, undefined])) as Record<
+      string,
+      string | undefined
+    >,
+  );
+}
+
+let restoreFetchTestEnv = () => {};
 
 vi.mock('../src/util/time', () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
@@ -135,28 +152,19 @@ vi.mock('../src/cliState', () => ({
 
 describe('fetchWithProxy', () => {
   beforeEach(() => {
+    restoreFetchTestEnv();
+    restoreFetchTestEnv = mockFetchTestEnv();
     vi.clearAllMocks();
     clearAgentCache();
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response());
     vi.mocked(ProxyAgent).mockClear();
     cliState.maxConcurrency = undefined;
-
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.npm_config_https_proxy;
-    delete process.env.npm_config_http_proxy;
-    delete process.env.npm_config_proxy;
-    delete process.env.all_proxy;
-    delete process.env.PROMPTFOO_INSECURE_SSL;
-    delete process.env.PROMPTFOO_CA_CERT_PATH;
   });
 
   afterEach(() => {
     vi.resetAllMocks();
-    delete process.env.PROMPTFOO_INSECURE_SSL;
-    delete process.env.PROMPTFOO_CA_CERT_PATH;
+    restoreFetchTestEnv();
+    restoreFetchTestEnv = () => {};
   });
 
   it('should add version header to all requests', async () => {
@@ -554,8 +562,6 @@ describe('fetchWithProxy', () => {
       http_proxy: 'http://http-proxy-lower.example.com',
     } as const;
 
-    const allProxyVars = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'];
-
     const httpTestCases = [
       {
         env: { HTTP_PROXY: mockProxyUrls.HTTP_PROXY },
@@ -581,9 +587,7 @@ describe('fetchWithProxy', () => {
     for (const testCase of httpTestCases) {
       vi.clearAllMocks();
 
-      allProxyVars.forEach((key) => {
-        delete process.env[key];
-      });
+      clearProxyEnv();
 
       Object.entries(testCase.env).forEach(([key, value]) => {
         process.env[key] = value;
@@ -616,17 +620,13 @@ describe('fetchWithProxy', () => {
 
       expect(proxyConfigCalls).toEqual([`Using proxy: ${testCase.expected.url}`]);
 
-      allProxyVars.forEach((key) => {
-        delete process.env[key];
-      });
+      clearProxyEnv();
     }
 
     for (const testCase of httpsTestCases) {
       vi.clearAllMocks();
 
-      allProxyVars.forEach((key) => {
-        delete process.env[key];
-      });
+      clearProxyEnv();
 
       Object.entries(testCase.env).forEach(([key, value]) => {
         process.env[key] = value;
@@ -659,9 +659,7 @@ describe('fetchWithProxy', () => {
 
       expect(proxyConfigCalls).toEqual([`Using proxy: ${testCase.expected.url}`]);
 
-      allProxyVars.forEach((key) => {
-        delete process.env[key];
-      });
+      clearProxyEnv();
     }
   });
 
@@ -1275,35 +1273,18 @@ describe('fetchWithRetries', () => {
 
 describe('fetchWithProxy with NO_PROXY', () => {
   beforeEach(() => {
+    restoreFetchTestEnv();
+    restoreFetchTestEnv = mockFetchTestEnv();
     vi.clearAllMocks();
     clearAgentCache();
     vi.spyOn(global, 'fetch').mockImplementation(() => Promise.resolve(new Response()));
     vi.mocked(ProxyAgent).mockClear();
-
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.npm_config_https_proxy;
-    delete process.env.npm_config_http_proxy;
-    delete process.env.npm_config_proxy;
-    delete process.env.all_proxy;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
   });
 
   afterEach(() => {
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.npm_config_https_proxy;
-    delete process.env.npm_config_http_proxy;
-    delete process.env.npm_config_proxy;
-    delete process.env.all_proxy;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
     vi.resetAllMocks();
+    restoreFetchTestEnv();
+    restoreFetchTestEnv = () => {};
   });
 
   it('should respect NO_PROXY for localhost URLs', async () => {

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -115,6 +115,29 @@ export function mockProcessEnv(
   };
 }
 
+export const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'NPM_CONFIG_PROXY',
+  'NPM_CONFIG_HTTP_PROXY',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'npm_config_proxy',
+  'npm_config_http_proxy',
+  'npm_config_https_proxy',
+] as const;
+
+export function clearProxyEnv(): void {
+  for (const key of PROXY_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
 export function mockGlobal<T>(name: string, value: T): () => void {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
 


### PR DESCRIPTION
## Summary

- adds a shared proxy environment key list and cleanup helper for tests
- snapshots/restores fetch test proxy-related environment variables around each test
- updates `test/fetch.test.ts` to clear `ALL_PROXY` and other proxy aliases before exercising no-proxy behavior

## Why

The shuffled backend suite failed under seed `424242` when the local environment had `ALL_PROXY=socks5h://127.0.0.1:54952`. The fetch proxy tests cleared several proxy variables but missed uppercase `ALL_PROXY`, so ambient developer/CI proxy settings could change which dispatcher path was exercised.

## Validation

- `ALL_PROXY=socks5h://127.0.0.1:54952 npx vitest run test/fetch.test.ts --sequence.seed=424242 --reporter=dot`
- `npm run l && npm run f`
- `ALL_PROXY=socks5h://127.0.0.1:54952 npm test -- --sequence.seed=424242 --reporter=dot`
