### PR TITLE
test(redteam): stabilize empty warning test

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -43,6 +43,7 @@ import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageU
 import { isUuid } from '../util/uuid';
 import { filterProviders } from './eval/filterProviders';
 import { filterTests } from './eval/filterTests';
+import { warnIfRedteamConfigHasNoTests } from './eval/redteamWarning';
 import { generateEvalSummary } from './eval/summary';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './share';
@@ -310,19 +311,7 @@ export async function doEval(
       setupEnv(commandLineOptions.envPath);
     }
 
-    // Check if config has redteam section but no test cases
-    if (
-      config.redteam &&
-      (!testSuite.tests || testSuite.tests.length === 0) &&
-      (!testSuite.scenarios || testSuite.scenarios.length === 0)
-    ) {
-      logger.warn(
-        chalk.yellow(dedent`
-        Warning: Config file has a redteam section but no test cases.
-        Did you mean to run ${chalk.bold('promptfoo redteam generate')} instead?
-        `),
-      );
-    }
+    warnIfRedteamConfigHasNoTests(config, testSuite);
 
     // TODO(faizan): Crazy condition to see when we run the example redteam config.
     // Remove this once we have a better way to track this.

--- a/src/commands/eval/redteamWarning.ts
+++ b/src/commands/eval/redteamWarning.ts
@@ -1,0 +1,23 @@
+import chalk from 'chalk';
+import dedent from 'dedent';
+import logger from '../../logger';
+
+import type { TestSuite, UnifiedConfig } from '../../types/index';
+
+export function warnIfRedteamConfigHasNoTests(
+  config: Partial<UnifiedConfig>,
+  testSuite: TestSuite,
+) {
+  if (
+    config.redteam &&
+    (!testSuite.tests || testSuite.tests.length === 0) &&
+    (!testSuite.scenarios || testSuite.scenarios.length === 0)
+  ) {
+    logger.warn(
+      chalk.yellow(dedent`
+        Warning: Config file has a redteam section but no test cases.
+        Did you mean to run ${chalk.bold('promptfoo redteam generate')} instead?
+        `),
+    );
+  }
+}

--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -1,98 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { doEval } from '../../../src/commands/eval';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { warnIfRedteamConfigHasNoTests } from '../../../src/commands/eval/redteamWarning';
 import logger from '../../../src/logger';
 
-// Mock util/config/default.ts
-vi.mock('../../../src/util/config/default', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
+import type { TestSuite, UnifiedConfig } from '../../../src/types/index';
 
-    loadDefaultConfig: vi.fn().mockResolvedValue({
-      defaultConfig: {},
-      defaultConfigPath: null,
-    }),
-
-    clearConfigCache: vi.fn(),
-  };
-});
-
-vi.mock('../../../src/util/config/load', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-
-    resolveConfigs: vi.fn().mockResolvedValue({
-      config: {
-        redteam: {
-          purpose: 'Test red team purpose',
-        },
-      },
-      testSuite: {
-        prompts: [],
-        providers: [],
-        tests: [], // Empty tests array
-      },
-      basePath: '',
-    }),
-  };
-});
-
-vi.mock('../../../src/evaluator', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-    evaluate: vi.fn().mockResolvedValue({}),
-    DEFAULT_MAX_CONCURRENCY: 4,
-  };
-});
-
-// Mock other dependencies to prevent actual execution
-vi.mock('../../../src/migrate', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-    runDbMigrations: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-// Mock the table generation
-vi.mock('../../../src/table', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-
-    generateTable: vi.fn().mockReturnValue({
-      toString: vi.fn().mockReturnValue('Mock Table Output'),
-    }),
-  };
-});
-
-vi.mock('../../../src/models/eval', () => {
-  return {
-    __esModule: true,
-    default: vi.fn().mockImplementation(function (config) {
-      return {
-        addResult: vi.fn().mockResolvedValue({}),
-        addPrompts: vi.fn().mockResolvedValue({}),
-        clearResults: vi.fn().mockReturnValue(undefined),
-        setDurationMs: vi.fn(),
-        findTargetErrorStatus: vi.fn().mockResolvedValue(undefined),
-
-        getTable: vi.fn().mockResolvedValue({
-          head: {
-            prompts: [],
-            vars: [],
-          },
-          body: [],
-        }),
-
-        resultsCount: 0,
-        prompts: [],
-        persisted: false,
-        results: [],
-        config: config || {},
-      };
-    }),
-  };
-});
-
-// Mock the logger module with both default and named exports
 vi.mock('../../../src/logger', () => {
   const mockLogger = {
     info: vi.fn(),
@@ -104,49 +15,28 @@ vi.mock('../../../src/logger', () => {
   return {
     __esModule: true,
     default: mockLogger,
-    getLogLevel: vi.fn().mockReturnValue('info'),
-    setLogLevel: vi.fn(),
-    isDebugEnabled: vi.fn().mockReturnValue(false),
   };
 });
 
-vi.mock('../../../src/share', () => ({
-  isSharingEnabled: vi.fn().mockReturnValue(false),
-  createShareableUrl: vi.fn().mockResolvedValue(null),
-}));
-
 describe('redteam warning in eval command', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.resetAllMocks();
-  });
+  it('should warn when config has redteam section but no test cases', () => {
+    const config = {
+      redteam: {
+        purpose: 'Test red team purpose',
+      },
+    } as Partial<UnifiedConfig>;
+    const testSuite = {
+      prompts: [],
+      providers: [],
+      tests: [],
+    } as TestSuite;
 
-  it('should warn when config has redteam section but no test cases', async () => {
-    // Mock command object with all required properties
-    const mockCmd = {
-      config: ['test-config.yaml'],
-      write: false, // Prevent database operations
-      progressBar: false,
-      verbose: false,
-      table: false, // Set to false to avoid table generation
-    };
+    warnIfRedteamConfigHasNoTests(config, testSuite);
 
-    // Mock defaultConfig
-    const mockDefaultConfig = {};
-
-    // Mock defaultConfigPath
-    const mockDefaultConfigPath = 'test-config.yaml';
-
-    // Mock evaluateOptions
-    const mockEvaluateOptions = {};
-
-    // Call doEval
-    await doEval(mockCmd, mockDefaultConfig, mockDefaultConfigPath, mockEvaluateOptions);
-
-    // Verify that logger.warn was called with a message containing the expected text
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('redteam section but no test cases'),
     );


### PR DESCRIPTION
## Summary
- move the empty-redteam warning into a small helper used by `doEval`
- make the warning unit test call the helper directly instead of running the full eval command path

## Root cause
The main CI failure was a Windows Node 22.22 shard timeout in `test/commands/eval/redteamWarning.test.ts`. The test only needed to assert warning text, but it exercised the full eval command path, which became slow enough under Windows CI load to hit Vitest 30s per-test timeout.

## Validation
- `npx vitest run test/commands/eval/redteamWarning.test.ts`
- `npm run tsc`
- `npm run l`
- `npm run f`