### PR TITLE
fix(scheduler): honor provider maxRetries across retry layers

### DIFF
--- a/site/docs/configuration/rate-limits.md
+++ b/site/docs/configuration/rate-limits.md
@@ -13,7 +13,7 @@ Promptfoo automatically handles rate limits from LLM providers. When a provider 
 
 Rate limit handling is built into the evaluator and requires no configuration:
 
-- **Automatic retry**: Failed requests are retried up to 3 times with exponential backoff
+- **Automatic retry**: Failed requests are retried up to 3 times with exponential backoff by default (overridable per provider via `maxRetries`, including `0` to disable retries)
 - **Header-aware delays**: Respects `retry-after` headers from providers
 - **Adaptive concurrency**: Reduces concurrent requests when rate limits are hit
 - **Per-provider isolation**: Each provider and API key has separate rate limit tracking
@@ -96,8 +96,19 @@ PROMPTFOO_DELAY_MS=1000 promptfoo eval
 
 Promptfoo has two retry layers:
 
-1. **Provider-level retry** (scheduler): Retries `callApi()` with 1-second base backoff, up to 3 times
-2. **HTTP-level retry**: Retries failed HTTP requests with configurable backoff
+1. **Provider-level retry** (scheduler): Retries `callApi()` with 1-second base backoff, up to 3 times by default. If a provider config sets `maxRetries`, the scheduler uses that value (including `0` to disable scheduler retries entirely).
+2. **HTTP-level retry**: Retries failed HTTP requests. Defaults to 4 retries, or the provider's `maxRetries` when set.
+
+When a provider config includes `maxRetries`, promptfoo propagates that value to both layers. Explicit per-call overrides (e.g. a provider that passes a specific `maxRetries` to `fetchWithRetries`) still take precedence. For direct `fetchWithProxy` calls, transient retries (502/503/504/524) are disabled when the provider sets `maxRetries: 0`.
+
+Example — disable retries for a provider to fail fast on rate limits:
+
+```yaml
+providers:
+  - id: openai:chat:gpt-4.1-mini
+    config:
+      maxRetries: 0
+```
 
 Environment variables for the scheduler:
 

