### PR TITLE
chore(webui): clean up AI quality findings

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -152,10 +152,6 @@ describe('ResultsTable Metrics Display', () => {
         },
       },
     }));
-    vi.mocked(useResultsViewSettingsStore).mockImplementation(() => ({
-      inComparisonMode: false,
-      renderMarkdown: true,
-    }));
   });
 
   it('displays total cost with correct formatting', () => {
@@ -410,7 +406,7 @@ describe('ResultsTable Metrics Display', () => {
       vi.mocked(useTableStore).mockImplementation(() => ({
         config: {},
         evalId: '123',
-
+        inComparisonMode: false,
         setTable: vi.fn(),
         table: mockTableWithObjectVar,
         version: 4,
@@ -1631,8 +1627,6 @@ describe('ResultsTable handleRating - Updating existing human rating', () => {
         },
       },
     }));
-
-    renderWithProviders(<ResultsTable {...defaultProps} />);
 
     // Simulate calling handleRating with updated values
     const updatedIsPass = false;

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -703,7 +703,7 @@ export default function ResultsView({
     if (!table?.body) {
       return [];
     }
-    return table?.body
+    return table.body
       .flatMap((row) => row.outputs.map((output) => output?.score))
       .filter((score) => typeof score === 'number' && !Number.isNaN(score));
   }, [table]);
@@ -882,7 +882,7 @@ export default function ResultsView({
                     {debouncedSearchText && (
                       <Badge variant="secondary" className="text-xs h-5 gap-1">
                         Search:{' '}
-                        {debouncedSearchText.length > 4
+                        {debouncedSearchText.length > 5
                           ? debouncedSearchText.substring(0, 5) + '...'
                           : debouncedSearchText}
                         <button

--- a/test/integration/envPath.test.ts
+++ b/test/integration/envPath.test.ts
@@ -188,7 +188,6 @@ tests:
   it('should handle multiple config files and use first envPath found', async () => {
     const config1File = path.join(tempDir, 'config1.yaml');
     const config2File = path.join(tempDir, 'config2.yaml');
-    const _envFile1 = path.join(tempDir, '.env1');
     const envFile2 = path.join(tempDir, '.env2');
 
     fs.writeFileSync(

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -33,14 +33,17 @@ vi.mock('../../src/logger', () => ({
   },
 }));
 
-const websocketMocks = vi.hoisted(() => {
-  let factory: (() => any) | null = null;
+type WebSocketMockInstance = Record<string, unknown>;
+type WebSocketFactory = () => WebSocketMockInstance;
 
-  const WebSocketMock = vi.fn(function (_url: string, ..._args: any[]) {
+const websocketMocks = vi.hoisted(() => {
+  let factory: WebSocketFactory | null = null;
+
+  const WebSocketMock = vi.fn(function (_url: string, ..._args: unknown[]) {
     return factory?.() ?? {};
   });
 
-  const setFactory = (nextFactory: () => any) => {
+  const setFactory = (nextFactory: WebSocketFactory) => {
     factory = nextFactory;
   };
 
@@ -1261,14 +1264,47 @@ describe('OpenClaw Provider', () => {
   });
 
   describe('OpenClawAgentProvider', () => {
+    type AgentTestMessageHandler = (data: Buffer) => void;
+    type AgentTestErrorHandler = (error: Error) => void;
+    type AgentTestCloseHandler = () => void;
+    type AgentTestEventHandler =
+      | AgentTestMessageHandler
+      | AgentTestErrorHandler
+      | AgentTestCloseHandler;
+
+    interface ConnectResponsePayload {
+      type: string;
+      [key: string]: unknown;
+    }
+
     let mockWs: any;
-    let messageHandlers: Map<string, Function>;
+    let messageHandlers: Map<string, AgentTestEventHandler>;
+
+    function getWebSocketHandler<T extends AgentTestEventHandler>(event: string): T {
+      const handler = messageHandlers.get(event);
+      if (!handler) {
+        throw new Error(`Expected WebSocket ${event} handler to be registered`);
+      }
+      return handler as T;
+    }
+
+    function getMessageHandler() {
+      return getWebSocketHandler<AgentTestMessageHandler>('message');
+    }
+
+    function getErrorHandler() {
+      return getWebSocketHandler<AgentTestErrorHandler>('error');
+    }
+
+    function getCloseHandler() {
+      return getWebSocketHandler<AgentTestCloseHandler>('close');
+    }
 
     beforeEach(() => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
       messageHandlers = new Map();
       mockWs = {
-        on: vi.fn((event: string, handler: Function) => {
+        on: vi.fn((event: string, handler: AgentTestEventHandler) => {
           messageHandlers.set(event, handler);
         }),
         send: vi.fn(),
@@ -1290,8 +1326,8 @@ describe('OpenClaw Provider', () => {
 
     /** Helper: simulate challenge → connect → agent accepted flow, return agent req ID */
     function simulateHandshake(
-      onMessage: Function,
-      connectPayload: Record<string, unknown> = { type: 'hello-ok' },
+      onMessage: AgentTestMessageHandler,
+      connectPayload: ConnectResponsePayload = { type: 'hello-ok' },
     ) {
       // Challenge
       onMessage(
@@ -1341,7 +1377,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello agent');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { connectReq, agentReq, waitReq } = simulateHandshake(onMessage);
 
       // Verify connect request
@@ -1416,7 +1452,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       // Streaming events — text is accumulated (full text so far), not incremental
@@ -1468,7 +1504,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       onMessage(
@@ -1518,7 +1554,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage, {
         type: 'hello-ok',
         auth: {
@@ -1551,7 +1587,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       // Event from a different run should be ignored
@@ -1605,7 +1641,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       // Challenge
       onMessage(
@@ -1641,7 +1677,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       // Challenge → connect
       onMessage(
@@ -1681,7 +1717,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       onMessage(
         Buffer.from(
@@ -1720,7 +1756,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onError = messageHandlers.get('error')!;
+      const onError = getErrorHandler();
       onError(new Error('Connection refused'));
 
       const result = await promise;
@@ -1755,7 +1791,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { agentReq, waitReq } = simulateHandshake(onMessage);
 
       expect(agentReq.params.sessionKey).toBe('my-session');
@@ -1783,7 +1819,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { agentReq, waitReq } = simulateHandshake(onMessage);
 
       expect(agentReq.params.agentId).toBe('dev');
@@ -1804,7 +1840,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { agentReq, waitReq } = simulateHandshake(onMessage);
 
       expect(agentReq.params.agentId).toBe('dev');
@@ -1829,7 +1865,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { agentReq, waitReq } = simulateHandshake(onMessage);
 
       expect(agentReq.params.channel).toBe('slack');
@@ -1859,7 +1895,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { connectReq, waitReq } = simulateHandshake(onMessage);
 
       expect(connectReq.params.client.deviceFamily).toBe('promptfoo-e2e');
@@ -1890,7 +1926,7 @@ describe('OpenClaw Provider', () => {
       });
 
       void provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       onMessage(
         Buffer.from(
@@ -1917,7 +1953,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       onMessage(
         Buffer.from(
@@ -1933,7 +1969,7 @@ describe('OpenClaw Provider', () => {
       expect(connectReq.params.device).toBeUndefined();
       expect(deviceAuthMocks.loadOrCreateOpenClawDeviceIdentity).not.toHaveBeenCalled();
 
-      const onError = messageHandlers.get('error')!;
+      const onError = getErrorHandler();
       onError(new Error('test cleanup'));
       await promise;
     });
@@ -1950,12 +1986,15 @@ describe('OpenClaw Provider', () => {
       const promise = provider.callApi('Hello');
 
       const wsConstructorCall = websocketMocks.WebSocketMock.mock.calls[0];
-      expect(wsConstructorCall[1].headers).toEqual({
+      const wsConstructorOptions = wsConstructorCall[1] as {
+        headers?: Record<string, string>;
+      };
+      expect(wsConstructorOptions.headers).toEqual({
         'x-trusted-user': 'alice',
         'x-openclaw-account-id': 'work',
       });
 
-      const onError = messageHandlers.get('error')!;
+      const onError = getErrorHandler();
       onError(new Error('test cleanup'));
       await promise;
     });
@@ -1969,7 +2008,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { agentReq, waitReq } = simulateHandshake(onMessage);
 
       expect(agentReq.params.extraSystemPrompt).toBe('Be terse.');
@@ -1995,7 +2034,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       // Wait response with error
@@ -2020,7 +2059,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       onMessage(
@@ -2044,7 +2083,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       onMessage(
@@ -2068,7 +2107,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       onMessage(
@@ -2100,7 +2139,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       onMessage(
@@ -2145,7 +2184,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onClose = messageHandlers.get('close')!;
+      const onClose = getCloseHandler();
 
       // Server closes connection unexpectedly
       onClose();
@@ -2186,7 +2225,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       // Challenge
       onMessage(
@@ -2204,7 +2243,7 @@ describe('OpenClaw Provider', () => {
       expect(connectReq.params.device.signature).toBe('signature:abc:');
 
       // Clean up: error to resolve the promise
-      const onError = messageHandlers.get('error')!;
+      const onError = getErrorHandler();
       onError(new Error('test cleanup'));
       await promise;
     });
@@ -2222,7 +2261,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       onMessage(
         Buffer.from(
@@ -2244,7 +2283,7 @@ describe('OpenClaw Provider', () => {
         }),
       );
 
-      const onError = messageHandlers.get('error')!;
+      const onError = getErrorHandler();
       onError(new Error('test cleanup'));
       await promise;
     });
@@ -2370,7 +2409,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       // Send malformed JSON — should be silently ignored
       onMessage(Buffer.from('not valid json {{{'));
@@ -2404,7 +2443,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       // Non-assistant stream events should be ignored
@@ -2445,7 +2484,7 @@ describe('OpenClaw Provider', () => {
       });
 
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
       const { waitReq } = simulateHandshake(onMessage);
 
       // Wait response with no streaming events
@@ -2462,7 +2501,7 @@ describe('OpenClaw Provider', () => {
     /** Helper: simulate challenge → connect mismatch error, return the resolved promise */
     async function simulateDeviceTokenMismatch(provider: OpenClawAgentProvider) {
       const promise = provider.callApi('Hello');
-      const onMessage = messageHandlers.get('message')!;
+      const onMessage = getMessageHandler();
 
       onMessage(
         Buffer.from(

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -405,18 +405,6 @@ describe('getNunjucksEngine', () => {
   });
 
   describe('environment variables as globals', () => {
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-      vi.resetModules();
-      process.env = { ...originalEnv };
-    });
-
-    afterEach(() => {
-      process.env = originalEnv;
-      vi.resetModules();
-    });
-
     it('should add environment variables as globals by default', () => {
       process.env.TEST_VAR = 'test_value';
       const engine = getNunjucksEngine();


### PR DESCRIPTION
## Summary
- Clean up the 12 GitHub AI code quality findings from the AI findings page.
- Simplify ResultsView score extraction and make the search badge truncation threshold consistent.
- Remove redundant test setup, unused variables, duplicate environment hooks, and tighten OpenClaw test WebSocket helper typing/diagnostics.

## Impact
These are maintenance-focused changes. The only runtime behavior change is that a 5-character search chip now displays as the full value instead of being considered over the truncation threshold; longer terms still truncate to five characters plus ellipsis.

## Validation
- npm run test:app -- src/pages/eval/components/ResultsTable.test.tsx --run
- npx vitest test/integration/envPath.test.ts test/providers/openclaw.test.ts test/util/templates.test.ts --run
- npx vitest test/providers/openclaw.test.ts --run
- npm run tsc
- npm run l
- npm run f