### PR TITLE
chore(deps): bump protobufjs to 7.5.5 via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12713,9 +12713,9 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -12794,9 +12794,9 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -32447,9 +32447,9 @@
       "optional": true
     },
     "node_modules/onnxruntime-web/node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,


### PR DESCRIPTION
## Summary

- Ran `npm audit fix` to resolve a critical-severity advisory flagged by npm audit
- Bumps transitive `protobufjs` from 7.5.4 → 7.5.5 in three nested lockfile entries (`@opentelemetry/exporter-logs-otlp-http`, `@opentelemetry/otlp-transformer`, `onnxruntime-web`)
- No direct dependencies changed; `package.json` is untouched

## Test plan

- [ ] CI passes (install, build, lint, tests)
- [ ] `npm audit` reports 0 vulnerabilities after install