### PR TITLE
fix(eval): show chart unavailable reason on demand

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -176,19 +176,42 @@ const renderWithRouter = (component: React.ReactElement) => {
   return renderWithProviders(<MemoryRouter>{component}</MemoryRouter>);
 };
 
-function expectChartsUnavailable(...reasonTexts: string[]) {
-  expect(screen.queryByText('Show Charts')).toBeNull();
+async function expectChartsUnavailable(...reasonTexts: string[]) {
+  const showChartsButton = screen.getByRole('button', { name: 'Show Charts' });
+  expect(showChartsButton).toBeInTheDocument();
   expect(screen.queryByText('Hide Charts')).toBeNull();
   expect(screen.queryByTestId('results-charts')).toBeNull();
   expect(screen.queryByRole('button', { name: 'Why no charts?' })).toBeNull();
   expect(screen.queryByText('Charts are unavailable for this evaluation')).toBeNull();
-  expect(screen.queryByText('Charts are unavailable')).toBeNull();
   expect(
     screen.queryByText(
-      'Charts appear when the results include comparable prompts and chartable scores.',
+      'We can show charts when the results include comparable prompts and chartable scores.',
     ),
   ).toBeNull();
 
+  for (const reasonText of reasonTexts) {
+    expect(screen.queryByText(reasonText)).toBeNull();
+  }
+
+  await userEvent.click(showChartsButton);
+
+  expect(screen.getByRole('button', { name: 'Hide Charts' })).toBeInTheDocument();
+  expect(screen.queryByTestId('results-charts')).toBeNull();
+  expect(screen.getByText('Charts are unavailable for this evaluation')).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      'We can show charts when the results include comparable prompts and chartable scores.',
+    ),
+  ).toBeInTheDocument();
+
+  for (const reasonText of reasonTexts) {
+    expect(screen.getByText(reasonText)).toBeInTheDocument();
+  }
+
+  await userEvent.click(screen.getByRole('button', { name: 'Hide Charts' }));
+
+  expect(screen.getByRole('button', { name: 'Show Charts' })).toBeInTheDocument();
+  expect(screen.queryByText('Charts are unavailable for this evaluation')).toBeNull();
   for (const reasonText of reasonTexts) {
     expect(screen.queryByText(reasonText)).toBeNull();
   }
@@ -876,7 +899,7 @@ describe('ResultsView', () => {
 
     expect(screen.getByTestId('results-charts')).toBeInTheDocument();
   });
