### PR TITLE
fix(assertions): guard against empty array in handleGEval to prevent NaN score

### DIFF
--- a/src/assertions/geval.ts
+++ b/src/assertions/geval.ts
@@ -19,6 +19,14 @@ export const handleGEval = async ({
   const threshold = assertion.threshold ?? 0.7;
 
   if (Array.isArray(renderedValue)) {
+    if (renderedValue.length === 0) {
+      return {
+        assertion,
+        pass: false,
+        score: 0,
+        reason: 'G-Eval assertion requires at least one criterion string in the value array.',
+      };
+    }
     const scores: number[] = [];
     const reasons: string[] = [];
     for (const value of renderedValue) {


### PR DESCRIPTION
## Summary

- `handleGEval` in `src/assertions/geval.ts` divides by `scores.length` without checking for empty arrays, producing `NaN` for both `score` and `pass` with no user-visible reason
- Add an explicit early-return with a clear error message when `renderedValue` is `[]`

## Test plan

- [ ] Run `promptfoo eval` with `type: g-eval` and `value: []` — should now fail with `score: 0` and message `"G-Eval assertion requires at least one criterion string in the value array."` instead of `NaN`
- [ ] Run `promptfoo eval` with a non-empty string array — no behaviour change expected
- [ ] Run `promptfoo eval` with a plain string value — no behaviour change expected

Fixes #8613

🤖 Generated with [Claude Code](https://claude.com/claude-code)