### PR TITLE
feat(claude-agent-sdk): bump to 0.2.112 and expose exclude_dynamic_sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "promptfoo": "dist/src/entrypoint.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.111",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.112",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1028.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1028.0",
         "@aws-sdk/client-s3": "^3.1003.0",
@@ -167,7 +167,7 @@
         "node": "^20.20.0 || >=22.22.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.111",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.112",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1028.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1028.0",
         "@aws-sdk/client-s3": "^3.1003.0",
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.111",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.111.tgz",
-      "integrity": "sha512-DwXyJpVL8JXB8L2toSw1by7uIt1p8hPGi0P+hqr5tL+Ae7DcK9O3tUd6XcGown3LZ49zNCUAIpqX3wDmOhqp0Q==",
+      "version": "0.2.112",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.112.tgz",
+      "integrity": "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     }
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.111",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1028.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1028.0",
     "@aws-sdk/client-s3": "^3.1003.0",
@@ -215,7 +215,7 @@
     "winston-transport": "^4.9.0"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.111",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1028.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1028.0",
     "@aws-sdk/client-s3": "^3.1003.0",

--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -156,6 +156,7 @@ prompts:
 | `betas`                              | string[]      | Enable beta features (e.g., `['context-1m-2025-08-07']` for 1M context)                                      | None                     |
 | `custom_system_prompt`               | string        | Replace default system prompt                                                                                | None                     |
 | `append_system_prompt`               | string        | Append to default system prompt                                                                              | None                     |
+| `exclude_dynamic_sections`           | boolean       | Strip per-user dynamic sections from the preset prompt so it stays cacheable across runs                     | false                    |
 | `tools`                              | array/object  | Base set of built-in tools (array of names or `{type: 'preset', preset: 'claude_code'}`)                     | None                     |
 | `custom_allowed_tools`               | string[]      | Replace default allowed tools                                                                                | None                     |
 | `append_allowed_tools`               | string[]      | Add to default allowed tools                                                                                 | None                     |
@@ -219,6 +220,8 @@ Claude Agent SDK also supports configuring models through [environment variables
 ## System Prompt
 
 Unless you specify a `custom_system_prompt`, the default Claude Code system prompt will be used. You can append additional instructions to it with `append_system_prompt`.
+
+For multi-user or high-volume eval fleets, set `exclude_dynamic_sections: true` to strip per-user context (working directory, auto-memory, git status) from the preset prompt so the prompt-caching prefix stays static and hits cross-user. The stripped context is re-injected as the first user message so the model still has access to it. Has no effect when `custom_system_prompt` is set.
 
 :::info
 Note that this differs slightly from the Claude Agent SDK's behavior when used independently of Promptfoo. The Agent SDK will _not_ use the Claude Code system prompt by default unless it's specified—it will instead use an empty system prompt if none is provided. If you want to use an empty system prompt with this provider, set `custom_system_prompt` to an empty string.

--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -221,7 +221,7 @@ Claude Agent SDK also supports configuring models through [environment variables
 
 Unless you specify a `custom_system_prompt`, the default Claude Code system prompt will be used. You can append additional instructions to it with `append_system_prompt`.
 
-For multi-user or high-volume eval fleets, set `exclude_dynamic_sections: true` to strip per-user context (working directory, auto-memory, git status) from the preset prompt so the prompt-caching prefix stays static and hits cross-user. The stripped context is re-injected as the first user message so the model still has access to it. Has no effect when `custom_system_prompt` is set.
+Set `exclude_dynamic_sections: true` to strip per-user context (working directory, auto-memory, git status) from the preset prompt. This keeps the prompt-caching prefix static across runs, which matters for high-volume evals. The stripped context is re-injected as the first user message. Has no effect when `custom_system_prompt` is set.
 
 :::info
 Note that this differs slightly from the Claude Agent SDK's behavior when used independently of Promptfoo. The Agent SDK will _not_ use the Claude Code system prompt by default unless it's specified—it will instead use an empty system prompt if none is provided. If you want to use an empty system prompt with this provider, set `custom_system_prompt` to an empty string.

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -287,6 +287,20 @@ export interface ClaudeCodeOptions {
   append_system_prompt?: string;
 
   /**
+   * When `true`, strip per-user dynamic sections (working directory, auto-memory,
+   * git status) from the Claude Code preset system prompt so the prompt-caching
+   * prefix stays static and eligible for cross-user cache hits. The stripped
+   * context is re-injected as the first user message so the model still has
+   * access to it. Has no effect when `custom_system_prompt` is set.
+   *
+   * Useful for large eval fleets where many runs share the same system prompt
+   * and the per-user dynamic context would otherwise bust the cache.
+   *
+   * @see https://platform.claude.com/docs/en/agent-sdk/settings
+   */
+  exclude_dynamic_sections?: boolean;
+
+  /**
    * Since we run CC by default with a readonly set of allowed_tools, user can either fully replace the list ('custom_allowed_tools'), append to it ('append_allowed_tools'), or allow all tools ('allow_all_tools')
    */
   custom_allowed_tools?: string[];
@@ -988,6 +1002,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
             type: 'preset',
             preset: 'claude_code',
             append: config.append_system_prompt,
+            ...(config.exclude_dynamic_sections ? { excludeDynamicSections: true } : {}),
           },
       maxThinkingTokens: config.max_thinking_tokens,
       allowedTools,

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -207,10 +207,14 @@ async function loadClaudeCodeSDK(): Promise<typeof import('@anthropic-ai/claude-
 
   if (!claudeCodePath) {
     throw new Error(
-      dedent`The @anthropic-ai/claude-agent-sdk package is required but not installed.
+      dedent`The @anthropic-ai/claude-agent-sdk package could not be resolved from ${basePath}.
 
       To use the Claude Agent SDK provider, install it with:
         npm install @anthropic-ai/claude-agent-sdk
+
+      If the package is already installed elsewhere, run promptfoo from the
+      project root (or point the config at that root) so node_modules is on
+      the resolution path.
 
       For more information, see: https://www.promptfoo.dev/docs/providers/claude-agent-sdk/`,
     );

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -2218,6 +2218,45 @@ describe('ClaudeCodeSDKProvider', () => {
             }),
           });
         });
