### PR TITLE
test(providers): cover repo-local codex app-server skill metadata

### DIFF
--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3653,6 +3653,75 @@ describe('OpenAICodexAppServerProvider', () => {
     ]);
   });
 
+  it('records attempted repo-local skill calls when command execution fails', async () => {
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    const provider = new OpenAICodexAppServerProvider({
+      config: {
+        thread_cleanup: 'none',
+      },
+    });
+
+    const resultPromise = provider.callApi('Try a repo skill');
+
+    const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+    server.send({ id: initialize.id, result: {} });
+    const threadStart = await waitForMessage(
+      server,
+      (message) => message.method === 'thread/start',
+    );
+    server.send({ id: threadStart.id, result: { thread: { id: 'thr_repo_skill' } } });
+    const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+    server.send({
+      id: turnStart.id,
+      result: { turn: { id: 'turn_repo_skill', status: 'inProgress' } },
+    });
+
+    server.send({
+      method: 'item/completed',
+      params: {
+        threadId: 'thr_repo_skill',
+        turnId: 'turn_repo_skill',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd_repo_skill',
+          command: '.agents/skills/repo-skill/SKILL.md --help',
+          cwd: process.cwd(),
+          status: 'failed',
+          exitCode: 1,
+          durationMs: 1,
+        },
+      },
+    });
+    server.send({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thr_repo_skill',
+        turnId: 'turn_repo_skill',
+        itemId: 'msg_repo_skill',
+        delta: 'Skill attempt recorded',
+      },
+    });
+    server.send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thr_repo_skill',
+        turn: { id: 'turn_repo_skill', status: 'completed', items: [], error: null },
+      },
+    });
+
+    const result = await resultPromise;
+    expect(result.metadata?.skillCalls).toBeUndefined();
+    expect(result.metadata?.attemptedSkillCalls).toEqual([
+      {
+        name: 'repo-skill',
+        path: '.agents/skills/repo-skill/SKILL.md',
+        source: 'heuristic',
+      },
+    ]);
+  });
+
   it('kills the app-server process during cleanup', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);


### PR DESCRIPTION
## Summary
- add a focused Codex app-server provider test for repo-local `.agents/skills/.../SKILL.md` paths
- verify failed command executions are surfaced as `attemptedSkillCalls` without populating successful `skillCalls`
- cover a recent metadata branch in the new provider without widening the scope beyond the provider test file

## Why
The recent OpenAI Codex app-server provider added heuristic skill-call metadata, but the suite only covered home-directory skills. Repo-local skills and failed command attempts were still untested.

## Validation
- `source ~/.nvm/nvm.sh && nvm use >/dev/null && ./node_modules/.bin/vitest run test/providers/openai-codex-app-server.test.ts --coverage.enabled true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/providers/openai/codex-app-server.ts`
- `source ~/.nvm/nvm.sh && nvm use >/dev/null && npm_config_cache=/tmp/promptfoo-npm-cache npm run l`
- `source ~/.nvm/nvm.sh && nvm use >/dev/null && npm_config_cache=/tmp/promptfoo-npm-cache npm run f`
