### PR TITLE
test(webui): cover pinned results footer layout

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -2286,6 +2286,39 @@ describe('ResultsTable Pagination', () => {
     const paginationElement = screen.getByText(/results per page/i);
     expect(paginationElement).toBeInTheDocument();
   });
+
+  it('should keep the pagination footer pinned for short tables', () => {
+    vi.mocked(useTableStore).mockImplementation(() => ({
+      config: {},
+      evalId: '123',
+      setTable: vi.fn(),
+      table: {
+        body: [],
+        head: {
+          prompts: [],
+          vars: [],
+        },
+      },
+      version: 4,
+      fetchEvalData: vi.fn(),
+      filteredResultsCount: 1,
+      totalResultsCount: 1,
+      filters: {
+        values: {},
+        appliedCount: 0,
+        options: {
+          metric: [],
+        },
+      },
+    }));
+
+    const { container } = renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    expect(container.querySelector('#results-table-container')).toHaveStyle({
+      minHeight: '0px',
+    });
+    expect(container.querySelector('.pagination')).toHaveClass('sticky', 'bottom-0', 'shrink-0');
+  });
 });
 
 describe('ResultsTable BaseNumberInput onChange undefined', () => {


### PR DESCRIPTION
## Summary
The recent `fix(webui): pin eval results footer for short tables` change added the layout constraints that keep the results pagination footer at the viewport bottom when an eval has only a small number of rows. The merged fix updated the parent wrapper in `ResultsView`, the scroll container in `ResultsTable`, and the footer itself, but the test coverage only checked the wrapper-level flex classes.

This PR closes the remaining gap by adding a focused `ResultsTable` regression test that asserts the two layout constraints that actually keep the footer pinned: the results-table scroller keeps `minHeight: 0`, and the pagination footer keeps the `shrink-0` class. Those assertions protect the precise DOM contract introduced by the recent fix without broadening the test surface beyond the changed area.

## Validation
- `npm run test:app -- src/pages/eval/components/ResultsTable.test.tsx --run`
- `npm run l`
- `npm run f`
