### PR TITLE
test: reduce test output noise

### DIFF
--- a/src/app/src/components/Navigation.test.tsx
+++ b/src/app/src/components/Navigation.test.tsx
@@ -236,11 +236,8 @@ describe('Navigation', () => {
       expect(modelAuditItem).toHaveAttribute('href', '/model-audit/setup');
 
       // Verify keyboard accessibility of the link
-      // Note: MUI may set tabindex="-1" for accessibility reasons in some cases
-      const tabIndex = modelAuditItem?.getAttribute('tabindex');
-      console.log('Model Audit link tabindex:', tabIndex);
-      // Accept current behavior rather than assert specific tabindex value
       expect(modelAuditItem).toBeInTheDocument();
+      expect(modelAuditItem).not.toHaveAttribute('aria-hidden', 'true');
     });
 
     it('shows correct descriptions for all dropdown items', () => {

--- a/src/app/src/components/ui/number-input.test.tsx
+++ b/src/app/src/components/ui/number-input.test.tsx
@@ -192,6 +192,12 @@ describe('NumberInput', () => {
     expect(input.value).toBe('');
   });
 
+  it('handles NaN value as empty string', () => {
+    render(<NumberInput value={Number.NaN} onChange={vi.fn()} />);
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+
   it('calls onBlur when provided', async () => {
     const user = userEvent.setup();
     const handleBlur = vi.fn();

--- a/src/app/src/components/ui/number-input.tsx
+++ b/src/app/src/components/ui/number-input.tsx
@@ -97,6 +97,7 @@ function NumberInput({
 
   const hasError = Boolean(error);
   const errorMessage = typeof error === 'string' ? error : undefined;
+  const displayValue = typeof value === 'number' && Number.isNaN(value) ? '' : (value ?? '');
 
   return (
     <div className={cn('flex flex-col', fullWidth && 'w-full')}>
@@ -112,7 +113,7 @@ function NumberInput({
         <input
           id={inputId}
           type="number"
-          value={value ?? ''}
+          value={displayValue}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onWheel={handleWheel}

--- a/src/app/src/pages/eval/components/EvaluationPanel.tsx
+++ b/src/app/src/pages/eval/components/EvaluationPanel.tsx
@@ -379,7 +379,7 @@ function GradingPromptSection({ gradingResults }: { gradingResults?: GradingResu
       <h4 className="mb-2 text-sm font-medium">Grading Prompts</h4>
       <div className="space-y-2">
         {promptsWithData.map((result, i) => (
-          <Collapsible key={i} open={openItems[i]} onOpenChange={() => toggleItem(i)}>
+          <Collapsible key={i} open={Boolean(openItems[i])} onOpenChange={() => toggleItem(i)}>
             <div className="rounded-lg border border-border">
               <CollapsibleTrigger asChild>
                 <button className="flex w-full items-center justify-between px-4 py-3 text-sm hover:bg-muted/50 transition-colors">

--- a/src/app/src/pages/eval/components/TruncatedText.tsx
+++ b/src/app/src/pages/eval/components/TruncatedText.tsx
@@ -73,7 +73,7 @@ function TruncatedText({ text: rawText, maxLength }: TruncatedTextProps) {
     if (Array.isArray(node)) {
       const nodes: React.ReactNode[] = [];
       let currentLength = length;
-      for (const child of node) {
+      for (const child of React.Children.toArray(node)) {
         const childLength = textLength(child);
         if (currentLength + childLength > maxLength) {
           nodes.push(truncateText(child, currentLength));

--- a/src/app/src/pages/redteam/report/components/PluginStrategyFlow.test.tsx
+++ b/src/app/src/pages/redteam/report/components/PluginStrategyFlow.test.tsx
@@ -13,15 +13,17 @@ vi.mock('recharts', () => ({
     <div data-testid="sankey-chart">
       {props.data.nodes.map((node: any, index: number) => (
         <div key={index}>
-          {React.cloneElement(props.node, {
-            x: 0,
-            y: 0,
-            width: 10,
-            height: 10,
-            index,
-            payload: node,
-            containerWidth: 500,
-          })}
+          <svg>
+            {React.cloneElement(props.node, {
+              x: 0,
+              y: 0,
+              width: 10,
+              height: 10,
+              index,
+              payload: node,
+              containerWidth: 500,
+            })}
+          </svg>
         </div>
       ))}
       {props.data.links.map((_link: any, index: number) => (

--- a/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategoryDrawer.tsx
@@ -203,9 +203,19 @@ const RiskCategoryDrawer = ({
         <div className="group rounded-lg border border-border bg-card overflow-hidden transition-colors hover:border-primary/30 hover:shadow-sm">
           {/* Header */}
           <CollapsibleTrigger asChild>
-            <button
-              type="button"
+            <div
+              role="button"
+              tabIndex={0}
               className="flex w-full flex-col gap-1 p-3 text-left cursor-pointer hover:bg-muted/50"
+              onKeyDown={(e) => {
+                if (e.target !== e.currentTarget) {
+                  return;
+                }
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  e.currentTarget.click();
+                }
+              }}
             >
               <div className="flex w-full items-center gap-3">
                 <ChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform [[data-state=closed]_&]:-rotate-90" />
@@ -222,6 +232,8 @@ const RiskCategoryDrawer = ({
                 <div className="flex items-center gap-2 shrink-0">
                   {hasSuggestions && (
                     <button
+                      type="button"
+                      aria-label="View suggestions"
                       className="rounded-md p-1 hover:bg-muted"
                       onClick={(e) => {
                         e.stopPropagation();
@@ -256,7 +268,7 @@ const RiskCategoryDrawer = ({
                   </p>
                 </div>
               )}
-            </button>
+            </div>
           </CollapsibleTrigger>
 
           {/* Collapsible content */}

--- a/src/app/src/pages/redteam/report/components/SuggestionsDialog.tsx
+++ b/src/app/src/pages/redteam/report/components/SuggestionsDialog.tsx
@@ -239,7 +239,7 @@ export default function SuggestionsDialog({
                 ) : (
                   suggestion.action === 'replace-prompt' && (
                     <Collapsible
-                      open={expandedItems[index]}
+                      open={Boolean(expandedItems[index])}
                       onOpenChange={() => toggleExpanded(index)}
                     >
                       <CollapsibleTrigger asChild>

--- a/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
@@ -54,7 +54,15 @@ vi.mock('./PluginConfigDialog', () => ({
 
 vi.mock('./TestCaseDialog', () => ({
   TestCaseDialog: () => <div data-testid="test-case-dialog" />,
-  TestCaseGenerateButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
+  TestCaseGenerateButton: ({
+    children,
+    isGenerating: _isGenerating,
+    tooltipTitle: _tooltipTitle,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    isGenerating?: boolean;
+    tooltipTitle?: string;
+  }) => (
     <button type="button" {...props}>
       {children ?? 'Generate test case'}
     </button>

--- a/src/app/src/pages/redteam/setup/components/Plugins.unit.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.unit.test.tsx
@@ -55,7 +55,15 @@ vi.mock('./PluginConfigDialog', () => ({
 
 vi.mock('./TestCaseDialog', () => ({
   TestCaseDialog: () => <div data-testid="test-case-dialog" />,
-  TestCaseGenerateButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
+  TestCaseGenerateButton: ({
+    children,
+    isGenerating: _isGenerating,
+    tooltipTitle: _tooltipTitle,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    isGenerating?: boolean;
+    tooltipTitle?: string;
+  }) => (
     <button type="button" {...props}>
       {children ?? 'Generate test case'}
     </button>

--- a/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
@@ -168,7 +168,15 @@ vi.mock('./PresetCard', () => ({
 
 vi.mock('./TestCaseDialog', () => ({
   TestCaseDialog: () => <div data-testid="test-case-dialog" />,
-  TestCaseGenerateButton: ({ children, ...props }: React.ComponentProps<'button'>) => (
+  TestCaseGenerateButton: ({
+    children,
+    isGenerating: _isGenerating,
+    tooltipTitle: _tooltipTitle,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    isGenerating?: boolean;
+    tooltipTitle?: string;
+  }) => (
     <button type="button" {...props}>
       {children ?? 'Generate test case'}
     </button>

--- a/src/app/src/pages/redteam/setup/page.test.tsx
+++ b/src/app/src/pages/redteam/setup/page.test.tsx
@@ -1,5 +1,6 @@
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import { useToast } from '@app/hooks/useToast';
+import { callApi } from '@app/utils/api';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -56,6 +57,7 @@ vi.mock('./components/Setup', () => ({
 const mockedUseTelemetry = useTelemetry as Mock;
 const mockedUseToast = useToast as Mock;
 const mockedUseSetupState = useSetupState as unknown as Mock;
+const mockedCallApi = vi.mocked(callApi);
 
 // Capture initial store state for reset
 const initialRedTeamState = useRedTeamConfig.getState();
@@ -79,6 +81,10 @@ describe('RedTeamSetupPage', () => {
       hasSeenSetup: true, // Assume setup has been seen to not render the modal
       markSetupAsSeen: vi.fn(),
     });
+    mockedCallApi.mockResolvedValue({
+      ok: true,
+      json: async () => ({ configs: [] }),
+    } as Response);
   });
 
   afterEach(() => {

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -340,7 +340,6 @@ export default function RedTeamSetupPage() {
       const hasAnyStatefulStrategies = strategies.some(
         (strat: RedteamStrategy) => typeof strat !== 'string' && strat?.config?.stateful,
       );
-      console.log({ hasAnyStatefulStrategies, strategies });
       if (hasAnyStatefulStrategies) {
         if (typeof target === 'string') {
           target = { id: target, config: { stateful: true } };

--- a/src/app/src/setupTests.ts
+++ b/src/app/src/setupTests.ts
@@ -7,6 +7,12 @@ import { afterEach, expect, vi } from 'vitest';
 import { restoreBrowserMocks } from './tests/browserMocks';
 import { restoreTestTimers } from './tests/timers';
 
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();
 

--- a/src/app/src/utils/performanceProfiler.test.ts
+++ b/src/app/src/utils/performanceProfiler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearProfilerMetrics,
   getAllProfilerSummaries,
@@ -14,6 +14,10 @@ describe('performanceProfiler', () => {
     // Clear metrics before each test
     clearProfilerMetrics();
     consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleDebugSpy.mockRestore();
   });
 
   describe('onRenderCallback', () => {

--- a/src/app/src/utils/performanceProfiler.test.ts
+++ b/src/app/src/utils/performanceProfiler.test.ts
@@ -8,10 +8,12 @@ import {
 } from './performanceProfiler';
 
 describe('performanceProfiler', () => {
+  let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     // Clear metrics before each test
     clearProfilerMetrics();
-    vi.clearAllMocks();
+    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
   });
 
   describe('onRenderCallback', () => {
@@ -50,27 +52,19 @@ describe('performanceProfiler', () => {
     });
 
     it('logs significant renders to console.debug', () => {
-      const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-
       // Significant render (> 1ms)
       onRenderCallback('SlowComponent', 'mount', 5.5, 4.0, 100, 105);
 
       expect(consoleDebugSpy).toHaveBeenCalledWith(
         expect.stringContaining('[Profiler] SlowComponent mount: 5.50ms'),
       );
-
-      consoleDebugSpy.mockRestore();
     });
 
     it('does not log insignificant renders', () => {
-      const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-
       // Insignificant render (<= 1ms)
       onRenderCallback('FastComponent', 'mount', 0.5, 0.4, 100, 100.5);
 
       expect(consoleDebugSpy).not.toHaveBeenCalled();
-
-      consoleDebugSpy.mockRestore();
     });
 
     it('handles nested-update phase', () => {

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import react from '@vitejs/plugin-react';
+import { configDefaults } from 'vitest/config';
 import packageJson from '../../package.json' with { type: 'json' };
 import {
   browserModulesPlugin,
@@ -22,6 +23,37 @@ const maxForks = process.env.CI
   : Math.max(cpuCount - 2, 2); // Leave headroom for system locally
 
 const API_PORT = process.env.API_PORT || '15500';
+
+const ignoredTestConsolePatterns = [
+  'not wrapped in act',
+  'The current testing environment is not configured to support act',
+  'Received NaN for the `children` attribute',
+  'Error checking ModelAudit installation:',
+  'Error loading eval:',
+  'Failed to fetch datasets:',
+  'Error parsing file:',
+  'deeply nested key "metrics.score" returned undefined',
+  'Logout failed',
+  'Error during logout:',
+  'Error fetching user email:',
+  'Failed to parse YAML:',
+  'Invalid JSON configuration:',
+  'Error fetching eval data:',
+  'Error fetching metadata keys:',
+  'Error parsing CSV:',
+  'No worst strategy found for plugin',
+  'Failed to delete eval:',
+  'EnterpriseBanner: No evalId provided',
+  'Error checking cloud status:',
+  'Error setting email:',
+  'Error checking email status:',
+  'Error clearing email:',
+  'Error fetching cloud config:',
+  'Failed to copy text:',
+  'Failed to check share domain:',
+  'Failed to generate share URL',
+  'Error during target purpose discovery:',
+];
 
 // These environment variables are inherited from the parent process (main promptfoo server)
 // We set VITE_ prefixed variables here so Vite can expose them to the client code
@@ -95,9 +127,21 @@ export default {
     // Limit concurrent tests within each worker to prevent memory spikes
     maxConcurrency: 5,
 
+    // Keep ad hoc benchmarks out of ordinary unit-test runs; they print timing diagnostics by design.
+    exclude: [...configDefaults.exclude, 'src/**/__benchmarks__/**'],
+
     // Run tests in random order to catch test isolation issues early.
     sequence: {
       shuffle: true,
+    },
+
+    onConsoleLog(log: string, type: 'stdout' | 'stderr') {
+      if (
+        type === 'stderr' &&
+        ignoredTestConsolePatterns.some((pattern) => log.includes(pattern))
+      ) {
+        return false;
+      }
     },
 
     // Fail fast on first error in CI

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -55,6 +55,10 @@ const ignoredTestConsolePatterns = [
   'Error during target purpose discovery:',
 ];
 
+const showTestConsoleOutput =
+  process.env.PROMPTFOO_TEST_SHOW_OUTPUT === 'true' ||
+  process.env.PROMPTFOO_APP_TEST_SHOW_OUTPUT === 'true';
+
 // These environment variables are inherited from the parent process (main promptfoo server)
 // We set VITE_ prefixed variables here so Vite can expose them to the client code
 if (process.env.NODE_ENV === 'development') {
@@ -137,6 +141,7 @@ export default {
 
     onConsoleLog(log: string, type: 'stdout' | 'stderr') {
       if (
+        !showTestConsoleOutput &&
         type === 'stderr' &&
         ignoredTestConsolePatterns.some((pattern) => log.includes(pattern))
       ) {

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -25,34 +25,35 @@ const maxForks = process.env.CI
 const API_PORT = process.env.API_PORT || '15500';
 
 const ignoredTestConsolePatterns = [
-  'not wrapped in act',
-  'The current testing environment is not configured to support act',
-  'Received NaN for the `children` attribute',
-  'Error checking ModelAudit installation:',
-  'Error loading eval:',
-  'Failed to fetch datasets:',
-  'Error parsing file:',
-  'deeply nested key "metrics.score" returned undefined',
-  'Logout failed',
-  'Error during logout:',
-  'Error fetching user email:',
-  'Failed to parse YAML:',
-  'Invalid JSON configuration:',
-  'Error fetching eval data:',
-  'Error fetching metadata keys:',
-  'Error parsing CSV:',
-  'No worst strategy found for plugin',
-  'Failed to delete eval:',
-  'EnterpriseBanner: No evalId provided',
-  'Error checking cloud status:',
-  'Error setting email:',
-  'Error checking email status:',
-  'Error clearing email:',
-  'Error fetching cloud config:',
-  'Failed to copy text:',
-  'Failed to check share domain:',
-  'Failed to generate share URL',
-  'Error during target purpose discovery:',
+  /^Warning: .*not wrapped in act/,
+  /^An update to .*not wrapped in act/,
+  /^(Warning: )?The current testing environment is not configured to support act/,
+  /^Warning: Received NaN for the `children` attribute/,
+  /^Error checking ModelAudit installation:/,
+  /^Error loading eval:/,
+  /^Failed to fetch datasets:/,
+  /^Error parsing file:/,
+  /^deeply nested key "metrics\.score" returned undefined/,
+  /^Logout failed/,
+  /^Error during logout:/,
+  /^Error fetching user email:/,
+  /^Failed to parse YAML:/,
+  /^Invalid JSON configuration:/,
+  /^Error fetching eval data:/,
+  /^Error fetching metadata keys:/,
+  /^Error parsing CSV:/,
+  /^No worst strategy found for plugin/,
+  /^Failed to delete eval:/,
+  /^EnterpriseBanner: No evalId provided/,
+  /^Error checking cloud status:/,
+  /^Error setting email:/,
+  /^Error checking email status:/,
+  /^Error clearing email:/,
+  /^Error fetching cloud config:/,
+  /^Failed to copy text:/,
+  /^Failed to check share domain:/,
+  /^Failed to generate share URL/,
+  /^Error during target purpose discovery:/,
 ];
 
 const showTestConsoleOutput =
@@ -143,7 +144,7 @@ export default {
       if (
         !showTestConsoleOutput &&
         type === 'stderr' &&
-        ignoredTestConsolePatterns.some((pattern) => log.includes(pattern))
+        ignoredTestConsolePatterns.some((pattern) => pattern.test(log.trimStart()))
       ) {
         return false;
       }

--- a/test/config-schema.test.ts
+++ b/test/config-schema.test.ts
@@ -49,10 +49,7 @@ describe('config-schema.json', () => {
 
   it('should be a valid JSON Schema', () => {
     const valid = ajv.validateSchema(schema);
-    if (!valid) {
-      console.error('Schema validation errors:', ajv.errors);
-    }
-    expect(valid).toBe(true);
+    expect(valid, `Schema validation errors: ${JSON.stringify(ajv.errors, null, 2)}`).toBe(true);
   });
 
   it('should have required top-level properties', () => {
@@ -93,11 +90,9 @@ describe('config-schema.json', () => {
         const uniqueValues = [...new Set(values)];
         const duplicates = values.filter((item, index) => values.indexOf(item) !== index);
 
-        if (duplicates.length > 0) {
-          console.error(`Duplicates found at ${path}:`, duplicates);
-        }
-
-        expect(values).toHaveLength(uniqueValues.length);
+        expect(values, `Duplicates found at ${path}: ${duplicates.join(', ')}`).toHaveLength(
+          uniqueValues.length,
+        );
       });
     });
 

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -26,6 +26,15 @@ vi.mock('../../src/cache', () => ({
   isCacheEnabled: mockIsCacheEnabled,
 }));
 
+vi.mock('../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 vi.mock('fs');
 vi.mock('path');
 

--- a/test/providers/openai-codex-sdk.e2e.test.ts
+++ b/test/providers/openai-codex-sdk.e2e.test.ts
@@ -21,7 +21,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 
 vi.unmock('@openai/codex-sdk');
 vi.unmock('../../src/esm');
@@ -70,19 +70,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
   // Skip all tests if no API key or SDK not installed
   const describeOrSkip = hasApiKey && hasSdk ? describe : describe.skip;
 
-  beforeAll(() => {
-    if (!hasSdk) {
-      console.warn('Skipping E2E tests: @openai/codex-sdk not installed');
-    } else if (hasApiKey) {
-      console.info(`Running E2E tests with model: ${DEFAULT_E2E_MODEL}`);
-      console.info('(Set CODEX_E2E_MODEL to use a different model)');
-    } else {
-      console.warn(
-        'Skipping E2E tests: No real CODEX_API_KEY, CODEX_E2E_API_KEY, or OPENAI_API_KEY found',
-      );
-    }
-  });
-
   describeOrSkip('Real SDK Integration', () => {
     it(
       'should successfully generate code with real SDK',
@@ -106,9 +93,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
         expect(response.tokenUsage).toBeDefined();
         expect(response.tokenUsage?.total).toBeGreaterThan(0);
         expect(response.sessionId).toBeTruthy();
-
-        console.log('Generated code:', response.output);
-        console.log('Token usage:', response.tokenUsage);
       },
       testTimeout,
     );
@@ -148,8 +132,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
         expect(parsed.function_name).toBeTruthy();
         expect(Array.isArray(parsed.parameters)).toBe(true);
         expect(parsed.return_type).toBeTruthy();
-
-        console.log('Structured output:', parsed);
       },
       testTimeout,
     );
@@ -179,8 +161,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
         // Thread IDs should match (same thread reused)
         expect(sessionId1).toBe(sessionId2);
 
-        console.log('Thread reused:', sessionId1);
-
         await provider.cleanup();
       },
       testTimeout * 2,
@@ -193,7 +173,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
 
         // Skip if examples dir doesn't exist
         if (!fs.existsSync(examplesDir)) {
-          console.warn('Skipping: examples directory not found');
           return;
         }
 
@@ -209,8 +188,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
 
         expect(response.error).toBeUndefined();
         expect(response.output).toBeTruthy();
-
-        console.log('Working directory response:', response.output);
       },
       testTimeout,
     );
@@ -232,8 +209,6 @@ describe('OpenAICodexSDKProvider E2E', () => {
         expect(response.error).toBeUndefined();
         expect(response.output).toBeTruthy();
         expect(response.output).toContain('Paris');
-
-        console.log('Streaming response:', response.output);
       },
       testTimeout,
     );
@@ -286,9 +261,6 @@ Do not add extra words, punctuation, or explanation.
               }),
             ]),
           );
-
-          console.log('Skill response:', response.output);
-          console.log('Skill calls:', response.metadata?.skillCalls);
         } finally {
           fs.rmSync(tempDir, { recursive: true, force: true });
         }
@@ -331,8 +303,6 @@ Do not add extra words, punctuation, or explanation.
         // Pool should only have 2 threads (oldest evicted)
         const threadCount = (provider as any).threads.size;
         expect(threadCount).toBeLessThanOrEqual(2);
-
-        console.log('Thread pool size:', threadCount);
 
         await provider.cleanup();
       },

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { PythonWorker } from '../../src/python/worker';
 
 vi.mock('../../src/logger', () => ({
@@ -12,6 +12,10 @@ vi.mock('../../src/logger', () => ({
     warn: vi.fn(),
   },
 }));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 // Windows CI has severe filesystem delays (antivirus, etc.) - allow up to 90s
 // Non-Windows CI can also have timing variance with Python IPC, so use 15s (matching windows-path.test.ts)

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -1,8 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { PythonWorker } from '../../src/python/worker';
+
+vi.mock('../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
 
 // Windows CI has severe filesystem delays (antivirus, etc.) - allow up to 90s
 // Non-Windows CI can also have timing variance with Python IPC, so use 15s (matching windows-path.test.ts)

--- a/test/redteam/plugins/pluginDocumentation.test.ts
+++ b/test/redteam/plugins/pluginDocumentation.test.ts
@@ -135,13 +135,10 @@ describe('Plugin Documentation', () => {
         (plugin) => !docsPlugins.has(plugin) && !collections.has(plugin),
       );
 
-      if (missingFromDocs.length > 0) {
-        console.log('\nPlugins missing from documentation data:');
-        missingFromDocs.forEach((plugin) => console.log(`  - ${plugin}`));
-        console.log('\nAdd these plugins to site/docs/_shared/data/plugins.ts');
-      }
-
-      expect(missingFromDocs).toEqual([]);
+      expect(
+        missingFromDocs,
+        `Plugins missing from documentation data. Add these plugins to site/docs/_shared/data/plugins.ts:\n${missingFromDocs.map((plugin) => `  - ${plugin}`).join('\n')}`,
+      ).toEqual([]);
     });
 
     it('should not have orphaned plugins in documentation data', async () => {
@@ -153,15 +150,10 @@ describe('Plugin Documentation', () => {
         (plugin) => !constantsPlugins.has(plugin),
       );
 
-      if (missingFromConstants.length > 0) {
-        console.log('\nOrphaned plugins in documentation data:');
-        missingFromConstants.forEach((plugin) => console.log(`  - ${plugin}`));
-        console.log(
-          '\nRemove these from site/docs/_shared/data/plugins.ts or add them to src/redteam/constants/plugins.ts',
-        );
-      }
-
-      expect(missingFromConstants).toEqual([]);
+      expect(
+        missingFromConstants,
+        `Orphaned plugins in documentation data. Remove these from site/docs/_shared/data/plugins.ts or add them to src/redteam/constants/plugins.ts:\n${missingFromConstants.map((plugin) => `  - ${plugin}`).join('\n')}`,
+      ).toEqual([]);
     });
 
     it('should have plugin constants and documentation data files', async () => {

--- a/test/redteam/plugins/pluginId.test.ts
+++ b/test/redteam/plugins/pluginId.test.ts
@@ -122,12 +122,11 @@ describe('Plugin IDs', () => {
 
     // For each plugin ID found in the implementations, check if it matches an expected format
     const unexpectedPlugins: { id: string; baseId: string }[] = [];
+    const idsMissingPrefix: string[] = [];
 
     uniqueIds.forEach((id) => {
       if (!id.startsWith('promptfoo:redteam:') && id !== 'policy') {
-        console.warn(
-          `Plugin ID '${id}' does not start with the expected prefix 'promptfoo:redteam:'`,
-        );
+        idsMissingPrefix.push(id);
       }
 
       if (!expectedPrefixedPluginIds.has(id) && id !== 'policy') {
@@ -152,7 +151,6 @@ describe('Plugin IDs', () => {
           const matchesExpectedPlugin = allPluginsList.some((p) => baseId === p);
 
           if (!matchesExpectedPlugin) {
-            console.warn(`Plugin ID '${id}' (base: '${baseId}') is not listed in constants`);
             unexpectedPlugins.push({ id, baseId });
           }
         }
@@ -160,6 +158,16 @@ describe('Plugin IDs', () => {
     });
 
     // Make a single assertion for all unexpected plugins
-    expect(unexpectedPlugins).toEqual([]);
+    expect(
+      unexpectedPlugins,
+      [
+        'Unexpected plugin IDs:',
+        ...unexpectedPlugins.map(({ id, baseId }) => `  - ${id} (base: ${baseId})`),
+        idsMissingPrefix.length > 0 ? 'IDs missing promptfoo:redteam: prefix:' : '',
+        ...idsMissingPrefix.map((id) => `  - ${id}`),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    ).toEqual([]);
   });
 });

--- a/test/redteam/plugins/pluginId.test.ts
+++ b/test/redteam/plugins/pluginId.test.ts
@@ -159,7 +159,7 @@ describe('Plugin IDs', () => {
 
     // Make a single assertion for all unexpected plugins
     expect(
-      unexpectedPlugins,
+      { unexpectedPlugins, idsMissingPrefix },
       [
         'Unexpected plugin IDs:',
         ...unexpectedPlugins.map(({ id, baseId }) => `  - ${id} (base: ${baseId})`),
@@ -168,6 +168,6 @@ describe('Plugin IDs', () => {
       ]
         .filter(Boolean)
         .join('\n'),
-    ).toEqual([]);
+    ).toEqual({ unexpectedPlugins: [], idsMissingPrefix: [] });
   });
 });

--- a/test/redteam/providers/crescendo/index.test.ts
+++ b/test/redteam/providers/crescendo/index.test.ts
@@ -53,6 +53,15 @@ vi.mock('../../../../src/redteam/graders', () => ({
   getGraderById: mockGetGraderById,
 }));
 
+vi.mock('../../../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 vi.mock('../../../../src/redteam/remoteGeneration', async (importOriginal) => {
   return {
     ...(await importOriginal()),

--- a/test/redteam/strategies/strategyId.test.ts
+++ b/test/redteam/strategies/strategyId.test.ts
@@ -133,11 +133,10 @@ describe('Strategy IDs', () => {
       const directPath = path.join(strategyDir, `${strategy}.ts`);
 
       const fileExists = fs.existsSync(expectedPath) || fs.existsSync(directPath);
-      if (!fileExists) {
-        console.error(`Strategy implementation not found for: ${strategy}`);
-        console.error(`Checked paths: ${expectedPath} and ${directPath}`);
-      }
-      expect(fileExists).toBe(true);
+      expect(
+        fileExists,
+        `Strategy implementation not found for ${strategy}. Checked paths: ${expectedPath} and ${directPath}`,
+      ).toBe(true);
     });
   });
 });

--- a/test/smoke/configs-and-providers.test.ts
+++ b/test/smoke/configs-and-providers.test.ts
@@ -187,7 +187,6 @@ describe('Provider Smoke Tests', () => {
       if (exitCode !== 0) {
         const output = stdout + stderr;
         if (output.includes('python') || output.includes('Python')) {
-          console.warn('Skipping Python provider test - Python not available');
           return;
         }
       }

--- a/test/smoke/features-and-assertions.test.ts
+++ b/test/smoke/features-and-assertions.test.ts
@@ -89,7 +89,6 @@ describe('Named Function Provider Smoke Tests', () => {
           (output.toLowerCase().includes('not found') ||
             output.toLowerCase().includes('no such file'))
         ) {
-          console.warn('Skipping Python named function test - Python not available');
           return;
         }
       }

--- a/test/smoke/js-ts-and-data.test.ts
+++ b/test/smoke/js-ts-and-data.test.ts
@@ -321,7 +321,6 @@ describe('Script Assertion Smoke Tests', () => {
       if (exitCode !== 0) {
         const output = stdout + stderr;
         if (output.toLowerCase().includes('python') && output.toLowerCase().includes('not found')) {
-          console.warn('Skipping Python assertion test - Python not available');
           return;
         }
       }

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -959,10 +959,10 @@ describe('TestSuiteConfigSchema', () => {
       );
 
       const result = extendedSchema.safeParse(config);
-      if (!result.success) {
-        console.error(`Validation failed for ${file}:`, result.error);
-      }
-      expect(result.success).toBe(true);
+      expect(
+        result.success,
+        `Validation failed for ${file}: ${result.success ? '' : result.error.message}`,
+      ).toBe(true);
     });
   }
 });

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockConsole } from './util/utils';
 
 // Create mock for exec - using vi.hoisted to ensure it's available in vi.mock factory
 const { mockExecAsync } = vi.hoisted(() => {
@@ -29,6 +28,7 @@ vi.mock('../src/version', () => ({
   ENGINES: { node: '>=20.0.0' },
 }));
 
+import logger from '../src/logger';
 import {
   checkForUpdates,
   checkModelAuditUpdates,
@@ -71,18 +71,18 @@ describe('getLatestVersion', () => {
 });
 
 describe('checkForUpdates', () => {
-  let consoleLogSpy: ReturnType<typeof mockConsole>;
+  let loggerInfoSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     // Reset fetchWithTimeout to clear any queued mockResolvedValueOnce from other tests
     vi.mocked(fetchWithTimeout).mockReset();
     // Clear env var that other tests may have set
     delete process.env.PROMPTFOO_DISABLE_UPDATE;
-    consoleLogSpy = mockConsole('log');
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
   });
 
   afterEach(() => {
-    consoleLogSpy.mockRestore();
+    loggerInfoSpy.mockRestore();
   });
 
   it('should log an update message if a newer version is available - minor ver', async () => {
@@ -179,15 +179,15 @@ describe('getModelAuditCurrentVersion', () => {
 });
 
 describe('checkModelAuditUpdates', () => {
-  let consoleLogSpy: ReturnType<typeof mockConsole>;
+  let loggerInfoSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    consoleLogSpy = mockConsole('log');
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
     delete process.env.PROMPTFOO_DISABLE_UPDATE;
   });
 
   afterEach(() => {
-    consoleLogSpy.mockRestore();
+    loggerInfoSpy.mockRestore();
   });
 
   it('should return true and log message when update is available', async () => {

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -26,7 +26,7 @@ import type { AssertionType, TestCase, TestCaseWithVarsFile } from '../../src/ty
 import type { ApiProvider, ProviderOptions } from '../../src/types/providers';
 
 // Spy on logger.warn for tests that check warnings
-vi.spyOn(logger, 'warn');
+vi.spyOn(logger, 'warn').mockImplementation(() => logger);
 
 // Mock fetchWithTimeout before any imports that might use telemetry
 vi.mock('../../src/util/fetch', () => ({
@@ -559,11 +559,11 @@ describe('readStandaloneTestsFile', () => {
         expect(frenchTest).toBeDefined();
         expect(frenchTest?.vars?.body).toBe('Hello world');
       } else {
-        console.log('Skipping integration test - example Excel file not found');
+        return;
       }
-    } catch (error) {
+    } catch {
       // Skip test if read-excel-file is not installed
-      console.log('Skipping integration test - read-excel-file not available:', error);
+      return;
     }
   });
 

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -539,32 +539,34 @@ describe('readStandaloneTestsFile', () => {
     // Only run if read-excel-file is actually installed (in dev environment)
     try {
       await import('read-excel-file/node');
-      const fs = require('fs');
-
-      if (fs.existsSync(exampleFile)) {
-        const result = await readStandaloneTestsFile(exampleFile);
-
-        // Verify the structure matches expected test cases
-        expect(result).toHaveLength(4); // Based on the known test data
-        expect(result[0]).toMatchObject({
-          vars: expect.objectContaining({
-            language: expect.any(String),
-            body: expect.any(String),
-          }),
-          assert: expect.any(Array),
-        });
-
-        // Verify specific test case content
-        const frenchTest = result.find((test) => test.vars?.language === 'French');
-        expect(frenchTest).toBeDefined();
-        expect(frenchTest?.vars?.body).toBe('Hello world');
-      } else {
-        return;
-      }
     } catch {
       // Skip test if read-excel-file is not installed
       return;
     }
+
+    const actualFs = await vi.importActual<typeof import('fs')>('fs');
+    if (!actualFs.existsSync(exampleFile)) {
+      return;
+    }
+
+    vi.mocked(fs.existsSync).mockImplementation((filePath) => actualFs.existsSync(filePath));
+
+    const result = await readStandaloneTestsFile(exampleFile);
+
+    // Verify the structure matches expected test cases
+    expect(result).toHaveLength(4); // Based on the known test data
+    expect(result[0]).toMatchObject({
+      vars: expect.objectContaining({
+        language: expect.any(String),
+        body: expect.any(String),
+      }),
+      assert: expect.any(Array),
+    });
+
+    // Verify specific test case content
+    const frenchTest = result.find((test) => test.vars?.language === 'French');
+    expect(frenchTest).toBeDefined();
+    expect(frenchTest?.vars?.body).toBe('Hello world');
   });
 
   it('should handle Python files with default function name', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     root: '.',
     setupFiles: ['./vitest.setup.ts'],
 
+    // Keep successful backend unit-test runs focused on failures. Set
+    // PROMPTFOO_TEST_SHOW_OUTPUT=true when debugging stdout/stderr from tests.
+    silent: process.env.PROMPTFOO_TEST_SHOW_OUTPUT !== 'true',
+
     // Run tests in random order to catch test isolation issues early.
     // Tests should not depend on execution order or shared state.
     // Override with --sequence.shuffle=false when debugging specific failures.


### PR DESCRIPTION
## Summary

This PR reduces pass-time noise from the unit test suite so real failures are easier to spot in shuffled runs.

It focuses on three kinds of noise that were called out during the test audit:

- expected backend/provider errors that were printing during passing tests
- frontend React and DOM warnings from test fixtures or controlled component state
- direct diagnostic `console.*` output in tests that should instead be assertion context

## Cause and impact

Several tests intentionally exercise error paths but allowed the product logger, React warnings, or diagnostic `console.log` calls to print during successful runs. That makes shuffled test output hard to trust because expected errors, tracebacks, update banners, and React warnings look similar to real regressions.

The frontend suite also had a few component/test-fixture issues that caused avoidable warnings: uncontrolled-to-controlled Collapsible state, `NaN` rendered into the DOM, invalid nested button markup, cloned SVG nodes outside an SVG parent, and mocked props being forwarded to DOM buttons.

## Changes

- Quiet backend unit-test pass output by default via Vitest `silent`, with `PROMPTFOO_TEST_SHOW_OUTPUT=true` as an explicit debugging escape hatch.
- Remove direct diagnostic `console.log`/`console.warn`/`console.error` usage from audited tests and move details into assertion messages.
- Suppress expected logger output locally where tests assert warning/error behavior, including update checks, Python worker failures, Go provider errors, and Crescendo error handling.
- Remove OpenAI Codex SDK E2E diagnostic logging from skipped/running paths.
- Fix frontend warning sources: React act environment setup, `NaN` number input rendering, Collapsible boolean state, test-only Recharts SVG structure, invalid DOM props in mocks, and nested native buttons in the risk drawer trigger.
- Keep ad hoc frontend benchmarks out of ordinary app unit-test discovery.

## Validation

Passed:

```sh
source ~/.nvm/nvm.sh && nvm use && npx vitest run test/updates.test.ts test/providers/golangCompletion.test.ts test/python/worker.test.ts test/redteam/providers/crescendo/index.test.ts test/config-schema.test.ts test/redteam/plugins/pluginDocumentation.test.ts test/redteam/plugins/pluginId.test.ts test/redteam/strategies/strategyId.test.ts test/types/index.test.ts test/util/testCaseReader.test.ts test/providers/openai-codex-sdk.test.ts test/providers/bedrock/index.test.ts --sequence.seed=424242 --reporter=dot
```

Passed:

```sh
source ~/.nvm/nvm.sh && nvm use && npm run test --prefix src/app -- --run --sequence.seed=424242 --reporter=dot
```

Passed:

```sh
source ~/.nvm/nvm.sh && nvm use && npm run l && npm run f
```

Passed:

```sh
git diff --check
```

I also grepped the backend/app validation logs for the audited noise patterns (`stdout |`, `stderr |`, direct console diagnostics, tracebacks, update banners, React act/NaN warnings, and the known frontend fetch/parsing warning strings); the touched-scope runs were clean aside from npm's ambient local proxy warning outside Vitest.

## Notes

A full backend shuffled run is not clean on this standalone branch for issues outside this PR:

- With the local ambient proxy environment intact, `test/fetch.test.ts` still fails under seed `424242` because this branch intentionally does not include the separate proxy-isolation fix from #8610.
- With proxy variables cleared, the full backend run exposes an existing server-route/OTLP localhost failure cluster (`EADDRNOTAVAIL` / 502) in `test/server/routes/providers.test.ts`, `test/server/routes/user.test.ts`, `test/server/routes/traces.test.ts`, and `test/tracing/otlpReceiver.test.ts`. I reproduced the cluster separately; that should be handled as its own isolation follow-up rather than folded into this noise-only PR.
