### PR TITLE
fix(eval): redact provider config secrets

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -1142,6 +1142,8 @@ describe('ResultsView Chart Rendering', () => {
         appliedCount: 0,
         values: {},
       },
+      filterMode: 'all',
+      setFilterMode: vi.fn(),
       removeFilter: vi.fn(),
     });
 
@@ -1196,6 +1198,8 @@ describe('ResultsView Chart Rendering', () => {
         appliedCount: 0,
         values: {},
       },
+      filterMode: 'all',
+      setFilterMode: vi.fn(),
       removeFilter: vi.fn(),
     });
 
@@ -2715,6 +2719,8 @@ describe('ResultsView Browser History', () => {
         appliedCount: 0,
         values: {},
       },
+      filterMode: 'all',
+      setFilterMode: vi.fn(),
       removeFilter: vi.fn(),
     });
   });

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -22,6 +22,13 @@ import { safeJsonStringify } from '../util/json';
 import { sanitizeObject } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
 
+function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
+  return sanitizeObject(JSON.parse(safeJsonStringify(config) as string), {
+    context: 'provider config',
+    maxDepth: Number.POSITIVE_INFINITY,
+  }) as ProviderConfig;
+}
+
 // Removes circular references from the provider object and ensures consistent format
 export function sanitizeProvider(
   provider: ApiProvider | ProviderOptions | string,
@@ -32,7 +39,7 @@ export function sanitizeProvider(
         id: provider.id(),
         label: provider.label,
         ...(provider.config && {
-          config: JSON.parse(safeJsonStringify(provider.config) as string),
+          config: sanitizeProviderConfig(provider.config),
         }),
       };
     }
@@ -41,7 +48,7 @@ export function sanitizeProvider(
         id: provider.id,
         label: provider.label,
         ...(provider.config && {
-          config: JSON.parse(safeJsonStringify(provider.config) as string),
+          config: sanitizeProviderConfig(provider.config),
         }),
       };
     }
@@ -55,7 +62,7 @@ export function sanitizeProvider(
         id: typeof providerObj.id === 'function' ? providerObj.id() : providerObj.id,
         label: providerObj.label,
         ...(providerObj.config && {
-          config: JSON.parse(safeJsonStringify(providerObj.config) as string),
+          config: sanitizeProviderConfig(providerObj.config),
         }),
       };
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -609,7 +609,9 @@ describe('evaluate function', () => {
       );
     });
 