--- a/src/scheduler/providerRateLimitState.ts
+++ b/src/scheduler/providerRateLimitState.ts
@@ -131,11 +131,21 @@ export class ProviderRateLimitState extends EventEmitter {
       getHeaders?: (result: T) => Record<string, string> | undefined;
       isRateLimited?: (result: T | undefined, error?: Error) => boolean;
       getRetryAfter?: (result: T | undefined, error?: Error) => number | undefined;
+      /**
+       * Per-call override for `maxRetries` only. Preserves the state's other
+       * policy fields (backoff, jitter) so provider config cannot silently
+       * reset them.
+       */
+      maxRetriesOverride?: number;
     },
   ): Promise<T> {
     this.totalRequests++;
     let attempt = 0;
     let lastError: Error | undefined;
+    const retryPolicy =
+      options.maxRetriesOverride === undefined
+        ? this.retryPolicy
+        : { ...this.retryPolicy, maxRetries: options.maxRetriesOverride };
 
     while (true) {
       // Acquire slot (may wait for rate limit window via queue)
@@ -177,10 +187,10 @@ export class ProviderRateLimitState extends EventEmitter {
           this.handleRateLimit(retryAfterMs);
 
           // Check if we should retry
-          if (shouldRetry(attempt, undefined, true, this.retryPolicy)) {
+          if (shouldRetry(attempt, undefined, true, retryPolicy)) {
             attempt++;
             this.retriedRequests++;
-            const delay = getRetryDelay(attempt, this.retryPolicy, retryAfterMs);
+            const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
 
             this.emit('request:retrying', {
               rateLimitKey: this.rateLimitKey,
@@ -229,10 +239,10 @@ export class ProviderRateLimitState extends EventEmitter {
         }
 
         // Check if we should retry
-        if (shouldRetry(attempt, lastError, isRateLimited, this.retryPolicy)) {
+        if (shouldRetry(attempt, lastError, isRateLimited, retryPolicy)) {
           attempt++;
           this.retriedRequests++;
-          const delay = getRetryDelay(attempt, this.retryPolicy, retryAfterMs);
+          const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
 
           this.emit('request:retrying', {
             rateLimitKey: this.rateLimitKey,

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -178,7 +178,13 @@ function getProviderMaxRetries(provider: ApiProvider): number | undefined {
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
     if (/^\d+$/.test(trimmed)) {
-      return Number(trimmed);
+      // Reject digit strings that overflow to Infinity or lose precision past
+      // Number.MAX_SAFE_INTEGER — otherwise the retry loops would never
+      // terminate (attempt < Infinity is always true).
+      const parsed = Number(trimmed);
+      if (Number.isSafeInteger(parsed)) {
+        return parsed;
+      }
     }
   }
 

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { getEnvBool, getEnvInt } from '../envars';
 import logger from '../logger';
 import { withFetchRetryContext } from '../util/fetch/retryContext';
+import { sanitizeUrl } from '../util/sanitizer';
 import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
 import { getRateLimitKey } from './rateLimitKey';
 
@@ -189,7 +190,17 @@ function getProviderMaxRetries(provider: ApiProvider): number | undefined {
   }
 
   logger.warn(
-    `[RateLimit] Ignoring invalid provider.config.maxRetries=${JSON.stringify(raw)} for ${provider.id()}; expected a non-negative integer.`,
+    '[RateLimit] Ignoring invalid provider.config.maxRetries; expected a non-negative integer.',
+    {
+      maxRetries: raw,
+      providerId: sanitizeProviderIdForLog(provider.id()),
+    },
   );
   return undefined;
+}
+
+function sanitizeProviderIdForLog(providerId: string): string {
+  return providerId.includes('://') || providerId.startsWith('/')
+    ? sanitizeUrl(providerId)
+    : providerId;
 }

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events';
 
 import { getEnvBool, getEnvInt } from '../envars';
+import logger from '../logger';
+import { withFetchRetryContext } from '../util/fetch/retryContext';
 import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
 import { getRateLimitKey } from './rateLimitKey';
 
@@ -48,9 +50,13 @@ export class RateLimitRegistry extends EventEmitter {
       getRetryAfter?: (result: T | undefined, error?: Error) => number | undefined;
     },
   ): Promise<T> {
-    // If disabled, just call directly
+    const providerMaxRetries = getProviderMaxRetries(provider);
+
+    // Even when the scheduler is disabled, propagate the retry context so
+    // `fetchWithRetries` picks up the provider's `maxRetries` as its default
+    // and `fetchWithProxy` disables transient retries when `maxRetries: 0`.
     if (!this.enabled) {
-      return callFn();
+      return withFetchRetryContext(providerMaxRetries, callFn);
     }
 
     const rateLimitKey = getRateLimitKey(provider);
@@ -65,12 +71,16 @@ export class RateLimitRegistry extends EventEmitter {
       queueDepth: state.getQueueDepth(),
     });
 
-    try {
-      const result = await state.executeWithRetry(requestId, callFn, {
+    const run = () =>
+      state.executeWithRetry(requestId, callFn, {
         getHeaders: options?.getHeaders,
         isRateLimited: options?.isRateLimited,
         getRetryAfter: options?.getRetryAfter,
+        maxRetriesOverride: providerMaxRetries,
       });
+
+    try {
+      const result = await withFetchRetryContext(providerMaxRetries, run);
 
       this.emit('request:completed', {
         rateLimitKey,
@@ -142,4 +152,38 @@ export class RateLimitRegistry extends EventEmitter {
  */
 export function createRateLimitRegistry(options: RateLimitRegistryOptions): RateLimitRegistry {
   return new RateLimitRegistry(options);
+}
+
+/**
+ * Read the provider's configured maxRetries value, tolerating numeric strings
+ * (e.g. from environment overrides) and rejecting invalid values.
+ *
+ * Returning `undefined` means "fall back to defaults" — distinct from `0`, which
+ * means "disable retries". Invalid user-supplied values (negatives, floats,
+ * non-numeric strings) are logged so config typos aren't silently ignored.
+ */
+function getProviderMaxRetries(provider: ApiProvider): number | undefined {
+  const raw: unknown =
+    provider.config && typeof provider.config === 'object'
+      ? (provider.config as { maxRetries?: unknown }).maxRetries
+      : undefined;
+
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (/^\d+$/.test(trimmed)) {
+      return Number(trimmed);
+    }
+  }
+
+  logger.warn(
+    `[RateLimit] Ignoring invalid provider.config.maxRetries=${JSON.stringify(raw)} for ${provider.id()}; expected a non-negative integer.`,
+  );
+  return undefined;
 }

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -14,6 +14,7 @@ import invariant from '../../util/invariant';
 import { sleep } from '../../util/time';
 import { sanitizeUrl } from '../sanitizer';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
+import { getFetchRetryContextMaxRetries } from './retryContext';
 
 import type { SystemError } from './errors';
 import type { FetchOptions } from './types';
@@ -105,6 +106,19 @@ function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions):
   });
   cachedProxyAgents.set(cacheKey, agent);
   return agent;
+}
+
+/**
+ * Resolve whether to disable transient-error retries. An explicit caller flag
+ * always wins (a caller may opt back in even when the provider set
+ * `maxRetries: 0`); otherwise we disable only when the retry context carries
+ * `maxRetries === 0`.
+ */
+function resolveTransientRetryDisabled(explicit?: boolean): boolean {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  return getFetchRetryContextMaxRetries() === 0;
 }
 
 export async function fetchWithProxy(
@@ -204,17 +218,16 @@ export async function fetchWithProxy(
     }
   }
 
-  // Transient error retry logic (502/503/504/524 with matching status text)
-  const maxTransientRetries = options.disableTransientRetries ? 0 : 3;
+  // Transient error retry logic (502/503/504/524 with matching status text).
+  // When a provider sets maxRetries: 0 and the caller did not pass an explicit
+  // disableTransientRetries, honor the provider intent via the retry context.
+  const disableTransientRetries = resolveTransientRetryDisabled(options.disableTransientRetries);
+  const maxTransientRetries = disableTransientRetries ? 0 : 3;
 
   for (let attempt = 0; attempt <= maxTransientRetries; attempt++) {
     const response = await monkeyPatchFetch(finalUrl, finalOptions);
 
-    if (
-      !options.disableTransientRetries &&
-      isTransientError(response) &&
-      attempt < maxTransientRetries
-    ) {
+    if (!disableTransientRetries && isTransientError(response) && attempt < maxTransientRetries) {
       const backoffMs = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
       logger.debug(
         `Transient error (${response.status} ${response.statusText}), retry ${attempt + 1}/${maxTransientRetries} after ${backoffMs}ms`,
@@ -340,13 +353,29 @@ export function isTransientError(response: Response): boolean {
  */
 export type { FetchOptions } from './types';
 
+function formatFetchErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const typedError = error as SystemError;
+  let message = `${typedError.name}: ${typedError.message}`;
+  if (typedError.cause) {
+    message += ` (Cause: ${typedError.cause})`;
+  }
+  if (typedError.code) {
+    message += ` (Code: ${typedError.code})`;
+  }
+  return message;
+}
+
 export async function fetchWithRetries(
   url: RequestInfo,
   options: FetchOptions = {},
   timeout: number,
   maxRetries?: number,
 ): Promise<Response> {
-  maxRetries = Math.max(0, maxRetries ?? 4);
+  const contextMaxRetries = getFetchRetryContextMaxRetries();
+  maxRetries = Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
 
   let lastErrorMessage: string | undefined;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);
@@ -366,10 +395,18 @@ export async function fetchWithRetries(
       }
 
       if (response && isRateLimited(response)) {
+        lastErrorMessage = `Rate limited: ${response.status} ${response.statusText}`;
+        if (i >= maxRetries) {
+          // No retries remain: fail fast instead of honoring the Retry-After delay.
+          // `lastErrorMessage` was set above so the throw below carries the 429 detail.
+          logger.debug(
+            `Rate limited on URL ${url}: ${response.status} ${response.statusText}, attempt ${i + 1}/${maxRetries + 1}, no retries remain.`,
+          );
+          break;
+        }
         logger.debug(
           `Rate limited on URL ${url}: ${response.status} ${response.statusText}, attempt ${i + 1}/${maxRetries + 1}, waiting before retry...`,
         );
-        lastErrorMessage = `Rate limited: ${response.status} ${response.statusText}`;
         await handleRateLimit(response);
         continue;
       }
@@ -381,21 +418,7 @@ export async function fetchWithRetries(
         throw error;
       }
 
-      let errorMessage;
-      if (error instanceof Error) {
-        // Extract as much detail as possible from the error
-        const typedError = error as SystemError;
-        errorMessage = `${typedError.name}: ${typedError.message}`;
-        if (typedError.cause) {
-          errorMessage += ` (Cause: ${typedError.cause})`;
-        }
-        if (typedError.code) {
-          // Node.js system errors often have error codes
-          errorMessage += ` (Code: ${typedError.code})`;
-        }
-      } else {
-        errorMessage = String(error);
-      }
+      const errorMessage = formatFetchErrorMessage(error);
 
       logger.debug(`Request to ${url} failed (attempt #${i + 1}), retrying: ${errorMessage}`);
       if (i < maxRetries) {

--- a/src/util/fetch/retryContext.ts
+++ b/src/util/fetch/retryContext.ts
@@ -1,0 +1,32 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface FetchRetryContext {
+  maxRetries?: number;
+}
+
+const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
+
+/**
+ * Run `fn` with a fetch retry context so nested `fetchWithRetries` /
+ * `fetchWithProxy` calls inherit the provider's configured `maxRetries`.
+ *
+ * When `maxRetries` is `undefined` this is a no-op — the outer context (if any)
+ * passes through unchanged. Callers should pass a concrete value only when the
+ * provider has opted in to a specific retry count.
+ */
+export function withFetchRetryContext<T>(
+  maxRetries: number | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (maxRetries === undefined) {
+    return fn();
+  }
+  return fetchRetryContext.run({ maxRetries }, fn);
+}
+
+/**
+ * Read the active context's `maxRetries`, or `undefined` when none is set.
+ */
+export function getFetchRetryContextMaxRetries(): number | undefined {
+  return fetchRetryContext.getStore()?.maxRetries;
+}

--- a/src/util/fetch/retryContext.ts
+++ b/src/util/fetch/retryContext.ts
@@ -10,17 +10,13 @@ const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
  * Run `fn` with a fetch retry context so nested `fetchWithRetries` /
  * `fetchWithProxy` calls inherit the provider's configured `maxRetries`.
  *
- * When `maxRetries` is `undefined` this is a no-op — the outer context (if any)
- * passes through unchanged. Callers should pass a concrete value only when the
- * provider has opted in to a specific retry count.
+ * When `maxRetries` is `undefined`, the new scope deliberately shadows any
+ * outer provider context so providers without an override fall back to defaults.
  */
 export function withFetchRetryContext<T>(
   maxRetries: number | undefined,
   fn: () => Promise<T>,
 ): Promise<T> {
-  if (maxRetries === undefined) {
-    return fn();
-  }
   return fetchRetryContext.run({ maxRetries }, fn);
 }
 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -17,6 +17,7 @@ import {
   isRateLimited,
   isTransientError,
 } from '../src/util/fetch/index';
+import { withFetchRetryContext } from '../src/util/fetch/retryContext';
 import { sleep } from '../src/util/time';
 import { clearProxyEnv, createMockResponse, mockProcessEnv, PROXY_ENV_KEYS } from './util/utils';
 
@@ -1092,6 +1093,28 @@ describe('fetchWithRetries', () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
+  it('should honor retry context maxRetries when explicit argument is omitted', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      withFetchRetryContext(0, () => fetchWithRetries('https://example.com', {}, 1000)),
+    ).rejects.toThrow('Request failed after 0 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should prefer explicit maxRetries over retry context', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      withFetchRetryContext(0, () => fetchWithRetries('https://example.com', {}, 1000, 2)),
+    ).rejects.toThrow('Request failed after 2 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
   it('should make retries+1 total attempts', async () => {
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
@@ -1244,6 +1267,67 @@ describe('fetchWithRetries', () => {
     await expect(fetchWithRetries('https://example.com', {}, 1000, 2)).rejects.toThrow(
       'Rate limited: 429 Too Many Requests',
     );
+  });
+
+  it('should fail fast on rate limit when maxRetries is 0 without honoring Retry-After', async () => {
+    const rateLimitResponse = createMockResponse({
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: new Headers({ 'Retry-After': '60' }),
+    });
+    vi.mocked(global.fetch).mockResolvedValue(rateLimitResponse);
+
+    await expect(fetchWithRetries('https://example.com', {}, 1000, 0)).rejects.toThrow(
+      'Request failed after 0 retries: Rate limited: 429 Too Many Requests',
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    // Crucially, we must NOT sleep on the 60s Retry-After when no retries remain.
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should still retry on 429 and return success when a later attempt succeeds', async () => {
+    const rateLimitResponse = createMockResponse({
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: new Headers({ 'Retry-After': '0' }),
+    });
+    const successResponse = createMockResponse({ ok: true });
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse)
+      .mockResolvedValueOnce(successResponse);
+    global.fetch = mockFetch;
+
+    const result = await fetchWithRetries('https://example.com', {}, 1000, 2);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toBe(successResponse);
+    // handleRateLimit invokes sleep exactly once for the single retry before success.
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use the default maxRetries (4) when no context and no explicit arg', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(fetchWithRetries('https://example.com', {}, 1000)).rejects.toThrow(
+      'Request failed after 4 retries: Error: Network error',
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('should let an inner retry context shadow an outer context', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      withFetchRetryContext(0, () =>
+        withFetchRetryContext(2, () => fetchWithRetries('https://example.com', {}, 1000)),
+      ),
+    ).rejects.toThrow('Request failed after 2 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
   describe('Abort Signal Handling', () => {
@@ -1740,6 +1824,46 @@ describe('fetchWithProxy transient error retries', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result).toBe(transientResponse);
     expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should disable transient retries when retry context maxRetries is 0', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(transientResponse);
+    global.fetch = mockFetch;
+
+    const result = await withFetchRetryContext(0, () => fetchWithProxy('https://example.com'));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(transientResponse);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('should let explicit disableTransientRetries=false override retry context maxRetries=0', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+    const successResponse = createMockResponse({ ok: true });
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(transientResponse)
+      .mockResolvedValueOnce(successResponse);
+    global.fetch = mockFetch;
+
+    const result = await withFetchRetryContext(0, () =>
+      fetchWithProxy('https://example.com', {
+        disableTransientRetries: false,
+      }),
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toBe(successResponse);
+    expect(sleep).toHaveBeenCalledTimes(1);
   });
 
   it('should retry on 524 A Timeout Occurred (Cloudflare)', async () => {

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -57,6 +57,24 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
     }
   });
 
+  it('should clear an outer retry context when a nested provider has no maxRetries', async () => {
+    const registry = new RateLimitRegistry({
+      maxConcurrency: 2,
+      queueTimeoutMs: 100,
+    });
+    const outerProvider = createProvider(0);
+    const innerProvider = createProvider(undefined);
+
+    try {
+      const contextValue = await registry.execute(outerProvider, () =>
+        registry.execute(innerProvider, async () => getFetchRetryContextMaxRetries()),
+      );
+      expect(contextValue).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('should propagate fetch retry context when scheduler is disabled', async () => {
     vi.stubEnv('PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER', 'true');
     try {

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -4,10 +4,10 @@ import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContex
 
 import type { ApiProvider } from '../../src/types/providers';
 
-function createProvider(maxRetries?: unknown): ApiProvider {
+function createProvider(maxRetries?: unknown, id = 'test-provider'): ApiProvider {
   const config = maxRetries === undefined ? {} : { maxRetries };
   return {
-    id: () => 'test-provider',
+    id: () => id,
     config,
     callApi: vi.fn(),
   } as unknown as ApiProvider;
@@ -58,12 +58,15 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
   });
 
   it('should clear an outer retry context when a nested provider has no maxRetries', async () => {
+    // Use distinct provider ids so the outer and inner calls map to separate
+    // ProviderRateLimitState instances — otherwise shared slot queue state
+    // could mask the ALS-scope behavior we're asserting.
     const registry = new RateLimitRegistry({
       maxConcurrency: 2,
       queueTimeoutMs: 100,
     });
-    const outerProvider = createProvider(0);
-    const innerProvider = createProvider(undefined);
+    const outerProvider = createProvider(0, 'outer-provider');
+    const innerProvider = createProvider(undefined, 'inner-provider');
 
     try {
       const contextValue = await registry.execute(outerProvider, () =>
@@ -130,26 +133,18 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
       queueTimeoutMs: 100,
     });
 
-    const seen: Array<{ id: string; ctx: number | undefined }> = [];
-    function provider(id: string, maxRetries: unknown): ApiProvider {
-      return {
-        id: () => id,
-        config: { maxRetries },
-        callApi: vi.fn(),
-      } as unknown as ApiProvider;
-    }
-    async function capture(id: string): Promise<number | undefined> {
+    async function capture(): Promise<number | undefined> {
       const ctx = getFetchRetryContextMaxRetries();
-      seen.push({ id, ctx });
-      // Yield so both calls can interleave before returning.
+      // Yield so both calls can interleave before returning — guards against
+      // a regression where the context from the later call leaks into the earlier.
       await new Promise((resolve) => setImmediate(resolve));
       return ctx;
     }
 
     try {
       const [a, b] = await Promise.all([
-        registry.execute(provider('p0', 0), () => capture('p0')),
-        registry.execute(provider('p5', 5), () => capture('p5')),
+        registry.execute(createProvider(0, 'p0'), capture),
+        registry.execute(createProvider(5, 'p5'), capture),
       ]);
       expect(a).toBe(0);
       expect(b).toBe(5);

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
+import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContext';
+
+import type { ApiProvider } from '../../src/types/providers';
+
+function createProvider(maxRetries?: unknown): ApiProvider {
+  const config = maxRetries === undefined ? {} : { maxRetries };
+  return {
+    id: () => 'test-provider',
+    config,
+    callApi: vi.fn(),
+  } as unknown as ApiProvider;
+}
+
+async function runRateLimitedCall(maxRetries?: unknown): Promise<number> {
+  const registry = new RateLimitRegistry({
+    maxConcurrency: 1,
+    queueTimeoutMs: 100,
+  });
+  const provider = createProvider(maxRetries);
+  const callFn = vi.fn().mockResolvedValue({ status: 429 });
+
+  try {
+    await expect(
+      registry.execute(provider, callFn, {
+        isRateLimited: (result) => (result as { status?: number } | undefined)?.status === 429,
+        getRetryAfter: () => 0,
+      }),
+    ).rejects.toThrow('Rate limit exceeded');
+  } finally {
+    registry.dispose();
+  }
+
+  return callFn.mock.calls.length;
+}
+
+describe('RateLimitRegistry integration - provider maxRetries', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('should propagate provider maxRetries into the fetch retry context', async () => {
+    const registry = new RateLimitRegistry({
+      maxConcurrency: 1,
+      queueTimeoutMs: 100,
+    });
+    const provider = createProvider(0);
+    const callFn = vi.fn().mockImplementation(async () => getFetchRetryContextMaxRetries());
+
+    try {
+      const contextValue = await registry.execute(provider, callFn);
+      expect(contextValue).toBe(0);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('should propagate fetch retry context when scheduler is disabled', async () => {
+    vi.stubEnv('PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER', 'true');
+    try {
+      const registry = new RateLimitRegistry({
+        maxConcurrency: 1,
+        queueTimeoutMs: 100,
+      });
+      const provider = createProvider(0);
+      const callFn = vi.fn().mockImplementation(async () => getFetchRetryContextMaxRetries());
+
+      try {
+        const contextValue = await registry.execute(provider, callFn);
+        expect(contextValue).toBe(0);
+      } finally {
+        registry.dispose();
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('should not retry when provider maxRetries is 0', async () => {
+    expect(await runRateLimitedCall(0)).toBe(1);
+  });
+
+  it('should retry provider maxRetries + 1 total attempts', async () => {
+    expect(await runRateLimitedCall(2)).toBe(3);
+  });
+
+  it('should parse numeric string maxRetries values', async () => {
+    expect(await runRateLimitedCall('2')).toBe(3);
+  });
+
+  it('should use default scheduler retries (4 attempts) when provider maxRetries is not set', async () => {
+    expect(await runRateLimitedCall(undefined)).toBe(4);
+  });
+
+  it('should ignore negative maxRetries and use default scheduler retries', async () => {
+    expect(await runRateLimitedCall(-1)).toBe(4);
+  });
+
+  it('should ignore non-integer string maxRetries values', async () => {
+    expect(await runRateLimitedCall('2.5')).toBe(4);
+  });
+
+  it('should ignore non-integer number maxRetries values', async () => {
+    expect(await runRateLimitedCall(2.5)).toBe(4);
+  });
+
+  it('should isolate retry context per concurrent provider', async () => {
+    const registry = new RateLimitRegistry({
+      maxConcurrency: 4,
+      queueTimeoutMs: 100,
+    });
+
+    const seen: Array<{ id: string; ctx: number | undefined }> = [];
+    function provider(id: string, maxRetries: unknown): ApiProvider {
+      return {
+        id: () => id,
+        config: { maxRetries },
+        callApi: vi.fn(),
+      } as unknown as ApiProvider;
+    }
+    async function capture(id: string): Promise<number | undefined> {
+      const ctx = getFetchRetryContextMaxRetries();
+      seen.push({ id, ctx });
+      // Yield so both calls can interleave before returning.
+      await new Promise((resolve) => setImmediate(resolve));
+      return ctx;
+    }
+
+    try {
+      const [a, b] = await Promise.all([
+        registry.execute(provider('p0', 0), () => capture('p0')),
+        registry.execute(provider('p5', 5), () => capture('p5')),
+      ]);
+      expect(a).toBe(0);
+      expect(b).toBe(5);
+    } finally {
+      registry.dispose();
+    }
+  });
+});

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -71,6 +71,17 @@ vi.mock('../../src/envars', () => ({
   getEnvBool: mockGetEnvBool,
 }));
 
+vi.mock('../../src/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  logRequestResponse: vi.fn(),
+}));
+
 // Import after mocks are set up
 const { RateLimitRegistry, createRateLimitRegistry } = await import(
   '../../src/scheduler/rateLimitRegistry'
@@ -253,6 +264,7 @@ describe('RateLimitRegistry', () => {
           getHeaders: undefined,
           isRateLimited: undefined,
           getRetryAfter: undefined,
+          maxRetriesOverride: undefined,
         },
       );
       expect(result).toBe('state-result');
@@ -277,7 +289,74 @@ describe('RateLimitRegistry', () => {
         getHeaders,
         isRateLimited,
         getRetryAfter,
+        maxRetriesOverride: undefined,
       });
+    });
+
+    it.each([
+      { input: 0, expected: 0 },
+      { input: 5, expected: 5 },
+      { input: '2', expected: 2 },
+    ])('should forward maxRetriesOverride=$expected for provider config.maxRetries=$input', async ({
+      input,
+      expected,
+    }) => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const provider = {
+        ...mockProvider,
+        config: { ...mockProvider.config, maxRetries: input },
+      } as ApiProvider;
+
+      await registry.execute(provider, vi.fn());
+
+      expect(mockState.executeWithRetry).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        expect.objectContaining({ maxRetriesOverride: expected }),
+      );
+    });
+
+    it.each([
+      { label: 'negative number', input: -1 },
+      { label: 'non-integer number', input: 2.5 },
+      { label: 'non-integer string', input: '2.5' },
+    ])('should warn and forward maxRetriesOverride=undefined for invalid $label ($input)', async ({
+      input,
+    }) => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const logger = (await import('../../src/logger')).default;
+      const warnSpy = vi.mocked(logger.warn);
+      warnSpy.mockClear();
+
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const provider = {
+        ...mockProvider,
+        config: { ...mockProvider.config, maxRetries: input },
+      } as ApiProvider;
+
+      await registry.execute(provider, vi.fn());
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring invalid provider.config.maxRetries'),
+      );
+      expect(mockState.executeWithRetry).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        expect.objectContaining({ maxRetriesOverride: undefined }),
+      );
+    });
+
+    it('should not warn when provider does not set maxRetries', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const logger = (await import('../../src/logger')).default;
+      const warnSpy = vi.mocked(logger.warn);
+      warnSpy.mockClear();
+
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      await registry.execute(mockProvider, vi.fn());
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('should generate unique request IDs', async () => {

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -342,7 +342,11 @@ describe('RateLimitRegistry', () => {
       await registry.execute(provider, vi.fn());
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Ignoring invalid provider.config.maxRetries'),
+        '[RateLimit] Ignoring invalid provider.config.maxRetries; expected a non-negative integer.',
+        expect.objectContaining({
+          maxRetries: input,
+          providerId: 'test-provider',
+        }),
       );
       expect(mockState.executeWithRetry).toHaveBeenLastCalledWith(
         expect.any(String),
@@ -361,6 +365,31 @@ describe('RateLimitRegistry', () => {
       await registry.execute(mockProvider, vi.fn());
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should sanitize URL provider ids in invalid maxRetries warnings', async () => {
+      mockState.executeWithRetry.mockResolvedValue('result');
+      const logger = (await import('../../src/logger')).default;
+      const warnSpy = vi.mocked(logger.warn);
+      warnSpy.mockClear();
+
+      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+      const provider = {
+        ...mockProvider,
+        id: () => 'https://example.com/api?api_key=secret&model=test',
+        config: { ...mockProvider.config, maxRetries: -1 },
+      } as ApiProvider;
+
+      await registry.execute(provider, vi.fn());
+
+      const [, context] = warnSpy.mock.calls[0];
+      expect(context).toEqual(
+        expect.objectContaining({
+          maxRetries: -1,
+          providerId: expect.stringContaining('api_key=%5BREDACTED%5D'),
+        }),
+      );
+      expect((context as { providerId: string }).providerId).not.toContain('secret');
     });
 
     it('should generate unique request IDs', async () => {

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -321,6 +321,10 @@ describe('RateLimitRegistry', () => {
       { label: 'negative number', input: -1 },
       { label: 'non-integer number', input: 2.5 },
       { label: 'non-integer string', input: '2.5' },
+      // Digit strings that overflow to Infinity / lose precision would cause
+      // unbounded retry loops if accepted — reject them.
+      { label: 'unsafe-integer string', input: '1' + '0'.repeat(400) },
+      { label: 'above MAX_SAFE_INTEGER', input: String(Number.MAX_SAFE_INTEGER) + '0' },
     ])('should warn and forward maxRetriesOverride=undefined for invalid $label ($input)', async ({
       input,
     }) => {


### PR DESCRIPTION
## Summary

- Scheduler and fetch layers now honor `provider.config.maxRetries` (including `0` for fail-fast), fixing the case where setting `maxRetries: 0` did nothing because the adaptive scheduler always retried 429s three times.
- `fetchWithRetries` now short-circuits on 429 when no retries remain instead of waiting out the server's `Retry-After` (previously caused ~60s hangs per request before throwing).
- Provider `maxRetries` is propagated through a new `withFetchRetryContext` (AsyncLocalStorage), so providers that don't forward `maxRetries` into `fetchWithCache` still inherit the setting, and the disabled-scheduler path (`PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER=true`) is covered too.
- Invalid `provider.config.maxRetries` values (negatives, floats, non-numeric strings) now emit a `logger.warn` so YAML typos surface instead of silently falling back to defaults.

Fixes #7727. Replaces #7745.

## Behavior change notes

- `fetchWithRetries(url, opts, timeout, 0)` on a persistent 429 now throws immediately with `Request failed after 0 retries: Rate limited: 429 ...` instead of calling `handleRateLimit` once before throwing. Existing callers already threw on exhaustion; only the pre-throw wait is removed.
- `fetchWithProxy` disables transient retries (502/503/504/524) when the active retry context has `maxRetries: 0` and the caller did not pass `disableTransientRetries` explicitly. An explicit `disableTransientRetries: false` still wins.
- Provider retry policies for non-default scheduler states: the per-call override only changes `maxRetries` and preserves `baseDelayMs`/`maxDelayMs`/`jitterFactor` from `this.retryPolicy`.

## Example

```yaml
providers:
  - id: openai:chat:gpt-4.1-mini
    config:
      maxRetries: 0 # Fail fast on rate limits; do not retry.
```

## Test plan

- [x] `npx vitest run test/fetch.test.ts test/scheduler/` — 381 tests pass, including new cases for context priority, concurrent-provider isolation via `Promise.all`, nested context shadowing, 429→success mid-loop, and warn emission on invalid values.
- [x] `npx vitest run test/fetch.test.ts test/scheduler/ test/cache.test.ts test/evaluator.test.ts test/providers/openai` — 1208 tests pass.
- [x] `npm run tsc` — clean.
- [x] `npm run l && npm run f` — no new warnings (`fetchWithProxy` complexity 33 is pre-existing on `main`).
- [x] End-to-end: built locally, ran `eval` against a mock 429 server.
  - With `maxRetries: 0`: 1 server request, 0 sleep, ~0s duration (was 1m1s on main).
  - Without override: scheduler × HTTP retries both fire as before.

## Related

- Closes #7727
- Supersedes #7745