### PR TITLE
chore: address AI SAST findings

### DIFF
--- a/src/app/src/pages/launcher/page.tsx
+++ b/src/app/src/pages/launcher/page.tsx
@@ -37,7 +37,7 @@ export default function LauncherPage() {
 
   useEffect(() => {
     // Simple delay to allow server startup, then start health checks
-    let interval: NodeJS.Timeout;
+    let interval: NodeJS.Timeout | undefined;
     const timeout = setTimeout(() => {
       checkHealth();
       interval = setInterval(() => {
@@ -189,7 +189,7 @@ export default function LauncherPage() {
           </div>
           <p className="mb-4 leading-relaxed text-muted-foreground">
             Safari and Brave block access to localhost by default. You need to install mkcert and
-            generate self-signed certificate:
+            generate a self-signed certificate:
           </p>
           <ol className="list-decimal space-y-4 pl-5">
             <li className="leading-relaxed">

--- a/test/providers/scriptCompletion.test.ts
+++ b/test/providers/scriptCompletion.test.ts
@@ -54,6 +54,14 @@ let statSyncMock: MockedFunction<typeof fs.statSync>;
 let readFileSyncMock: MockedFunction<typeof fs.readFileSync>;
 let createHashMock: MockedFunction<typeof crypto.createHash>;
 
+function normalizeFsPath(path: fs.PathOrFileDescriptor): string {
+  if (path instanceof URL) {
+    return path.pathname;
+  }
+
+  return String(path);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -89,7 +97,7 @@ describe('getFileHashes', () => {
     const mockHash2 = 'hash2';
 
     existsSyncMock.mockImplementation(function (path: fs.PathLike) {
-      return path !== 'nonexistent.js';
+      return normalizeFsPath(path) !== 'nonexistent.js';
     });
     statSyncMock.mockReturnValue({
       isFile: () => true,
@@ -101,10 +109,11 @@ describe('getFileHashes', () => {
       isSocket: () => false,
     } as fs.Stats);
     readFileSyncMock.mockImplementation(function (path: fs.PathOrFileDescriptor) {
-      if (path === 'file1.js') {
+      const normalizedPath = normalizeFsPath(path);
+      if (normalizedPath === 'file1.js') {
         return mockFileContent1;
       }
-      if (path === 'file2.js') {
+      if (normalizedPath === 'file2.js') {
         return mockFileContent2;
       }
       throw new Error('File not found');

--- a/test/smoke/configs-and-providers.test.ts
+++ b/test/smoke/configs-and-providers.test.ts
@@ -118,7 +118,7 @@ describe('Provider Smoke Tests', () => {
     });
   });
 
-  describe('3.3 OpenAI Tool Format', () => {
+  describe('3.3 OpenAI Providers', () => {
     it('3.3.1 - passes tools and tool_choice to providers', () => {
       const configPath = path.join(FIXTURES_DIR, 'configs/normalized-tools.yaml');
       const outputPath = path.join(OUTPUT_DIR, 'normalized-tools-output.json');
@@ -163,9 +163,7 @@ describe('Provider Smoke Tests', () => {
       expect(specificOutput.tool_choice.type).toBe('function');
       expect(specificOutput.tool_choice.function.name).toBe('get_weather');
     });
-  });
 
-  describe('3.3 OpenAI Provider Errors', () => {
     it('3.3.2 - surfaces custom apiKeyEnvar in missing API key errors', () => {
       const configPath = path.join(FIXTURES_DIR, 'configs/openai-custom-api-key-envar.yaml');
       const outputPath = path.join(OUTPUT_DIR, 'openai-custom-api-key-envar-output.json');

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -13,7 +13,8 @@ type TestControlUsage = {
   file: string;
   kind: TestControlKind;
   line: number;
-  lineText: string;
+  fullLineText: string;
+  trimmedLineText: string;
 };
 
 type AllowedSkip = {
@@ -265,11 +266,24 @@ const legacyDirectProcessEnvMutationFiles = new Set([
 ]);
 
 const hoistedMockPattern = /\bvi\.hoisted\s*\(/;
-const persistentMockImplementationPattern =
-  /\.(?:mockImplementation|mockRejectedValue|mockResolvedValue|mockReturnValue)\s*\(/;
+const persistentMockMethods = [
+  'mockImplementation',
+  'mockRejectedValue',
+  'mockResolvedValue',
+  'mockReturnValue',
+] as const;
+const persistentMockImplementationPattern = new RegExp(
+  `\\.(?:${persistentMockMethods.join('|')})\\s*\\(`,
+);
 const mockImplementationResetPattern = /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\s*\()/;
-const directProcessEnvMutationPattern =
-  /(?:\bprocess\.env\s*=|\bprocess\.env(?:\.[A-Za-z_][A-Za-z0-9_]*|\[['"][A-Za-z_][A-Za-z0-9_]*['"]\])\s*=|\bdelete\s+process\.env(?:\.[A-Za-z_][A-Za-z0-9_]*|\[['"][A-Za-z_][A-Za-z0-9_]*['"]\]))/;
+const envKeyPattern = String.raw`[A-Za-z_][A-Za-z0-9_]*`;
+const processEnvPropertyAccessPattern = String.raw`\bprocess\.env(?:\.${envKeyPattern}|\[['"]${envKeyPattern}['"]\])`;
+const processEnvObjectAssignmentPattern = String.raw`\bprocess\.env\s*=`;
+const processEnvPropertyAssignmentPattern = String.raw`${processEnvPropertyAccessPattern}\s*=`;
+const processEnvPropertyDeletePattern = String.raw`\bdelete\s+${processEnvPropertyAccessPattern}`;
+const directProcessEnvMutationPattern = new RegExp(
+  `(?:${processEnvObjectAssignmentPattern}|${processEnvPropertyAssignmentPattern}|${processEnvPropertyDeletePattern})`,
+);
 
 function findTestFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -374,7 +388,8 @@ function findTestControlUsages(file: string, source: string): TestControlUsage[]
       hasTestApiBase(node.expression)
     ) {
       const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-      const lineText = sourceLines[position.line]?.trim() ?? '';
+      const fullLineText = sourceLines[position.line] ?? '';
+      const trimmedLineText = fullLineText.trim();
 
       usages.push({
         column: position.character + 1,
@@ -382,7 +397,8 @@ function findTestControlUsages(file: string, source: string): TestControlUsage[]
         file,
         kind: node.name.text,
         line: position.line + 1,
-        lineText,
+        fullLineText,
+        trimmedLineText,
       });
     }
 
@@ -400,7 +416,7 @@ function findRootTestControlUsages(): TestControlUsage[] {
 }
 
 function formatUsage(usage: TestControlUsage) {
-  return `${usage.file}:${usage.line}:${usage.column}: ${usage.kind} is not allowed: ${usage.lineText || usage.expression}`;
+  return `${usage.file}:${usage.line}:${usage.column}: ${usage.kind} is not allowed: ${usage.trimmedLineText || usage.expression}`;
 }
 
 function isAllowedSkip(usage: TestControlUsage) {
@@ -408,7 +424,7 @@ function isAllowedSkip(usage: TestControlUsage) {
     (allowed) =>
       allowed.file === usage.file &&
       allowed.kind === usage.kind &&
-      allowed.linePattern.test(usage.lineText),
+      allowed.linePattern.test(usage.trimmedLineText),
   );
 }
 
@@ -465,7 +481,7 @@ describe('root test hygiene', () => {
             (usage) =>
               usage.file === allowed.file &&
               usage.kind === allowed.kind &&
-              allowed.linePattern.test(usage.lineText),
+              allowed.linePattern.test(usage.trimmedLineText),
           ),
       )
       .map((allowed) => `${allowed.file}: ${allowed.kind} allowlist is stale: ${allowed.reason}`);


### PR DESCRIPTION
## Summary

- Make the launcher health-check interval explicitly optional during delayed startup cleanup.
- Fix Safari/Brave localhost certificate copy and merge duplicate OpenAI smoke-test grouping.
- Normalize mocked filesystem paths in script completion tests and split hygiene regexes into named pieces.
- Leave the Octokit `pulls.get` diff mock unchanged after verifying the production code expects the diff string at `response.data`.

## Validation

- `npx vitest run test/providers/scriptCompletion.test.ts test/test-hygiene.test.ts`
- `npx vitest run test/code-scan-action/github.test.ts`
- `npm run l`
- `npm run f`
- `npm run tsc`

Note: did not run the smoke test file because this fresh worktree does not have `dist/src/main.js`; the smoke change is label/grouping only.