### PR TITLE
chore: include commit authors in changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bootstrap-sha": "779729198d01eacd9d00b0796d62cc5a16f0ccac",
+  "include-commit-authors": true,
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "packages": {


### PR DESCRIPTION
## Summary

- Enable `include-commit-authors` in `release-please-config.json` so changelog entries include the commit author (e.g. `(@username)`)
- Requires release-please >= 17.5.0 ([googleapis/release-please#2628](https://github.com/googleapis/release-please/pull/2628)); will activate once the action bumps its bundled dependency ([googleapis/release-please-action#1199](https://github.com/googleapis/release-please-action/pull/1199))

## Test plan

- [x] Config key is valid per release-please docs — unknown keys are safely ignored until the action is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)