### PR TITLE
feat(tracing): accept OTLP logs and render SDK-internal events as spans

### DIFF
--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -985,6 +985,21 @@ tracing:
       port: 4318
 ```
 
+### Deep tracing (SDK-internal events)
+
+To also capture Claude Code's internal events — API requests, tool decisions, tool results — set `OTEL_LOGS_EXPORTER=otlp` and use the JSON logs protocol. Each log record becomes a child span on the provider span.
+
+```yaml
+config:
+  env:
+    CLAUDE_CODE_ENABLE_TELEMETRY: '1'
+    OTEL_LOGS_EXPORTER: otlp
+    OTEL_EXPORTER_OTLP_ENDPOINT: 'http://127.0.0.1:4318'
+    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json'
+```
+
+The receiver's `/v1/logs` endpoint accepts JSON only. The provider automatically injects `OTEL_RESOURCE_ATTRIBUTES=promptfoo.trace_id=...,promptfoo.parent_span_id=...` so logs link to the correct evaluation trace even though the SDK's logs signal doesn't natively inherit `TRACEPARENT`.
+
 ## Caching Behavior
 
 This provider automatically caches responses, and will read from the cache if the prompt, configuration, and files in the working directory (if `working_dir` is set) are the same as a previous run.

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1151,6 +1151,22 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
           if (traceparent && !env.TRACEPARENT) {
             env.TRACEPARENT = traceparent;
           }
+          // Some SDK telemetry signals (logs in particular) do not inherit
+          // TRACEPARENT into their OTEL context. Encode the trace + parent span
+          // IDs as resource attributes too — promptfoo's OTLP /v1/logs receiver
+          // reads these to link log-derived spans to the evaluation trace.
+          if (traceparent) {
+            const parts = traceparent.split('-');
+            if (parts.length >= 3) {
+              const extras: string[] = [
+                `promptfoo.trace_id=${parts[1]}`,
+                `promptfoo.parent_span_id=${parts[2]}`,
+              ];
+              env.OTEL_RESOURCE_ATTRIBUTES = env.OTEL_RESOURCE_ATTRIBUTES
+                ? `${env.OTEL_RESOURCE_ATTRIBUTES},${extras.join(',')}`
+                : extras.join(',');
+            }
+          }
 
           // Dynamically import the ESM module once and cache it
           if (!this.claudeCodeModule) {

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -14,6 +14,10 @@ import {
   sanitizeBody,
   withGenAISpan,
 } from '../tracing/genaiTracer';
+import {
+  PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID,
+  PROMPTFOO_RESOURCE_ATTR_TRACE_ID,
+} from '../tracing/resourceAttributes';
 import { safeResolve } from '../util/pathUtils';
 import { cacheResponse, getCachedResponse, initializeAgenticCache } from './agentic-utils';
 import { ANTHROPIC_MODELS } from './anthropic/util';
@@ -61,6 +65,34 @@ export interface ToolCallEntry {
 
 /** Hard cap for attribute body length on synthesized tool spans. */
 const TOOL_SPAN_BODY_LIMIT = 4096;
+
+/**
+ * Append promptfoo-specific resource-attribute kvs to a W3C-style
+ * `OTEL_RESOURCE_ATTRIBUTES` string, removing trailing whitespace/commas from
+ * the existing value and stripping any previous occurrence of our keys so the
+ * producer can't double-up. Returns the new string. Exported for tests.
+ */
+export function appendPromptfooResourceAttrs(
+  existing: string | undefined,
+  traceId: string,
+  parentSpanId: string,
+): string {
+  const incoming = `${PROMPTFOO_RESOURCE_ATTR_TRACE_ID}=${traceId},${PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID}=${parentSpanId}`;
+  if (!existing) {
+    return incoming;
+  }
+  const cleaned = existing
+    .split(',')
+    .map((pair) => pair.trim())
+    .filter(
+      (pair) =>
+        pair.length > 0 &&
+        !pair.startsWith(`${PROMPTFOO_RESOURCE_ATTR_TRACE_ID}=`) &&
+        !pair.startsWith(`${PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID}=`),
+    )
+    .join(',');
+  return cleaned.length > 0 ? `${cleaned},${incoming}` : incoming;
+}
 
 function stringifyForSpan(value: unknown): string | undefined {
   if (value === undefined || value === null) {
@@ -1155,17 +1187,14 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
           // TRACEPARENT into their OTEL context. Encode the trace + parent span
           // IDs as resource attributes too — promptfoo's OTLP /v1/logs receiver
           // reads these to link log-derived spans to the evaluation trace.
-          if (traceparent) {
-            const parts = traceparent.split('-');
-            if (parts.length >= 3) {
-              const extras: string[] = [
-                `promptfoo.trace_id=${parts[1]}`,
-                `promptfoo.parent_span_id=${parts[2]}`,
-              ];
-              env.OTEL_RESOURCE_ATTRIBUTES = env.OTEL_RESOURCE_ATTRIBUTES
-                ? `${env.OTEL_RESOURCE_ATTRIBUTES},${extras.join(',')}`
-                : extras.join(',');
-            }
+          // traceparent format: "version-traceId-spanId-flags".
+          const [, tpTraceId, tpSpanId] = traceparent ? traceparent.split('-') : [];
+          if (tpTraceId && tpSpanId) {
+            env.OTEL_RESOURCE_ATTRIBUTES = appendPromptfooResourceAttrs(
+              env.OTEL_RESOURCE_ATTRIBUTES,
+              tpTraceId,
+              tpSpanId,
+            );
           }
 
           // Dynamically import the ESM module once and cache it

--- a/src/tracing/otlpReceiver.ts
+++ b/src/tracing/otlpReceiver.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import express from 'express';
 import logger from '../logger';
 import {
@@ -55,6 +57,49 @@ interface OTLPResourceSpan {
 
 interface OTLPTraceRequest {
   resourceSpans: OTLPResourceSpan[];
+}
+
+// Minimal OTLP logs JSON shapes. Full OTEL log signal includes severity,
+// observedTimeUnixNano, and more — we only use the fields needed to synthesize
+// point-in-time spans under the log's trace.
+interface OTLPLogRecord {
+  timeUnixNano?: string;
+  observedTimeUnixNano?: string;
+  traceId?: string;
+  spanId?: string;
+  severityNumber?: number;
+  severityText?: string;
+  body?: OTLPAttribute['value'];
+  attributes?: OTLPAttribute[];
+}
+
+interface OTLPScopeLogs {
+  scope?: {
+    name: string;
+    version?: string;
+  };
+  logRecords: OTLPLogRecord[];
+}
+
+interface OTLPResourceLogs {
+  resource?: {
+    attributes?: OTLPAttribute[];
+  };
+  scopeLogs: OTLPScopeLogs[];
+}
+
+interface OTLPLogsRequest {
+  resourceLogs: OTLPResourceLogs[];
+}
+
+// Log event names we don't want cluttering traces (internal, not actionable).
+const LOG_EVENT_NAME_DENYLIST: ReadonlySet<string> = new Set(['claude_code.tracing']);
+// Nominal span duration for a log-derived span so it renders as a thin bar
+// instead of a zero-width point in trace UIs.
+const LOG_SPAN_DURATION_MS = 1;
+
+function randomHex(chars: number): string {
+  return crypto.randomBytes(chars / 2).toString('hex');
 }
 
 type OTLPFormat = 'json' | 'protobuf';
@@ -160,6 +205,32 @@ export class OTLPReceiver {
           getRequestFormat(req.headers['content-type']) === 'protobuf',
       }),
     );
+
+    // /v1/logs accepts JSON only. Claude Agent SDK emits most useful telemetry
+    // (tool executions, API requests, interactions) as OTEL logs, not spans;
+    // we materialize each log record as a zero-ish-duration span so the
+    // Traces tab can render them under the evaluation trace.
+    this.app.use('/v1/logs', (req, res, next) => {
+      if (req.method !== 'POST') {
+        next();
+        return;
+      }
+      const format = getRequestFormat(req.headers['content-type']);
+      if (format !== 'json') {
+        res.status(415).json({
+          error: 'Only application/json is supported for /v1/logs',
+        });
+        return;
+      }
+      next();
+    });
+    this.app.use(
+      '/v1/logs',
+      express.json({
+        limit: '10mb',
+        type: (req) => getRequestFormat(req.headers['content-type']) === 'json',
+      }),
+    );
     logger.debug('[OtlpReceiver] Middleware configured for accepted OTLP formats');
   }
 
@@ -188,6 +259,23 @@ export class OTLPReceiver {
         // OTLP success response
         res.status(200).json({ partialSuccess: {} });
         logger.debug('[OtlpReceiver] Successfully processed traces');
+      } catch (error) {
+        this.handleProcessingError(error, res);
+      }
+    });
+
+    // OTLP HTTP endpoint for logs (JSON only). Each log record becomes a span
+    // parented to the span it was emitted from, so SDK-internal events show up
+    // in the Traces tab alongside provider and tool spans.
+    this.app.post('/v1/logs', async (req, res) => {
+      logger.debug('[OtlpReceiver] Received logs request');
+      try {
+        const traces = this.parseOTLPLogsJSONRequest(req.body as OTLPLogsRequest);
+        logger.debug(`[OtlpReceiver] Parsed ${traces.length} logs into span records`);
+        if (traces.length > 0) {
+          await this.persistTraces(this.groupTraces(traces));
+        }
+        res.status(200).json({ partialSuccess: {} });
       } catch (error) {
         this.handleProcessingError(error, res);
       }
@@ -375,6 +463,109 @@ export class OTLPReceiver {
     }
 
     return traces;
+  }
+
+  private parseOTLPLogsJSONRequest(body: OTLPLogsRequest): ParsedTrace[] {
+    const traces: ParsedTrace[] = [];
+    const resourceLogs = body?.resourceLogs ?? [];
+    logger.debug(`[OtlpReceiver] Parsing logs request with ${resourceLogs.length} resource logs`);
+
+    for (const resourceLog of resourceLogs) {
+      const resourceAttributes = this.parseAttributes(resourceLog.resource?.attributes);
+      for (const scopeLog of resourceLog.scopeLogs ?? []) {
+        for (const log of scopeLog.logRecords ?? []) {
+          const parsed = this.logRecordToParsedTrace(log, scopeLog, resourceAttributes);
+          if (parsed) {
+            traces.push(parsed);
+          }
+        }
+      }
+    }
+
+    return traces;
+  }
+
+  private logRecordToParsedTrace(
+    log: OTLPLogRecord,
+    scopeLog: OTLPScopeLogs,
+    resourceAttributes: Record<string, any>,
+  ): ParsedTrace | null {
+    // Prefer an inline traceId on the log record (set when the SDK propagated
+    // TRACEPARENT into its logs context). Fall back to the resource attribute
+    // promptfoo.trace_id — the claude-agent-sdk provider injects this via
+    // OTEL_RESOURCE_ATTRIBUTES because Claude Code's logs signal does not
+    // inherit TRACEPARENT. Without either, we can't link anywhere useful.
+    const resourceTraceId =
+      typeof resourceAttributes['promptfoo.trace_id'] === 'string'
+        ? (resourceAttributes['promptfoo.trace_id'] as string)
+        : undefined;
+    const rawTraceId = log.traceId ?? resourceTraceId;
+    if (!rawTraceId) {
+      return null;
+    }
+    const traceId = this.convertId(rawTraceId, 32);
+
+    const attributes: Record<string, any> = {
+      ...resourceAttributes,
+      ...this.parseAttributes(log.attributes),
+      'otel.scope.name': scopeLog.scope?.name,
+      'otel.scope.version': scopeLog.scope?.version,
+      'otel.log.severity_number': log.severityNumber,
+      'otel.log.severity_text': log.severityText,
+    };
+
+    // Prefer the OTEL "event.name" semantic convention for the span name, which
+    // Claude Code sets to things like "claude_code.tool.execution".
+    const eventName = attributes['event.name'] ?? attributes['claude_code.event.name'];
+    const bodyValue = log.body ? this.parseAttributeValue(log.body) : undefined;
+    const name =
+      typeof eventName === 'string' && eventName.length > 0
+        ? eventName
+        : typeof bodyValue === 'string' && bodyValue.length > 0 && bodyValue.length <= 128
+          ? bodyValue
+          : 'otel.log';
+
+    if (LOG_EVENT_NAME_DENYLIST.has(name)) {
+      return null;
+    }
+
+    if (bodyValue !== undefined) {
+      attributes['otel.log.body'] = bodyValue;
+    }
+
+    const timeNano = log.timeUnixNano ?? log.observedTimeUnixNano;
+    const startTime = timeNano ? Number(timeNano) / 1_000_000 : Date.now();
+    const endTime = startTime + LOG_SPAN_DURATION_MS;
+
+    // Log's own span_id is the span the log was emitted from, so that span
+    // becomes our synthesized span's parent. Fall back to the resource-level
+    // promptfoo.parent_span_id the provider injected. We mint a fresh 16-hex
+    // span id so multiple logs within the same span don't collide on
+    // (trace_id, span_id).
+    const resourceParentSpanId =
+      typeof resourceAttributes['promptfoo.parent_span_id'] === 'string'
+        ? (resourceAttributes['promptfoo.parent_span_id'] as string)
+        : undefined;
+    const rawParentSpanId =
+      log.spanId && /[1-9a-f]/i.test(log.spanId) ? log.spanId : resourceParentSpanId;
+    const parentSpanId = rawParentSpanId ? this.convertId(rawParentSpanId, 16) : undefined;
+
+    return {
+      traceId,
+      span: {
+        spanId: randomHex(16),
+        parentSpanId,
+        name,
+        startTime,
+        endTime,
+        attributes,
+        statusCode: 1, // OK — OTEL logs don't carry a span status; success unless severity >= ERROR
+        statusMessage:
+          typeof log.severityNumber === 'number' && log.severityNumber >= 17
+            ? log.severityText
+            : undefined,
+      },
+    };
   }
 
   private async parseOTLPProtobufRequest(body: Buffer): Promise<ParsedTrace[]> {

--- a/src/tracing/otlpReceiver.ts
+++ b/src/tracing/otlpReceiver.ts
@@ -11,6 +11,10 @@ import {
   type DecodedSpan,
   decodeExportTraceServiceRequest,
 } from './protobuf';
+import {
+  PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID,
+  PROMPTFOO_RESOURCE_ATTR_TRACE_ID,
+} from './resourceAttributes';
 import { getTraceStore, type ParsedTrace, type SpanData, type TraceStore } from './store';
 
 interface OTLPAttribute {
@@ -97,9 +101,57 @@ const LOG_EVENT_NAME_DENYLIST: ReadonlySet<string> = new Set(['claude_code.traci
 // Nominal span duration for a log-derived span so it renders as a thin bar
 // instead of a zero-width point in trace UIs.
 const LOG_SPAN_DURATION_MS = 1;
+// Max characters of a log body that we're willing to use as a span name when
+// no event.name attribute is present — longer bodies would clutter the UI.
+const MAX_BODY_AS_NAME_LENGTH = 128;
+// OTEL severityNumber >= 17 corresponds to ERROR and above.
+const SEVERITY_NUMBER_ERROR = 17;
+// Hard cap on the otel.log.body attribute so malicious or overly-chatty SDKs
+// can't bloat the trace DB with multi-megabyte log bodies.
+const MAX_LOG_BODY_ATTR_LENGTH = 8192;
 
-function randomHex(chars: number): string {
-  return crypto.randomBytes(chars / 2).toString('hex');
+function truncateLogBody(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.length <= MAX_LOG_BODY_ATTR_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_LOG_BODY_ATTR_LENGTH - 15)}... [truncated]`;
+}
+
+// OTEL span_id is 16 hex chars / 8 bytes; base64 form is 11 chars + optional '='.
+// An all-zero 8-byte value encodes to "AAAAAAAAAAA=" (or "AAAAAAAAAAAA"), which
+// would otherwise pass a `[1-9a-f]` scan since 'A' is in the hex alphabet.
+const BASE64_ZERO_SPAN_ID = /^A{11,12}=?$/;
+function isZeroSpanId(id: string): boolean {
+  return /^0+$/.test(id) || BASE64_ZERO_SPAN_ID.test(id);
+}
+
+function randomSpanId(): string {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+function getStringAttribute(attributes: Record<string, any>, key: string): string | undefined {
+  const value = attributes[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function resolveLogSpanName(attributes: Record<string, any>, bodyValue: unknown): string {
+  // Prefer the OTEL "event.name" semantic convention, which Claude Code sets
+  // to values like "claude_code.tool.execution".
+  const eventName = attributes['event.name'] ?? attributes['claude_code.event.name'];
+  if (typeof eventName === 'string' && eventName.length > 0) {
+    return eventName;
+  }
+  if (
+    typeof bodyValue === 'string' &&
+    bodyValue.length > 0 &&
+    bodyValue.length <= MAX_BODY_AS_NAME_LENGTH
+  ) {
+    return bodyValue;
+  }
+  return 'otel.log';
 }
 
 type OTLPFormat = 'json' | 'protobuf';
@@ -474,9 +526,17 @@ export class OTLPReceiver {
       const resourceAttributes = this.parseAttributes(resourceLog.resource?.attributes);
       for (const scopeLog of resourceLog.scopeLogs ?? []) {
         for (const log of scopeLog.logRecords ?? []) {
-          const parsed = this.logRecordToParsedTrace(log, scopeLog, resourceAttributes);
-          if (parsed) {
-            traces.push(parsed);
+          // Log-and-skip on a per-record basis so one malformed record can't
+          // drop the entire batch (the SDK often batches dozens per flush).
+          try {
+            const parsed = this.logRecordToParsedTrace(log, scopeLog, resourceAttributes);
+            if (parsed) {
+              traces.push(parsed);
+            }
+          } catch (err) {
+            logger.warn(
+              `[OtlpReceiver] Skipping malformed log record in scope ${scopeLog.scope?.name ?? '(unknown)'}: ${err}`,
+            );
           }
         }
       }
@@ -495,15 +555,21 @@ export class OTLPReceiver {
     // promptfoo.trace_id — the claude-agent-sdk provider injects this via
     // OTEL_RESOURCE_ATTRIBUTES because Claude Code's logs signal does not
     // inherit TRACEPARENT. Without either, we can't link anywhere useful.
-    const resourceTraceId =
-      typeof resourceAttributes['promptfoo.trace_id'] === 'string'
-        ? (resourceAttributes['promptfoo.trace_id'] as string)
-        : undefined;
-    const rawTraceId = log.traceId ?? resourceTraceId;
+    const rawTraceId =
+      log.traceId ?? getStringAttribute(resourceAttributes, PROMPTFOO_RESOURCE_ATTR_TRACE_ID);
     if (!rawTraceId) {
+      logger.debug(
+        `[OtlpReceiver] Dropping log: no traceId and no ${PROMPTFOO_RESOURCE_ATTR_TRACE_ID} resource attribute (scope=${scopeLog.scope?.name ?? 'unknown'}). Ensure TRACEPARENT is propagated or OTEL_RESOURCE_ATTRIBUTES is set by the provider.`,
+      );
       return null;
     }
     const traceId = this.convertId(rawTraceId, 32);
+    // convertId is lenient and returns garbage on shape mismatch; skip the
+    // record rather than orphaning a span under a nonexistent trace.
+    if (traceId.length !== 32 || !/^[0-9a-f]+$/.test(traceId)) {
+      logger.debug(`[OtlpReceiver] Dropping log: invalid trace_id shape '${rawTraceId}'`);
+      return null;
+    }
 
     const attributes: Record<string, any> = {
       ...resourceAttributes,
@@ -514,23 +580,16 @@ export class OTLPReceiver {
       'otel.log.severity_text': log.severityText,
     };
 
-    // Prefer the OTEL "event.name" semantic convention for the span name, which
-    // Claude Code sets to things like "claude_code.tool.execution".
-    const eventName = attributes['event.name'] ?? attributes['claude_code.event.name'];
     const bodyValue = log.body ? this.parseAttributeValue(log.body) : undefined;
-    const name =
-      typeof eventName === 'string' && eventName.length > 0
-        ? eventName
-        : typeof bodyValue === 'string' && bodyValue.length > 0 && bodyValue.length <= 128
-          ? bodyValue
-          : 'otel.log';
+    const name = resolveLogSpanName(attributes, bodyValue);
 
     if (LOG_EVENT_NAME_DENYLIST.has(name)) {
+      logger.debug(`[OtlpReceiver] Dropping log: event '${name}' is in the denylist`);
       return null;
     }
 
     if (bodyValue !== undefined) {
-      attributes['otel.log.body'] = bodyValue;
+      attributes['otel.log.body'] = truncateLogBody(bodyValue);
     }
 
     const timeNano = log.timeUnixNano ?? log.observedTimeUnixNano;
@@ -542,28 +601,27 @@ export class OTLPReceiver {
     // promptfoo.parent_span_id the provider injected. We mint a fresh 16-hex
     // span id so multiple logs within the same span don't collide on
     // (trace_id, span_id).
-    const resourceParentSpanId =
-      typeof resourceAttributes['promptfoo.parent_span_id'] === 'string'
-        ? (resourceAttributes['promptfoo.parent_span_id'] as string)
-        : undefined;
-    const rawParentSpanId =
-      log.spanId && /[1-9a-f]/i.test(log.spanId) ? log.spanId : resourceParentSpanId;
+    const hasValidInlineSpanId = !!log.spanId && !isZeroSpanId(log.spanId);
+    const rawParentSpanId = hasValidInlineSpanId
+      ? log.spanId
+      : getStringAttribute(resourceAttributes, PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID);
     const parentSpanId = rawParentSpanId ? this.convertId(rawParentSpanId, 16) : undefined;
+
+    const severityIsError =
+      typeof log.severityNumber === 'number' && log.severityNumber >= SEVERITY_NUMBER_ERROR;
 
     return {
       traceId,
       span: {
-        spanId: randomHex(16),
+        spanId: randomSpanId(),
         parentSpanId,
         name,
         startTime,
         endTime,
         attributes,
-        statusCode: 1, // OK — OTEL logs don't carry a span status; success unless severity >= ERROR
-        statusMessage:
-          typeof log.severityNumber === 'number' && log.severityNumber >= 17
-            ? log.severityText
-            : undefined,
+        // OTEL logs don't carry a span status; treat as OK unless severity indicates error.
+        statusCode: 1,
+        statusMessage: severityIsError ? log.severityText : undefined,
       },
     };
   }

--- a/src/tracing/resourceAttributes.ts
+++ b/src/tracing/resourceAttributes.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared resource-attribute keys used to link SDK-emitted OTEL logs back to
+ * the evaluation trace. The claude-agent-sdk provider sets these via
+ * `OTEL_RESOURCE_ATTRIBUTES` on the subprocess env, and the OTLP /v1/logs
+ * receiver reads them to resolve the log record's parent span.
+ *
+ * Both producer and consumer must agree; keep these constants as the single
+ * source of truth.
+ */
+export const PROMPTFOO_RESOURCE_ATTR_TRACE_ID = 'promptfoo.trace_id';
+export const PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID = 'promptfoo.parent_span_id';

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -654,6 +654,99 @@ describe('ClaudeCodeSDKProvider', () => {
           }
         }
       });
+
+      it('injects promptfoo.trace_id and promptfoo.parent_span_id as OTEL_RESOURCE_ATTRIBUTES', async () => {
+        mockQuery.mockReturnValue(createMockResponse('ok'));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const traceId = '0af7651916cd43dd8448eb211c80319c';
+        const spanId = 'b7ad6b7169203331';
+        await provider.callApi('prompt', {
+          traceparent: `00-${traceId}-${spanId}-01`,
+          prompt: { raw: 'prompt', label: 'prompt' },
+          vars: {},
+        } as CallApiContextParams);
+
+        const callArgs = mockQuery.mock.calls.at(-1)?.[0];
+        expect(callArgs.options.env.OTEL_RESOURCE_ATTRIBUTES).toBe(
+          `promptfoo.trace_id=${traceId},promptfoo.parent_span_id=${spanId}`,
+        );
+      });
+
+      it('preserves a pre-existing OTEL_RESOURCE_ATTRIBUTES and trims trailing commas', async () => {
+        mockQuery.mockReturnValue(createMockResponse('ok'));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          config: {
+            env: {
+              OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment=prod, service.owner=team-x,',
+            },
+          },
+        });
+        const traceId = '0af7651916cd43dd8448eb211c80319c';
+        const spanId = 'b7ad6b7169203331';
+        await provider.callApi('prompt', {
+          traceparent: `00-${traceId}-${spanId}-01`,
+          prompt: { raw: 'prompt', label: 'prompt' },
+          vars: {},
+        } as CallApiContextParams);
+
+        const callArgs = mockQuery.mock.calls.at(-1)?.[0];
+        expect(callArgs.options.env.OTEL_RESOURCE_ATTRIBUTES).toBe(
+          `deployment.environment=prod,service.owner=team-x,promptfoo.trace_id=${traceId},promptfoo.parent_span_id=${spanId}`,
+        );
+      });
+
+      it('overrides a user-provided promptfoo.trace_id rather than duplicating it', async () => {
+        mockQuery.mockReturnValue(createMockResponse('ok'));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          config: {
+            env: {
+              OTEL_RESOURCE_ATTRIBUTES:
+                'promptfoo.trace_id=stale,promptfoo.parent_span_id=stale,other.key=keep',
+            },
+          },
+        });
+        const traceId = '0af7651916cd43dd8448eb211c80319c';
+        const spanId = 'b7ad6b7169203331';
+        await provider.callApi('prompt', {
+          traceparent: `00-${traceId}-${spanId}-01`,
+          prompt: { raw: 'prompt', label: 'prompt' },
+          vars: {},
+        } as CallApiContextParams);
+
+        const callArgs = mockQuery.mock.calls.at(-1)?.[0];
+        const attrs = callArgs.options.env.OTEL_RESOURCE_ATTRIBUTES as string;
+        // User's `other.key` is kept; the stale promptfoo.* kvs are stripped;
+        // the fresh values land at the end so last-wins semantics in OTEL
+        // parsers pick ours even for parsers that don't dedupe.
+        expect(attrs).toBe(
+          `other.key=keep,promptfoo.trace_id=${traceId},promptfoo.parent_span_id=${spanId}`,
+        );
+        expect(attrs.match(/promptfoo\.trace_id=/g)?.length).toBe(1);
+      });
+
+      it('skips OTEL_RESOURCE_ATTRIBUTES entirely when traceparent is malformed', async () => {
+        mockQuery.mockReturnValue(createMockResponse('ok'));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        await provider.callApi('prompt', {
+          // Missing the span_id segment.
+          traceparent: '00-0af7651916cd43dd8448eb211c80319c',
+          prompt: { raw: 'prompt', label: 'prompt' },
+          vars: {},
+        } as CallApiContextParams);
+
+        const callArgs = mockQuery.mock.calls.at(-1)?.[0];
+        expect(callArgs.options.env.OTEL_RESOURCE_ATTRIBUTES).toBeUndefined();
+      });
     });
 
     describe('working directory management', () => {

--- a/test/tracing/otlpReceiver.test.ts
+++ b/test/tracing/otlpReceiver.test.ts
@@ -72,7 +72,7 @@ describe('OTLPReceiver', () => {
   let receiver: OTLPReceiver;
   let mockTraceStore: {
     createTrace: MockedFunction<() => Promise<void>>;
-    addSpans: MockedFunction<() => Promise<void>>;
+    addSpans: MockedFunction<(traceId: string, spans: any[], options?: any) => Promise<void>>;
     getTracesByEvaluation: MockedFunction<() => Promise<any[]>>;
     getTrace: MockedFunction<() => Promise<any | null>>;
     deleteOldTraces: MockedFunction<() => Promise<void>>;
@@ -89,7 +89,9 @@ describe('OTLPReceiver', () => {
     // Create mock trace store
     mockTraceStore = {
       createTrace: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-      addSpans: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      addSpans: vi
+        .fn<(traceId: string, spans: any[], options?: any) => Promise<void>>()
+        .mockResolvedValue(undefined),
       getTracesByEvaluation: vi.fn<() => Promise<any[]>>().mockResolvedValue([]),
       getTrace: vi.fn<() => Promise<any | null>>().mockResolvedValue(null),
       deleteOldTraces: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
@@ -843,6 +845,182 @@ describe('OTLPReceiver', () => {
       // Sanity check that /v1/traces stays stable despite the new /v1/logs route.
       const response = await request(receiver.getApp()).get('/v1/traces').expect(200);
       expect(response.body.service).toBe('promptfoo-otlp-receiver');
+    });
+
+    it('marks log-derived spans as ERROR when severityNumber >= 17', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          severityNumber: 17,
+          severityText: 'ERROR',
+          body: { stringValue: 'something failed' },
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.error' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      const span = (spans as any[])[0];
+      expect(span.statusMessage).toBe('ERROR');
+      // The synthesized span still reports statusCode=1 (OK for the OTEL span itself)
+      // while statusMessage surfaces the severity — verifies the mapping contract.
+      expect(span.attributes['otel.log.severity_number']).toBe(17);
+    });
+
+    it('uses claude_code.event.name as a secondary span-name source when event.name is absent', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [
+            { key: 'claude_code.event.name', value: { stringValue: 'claude_code.llm_request' } },
+          ],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[])[0].name).toBe('claude_code.llm_request');
+    });
+
+    it('drops log records with a malformed trace_id rather than creating orphan spans', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: 'not-a-real-trace-id',
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.tool.execution' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      expect(mockTraceStore.addSpans).not.toHaveBeenCalled();
+    });
+
+    it('falls back to otel.log for span name when body exceeds the body-as-name limit', async () => {
+      const longBody = 'A'.repeat(200);
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          body: { stringValue: longBody },
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[])[0].name).toBe('otel.log');
+    });
+
+    it('truncates oversize otel.log.body to prevent trace-DB bloat', async () => {
+      const huge = 'x'.repeat(20_000);
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          body: { stringValue: huge },
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.noise' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      const storedBody = (spans as any[])[0].attributes['otel.log.body'] as string;
+      expect(storedBody.length).toBeLessThan(huge.length);
+      expect(storedBody.endsWith('... [truncated]')).toBe(true);
+    });
+
+    it('skips a malformed record but keeps good ones in the same batch', async () => {
+      const req = makeLogsRequest([
+        {
+          // Missing attribute value shape — triggers a throw inside parseAttributes.
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'broken' } as any],
+        },
+        {
+          timeUnixNano: '1700000000100000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.tool.execution' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      // Either both survived (because parseAttributes was lenient) or the bad
+      // one was skipped while the good one survived — both acceptable. The
+      // failure mode we're guarding against is "bad record → 500 → whole
+      // batch dropped", verified by the 200 status.
+      expect(mockTraceStore.addSpans).toHaveBeenCalled();
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[]).some((s: any) => s.name === 'claude_code.tool.execution')).toBe(true);
+    });
+
+    it('treats a base64-encoded all-zero span_id as no parent linkage', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          // Eight zero bytes encoded as base64.
+          spanId: 'AAAAAAAAAAA=',
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.noise' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[])[0].parentSpanId).toBeUndefined();
+    });
+
+    it('200s on empty resourceLogs without persisting anything', async () => {
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send({ resourceLogs: [] })
+        .expect(200);
+
+      expect(mockTraceStore.addSpans).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/tracing/otlpReceiver.test.ts
+++ b/test/tracing/otlpReceiver.test.ts
@@ -618,4 +618,231 @@ describe('OTLPReceiver', () => {
       });
     });
   });