+
+        it('forwards exclude_dynamic_sections to the preset system prompt', async () => {
+          mockQuery.mockReturnValue(createMockResponse('Response'));
+
+          const provider = new ClaudeCodeSDKProvider({
+            config: { exclude_dynamic_sections: true, append_system_prompt: 'Extras' },
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          await provider.callApi('Test prompt');
+
+          expect(mockQuery).toHaveBeenCalledWith({
+            prompt: 'Test prompt',
+            options: expect.objectContaining({
+              systemPrompt: {
+                type: 'preset',
+                preset: 'claude_code',
+                append: 'Extras',
+                excludeDynamicSections: true,
+              },
+            }),
+          });
+        });
+
+        it('omits excludeDynamicSections when exclude_dynamic_sections is false/unset', async () => {
+          mockQuery.mockReturnValue(createMockResponse('Response'));
+
+          const provider = new ClaudeCodeSDKProvider({
+            config: { exclude_dynamic_sections: false },
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          await provider.callApi('Test prompt');
+
+          const passedOptions = mockQuery.mock.calls.at(-1)?.[0]?.options as Record<
+            string,
+            unknown
+          >;
+          const passedSystemPrompt = passedOptions.systemPrompt as Record<string, unknown>;
+          expect(passedSystemPrompt).not.toHaveProperty('excludeDynamicSections');
+        });
       });
     });
 

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -2250,12 +2250,16 @@ describe('ClaudeCodeSDKProvider', () => {
           });
           await provider.callApi('Test prompt');
 
-          const passedOptions = mockQuery.mock.calls.at(-1)?.[0]?.options as Record<
-            string,
-            unknown
-          >;
-          const passedSystemPrompt = passedOptions.systemPrompt as Record<string, unknown>;
-          expect(passedSystemPrompt).not.toHaveProperty('excludeDynamicSections');
+          expect(mockQuery).toHaveBeenCalledWith({
+            prompt: 'Test prompt',
+            options: expect.objectContaining({
+              systemPrompt: {
+                type: 'preset',
+                preset: 'claude_code',
+                append: undefined,
+              },
+            }),
+          });
         });
       });
     });


### PR DESCRIPTION
## Summary

Brings promptfoo's Claude Agent SDK wrapper in line with `@anthropic-ai/claude-agent-sdk` 0.2.112.

### Dependency bump

- `@anthropic-ai/claude-agent-sdk` 0.2.111 → **^0.2.112**
- Upstream changes are runtime-only (WebSocket keepalive/ping handling); no public type changes

### Gap analysis

Audited the wrapper at `src/providers/claude-agent-sdk.ts` against the SDK's `Options` type. 49 of 51 fields already wired. Two gaps surfaced in `systemPrompt`; only one is worth exposing right now:

| Gap | Action |
| --- | --- |
| `excludeDynamicSections` preset option | ✅ **Implemented** — new `exclude_dynamic_sections: boolean` config field |
| `string[]` system prompt + `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` | Skipped — low user demand, awkward in YAML |
| Arbitrary `canUseTool` callback | Skipped — already covered by `ask_user_question.behavior` for the common case |

### What `exclude_dynamic_sections` does

Strips per-user dynamic sections (working directory, auto-memory, git status) from the Claude Code preset prompt and re-injects them as the first user message. Keeps the prompt-caching prefix static and cross-user-hitting — valuable for eval fleets where many runs share the same system prompt.

```yaml
providers:
  - id: claude-agent-sdk
    config:
      exclude_dynamic_sections: true # cache prefix hits across users
      append_system_prompt: 'Additional team-wide instructions'
```

Has no effect when `custom_system_prompt` is set. The wire shape is unchanged for existing users (only added when truthy).

### Side fix: clearer "SDK not found" error

While live-verifying the new option, I noticed that pointing promptfoo at a config file outside the project root (e.g. `/tmp/foo.yaml`) made the wrapper fail with "package is required but not installed" — even though the SDK was installed. Root cause: `resolvePackageEntryPoint` resolves relative to the config file's directory. The error message now names the `basePath` that was searched and suggests running from the project root.

## Test plan

- [x] `npm run tsc` clean
- [x] `npx vitest run test/providers/claude-agent-sdk.test.ts` — 120/120 (2 new tests: forwarding + omission)
- [x] Full provider test suites: `test/providers/anthropic`, `test/providers/bedrock`, `test/providers/azure`, `test/providers/google/vertex.test.ts` — 1180/1180
- [x] Live end-to-end against real SDK 0.2.112: 4/4 Claude Agent SDK eval cases pass (baseline, exclude-dynamic-true, exclude-dynamic-with-append, custom-prompt-excludes-ignored)
- [x] Debug-log verification of the outgoing `systemPrompt` wire shape across all four cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)