### PR TITLE
fix(eval): handle empty array

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -305,7 +305,7 @@ export async function doEval(
     }
 
     // Phase 2: Load environment from config files if not already set via CLI
-    if (!cmdObj.envPath && commandLineOptions?.envPath) {
+    if ((!cmdObj.envPath || cmdObj.envPath.length === 0) && commandLineOptions?.envPath) {
       logger.debug(`Loading additional environment from config: ${commandLineOptions.envPath}`);
       setupEnv(commandLineOptions.envPath);
     }

--- a/test/integration/envPath.test.ts
+++ b/test/integration/envPath.test.ts
@@ -378,5 +378,41 @@ tests:
       expect(mockSetupEnv).toHaveBeenCalledTimes(1);
       expect(mockSetupEnv).toHaveBeenCalledWith([envFile1, envFile2]);
     });
+
+    it('should load config envPath when CLI envPath defaults to an empty array', async () => {
+      const envFile1 = path.join(tempDir, '.env.empty-cli1');
+      const envFile2 = path.join(tempDir, '.env.empty-cli2');
+
+      fs.writeFileSync(envFile1, 'CONFIG_VAR1=config1');
+      fs.writeFileSync(envFile2, 'CONFIG_VAR2=config2');
+
+      fs.writeFileSync(
+        tempConfigFile,
+        `
+commandLineOptions:
+  envPath:
+    - ${envFile1}
+    - ${envFile2}
+
+prompts:
+  - "Test prompt"
+
+providers:
+  - echo
+
+tests:
+  - vars:
+      input: "test"
+`,
+      );
+
+      try {
+        await doEval({ config: [tempConfigFile], envPath: [] }, {}, undefined, {});
+      } catch {}
+
+      expect(mockSetupEnv).toHaveBeenCalledTimes(2);
+      expect(mockSetupEnv).toHaveBeenNthCalledWith(1, []);
+      expect(mockSetupEnv).toHaveBeenNthCalledWith(2, [envFile1, envFile2]);
+    });
   });
 });

--- a/test/integration/envPath.test.ts
+++ b/test/integration/envPath.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import * as path from 'path';
 
+import dedent from 'dedent';
 import {
   afterAll,
   beforeAll,
@@ -273,22 +274,22 @@ tests:
 
       fs.writeFileSync(
         tempConfigFile,
-        `
-commandLineOptions:
-  envPath:
-    - ${envFile1}
-    - ${envFile2}
+        dedent`
+          commandLineOptions:
+            envPath:
+              - ${envFile1}
+              - ${envFile2}
 
-prompts:
-  - "Test prompt"
+          prompts:
+            - "Test prompt"
 
-providers:
-  - echo
+          providers:
+            - echo
 
-tests:
-  - vars:
-      input: "test"
-`,
+          tests:
+            - vars:
+                input: "test"
+        `,
       );
 
       const cmdObj = { config: [tempConfigFile] };
@@ -388,22 +389,22 @@ tests:
 
       fs.writeFileSync(
         tempConfigFile,
-        `
-commandLineOptions:
-  envPath:
-    - ${envFile1}
-    - ${envFile2}
+        dedent`
+          commandLineOptions:
+            envPath:
+              - ${envFile1}
+              - ${envFile2}
 
-prompts:
-  - "Test prompt"
+          prompts:
+            - "Test prompt"
 
-providers:
-  - echo
+          providers:
+            - echo
 
-tests:
-  - vars:
-      input: "test"
-`,
+          tests:
+            - vars:
+                input: "test"
+        `,
       );
 
       try {

--- a/test/integration/envPath.test.ts
+++ b/test/integration/envPath.test.ts
@@ -59,6 +59,7 @@ vi.mock('../../src/util', async () => {
 });
 
 const mockSetupEnv = setupEnv as MockedFunction<typeof setupEnv>;
+const dedentYaml = dedent.withOptions({ escapeSpecialCharacters: false });
 
 describe('Integration: commandLineOptions.envPath', () => {
   let tempDir: string;
@@ -274,7 +275,7 @@ tests:
 
       fs.writeFileSync(
         tempConfigFile,
-        dedent`
+        dedentYaml`
           commandLineOptions:
             envPath:
               - ${envFile1}
@@ -389,7 +390,7 @@ tests:
 
       fs.writeFileSync(
         tempConfigFile,
-        dedent`
+        dedentYaml`
           commandLineOptions:
             envPath:
               - ${envFile1}


### PR DESCRIPTION
Hello, 

I created this PR because i had issue with custom envFiles not being loaded.
exemple of my promptfooconfig.yaml file:

```yaml
...
commandLineOptions:
    envPath:
        - ../.env.dev
...
```

After few investigations it's because envPath can be an array or string, but the condition does not handle the case of an empty array.
By handling empty array case I can load my custom env file