### PR TITLE
test(site): report coverage to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -380,9 +380,18 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run Site Tests
+      - name: Run Site Tests with Coverage
         working-directory: site
-        run: npm test
+        run: npm run test:coverage
+
+      - name: Upload Site Coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./site/coverage/coverage-final.json
+          flags: site
+          name: site-coverage
+          fail_ci_if_error: true
+          use_oidc: true
 
   webui:
     name: webui tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,7 +30,6 @@ ignore:
   - '**/*.test.tsx'
   - '**/*.d.ts'
   - 'src/app/**/*' # Frontend has separate coverage
-  - 'site/**/*' # Documentation site - no coverage tracking
   - 'examples/**/*'
   - 'drizzle/**/*'
   - 'scripts/**/*'
@@ -54,4 +53,8 @@ flags:
   frontend:
     paths:
       - src/app/src/
+    carryforward: true
+  site:
+    paths:
+      - site/src/
     carryforward: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -18502,6 +18502,39 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/browser": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.3.tgz",
@@ -43290,6 +43323,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@tsconfig/docusaurus": "^2.0.9",
+        "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.0",
         "canvas-confetti": "^1.9.4",
         "clsx": "^2.1.1",
@@ -43630,35 +43664,6 @@
         "vite": "^8.0.5",
         "vitest": "^4.1.0",
         "zustand": "^5.0.12"
-      }
-    },
-    "src/app/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "src/app/node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rolldown/plugin-babel": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        }
       }
     },
     "src/app/node_modules/diff": {

--- a/site/package.json
+++ b/site/package.json
@@ -42,6 +42,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@tsconfig/docusaurus": "^2.0.9",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.0",
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",

--- a/site/src/test/docusaurusComponentStub.tsx
+++ b/site/src/test/docusaurusComponentStub.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type ComponentStubProps = {
+  children?: React.ReactNode;
+};
+
+export default function DocusaurusComponentStub({
+  children,
+}: ComponentStubProps): React.ReactElement {
+  return <>{children}</>;
+}

--- a/site/src/test/docusaurusRuntimeStub.tsx
+++ b/site/src/test/docusaurusRuntimeStub.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+type ProviderProps = {
+  children?: React.ReactNode;
+};
+
+export default function docusaurusDefault(value?: string) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return {
+    siteConfig: {
+      title: 'Promptfoo',
+      tagline: 'Test site',
+      url: 'https://www.promptfoo.dev',
+    },
+  };
+}
+
+export function HtmlClassNameProvider({ children }: ProviderProps): React.ReactElement {
+  return <>{children}</>;
+}
+
+export function PageMetadata(): null {
+  return null;
+}
+
+export const ThemeClassNames = {
+  page: {
+    blogListPage: 'blog-list-page',
+  },
+  wrapper: {
+    blogPages: 'blog-pages',
+  },
+};
+
+export function useBlogListPageStructuredData(): Record<string, never> {
+  return {};
+}
+
+export function useColorMode() {
+  return {
+    colorMode: 'light',
+    colorModeChoice: 'light',
+    setColorMode: () => {},
+  };
+}
+
+export function useDoc() {
+  return {
+    frontMatter: {},
+    metadata: {},
+    toc: [],
+  };
+}
+
+export function useLocation() {
+  return {
+    pathname: '/',
+  };
+}
+
+export function useThemeConfig() {
+  return {
+    colorMode: {
+      disableSwitch: false,
+    },
+  };
+}

