### PR TITLE
test: address ai quality findings

### DIFF
--- a/test/commands/eval/redteamWarning.test.ts
+++ b/test/commands/eval/redteamWarning.test.ts
@@ -42,4 +42,22 @@ describe('redteam warning in eval command', () => {
     );
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('promptfoo redteam generate'));
   });
+
+  it('should not warn when scenarios are present even if tests is empty', () => {
+    const config = {
+      redteam: {
+        purpose: 'Test red team purpose',
+      },
+    } as Partial<UnifiedConfig>;
+    const testSuite = {
+      prompts: [],
+      providers: [],
+      tests: [],
+      scenarios: [{ config: [], tests: [] }],
+    } as TestSuite;
+
+    warnIfRedteamConfigHasNoTests(config, testSuite);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/test/providers/xai/chat.test.ts
+++ b/test/providers/xai/chat.test.ts
@@ -499,9 +499,7 @@ describe('xAI Chat Provider', () => {
       // Unknown model
       expect(calculateXAICost('invalid-model', {}, 600, 400)).toBe(undefined);
       // Missing token counts
-      expect(calculateXAICost('grok-2-1212', {}, undefined as any, undefined as any)).toBe(
-        undefined,
-      );
+      expect(calculateXAICost('grok-2-1212', {})).toBe(undefined);
       expect(calculateXAICost('grok-2-1212', {}, 0, 0)).toBe(undefined);
     });
 

--- a/test/redteam/providers/goat.test.ts
+++ b/test/redteam/providers/goat.test.ts
@@ -2,11 +2,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import RedteamGoatProvider from '../../../src/redteam/providers/goat';
 import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import { createMockProvider } from '../../factories/provider';
-import type { Mock } from 'vitest';
 
 import type {
   ApiProvider,
@@ -156,7 +155,7 @@ describe('RedteamGoatProvider', () => {
     });
   });
 
-  it('should enforce maxCharsPerMessage from provider config without cliState', async () => {
+  it('should enforce maxCharsPerMessage from provider config', async () => {
     const provider = new RedteamGoatProvider({
       injectVar: 'goal',
       maxCharsPerMessage: 5,
@@ -483,7 +482,7 @@ describe('RedteamGoatProvider', () => {
       completion: 5,
     });
 
-    // Mock grader to fail (indicating success)
+    // Mock grader with pass:false (attack succeeded / jailbreak detected)
     (mockGrader.getResult as any).mockResolvedValue({
       grade: {
         pass: false,
@@ -602,7 +601,7 @@ describe('RedteamGoatProvider', () => {
         completion: 5,
       });
 
-      // Mock grader to fail on first attempt (indicating success)
+      // Mock grader with pass:false on first attempt (indicating attack success)
       (mockGrader.getResult as any).mockResolvedValue({
         grade: {
           pass: false,

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -294,13 +294,10 @@ describe('RateLimitRegistry', () => {
     });
 
     it.each([
-      { input: 0, expected: 0 },
-      { input: 5, expected: 5 },
-      { input: '2', expected: 2 },
-    ])('should forward maxRetriesOverride=$expected for provider config.maxRetries=$input', async ({
-      input,
-      expected,
-    }) => {
+      [0, 0],
+      [5, 5],
+      ['2', 2],
+    ])('should forward provider config.maxRetries %p as maxRetriesOverride %p', async (input, expected) => {
       mockState.executeWithRetry.mockResolvedValue('result');
       const registry = new RateLimitRegistry({ maxConcurrency: 10 });
       const provider = {
@@ -318,16 +315,14 @@ describe('RateLimitRegistry', () => {
     });
 
     it.each([
-      { label: 'negative number', input: -1 },
-      { label: 'non-integer number', input: 2.5 },
-      { label: 'non-integer string', input: '2.5' },
+      ['negative number', -1],
+      ['non-integer number', 2.5],
+      ['non-integer string', '2.5'],
       // Digit strings that overflow to Infinity / lose precision would cause
       // unbounded retry loops if accepted — reject them.
-      { label: 'unsafe-integer string', input: '1' + '0'.repeat(400) },
-      { label: 'above MAX_SAFE_INTEGER', input: String(Number.MAX_SAFE_INTEGER) + '0' },
-    ])('should warn and forward maxRetriesOverride=undefined for invalid $label ($input)', async ({
-      input,
-    }) => {
+      ['unsafe-integer string', '1' + '0'.repeat(400)],
+      ['above MAX_SAFE_INTEGER', String(Number.MAX_SAFE_INTEGER) + '0'],
+    ])('should warn and forward maxRetriesOverride=undefined for invalid %s (%p)', async (_label, input) => {
       mockState.executeWithRetry.mockResolvedValue('result');
       const logger = (await import('../../src/logger')).default;
       const warnSpy = vi.mocked(logger.warn);

--- a/test/tracing/localSpanExporter.test.ts
+++ b/test/tracing/localSpanExporter.test.ts
@@ -57,7 +57,7 @@ describe('LocalSpanExporter', () => {
         traceFlags: 1,
         isRemote: false,
       }),
-      // SDK 2.x uses parentSpanContext instead of parentSpanId
+      // OpenTelemetry SDK 2.x uses parentSpanContext instead of parentSpanId
       parentSpanContext: overrides.parentSpanId
         ? { traceId, spanId: overrides.parentSpanId, traceFlags: 1, isRemote: false }
         : undefined,
@@ -135,7 +135,8 @@ describe('LocalSpanExporter', () => {
       expect(mockAddSpans).toHaveBeenCalledTimes(2);
 
       // First call for trace-1 with 2 spans
-      expect(mockAddSpans).toHaveBeenCalledWith(
+      expect(mockAddSpans).toHaveBeenNthCalledWith(
+        1,
         'trace-1',
         expect.arrayContaining([
           expect.objectContaining({ spanId: 'span-1' }),
@@ -145,7 +146,8 @@ describe('LocalSpanExporter', () => {
       );
 
       // Second call for trace-2 with 1 span
-      expect(mockAddSpans).toHaveBeenCalledWith(
+      expect(mockAddSpans).toHaveBeenNthCalledWith(
+        2,
         'trace-2',
         [expect.objectContaining({ spanId: 'span-3' })],
         { skipTraceCheck: false, warnIfMissingTrace: false },
@@ -154,30 +156,34 @@ describe('LocalSpanExporter', () => {
 
     it('retries once when the trace record is not visible yet', async () => {
       vi.useFakeTimers();
-      const span = createMockSpan();
+      try {
+        const span = createMockSpan();
 
-      mockAddSpans
-        .mockResolvedValueOnce({ stored: false, reason: 'Trace trace-id-123 not found' })
-        .mockResolvedValueOnce({ stored: true });
+        mockAddSpans
+          .mockResolvedValueOnce({ stored: false, reason: 'Trace trace-id-123 not found' })
+          .mockResolvedValueOnce({ stored: true });
 
-      const resultPromise = exportSpans([span]);
-      await vi.advanceTimersByTimeAsync(50);
-      const result = await resultPromise;
+        const resultPromise = exportSpans([span]);
+        await vi.advanceTimersByTimeAsync(50);
+        const result = await resultPromise;
 
-      expect(result.code).toBe(ExportResultCode.SUCCESS);
-      expect(mockAddSpans).toHaveBeenCalledTimes(2);
-      expect(mockAddSpans).toHaveBeenNthCalledWith(
-        1,
-        'trace-id-123',
-        [expect.objectContaining({ spanId: 'span-id-456' })],
-        { skipTraceCheck: false, warnIfMissingTrace: false },
-      );
-      expect(mockAddSpans).toHaveBeenNthCalledWith(
-        2,
-        'trace-id-123',
-        [expect.objectContaining({ spanId: 'span-id-456' })],
-        { skipTraceCheck: false, warnIfMissingTrace: false },
-      );
+        expect(result.code).toBe(ExportResultCode.SUCCESS);
+        expect(mockAddSpans).toHaveBeenCalledTimes(2);
+        expect(mockAddSpans).toHaveBeenNthCalledWith(
+          1,
+          'trace-id-123',
+          [expect.objectContaining({ spanId: 'span-id-456' })],
+          { skipTraceCheck: false, warnIfMissingTrace: false },
+        );
+        expect(mockAddSpans).toHaveBeenNthCalledWith(
+          2,
+          'trace-id-123',
+          [expect.objectContaining({ spanId: 'span-id-456' })],
+          { skipTraceCheck: false, warnIfMissingTrace: false },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should convert span times to milliseconds', async () => {


### PR DESCRIPTION
## Summary
- Add coverage for redteam configs that use scenarios without tests
- Tighten AI-suggested test quality issues across xAI cost, GOAT provider, rate limit registry, and local span exporter tests
- Clarify grader comments, parameterized test names, OpenTelemetry wording, and span grouping order assertions

## Verification
- `npm run l`
- `npm run f`
- `npm run tsc`
- `npx vitest run test/commands/eval/redteamWarning.test.ts test/providers/xai/chat.test.ts test/redteam/providers/goat.test.ts test/scheduler/rateLimitRegistry.test.ts test/tracing/localSpanExporter.test.ts`
- `npm test`