### PR TITLE
fix(test): replace process.env mutations in import.test.ts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/account.test.ts",
         "!!test/assertions/assertionResult.test.ts",
         "!!test/assertions/trace.test.ts",
         "!!test/cache.test.ts",

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -9,6 +9,7 @@ import logger from '../../src/logger';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import EvalResult from '../../src/models/evalResult';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/logger', () => ({
   default: {
@@ -174,8 +175,7 @@ describe('importCommand', () => {
       // Simulate a cloud-authed importer with a different local identity. The
       // imported eval's historical author must still win — this is a
       // regression test for PR #7760.
-      const originalApiKey = process.env.PROMPTFOO_API_KEY;
-      process.env.PROMPTFOO_API_KEY = 'fake-test-api-key';
+      const restoreEnv = mockProcessEnv({ PROMPTFOO_API_KEY: 'fake-test-api-key' });
       try {
         const sampleFilePath = path.join(__dirname, '../__fixtures__/sample-export.json');
         const sampleData = JSON.parse(fs.readFileSync(sampleFilePath, 'utf-8'));
@@ -187,11 +187,7 @@ describe('importCommand', () => {
         expect(importedEval).toBeDefined();
         expect(importedEval!.author).toBe(sampleData.metadata.author);
       } finally {
-        if (originalApiKey === undefined) {
-          delete process.env.PROMPTFOO_API_KEY;
-        } else {
-          process.env.PROMPTFOO_API_KEY = originalApiKey;
-        }
+        restoreEnv();
       }
     });
   });

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -146,7 +146,6 @@ const legacyHoistedPersistentMockFiles = new Set([
 ]);
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'account.test.ts',
   'assertions/assertionResult.test.ts',
   'assertions/trace.test.ts',
   'cache.test.ts',


### PR DESCRIPTION
## Summary

- **Fixes the Style Check CI failure on main.** PR #7760 added a test case to `test/commands/import.test.ts` that directly mutates `process.env.PROMPTFOO_API_KEY`, but the file is not on the legacy allowlist maintained in `biome.jsonc` / `test/test-hygiene.test.ts`. The `no-direct-process-env-mutation.grit` plugin flags this with "Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env." and fails CI.
- Rewrite the test to use `mockProcessEnv()` from `test/util/utils.ts`, the project convention for root tests that need env changes.
- While here, prune `test/account.test.ts` from the legacy allowlist — it no longer contains any direct `process.env` mutations, and the stale entry was already failing the hygiene suite on main.

## Test plan

- [x] `npx vitest run test/commands/import.test.ts` — 13/13 pass
- [x] `npx vitest run test/test-hygiene.test.ts` — 28/28 pass (previously 2 failures on main)
- [x] `npx vitest run test/account.test.ts` — 7/7 pass
- [x] `npx @biomejs/biome lint test/commands/import.test.ts` — clean (previously 3 errors)
- [x] `npm run tsc` — clean
- [ ] CI Style Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)