### PR TITLE
test(providers): cover exec stdin error cleanup

### DIFF
--- a/test/providers/scriptCompletion.test.ts
+++ b/test/providers/scriptCompletion.test.ts
@@ -209,18 +209,24 @@ describe('ScriptCompletionProvider', () => {
     expect(result.output).toBe('ok');
   });
 
-  it('should close stdin before rejecting on script execution errors', async () => {
+  it('should close stdin before the exec callback rejects on script execution errors', async () => {
     const stdinEnd = vi.fn();
     const errorMessage = 'Script execution failed';
+    let stdinClosedBeforeCallback = false;
     vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {
-      if (typeof callback === 'function') {
-        callback(new Error(errorMessage), '', '');
-      }
-      return { stdin: { end: stdinEnd } } as any;
+      const childProcess = { stdin: { end: stdinEnd } } as any;
+      queueMicrotask(() => {
+        stdinClosedBeforeCallback = stdinEnd.mock.calls.length > 0;
+        if (typeof callback === 'function') {
+          callback(new Error(errorMessage), '', '');
+        }
+      });
+      return childProcess;
     });
 
     await expect(provider.callApi('test prompt')).rejects.toThrow(errorMessage);
     expect(stdinEnd).toHaveBeenCalledOnce();
+    expect(stdinClosedBeforeCallback).toBe(true);
   });
 
   it('should handle UTF-8 characters in script output', async () => {

--- a/test/providers/scriptCompletion.test.ts
+++ b/test/providers/scriptCompletion.test.ts
@@ -209,6 +209,20 @@ describe('ScriptCompletionProvider', () => {
     expect(result.output).toBe('ok');
   });
 
+  it('should close stdin before rejecting on script execution errors', async () => {
+    const stdinEnd = vi.fn();
+    const errorMessage = 'Script execution failed';
+    vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {
+      if (typeof callback === 'function') {
+        callback(new Error(errorMessage), '', '');
+      }
+      return { stdin: { end: stdinEnd } } as any;
+    });
+
+    await expect(provider.callApi('test prompt')).rejects.toThrow(errorMessage);
+    expect(stdinEnd).toHaveBeenCalledOnce();
+  });
+
   it('should handle UTF-8 characters in script output', async () => {
     const utf8Output = 'Hello, 世界!';
     vi.mocked(execFile).mockImplementation(function (_cmd, _args, _options, callback) {


### PR DESCRIPTION
## Summary
- add a regression test for `ScriptCompletionProvider` when `execFile` fails
- verify the provider still closes child stdin before rejecting
- cover the error-path behavior added in the recent stdin cleanup fix

## Why
A recent provider fix closed exec-provider stdin immediately so child processes do not hang waiting for input. The happy-path coverage landed with that change, but the rejection path was still untested.

## Validation
- `npx vitest run test/providers/scriptCompletion.test.ts`
- `npm run l`
- `npm run f`
