### PR TITLE
fix(eval): detect _conversation references precisely

### DIFF
--- a/site/docs/configuration/chat.md
+++ b/site/docs/configuration/chat.md
@@ -226,7 +226,7 @@ The prompt inserts the previous conversation into the test case, creating a full
 Try it yourself by using the [full example config](https://github.com/promptfoo/promptfoo/tree/main/examples/config-multi-turn).
 
 :::info
-When the `_conversation` variable is present, the eval will run single-threaded (concurrency of 1).
+When a prompt references `_conversation` as a Nunjucks variable, the eval will run single-threaded (concurrency of 1).
 :::
 
 ## Separating Chat Conversations

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -76,7 +76,7 @@ import {
   isProviderAllowed,
 } from './util/provider';
 import { promptYesNo } from './util/readline';
-import { extractVariablesFromTemplate } from './util/templates';
+import { extractVariablesFromTemplate, templateReferencesVariable } from './util/templates';
 import { sleep } from './util/time';
 import { TokenUsageTracker } from './util/tokenUsage';
 import {
@@ -103,6 +103,12 @@ import type {
   VarValue,
 } from './types/index';
 import type { CallApiContextParams } from './types/providers';
+
+const CONVERSATION_VAR_NAME = '_conversation';
+
+function promptUsesConversationVariable(prompt: Pick<Prompt, 'raw'>): boolean {
+  return templateReferencesVariable(prompt.raw, CONVERSATION_VAR_NAME);
+}
 
 /**
  * Manages a single progress bar for the evaluation
@@ -551,7 +557,7 @@ function attachConversationVar({
   test: AtomicTestCase;
   vars: Vars;
 }) {
-  const usesConversation = prompt.raw.includes('_conversation');
+  const usesConversation = promptUsesConversationVariable(prompt);
   if (
     !getEnvBool('PROMPTFOO_DISABLE_CONVERSATION_VAR') &&
     !test.options?.disableConversationVar &&
@@ -2416,7 +2422,7 @@ function adjustConcurrencyForSerialFeatures({
   prompts: CompletedPrompt[];
   tests: AtomicTestCase[];
 }) {
-  const usesConversationVar = prompts.some((p) => p.raw.includes('_conversation'));
+  const usesConversationVar = prompts.some(promptUsesConversationVariable);
   if (concurrency <= 1) {
     return { concurrency, usesConversationVar };
   }
@@ -2424,7 +2430,7 @@ function adjustConcurrencyForSerialFeatures({
   const usesStoreOutputAs = tests.some((t) => t.options?.storeOutputAs);
   if (usesConversationVar) {
     logger.info(
-      `Setting concurrency to 1 because the ${chalk.cyan('_conversation')} variable is used.`,
+      `Setting concurrency to 1 because the ${chalk.cyan(CONVERSATION_VAR_NAME)} variable is used.`,
     );
     return { concurrency: 1, usesConversationVar };
   }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -4,6 +4,7 @@ import async from 'async';
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 import { globSync } from 'glob';
+import { LRUCache } from 'lru-cache';
 import {
   getAssertionBaseType,
   hasTraceAwareAssertions,
@@ -76,7 +77,7 @@ import {
   isProviderAllowed,
 } from './util/provider';
 import { promptYesNo } from './util/readline';
-import { extractVariablesFromTemplate, templateReferencesVariable } from './util/templates';
+import { analyzeTemplateReference, extractVariablesFromTemplate } from './util/templates';
 import { sleep } from './util/time';
 import { TokenUsageTracker } from './util/tokenUsage';
 import {
@@ -105,7 +106,10 @@ import type {
 import type { CallApiContextParams } from './types/providers';
 
 const CONVERSATION_VAR_NAME = '_conversation';
-const promptUsesConversationVariableCache = new Map<string, boolean>();
+const PROMPT_CONVERSATION_CACHE_MAX = 1024;
+const promptUsesConversationVariableCache = new LRUCache<string, boolean>({
+  max: PROMPT_CONVERSATION_CACHE_MAX,
+});
 
 function promptUsesConversationVariable(prompt: Pick<Prompt, 'raw'>): boolean {
   const cached = promptUsesConversationVariableCache.get(prompt.raw);
@@ -113,9 +117,19 @@ function promptUsesConversationVariable(prompt: Pick<Prompt, 'raw'>): boolean {
     return cached;
   }
 
-  const usesConversationVariable = templateReferencesVariable(prompt.raw, CONVERSATION_VAR_NAME);
-  promptUsesConversationVariableCache.set(prompt.raw, usesConversationVariable);
-  return usesConversationVariable;
+  const { referenced, parsed } = analyzeTemplateReference(prompt.raw, CONVERSATION_VAR_NAME);
+  // Only cache successfully parsed results. Caching a parse failure would
+  // poison the cache for the lifetime of the process and silently downgrade
+  // future conversation-aware runs to parallel execution.
+  if (parsed) {
+    promptUsesConversationVariableCache.set(prompt.raw, referenced);
+  }
+  return referenced;
+}
+
+/** Test-only: reset the per-process prompt conversation-variable cache. */
+export function __resetPromptConversationCacheForTests(): void {
+  promptUsesConversationVariableCache.clear();
 }
 
 /**

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -105,9 +105,17 @@ import type {
 import type { CallApiContextParams } from './types/providers';
 
 const CONVERSATION_VAR_NAME = '_conversation';
+const promptUsesConversationVariableCache = new Map<string, boolean>();
 
 function promptUsesConversationVariable(prompt: Pick<Prompt, 'raw'>): boolean {
-  return templateReferencesVariable(prompt.raw, CONVERSATION_VAR_NAME);
+  const cached = promptUsesConversationVariableCache.get(prompt.raw);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const usesConversationVariable = templateReferencesVariable(prompt.raw, CONVERSATION_VAR_NAME);
+  promptUsesConversationVariableCache.set(prompt.raw, usesConversationVariable);
+  return usesConversationVariable;
 }
 
 /**

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -209,26 +209,66 @@ function collectMacroParamNames(argsNode: unknown): string[] {
   return names;
 }
 
+function macroArgsReferenceVariable(
+  argsNode: unknown,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  if (!isNunjucksAstNode(argsNode) || !Array.isArray(argsNode.children)) {
+    return false;
+  }
+
+  for (const child of argsNode.children) {
+    if (!isNunjucksAstNode(child)) {
+      continue;
+    }
+    if (child.typename === 'Symbol') {
+      continue;
+    }
+    if (child.typename === 'KeywordArgs' && Array.isArray(child.children)) {
+      for (const pair of child.children) {
+        if (
+          isNunjucksAstNode(pair) &&
+          pair.typename === 'Pair' &&
+          astChildReferencesVariable(pair, 'value', variableName, boundSymbols)
+        ) {
+          return true;
+        }
+      }
+      continue;
+    }
+    if (
+      astReferencesVariable(
+        child,
+        variableName,
+        { field: 'children', node: argsNode },
+        boundSymbols,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function macroNodeReferencesVariable(
   node: NunjucksAstNode,
   variableName: string,
   boundSymbols: ReadonlySet<string>,
 ): boolean {
-  // Walk the arg list with a scope that shadows only param names (not their
-  // default-value expressions). This catches references like
-  // `{% macro render(x=_conversation) %}` where `_conversation` in the default
-  // is a real symbol read evaluated at call time.
+  // Macro defaults are evaluated before the parameter is assigned, so only
+  // parameter names themselves are bindings while Pair.value remains outer-scope.
   const paramNames = collectMacroParamNames(node.args);
-  const argScope = new Set(boundSymbols);
-  for (const name of paramNames) {
-    argScope.add(name);
-  }
-  if (astChildReferencesVariable(node, 'args', variableName, argScope)) {
+  if (macroArgsReferenceVariable(node.args, variableName, boundSymbols)) {
     return true;
   }
 
   // Walk the body with the full macro scope (outer + param names + macro name).
-  const macroScope = new Set(argScope);
+  const macroScope = new Set(boundSymbols);
+  for (const name of paramNames) {
+    macroScope.add(name);
+  }
   if (
     isNunjucksAstNode(node.name) &&
     node.name.typename === 'Symbol' &&
@@ -237,6 +277,30 @@ function macroNodeReferencesVariable(
     macroScope.add(node.name.value);
   }
   return astChildReferencesVariable(node, 'body', variableName, macroScope);
+}
+
+function isNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  if (astChildReferencesVariable(node, 'left', variableName, boundSymbols)) {
+    return true;
+  }
+
+  const right = node.right;
+  if (!isNunjucksAstNode(right)) {
+    return false;
+  }
+
+  if (right.typename === 'FunCall') {
+    return astChildReferencesVariable(right, 'args', variableName, boundSymbols);
+  }
+
+  return (
+    right.typename !== 'Symbol' &&
+    astReferencesVariable(right, variableName, { field: 'right', node }, boundSymbols)
+  );
 }
 
 function setNodeReferencesVariable(
@@ -269,6 +333,15 @@ function blockNodeReferencesVariable(
   // `{% block name %}...{% endblock %}` — `name` is a template-inheritance
   // label, not a variable reference. Only the body can reference variables.
   return astChildReferencesVariable(node, 'body', variableName, boundSymbols);
+}
+
+function callerNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  const callerScope = addBoundSymbols(boundSymbols, node.args);
+  return astChildReferencesVariable(node, 'body', variableName, callerScope);
 }
 
 function astFieldsReferenceVariable(
@@ -308,6 +381,10 @@ function astReferencesVariable(
     return macroNodeReferencesVariable(node, variableName, boundSymbols);
   }
 
+  if (node.typename === 'Is') {
+    return isNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
   if (node.typename === 'Set') {
     return setNodeReferencesVariable(node, variableName, boundSymbols);
   }
@@ -318,6 +395,10 @@ function astReferencesVariable(
 
   if (node.typename === 'Block') {
     return blockNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  if (node.typename === 'Caller') {
+    return callerNodeReferencesVariable(node, variableName, boundSymbols);
   }
 
   return astFieldsReferenceVariable(node, variableName, boundSymbols);

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -172,12 +172,70 @@ function forNodeReferencesVariable(
   );
 }
 
+/**
+ * Collect only parameter NAMES from a Macro.args NodeList. This is the set of
+ * names bound inside the macro body — positional Symbols and `Pair.key`
+ * Symbols inside `KeywordArgs`. Default-value expressions (`Pair.value`) are
+ * *not* bindings and must be walked separately as references in the outer
+ * scope.
+ */
+function collectMacroParamNames(argsNode: unknown): string[] {
+  const names: string[] = [];
+  if (!isNunjucksAstNode(argsNode) || !Array.isArray(argsNode.children)) {
+    return names;
+  }
+  for (const child of argsNode.children) {
+    if (!isNunjucksAstNode(child)) {
+      continue;
+    }
+    if (child.typename === 'Symbol' && typeof child.value === 'string') {
+      names.push(child.value);
+      continue;
+    }
+    if (child.typename === 'KeywordArgs' && Array.isArray(child.children)) {
+      for (const pair of child.children) {
+        if (
+          isNunjucksAstNode(pair) &&
+          pair.typename === 'Pair' &&
+          isNunjucksAstNode(pair.key) &&
+          pair.key.typename === 'Symbol' &&
+          typeof pair.key.value === 'string'
+        ) {
+          names.push(pair.key.value);
+        }
+      }
+    }
+  }
+  return names;
+}
+
 function macroNodeReferencesVariable(
   node: NunjucksAstNode,
   variableName: string,
   boundSymbols: ReadonlySet<string>,
 ): boolean {
-  const macroScope = addBoundSymbols(addBoundSymbols(boundSymbols, node.name), node.args);
+  // Walk the arg list with a scope that shadows only param names (not their
+  // default-value expressions). This catches references like
+  // `{% macro render(x=_conversation) %}` where `_conversation` in the default
+  // is a real symbol read evaluated at call time.
+  const paramNames = collectMacroParamNames(node.args);
+  const argScope = new Set(boundSymbols);
+  for (const name of paramNames) {
+    argScope.add(name);
+  }
+  if (astChildReferencesVariable(node, 'args', variableName, argScope)) {
+    return true;
+  }
+
+  // Walk the body with the full macro scope (outer + param names + macro name).
+  const macroScope = new Set(argScope);
+  if (
+    isNunjucksAstNode(node.name) &&
+    node.name.typename === 'Symbol' &&
+    typeof node.name.value === 'string'
+  ) {
+    macroScope.add(node.name.value);
+  }
   return astChildReferencesVariable(node, 'body', variableName, macroScope);
 }
 
@@ -190,6 +248,27 @@ function setNodeReferencesVariable(
     astChildReferencesVariable(node, 'value', variableName, boundSymbols) ||
     astChildReferencesVariable(node, 'body', variableName, boundSymbols)
   );
+}
+
+function fromImportNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  // `{% from template import a, b as c %}` — the template expression may
+  // reference variables, but the `names` list introduces local bindings
+  // (both plain and aliased) and must never be walked as references.
+  return astChildReferencesVariable(node, 'template', variableName, boundSymbols);
+}
+
+function blockNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  // `{% block name %}...{% endblock %}` — `name` is a template-inheritance
+  // label, not a variable reference. Only the body can reference variables.
+  return astChildReferencesVariable(node, 'body', variableName, boundSymbols);
 }
 
 function astFieldsReferenceVariable(
@@ -231,6 +310,14 @@ function astReferencesVariable(
 
   if (node.typename === 'Set') {
     return setNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  if (node.typename === 'FromImport') {
+    return fromImportNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  if (node.typename === 'Block') {
+    return blockNodeReferencesVariable(node, variableName, boundSymbols);
   }
 
   return astFieldsReferenceVariable(node, variableName, boundSymbols);

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -4,6 +4,88 @@ import { getEnvBool } from '../envars';
 
 import type { NunjucksFilterMap } from '../types/index';
 
+type NunjucksAstNode = {
+  fields?: readonly string[];
+  typename?: string;
+  value?: unknown;
+  [field: string]: unknown;
+};
+
+type NunjucksParser = {
+  parse: (template: string) => NunjucksAstNode;
+};
+
+type NunjucksWithParser = typeof nunjucks & {
+  parser: NunjucksParser;
+};
+
+type NunjucksParentContext = {
+  field: string;
+  node: NunjucksAstNode;
+};
+
+function isNunjucksAstNode(value: unknown): value is NunjucksAstNode {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      typeof (value as { typename?: unknown }).typename === 'string',
+  );
+}
+
+function parseNunjucksTemplate(template: string): NunjucksAstNode | undefined {
+  try {
+    return (nunjucks as unknown as NunjucksWithParser).parser.parse(template);
+  } catch {
+    return undefined;
+  }
+}
+
+function isNonReferenceSymbol(parent?: NunjucksParentContext): boolean {
+  if (!parent) {
+    return false;
+  }
+
+  return (
+    (parent.node.typename === 'Pair' && parent.field === 'key') ||
+    (parent.node.typename === 'Filter' && parent.field === 'name') ||
+    (parent.node.typename === 'Is' && parent.field === 'right') ||
+    (parent.node.typename === 'Set' && parent.field === 'targets') ||
+    (parent.node.typename === 'For' && parent.field === 'name') ||
+    (parent.node.typename === 'Macro' && parent.field === 'name')
+  );
+}
+
+function astReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  parent?: NunjucksParentContext,
+): boolean {
+  if (node.typename === 'Symbol' && node.value === variableName) {
+    return !isNonReferenceSymbol(parent);
+  }
+
+  for (const field of node.fields ?? []) {
+    const child = node[field];
+    if (Array.isArray(child)) {
+      if (
+        child.some(
+          (item) =>
+            isNunjucksAstNode(item) && astReferencesVariable(item, variableName, { field, node }),
+        )
+      ) {
+        return true;
+      }
+    } else if (
+      isNunjucksAstNode(child) &&
+      astReferencesVariable(child, variableName, { field, node })
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Get a Nunjucks engine instance with optional filters and configuration.
  * @param filters - Optional map of custom Nunjucks filters.
@@ -99,4 +181,16 @@ export function extractVariablesFromTemplates(templates: string[]): string[] {
     variables.forEach((variable) => variableSet.add(variable));
   }
   return Array.from(variableSet);
+}
+
+/**
+ * Check whether a valid Nunjucks template references a variable as an expression symbol.
+ */
+export function templateReferencesVariable(template: string, variableName: string): boolean {
+  if (!variableName) {
+    return false;
+  }
+
+  const ast = parseNunjucksTemplate(template);
+  return ast ? astReferencesVariable(ast, variableName) : false;
 }

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -309,7 +309,7 @@ export function extractVariablesFromTemplates(templates: string[]): string[] {
  * Check whether a valid Nunjucks template references a variable as an expression symbol.
  */
 export function templateReferencesVariable(template: string, variableName: string): boolean {
-  if (!variableName) {
+  if (!variableName || !template.includes(variableName)) {
     return false;
   }
 

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -55,35 +55,157 @@ function isNonReferenceSymbol(parent?: NunjucksParentContext): boolean {
   );
 }
 
+function collectSymbolValues(node: unknown): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item) => collectSymbolValues(item));
+  }
+  if (!isNunjucksAstNode(node)) {
+    return [];
+  }
+  if (node.typename === 'Symbol' && typeof node.value === 'string') {
+    return [node.value];
+  }
+
+  const values: string[] = [];
+  for (const field of node.fields ?? []) {
+    const child = node[field];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        values.push(...collectSymbolValues(item));
+      }
+    } else {
+      values.push(...collectSymbolValues(child));
+    }
+  }
+  return values;
+}
+
+function addBoundSymbols(scope: ReadonlySet<string>, node: unknown): Set<string> {
+  const nextScope = new Set(scope);
+  for (const value of collectSymbolValues(node)) {
+    nextScope.add(value);
+  }
+  return nextScope;
+}
+
+function astNodeListReferencesVariable(
+  nodes: readonly unknown[],
+  variableName: string,
+  parent: NunjucksParentContext,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  let scope = new Set(boundSymbols);
+  for (const item of nodes) {
+    if (!isNunjucksAstNode(item)) {
+      continue;
+    }
+    if (astReferencesVariable(item, variableName, parent, scope)) {
+      return true;
+    }
+    if (item.typename === 'Set') {
+      scope = addBoundSymbols(scope, item.targets);
+    } else if (item.typename === 'Macro') {
+      scope = addBoundSymbols(scope, item.name);
+    }
+  }
+  return false;
+}
+
+function astChildReferencesVariable(
+  node: NunjucksAstNode,
+  field: string,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  const child = node[field];
+  if (Array.isArray(child)) {
+    return child.some(
+      (item) =>
+        isNunjucksAstNode(item) &&
+        astReferencesVariable(item, variableName, { field, node }, boundSymbols),
+    );
+  }
+  return (
+    isNunjucksAstNode(child) &&
+    astReferencesVariable(child, variableName, { field, node }, boundSymbols)
+  );
+}
+
+function forNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  const loopScope = addBoundSymbols(boundSymbols, node.name);
+  return (
+    astChildReferencesVariable(node, 'arr', variableName, boundSymbols) ||
+    astChildReferencesVariable(node, 'body', variableName, loopScope) ||
+    astChildReferencesVariable(node, 'else_', variableName, boundSymbols)
+  );
+}
+
+function macroNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  const macroScope = addBoundSymbols(addBoundSymbols(boundSymbols, node.name), node.args);
+  return astChildReferencesVariable(node, 'body', variableName, macroScope);
+}
+
+function setNodeReferencesVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  return (
+    astChildReferencesVariable(node, 'value', variableName, boundSymbols) ||
+    astChildReferencesVariable(node, 'body', variableName, boundSymbols)
+  );
+}
+
+function astFieldsReferenceVariable(
+  node: NunjucksAstNode,
+  variableName: string,
+  boundSymbols: ReadonlySet<string>,
+): boolean {
+  return (node.fields ?? []).some((field) =>
+    astChildReferencesVariable(node, field, variableName, boundSymbols),
+  );
+}
+
 function astReferencesVariable(
   node: NunjucksAstNode,
   variableName: string,
   parent?: NunjucksParentContext,
+  boundSymbols: ReadonlySet<string> = new Set(),
 ): boolean {
   if (node.typename === 'Symbol' && node.value === variableName) {
-    return !isNonReferenceSymbol(parent);
+    return !boundSymbols.has(variableName) && !isNonReferenceSymbol(parent);
   }
 
-  for (const field of node.fields ?? []) {
-    const child = node[field];
-    if (Array.isArray(child)) {
-      if (
-        child.some(
-          (item) =>
-            isNunjucksAstNode(item) && astReferencesVariable(item, variableName, { field, node }),
-        )
-      ) {
-        return true;
-      }
-    } else if (
-      isNunjucksAstNode(child) &&
-      astReferencesVariable(child, variableName, { field, node })
-    ) {
-      return true;
-    }
+  if ((node.typename === 'Root' || node.typename === 'NodeList') && Array.isArray(node.children)) {
+    return astNodeListReferencesVariable(
+      node.children,
+      variableName,
+      { field: 'children', node },
+      boundSymbols,
+    );
   }
 
-  return false;
+  if (node.typename === 'For') {
+    return forNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  if (node.typename === 'Macro') {
+    return macroNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  if (node.typename === 'Set') {
+    return setNodeReferencesVariable(node, variableName, boundSymbols);
+  }
+
+  return astFieldsReferenceVariable(node, variableName, boundSymbols);
 }
 
 /**

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -1,6 +1,7 @@
 import nunjucks from 'nunjucks';
 import cliState from '../cliState';
 import { getEnvBool } from '../envars';
+import logger from '../logger';
 
 import type { NunjucksFilterMap } from '../types/index';
 
@@ -16,13 +17,15 @@ type NunjucksParser = {
 };
 
 type NunjucksWithParser = typeof nunjucks & {
-  parser: NunjucksParser;
+  parser?: NunjucksParser;
 };
 
 type NunjucksParentContext = {
   field: string;
   node: NunjucksAstNode;
 };
+
+type ParseResult = { ok: true; ast: NunjucksAstNode } | { ok: false };
 
 function isNunjucksAstNode(value: unknown): value is NunjucksAstNode {
   return Boolean(
@@ -32,11 +35,30 @@ function isNunjucksAstNode(value: unknown): value is NunjucksAstNode {
   );
 }
 
-function parseNunjucksTemplate(template: string): NunjucksAstNode | undefined {
+function getNunjucksParser(): NunjucksParser | undefined {
+  return (nunjucks as unknown as NunjucksWithParser).parser;
+}
+
+function parseNunjucksTemplate(template: string): ParseResult {
+  const parser = getNunjucksParser();
+  if (!parser || typeof parser.parse !== 'function') {
+    // Nunjucks private parser export is missing — likely a version drift.
+    // Surface it once at debug level and signal parse failure so callers
+    // can fall back conservatively.
+    logger.debug(
+      '[templates] nunjucks.parser.parse is not available; falling back to conservative detection',
+    );
+    return { ok: false };
+  }
   try {
-    return (nunjucks as unknown as NunjucksWithParser).parser.parse(template);
-  } catch {
-    return undefined;
+    return { ok: true, ast: parser.parse(template) };
+  } catch (err) {
+    logger.debug(
+      `[templates] nunjucks parse failed; falling back to conservative detection: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return { ok: false };
   }
 }
 
@@ -51,7 +73,9 @@ function isNonReferenceSymbol(parent?: NunjucksParentContext): boolean {
     (parent.node.typename === 'Is' && parent.field === 'right') ||
     (parent.node.typename === 'Set' && parent.field === 'targets') ||
     (parent.node.typename === 'For' && parent.field === 'name') ||
-    (parent.node.typename === 'Macro' && parent.field === 'name')
+    (parent.node.typename === 'Macro' && parent.field === 'name') ||
+    (parent.node.typename === 'Import' && parent.field === 'target') ||
+    (parent.node.typename === 'FromImport' && parent.field === 'names')
   );
 }
 
@@ -106,6 +130,10 @@ function astNodeListReferencesVariable(
       scope = addBoundSymbols(scope, item.targets);
     } else if (item.typename === 'Macro') {
       scope = addBoundSymbols(scope, item.name);
+    } else if (item.typename === 'Import') {
+      scope = addBoundSymbols(scope, item.target);
+    } else if (item.typename === 'FromImport') {
+      scope = addBoundSymbols(scope, item.names);
     }
   }
   return false;
@@ -306,13 +334,53 @@ export function extractVariablesFromTemplates(templates: string[]): string[] {
 }
 
 /**
- * Check whether a valid Nunjucks template references a variable as an expression symbol.
+ * Detailed result for {@link analyzeTemplateReference}. `parsed` is `false`
+ * only when the Nunjucks parser threw or its private export is missing; in
+ * that case `referenced` is set conservatively from a textual substring check
+ * so callers can preserve the old substring-match safety envelope without
+ * memoizing a parse failure.
  */
-export function templateReferencesVariable(template: string, variableName: string): boolean {
+export type TemplateReferenceResult = {
+  referenced: boolean;
+  parsed: boolean;
+};
+
+/**
+ * Classify whether a template references `variableName` as a real Nunjucks
+ * expression symbol, and surface whether the template parsed successfully.
+ *
+ * Callers that cache results should avoid caching when `parsed` is `false`,
+ * otherwise a transient parse failure would poison the cache for the lifetime
+ * of the process.
+ */
+export function analyzeTemplateReference(
+  template: string,
+  variableName: string,
+): TemplateReferenceResult {
   if (!variableName || !template.includes(variableName)) {
-    return false;
+    return { referenced: false, parsed: true };
   }
 
-  const ast = parseNunjucksTemplate(template);
-  return ast ? astReferencesVariable(ast, variableName) : false;
+  const parseResult = parseNunjucksTemplate(template);
+  if (!parseResult.ok) {
+    return { referenced: true, parsed: false };
+  }
+  return {
+    referenced: astReferencesVariable(parseResult.ast, variableName),
+    parsed: true,
+  };
+}
+
+/**
+ * Check whether a Nunjucks template references a variable as a real expression
+ * symbol (not a string literal, comment, object key, filter/test name, property
+ * access, macro/for/set binding, or `{% import %}` alias).
+ *
+ * If parsing fails, returns `true` whenever the template textually contains
+ * `variableName`. This preserves the safety envelope of the old substring-based
+ * check so callers that gate serial-only behavior on this result do not
+ * silently downgrade to parallel execution when a template is malformed.
+ */
+export function templateReferencesVariable(template: string, variableName: string): boolean {
+  return analyzeTemplateReference(template, variableName).referenced;
 }

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -53,11 +53,9 @@ function parseNunjucksTemplate(template: string): ParseResult {
   try {
     return { ok: true, ast: parser.parse(template) };
   } catch (err) {
-    logger.debug(
-      `[templates] nunjucks parse failed; falling back to conservative detection: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
+    logger.debug('[templates] nunjucks parse failed; falling back to conservative detection', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return { ok: false };
   }
 }
@@ -72,44 +70,73 @@ function isNonReferenceSymbol(parent?: NunjucksParentContext): boolean {
     (parent.node.typename === 'Filter' && parent.field === 'name') ||
     (parent.node.typename === 'Is' && parent.field === 'right') ||
     (parent.node.typename === 'Set' && parent.field === 'targets') ||
-    (parent.node.typename === 'For' && parent.field === 'name') ||
+    (isForLikeNode(parent.node) && parent.field === 'name') ||
     (parent.node.typename === 'Macro' && parent.field === 'name') ||
     (parent.node.typename === 'Import' && parent.field === 'target') ||
     (parent.node.typename === 'FromImport' && parent.field === 'names')
   );
 }
 
-function collectSymbolValues(node: unknown): string[] {
-  if (Array.isArray(node)) {
-    return node.flatMap((item) => collectSymbolValues(item));
-  }
-  if (!isNunjucksAstNode(node)) {
-    return [];
-  }
-  if (node.typename === 'Symbol' && typeof node.value === 'string') {
-    return [node.value];
-  }
-
-  const values: string[] = [];
-  for (const field of node.fields ?? []) {
-    const child = node[field];
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        values.push(...collectSymbolValues(item));
-      }
-    } else {
-      values.push(...collectSymbolValues(child));
-    }
-  }
-  return values;
+function getSymbolName(node: unknown): string | undefined {
+  return isNunjucksAstNode(node) && node.typename === 'Symbol' && typeof node.value === 'string'
+    ? node.value
+    : undefined;
 }
 
-function addBoundSymbols(scope: ReadonlySet<string>, node: unknown): Set<string> {
+function collectBindingNames(node: unknown): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item) => collectBindingNames(item));
+  }
+
+  const symbolName = getSymbolName(node);
+  if (symbolName) {
+    return [symbolName];
+  }
+
+  if (!isNunjucksAstNode(node) || !Array.isArray(node.children)) {
+    return [];
+  }
+
+  return node.children.flatMap((child) => collectBindingNames(child));
+}
+
+function addBindingNames(scope: ReadonlySet<string>, node: unknown): Set<string> {
   const nextScope = new Set(scope);
-  for (const value of collectSymbolValues(node)) {
-    nextScope.add(value);
+  for (const name of collectBindingNames(node)) {
+    nextScope.add(name);
   }
   return nextScope;
+}
+
+function addNamesToScope(scope: ReadonlySet<string>, names: readonly string[]): Set<string> {
+  const nextScope = new Set(scope);
+  for (const name of names) {
+    nextScope.add(name);
+  }
+  return nextScope;
+}
+
+function collectFromImportBindingNames(namesNode: unknown): string[] {
+  if (!isNunjucksAstNode(namesNode) || !Array.isArray(namesNode.children)) {
+    return [];
+  }
+
+  const names: string[] = [];
+  for (const child of namesNode.children) {
+    const plainImportName = getSymbolName(child);
+    if (plainImportName) {
+      names.push(plainImportName);
+      continue;
+    }
+
+    if (isNunjucksAstNode(child) && child.typename === 'Pair') {
+      const aliasName = getSymbolName(child.value);
+      if (aliasName) {
+        names.push(aliasName);
+      }
+    }
+  }
+  return names;
 }
 
 function astNodeListReferencesVariable(
@@ -127,13 +154,13 @@ function astNodeListReferencesVariable(
       return true;
     }
     if (item.typename === 'Set') {
-      scope = addBoundSymbols(scope, item.targets);
+      scope = addBindingNames(scope, item.targets);
     } else if (item.typename === 'Macro') {
-      scope = addBoundSymbols(scope, item.name);
+      scope = addBindingNames(scope, item.name);
     } else if (item.typename === 'Import') {
-      scope = addBoundSymbols(scope, item.target);
+      scope = addBindingNames(scope, item.target);
     } else if (item.typename === 'FromImport') {
-      scope = addBoundSymbols(scope, item.names);
+      scope = addNamesToScope(scope, collectFromImportBindingNames(item.names));
     }
   }
   return false;
@@ -159,12 +186,16 @@ function astChildReferencesVariable(
   );
 }
 
-function forNodeReferencesVariable(
+function isForLikeNode(node: NunjucksAstNode): boolean {
+  return node.typename === 'For' || node.typename === 'AsyncEach' || node.typename === 'AsyncAll';
+}
+
+function forLikeNodeReferencesVariable(
   node: NunjucksAstNode,
   variableName: string,
   boundSymbols: ReadonlySet<string>,
 ): boolean {
-  const loopScope = addBoundSymbols(boundSymbols, node.name);
+  const loopScope = addBindingNames(boundSymbols, node.name);
   return (
     astChildReferencesVariable(node, 'arr', variableName, boundSymbols) ||
     astChildReferencesVariable(node, 'body', variableName, loopScope) ||
@@ -173,66 +204,45 @@ function forNodeReferencesVariable(
 }
 
 /**
- * Collect only parameter NAMES from a Macro.args NodeList. This is the set of
- * names bound inside the macro body — positional Symbols and `Pair.key`
- * Symbols inside `KeywordArgs`. Default-value expressions (`Pair.value`) are
- * *not* bindings and must be walked separately as references in the outer
- * scope.
+ * Walk a Nunjucks macro/caller signature left-to-right. Positional args and
+ * earlier keyword defaults are visible to later defaults, but the current
+ * keyword is not bound until its own default value has been evaluated.
  */
-function collectMacroParamNames(argsNode: unknown): string[] {
-  const names: string[] = [];
-  if (!isNunjucksAstNode(argsNode) || !Array.isArray(argsNode.children)) {
-    return names;
-  }
-  for (const child of argsNode.children) {
-    if (!isNunjucksAstNode(child)) {
-      continue;
-    }
-    if (child.typename === 'Symbol' && typeof child.value === 'string') {
-      names.push(child.value);
-      continue;
-    }
-    if (child.typename === 'KeywordArgs' && Array.isArray(child.children)) {
-      for (const pair of child.children) {
-        if (
-          isNunjucksAstNode(pair) &&
-          pair.typename === 'Pair' &&
-          isNunjucksAstNode(pair.key) &&
-          pair.key.typename === 'Symbol' &&
-          typeof pair.key.value === 'string'
-        ) {
-          names.push(pair.key.value);
-        }
-      }
-    }
-  }
-  return names;
-}
-
-function macroArgsReferenceVariable(
+function analyzeSignatureArgs(
   argsNode: unknown,
   variableName: string,
   boundSymbols: ReadonlySet<string>,
-): boolean {
+): { paramNames: string[]; referencesVariable: boolean } {
+  const paramNames: string[] = [];
   if (!isNunjucksAstNode(argsNode) || !Array.isArray(argsNode.children)) {
-    return false;
+    return { paramNames, referencesVariable: false };
   }
 
+  const defaultScope = new Set(boundSymbols);
   for (const child of argsNode.children) {
     if (!isNunjucksAstNode(child)) {
       continue;
     }
-    if (child.typename === 'Symbol') {
+    const positionalParamName = getSymbolName(child);
+    if (positionalParamName) {
+      paramNames.push(positionalParamName);
+      defaultScope.add(positionalParamName);
       continue;
     }
     if (child.typename === 'KeywordArgs' && Array.isArray(child.children)) {
       for (const pair of child.children) {
+        const keywordParamName =
+          isNunjucksAstNode(pair) && pair.typename === 'Pair' ? getSymbolName(pair.key) : undefined;
         if (
           isNunjucksAstNode(pair) &&
           pair.typename === 'Pair' &&
-          astChildReferencesVariable(pair, 'value', variableName, boundSymbols)
+          astChildReferencesVariable(pair, 'value', variableName, defaultScope)
         ) {
-          return true;
+          return { paramNames, referencesVariable: true };
+        }
+        if (keywordParamName) {
+          paramNames.push(keywordParamName);
+          defaultScope.add(keywordParamName);
         }
       }
       continue;
@@ -242,14 +252,14 @@ function macroArgsReferenceVariable(
         child,
         variableName,
         { field: 'children', node: argsNode },
-        boundSymbols,
+        defaultScope,
       )
     ) {
-      return true;
+      return { paramNames, referencesVariable: true };
     }
   }
 
-  return false;
+  return { paramNames, referencesVariable: false };
 }
 
 function macroNodeReferencesVariable(
@@ -257,24 +267,20 @@ function macroNodeReferencesVariable(
   variableName: string,
   boundSymbols: ReadonlySet<string>,
 ): boolean {
-  // Macro defaults are evaluated before the parameter is assigned, so only
-  // parameter names themselves are bindings while Pair.value remains outer-scope.
-  const paramNames = collectMacroParamNames(node.args);
-  if (macroArgsReferenceVariable(node.args, variableName, boundSymbols)) {
+  const { paramNames, referencesVariable } = analyzeSignatureArgs(
+    node.args,
+    variableName,
+    boundSymbols,
+  );
+  if (referencesVariable) {
     return true;
   }
 
   // Walk the body with the full macro scope (outer + param names + macro name).
-  const macroScope = new Set(boundSymbols);
-  for (const name of paramNames) {
-    macroScope.add(name);
-  }
-  if (
-    isNunjucksAstNode(node.name) &&
-    node.name.typename === 'Symbol' &&
-    typeof node.name.value === 'string'
-  ) {
-    macroScope.add(node.name.value);
+  const macroScope = addNamesToScope(boundSymbols, paramNames);
+  const macroName = getSymbolName(node.name);
+  if (macroName) {
+    macroScope.add(macroName);
   }
   return astChildReferencesVariable(node, 'body', variableName, macroScope);
 }
@@ -340,7 +346,16 @@ function callerNodeReferencesVariable(
   variableName: string,
   boundSymbols: ReadonlySet<string>,
 ): boolean {
-  const callerScope = addBoundSymbols(boundSymbols, node.args);
+  const { paramNames, referencesVariable } = analyzeSignatureArgs(
+    node.args,
+    variableName,
+    boundSymbols,
+  );
+  if (referencesVariable) {
+    return true;
+  }
+
+  const callerScope = addNamesToScope(boundSymbols, paramNames);
   return astChildReferencesVariable(node, 'body', variableName, callerScope);
 }
 
@@ -373,8 +388,8 @@ function astReferencesVariable(
     );
   }
 
-  if (node.typename === 'For') {
-    return forNodeReferencesVariable(node, variableName, boundSymbols);
+  if (isForLikeNode(node)) {
+    return forLikeNodeReferencesVariable(node, variableName, boundSymbols);
   }
 
   if (node.typename === 'Macro') {

--- a/test/evaluator/execution.test.ts
+++ b/test/evaluator/execution.test.ts
@@ -2,8 +2,8 @@ import './setup';
 
 import { randomUUID } from 'crypto';
 
-import { afterEach, expect, it, vi } from 'vitest';
-import { evaluate } from '../../src/evaluator';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { __resetPromptConversationCacheForTests, evaluate } from '../../src/evaluator';
 import logger from '../../src/logger';
 import Eval from '../../src/models/eval';
 import {
@@ -16,6 +16,10 @@ import { sleep } from '../../src/util/time';
 import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
 import { toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
+
+beforeEach(() => {
+  __resetPromptConversationCacheForTests();
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -68,51 +72,124 @@ describeEvaluator('evaluator execution control', () => {
     expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
   });
 
-  async function getMaxInFlightProviderCalls(rawPrompt: string): Promise<number> {
+  type ConcurrencyProbe = {
+    maxActiveCalls: number;
+    callApi: ReturnType<typeof vi.fn>;
+  };
+
+  async function runConcurrencyProbe(rawPrompt: string, testCount = 4): Promise<ConcurrencyProbe> {
     let activeCalls = 0;
     let maxActiveCalls = 0;
+    // Explicit barrier so every concurrent slot actually observes peak
+    // overlap, independent of wall-clock timing. With setTimeout-only
+    // sleeps a slow CI runner can serialize short sleeps and falsely
+    // report maxActiveCalls=1 even when the evaluator dispatched in
+    // parallel.
+    let releaseHold: (() => void) | undefined;
+    let holdPromise = new Promise<void>((resolve) => {
+      releaseHold = resolve;
+    });
+    const targetConcurrency = Math.min(testCount, 4);
+    const callApi = vi.fn().mockImplementation(async (prompt) => {
+      activeCalls += 1;
+      maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+      if (activeCalls >= targetConcurrency) {
+        releaseHold?.();
+      }
+      // Wait until either the barrier trips (parallel path) or a short
+      // fallback fires (serial path — we'll never reach targetConcurrency).
+      await Promise.race([holdPromise, new Promise<void>((resolve) => setTimeout(resolve, 100))]);
+      activeCalls -= 1;
+      return {
+        output: String(prompt),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      };
+    });
     const mockApiProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('test-provider'),
-      callApi: vi.fn().mockImplementation(async (prompt) => {
-        activeCalls += 1;
-        maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
-        await new Promise((resolve) => setTimeout(resolve, 25));
-        activeCalls -= 1;
-
-        return {
-          output: String(prompt),
-          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
-        };
-      }),
+      callApi,
     };
 
+    const tests = Array.from({ length: testCount }, (_, idx) => ({
+      vars: { question: `Turn ${idx + 1}` },
+    }));
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
       prompts: [toPrompt(rawPrompt)],
-      tests: [{ vars: { question: 'First turn' } }, { vars: { question: 'Second turn' } }],
+      tests,
     };
     const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
 
-    await evaluate(testSuite, evalRecord, { maxConcurrency: 2 });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: targetConcurrency });
 
-    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(2);
-    return maxActiveCalls;
+    expect(callApi).toHaveBeenCalledTimes(testCount);
+    // Release the barrier if it's still held (e.g. serial path never tripped it).
+    releaseHold?.();
+    // Suppress unused-variable lint noise for holdPromise.
+    holdPromise = holdPromise.then(() => undefined);
+    return { maxActiveCalls, callApi };
   }
 
   it('does not force concurrency to 1 for _conversation substrings', async () => {
-    const maxInFlightCalls = await getMaxInFlightProviderCalls(
+    const { maxActiveCalls } = await runConcurrencyProbe(
       'Summarize the pre_conversation_context for {{ question }}',
     );
 
-    expect(maxInFlightCalls).toBeGreaterThan(1);
+    expect(maxActiveCalls).toBeGreaterThan(1);
   });
 
   it('forces concurrency to 1 for real _conversation template references', async () => {
-    const maxInFlightCalls = await getMaxInFlightProviderCalls(
+    const { maxActiveCalls } = await runConcurrencyProbe(
       '{{ {"history": _conversation}["history"][0].output }} {{ question }}',
+      2,
     );
 
-    expect(maxInFlightCalls).toBe(1);
+    expect(maxActiveCalls).toBe(1);
+  });
+
+  it('falls back to serial execution when a prompt that mentions _conversation fails to parse', async () => {
+    // Invalid Nunjucks ({% if %} with no condition), but the literal text
+    // contains `_conversation`. The old substring check always forced serial
+    // mode here, and the new parser-based check must preserve that safety
+    // envelope instead of silently running in parallel. The render itself
+    // will fail for an invalid template, so assert on the evaluator's
+    // concurrency-adjustment log rather than on peak in-flight calls.
+    const infoSpy = vi.spyOn(logger, 'info');
+    try {
+      const mockApiProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('test-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: 'ok',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+        }),
+      };
+      const testSuite: TestSuite = {
+        providers: [mockApiProvider],
+        prompts: [toPrompt('{{ _conversation[0].output }} {% if %} {{ question }}')],
+        tests: [{ vars: { question: 'a' } }, { vars: { question: 'b' } }],
+      };
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+      await evaluate(testSuite, evalRecord, { maxConcurrency: 4 });
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Setting concurrency to 1'));
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('propagates prior turn output into _conversation on the next serial call', async () => {
+    const { callApi } = await runConcurrencyProbe(
+      '{% if _conversation and _conversation|length > 0 %}prior={{ _conversation[0].response.output }} {% endif %}now={{ question }}',
+      2,
+    );
+
+    // First call has no prior history; second call should have received
+    // turn 1's rendered output threaded through the `_conversation` variable.
+    const firstRenderedPrompt = String(callApi.mock.calls[0][0]);
+    const secondRenderedPrompt = String(callApi.mock.calls[1][0]);
+    expect(firstRenderedPrompt).not.toContain('prior=');
+    expect(secondRenderedPrompt).toContain('prior=');
+    expect(secondRenderedPrompt).toContain('now=Turn 2');
   });
 
   it('skips delay for cached responses', async () => {

--- a/test/evaluator/execution.test.ts
+++ b/test/evaluator/execution.test.ts
@@ -2,7 +2,7 @@ import './setup';
 
 import { randomUUID } from 'crypto';
 
-import { afterEach, expect, it, vi } from 'vitest';
+import { afterEach, expect, it, type MockInstance, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import logger from '../../src/logger';
 import Eval from '../../src/models/eval';
@@ -17,7 +17,22 @@ import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
 import { toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
+let loggerInfoSpy: MockInstance | undefined;
+
+function sawConversationConcurrencyLog(): boolean {
+  return (
+    loggerInfoSpy?.mock.calls.some(
+      ([message]) =>
+        typeof message === 'string' &&
+        message.includes('Setting concurrency to 1 because the') &&
+        message.includes('_conversation'),
+    ) ?? false
+  );
+}
+
 afterEach(() => {
+  loggerInfoSpy?.mockRestore();
+  loggerInfoSpy = undefined;
   vi.useRealTimers();
 });
 
@@ -69,7 +84,7 @@ describeEvaluator('evaluator execution control', () => {
   });
 
   it('does not force concurrency to 1 for _conversation substrings', async () => {
-    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
     const mockApiProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('test-provider'),
       callApi: vi.fn().mockResolvedValue({
@@ -85,23 +100,13 @@ describeEvaluator('evaluator execution control', () => {
     };
     const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
 
-    try {
-      await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
-      expect(
-        infoSpy.mock.calls.some(
-          ([message]) =>
-            typeof message === 'string' &&
-            message.includes('Setting concurrency to 1 because the') &&
-            message.includes('_conversation'),
-        ),
-      ).toBe(false);
-    } finally {
-      infoSpy.mockRestore();
-    }
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+
+    expect(sawConversationConcurrencyLog()).toBe(false);
   });
 
   it('forces concurrency to 1 for real _conversation template references', async () => {
-    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
     const mockApiProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('test-provider'),
       callApi: vi.fn().mockResolvedValue({
@@ -117,19 +122,9 @@ describeEvaluator('evaluator execution control', () => {
     };
     const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
 
-    try {
-      await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
-      expect(
-        infoSpy.mock.calls.some(
-          ([message]) =>
-            typeof message === 'string' &&
-            message.includes('Setting concurrency to 1 because the') &&
-            message.includes('_conversation'),
-        ),
-      ).toBe(true);
-    } finally {
-      infoSpy.mockRestore();
-    }
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+
+    expect(sawConversationConcurrencyLog()).toBe(true);
   });
 
   it('skips delay for cached responses', async () => {

--- a/test/evaluator/execution.test.ts
+++ b/test/evaluator/execution.test.ts
@@ -2,7 +2,7 @@ import './setup';
 
 import { randomUUID } from 'crypto';
 
-import { afterEach, expect, it, type MockInstance, vi } from 'vitest';
+import { afterEach, expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import logger from '../../src/logger';
 import Eval from '../../src/models/eval';
@@ -17,22 +17,7 @@ import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
 import { toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
-let loggerInfoSpy: MockInstance | undefined;
-
-function sawConversationConcurrencyLog(): boolean {
-  return (
-    loggerInfoSpy?.mock.calls.some(
-      ([message]) =>
-        typeof message === 'string' &&
-        message.includes('Setting concurrency to 1 because the') &&
-        message.includes('_conversation'),
-    ) ?? false
-  );
-}
-
 afterEach(() => {
-  loggerInfoSpy?.mockRestore();
-  loggerInfoSpy = undefined;
   vi.useRealTimers();
 });
 
@@ -83,48 +68,51 @@ describeEvaluator('evaluator execution control', () => {
     expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
   });
 
-  it('does not force concurrency to 1 for _conversation substrings', async () => {
-    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+  async function getMaxInFlightProviderCalls(rawPrompt: string): Promise<number> {
+    let activeCalls = 0;
+    let maxActiveCalls = 0;
     const mockApiProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('test-provider'),
-      callApi: vi.fn().mockResolvedValue({
-        output: 'Test output',
-        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      callApi: vi.fn().mockImplementation(async (prompt) => {
+        activeCalls += 1;
+        maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        activeCalls -= 1;
+
+        return {
+          output: String(prompt),
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+        };
       }),
     };
 
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
-      prompts: [toPrompt('Summarize the pre_conversation_context for {{ question }}')],
-      tests: [{ vars: { question: 'What changed?' } }],
+      prompts: [toPrompt(rawPrompt)],
+      tests: [{ vars: { question: 'First turn' } }, { vars: { question: 'Second turn' } }],
     };
     const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
 
-    await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 2 });
 
-    expect(sawConversationConcurrencyLog()).toBe(false);
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(2);
+    return maxActiveCalls;
+  }
+
+  it('does not force concurrency to 1 for _conversation substrings', async () => {
+    const maxInFlightCalls = await getMaxInFlightProviderCalls(
+      'Summarize the pre_conversation_context for {{ question }}',
+    );
+
+    expect(maxInFlightCalls).toBeGreaterThan(1);
   });
 
   it('forces concurrency to 1 for real _conversation template references', async () => {
-    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
-    const mockApiProvider: ApiProvider = {
-      id: vi.fn().mockReturnValue('test-provider'),
-      callApi: vi.fn().mockResolvedValue({
-        output: 'Test output',
-        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
-      }),
-    };
+    const maxInFlightCalls = await getMaxInFlightProviderCalls(
+      '{{ {"history": _conversation}["history"][0].output }} {{ question }}',
+    );
 
-    const testSuite: TestSuite = {
-      providers: [mockApiProvider],
-      prompts: [toPrompt('{{ {"history": _conversation}["history"][0].output }} {{ question }}')],
-      tests: [{ vars: { question: 'What changed?' } }],
-    };
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
-
-    await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
-
-    expect(sawConversationConcurrencyLog()).toBe(true);
+    expect(maxInFlightCalls).toBe(1);
   });
 
   it('skips delay for cached responses', async () => {

--- a/test/evaluator/execution.test.ts
+++ b/test/evaluator/execution.test.ts
@@ -68,6 +68,70 @@ describeEvaluator('evaluator execution control', () => {
     expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
   });
 
+  it('does not force concurrency to 1 for _conversation substrings', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    const mockApiProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('test-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Test output',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Summarize the pre_conversation_context for {{ question }}')],
+      tests: [{ vars: { question: 'What changed?' } }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    try {
+      await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+      expect(
+        infoSpy.mock.calls.some(
+          ([message]) =>
+            typeof message === 'string' &&
+            message.includes('Setting concurrency to 1 because the') &&
+            message.includes('_conversation'),
+        ),
+      ).toBe(false);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('forces concurrency to 1 for real _conversation template references', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    const mockApiProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('test-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Test output',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('{{ {"history": _conversation}["history"][0].output }} {{ question }}')],
+      tests: [{ vars: { question: 'What changed?' } }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    try {
+      await evaluate(testSuite, evalRecord, { maxConcurrency: 3 });
+      expect(
+        infoSpy.mock.calls.some(
+          ([message]) =>
+            typeof message === 'string' &&
+            message.includes('Setting concurrency to 1 because the') &&
+            message.includes('_conversation'),
+        ),
+      ).toBe(true);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
   it('skips delay for cached responses', async () => {
     const mockApiProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('test-provider'),

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -151,6 +151,16 @@ describe('templateReferencesVariable', () => {
       'call block body reference with unrelated caller arg',
       '{% macro m() %}{{ caller("local") }}{% endmacro %}{% call(x) m() %}{{ _conversation }}{% endcall %}',
     ],
+    [
+      'call block caller default value',
+      '{% macro m() %}{{ caller() }}{% endmacro %}{% call(x=_conversation) m() %}{{ x[0].output }}{% endcall %}',
+    ],
+    [
+      'call block caller self-referential default value',
+      '{% macro m() %}{{ caller() }}{% endmacro %}{% call(_conversation=_conversation) m() %}{{ _conversation[0].output }}{% endcall %}',
+    ],
+    ['asyncEach iterable', '{% asyncEach turn in _conversation %}{{ turn.output }}{% endeach %}'],
+    ['asyncAll iterable', '{% asyncAll turn in _conversation %}{{ turn.output }}{% endall %}'],
   ])('detects a real reference in %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(true);
   });
@@ -192,11 +202,47 @@ describe('templateReferencesVariable', () => {
       '{% macro render(_conversation=something) %}{{ _conversation }}{% endmacro %}',
     ],
     [
+      'macro keyword default left-to-right shadow',
+      '{% macro render(_conversation=[], history=_conversation) %}{{ history | length }}{% endmacro %}{{ render() }}',
+    ],
+    [
+      'macro positional param used by keyword default',
+      '{% macro render(_conversation, history=_conversation) %}{{ history }}{% endmacro %}',
+    ],
+    [
       'call block caller argument shadow',
       '{% macro m() %}{{ caller("local") }}{% endmacro %}{% call(_conversation) m() %}{{ _conversation }}{% endcall %}',
     ],
+    [
+      'call block caller keyword default left-to-right shadow',
+      '{% macro m() %}{{ caller() }}{% endmacro %}{% call(_conversation=[], history=_conversation) m() %}{{ history | length }}{% endcall %}',
+    ],
+    [
+      'asyncEach target shadow',
+      '{% asyncEach _conversation in items %}{{ _conversation }}{% endeach %}',
+    ],
+    [
+      'asyncAll target shadow',
+      '{% asyncAll _conversation in items %}{{ _conversation }}{% endall %}',
+    ],
   ])('ignores %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(false);
+  });
+
+  it('handles from-import aliases without shadowing source names', () => {
+    expect(templateReferencesVariable('{% from "x.njk" import foo %}{{ foo }}', 'foo')).toBe(false);
+    expect(
+      templateReferencesVariable('{% from "x.njk" import foo as helper %}{{ helper }}', 'helper'),
+    ).toBe(false);
+    expect(
+      templateReferencesVariable('{% from "x.njk" import foo as helper %}{{ foo }}', 'foo'),
+    ).toBe(true);
+    expect(
+      templateReferencesVariable(
+        '{% from templateName import foo as helper %}{{ helper }}',
+        'templateName',
+      ),
+    ).toBe(true);
   });
 
   it('returns false for empty variable names', () => {

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -5,6 +5,7 @@ import {
   extractVariablesFromTemplate,
   extractVariablesFromTemplates,
   getNunjucksEngine,
+  templateReferencesVariable,
 } from '../../src/util/templates';
 
 describe('extractVariablesFromTemplate', () => {
@@ -96,6 +97,57 @@ describe('extractVariablesFromTemplates', () => {
     const result = extractVariablesFromTemplates(templates);
 
     expect(result).toEqual(['name', 'age']);
+  });
+});
+
+describe('templateReferencesVariable', () => {
+  it('matches real expression references to the variable', () => {
+    expect(templateReferencesVariable('{{ _conversation[0].output }}', '_conversation')).toBe(true);
+    expect(templateReferencesVariable('{{ _conversation | length }}', '_conversation')).toBe(true);
+    expect(
+      templateReferencesVariable('{% if _conversation %}yes{% endif %}', '_conversation'),
+    ).toBe(true);
+    expect(
+      templateReferencesVariable(
+        '{% for turn in _conversation %}{{ turn.output }}{% endfor %}',
+        '_conversation',
+      ),
+    ).toBe(true);
+    expect(templateReferencesVariable('{{ summarize(_conversation) }}', '_conversation')).toBe(
+      true,
+    );
+    expect(
+      templateReferencesVariable(
+        '{{ {"history": _conversation}["history"][0].output }}',
+        '_conversation',
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores text, strings, comments, keys, filters, tests, and other object properties', () => {
+    expect(
+      templateReferencesVariable(
+        'Summarize the pre_conversation_context for {{ question }}',
+        '_conversation',
+      ),
+    ).toBe(false);
+    expect(templateReferencesVariable('{{ pre_conversation_context }}', '_conversation')).toBe(
+      false,
+    );
+    expect(templateReferencesVariable('{{ "_conversation" }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('{# _conversation #}{{ question }}', '_conversation')).toBe(
+      false,
+    );
+    expect(templateReferencesVariable('{{ foo._conversation }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('{{ foo["_conversation"] }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('{{ {_conversation: input} }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('{{ input | _conversation }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('{{ input is _conversation }}', '_conversation')).toBe(false);
+  });
+
+  it('returns false for empty variable names and invalid templates', () => {
+    expect(templateReferencesVariable('{{ _conversation }}', '')).toBe(false);
+    expect(templateReferencesVariable('{{ _conversation', '_conversation')).toBe(false);
   });
 });
 

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -122,6 +122,15 @@ describe('templateReferencesVariable', () => {
         '_conversation',
       ),
     ).toBe(true);
+    expect(
+      templateReferencesVariable('{% set history = _conversation %}{{ history }}', '_conversation'),
+    ).toBe(true);
+    expect(
+      templateReferencesVariable(
+        '{% set history %}{{ _conversation }}{% endset %}{{ history }}',
+        '_conversation',
+      ),
+    ).toBe(true);
   });
 
   it('ignores text, strings, comments, keys, filters, tests, and other object properties', () => {
@@ -143,6 +152,30 @@ describe('templateReferencesVariable', () => {
     expect(templateReferencesVariable('{{ {_conversation: input} }}', '_conversation')).toBe(false);
     expect(templateReferencesVariable('{{ input | _conversation }}', '_conversation')).toBe(false);
     expect(templateReferencesVariable('{{ input is _conversation }}', '_conversation')).toBe(false);
+    expect(
+      templateReferencesVariable(
+        '{% for _conversation in items %}{{ _conversation }}{% endfor %}',
+        '_conversation',
+      ),
+    ).toBe(false);
+    expect(
+      templateReferencesVariable(
+        '{% macro render(_conversation) %}{{ _conversation }}{% endmacro %}',
+        '_conversation',
+      ),
+    ).toBe(false);
+    expect(
+      templateReferencesVariable(
+        '{% set _conversation = [] %}{{ _conversation }}',
+        '_conversation',
+      ),
+    ).toBe(false);
+    expect(
+      templateReferencesVariable(
+        '{% set _conversation %}local{% endset %}{{ _conversation }}',
+        '_conversation',
+      ),
+    ).toBe(false);
   });
 
   it('returns false for empty variable names and invalid templates', () => {

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -105,20 +105,43 @@ describe('templateReferencesVariable', () => {
   it.each<[string, string]>([
     ['basic symbol read', '{{ _conversation[0].output }}'],
     ['filter input', '{{ _conversation | length }}'],
+    ['chained filters', '{{ _conversation | first | length }}'],
     ['if condition', '{% if _conversation %}yes{% endif %}'],
     ['elif condition', '{% if false %}no{% elif _conversation %}yes{% endif %}'],
     ['ternary true branch', '{{ "yes" if _conversation else "no" }}'],
     ['ternary condition', '{{ first if _conversation else second }}'],
+    ['ternary else branch', '{{ a if x else _conversation }}'],
     ['logical expression', '{{ _conversation and foo }}'],
     ['not expression', '{{ not _conversation }}'],
     ['comparison', '{{ _conversation == [] }}'],
+    ['less-than', '{{ x < _conversation }}'],
     ['for loop iterable', '{% for turn in _conversation %}{{ turn.output }}{% endfor %}'],
     ['function argument', '{{ summarize(_conversation) }}'],
+    ['keyword argument value', '{{ fn(arg=_conversation) }}'],
     ['filter argument', '{{ input | default(_conversation) }}'],
+    ['is test with call arg', '{{ foo is divisibleby(_conversation) }}'],
     ['bracket index lookup', '{{ obj[_conversation] }}'],
+    ['array literal member', '{{ [_conversation, other] }}'],
+    ['group expression', '{{ (_conversation) }}'],
+    ['negated expression', '{{ -_conversation }}'],
+    ['concat', '{{ "a" ~ _conversation ~ "b" }}'],
     ['dict literal value', '{{ {"history": _conversation}["history"][0].output }}'],
     ['set value binding', '{% set history = _conversation %}{{ history }}'],
     ['set block binding', '{% set history %}{{ _conversation }}{% endset %}{{ history }}'],
+    ['macro body free variable', '{% macro render() %}{{ _conversation }}{% endmacro %}'],
+    ['macro default value', '{% macro render(x=_conversation) %}{{ x }}{% endmacro %}'],
+    [
+      'macro default value with body ref',
+      '{% macro render(x=_conversation) %}{{ _conversation }}{% endmacro %}',
+    ],
+    ['include expression', '{% include _conversation %}'],
+    ['extends expression', '{% extends _conversation %}{% block b %}{% endblock %}'],
+    ['from-import template expression', '{% from template_name import foo %}{{ _conversation }}'],
+    ['block body reference', '{% block body %}{{ _conversation }}{% endblock %}'],
+    [
+      'call block body reference',
+      '{% macro m() %}{{ caller() }}{% endmacro %}{% call m() %}{{ _conversation }}{% endcall %}',
+    ],
   ])('detects a real reference in %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(true);
   });
@@ -143,6 +166,21 @@ describe('templateReferencesVariable', () => {
       '{% for i in range(3) %}{% set _conversation = [] %}{{ _conversation }}{% endfor %}',
     ],
     ['import target shadow', '{% import "x.njk" as _conversation %}{{ _conversation }}'],
+    ['from-import alias binding', '{% from "x.njk" import foo as _conversation %}{{ question }}'],
+    ['block name label', '{% block _conversation %}hi{% endblock %}'],
+    [
+      'for-loop tuple target shadow',
+      '{% for k, _conversation in items %}{{ _conversation }}{% endfor %}',
+    ],
+    [
+      'nested for target shadow',
+      '{% for _conversation in outer %}{% for x in _conversation %}{{ _conversation }}{% endfor %}{% endfor %}',
+    ],
+    ['set tuple target shadow', '{% set a, _conversation = pair %}{{ _conversation }}'],
+    [
+      'macro keyword-default param name shadow',
+      '{% macro render(_conversation=something) %}{{ _conversation }}{% endmacro %}',
+    ],
   ])('ignores %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(false);
   });

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -120,6 +120,7 @@ describe('templateReferencesVariable', () => {
     ['keyword argument value', '{{ fn(arg=_conversation) }}'],
     ['filter argument', '{{ input | default(_conversation) }}'],
     ['is test with call arg', '{{ foo is divisibleby(_conversation) }}'],
+    ['is test function argument value', '{{ foo is _conversation(_conversation) }}'],
     ['bracket index lookup', '{{ obj[_conversation] }}'],
     ['array literal member', '{{ [_conversation, other] }}'],
     ['group expression', '{{ (_conversation) }}'],
@@ -134,6 +135,10 @@ describe('templateReferencesVariable', () => {
       'macro default value with body ref',
       '{% macro render(x=_conversation) %}{{ _conversation }}{% endmacro %}',
     ],
+    [
+      'macro self-referential default value',
+      '{% macro render(_conversation=_conversation) %}{{ _conversation[0].output }}{% endmacro %}{{ render() }}',
+    ],
     ['include expression', '{% include _conversation %}'],
     ['extends expression', '{% extends _conversation %}{% block b %}{% endblock %}'],
     ['from-import template expression', '{% from template_name import foo %}{{ _conversation }}'],
@@ -141,6 +146,10 @@ describe('templateReferencesVariable', () => {
     [
       'call block body reference',
       '{% macro m() %}{{ caller() }}{% endmacro %}{% call m() %}{{ _conversation }}{% endcall %}',
+    ],
+    [
+      'call block body reference with unrelated caller arg',
+      '{% macro m() %}{{ caller("local") }}{% endmacro %}{% call(x) m() %}{{ _conversation }}{% endcall %}',
     ],
   ])('detects a real reference in %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(true);
@@ -156,6 +165,7 @@ describe('templateReferencesVariable', () => {
     ['dict literal key', '{{ {_conversation: input} }}'],
     ['filter name', '{{ input | _conversation }}'],
     ['is test name', '{{ input is _conversation }}'],
+    ['is test function name', '{{ input is _conversation(foo) }}'],
     ['raw block', '{% raw %}{{ _conversation }}{% endraw %}'],
     ['for-loop target shadow', '{% for _conversation in items %}{{ _conversation }}{% endfor %}'],
     ['macro argument shadow', '{% macro render(_conversation) %}{{ _conversation }}{% endmacro %}'],
@@ -180,6 +190,10 @@ describe('templateReferencesVariable', () => {
     [
       'macro keyword-default param name shadow',
       '{% macro render(_conversation=something) %}{{ _conversation }}{% endmacro %}',
+    ],
+    [
+      'call block caller argument shadow',
+      '{% macro m() %}{{ caller("local") }}{% endmacro %}{% call(_conversation) m() %}{{ _conversation }}{% endcall %}',
     ],
   ])('ignores %s', (_label, template) => {
     expect(templateReferencesVariable(template, '_conversation')).toBe(false);

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -2,6 +2,7 @@ import nunjucks from 'nunjucks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../src/cliState';
 import {
+  analyzeTemplateReference,
   extractVariablesFromTemplate,
   extractVariablesFromTemplates,
   getNunjucksEngine,
@@ -101,86 +102,105 @@ describe('extractVariablesFromTemplates', () => {
 });
 
 describe('templateReferencesVariable', () => {
-  it('matches real expression references to the variable', () => {
-    expect(templateReferencesVariable('{{ _conversation[0].output }}', '_conversation')).toBe(true);
-    expect(templateReferencesVariable('{{ _conversation | length }}', '_conversation')).toBe(true);
-    expect(
-      templateReferencesVariable('{% if _conversation %}yes{% endif %}', '_conversation'),
-    ).toBe(true);
-    expect(
-      templateReferencesVariable(
-        '{% for turn in _conversation %}{{ turn.output }}{% endfor %}',
-        '_conversation',
-      ),
-    ).toBe(true);
-    expect(templateReferencesVariable('{{ summarize(_conversation) }}', '_conversation')).toBe(
+  it.each<[string, string]>([
+    ['basic symbol read', '{{ _conversation[0].output }}'],
+    ['filter input', '{{ _conversation | length }}'],
+    ['if condition', '{% if _conversation %}yes{% endif %}'],
+    ['elif condition', '{% if false %}no{% elif _conversation %}yes{% endif %}'],
+    ['ternary true branch', '{{ "yes" if _conversation else "no" }}'],
+    ['ternary condition', '{{ first if _conversation else second }}'],
+    ['logical expression', '{{ _conversation and foo }}'],
+    ['not expression', '{{ not _conversation }}'],
+    ['comparison', '{{ _conversation == [] }}'],
+    ['for loop iterable', '{% for turn in _conversation %}{{ turn.output }}{% endfor %}'],
+    ['function argument', '{{ summarize(_conversation) }}'],
+    ['filter argument', '{{ input | default(_conversation) }}'],
+    ['bracket index lookup', '{{ obj[_conversation] }}'],
+    ['dict literal value', '{{ {"history": _conversation}["history"][0].output }}'],
+    ['set value binding', '{% set history = _conversation %}{{ history }}'],
+    ['set block binding', '{% set history %}{{ _conversation }}{% endset %}{{ history }}'],
+  ])('detects a real reference in %s', (_label, template) => {
+    expect(templateReferencesVariable(template, '_conversation')).toBe(true);
+  });
+
+  it.each<[string, string]>([
+    ['substring in plain text', 'Summarize the pre_conversation_context for {{ question }}'],
+    ['substring in symbol name', '{{ pre_conversation_context }}'],
+    ['string literal', '{{ "_conversation" }}'],
+    ['comment mention', '{# _conversation #}{{ question }}'],
+    ['property of another object', '{{ foo._conversation }}'],
+    ['bracket lookup on another object', '{{ foo["_conversation"] }}'],
+    ['dict literal key', '{{ {_conversation: input} }}'],
+    ['filter name', '{{ input | _conversation }}'],
+    ['is test name', '{{ input is _conversation }}'],
+    ['raw block', '{% raw %}{{ _conversation }}{% endraw %}'],
+    ['for-loop target shadow', '{% for _conversation in items %}{{ _conversation }}{% endfor %}'],
+    ['macro argument shadow', '{% macro render(_conversation) %}{{ _conversation }}{% endmacro %}'],
+    ['set value shadow', '{% set _conversation = [] %}{{ _conversation }}'],
+    ['set block shadow', '{% set _conversation %}local{% endset %}{{ _conversation }}'],
+    [
+      'set inside loop body',
+      '{% for i in range(3) %}{% set _conversation = [] %}{{ _conversation }}{% endfor %}',
+    ],
+    ['import target shadow', '{% import "x.njk" as _conversation %}{{ _conversation }}'],
+  ])('ignores %s', (_label, template) => {
+    expect(templateReferencesVariable(template, '_conversation')).toBe(false);
+  });
+
+  it('returns false for empty variable names', () => {
+    expect(templateReferencesVariable('{{ _conversation }}', '')).toBe(false);
+  });
+
+  it('returns false for templates that do not mention the variable at all', () => {
+    expect(templateReferencesVariable('{{ question }}', '_conversation')).toBe(false);
+    expect(templateReferencesVariable('', '_conversation')).toBe(false);
+  });
+
+  it('falls back to a conservative match when the template fails to parse', () => {
+    // Old substring-based code would force serial execution here; the new
+    // AST-based code must preserve that safety envelope when parsing fails
+    // rather than silently returning false.
+    expect(templateReferencesVariable('{{ _conversation', '_conversation')).toBe(true);
+    expect(templateReferencesVariable('{{ _conversation[0].output {% if %}', '_conversation')).toBe(
       true,
     );
-    expect(
-      templateReferencesVariable(
-        '{{ {"history": _conversation}["history"][0].output }}',
-        '_conversation',
-      ),
-    ).toBe(true);
-    expect(
-      templateReferencesVariable('{% set history = _conversation %}{{ history }}', '_conversation'),
-    ).toBe(true);
-    expect(
-      templateReferencesVariable(
-        '{% set history %}{{ _conversation }}{% endset %}{{ history }}',
-        '_conversation',
-      ),
-    ).toBe(true);
+    expect(templateReferencesVariable('{{ _conversation }}{% endif %}', '_conversation')).toBe(
+      true,
+    );
   });
 
-  it('ignores text, strings, comments, keys, filters, tests, and other object properties', () => {
-    expect(
-      templateReferencesVariable(
-        'Summarize the pre_conversation_context for {{ question }}',
-        '_conversation',
-      ),
-    ).toBe(false);
-    expect(templateReferencesVariable('{{ pre_conversation_context }}', '_conversation')).toBe(
-      false,
-    );
-    expect(templateReferencesVariable('{{ "_conversation" }}', '_conversation')).toBe(false);
-    expect(templateReferencesVariable('{# _conversation #}{{ question }}', '_conversation')).toBe(
-      false,
-    );
-    expect(templateReferencesVariable('{{ foo._conversation }}', '_conversation')).toBe(false);
-    expect(templateReferencesVariable('{{ foo["_conversation"] }}', '_conversation')).toBe(false);
-    expect(templateReferencesVariable('{{ {_conversation: input} }}', '_conversation')).toBe(false);
-    expect(templateReferencesVariable('{{ input | _conversation }}', '_conversation')).toBe(false);
-    expect(templateReferencesVariable('{{ input is _conversation }}', '_conversation')).toBe(false);
-    expect(
-      templateReferencesVariable(
-        '{% for _conversation in items %}{{ _conversation }}{% endfor %}',
-        '_conversation',
-      ),
-    ).toBe(false);
-    expect(
-      templateReferencesVariable(
-        '{% macro render(_conversation) %}{{ _conversation }}{% endmacro %}',
-        '_conversation',
-      ),
-    ).toBe(false);
-    expect(
-      templateReferencesVariable(
-        '{% set _conversation = [] %}{{ _conversation }}',
-        '_conversation',
-      ),
-    ).toBe(false);
-    expect(
-      templateReferencesVariable(
-        '{% set _conversation %}local{% endset %}{{ _conversation }}',
-        '_conversation',
-      ),
-    ).toBe(false);
+  it('does not throw on malformed templates', () => {
+    expect(() => templateReferencesVariable('{{ _conversation', '_conversation')).not.toThrow();
+    expect(() => templateReferencesVariable('{% for %}', '_conversation')).not.toThrow();
+  });
+});
+
+describe('analyzeTemplateReference', () => {
+  it('reports parsed=true when the template parses', () => {
+    expect(analyzeTemplateReference('{{ _conversation }}', '_conversation')).toEqual({
+      referenced: true,
+      parsed: true,
+    });
+    expect(analyzeTemplateReference('{{ question }}', '_conversation')).toEqual({
+      referenced: false,
+      parsed: true,
+    });
   });
 
-  it('returns false for empty variable names and invalid templates', () => {
-    expect(templateReferencesVariable('{{ _conversation }}', '')).toBe(false);
-    expect(templateReferencesVariable('{{ _conversation', '_conversation')).toBe(false);
+  it('reports parsed=false and conservative referenced=true on parse failure', () => {
+    expect(analyzeTemplateReference('{{ _conversation', '_conversation')).toEqual({
+      referenced: true,
+      parsed: false,
+    });
+  });
+
+  it('reports parsed=true with referenced=false when the variable is not mentioned', () => {
+    // The textual fast path returns parsed=true because nothing was actually parsed
+    // — no parse failure to surface.
+    expect(analyzeTemplateReference('{{ question }}', '_conversation')).toEqual({
+      referenced: false,
+      parsed: true,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #7845 by replacing raw substring checks for `_conversation` with Nunjucks AST-based reference detection.

This makes the evaluator serialize only when a prompt actually references the built-in `_conversation` template variable, while preserving normal concurrency for prompts that merely contain `_conversation` in text, string literals, comments, object keys, property names, filter/test names, or locally bound template variables.

Also updates the chat docs to say the serial-concurrency behavior is triggered when a prompt references `_conversation` as a Nunjucks variable, not merely when the text is present.

## Why this is the right fix

The bug is not just about word boundaries. `_conversation` is meaningful only as a Nunjucks expression symbol. Regex or string-extractor solutions can cover the original `pre_conversation_context` repro, but they still have blind spots because they do not understand the template syntax.

This PR uses the parser we already depend on through Nunjucks, walks the AST, and treats `_conversation` as a reference only when it is a real symbol read from the template scope. It deliberately ignores non-references such as object keys, filter names, test names, property names, string literals, comments, and local bindings introduced by `{% for %}`, `{% macro %}`, or `{% set %}`.

That is the behavior we actually need: precise enough to avoid false serialization, broad enough to keep the conversation-history safeguard for valid expressions such as conditionals, function calls, object literals, loops, and set bodies.

## Related PR comparison

Related open PRs for the same issue:

- #8032 narrows detection through the existing variable extraction helper. That is a small patch, but the extractor is regex-based and intentionally does not cover complex expression references such as function arguments and object-literal expressions. Its own PR body calls out that tradeoff. It is also currently conflicting.
- #8131 uses a word-boundary regex in `src/evaluator.ts`. That fixes the basic substring case, but still matches `_conversation` inside template string literals or other non-reference text, includes an unrelated `llm-rubric` change, has merge conflicts, and has failing CI.
- #8150 improves on #8032 by adding a `templateReferencesVariable()` helper, but it is still layered on the existing regex extractor. That misses references where `_conversation` is not the root token of the extracted expression, such as `{{ summarize(_conversation) }}` or `{{ {"history": _conversation}["history"] }}`.
- #8251 recognizes the object-literal gap and broadens detection with a template-shaped regex. That catches more real references than the earlier regex/extractor approaches, but it still does not distinguish symbol reads from string literals, property names, object keys, filters/tests, or local shadowing. It also still has a stale changes-requested review state.

Related closed PR:

- #8196 was another word-boundary regex approach. It had the same core limitation as #8131: it treats lexical matches as semantic variable references.

This PR is the most correct solution because it models the thing being detected: a Nunjucks variable reference, not a substring, token fragment, or broad template-block regex match.

## Validation

- `npx vitest run test/util/templates.test.ts test/evaluator/execution.test.ts test/evaluator/metadata.test.ts --sequence.shuffle=false`
- Real eval, false-positive side: substring text, string literal, object property, loop-local `_conversation`, and set-local `_conversation` all passed while staying at requested concurrency 4.
- Real eval, true-positive side: actual `_conversation` expression forced serial execution and carried the first turn into the second turn.
- `npm run f`
- `npm run l`
- `npm run tsc -- --pretty false`
- `git diff --check`
- `SKIP_OG_GENERATION=true npm run build` from `site/`
- `npm run build`

Root build and docs build passed. The only warnings seen were existing bundler warnings from the current build tooling.