### PR TITLE
fix(providers): close stdin on exec provider to prevent child process hanging

### DIFF
--- a/src/providers/scriptCompletion.ts
+++ b/src/providers/scriptCompletion.ts
@@ -105,7 +105,7 @@ export class ScriptCompletionProvider implements ApiProvider {
       ]);
       const options = this.options?.config.basePath ? { cwd: this.options.config.basePath } : {};
 
-      execFile(command, scriptArgs, options, async (error, stdout, stderr) => {
+      const child = execFile(command, scriptArgs, options, async (error, stdout, stderr) => {
         if (error) {
           logger.debug(`Error running script ${this.scriptPath}: ${error.message}`);
           reject(error);
@@ -128,6 +128,10 @@ export class ScriptCompletionProvider implements ApiProvider {
         }
         resolve(result);
       });
+      // Close stdin immediately so child processes that read stdin don't hang.
+      // execFile pipes stdin by default but never writes to it, causing tools
+      // like opencode to block forever waiting for input.
+      child.stdin?.end();
     });
   }
 }

--- a/test/providers/scriptCompletion.test.ts
+++ b/test/providers/scriptCompletion.test.ts
@@ -180,6 +180,35 @@ describe('ScriptCompletionProvider', () => {
     expect(provider.id()).toBe('exec:node script.js');
   });
 
+  it('should close stdin on the child process to prevent hanging', async () => {
+    const stdinEnd = vi.fn();
+    vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {
+      (callback as (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void)(
+        null,
+        Buffer.from('ok'),
+        '',
+      );
+      return { stdin: { end: stdinEnd } } as any;
+    });
+
+    await provider.callApi('test prompt');
+    expect(stdinEnd).toHaveBeenCalledOnce();
+  });
+
+  it('should handle child process with no stdin gracefully', async () => {
+    vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {
+      (callback as (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void)(
+        null,
+        Buffer.from('ok'),
+        '',
+      );
+      return { stdin: null } as any;
+    });
+
+    const result = await provider.callApi('test prompt');
+    expect(result.output).toBe('ok');
+  });
+
   it('should handle UTF-8 characters in script output', async () => {
     const utf8Output = 'Hello, 世界!';
     vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {

--- a/test/smoke/configs-and-providers.test.ts
+++ b/test/smoke/configs-and-providers.test.ts
@@ -98,6 +98,24 @@ describe('Provider Smoke Tests', () => {
       // Exec provider should have executed the echo command
       expect(result.response.output).toContain('Echo from exec');
     });
+
+    // Regression for #8686: exec provider must close the child's stdin so that
+    // scripts reading from stdin (e.g. opencode) do not hang forever.
+    it('3.1.3 - exec provider closes stdin on child process', () => {
+      const configPath = path.join(FIXTURES_DIR, 'configs/exec-provider-stdin.yaml');
+      const outputPath = path.join(OUTPUT_DIR, 'exec-provider-stdin-output.json');
+
+      const { exitCode } = runCli(['eval', '-c', configPath, '-o', outputPath, '--no-cache']);
+
+      expect(exitCode).toBe(0);
+
+      const content = fs.readFileSync(outputPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      const result = parsed.results.results[0];
+
+      expect(result.success).toBe(true);
+      expect(result.response.output).toContain('stdin closed');
+    });
   });
 
   describe('3.3 OpenAI Tool Format', () => {

--- a/test/smoke/fixtures/configs/exec-provider-stdin.yaml
+++ b/test/smoke/fixtures/configs/exec-provider-stdin.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Smoke test - exec provider closes stdin (regression for #8686)'
+
+providers:
+  - 'exec:node ../providers/exec-provider-reads-stdin.js'
+
+prompts:
+  - 'Hello {{name}}'
+
+tests:
+  - vars:
+      name: World
+    assert:
+      - type: contains
+        value: stdin closed

--- a/test/smoke/fixtures/providers/exec-provider-reads-stdin.js
+++ b/test/smoke/fixtures/providers/exec-provider-reads-stdin.js
@@ -1,0 +1,4 @@
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(`stdin closed, prompt=${process.argv[2] ?? ''}`);
+});


### PR DESCRIPTION
## Summary

- Close stdin immediately after spawning child process in exec provider (`ScriptCompletionProvider`)
- Node's `execFile` pipes stdin by default but never writes to or closes it — tools that read stdin at startup (e.g. [opencode](https://github.com/sst/opencode)) block forever waiting for input
- Added two tests: verifies `stdin.end()` is called, and handles null stdin gracefully

## Problem

When using the exec provider to wrap CLI tools, some tools (like `opencode run`) attempt to read stdin during initialization. Since `execFile` creates a piped stdin that is never closed, the child process hangs indefinitely:

- **Direct shell execution**: works fine (stdin is /dev/null or TTY)
- **Via promptfoo exec provider**: hangs forever, 0 bytes output

Debug logs show the child process stalls before even completing its initialization sequence.

## Root Cause

`child_process.execFile()` defaults stdio to `['pipe', 'pipe', 'pipe']`. The parent (promptfoo) holds the stdin pipe open but never writes to it or closes it. Any child process that checks/reads stdin at startup will block forever.

Note: `execFile` does not properly support the `stdio` option (unlike `spawn`), so setting `stdio: ['ignore', 'pipe', 'pipe']` does not work. The fix is to explicitly call `child.stdin.end()` after spawning.

## Fix

```ts
const child = execFile(command, scriptArgs, options, callback);
child.stdin?.end();
```

## Test plan

- [x] Existing 11 tests pass
- [x] Added test: verifies `stdin.end()` is called on the child process
- [x] Added test: handles child process with null stdin gracefully
- [x] Verified end-to-end: opencode CLI now completes successfully via exec provider (was hanging indefinitely before)