### PR TITLE
test(assertions): cover custom elements in is-html

### DIFF
--- a/test/assertions/html.test.ts
+++ b/test/assertions/html.test.ts
@@ -392,6 +392,25 @@ describe('handleIsHtml', () => {
     });
   });
 
+  it('should accept custom elements', () => {
+    const fragments = [
+      '<custom-element data-id="123">Web component</custom-element>',
+      '<CUSTOM-ELEMENT>Uppercase custom element</CUSTOM-ELEMENT>',
+    ];
+
+    fragments.forEach((html) => {
+      const params: AssertionParams = {
+        ...defaultParams,
+        assertion: { type: 'is-html' },
+        outputString: html,
+        inverse: false,
+      };
+
+      const result = handleIsHtml(params);
+      expect(result.pass).toBe(true);
+    });
+  });
+
   it('should reject doctype-only input', () => {
     const params: AssertionParams = {
       ...defaultParams,


### PR DESCRIPTION
## Summary
- add `is-html` regression coverage for custom elements after the recent `parse5` migration in `src/assertions/html.ts`
- cover both lowercase and uppercase custom-element tags so the hyphenated custom-element path stays exercised
- lock in the gap found during review: the pre-existing suite still passed after removing custom-element support from `is-html`

## Validation
- `./node_modules/.bin/vitest run test/assertions/html.test.ts`
- `./node_modules/.bin/vitest run test/assertions/html.test.ts --coverage.enabled=true --coverage.provider=v8 --coverage.reporter=text --coverage.include=src/assertions/html.ts`
