### PR TITLE
fix(server): prevent circular JSON when Bedrock/Anthropic provider is used as llm-rubric judge from web UI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,15 +45,15 @@ export type {
 } from './evaluatorHelpers';
 
 /**
- * Shallow-clone a test case and its `options` and `assert[]` entries so that the
- * caller can freely mutate `test.options.provider` / `assertion.provider` with
- * resolved ApiProvider instances without leaking those mutations back to the
- * input (inline test case objects in `testSuite.tests` alias through
- * `readTests()`'s shallow copy). See the defaultTest block in `evaluate()` for
- * the full rationale — this is the same pattern for individual test cases.
+ * Shallow-clone a test case so the caller can swap in resolved ApiProvider
+ * instances on `options.provider` / `assert[].provider` without leaking those
+ * mutations back to the input. The input may alias the unified config written
+ * to the Eval record, and a live SDK client (e.g. Bedrock's BedrockRuntime,
+ * Anthropic's client) holds circular references that break drizzle's JSON
+ * serialization on `evalRecord.save()`. Fixes #8687.
  */
-function cloneTestForResolve(test: TestCase): TestCase {
-  const cloned: TestCase = { ...test };
+function cloneTestForResolve<T extends Pick<TestCase, 'options' | 'assert'>>(test: T): T {
+  const cloned: T = { ...test };
   if (test.options) {
     cloned.options = { ...test.options };
   }
@@ -98,20 +98,13 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     prompts: await processPrompts(testSuite.prompts),
   };
 
-  // Resolve nested providers
+  // Resolve nested providers. `constructedTestSuite` shallow-shares `defaultTest` and
+  // its `options` with the input, and `readTests()` shallow-copies inline test cases —
+  // so we clone before mutating to keep resolved ApiProvider instances out of the
+  // unified config persisted to the Eval record. See `cloneTestForResolve()`.
   if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
-    // Shallow-clone defaultTest (and options) before mutating so resolved ApiProvider
-    // instances don't leak back into testSuite.defaultTest via the shared reference.
-    // testSuite is reused below to build the unified config written to the Eval record;
-    // an instantiated SDK client (e.g. Bedrock's BedrockRuntime, Anthropic's client) holds
-    // circular references that break drizzle's JSON serialization on `evalRecord.save()`.
-    // Fixes #8687.
-    constructedTestSuite.defaultTest = { ...constructedTestSuite.defaultTest };
-    if (constructedTestSuite.defaultTest.options) {
-      constructedTestSuite.defaultTest.options = { ...constructedTestSuite.defaultTest.options };
-    }
+    constructedTestSuite.defaultTest = cloneTestForResolve(constructedTestSuite.defaultTest);
 
-    // Resolve defaultTest.provider (only if it's not already an ApiProvider instance)
     if (
       constructedTestSuite.defaultTest.provider &&
       !isApiProvider(constructedTestSuite.defaultTest.provider)
@@ -122,7 +115,6 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
         { env: testSuite.env, basePath: cliState.basePath },
       );
     }
-    // Resolve defaultTest.options.provider (only if it's not already an ApiProvider instance)
     if (
       constructedTestSuite.defaultTest.options?.provider &&
       !isApiProvider(constructedTestSuite.defaultTest.options.provider)
@@ -135,11 +127,6 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     }
   }
 