-  it('does not render ResultsCharts when table data is in a loading state', () => {
+  it('does not render ResultsCharts when table data is in a loading state', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -914,10 +937,10 @@ describe('ResultsView', () => {
       />,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
   });
 
-  it('hides chart controls when scores are all the same binary edge value', async () => {
+  it('shows an unavailable reason on demand when scores are all the same binary edge value', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -983,7 +1006,7 @@ describe('ResultsView', () => {
       />,
     );
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1036,7 +1059,7 @@ describe('ResultsView Chart Rendering', () => {
       setFilterMode: vi.fn(),
     });
   });
-  it('hides chart controls if there is only one prompt', async () => {
+  it('shows an unavailable reason on demand if there is only one prompt', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1080,10 +1103,10 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
+    await expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
   });
 
-  it('hides chart controls if all scores are binary edge values (all 1s)', async () => {
+  it('shows an unavailable reason on demand if all scores are binary edge values (all 1s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1132,12 +1155,12 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
 
-  it('hides chart controls if all scores are binary edge values (all 0s)', async () => {
+  it('shows an unavailable reason on demand if all scores are binary edge values (all 0s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1186,7 +1209,7 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1295,7 +1318,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
 
     tableStoreValue = {
       ...tableStoreValue,
@@ -1450,10 +1473,10 @@ describe('ResultsView Chart Rendering', () => {
       </MemoryRouter>,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
   });
 
-  it('hides chart controls if there are no valid scores', async () => {
+  it('shows an unavailable reason on demand if there are no valid scores', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1502,7 +1525,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable('Charts require at least one valid numeric score.');
+    await expectChartsUnavailable('Charts require at least one valid numeric score.');
   });
 
   it('hides chart controls entirely for redteam evals', () => {

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -176,11 +176,28 @@ const renderWithRouter = (component: React.ReactElement) => {
   return renderWithProviders(<MemoryRouter>{component}</MemoryRouter>);
 };
 
-function expectChartsUnavailable(...reasonTexts: string[]) {
+async function expectChartsUnavailable(...reasonTexts: string[]) {
   expect(screen.queryByText('Show Charts')).toBeNull();
   expect(screen.queryByText('Hide Charts')).toBeNull();
   expect(screen.queryByTestId('results-charts')).toBeNull();
-  expect(screen.getByText('Charts are unavailable for this evaluation')).toBeInTheDocument();
+  expect(screen.queryByText('Charts are unavailable for this evaluation')).toBeNull();
+  expect(screen.queryByText('Charts are unavailable')).toBeNull();
+
+  const unavailableButton = screen.getByRole('button', { name: 'Why no charts?' });
+  expect(unavailableButton).toBeInTheDocument();
+
+  for (const reasonText of reasonTexts) {
+    expect(screen.queryByText(reasonText)).toBeNull();
+  }
+
+  await userEvent.click(unavailableButton);
+
+  expect(screen.getByText('Charts are unavailable')).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      'Charts appear when the results include comparable prompts and chartable scores.',
+    ),
+  ).toBeInTheDocument();
 
   for (const reasonText of reasonTexts) {
     expect(screen.getByText(reasonText)).toBeInTheDocument();
@@ -869,7 +886,7 @@ describe('ResultsView', () => {
 
     expect(screen.getByTestId('results-charts')).toBeInTheDocument();
   });
-  it('does not render ResultsCharts when table data is in a loading state', () => {
+  it('does not render ResultsCharts when table data is in a loading state', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -907,10 +924,10 @@ describe('ResultsView', () => {
       />,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
   });
 
-  it('shows an explanatory message when scores are all the same binary edge value', async () => {
+  it('offers an explanation when scores are all the same binary edge value', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -976,7 +993,7 @@ describe('ResultsView', () => {
       />,
     );
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1029,7 +1046,7 @@ describe('ResultsView Chart Rendering', () => {
       setFilterMode: vi.fn(),
     });
   });
-  it('shows an explanatory message if there is only one prompt', async () => {
+  it('offers an explanation if there is only one prompt', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1073,10 +1090,10 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
+    await expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
   });
 
-  it('shows an explanatory message if all scores are binary edge values (all 1s)', async () => {
+  it('offers an explanation if all scores are binary edge values (all 1s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1125,12 +1142,12 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
 
-  it('shows an explanatory message if all scores are binary edge values (all 0s)', async () => {
+  it('offers an explanation if all scores are binary edge values (all 0s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1179,7 +1196,7 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    expectChartsUnavailable(
+    await expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1288,7 +1305,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
 
     tableStoreValue = {
       ...tableStoreValue,
@@ -1335,7 +1352,7 @@ describe('ResultsView Chart Rendering', () => {
     expect(screen.getByTestId('results-charts')).toBeInTheDocument();
   });
 
-  it('hides the charts panel when navigating from an eligible eval to an ineligible eval', () => {
+  it('hides the charts panel when navigating from an eligible eval to an ineligible eval', async () => {
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1100);
 
     let tableStoreValue = {
@@ -1443,10 +1460,10 @@ describe('ResultsView Chart Rendering', () => {
       </MemoryRouter>,
     );
 
-    expectChartsUnavailable();
+    await expectChartsUnavailable();
   });
 
-  it('shows an explanatory message if there are no valid scores', async () => {
+  it('offers an explanation if there are no valid scores', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1495,7 +1512,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    expectChartsUnavailable('Charts require at least one valid numeric score.');
+    await expectChartsUnavailable('Charts require at least one valid numeric score.');
   });
 
   it('hides chart controls entirely for redteam evals', () => {

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -176,31 +176,21 @@ const renderWithRouter = (component: React.ReactElement) => {
   return renderWithProviders(<MemoryRouter>{component}</MemoryRouter>);
 };
 
-async function expectChartsUnavailable(...reasonTexts: string[]) {
+function expectChartsUnavailable(...reasonTexts: string[]) {
   expect(screen.queryByText('Show Charts')).toBeNull();
   expect(screen.queryByText('Hide Charts')).toBeNull();
   expect(screen.queryByTestId('results-charts')).toBeNull();
+  expect(screen.queryByRole('button', { name: 'Why no charts?' })).toBeNull();
   expect(screen.queryByText('Charts are unavailable for this evaluation')).toBeNull();
   expect(screen.queryByText('Charts are unavailable')).toBeNull();
-
-  const unavailableButton = screen.getByRole('button', { name: 'Why no charts?' });
-  expect(unavailableButton).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      'Charts appear when the results include comparable prompts and chartable scores.',
+    ),
+  ).toBeNull();
 
   for (const reasonText of reasonTexts) {
     expect(screen.queryByText(reasonText)).toBeNull();
-  }
-
-  await userEvent.click(unavailableButton);
-
-  expect(screen.getByText('Charts are unavailable')).toBeInTheDocument();
-  expect(
-    screen.getByText(
-      'Charts appear when the results include comparable prompts and chartable scores.',
-    ),
-  ).toBeInTheDocument();
-
-  for (const reasonText of reasonTexts) {
-    expect(screen.getByText(reasonText)).toBeInTheDocument();
   }
 }
 
@@ -886,7 +876,7 @@ describe('ResultsView', () => {
 
     expect(screen.getByTestId('results-charts')).toBeInTheDocument();
   });
-  it('does not render ResultsCharts when table data is in a loading state', async () => {
+  it('does not render ResultsCharts when table data is in a loading state', () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -924,10 +914,10 @@ describe('ResultsView', () => {
       />,
     );
 
-    await expectChartsUnavailable();
+    expectChartsUnavailable();
   });
 
-  it('offers an explanation when scores are all the same binary edge value', async () => {
+  it('hides chart controls when scores are all the same binary edge value', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -993,7 +983,7 @@ describe('ResultsView', () => {
       />,
     );
 
-    await expectChartsUnavailable(
+    expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1046,7 +1036,7 @@ describe('ResultsView Chart Rendering', () => {
       setFilterMode: vi.fn(),
     });
   });
-  it('offers an explanation if there is only one prompt', async () => {
+  it('hides chart controls if there is only one prompt', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1090,10 +1080,10 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    await expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
+    expectChartsUnavailable('Charts require at least two prompts to compare side by side.');
   });
 
-  it('offers an explanation if all scores are binary edge values (all 1s)', async () => {
+  it('hides chart controls if all scores are binary edge values (all 1s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1142,12 +1132,12 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    await expectChartsUnavailable(
+    expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
 
-  it('offers an explanation if all scores are binary edge values (all 0s)', async () => {
+  it('hides chart controls if all scores are binary edge values (all 0s)', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1196,7 +1186,7 @@ describe('ResultsView Chart Rendering', () => {
       );
     });
 
-    await expectChartsUnavailable(
+    expectChartsUnavailable(
       'All scores are the same binary edge value (0 or 1), so there is no meaningful distribution to visualize.',
     );
   });
@@ -1305,7 +1295,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    await expectChartsUnavailable();
+    expectChartsUnavailable();
 
     tableStoreValue = {
       ...tableStoreValue,
@@ -1460,10 +1450,10 @@ describe('ResultsView Chart Rendering', () => {
       </MemoryRouter>,
     );
 
-    await expectChartsUnavailable();
+    expectChartsUnavailable();
   });
 
-  it('offers an explanation if there are no valid scores', async () => {
+  it('hides chart controls if there are no valid scores', async () => {
     vi.mocked(useTableStore).mockReturnValue({
       author: 'Test Author',
       table: {
@@ -1512,7 +1502,7 @@ describe('ResultsView Chart Rendering', () => {
       />,
     );
 
-    await expectChartsUnavailable('Charts require at least one valid numeric score.');
+    expectChartsUnavailable('Charts require at least one valid numeric score.');
   });
 
   it('hides chart controls entirely for redteam evals', () => {

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Alert, AlertContent, AlertDescription } from '@app/components/ui/alert';
+import { Alert, AlertContent, AlertDescription, AlertTitle } from '@app/components/ui/alert';
 import { Badge } from '@app/components/ui/badge';
 import { Button } from '@app/components/ui/button';
 import {
@@ -64,6 +64,7 @@ interface ResultsChartsSectionProps {
   canRenderResultsCharts: boolean;
   isRedteamEval: boolean;
   resultsChartsScores: number[];
+  resultsChartsUnavailableReasons: string[];
   children: (toggleButton: React.ReactNode) => React.ReactNode;
 }
 
@@ -169,6 +170,7 @@ function ResultsChartsSection({
   canRenderResultsCharts,
   isRedteamEval,
   resultsChartsScores,
+  resultsChartsUnavailableReasons,
   children,
 }: ResultsChartsSectionProps) {
   const [renderResultsCharts, setRenderResultsCharts] = React.useState(
@@ -177,10 +179,6 @@ function ResultsChartsSection({
 
   if (isRedteamEval) {
     return null;
-  }
-
-  if (!canRenderResultsCharts) {
-    return <>{children(null)}</>;
   }
 
   const toggleButton = (
@@ -203,7 +201,28 @@ function ResultsChartsSection({
           pointerEvents: renderResultsCharts ? 'auto' : 'none',
         }}
       >
-        <ResultsCharts scores={resultsChartsScores} />
+        {renderResultsCharts &&
+          (canRenderResultsCharts ? (
+            <ResultsCharts scores={resultsChartsScores} />
+          ) : (
+            <Alert variant="info" className="mt-4 items-start">
+              <BarChart className="size-4 mt-0.5" />
+              <AlertContent>
+                <AlertTitle>Charts are unavailable for this evaluation</AlertTitle>
+                <AlertDescription className="space-y-3">
+                  <p>
+                    We can show charts when the results include comparable prompts and chartable
+                    scores.
+                  </p>
+                  <ul className="list-disc pl-5 space-y-1">
+                    {resultsChartsUnavailableReasons.map((reason) => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </AlertContent>
+            </Alert>
+          ))}
       </div>
     </>
   );
@@ -788,6 +807,7 @@ export default function ResultsView({
               canRenderResultsCharts={canRenderResultsCharts}
               isRedteamEval={isRedteamEval}
               resultsChartsScores={resultsChartsScores}
+              resultsChartsUnavailableReasons={resultsChartsUnavailableReasons}
             >
               {(chartsToggleButton) => (
                 <div className="flex flex-col gap-3 mt-4 pt-4 border-t border-border/50">

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -11,7 +11,6 @@ import {
   DialogTitle,
 } from '@app/components/ui/dialog';
 import { DropdownMenuItem } from '@app/components/ui/dropdown-menu';
-import { Popover, PopoverContent, PopoverTrigger } from '@app/components/ui/popover';
 import { SearchInput } from '@app/components/ui/search-input';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@app/components/ui/select';
 import { Separator } from '@app/components/ui/separator';
@@ -65,7 +64,6 @@ interface ResultsChartsSectionProps {
   canRenderResultsCharts: boolean;
   isRedteamEval: boolean;
   resultsChartsScores: number[];
-  resultsChartsUnavailableReasons: string[];
   children: (toggleButton: React.ReactNode) => React.ReactNode;
 }
 
@@ -171,7 +169,6 @@ function ResultsChartsSection({
   canRenderResultsCharts,
   isRedteamEval,
   resultsChartsScores,
-  resultsChartsUnavailableReasons,
   children,
 }: ResultsChartsSectionProps) {
   const [renderResultsCharts, setRenderResultsCharts] = React.useState(
@@ -183,33 +180,7 @@ function ResultsChartsSection({
   }
 
   if (!canRenderResultsCharts) {
-    const unavailableButton = (
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button variant="ghost" size="sm">
-            <BarChart className="size-4 mr-2" />
-            Why no charts?
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-80" align="end">
-          <div className="space-y-3 text-sm">
-            <div className="space-y-1">
-              <h3 className="font-medium leading-none">Charts are unavailable</h3>
-              <p className="text-muted-foreground">
-                Charts appear when the results include comparable prompts and chartable scores.
-              </p>
-            </div>
-            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
-              {resultsChartsUnavailableReasons.map((reason) => (
-                <li key={reason}>{reason}</li>
-              ))}
-            </ul>
-          </div>
-        </PopoverContent>
-      </Popover>
-    );
-
-    return <>{children(unavailableButton)}</>;
+    return <>{children(null)}</>;
   }
 
   const toggleButton = (
@@ -817,7 +788,6 @@ export default function ResultsView({
               canRenderResultsCharts={canRenderResultsCharts}
               isRedteamEval={isRedteamEval}
               resultsChartsScores={resultsChartsScores}
-              resultsChartsUnavailableReasons={resultsChartsUnavailableReasons}
             >
               {(chartsToggleButton) => (
                 <div className="flex flex-col gap-3 mt-4 pt-4 border-t border-border/50">

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Alert, AlertContent, AlertDescription, AlertTitle } from '@app/components/ui/alert';
+import { Alert, AlertContent, AlertDescription } from '@app/components/ui/alert';
 import { Badge } from '@app/components/ui/badge';
 import { Button } from '@app/components/ui/button';
 import {
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from '@app/components/ui/dialog';
 import { DropdownMenuItem } from '@app/components/ui/dropdown-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@app/components/ui/popover';
 import { SearchInput } from '@app/components/ui/search-input';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@app/components/ui/select';
 import { Separator } from '@app/components/ui/separator';
@@ -182,27 +183,33 @@ function ResultsChartsSection({
   }
 
   if (!canRenderResultsCharts) {
-    return (
-      <>
-        {children(null)}
-        <Alert variant="info" className="mt-4 items-start">
-          <BarChart className="size-4 mt-0.5" />
-          <AlertContent>
-            <AlertTitle>Charts are unavailable for this evaluation</AlertTitle>
-            <AlertDescription className="space-y-3">
-              <p>
-                We can show charts when the results include comparable prompts and chartable scores.
+    const unavailableButton = (
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="ghost" size="sm">
+            <BarChart className="size-4 mr-2" />
+            Why no charts?
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80" align="end">
+          <div className="space-y-3 text-sm">
+            <div className="space-y-1">
+              <h3 className="font-medium leading-none">Charts are unavailable</h3>
+              <p className="text-muted-foreground">
+                Charts appear when the results include comparable prompts and chartable scores.
               </p>
-              <ul className="list-disc pl-5 space-y-1">
-                {resultsChartsUnavailableReasons.map((reason) => (
-                  <li key={reason}>{reason}</li>
-                ))}
-              </ul>
-            </AlertDescription>
-          </AlertContent>
-        </Alert>
-      </>
+            </div>
+            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
+              {resultsChartsUnavailableReasons.map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          </div>
+        </PopoverContent>
+      </Popover>
     );
+
+    return <>{children(unavailableButton)}</>;
   }
 
   const toggleButton = (


### PR DESCRIPTION
## Summary
- Keep the small Show Charts toggle visible for non-redteam evals.
- Show the unavailable-charts explanation only after a user clicks Show Charts on an ineligible eval.
- Keep eligible charts behavior unchanged, including default display on tall viewports.
- Update ResultsView tests to cover the quiet default state, on-demand explanation, and closing the explanation again.

## Screenshots
Current behavior on main, where the unavailable message is shown immediately:

![Current main behavior with unavailable chart message visible](https://iili.io/BelpxvS.png)

Updated default state, before clicking Show Charts:

![Default state with Show Charts toggle](https://iili.io/BelrNbp.png)

After clicking Show Charts on an ineligible eval:

![Unavailable charts reason shown after toggle](https://iili.io/BelrQXS.png)

## Test Plan
- npm run test:app -- src/pages/eval/components/ResultsView.test.tsx --run
- npm run l
- npm run f
- git diff --check