### PR TITLE
fix(providers): preserve OpenClaw agent write scopes

### DIFF
--- a/src/providers/openclaw/agent.ts
+++ b/src/providers/openclaw/agent.ts
@@ -643,7 +643,7 @@ export class OpenClawAgentProvider implements ApiProvider {
     if (this.hasExplicitScopes) {
       return this.scopes;
     }
-    return deviceToken.scopes && deviceToken.scopes.length > 0 ? deviceToken.scopes : this.scopes;
+    return normalizeScopes([...this.scopes, ...(deviceToken.scopes || [])]);
   }
 
   private storeDeviceTokenFromHello(

--- a/src/providers/openclaw/shared.ts
+++ b/src/providers/openclaw/shared.ts
@@ -153,8 +153,11 @@ function resolveGatewayPortOverride(env?: Record<string, string | undefined>): n
 
 function toAuthSecret(
   kind: OpenClawAuthSecret['kind'],
-  value: string | undefined,
+  value: unknown,
 ): OpenClawAuthSecret | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
   const trimmed = value?.trim();
   return trimmed ? { kind, value: trimmed } : undefined;
 }

--- a/src/providers/openclaw/types.ts
+++ b/src/providers/openclaw/types.ts
@@ -9,8 +9,8 @@ export interface OpenClawGatewayConfig {
     customBindHost?: string;
     remote?: {
       enabled?: boolean;
-      password?: string;
-      token?: string;
+      password?: unknown;
+      token?: unknown;
       url?: string;
     };
     tls?: {
@@ -18,8 +18,8 @@ export interface OpenClawGatewayConfig {
     };
     auth?: {
       mode?: string;
-      password?: string;
-      token?: string;
+      password?: unknown;
+      token?: unknown;
     };
     http?: {
       endpoints?: {

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -658,6 +658,23 @@ describe('OpenClaw Provider', () => {
       expect(resolveAuthToken()).toBe('legacy-token');
     });
 
+    it('should ignore SecretRef-shaped config tokens when env token is unavailable', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs: 12180 } as fs.Stats);
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        JSON.stringify({
+          gateway: {
+            auth: {
+              mode: 'token',
+              token: { source: 'env', provider: 'default', id: 'OPENCLAW_GATEWAY_TOKEN' },
+            },
+          },
+        }),
+      );
+
+      expect(resolveAuthToken()).toBeUndefined();
+    });
+
     it('should return undefined when no token available', () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
       expect(resolveAuthToken()).toBeUndefined();
@@ -2192,6 +2209,46 @@ describe('OpenClaw Provider', () => {
       await promise;
     });
 
+    it('should preserve required agent write scopes when reusing a read-only cached device token', async () => {
+      deviceAuthMocks.loadOpenClawDeviceAuthToken.mockReturnValue({
+        token: 'read-only-device-token',
+        role: 'operator',
+        scopes: ['operator.read'],
+        updatedAtMs: 1,
+      });
+
+      const provider = new OpenClawAgentProvider('main', {
+        config: { gateway_url: 'http://test:18789' },
+      });
+
+      const promise = provider.callApi('Hello');
+      const onMessage = messageHandlers.get('message')!;
+
+      onMessage(
+        Buffer.from(
+          JSON.stringify({
+            type: 'event',
+            event: 'connect.challenge',
+            payload: { nonce: 'abc', ts: Date.now() },
+          }),
+        ),
+      );
+
+      const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
+      expect(connectReq.params.auth.deviceToken).toBe('read-only-device-token');
+      expect(connectReq.params.scopes).toEqual(['operator.read', 'operator.write']);
+      expect(deviceAuthMocks.buildSignedOpenClawDevice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopes: ['operator.read', 'operator.write'],
+          token: 'read-only-device-token',
+        }),
+      );
+
+      const onError = messageHandlers.get('error')!;
+      onError(new Error('test cleanup'));
+      await promise;
+    });
+
     it('should reconnect with a cached device token on auth token mismatch', async () => {
       const wsInstances: Array<{ handlers: Map<string, Function>; send: any; close: any }> = [];
       websocketMocks.setFactory(() => {
@@ -2268,7 +2325,7 @@ describe('OpenClaw Provider', () => {
       );
       const secondConnectReq = JSON.parse(wsInstances[1].send.mock.calls[0][0]);
       expect(secondConnectReq.params.auth.deviceToken).toBe('cached-device-token');
-      expect(secondConnectReq.params.scopes).toEqual(['operator.read']);
+      expect(secondConnectReq.params.scopes).toEqual(['operator.read', 'operator.write']);
       expect(secondConnectReq.params.device.signature).toBe('signature:second:cached-device-token');
 
       secondOnMessage(


### PR DESCRIPTION
## Summary
- keep OpenClaw agent device-token reconnects write-capable by merging cached token scopes with the provider's default required scopes
- tolerate SecretRef-shaped OpenClaw gateway auth config values so cached device-token auth can be used when the env token is absent
- add regressions for read-only cached device-token metadata and SecretRef auth config parsing

Fixes #8261

## Testing
- `npm run l && npm run f`
- `npx vitest run test/providers/openclaw.test.ts test/providers/openclaw-device-auth.test.ts`
- `npm run tsc`
- live OpenClaw 2026.4.14 gateway e2e with `openclaw:agent:main` backed by OpenAI `openai/gpt-5.4`
- live cached-device-token e2e with `OPENCLAW_GATEWAY_TOKEN` unset and promptfoo cache initially downgraded to `operator.read`; gateway connected with `auth=device-token` and eval passed
