### PR TITLE
chore(deps): disable Chevrotain major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,12 @@
       "groupName": "@inquirer packages"
     },
     {
+      "description": "Disable Chevrotain major updates while Node 20 is supported",
+      "matchPackageNames": ["chevrotain", "/^@chevrotain\\//"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "Group Anthropic packages together across all dependency types",
       "matchPackagePatterns": ["^@anthropic-ai/"],
       "matchDepTypes": [


### PR DESCRIPTION
## Summary
- Disable Renovate major updates for `chevrotain` and `@chevrotain/*` packages while promptfoo still supports Node 20
- Prevent the Chevrotain v12 PR batch from reopening until the Node support policy changes

## Context
Chevrotain 12 requires Node >=22, but promptfoo currently declares support for Node ^20.20.0 and uses `engine-strict=true`. The v12 Renovate PRs also produced invalid lockfile updates that failed `npm ci`.

Closed incompatible Renovate PRs: #8726, #8727, #8728, #8729, #8735.

## Validation
- `npm run f`
- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`