### PR TITLE
fix(redteam): throw immediately on non-OK HTTP responses in redteam discover

### DIFF
--- a/site/docs/red-team/discovery.md
+++ b/site/docs/red-team/discovery.md
@@ -42,3 +42,13 @@ The agent discovers four key areas:
 4. **User Context**: How the system perceives and categorizes users
 
 The responses are synthesized into a comprehensive profile to inform attack strategies. For privacy, target responses are not stored except in error cases where they may appear in Promptfoo Cloud's error logs for debugging purposes.
+
+## Troubleshooting
+
+If `promptfoo redteam discover` fails with `Remote server returned HTTP 400: Unknown task: target-purpose-discovery` (or a similar 400/404 error), your client is most likely out of date. Update with `npm install -g promptfoo@latest` and rerun.
+
+Other common errors:
+
+- **HTTP 401 / 403** — Run `promptfoo auth login` and confirm your account has access to target discovery.
+- **HTTP 429** — You are being rate limited; wait a moment and try again.
+- **HTTP 5xx** — The remote generation service is temporarily unavailable. Retry in a few minutes.

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -127,24 +127,53 @@ export function normalizeTargetPurposeDiscoveryResult(
   };
 }
 
+function extractStringField(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
 async function getRemoteResponseErrorDetail(response: Response): Promise<string> {
-  const errorText = await response.text();
-  const fallbackDetail = errorText.trim() || response.statusText || 'Unknown error';
-
+  const rawText = (await response.text()).trim();
+  const fallback = rawText || response.statusText || 'Unknown error';
+  if (!rawText) {
+    return fallback;
+  }
   try {
-    const errorJson = JSON.parse(errorText) as unknown;
-    if (errorJson && typeof errorJson === 'object') {
-      const { message, error } = errorJson as Record<string, unknown>;
-      if (typeof message === 'string' && message.trim()) {
-        return message;
-      }
-      if (typeof error === 'string' && error.trim()) {
-        return error;
-      }
-    }
-  } catch {}
+    const parsed = JSON.parse(rawText) as { message?: unknown; error?: unknown } | null;
+    const detail = extractStringField(parsed?.message) ?? extractStringField(parsed?.error);
+    return detail ?? fallback;
+  } catch {
+    // Not JSON — fall through to raw text.
+    return fallback;
+  }
+}
 