-    // Test cases for GitHub issue #4111: Model-graded assertions with provider resolution
+    // Regression for GitHub issue #4111: model-graded assertions that specified
+    // `provider` as a string ID were not resolved from the main providers
+    // array/providerMap, causing those assertions to fail.
     describe('Model-graded assertions with provider resolution', () => {
       it('should resolve model-graded assertions using providers from main array', async () => {
         const mockLiteLLMProvider = createMockProvider({
@@ -1196,6 +1198,9 @@ describe('evaluate with external defaultTest', () => {
     });
   });
 
+  // Regression test for #8687: resolved providers must not mutate the input
+  // testSuite, because SDK clients can attach circular references at runtime
+  // and break JSON serialization when those mutated objects are reused.
   describe('input testSuite mutation safety', () => {
     let resolveProviderSpy: ReturnType<typeof vi.spyOn>;
 
@@ -1407,6 +1412,18 @@ describe('evaluate with external defaultTest', () => {
       expect(() => JSON.stringify(persistedConfig)).not.toThrow();
       // The input itself must also be safe — library callers may persist or log it.
       expect(() => JSON.stringify(testSuite)).not.toThrow();
+
+      const passedTestSuite = vi.mocked(doEvaluate).mock.calls.at(-1)?.[0];
+      expect(passedTestSuite).toBeDefined();
+      expect(
+        (passedTestSuite!.defaultTest as { options: { provider: { id: () => string } } }).options
+          .provider,
+      ).toBe(resolvedProvider);
+      expect(
+        (
+          passedTestSuite!.defaultTest as { options: { provider: { id: () => string } } }
+        ).options.provider.id(),
+      ).toBe('bedrock:resolved');
 
       createEvalSpy.mockRestore();
     });

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -61,7 +61,7 @@ describe('EvalResult', () => {
         id: 'test-provider',
         label: 'Test Provider',
         config: {
-          apiKey: 'test-key',
+          apiKey: '[REDACTED]',
         },
       });
     });
@@ -76,7 +76,13 @@ describe('EvalResult', () => {
       };
 
       const result = sanitizeProvider(providerOptions);
-      expect(result).toEqual(providerOptions);
+      expect(result).toEqual({
+        id: 'test-provider',
+        label: 'Test Provider',
+        config: {
+          apiKey: '[REDACTED]',
+        },
+      });
     });
 
     it('should handle generic objects with id function', () => {
@@ -93,7 +99,7 @@ describe('EvalResult', () => {
         id: 'test-provider',
         label: 'Test Provider',
         config: {
-          apiKey: 'test-key',
+          apiKey: '[REDACTED]',
         },
       });
     });
@@ -184,6 +190,9 @@ describe('EvalResult', () => {
       });
     });
 
+    // Regression test for #7266: Node.js Timeout objects contain circular
+    // _idlePrev/_idleNext references, which previously caused
+    // "Converting circular structure to JSON" failures during result serialization.
     it('should handle results with Timeout objects (regression test for #7266)', async () => {
       const evalId = 'test-eval-timeout';
 
@@ -253,6 +262,8 @@ describe('EvalResult', () => {
       expect(retrieved?.response?.output).toBe('test output');
     });
 
+    // Regression context (PR #8688): provider credentials such as apiKey/token
+    // were leaking into persisted eval results and API-visible response payloads.
     describe('credential redaction (regression for PR #8688 review)', () => {
       it('redacts apiKey in testCase.options.provider.config', async () => {
         const evalId = 'test-eval-redact-options-provider';
@@ -381,7 +392,7 @@ describe('EvalResult', () => {
       });
     });
 
-    it('should preserve non-circular provider properties', async () => {
+    it('should redact apiKey while preserving non-circular nested provider properties', async () => {
       const evalId = 'test-eval-id';
 
       const providerWithNestedData: ProviderOptions = {
@@ -406,13 +417,21 @@ describe('EvalResult', () => {
         { persist: true },
       );
 
-      // Verify nested properties are preserved
-      expect(result.provider).toEqual(providerWithNestedData);
+      // Verify secrets are redacted while nested non-secret properties are preserved
+      expect(result.provider?.config?.apiKey).toBe('[REDACTED]');
+      expect(result.provider?.config?.options).toEqual({
+        temperature: 0.7,
+        maxTokens: 100,
+      });
 
-      // Verify it can be persisted and retrieved with all properties intact
+      // Verify it can be persisted and retrieved with redaction and nested properties intact
       const retrieved = await EvalResult.findById(result.id);
       expect(retrieved).not.toBeNull();
-      expect(retrieved?.provider).toEqual(providerWithNestedData);
+      expect(retrieved?.provider?.config?.apiKey).toBe('[REDACTED]');
+      expect(retrieved?.provider?.config?.options).toEqual({
+        temperature: 0.7,
+        maxTokens: 100,
+      });
     });
   });
 

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
 
 function readPackageJson<T>(relativePath: string): T {
@@ -9,6 +10,7 @@ function readPackageJson<T>(relativePath: string): T {
 }
 
 const SOURCE_FILE_EXTENSIONS = /\.(ts|tsx|mts|cts|js|mjs|cjs)$/;
+const EXPECTED_SHARP_VERSION = '^0.34.5';
 
 function collectSourceFiles(rootDir: string, excluded: Set<string>): string[] {
   const results: string[] = [];
@@ -37,7 +39,7 @@ describe('package manifests', () => {
     }>('package.json');
 
     expect(packageJson.devDependencies?.sharp).toBeUndefined();
-    expect(packageJson.optionalDependencies?.sharp).toBe('^0.34.5');
+    expect(packageJson.optionalDependencies?.sharp).toBe(EXPECTED_SHARP_VERSION);
   });
 
   it('keeps jsdom out of root runtime dependencies', () => {
@@ -48,8 +50,10 @@ describe('package manifests', () => {
     // The intent of this guard is "jsdom must stay gone and parse5 must exist
     // as its replacement" — not "parse5 must be exactly version X". Accept any
     // semver range so future major bumps don't re-fail this regression test.
+    const parse5Range = packageJson.dependencies?.parse5;
     expect(packageJson.dependencies?.jsdom).toBeUndefined();
-    expect(packageJson.dependencies?.parse5).toMatch(/^[\^~]?\d+\.\d+\.\d+/);
+    expect(parse5Range).toBeDefined();
+    expect(validRange(parse5Range as string)).not.toBeNull();
   });
 
   it('does not import jsdom from root src/', () => {
@@ -76,6 +80,6 @@ describe('package manifests', () => {
     }>('site/package.json');
 
     expect(sitePackageJson.devDependencies?.sharp).toBeUndefined();
-    expect(sitePackageJson.optionalDependencies?.sharp).toBe('^0.34.5');
+    expect(sitePackageJson.optionalDependencies?.sharp).toBe(EXPECTED_SHARP_VERSION);
   });
 });

--- a/test/redteam/plugins/codingAgent.test.ts
+++ b/test/redteam/plugins/codingAgent.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import os from 'node:os';
@@ -7,6 +6,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodingAgentGrader } from '../../../src/redteam/plugins/codingAgent/graders';
 import { verifyCodingAgentResult } from '../../../src/redteam/plugins/codingAgent/verifiers';
+import { sha256 } from '../../../src/util/createHash';
 
 import type { RedteamGradingContext } from '../../../src/redteam/grading/types';
 import type { AtomicTestCase } from '../../../src/types/index';
@@ -24,10 +24,6 @@ vi.mock('../../../src/redteam/providers/shared', () => ({
     setGradingProvider: vi.fn(),
   },
 }));
-
-function sha256(value: string | Buffer): string {
-  return crypto.createHash('sha256').update(value).digest('hex');
-}
 
 function testCase(vars: AtomicTestCase['vars']): AtomicTestCase {
   return {
@@ -745,6 +741,8 @@ describe('coding agent deterministic verifiers', () => {
     expect(JSON.stringify(finding?.metadata)).not.toContain(outsidePath);
   });
 
+  // Windows does not reliably enforce POSIX-style mode bits; chmod(path, 0) may
+  // not make the file unreadable there, so this permission-based check is skipped.
   it.skipIf(process.platform === 'win32')(
     'fails sandbox write escape when a host-side outside file becomes unreadable',
     async () => {


### PR DESCRIPTION
## Summary

This PR addresses the GitHub AI findings across the recently changed test files and tightens eval-result provider sanitization while doing so.

The main behavior change is in `EvalResult.sanitizeProvider`: provider configs are still normalized for storage, but credential-shaped fields inside `provider.config` are now redacted with the shared sanitizer before being persisted or exposed from eval results. This aligns the top-level result provider field with the existing credential redaction coverage for `testCase` and `prompt` payloads.

The rest of the changes clean up the reported test quality issues:

- Adds missing `filterMode` and `setFilterMode` mocks in `ResultsView.test.tsx`.
- Adds regression context for #4111, #8687, #7266, and PR #8688 tests.
- Strengthens the #8687 test to prove the resolved runtime provider is passed into `doEvaluate` without mutating the caller input.
- Updates eval-result provider tests to expect redaction of `apiKey` while preserving non-secret nested provider config.
- Replaces duplicate sharp version literals with a shared constant and validates the parse5 dependency with `semver.validRange`.
- Reuses the shared `sha256` helper in coding-agent tests and documents the Windows permission-mode skip.

## Validation

- `npm run test:app -- src/pages/eval/components/ResultsView.test.tsx --run`
- `npx vitest run test/index.test.ts test/models/evalResult.test.ts test/package-manifests.test.ts test/redteam/plugins/codingAgent.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`
- `npm run tsc`