-  // readTests() shallow-copies inline test cases, so test.options and test.assert[]
-  // still alias the originals in testSuite.tests. Shallow-clone here before swapping
-  // in resolved ApiProvider instances so the originals (and thus the unified config
-  // written to the Eval record) stay free of live SDK clients with circular references.
-  // Same rationale as the defaultTest block above. Fixes #8687.
   constructedTestSuite.tests = (constructedTestSuite.tests || []).map(cloneTestForResolve);
 
   for (const test of constructedTestSuite.tests) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,13 +51,19 @@ export type {
  * to the Eval record, and a live SDK client (e.g. Bedrock's BedrockRuntime,
  * Anthropic's client) holds circular references that break drizzle's JSON
  * serialization on `evalRecord.save()`. Fixes #8687.
+ *
+ * Detaches only `options` and `assert[]`. Other reference fields (`provider`,
+ * `vars`, `metadata`, `providerOutput`) remain aliased — callers must reassign
+ * those by reference rather than mutating in place. `assert-set` children are
+ * not deep-cloned because the resolve loop skips `assert-set`; if that ever
+ * changes, extend this helper.
  */
 function cloneTestForResolve<T extends Pick<TestCase, 'options' | 'assert'>>(test: T): T {
   const cloned: T = { ...test };
   if (test.options) {
     cloned.options = { ...test.options };
   }
-  if (Array.isArray(test.assert)) {
+  if (test.assert) {
     cloned.assert = test.assert.map((assertion) => ({ ...assertion }));
   }
   return cloned;
@@ -98,10 +104,9 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     prompts: await processPrompts(testSuite.prompts),
   };
 
-  // Resolve nested providers. `constructedTestSuite` shallow-shares `defaultTest` and
-  // its `options` with the input, and `readTests()` shallow-copies inline test cases —
-  // so we clone before mutating to keep resolved ApiProvider instances out of the
-  // unified config persisted to the Eval record. See `cloneTestForResolve()`.
+  // Resolve nested providers. `constructedTestSuite` shallow-shares `defaultTest`
+  // and `readTests()` shallow-copies inline test cases, so detach via
+  // `cloneTestForResolve()` before mutating — see helper docstring for the why.
   if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
     constructedTestSuite.defaultTest = cloneTestForResolve(constructedTestSuite.defaultTest);
 
@@ -155,6 +160,10 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
   }
 
   const parsedProviderPromptMap = readProviderPromptMap(testSuite, constructedTestSuite.prompts);
+  // INVARIANT: the unified config persisted to the Eval record must not alias any
+  // object mutated above with a resolved ApiProvider (see `cloneTestForResolve()`).
+  // Live SDK clients hold circular refs and break drizzle JSON serialization on
+  // `evalRecord.save()`. Fixes #8687.
   const unifiedConfig = { ...testSuite, prompts: constructedTestSuite.prompts };
   const evalRecord = testSuite.writeLatestResults
     ? await Eval.create(unifiedConfig, constructedTestSuite.prompts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,13 @@ import { maybeLoadFromExternalFile } from './util/file';
 import { readFilters, writeMultipleOutputs, writeOutput } from './util/index';
 import { readTests } from './util/testCaseReader';
 
-import type { EvaluateOptions, EvaluateTestSuite, Scenario, TestSuite } from './types/index';
+import type {
+  EvaluateOptions,
+  EvaluateTestSuite,
+  Scenario,
+  TestCase,
+  TestSuite,
+} from './types/index';
 import type { ApiProvider } from './types/providers';
 
 export { generateTable } from './table';
@@ -37,6 +43,25 @@ export type {
   BeforeEachExtensionHookContext,
   ExtensionHookContextMap,
 } from './evaluatorHelpers';
+
+/**
+ * Shallow-clone a test case and its `options` and `assert[]` entries so that the
+ * caller can freely mutate `test.options.provider` / `assertion.provider` with
+ * resolved ApiProvider instances without leaking those mutations back to the
+ * input (inline test case objects in `testSuite.tests` alias through
+ * `readTests()`'s shallow copy). See the defaultTest block in `evaluate()` for
+ * the full rationale — this is the same pattern for individual test cases.
+ */
+function cloneTestForResolve(test: TestCase): TestCase {
+  const cloned: TestCase = { ...test };
+  if (test.options) {
+    cloned.options = { ...test.options };
+  }
+  if (Array.isArray(test.assert)) {
+    cloned.assert = test.assert.map((assertion) => ({ ...assertion }));
+  }
+  return cloned;
+}
 
 async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions = {}) {
   if (testSuite.writeLatestResults) {
@@ -74,10 +99,21 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
   };
 
   // Resolve nested providers
-  if (typeof constructedTestSuite.defaultTest === 'object') {
+  if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
+    // Shallow-clone defaultTest (and options) before mutating so resolved ApiProvider
+    // instances don't leak back into testSuite.defaultTest via the shared reference.
+    // testSuite is reused below to build the unified config written to the Eval record;
+    // an instantiated SDK client (e.g. Bedrock's BedrockRuntime, Anthropic's client) holds
+    // circular references that break drizzle's JSON serialization on `evalRecord.save()`.
+    // Fixes #8687.
+    constructedTestSuite.defaultTest = { ...constructedTestSuite.defaultTest };
+    if (constructedTestSuite.defaultTest.options) {
+      constructedTestSuite.defaultTest.options = { ...constructedTestSuite.defaultTest.options };
+    }
+
     // Resolve defaultTest.provider (only if it's not already an ApiProvider instance)
     if (
-      constructedTestSuite.defaultTest?.provider &&
+      constructedTestSuite.defaultTest.provider &&
       !isApiProvider(constructedTestSuite.defaultTest.provider)
     ) {
       constructedTestSuite.defaultTest.provider = await resolveProvider(
@@ -88,7 +124,7 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     }
     // Resolve defaultTest.options.provider (only if it's not already an ApiProvider instance)
     if (
-      constructedTestSuite.defaultTest?.options?.provider &&
+      constructedTestSuite.defaultTest.options?.provider &&
       !isApiProvider(constructedTestSuite.defaultTest.options.provider)
     ) {
       constructedTestSuite.defaultTest.options.provider = await resolveProvider(
@@ -99,25 +135,29 @@ async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions =
     }
   }
 
-  for (const test of constructedTestSuite.tests || []) {
+  // readTests() shallow-copies inline test cases, so test.options and test.assert[]
+  // still alias the originals in testSuite.tests. Shallow-clone here before swapping
+  // in resolved ApiProvider instances so the originals (and thus the unified config
+  // written to the Eval record) stay free of live SDK clients with circular references.
+  // Same rationale as the defaultTest block above. Fixes #8687.
+  constructedTestSuite.tests = (constructedTestSuite.tests || []).map(cloneTestForResolve);
+
+  for (const test of constructedTestSuite.tests) {
     if (test.options?.provider && !isApiProvider(test.options.provider)) {
       test.options.provider = await resolveProvider(test.options.provider, providerMap, {
         env: testSuite.env,
         basePath: cliState.basePath,
       });
     }
-    if (test.assert) {
-      for (const assertion of test.assert) {
-        if (assertion.type === 'assert-set' || typeof assertion.provider === 'function') {
-          continue;
-        }
-
-        if (assertion.provider && !isApiProvider(assertion.provider)) {
-          assertion.provider = await resolveProvider(assertion.provider, providerMap, {
-            env: testSuite.env,
-            basePath: cliState.basePath,
-          });
-        }
+    for (const assertion of test.assert || []) {
+      if (assertion.type === 'assert-set' || typeof assertion.provider === 'function') {
+        continue;
+      }
+      if (assertion.provider && !isApiProvider(assertion.provider)) {
+        assertion.provider = await resolveProvider(assertion.provider, providerMap, {
+          env: testSuite.env,
+          basePath: cliState.basePath,
+        });
       }
     }
   }

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -19,6 +19,7 @@ import {
 } from '../types/index';
 import { isApiProvider, isProviderOptions } from '../types/providers';
 import { safeJsonStringify } from '../util/json';
+import { sanitizeObject } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
 
 // Removes circular references from the provider object and ensures consistent format
@@ -95,6 +96,29 @@ function sanitizeForDb<T>(obj: T): T {
   }
 }
 
+/**
+ * Sanitize a per-test-case field for persistence: strips circular refs,
+ * collapses class instances (e.g. live SDK clients that leaked in via
+ * `defaultTest.options.provider`), and redacts credential fields (`apiKey`,
+ * `token`, etc.) at any depth. Use this for any slot that can carry a provider
+ * config — notably `testCase.options.provider` and `prompt.config.provider`,
+ * where the resolved runtime provider (with its Anthropic / Bedrock SDK
+ * client) flows in from the evaluator. Without this, credentials configured on
+ * the judge provider end up in the Eval results both in the DB and in the
+ * polling response served by `/api/eval/job/:id`.
+ */
+function sanitizeForDbWithSecrets<T>(obj: T): T {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+  return sanitizeObject(obj, {
+    context: 'evalResult field',
+    // Nested provider configs can be deeper than the default maxDepth (4);
+    // match the behavior of `sanitizeConfigForOutput` in `src/util/output.ts`.
+    maxDepth: Number.POSITIVE_INFINITY,
+  }) as T;
+}
+
 export default class EvalResult {
   static async createFromEvaluateResult(
     evalId: string,
@@ -117,7 +141,7 @@ export default class EvalResult {
       testCase,
     } = result;
 
-    // Normalize provider for storage and extract blobs from responses
+    // Normalize provider for storage and extract blobs from responses.
     const preSanitizeTestCase = {
       ...testCase,
       ...(testCase.provider && {
@@ -131,16 +155,20 @@ export default class EvalResult {
       promptIdx: result.promptIdx,
     });
 
-    // Sanitize all JSON fields to remove circular references and non-serializable values
-    // This prevents "Converting circular structure to JSON" errors from Timeout objects
-    // or other non-serializable data that may leak into results (e.g., from Python providers)
+    // Sanitize all JSON fields to remove circular references and non-serializable values.
+    // `testCase` and `prompt` can contain a resolved runtime provider under
+    // `options.provider` or `config.provider` (used for llm-rubric judging); that
+    // provider may hold a live SDK client with credentials (Anthropic apiKey, etc.)
+    // and circular references — see `sanitizeForDbWithSecrets`. Other fields go
+    // through the lighter `sanitizeForDb` which only strips circular refs /
+    // non-serializable values.
     const args = {
       id: crypto.randomUUID(),
       evalId,
-      testCase: sanitizeForDb(preSanitizeTestCase),
+      testCase: sanitizeForDbWithSecrets(preSanitizeTestCase),
       promptIdx: result.promptIdx,
       testIdx: result.testIdx,
-      prompt: sanitizeForDb(prompt),
+      prompt: sanitizeForDbWithSecrets(prompt),
       promptId: hashPrompt(prompt),
       error: error?.toString(),
       success,
@@ -180,11 +208,13 @@ export default class EvalResult {
 
     db.transaction(() => {
       for (const result of processedResults) {
-        // Sanitize JSON fields to prevent circular reference errors
+        // See `createFromEvaluateResult` for why `testCase` and `prompt` go
+        // through the credential-redacting sanitizer while the other fields
+        // stay on the lighter `sanitizeForDb`.
         const sanitizedResult = {
           ...result,
-          testCase: sanitizeForDb(result.testCase),
-          prompt: sanitizeForDb(result.prompt),
+          testCase: sanitizeForDbWithSecrets(result.testCase),
+          prompt: sanitizeForDbWithSecrets(result.prompt),
           response: sanitizeForDb(result.response),
           gradingResult: sanitizeForDb(result.gradingResult),
           namedScores: sanitizeForDb(result.namedScores),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1222,6 +1222,196 @@ describe('evaluate with external defaultTest', () => {
       );
     });
   });
+
+  describe('input testSuite mutation safety (regression for #8687)', () => {
+    let resolveProviderSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Return a minimal fake ApiProvider for any raw provider config we're asked to resolve.
+      resolveProviderSpy = vi
+        .spyOn(providers, 'resolveProvider')
+        .mockImplementation(async (provider) => {
+          const id =
+            typeof provider === 'string'
+              ? provider
+              : typeof provider === 'object' && provider && 'id' in provider
+                ? (provider as { id: string }).id
+                : 'resolved-provider';
+          return { id: () => id, callApi: vi.fn() };
+        });
+    });
+
+    afterEach(() => {
+      resolveProviderSpy.mockRestore();
+    });
+
+    it('does not mutate testSuite.defaultTest.options.provider when resolving for the runtime suite', async () => {
+      const rawProviderConfig = {
+        id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
+        config: { region: 'us-east-1' },
+      };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        defaultTest: {
+          options: {
+            provider: rawProviderConfig,
+          },
+        },
+        tests: [{ vars: { x: 'y' } }],
+      };
+      const originalDefaultTest = testSuite.defaultTest;
+      const originalOptions = testSuite.defaultTest.options;
+
+      await evaluate(testSuite);
+
+      // Reference preserved on the input.
+      expect(testSuite.defaultTest).toBe(originalDefaultTest);
+      expect(testSuite.defaultTest.options).toBe(originalOptions);
+      // Raw provider config on the input is untouched (no ApiProvider leaked in).
+      expect(testSuite.defaultTest.options.provider).toBe(rawProviderConfig);
+      expect(testSuite.defaultTest.options.provider).toEqual({
+        id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
+        config: { region: 'us-east-1' },
+      });
+    });
+
+    it('does not mutate testSuite.defaultTest.provider when resolving it', async () => {
+      const rawProviderConfig = {
+        id: 'anthropic:messages:claude-3-haiku',
+        config: { apiKey: 'sk-test' },
+      };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        defaultTest: {
+          provider: rawProviderConfig,
+        },
+        tests: [{ vars: { x: 'y' } }],
+      };
+
+      await evaluate(testSuite);
+
+      expect(testSuite.defaultTest.provider).toBe(rawProviderConfig);
+      expect(testSuite.defaultTest.provider).toEqual({
+        id: 'anthropic:messages:claude-3-haiku',
+        config: { apiKey: 'sk-test' },
+      });
+    });
+
+    it('does not mutate inline test.options.provider or assertion.provider', async () => {
+      const rawTestProviderConfig = { id: 'bedrock:test-model', config: { region: 'eu-west-1' } };
+      const rawAssertProviderConfig = {
+        id: 'anthropic:messages:claude-3-haiku',
+        config: { apiKey: 'sk-test' },
+      };
+      const inlineTest = {
+        vars: { x: 'y' },
+        options: { provider: rawTestProviderConfig },
+        assert: [
+          {
+            type: 'llm-rubric' as const,
+            value: 'checks the thing',
+            provider: rawAssertProviderConfig,
+          },
+        ],
+      };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        tests: [inlineTest],
+      };
+
+      await evaluate(testSuite);
+
+      expect(inlineTest.options.provider).toBe(rawTestProviderConfig);
+      expect(inlineTest.assert[0].provider).toBe(rawAssertProviderConfig);
+    });
+
+    it('passes the resolved provider to doEvaluate on a cloned defaultTest (regression for #8687)', async () => {
+      const rawProviderConfig = {
+        id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
+        config: { region: 'us-east-1' },
+      };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        defaultTest: {
+          options: {
+            provider: rawProviderConfig,
+          },
+        },
+        tests: [{ vars: { x: 'y' } }],
+      };
+
+      await evaluate(testSuite);
+
+      // doEvaluate should see a defaultTest that is NOT the same object as the input
+      // (so any downstream mutation — such as the Bedrock/Anthropic SDK lazily
+      // attaching circular references on first callApi — cannot leak back into the
+      // input, which the unified config persisted to the Eval record aliases).
+      const passedTestSuite = vi.mocked(doEvaluate).mock.calls.at(-1)?.[0];
+      expect(passedTestSuite).toBeDefined();
+      expect(passedTestSuite!.defaultTest).not.toBe(testSuite.defaultTest);
+      expect((passedTestSuite!.defaultTest as { options: unknown }).options).not.toBe(
+        testSuite.defaultTest.options,
+      );
+      // The resolved provider is still present on the runtime copy.
+      expect(
+        (
+          passedTestSuite!.defaultTest as { options: { provider: { id: () => string } } }
+        ).options.provider.id(),
+      ).toBe('bedrock:anthropic.claude-3-haiku-20240307-v1:0');
+    });
+
+    it('produces a unified config that is JSON-serializable even when the resolved provider gains circular references', async () => {
+      // Simulate the real-world Bedrock/Anthropic scenario: resolveProvider returns an
+      // ApiProvider instance that later (on first callApi) mutates itself to hold a live
+      // SDK client with circular references.
+      type ResolvedProvider = {
+        id: () => string;
+        callApi: ReturnType<typeof vi.fn>;
+        sdkClient?: { self?: unknown };
+      };
+      const resolvedProvider: ResolvedProvider = {
+        id: () => 'bedrock:resolved',
+        callApi: vi.fn().mockImplementation(async function (this: ResolvedProvider) {
+          // Mimic the AWS SDK's lazy-init behavior: attach a client with a circular ref.
+          const cyclic: { self?: unknown } = {};
+          cyclic.self = cyclic;
+          this.sdkClient = cyclic;
+          return { output: 'ok' };
+        }),
+      };
+      resolveProviderSpy.mockResolvedValue(resolvedProvider);
+
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        defaultTest: {
+          options: {
+            provider: {
+              id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
+              config: { region: 'us-east-1' },
+            },
+          },
+        },
+        tests: [{ vars: { x: 'y' } }],
+      };
+
+      await evaluate(testSuite);
+
+      // Force the lazy-init path the real provider takes on first callApi.
+      await resolvedProvider.callApi('anything', {} as never, {} as never);
+      expect(resolvedProvider.sdkClient).toBeDefined();
+
+      // The unified config persisted to the Eval record must remain JSON-serializable
+      // — i.e. must NOT hold a reference to the now-circular provider instance.
+      // Before the fix, defaultTest.options.provider on the input aliased resolvedProvider
+      // and JSON.stringify would throw "Converting circular structure to JSON".
+      expect(() => JSON.stringify(testSuite)).not.toThrow();
+    });
+  });
 });
 
 describe('evaluate sharing functionality', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1237,7 +1237,7 @@ describe('evaluate with external defaultTest', () => {
               : typeof provider === 'object' && provider && 'id' in provider
                 ? (provider as { id: string }).id
                 : 'resolved-provider';
-          return { id: () => id, callApi: vi.fn() };
+          return { id: () => id, callApi: vi.fn() as any };
         });
     });
 
@@ -1402,7 +1402,11 @@ describe('evaluate with external defaultTest', () => {
       await evaluate(testSuite);
 
       // Force the lazy-init path the real provider takes on first callApi.
-      await resolvedProvider.callApi('anything', {} as never, {} as never);
+      await (resolvedProvider.callApi as unknown as (...args: unknown[]) => Promise<unknown>)(
+        'anything',
+        {},
+        {},
+      );
       expect(resolvedProvider.sdkClient).toBeDefined();
 
       // The unified config persisted to the Eval record must remain JSON-serializable

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1223,11 +1223,11 @@ describe('evaluate with external defaultTest', () => {
     });
   });
 
-  describe('input testSuite mutation safety (regression for #8687)', () => {
+  describe('input testSuite mutation safety', () => {
     let resolveProviderSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-      // Return a minimal fake ApiProvider for any raw provider config we're asked to resolve.
+      vi.mocked(doEvaluate).mockClear();
       resolveProviderSpy = vi
         .spyOn(providers, 'resolveProvider')
         .mockImplementation(async (provider) => {
@@ -1265,10 +1265,8 @@ describe('evaluate with external defaultTest', () => {
 
       await evaluate(testSuite);
 
-      // Reference preserved on the input.
       expect(testSuite.defaultTest).toBe(originalDefaultTest);
       expect(testSuite.defaultTest.options).toBe(originalOptions);
-      // Raw provider config on the input is untouched (no ApiProvider leaked in).
       expect(testSuite.defaultTest.options.provider).toBe(rawProviderConfig);
       expect(testSuite.defaultTest.options.provider).toEqual({
         id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
@@ -1328,7 +1326,26 @@ describe('evaluate with external defaultTest', () => {
       expect(inlineTest.assert[0].provider).toBe(rawAssertProviderConfig);
     });
 
-    it('passes the resolved provider to doEvaluate on a cloned defaultTest (regression for #8687)', async () => {
+    it('only clones siblings of test cases that need provider resolution; unaffected siblings keep raw config', async () => {
+      const rawProviderConfig = { id: 'bedrock:test-model', config: { region: 'eu-west-1' } };
+      const testWithProvider = {
+        vars: { x: '1' },
+        options: { provider: rawProviderConfig },
+      };
+      const testWithoutProvider = { vars: { x: '2' } };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        tests: [testWithProvider, testWithoutProvider],
+      };
+
+      await evaluate(testSuite);
+
+      expect(testWithProvider.options.provider).toBe(rawProviderConfig);
+      expect(testSuite.tests[1]).toBe(testWithoutProvider);
+    });
+
+    it('passes the resolved provider to doEvaluate on a cloned defaultTest', async () => {
       const rawProviderConfig = {
         id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
         config: { region: 'us-east-1' },
@@ -1346,17 +1363,15 @@ describe('evaluate with external defaultTest', () => {
 
       await evaluate(testSuite);
 
-      // doEvaluate should see a defaultTest that is NOT the same object as the input
-      // (so any downstream mutation — such as the Bedrock/Anthropic SDK lazily
-      // attaching circular references on first callApi — cannot leak back into the
-      // input, which the unified config persisted to the Eval record aliases).
+      // The runtime defaultTest must be a different object than the input so the
+      // lazy SDK-client mutation downstream cannot leak back into the input that the
+      // unified config aliases.
       const passedTestSuite = vi.mocked(doEvaluate).mock.calls.at(-1)?.[0];
       expect(passedTestSuite).toBeDefined();
       expect(passedTestSuite!.defaultTest).not.toBe(testSuite.defaultTest);
       expect((passedTestSuite!.defaultTest as { options: unknown }).options).not.toBe(
         testSuite.defaultTest.options,
       );
-      // The resolved provider is still present on the runtime copy.
       expect(
         (
           passedTestSuite!.defaultTest as { options: { provider: { id: () => string } } }
@@ -1364,10 +1379,12 @@ describe('evaluate with external defaultTest', () => {
       ).toBe('bedrock:anthropic.claude-3-haiku-20240307-v1:0');
     });
 
-    it('produces a unified config that is JSON-serializable even when the resolved provider gains circular references', async () => {
-      // Simulate the real-world Bedrock/Anthropic scenario: resolveProvider returns an
-      // ApiProvider instance that later (on first callApi) mutates itself to hold a live
-      // SDK client with circular references.
+    it('produces an Eval config that is JSON-serializable even when the resolved provider gains circular references', async () => {
+      // Mimic the AWS / Anthropic SDK pattern: ApiProvider instance whose first
+      // `callApi` lazily attaches a client that holds a circular reference. Without
+      // the fix, the resolved instance was stored on the input, and once the cycle
+      // appeared the unified config persisted via drizzle's text-json column threw
+      // "Converting circular structure to JSON ... AwsRestJsonProtocol.serdeContext".
       type ResolvedProvider = {
         id: () => string;
         callApi: ReturnType<typeof vi.fn>;
@@ -1376,7 +1393,6 @@ describe('evaluate with external defaultTest', () => {
       const resolvedProvider: ResolvedProvider = {
         id: () => 'bedrock:resolved',
         callApi: vi.fn().mockImplementation(async function (this: ResolvedProvider) {
-          // Mimic the AWS SDK's lazy-init behavior: attach a client with a circular ref.
           const cyclic: { self?: unknown } = {};
           cyclic.self = cyclic;
           this.sdkClient = cyclic;
@@ -1384,6 +1400,8 @@ describe('evaluate with external defaultTest', () => {
         }),
       };
       resolveProviderSpy.mockResolvedValue(resolvedProvider);
+
+      const createEvalSpy = vi.spyOn(Eval, 'create');
 
       const testSuite = {
         prompts: ['test prompt'],
@@ -1397,11 +1415,11 @@ describe('evaluate with external defaultTest', () => {
           },
         },
         tests: [{ vars: { x: 'y' } }],
+        writeLatestResults: true,
       };
 
       await evaluate(testSuite);
 
-      // Force the lazy-init path the real provider takes on first callApi.
       await (resolvedProvider.callApi as unknown as (...args: unknown[]) => Promise<unknown>)(
         'anything',
         {},
@@ -1409,10 +1427,37 @@ describe('evaluate with external defaultTest', () => {
       );
       expect(resolvedProvider.sdkClient).toBeDefined();
 
-      // The unified config persisted to the Eval record must remain JSON-serializable
-      // — i.e. must NOT hold a reference to the now-circular provider instance.
-      // Before the fix, defaultTest.options.provider on the input aliased resolvedProvider
-      // and JSON.stringify would throw "Converting circular structure to JSON".
+      // Direct check on the actual production failure mode: the config object handed
+      // to Eval.create is what drizzle JSON-serializes via the text-json column.
+      const persistedConfig = createEvalSpy.mock.calls.at(-1)?.[0];
+      expect(persistedConfig).toBeDefined();
+      expect(() => JSON.stringify(persistedConfig)).not.toThrow();
+      // The input itself must also be safe — library callers may persist or log it.
+      expect(() => JSON.stringify(testSuite)).not.toThrow();
+
+      createEvalSpy.mockRestore();
+    });
+
+    it('passes scenario-nested test cases through unchanged (provider resolution there is the evaluator runtime path, not evaluate())', async () => {
+      // Pin current behavior: src/index.ts only resolves providers on
+      // `constructedTestSuite.tests`, NOT on `scenarios[i].tests`. If a future change
+      // adds scenario provider resolution at this layer, it must extend
+      // `cloneTestForResolve` coverage to scenarios — otherwise #8687 recurs.
+      const rawProviderConfig = {
+        id: 'bedrock:anthropic.claude-3-haiku-20240307-v1:0',
+        config: { region: 'us-east-1' },
+      };
+      const scenarioTest = { vars: { x: 'y' }, options: { provider: rawProviderConfig } };
+      const testSuite = {
+        prompts: ['test prompt'],
+        providers: [],
+        scenarios: [{ config: [{}], tests: [scenarioTest] }],
+        tests: [{ vars: { z: 'w' } }],
+      };
+
+      await evaluate(testSuite);
+
+      expect(scenarioTest.options.provider).toBe(rawProviderConfig);
       expect(() => JSON.stringify(testSuite)).not.toThrow();
     });
   });

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -263,6 +263,134 @@ describe('EvalResult', () => {
       expect(retrieved?.response?.output).toBe('test output');
     });
 
+    describe('credential redaction (regression for PR #8688 review)', () => {
+      it('redacts apiKey in testCase.options.provider.config', async () => {
+        const evalId = 'test-eval-redact-options-provider';
+        const result = await EvalResult.createFromEvaluateResult(
+          evalId,
+          {
+            ...mockEvaluateResult,
+            testCase: {
+              vars: {},
+              options: {
+                provider: {
+                  id: 'anthropic:messages:claude-3-haiku',
+                  config: { apiKey: 'sk-ant-api03-SHOULD-BE-REDACTED' },
+                },
+              },
+            } as AtomicTestCase,
+          },
+          { persist: true },
+        );
+
+        const serialized = JSON.stringify(result.testCase);
+        expect(serialized).not.toContain('sk-ant-api03-SHOULD-BE-REDACTED');
+        expect(serialized).toContain('[REDACTED]');
+
+        // Also verify the DB-persisted row is clean.
+        const retrieved = await EvalResult.findById(result.id);
+        expect(JSON.stringify(retrieved?.testCase)).not.toContain(
+          'sk-ant-api03-SHOULD-BE-REDACTED',
+        );
+      });
+
+      it('redacts apiKey in prompt.config.provider.config', async () => {
+        const evalId = 'test-eval-redact-prompt-provider';
+        const result = await EvalResult.createFromEvaluateResult(
+          evalId,
+          {
+            ...mockEvaluateResult,
+            prompt: {
+              ...mockPrompt,
+              config: {
+                provider: {
+                  id: 'anthropic:messages:claude-3-haiku',
+                  config: { apiKey: 'sk-ant-api03-PROMPT-SHOULD-BE-REDACTED' },
+                },
+              },
+            } as unknown as Prompt,
+          },
+          { persist: true },
+        );
+
+        const serialized = JSON.stringify(result.prompt);
+        expect(serialized).not.toContain('sk-ant-api03-PROMPT-SHOULD-BE-REDACTED');
+        expect(serialized).toContain('[REDACTED]');
+
+        const retrieved = await EvalResult.findById(result.id);
+        expect(JSON.stringify(retrieved?.prompt)).not.toContain(
+          'sk-ant-api03-PROMPT-SHOULD-BE-REDACTED',
+        );
+      });
+
+      it('redacts credentials from an instantiated provider object embedded in testCase.options.provider', async () => {
+        // Mimic the real Anthropic / Bedrock shape: the resolved judge provider is an
+        // ApiProvider instance whose internal SDK client carries `apiKey`, `_options`,
+        // `authToken`, and circular `_client` back-references. Before the fix, all of
+        // these survived sanitizeForDb (which only strips circular refs) and persisted
+        // through the eval results API.
+        const sdkClientA: { _client?: unknown; apiKey: string; _options: { apiKey: string } } = {
+          apiKey: 'sk-ant-api03-INSTANCE-KEY',
+          _options: { apiKey: 'sk-ant-api03-INSTANCE-KEY' },
+        };
+        sdkClientA._client = sdkClientA;
+        const instantiatedProvider = {
+          id: () => 'anthropic:messages:claude-3-haiku',
+          label: 'Judge',
+          config: { apiKey: 'sk-ant-api03-CONFIG-KEY' },
+          apiKey: 'sk-ant-api03-TOPLEVEL-KEY',
+          anthropic: sdkClientA,
+          callApi: async () => ({ output: 'ok' }),
+        };
+
+        const evalId = 'test-eval-redact-instantiated';
+        const result = await EvalResult.createFromEvaluateResult(
+          evalId,
+          {
+            ...mockEvaluateResult,
+            testCase: {
+              vars: {},
+              options: {
+                provider: instantiatedProvider as unknown as ApiProvider,
+              },
+            } as AtomicTestCase,
+          },
+          { persist: true },
+        );
+
+        const serialized = JSON.stringify(result.testCase);
+        expect(serialized).not.toContain('sk-ant-api03-INSTANCE-KEY');
+        expect(serialized).not.toContain('sk-ant-api03-CONFIG-KEY');
+        expect(serialized).not.toContain('sk-ant-api03-TOPLEVEL-KEY');
+        expect(serialized).toContain('[REDACTED]');
+      });
+
+      it('does not crash when redacting a provider with a live circular SDK client', async () => {
+        const sdkClient: { _client?: unknown; apiKey: string } = { apiKey: 'sk-live-leak' };
+        sdkClient._client = sdkClient;
+        const cyclicProvider = {
+          id: 'anthropic:messages:claude-3-haiku',
+          config: { apiKey: 'sk-live-leak', sdk: sdkClient },
+        };
+
+        const evalId = 'test-eval-redact-cyclic';
+        const result = await EvalResult.createFromEvaluateResult(
+          evalId,
+          {
+            ...mockEvaluateResult,
+            testCase: {
+              vars: {},
+              options: { provider: cyclicProvider },
+            } as AtomicTestCase,
+          },
+          { persist: true },
+        );
+
+        expect(result.persisted).toBe(true);
+        expect(JSON.stringify(result.testCase)).not.toContain('sk-live-leak');
+      });
+    });
+
     it('should preserve non-circular provider properties', async () => {
       const evalId = 'test-eval-id';
 


### PR DESCRIPTION
## Summary

Fixes #8687 and addresses a P1 credential-leak finding surfaced during PR review.

### Bug 1: circular JSON on web UI judge evals (#8687)

Running an eval from the web UI with a Bedrock or Anthropic provider configured as an `llm-rubric` judge (via `defaultTest.options.provider`) crashed with:

```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'protocol' -> object with constructor 'AwsRestJsonProtocol'
    --- property 'serdeContext' closes the circle
```

The CLI (`promptfoo eval`) path was unaffected.

### Bug 2: credential leak in eval results (P1, found during review)

After bug 1 is fixed and the web UI eval path completes, the eval **results** leak the judge's `apiKey` into both the persisted `evalResults` rows and the `POST /api/eval/job` polling response. Two leak sites:

- `testCase.options.provider.*` — the resolved judge provider (the instantiated Anthropic SDK client with `_options.apiKey`, `authToken`, and circular `_client` back-references)
- `prompt.config.provider.*` — same provider attached to the prompt's config for llm-rubric grading

`EvalResult.createFromEvaluateResult` only ran `sanitizeProvider()` on the top-level `testCase.provider` slot (circular-ref handling, not credential redaction) and `sanitizeForDb` on `testCase` / `prompt` (circular-ref handling only). Nothing was redacting `apiKey` at any depth, and nothing was handling the SDK-client-embedded credentials.

## Root cause (bug 1)

`promptfoo.evaluate()` in `src/index.ts` (the function called by `POST /api/eval/job`) shallow-copied the input test suite into `constructedTestSuite`, then mutated `constructedTestSuite.defaultTest.options.provider` in place with the resolved `ApiProvider` instance. Because the shallow copy left `defaultTest` (and its `options` object) aliased between the original and the constructed test suite, the mutation leaked back into `testSuite.defaultTest.options.provider`. The same alias was then used to build `unifiedConfig`, which `Eval.create()` stores as `this.config`.

The Bedrock and Anthropic SDK clients are created lazily inside `callApi()`, so `Eval.create()` succeeded — at that point the resolved provider was still serializable. But once the first llm-rubric assertion ran, the provider's `BedrockRuntime` (or `Anthropic`) client was attached, introducing circular references through `AwsRestJsonProtocol.serdeContext` / `Completions._client`. When `evaluator` then called `evalRecord.save()` at the end of the run, drizzle's `text('config', { mode: 'json' })` column hit `JSON.stringify` on the now-cyclic config and threw.

The CLI never tripped this because `commands/eval.ts` calls `evaluator.evaluate()` directly and passes the raw `config` (not the resolved test suite) to `Eval.create()`. The matchers resolve the judge provider on demand inside `matchers/providers.ts`, so the persisted config never aliases a live SDK client.

## Fix

### `src/index.ts` (bug 1)

Shallow-clone `defaultTest`, `defaultTest.options`, and any inline test case (plus its `options` and `assert[]` entries) on `constructedTestSuite` before swapping in the resolved `ApiProvider` instances. This keeps the inputs — and therefore the unified config persisted to the `Eval` record — pointing at the original raw provider configs, while the runtime test suite passed to `doEvaluate()` still gets the instantiated providers. Helper `cloneTestForResolve()` keeps the resolve loop readable and reduces the function's pre-existing biome cognitive complexity from 52 → 49.

### `src/models/evalResult.ts` (bug 2)

Add a `sanitizeForDbWithSecrets()` helper that wraps the project's existing `sanitizeObject()` from `src/util/sanitizer.ts` (same module that `src/util/output.ts`'s `sanitizeConfigForOutput` uses) with `maxDepth: Infinity` to match the file-export behavior. Apply it to `testCase` and `prompt` in both `createFromEvaluateResult` and `createManyFromEvaluateResult`. Other fields stay on the lighter `sanitizeForDb` since they don't carry provider configs.

`sanitizeObject()` handles both concerns in one pass: it uses `fast-safe-stringify` internally so circular SDK clients survive serialization, and then runs `recursiveSanitize` which redacts values by field name (`apikey`, `token`, etc. via `SECRET_FIELD_NAMES`) and by value pattern (e.g. `sk-ant-*` via `looksLikeSecret`).

## Scope notes (known gaps, not in this fix)

- `evaluate()` does not resolve providers inside `scenarios[].tests[]` today (only `constructedTestSuite.tests`). The new test `passes scenario-nested test cases through unchanged` pins this current behavior. If a future change adds scenario provider resolution at this layer, `cloneTestForResolve` coverage must be extended to scenarios — otherwise the same #8687 leak shape recurs through `unifiedConfig.scenarios`.
- The resolve loop deliberately skips `assert-set` children and function-typed providers (`assertion.type === 'assert-set' || typeof assertion.provider === 'function'`). The helper does not deep-clone `assert-set` nested arrays, which is fine while the skip stays — the helper docstring calls this out.
- **Pre-existing leak out of scope for this PR:** `/api/eval/:id/table` returns `config: eval_.config` raw, and the `Eval.config` column retains the raw `defaultTest.options.provider.config.apiKey` string because the Eval persistence path stores the user-supplied YAML config verbatim. The UI tooltip then renders the credential. That leak existed before #8687 and affects any eval whose config literally contains an apiKey field (not just llm-rubric judges), so it deserves its own PR — the fix is likely wrapping the `res.json({config: eval_.config, ...})` call in `sanitizeObject()` to mirror `sanitizeConfigForOutput` from `src/util/output.ts`.

## Security note

Any local promptfoo DB rows from evals that used a real Anthropic / OpenAI / custom-provider apiKey in `defaultTest.options.provider.config` (or equivalent) **before this patch** already contain the credential in the `eval_results.testCase` / `eval_results.prompt` JSON columns **and** in the `evals.config` column. Rotating the affected key is the safest response.

## Reproduction

### Bedrock circular-JSON (bug 1)

Direct repro through `promptfoo.evaluate()` (the same call the web UI route makes) **before the fix**:

```
Starting evaluation eval-v70-...
Running 1 test cases (up to 4 at a time)...
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'protocol' -> object with constructor 'AwsRestJsonProtocol'
    --- property 'serdeContext' closes the circle
    at JSON.stringify (<anonymous>)
    at SQLiteTextJson.mapToDriverValue (.../sqlite-core/columns/text.ts:113:15)
```

**After the fix**: `OK evalId= eval-Q4C-...`.

### Anthropic credential leak (bug 2)

With a canary `sk-ant-api03-LEAK-CANARY-*` key in `defaultTest.options.provider.config.apiKey`, pre-fix the eval summary contained the key at 8 paths:

```
results.0.prompt.config.provider.config.apiKey
results.0.prompt.config.provider.apiKey
results.0.prompt.config.provider.anthropic._options.apiKey
results.0.prompt.config.provider.anthropic.apiKey
results.0.testCase.options.provider.config.apiKey
results.0.testCase.options.provider.apiKey
results.0.testCase.options.provider.anthropic._options.apiKey
results.0.testCase.options.provider.anthropic.apiKey
```

**After the fix**: 0 leak paths. Every `apiKey` field is replaced with `[REDACTED]`. The non-credential provider shape (`modelName`, `baseURL`, `id`, `label`) is preserved.

### End-to-end `POST /api/eval/job`

```
$ curl -s -X POST http://localhost:15732/api/eval/job -H 'content-type: application/json' \
    -d '{...config with "apiKey": "sk-ant-api03-ROUTE-CANARY-..."...}'
{"id":"2c02c8e0-..."}

$ curl -s http://localhost:15732/api/eval/job/2c02c8e0-... | grep -c "ROUTE-CANARY"
0   ← clean
```

## Test plan

### `test/index.test.ts` — 7 regression tests under `input testSuite mutation safety`:

- [x] `does not mutate testSuite.defaultTest.options.provider when resolving for the runtime suite`
- [x] `does not mutate testSuite.defaultTest.provider when resolving it`
- [x] `does not mutate inline test.options.provider or assertion.provider`
- [x] `only clones siblings of test cases that need provider resolution; unaffected siblings keep raw config`
- [x] `passes the resolved provider to doEvaluate on a cloned defaultTest`
- [x] `produces an Eval config that is JSON-serializable even when the resolved provider gains circular references` — spies on `Eval.create` and asserts the actual config object handed to drizzle is serializable after the fake provider lazily attaches a self-referential `sdkClient`. Verified to fail against `origin/main`.
- [x] `passes scenario-nested test cases through unchanged` — pins the scenario scope gap.

### `test/models/evalResult.test.ts` — 4 regression tests under `credential redaction (regression for PR #8688 review)`:

- [x] `redacts apiKey in testCase.options.provider.config` — direct check + DB round-trip
- [x] `redacts apiKey in prompt.config.provider.config` — direct check + DB round-trip
- [x] `redacts credentials from an instantiated provider object embedded in testCase.options.provider` — three canary keys (`sk-ant-api03-INSTANCE-KEY`, `-CONFIG-KEY`, `-TOPLEVEL-KEY`) at different depths, all redacted
- [x] `does not crash when redacting a provider with a live circular SDK client` — self-referential `_client` + embedded apiKey

All 4 new redaction tests verified to fail against the unfixed code path (swapping `sanitizeForDbWithSecrets` back to `sanitizeForDb`).

### Other verification

- [x] All 48 tests in `test/index.test.ts` pass
- [x] All 27 tests in `test/models/evalResult.test.ts` pass
- [x] Broader related suites green: `test/models/eval.test.ts`, `test/server/eval.test.ts`, `test/server/routes-eval.test.ts`, `test/server/routes/eval.validation.test.ts`, `test/server/routes/eval.filteredMetrics.test.ts`, `test/util/config/load.test.ts`, `test/util/output.test.ts`, `test/util/sanitizer.test.ts`, `test/evaluator.test.ts` — 689 tests total across 12 files
- [x] `npx tsc -p .` clean
- [x] `npx biome check` — only pre-existing `evaluate()` cognitive complexity warning, now 49 (was 52 on `main`)
- [x] End-to-end repro fixed against real AWS Bedrock (`bedrock:anthropic.claude-3-haiku-20240307-v1:0`)
- [x] End-to-end credential leak fixed against real Anthropic (`anthropic:messages:claude-3-haiku-20240307`) with a canary apiKey — 0 occurrences in the eval summary, 0 occurrences in the `POST /api/eval/job` polling response
- [x] CLI control case (`promptfoo eval -c ...`) still passes for both providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)