-  return fallbackDetail;
+const REMOTE_ERROR_HINTS: Record<number, string> = {
+  400: 'This usually means your promptfoo client is out of date. Try `npm install -g promptfoo@latest` and rerun.',
+  401: 'Check that you are logged in (`promptfoo auth login`) and that your account has access to target discovery.',
+  403: 'Check that you are logged in (`promptfoo auth login`) and that your account has access to target discovery.',
+  404: 'This usually means your promptfoo client is out of date. Try `npm install -g promptfoo@latest` and rerun.',
+  429: 'You are being rate limited. Wait a moment and try again.',
+};
+
+function getRemoteErrorHint(status: number): string | undefined {
+  if (REMOTE_ERROR_HINTS[status]) {
+    return REMOTE_ERROR_HINTS[status];
+  }
+  if (status >= 500) {
+    return 'The remote generation service may be temporarily unavailable. Retry in a few minutes or contact support if the issue persists.';
+  }
+  return undefined;
+}
+
+async function buildRemoteErrorFromResponse(response: Response): Promise<Error> {
+  const detail = await getRemoteResponseErrorDetail(response);
+  const hint = getRemoteErrorHint(response.status);
+  const base = `Remote server returned HTTP ${response.status}: ${detail}`;
+  return new Error(hint ? `${base}\n${hint}` : base);
 }
 
 /**
@@ -212,8 +241,7 @@ export async function doTargetPurposeDiscovery(
       });
 
       if (!response.ok) {
-        const errorDetail = await getRemoteResponseErrorDetail(response);
-        throw new Error(`Remote server returned HTTP ${response.status}: ${errorDetail}`);
+        throw await buildRemoteErrorFromResponse(response);
       }
 
       const responseData = await response.json();

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -192,9 +192,17 @@ export async function doTargetPurposeDiscovery(
       });
 
       if (!response.ok) {
-        const error = await response.text();
-        logger.error(`${LOG_PREFIX} Error getting the next question from remote server: ${error}`);
-        continue;
+        const errorText = await response.text();
+        let errorDetail: string;
+        try {
+          const errorJson = JSON.parse(errorText);
+          errorDetail = errorJson.message || errorJson.error || errorText;
+        } catch {
+          errorDetail = errorText;
+        }
+        throw new Error(
+          `Remote server returned HTTP ${response.status}: ${errorDetail}`,
+        );
       }
 
       const responseData = await response.json();

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -127,6 +127,26 @@ export function normalizeTargetPurposeDiscoveryResult(
   };
 }
 
+async function getRemoteResponseErrorDetail(response: Response): Promise<string> {
+  const errorText = await response.text();
+  const fallbackDetail = errorText.trim() || response.statusText || 'Unknown error';
+
+  try {
+    const errorJson = JSON.parse(errorText) as unknown;
+    if (errorJson && typeof errorJson === 'object') {
+      const { message, error } = errorJson as Record<string, unknown>;
+      if (typeof message === 'string' && message.trim()) {
+        return message;
+      }
+      if (typeof error === 'string' && error.trim()) {
+        return error;
+      }
+    }
+  } catch {}
+
+  return fallbackDetail;
+}
+
 /**
  * Queries Cloud for the purpose-discovery logic, sends each logic to the target,
  * and summarizes the results.
@@ -192,17 +212,8 @@ export async function doTargetPurposeDiscovery(
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
-        let errorDetail: string;
-        try {
-          const errorJson = JSON.parse(errorText);
-          errorDetail = errorJson.message || errorJson.error || errorText;
-        } catch {
-          errorDetail = errorText;
-        }
-        throw new Error(
-          `Remote server returned HTTP ${response.status}: ${errorDetail}`,
-        );
+        const errorDetail = await getRemoteResponseErrorDetail(response);
+        throw new Error(`Remote server returned HTTP ${response.status}: ${errorDetail}`);
       }
 
       const responseData = await response.json();

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -294,7 +294,7 @@ describe('doTargetPurposeDiscovery', () => {
     });
   });
 
-  it('should throw immediately on non-OK HTTP response from remote server', async () => {
+  it('should throw immediately on non-OK HTTP response with an actionable hint', async () => {
     const errorBody = JSON.stringify({
       error: 'Invalid task',
       message: 'Unknown task: target-purpose-discovery',
@@ -312,10 +312,34 @@ describe('doTargetPurposeDiscovery', () => {
       callApi: vi.fn(),
     };
 
-    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
+    const error = await doTargetPurposeDiscovery(target, undefined, false).catch((e) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain(
       'Remote server returned HTTP 400: Unknown task: target-purpose-discovery',
     );
+    expect(error.message).toContain('promptfoo@latest');
     // Should not retry — fetch should only be called once
+    expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
+    expect(target.callApi).not.toHaveBeenCalled();
+  });
+
+  it('should surface an auth hint on 401 responses', async () => {
+    mockedFetchWithProxy.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const target = {
+      id: () => 'test',
+      callApi: vi.fn(),
+    };
+
+    const error = await doTargetPurposeDiscovery(target, undefined, false).catch((e) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('Remote server returned HTTP 401: Unauthorized');
+    expect(error.message).toContain('promptfoo auth login');
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
     expect(target.callApi).not.toHaveBeenCalled();
   });

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -294,6 +294,51 @@ describe('doTargetPurposeDiscovery', () => {
     });
   });
 
+  it('should throw immediately on non-OK HTTP response from remote server', async () => {
+    const errorBody = JSON.stringify({
+      error: 'Invalid task',
+      message: 'Unknown task: target-purpose-discovery',
+    });
+
+    mockedFetchWithProxy.mockResolvedValue(
+      new Response(errorBody, {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const target = {
+      id: () => 'test',
+      callApi: vi.fn(),
+    };
+
+    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
+      'Remote server returned HTTP 400: Unknown task: target-purpose-discovery',
+    );
+    // Should not retry — fetch should only be called once
+    expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
+    expect(target.callApi).not.toHaveBeenCalled();
+  });
+
+  it('should throw with raw text on non-OK response with non-JSON body', async () => {
+    mockedFetchWithProxy.mockResolvedValue(
+      new Response('Service Unavailable', {
+        status: 503,
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+
+    const target = {
+      id: () => 'test',
+      callApi: vi.fn(),
+    };
+
+    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
+      'Remote server returned HTTP 503: Service Unavailable',
+    );
+    expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
+  });
+
   it('should handle mixed valid/invalid tools from server', async () => {
     const mockResponses = [
       {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -337,6 +337,27 @@ describe('doTargetPurposeDiscovery', () => {
       'Remote server returned HTTP 503: Service Unavailable',
     );
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
+    expect(target.callApi).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to status text on non-OK response with empty body', async () => {
+    mockedFetchWithProxy.mockResolvedValue(
+      new Response('', {
+        status: 418,
+        statusText: "I'm a teapot",
+      }),
+    );
+
+    const target = {
+      id: () => 'test',
+      callApi: vi.fn(),
+    };
+
+    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
+      "Remote server returned HTTP 418: I'm a teapot",
+    );
+    expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
+    expect(target.callApi).not.toHaveBeenCalled();
   });
 
   it('should handle mixed valid/invalid tools from server', async () => {


### PR DESCRIPTION
Fixes #8581

## Problem

When `promptfoo redteam discover` receives a non-OK HTTP response from the remote server (e.g., HTTP 400 `{"error":"Invalid task","message":"Unknown task: target-purpose-discovery"}`), the `doTargetPurposeDiscovery` function was silently calling `continue` in the while loop instead of propagating the error. This caused the same failing request to be retried up to `MAX_TURN_COUNT` (10) times, giving no useful feedback to the user.

## Solution

Replace the `continue` with an immediate `throw` that surfaces the HTTP status code and error detail from the server response. The error message is parsed from JSON if possible (extracting `message` or `error` fields), otherwise the raw response text is used. This matches how `data.error` is already handled later in the same loop.

Before:
```
[Target Discovery Agent] Error getting the next question from remote server: {"error":"Invalid task","message":"Unknown task: target-purpose-discovery"}
[Target Discovery Agent] Error getting the next question from remote server: {"error":"Invalid task","message":"Unknown task: target-purpose-discovery"}
... (repeated 10 times)
```

After:
```
An unexpected error occurred during target scan: Remote server returned HTTP 400: Unknown task: target-purpose-discovery
```

## Testing

- Added two new tests to `test/redteam/commands/discover.test.ts`:
  1. Verifies that a 400 JSON error response throws immediately and does not retry (fetch called exactly once)
  2. Verifies that a non-JSON error response (e.g., 503 plain text) is also handled correctly
- All 11 tests in the discover test suite pass