### PR TITLE
docs(site): resolve AI SAST findings

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { promises as fsPromises } from 'fs';
+import { join } from 'path';
 
 import { themes } from 'prism-react-renderer';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -40,7 +40,7 @@ const config: Config = {
 
   onBrokenLinks: 'throw',
   onBrokenAnchors: 'throw',
-  // Even if you don't use internalization, you can use this field to set useful
+  // Even if you don't use internationalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".
   i18n: {
@@ -577,19 +577,19 @@ const config: Config = {
         name: 'llms-txt-plugin',
         loadContent: async () => {
           const { siteDir } = context;
-          const docsDir = path.join(siteDir, 'docs');
+          const docsDir = join(siteDir, 'docs');
           const allMdx: string[] = [];
 
           // Recursive function to get all mdx/md files
           const getMdFiles = async (dir: string): Promise<void> => {
-            const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+            const entries = await fsPromises.readdir(dir, { withFileTypes: true });
 
             for (const entry of entries) {
-              const fullPath = path.join(dir, entry.name);
+              const fullPath = join(dir, entry.name);
               if (entry.isDirectory()) {
                 await getMdFiles(fullPath);
               } else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) {
-                const content = await fs.promises.readFile(fullPath, 'utf8');
+                const content = await fsPromises.readFile(fullPath, 'utf8');
                 allMdx.push(content);
               }
             }
@@ -604,8 +604,8 @@ const config: Config = {
           const { allMdx } = pluginContent;
 
           // Write concatenated MDX content
-          const concatenatedPath = path.join(outDir, 'llms-full.txt');
-          await fs.promises.writeFile(concatenatedPath, allMdx.join('\n\n---\n\n'));
+          const concatenatedPath = join(outDir, 'llms-full.txt');
+          await fsPromises.writeFile(concatenatedPath, allMdx.join('\n\n---\n\n'));
 
           // Process routes - use routesPaths which is a string[] of all routes
           const docsRoutes: string[] = [];
@@ -629,9 +629,9 @@ const config: Config = {
           const llmsTxt = `# ${context.siteConfig.title}\n\n## Docs\n\n${docsRoutes.join('\n')}`;
 
           // Write llms.txt file
-          const llmsTxtPath = path.join(outDir, 'llms.txt');
+          const llmsTxtPath = join(outDir, 'llms.txt');
           try {
-            fs.writeFileSync(llmsTxtPath, llmsTxt);
+            await fsPromises.writeFile(llmsTxtPath, llmsTxt);
             console.log('Successfully created llms.txt and llms-full.txt files.');
           } catch (err) {
             console.error('Error writing llms.txt file:', err);

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -337,6 +337,7 @@ describe('createShareableUrl', () => {
 
     const result = await createShareableUrl(mockEval as Eval);
     expect(result).toBe(`https://app.example.com/eval/mock-eval-id`);
+    expect(mockEval.useOldResults).toHaveBeenCalled();
   });
 
   it('Cloud: creates correct URL (uses server-assigned ID for idempotency)', async () => {


### PR DESCRIPTION
## Summary

This PR addresses the AI SAST suggestions reported against recently changed files on `main`.

The site config was using namespace imports for Node built-ins and mixed sync and async filesystem writes inside the inline `llms.txt` Docusaurus plugin. That did not change runtime behavior for users, but it made the build helper less consistent and kept the static-analysis warnings open.

The update switches the config to named Node imports, uses async `fsPromises` helpers throughout the plugin, and fixes the `internationalization` spelling in the i18n comment. The share test keeps the `useOldResults` mock because `createShareableUrl` calls it during sharing, and now explicitly asserts that the mock is exercised so the test fixture stays intentional.

## Tests

- `npm run f`
- `npm run l`
- `npx vitest run test/share.test.ts --sequence.shuffle=false`
- `npm run lint:site` (passes with existing complexity warnings in untouched site files)
