### PR TITLE
test: clarify SAST test expectations

### DIFF
--- a/test/assertions/contains.test.ts
+++ b/test/assertions/contains.test.ts
@@ -573,7 +573,7 @@ describe('handleIContainsAny', () => {
     });
   });
 
-  it('should handle empty string in comma-separated list', () => {
+  it('should ignore empty entries in comma-separated list', () => {
     const params: AssertionParams = {
       ...defaultParams,
       assertion: { type: 'icontains-any', value: ',WORLD,,' },
@@ -587,6 +587,24 @@ describe('handleIContainsAny', () => {
       pass: false,
       score: 0,
       reason: 'Expected output to contain one of "WORLD"',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should preserve quoted empty strings in comma-separated list', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains-any', value: '"",WORLD' },
+      renderedValue: '"",WORLD' as AssertionValue,
+      outputString: '',
+      inverse: false,
+    };
+
+    const result = handleIContainsAny(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
       assertion: params.assertion,
     });
   });

--- a/test/providers/rubyCompletion.test.ts
+++ b/test/providers/rubyCompletion.test.ts
@@ -387,7 +387,7 @@ describe('RubyProvider', () => {
       });
     });
 
-    it('should preserve cached=false for fresh results with token usage', async () => {
+    it('should preserve Ruby fresh token usage without numRequests for compatibility', async () => {
       const provider = new RubyProvider('script.rb');
       mockIsCacheEnabled.mockReturnValue(true);
       const mockCache = {
@@ -415,6 +415,7 @@ describe('RubyProvider', () => {
           total: 30,
         },
       });
+      expect(result.tokenUsage).not.toHaveProperty('numRequests');
     });
 
     it('should handle missing token usage in cached results', async () => {
@@ -502,7 +503,9 @@ describe('RubyProvider', () => {
         cached: false,
       });
       expect(mockCache.set).toHaveBeenCalledWith(
-        'ruby:script.rb:default:call_api:5633d479dfae75ba7a78914ee380fa202bd6126e7c6b7c22e3ebc9e1a6ddc871:test prompt:undefined:undefined',
+        expect.stringMatching(
+          /^ruby:script\.rb:default:call_api:[a-f0-9]{64}:test prompt:undefined:undefined$/,
+        ),
         '{"output":"fresh result"}',
       );
     });

--- a/test/providers/scriptContext.test.ts
+++ b/test/providers/scriptContext.test.ts
@@ -43,11 +43,9 @@ describe('sanitizeScriptContext', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(1);
     const message = vi.mocked(logger.debug).mock.calls[0][0] as string;
-    expect(message).toContain('PythonProvider');
-    expect(message).toContain('getCache');
-    expect(message).toContain('logger');
-    expect(message).toContain('filters');
-    expect(message).toContain('originalProvider');
+    expect(message).toBe(
+      'PythonProvider sanitized context: stripped non-serializable keys [getCache, logger, filters, originalProvider]',
+    );
   });
 
   it('does not mutate the caller-owned context', () => {
@@ -95,8 +93,10 @@ describe('sanitizeScriptContext', () => {
       getCache: vi.fn(),
     } as unknown as CallApiContextParams;
 
-    sanitizeScriptContext('PythonProvider', context);
+    const sanitized = sanitizeScriptContext('PythonProvider', context);
 
+    expect(sanitized).toEqual({ vars: { foo: 'bar' } });
+    expect(sanitized).not.toHaveProperty('getCache');
     expect(logger.debug).toHaveBeenCalledTimes(1);
     const message = vi.mocked(logger.debug).mock.calls[0][0] as string;
     expect(message).toContain('getCache');

--- a/test/redteam/plugins/unsafebench.test.ts
+++ b/test/redteam/plugins/unsafebench.test.ts
@@ -144,6 +144,9 @@ vi.mock('../../../src/redteam/plugins/unsafebench', async () => {
         }),
       };
     });
+  Object.defineProperty(MockedUnsafeBenchPlugin, 'canGenerateRemote', {
+    value: originalModule.UnsafeBenchPlugin.canGenerateRemote,
+  });
 
   return {
     ...originalModule,
@@ -264,6 +267,7 @@ describe('UnsafeBenchPlugin', () => {
   });
 
   it('should set canGenerateRemote to false', () => {
+    expect(UnsafeBenchPlugin.canGenerateRemote).toBe(false);
     const plugin = new UnsafeBenchPlugin({ type: 'test' }, 'testing purposes', 'image');
     expect(plugin.canGenerateRemote).toBe(false);
   });

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -93,6 +93,10 @@ const mockedSleep = vi.mocked(sleep);
 const mockedLoadApiProviders = mockLoadApiProviders;
 const mockedCheckServerFeatureSupport = mockCheckServerFeatureSupport;
 
+function setCliStateConfig(config: typeof cliState.config) {
+  cliState.config = config;
+}
+
 describe('shared redteam provider utilities', () => {
   beforeEach(() => {
     // Clear all mocks thoroughly
@@ -110,11 +114,11 @@ describe('shared redteam provider utilities', () => {
     redteamProviderManager.clearProvider();
 
     // Reset cliState to default
-    cliState.config = {
+    setCliStateConfig({
       redteam: {
         provider: undefined,
       },
-    };
+    });
   });
 
   describe('RedteamProviderManager', () => {
@@ -200,18 +204,15 @@ describe('shared redteam provider utilities', () => {
       };
 
       // Clear and set up cliState for this test
-      cliState.config = {
+      setCliStateConfig({
         redteam: {
           provider: mockStateProvider,
         },
-      };
+      });
 
       const result = await redteamProviderManager.getProvider({});
 
       expect(result).toBe(mockStateProvider);
-
-      // Clean up for next test
-      cliState.config!.redteam!.provider = undefined;
     });
 
     it('sets and reuses providers', async () => {
@@ -230,7 +231,9 @@ describe('shared redteam provider utilities', () => {
 
       expect(result).toBe(mockProvider);
       expect(jsonResult).toBe(mockProvider);
-      expect(mockedLoadApiProviders).toHaveBeenCalledTimes(2); // Once for regular, once for jsonOnly
+      expect(mockedLoadApiProviders).toHaveBeenCalledTimes(2); // Preloads regular and jsonOnly caches
+      expect(mockedLoadApiProviders).toHaveBeenNthCalledWith(1, ['test-provider']);
+      expect(mockedLoadApiProviders).toHaveBeenNthCalledWith(2, ['test-provider']);
     });
 
     describe('getGradingProvider', () => {
@@ -256,11 +259,11 @@ describe('shared redteam provider utilities', () => {
         mockedLoadApiProviders.mockResolvedValue([mockProvider]);
 
         // Inject defaultTest provider config
-        (cliState as any).config = {
+        setCliStateConfig({
           defaultTest: {
             provider: 'from-defaultTest-provider',
           },
-        };
+        });
 
         const got = await redteamProviderManager.getGradingProvider();
         expect(got).toBe(mockProvider);
@@ -269,7 +272,7 @@ describe('shared redteam provider utilities', () => {
 
       it('falls back to redteam provider when grading not set', async () => {
         redteamProviderManager.clearProvider();
-        (cliState as any).config = {}; // no defaultTest
+        setCliStateConfig({}); // no defaultTest
 
         // Expect fallback to default OpenAI redteam provider
         const got = await redteamProviderManager.getGradingProvider({ jsonOnly: true });
@@ -291,7 +294,7 @@ describe('shared redteam provider utilities', () => {
         mockedLoadApiProviders.mockResolvedValue([mockProvider]);
 
         // Set defaultTest.options.provider but not redteam.provider
-        (cliState as any).config = {
+        setCliStateConfig({
           redteam: {
             provider: undefined,
           },
@@ -300,7 +303,7 @@ describe('shared redteam provider utilities', () => {
               provider: 'defaultTest-provider',
             },
           },
-        };
+        });
 
         const got = await redteamProviderManager.getProvider({});
         expect(got).toBe(mockProvider);
@@ -316,14 +319,14 @@ describe('shared redteam provider utilities', () => {
         mockedLoadApiProviders.mockResolvedValue([mockProvider]);
 
         // Set defaultTest.provider directly
-        (cliState as any).config = {
+        setCliStateConfig({
           redteam: {
             provider: undefined,
           },
           defaultTest: {
             provider: 'defaultTest-direct-provider',
           },
-        };
+        });
 
         const got = await redteamProviderManager.getProvider({});
         expect(got).toBe(mockProvider);
@@ -339,7 +342,7 @@ describe('shared redteam provider utilities', () => {
         mockedLoadApiProviders.mockResolvedValue([redteamProvider]);
 
         // Set both redteam.provider and defaultTest.options.provider
-        (cliState as any).config = {
+        setCliStateConfig({
           redteam: {
             provider: 'redteam-explicit-provider',
           },
@@ -348,7 +351,7 @@ describe('shared redteam provider utilities', () => {
               provider: 'defaultTest-provider',
             },
           },
-        };
+        });
 
         const got = await redteamProviderManager.getProvider({});
         expect(got).toBe(redteamProvider);
@@ -359,12 +362,12 @@ describe('shared redteam provider utilities', () => {
         redteamProviderManager.clearProvider();
         mockOpenAiInstances.length = 0;
 
-        (cliState as any).config = {
+        setCliStateConfig({
           redteam: {
             provider: undefined,
           },
           // No defaultTest
-        };
+        });
 
         const got = await redteamProviderManager.getProvider({});
         expect(got.id()).toContain('openai:');
@@ -454,11 +457,11 @@ describe('shared redteam provider utilities', () => {
 
   describe('getTargetResponse', () => {
     it('returns an error before calling the target when the prompt exceeds maxCharsPerMessage', async () => {
-      cliState.config = {
+      setCliStateConfig({
         redteam: {
           maxCharsPerMessage: 5,
         },
-      };
+      });
       const mockProvider: ApiProvider = {
         id: () => 'test-provider',
         callApi: vi.fn().mockResolvedValue({
@@ -478,11 +481,11 @@ describe('shared redteam provider utilities', () => {
     });
 
     it('only enforces maxCharsPerMessage for user messages in chat arrays', async () => {
-      cliState.config = {
+      setCliStateConfig({
         redteam: {
           maxCharsPerMessage: 5,
         },
-      };
+      });
       const mockProvider: ApiProvider = {
         id: () => 'test-provider',
         callApi: vi.fn().mockResolvedValue({

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -98,6 +98,10 @@ function setCliStateConfig(config: typeof cliState.config) {
 }
 
 describe('shared redteam provider utilities', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   beforeEach(() => {
     // Clear all mocks thoroughly
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- Clarify `icontains-any` comma parsing tests by distinguishing ignored empty entries from quoted empty strings.
- Document Ruby fresh token usage compatibility while making the cache-key assertion hash-agnostic.
- Tighten script-context, UnsafeBench, and redteam provider manager test assertions from the SAST findings.

## Validation
- `npx vitest run test/assertions/contains.test.ts test/providers/rubyCompletion.test.ts test/providers/scriptContext.test.ts test/redteam/plugins/unsafebench.test.ts test/redteam/providers/shared.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`