+
+  describe('Log ingestion (/v1/logs)', () => {
+    const hexTraceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const hexParentSpanId = '00f067aa0ba902b7';
+
+    function makeLogsRequest(records: any[]) {
+      return {
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [{ key: 'service.name', value: { stringValue: 'claude-agent-sdk' } }],
+            },
+            scopeLogs: [
+              {
+                scope: { name: 'com.anthropic.claude_code', version: '1.0.0' },
+                logRecords: records,
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    it('converts a Claude Code log into a child span with event.name attribute', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          severityNumber: 9,
+          severityText: 'INFO',
+          body: { stringValue: 'Tool execution complete' },
+          attributes: [
+            { key: 'event.name', value: { stringValue: 'claude_code.tool.execution' } },
+            { key: 'tool_name', value: { stringValue: 'Bash' } },
+            { key: 'duration_ms', value: { intValue: '342' } },
+          ],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      expect(mockTraceStore.addSpans).toHaveBeenCalledTimes(1);
+      const [persistedTraceId, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect(persistedTraceId).toBe(hexTraceId);
+      expect(spans).toHaveLength(1);
+      const span = (spans as any[])[0];
+      expect(span.name).toBe('claude_code.tool.execution');
+      expect(span.parentSpanId).toBe(hexParentSpanId);
+      expect(span.attributes['tool_name']).toBe('Bash');
+      expect(span.attributes['duration_ms']).toBe(342);
+      expect(span.attributes['otel.log.body']).toBe('Tool execution complete');
+      expect(span.attributes['service.name']).toBe('claude-agent-sdk');
+      // Time conversion: nanos → ms, plus a 1ms nominal duration.
+      expect(span.startTime).toBe(1700000000000);
+      expect(span.endTime).toBe(1700000000001);
+    });
+
+    it('drops log records without a trace id', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          attributes: [{ key: 'event.name', value: { stringValue: 'orphan' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      expect(mockTraceStore.addSpans).not.toHaveBeenCalled();
+    });
+
+    it('filters out internal tracing logs via denylist', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.tracing' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      expect(mockTraceStore.addSpans).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a short body string when no event.name attribute is present', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          body: { stringValue: 'agent.message' },
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[])[0].name).toBe('agent.message');
+    });
+
+    it('rejects non-JSON content types on /v1/logs', async () => {
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/x-protobuf')
+        .send(Buffer.from([0x00]))
+        .expect(415);
+    });
+
+    it('treats a zero span id as no parent linkage', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: '0000000000000000',
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.tool.execution' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[])[0].parentSpanId).toBeUndefined();
+    });
+
+    it('handles multiple log records in a single request', async () => {
+      const req = makeLogsRequest([
+        {
+          timeUnixNano: '1700000000000000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.tool.execution' } }],
+        },
+        {
+          timeUnixNano: '1700000000100000000',
+          traceId: hexTraceId,
+          spanId: hexParentSpanId,
+          attributes: [{ key: 'event.name', value: { stringValue: 'claude_code.llm_request' } }],
+        },
+      ]);
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect((spans as any[]).map((s: any) => s.name)).toEqual([
+        'claude_code.tool.execution',
+        'claude_code.llm_request',
+      ]);
+    });
+
+    it('falls back to promptfoo.trace_id / parent_span_id resource attrs when the log record has none', async () => {
+      // Mimics Claude Agent SDK logs: body carries the event type, the record
+      // itself has no traceId/spanId, and the provider injected trace context
+      // via OTEL_RESOURCE_ATTRIBUTES.
+      const req = {
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [
+                { key: 'service.name', value: { stringValue: 'claude-agent-sdk' } },
+                { key: 'promptfoo.trace_id', value: { stringValue: hexTraceId } },
+                { key: 'promptfoo.parent_span_id', value: { stringValue: hexParentSpanId } },
+              ],
+            },
+            scopeLogs: [
+              {
+                scope: { name: 'com.anthropic.claude_code' },
+                logRecords: [
+                  {
+                    timeUnixNano: '1700000000000000000',
+                    body: { stringValue: 'claude_code.tool_result' },
+                    attributes: [
+                      { key: 'event.name', value: { stringValue: 'tool_result' } },
+                      { key: 'tool_name', value: { stringValue: 'Read' } },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      await request(receiver.getApp())
+        .post('/v1/logs')
+        .set('Content-Type', 'application/json')
+        .send(req)
+        .expect(200);
+
+      const [persistedTraceId, spans] = mockTraceStore.addSpans.mock.calls[0];
+      expect(persistedTraceId).toBe(hexTraceId);
+      const span = (spans as any[])[0];
+      expect(span.parentSpanId).toBe(hexParentSpanId);
+      expect(span.name).toBe('tool_result');
+    });
+
+    it('is advertised on the service info endpoint', async () => {
+      // Sanity check that /v1/traces stays stable despite the new /v1/logs route.
+      const response = await request(receiver.getApp()).get('/v1/traces').expect(200);
+      expect(response.body.service).toBe('promptfoo-otlp-receiver');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #8764. The Claude Agent SDK exports most of its internal telemetry (API requests, tool decisions, tool results, interactions) as **OTEL logs**, not spans — so even with tracing enabled and env vars forwarded, those events never reached promptfoo's Traces tab because the existing OTLP receiver only handled `/v1/traces`.

This PR adds a JSON-only `/v1/logs` endpoint that materializes each incoming log record as a zero-ish-duration span under the eval's trace.

## What changed

- `src/tracing/otlpReceiver.ts`: new `/v1/logs` POST handler, JSON body parsing, `logRecordToParsedTrace()` converter. Each log becomes a span with the log's attributes + body as span attributes. Internal-noise events (`claude_code.tracing`) are filtered.
- `src/providers/claude-agent-sdk.ts`: inject `OTEL_RESOURCE_ATTRIBUTES=promptfoo.trace_id=...,promptfoo.parent_span_id=...`. The SDK's logs signal does not inherit `TRACEPARENT`, so resource attributes are how we link log-derived spans to the eval trace.
- `site/docs/providers/claude-agent-sdk.md`: documents the opt-in "Deep tracing" mode (`OTEL_LOGS_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`).

## Scope trade-off

- **JSON only.** Protobuf logs would require adding `logs.proto` + decoder ceremony (see how trace protobuf works). The SDK already supports `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/json` as a per-signal override, so users who want both protobuf traces and JSON logs can do so. Kept this PR narrow; protobuf logs can follow.
- **Flat log→span conversion.** Each log becomes one span with a 1ms nominal duration so it renders as a thin bar. No pairing logic (e.g. correlating `api_request` start/end) — that's fragile and speculative.

## E2E verified

Same eval as #8764 (`claude-haiku-4-5` with `working_dir` + `LS`/`Read` tools). Before this PR the trace had 3 spans. After:

```
chat claude-haiku-4-5         20.5s  OK
├── api_request                 1ms  OK   (log-derived, model=claude-haiku-4-5-20251001, input_tokens=373)
├── tool Bash                 738ms  OK   (synthesized, #8764)
├── tool_decision               1ms  OK   (log-derived)
├── tool Read                  30ms  OK   (synthesized, #8764)
├── tool_decision               1ms  OK   (log-derived)
├── tool_result                 1ms  OK   (log-derived)
├── api_request                 1ms  OK   (log-derived)
├── tool_result                 1ms  OK   (log-derived)
└── api_request                 1ms  OK   (log-derived)
```

All log-derived spans carry their full attribute set (event.name, event.timestamp, model, token counts, cost_usd, duration_ms, prompt.id, session.id, etc.) so filtering and analysis in the UI work as expected.

## Test plan

- [x] 9 new unit tests in `test/tracing/otlpReceiver.test.ts`: JSON parsing, event.name→span.name mapping, body-string fallback, content-type rejection, zero-span-id handling, multi-record batching, denylist, resource-attr linkage fallback, and backwards compat.
- [x] All 313 existing provider + tracing tests still pass (total now 5,348 passing in providers + tracing).
- [x] Lint + format clean (3 pre-existing complexity warnings, all present on main).
- [x] End-to-end eval produces the expected 10-span hierarchy shown above.

Closes #7361 (in spirit — this delivers the `/v1/logs` part of that stale PR, while #8764 covered the env passthrough and provider-level GenAI span).

🤖 Generated with [Claude Code](https://claude.com/claude-code)