### PR TITLE
test(redteam): isolate GOAT provider mocks

### DIFF
--- a/test/redteam/providers/goat.test.ts
+++ b/test/redteam/providers/goat.test.ts
@@ -102,6 +102,11 @@ describe('RedteamGoatProvider', () => {
   };
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGraderById.mockReset();
+    mockGetGraderById.mockReturnValue(mockGrader);
+    mockGrader.getResult.mockReset();
+
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-goat-provider-'));
     mockFetch = vi.fn().mockImplementation(async function () {
       return {
@@ -112,14 +117,12 @@ describe('RedteamGoatProvider', () => {
         ok: true,
       };
     });
-    global.fetch = mockFetch as unknown as typeof fetch;
-
-    // Reset mocks
-    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- reset GOAT grader mocks before each test so mock implementations do not leak between randomized Vitest cases
- use Vitest global stubbing for fetch and restore globals after each GOAT provider test

## Verification
- npm run l
- npm run f
- npx vitest run test/commands/eval/redteamWarning.test.ts test/providers/xai/chat.test.ts test/redteam/providers/goat.test.ts test/scheduler/rateLimitRegistry.test.ts test/tracing/localSpanExporter.test.ts

## Notes
- Opened ready for review per request.