--- a/site/src/test/useIsBrowserStub.ts
+++ b/site/src/test/useIsBrowserStub.ts
@@ -1,0 +1,3 @@
+export default function useIsBrowser(): boolean {
+  return true;
+}

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,16 +1,25 @@
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docusaurusComponentStub = path.resolve(__dirname, 'src/test/docusaurusComponentStub.tsx');
+const docusaurusRuntimeStub = path.resolve(__dirname, 'src/test/docusaurusRuntimeStub.tsx');
 
 export default defineConfig({
+  plugins: [...react()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     globals: false,
     include: ['src/**/*.test.{ts,tsx}'],
+    pool: 'forks',
+    isolate: true,
+    sequence: {
+      shuffle: true,
+    },
     // CSS processing for MUI components
     css: true,
     // Memory and timeout settings
@@ -24,14 +33,32 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
       include: ['src/**/*.ts', 'src/**/*.tsx'],
-      exclude: ['src/**/*.d.ts', 'src/**/*.test.ts', 'src/**/*.test.tsx', 'src/setupTests.ts'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+        'src/setupTests.ts',
+        'src/test/**',
+      ],
       // @ts-expect-error - 'all' is valid in Vitest v8 coverage but types are incomplete
       all: true,
     },
   },
   resolve: {
-    alias: {
-      '@site': path.resolve(__dirname),
-    },
+    alias: [
+      { find: '@site', replacement: path.resolve(__dirname) },
+      // Docusaurus provides these modules at build time. Vitest needs local
+      // stand-ins so V8 coverage can transform uncovered site files.
+      { find: /^@docusaurus\/(?:Head|Link)$/, replacement: docusaurusComponentStub },
+      {
+        find: /^@docusaurus\/(?:plugin-content-blog|plugin-content-docs)(?:\/client)?$/,
+        replacement: docusaurusRuntimeStub,
+      },
+      {
+        find: /^@docusaurus\/(?:router|theme-common|useBaseUrl|useDocusaurusContext|useIsBrowser)$/,
+        replacement: docusaurusRuntimeStub,
+      },
+      { find: /^@theme(?:-original)?\/.+$/, replacement: docusaurusComponentStub },
+    ],
   },
 });

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from 'vitest/config';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const docusaurusComponentStub = path.resolve(__dirname, 'src/test/docusaurusComponentStub.tsx');
 const docusaurusRuntimeStub = path.resolve(__dirname, 'src/test/docusaurusRuntimeStub.tsx');
+const docusaurusUseIsBrowserStub = path.resolve(__dirname, 'src/test/useIsBrowserStub.ts');
 
 export default defineConfig({
   plugins: [...react()],
@@ -54,8 +55,9 @@ export default defineConfig({
         find: /^@docusaurus\/(?:plugin-content-blog|plugin-content-docs)(?:\/client)?$/,
         replacement: docusaurusRuntimeStub,
       },
+      { find: /^@docusaurus\/useIsBrowser$/, replacement: docusaurusUseIsBrowserStub },
       {
-        find: /^@docusaurus\/(?:router|theme-common|useBaseUrl|useDocusaurusContext|useIsBrowser)$/,
+        find: /^@docusaurus\/(?:router|theme-common|useBaseUrl|useDocusaurusContext)$/,
         replacement: docusaurusRuntimeStub,
       },
       { find: /^@theme(?:-original)?\/.+$/, replacement: docusaurusComponentStub },


### PR DESCRIPTION
## Summary

- runs the site test job with coverage and uploads `site/coverage/coverage-final.json` to Codecov under a `site` flag
- removes the `site/**/*` Codecov ignore and adds a site flag path
- adds React transform support and Docusaurus test stubs so V8 coverage can transform uncovered TS/TSX site files
- makes the site Vitest config shuffle tests by default and run in fork-isolated workers

## Why

The site coverage command previously exited successfully while logging many `Failed to parse ... Excluding it from coverage` messages. Codecov also ignored `site/**/*`, so site coverage was not a useful CI signal.

## Validation

- `npm run test:coverage --prefix site -- --coverage.reporter=json-summary --coverage.reporter=text-summary --silent`
- verified the coverage output contains no `Failed to parse` messages
- `npm run test:site -- --silent`
- `npm run l && npm run f`
- `npx @biomejs/biome check --write site/vitest.config.ts site/src/test/docusaurusComponentStub.tsx site/src/test/docusaurusRuntimeStub.tsx`