### PR TITLE
fix(eval): harden grouped serial grading against edge cases

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -694,11 +694,11 @@ export async function runAssertions({
     }
   }
 
-  // When the grouping queue is active (serial mode with model-graded assertions),
-  // dispatching assertions concurrently lets per-assertion preprocessing reorder
-  // enqueues relative to declaration, which can split groups and defeat the
-  // single-judge-drain guarantee. Serialize so the queue can group by provider
-  // ID deterministically.
+  // When the grouping queue is active (serial mode with model-graded
+  // assertions), dispatching assertions concurrently lets per-assertion
+  // preprocessing reorder enqueues relative to declaration, which can split
+  // groups so judges for one provider no longer run contiguously. Serialize
+  // so the queue can group by provider ID deterministically.
   const concurrency = getProviderCallExecutionContext()?.providerCallQueue
     ? 1
     : ASSERTIONS_MAX_CONCURRENCY;

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -21,6 +21,7 @@ import {
 import { matchesSimilarity } from '../matchers/similarity';
 import { isPackagePath, loadFromPackage } from '../providers/packageParser';
 import { runPython } from '../python/pythonUtils';
+import { getProviderCallExecutionContext } from '../scheduler/providerCallExecutionContext';
 import { generateSpanId, generateTraceparent } from '../tracing/evaluatorTracing';
 import { getTraceStore } from '../tracing/store';
 import {
@@ -693,36 +694,41 @@ export async function runAssertions({
     }
   }
 
-  await async.forEachOfLimit(
-    asserts,
-    ASSERTIONS_MAX_CONCURRENCY,
-    async ({ assertion, assertResult, index }) => {
-      if (assertion.type.startsWith('select-') || assertion.type === 'max-score') {
-        // Select-type and max-score assertions are handled separately because they depend on multiple outputs.
-        return;
-      }
+  // When the grouping queue is active (serial mode with model-graded assertions),
+  // dispatching assertions concurrently lets per-assertion preprocessing reorder
+  // enqueues relative to declaration, which can split groups and defeat the
+  // single-judge-drain guarantee. Serialize so the queue can group by provider
+  // ID deterministically.
+  const concurrency = getProviderCallExecutionContext()?.providerCallQueue
+    ? 1
+    : ASSERTIONS_MAX_CONCURRENCY;
 
-      const result = await runAssertion({
-        prompt,
-        provider,
-        providerResponse,
-        assertion,
-        test,
-        vars,
-        latencyMs,
-        assertIndex: index,
-        traceId,
-        traceData: preloadedTraceData,
-      });
+  await async.forEachOfLimit(asserts, concurrency, async ({ assertion, assertResult, index }) => {
+    if (assertion.type.startsWith('select-') || assertion.type === 'max-score') {
+      // Select-type and max-score assertions are handled separately because they depend on multiple outputs.
+      return;
+    }
 
-      assertResult.addResult({
-        index,
-        result,
-        metric: renderMetricName(assertion.metric, vars || test.vars || {}),
-        weight: assertion.weight,
-      });
-    },
-  );
+    const result = await runAssertion({
+      prompt,
+      provider,
+      providerResponse,
+      assertion,
+      test,
+      vars,
+      latencyMs,
+      assertIndex: index,
+      traceId,
+      traceData: preloadedTraceData,
+    });
+
+    assertResult.addResult({
+      index,
+      result,
+      metric: renderMetricName(assertion.metric, vars || test.vars || {}),
+      weight: assertion.weight,
+    });
+  });
 
   await async.forEach(subAssertResults, async (subAssertResult) => {
     const result = await subAssertResult.testResult();

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -694,11 +694,8 @@ export async function runAssertions({
     }
   }
 
-  // When the grouping queue is active (serial mode with model-graded
-  // assertions), dispatching assertions concurrently lets per-assertion
-  // preprocessing reorder enqueues relative to declaration, which can split
-  // groups so judges for one provider no longer run contiguously. Serialize
-  // so the queue can group by provider ID deterministically.
+  // Serialize when the grouping queue is active: concurrent dispatch can
+  // reorder provider enqueues and split same-judge groups.
   const concurrency = getProviderCallExecutionContext()?.providerCallQueue
     ? 1
     : ASSERTIONS_MAX_CONCURRENCY;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -536,37 +536,37 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   row.gradingResult = checkResult;
 }
 
+const ABORTED_GRADING_PREFIX = 'Aborted: ';
+
 function isAbortShapedError(error: unknown): boolean {
   return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
 }
 
 function applyGradingError(row: EvaluateResult, error: unknown, abortSignal?: AbortSignal) {
-  const errorMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  // Treat the failure as abort-originated only when the evaluator's abort
-  // signal is actually tripped AND the caught error looks like an abort.
-  // Either alone would misclassify: a third-party SDK that throws `AbortError`
-  // during a non-aborted run is a real bug, and a genuine SyntaxError caught
-  // microseconds after an unrelated abort fires is also a real bug.
+  const errorAsError = error instanceof Error ? error : undefined;
+  // Require both signals: a third-party SDK that throws `AbortError` during a
+  // non-aborted run is a real bug, and a real SyntaxError caught microseconds
+  // after an unrelated abort is also a real bug.
   const aborted = Boolean(abortSignal?.aborted) && isAbortShapedError(error);
 
   if (aborted) {
-    // Keep the stack at debug for ops support while skipping the error-level
-    // noise users complained about on graceful shutdown. The "Aborted: "
-    // prefix on row.error is a stable sentinel so downstream consumers and
-    // the report UI can filter aborted rows out of genuine-failure counts.
+    // Skip stack serialization on the abort path — debug logs usually go
+    // unread and a noisy shutdown can fire this per row.
+    const shortMessage = errorAsError?.message ?? String(error);
     logger.debug('Assertion grading aborted', {
-      error: errorMessage,
+      error: shortMessage,
       promptIdx: row.promptIdx,
       testIdx: row.testIdx,
     });
-    row.error = `Aborted: ${error instanceof Error ? error.message : String(error)}`;
+    row.error = `${ABORTED_GRADING_PREFIX}${shortMessage}`;
   } else {
+    const fullMessage = errorAsError ? (errorAsError.stack ?? errorAsError.message) : String(error);
     logger.error('Assertion grading failed during eval', {
-      error: errorMessage,
+      error: fullMessage,
       promptIdx: row.promptIdx,
       testIdx: row.testIdx,
     });
-    row.error = errorMessage;
+    row.error = fullMessage;
   }
   row.failureReason = ResultFailureReason.ERROR;
   row.success = false;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -536,21 +536,38 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   row.gradingResult = checkResult;
 }
 
+function isAbortShapedError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
+}
+
 function applyGradingError(row: EvaluateResult, error: unknown, abortSignal?: AbortSignal) {
   const errorMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  // Don't log when the grading failure is caused by a user-initiated abort;
-  // the non-deferred path handles this via the combinedAbortSignal.aborted check.
-  const isAbortError =
-    abortSignal?.aborted ||
-    (error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException'));
-  if (!isAbortError) {
+  // Treat the failure as abort-originated only when the evaluator's abort
+  // signal is actually tripped AND the caught error looks like an abort.
+  // Either alone would misclassify: a third-party SDK that throws `AbortError`
+  // during a non-aborted run is a real bug, and a genuine SyntaxError caught
+  // microseconds after an unrelated abort fires is also a real bug.
+  const aborted = Boolean(abortSignal?.aborted) && isAbortShapedError(error);
+
+  if (aborted) {
+    // Keep the stack at debug for ops support while skipping the error-level
+    // noise users complained about on graceful shutdown. The "Aborted: "
+    // prefix on row.error is a stable sentinel so downstream consumers and
+    // the report UI can filter aborted rows out of genuine-failure counts.
+    logger.debug('Assertion grading aborted', {
+      error: errorMessage,
+      promptIdx: row.promptIdx,
+      testIdx: row.testIdx,
+    });
+    row.error = `Aborted: ${error instanceof Error ? error.message : String(error)}`;
+  } else {
     logger.error('Assertion grading failed during eval', {
       error: errorMessage,
       promptIdx: row.promptIdx,
       testIdx: row.testIdx,
     });
+    row.error = errorMessage;
   }
-  row.error = errorMessage;
   row.failureReason = ResultFailureReason.ERROR;
   row.success = false;
   row.score = 0;
@@ -3441,12 +3458,14 @@ class Evaluator {
       // Best-effort: flush any rows whose target calls completed but whose
       // deferred grading hadn't started/completed yet, so a mid-eval interrupt
       // doesn't lose the already-computed target outputs. Failures here must
-      // not shadow the original error.
+      // not shadow the original error, so we log and rethrow the outer error.
+      const pendingRowCount = groupedRows.reduce((sum, entry) => sum + entry.rows.length, 0);
       try {
         await flushGroupedRows();
       } catch (flushError) {
-        logger.debug('Failed to flush grouped rows after error', {
+        logger.warn('Failed to flush grouped rows after error; target outputs may be lost', {
           error: flushError instanceof Error ? flushError.message : String(flushError),
+          pendingRowCount,
         });
       }
       throw error;

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -471,6 +471,48 @@ function shouldDeferGradingForTest(test: AtomicTestCase): boolean {
   return Boolean(test.assert?.some(hasProviderGroupedAssertion));
 }
 
+function logGroupedGradingStatus({
+  concurrency,
+  hasEvalStepTimeout,
+  runEvalOptions,
+  shouldGroupGradingByProvider,
+  usesConversationVar,
+}: {
+  concurrency: number;
+  hasEvalStepTimeout: boolean;
+  runEvalOptions: RunEvalOptions[];
+  shouldGroupGradingByProvider: boolean;
+  usesConversationVar: boolean;
+}) {
+  const hasModelGradedAssertion = runEvalOptions.some(({ test }) =>
+    shouldDeferGradingForTest(test),
+  );
+  if (!hasModelGradedAssertion) {
+    return;
+  }
+  if (shouldGroupGradingByProvider) {
+    logger.info(
+      'Grouping model-graded assertions by provider to minimize local-model reload overhead.',
+    );
+    return;
+  }
+  if (concurrency !== 1) {
+    return;
+  }
+  const reasons: string[] = [];
+  if (hasEvalStepTimeout) {
+    reasons.push('per-eval-step timeout is configured');
+  }
+  if (usesConversationVar) {
+    reasons.push('conversation variables require per-row ordering');
+  }
+  if (reasons.length > 0) {
+    logger.info(
+      `Serial grading grouping disabled because ${reasons.join(' and ')}; model-graded judges may reload between rows.`,
+    );
+  }
+}
+
 function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   if (!checkResult.pass) {
     row.error = checkResult.reason;
@@ -494,13 +536,20 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   row.gradingResult = checkResult;
 }
 
-function applyGradingError(row: EvaluateResult, error: unknown) {
+function applyGradingError(row: EvaluateResult, error: unknown, abortSignal?: AbortSignal) {
   const errorMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  logger.error('Assertion grading failed during eval', {
-    error: errorMessage,
-    promptIdx: row.promptIdx,
-    testIdx: row.testIdx,
-  });
+  // Don't log when the grading failure is caused by a user-initiated abort;
+  // the non-deferred path handles this via the combinedAbortSignal.aborted check.
+  const isAbortError =
+    abortSignal?.aborted ||
+    (error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException'));
+  if (!isAbortError) {
+    logger.error('Assertion grading failed during eval', {
+      error: errorMessage,
+      promptIdx: row.promptIdx,
+      testIdx: row.testIdx,
+    });
+  }
   row.error = errorMessage;
   row.failureReason = ResultFailureReason.ERROR;
   row.success = false;
@@ -1091,7 +1140,7 @@ async function gradeRunEvalResponse({
           traceId,
         }).then((checkResult) => applyGradingResult(ret, checkResult)),
     ).catch((error) => {
-      applyGradingError(ret, error);
+      applyGradingError(ret, error, abortSignal);
     });
     deferredGradingPromises.set(ret, gradingPromise);
     return;
@@ -3389,7 +3438,17 @@ class Evaluator {
         }
       }
     } catch (error) {
-      await flushGroupedRows();
+      // Best-effort: flush any rows whose target calls completed but whose
+      // deferred grading hadn't started/completed yet, so a mid-eval interrupt
+      // doesn't lose the already-computed target outputs. Failures here must
+      // not shadow the original error.
+      try {
+        await flushGroupedRows();
+      } catch (flushError) {
+        logger.debug('Failed to flush grouped rows after error', {
+          error: flushError instanceof Error ? flushError.message : String(flushError),
+        });
+      }
       throw error;
     }
 
@@ -4275,6 +4334,14 @@ class Evaluator {
           `Running ${concurrentRunEvalOptions.length} test cases (up to ${concurrency} at a time)...`,
         );
       }
+
+      logGroupedGradingStatus({
+        concurrency,
+        hasEvalStepTimeout,
+        runEvalOptions,
+        shouldGroupGradingByProvider,
+        usesConversationVar,
+      });
     }
 
     // Now start the progress bar after info messages

--- a/test/evaluator/gradingConcurrency.test.ts
+++ b/test/evaluator/gradingConcurrency.test.ts
@@ -478,4 +478,137 @@ describeEvaluator('evaluator grading concurrency', () => {
     expect(gradingCacheMissCount).toBe(2);
     expect(gradingProvider.callApi).toHaveBeenCalledTimes(4);
   });
+
+  it('serializes async assert-set judges so grouping survives PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY', async () => {
+    // Regression: without forcing assertion concurrency to 1 when the grouping
+    // queue is active, async graders inside an assert-set would interleave
+    // judges across rows (judge-one row1, judge-two row1, judge-one row2, ...)
+    // and defeat the single-judge-drain guarantee.
+    const callOrder: string[] = [];
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const makeAsyncJudge = (id: string): ApiProvider => ({
+      id: vi.fn().mockReturnValue(id),
+      callApi: vi.fn(async () => {
+        // Yield to the event loop a few times to expose any interleaving that
+        // `async.forEachOfLimit(ASSERTIONS_MAX_CONCURRENCY)` would produce.
+        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        callOrder.push(id);
+        return {
+          output: JSON.stringify({ pass: true, score: 1, reason: `${id} passed` }),
+          tokenUsage: createEmptyTokenUsage(),
+        };
+      }),
+    });
+    const judgeOne = makeAsyncJudge('judge-one');
+    const judgeTwo = makeAsyncJudge('judge-two');
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [
+            {
+              type: 'assert-set',
+              assert: [
+                { type: 'llm-rubric', value: 'Judge alpha one', provider: judgeOne },
+                { type: 'llm-rubric', value: 'Judge alpha two', provider: judgeTwo },
+              ],
+            },
+          ],
+        },
+        {
+          vars: { topic: 'beta' },
+          assert: [
+            {
+              type: 'assert-set',
+              assert: [
+                { type: 'llm-rubric', value: 'Judge beta one', provider: judgeOne },
+                { type: 'llm-rubric', value: 'Judge beta two', provider: judgeTwo },
+              ],
+            },
+          ],
+        },
+        {
+          vars: { topic: 'gamma' },
+          assert: [
+            {
+              type: 'assert-set',
+              assert: [
+                { type: 'llm-rubric', value: 'Judge gamma one', provider: judgeOne },
+                { type: 'llm-rubric', value: 'Judge gamma two', provider: judgeTwo },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(summary.stats.successes).toBe(3);
+    expect(callOrder).toEqual([
+      'judge-one',
+      'judge-one',
+      'judge-one',
+      'judge-two',
+      'judge-two',
+      'judge-two',
+    ]);
+  });
+
+  it('does not log error-level message when deferred grading is aborted', async () => {
+    const { default: logger } = await import('../../src/logger');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    const abortController = new AbortController();
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => {
+        abortController.abort();
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {
+      maxConcurrency: 1,
+      abortSignal: abortController.signal,
+    });
+
+    const gradingErrorLogs = errorSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('Assertion grading failed'),
+    );
+    expect(gradingErrorLogs).toHaveLength(0);
+
+    errorSpy.mockRestore();
+  });
 });

--- a/test/evaluator/gradingConcurrency.test.ts
+++ b/test/evaluator/gradingConcurrency.test.ts
@@ -609,6 +609,324 @@ describeEvaluator('evaluator grading concurrency', () => {
     );
     expect(gradingErrorLogs).toHaveLength(0);
 
+    const failedResult = (await evalRecord.toEvaluateSummary()).results.find(
+      (result) => result.vars.topic === 'alpha',
+    );
+    expect(failedResult?.error).toMatch(/^Aborted: /);
+
     errorSpy.mockRestore();
+  });
+
+  it('suppresses the error log when deferred grading throws AbortException under abort', async () => {
+    const { default: logger } = await import('../../src/logger');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    const abortController = new AbortController();
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => {
+        abortController.abort();
+        const abortException = new Error('Python provider cancelled');
+        abortException.name = 'AbortException';
+        throw abortException;
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {
+      maxConcurrency: 1,
+      abortSignal: abortController.signal,
+    });
+
+    const gradingErrorLogs = errorSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('Assertion grading failed'),
+    );
+    expect(gradingErrorLogs).toHaveLength(0);
+
+    errorSpy.mockRestore();
+  });
+
+  it('still logs error-level when abort-shaped error fires WITHOUT an aborted signal', async () => {
+    // Regression guard: third-party SDKs sometimes surface unrelated cancellation
+    // as AbortError. If the evaluator's abort signal is NOT tripped, these are
+    // real bugs and must still surface at error level.
+    const { default: logger } = await import('../../src/logger');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => {
+        const sdkAbortLookalike = new Error('fetch aborted by keepalive');
+        sdkAbortLookalike.name = 'AbortError';
+        throw sdkAbortLookalike;
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+
+    const gradingErrorLogs = errorSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('Assertion grading failed'),
+    );
+    expect(gradingErrorLogs.length).toBeGreaterThanOrEqual(1);
+
+    const summary = await evalRecord.toEvaluateSummary();
+    expect(summary.stats.errors).toBe(1);
+    expect(summary.results[0].failureReason).toBe(ResultFailureReason.ERROR);
+    expect(summary.results[0].error).not.toMatch(/^Aborted: /);
+
+    errorSpy.mockRestore();
+  });
+
+  it('still logs error when a non-abort-shaped error fires during an unrelated abort', async () => {
+    // Regression guard: if abort is in flight but the caught error is a real
+    // bug (SyntaxError, TypeError, etc.), we must not silently suppress it.
+    const { default: logger } = await import('../../src/logger');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    const abortController = new AbortController();
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => {
+        abortController.abort();
+        throw new SyntaxError('Unexpected token in grader output');
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {
+      maxConcurrency: 1,
+      abortSignal: abortController.signal,
+    });
+
+    const gradingErrorLogs = errorSpy.mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('Assertion grading failed'),
+    );
+    expect(gradingErrorLogs.length).toBeGreaterThanOrEqual(1);
+
+    errorSpy.mockRestore();
+  });
+
+  it('logs grouping-active info when serial eval contains model-graded assertions', async () => {
+    const { default: logger } = await import('../../src/logger');
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => ({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+
+    const groupingLogs = infoSpy.mock.calls.filter(
+      ([message]) =>
+        typeof message === 'string' &&
+        message.includes('Grouping model-graded assertions by provider'),
+    );
+    expect(groupingLogs).toHaveLength(1);
+
+    infoSpy.mockRestore();
+  });
+
+  it('does not log grouping info when there are no model-graded assertions', async () => {
+    const { default: logger } = await import('../../src/logger');
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt {{topic}}')],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'contains', value: 'Target' }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+
+    const groupingLogs = infoSpy.mock.calls.filter(
+      ([message]) =>
+        typeof message === 'string' &&
+        (message.includes('Grouping model-graded assertions by provider') ||
+          message.includes('Serial grading grouping disabled')),
+    );
+    expect(groupingLogs).toHaveLength(0);
+
+    infoSpy.mockRestore();
+  });
+
+  it('logs grouping-disabled reason when conversation var forces per-row ordering', async () => {
+    const { default: logger } = await import('../../src/logger');
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async () => ({
+        output: 'Target output',
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => ({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [
+        toPrompt('{% for turn in _conversation %}{{ turn.input }}{% endfor %}Current: {{topic}}'),
+      ],
+      tests: [
+        {
+          vars: { topic: 'alpha' },
+          assert: [{ type: 'llm-rubric', value: 'Judge alpha', provider: judge }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+
+    const disabledLogs = infoSpy.mock.calls.filter(
+      ([message]) =>
+        typeof message === 'string' &&
+        message.includes('Serial grading grouping disabled') &&
+        message.includes('conversation variables'),
+    );
+    expect(disabledLogs).toHaveLength(1);
+
+    infoSpy.mockRestore();
+  });
+
+  it('keeps parallel assertion dispatch when the grouping queue is NOT active', async () => {
+    // Regression guard for the `? 1 : ASSERTIONS_MAX_CONCURRENCY` ternary in
+    // runAssertions. Without the queue present (non-deferred concurrent eval),
+    // per-test assertions must still fan out so we don't silently 3x-throttle
+    // normal eval users.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('target-provider'),
+      callApi: vi.fn(async (prompt: string) => ({
+        output: `Target output for ${prompt}`,
+        tokenUsage: createEmptyTokenUsage(),
+      })),
+    };
+    const judge: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        inFlight -= 1;
+        return {
+          output: JSON.stringify({ pass: true, score: 1, reason: 'ok' }),
+          tokenUsage: createEmptyTokenUsage(),
+        };
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          assert: [
+            { type: 'llm-rubric', value: 'Judge one', provider: judge },
+            { type: 'llm-rubric', value: 'Judge two', provider: judge },
+            { type: 'llm-rubric', value: 'Judge three', provider: judge },
+          ],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    // maxConcurrency > 1 takes the non-grouped path where the queue is absent.
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 5 });
+
+    expect(inFlight).toBe(0);
+    expect(maxInFlight).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #8509 that addresses four edge-case gaps found while reviewing the provider-grouped grading path. None of these block the original fix, but together they close the corners where Ollama users (#8391) could still see thrash or lose observability.

- **Deterministic assertion ordering (P0):** when the grouping queue is active, force per-test assertion concurrency to 1 so that async preprocessing inside individual assertion handlers cannot reorder enqueues relative to declaration order. Without this, `PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY` (default 3) can split groups for assert-sets and multi-judge tests where per-assertion preprocessing is uneven.
- **Abort-safe deferred grading (P1):** pass the evaluator abort signal into `applyGradingError` and suppress the `error`-level `"Assertion grading failed during eval"` log when the failure was caused by a user abort. Mirrors the non-deferred path's `combinedAbortSignal.aborted` check at `src/evaluator.ts:3304-3320`.
- **Observability when grouping is disabled (P1):** emit an info log when a serial eval contains model-graded assertions, stating whether grouping is active or why it was disabled (per-eval-step timeout or `_conversation` variable). Users hitting the original Ollama-reload case can now confirm the fix is live rather than guessing why their judges are still thrashing.
- **Interrupt robustness (P1):** wrap the recovery `flushGroupedRows()` call in the error path of `runGroupedEvalSteps` so a failure while flushing cannot shadow the original error from the user's eval loop.

## Why
Reviewing the merged PR #8509 surfaced four gaps:
1. `ASSERTIONS_MAX_CONCURRENCY=3` could let assertion dispatch interleave judges when per-assertion preprocessing is uneven, silently defeating the single-judge-drain guarantee inside an `assert-set` or multi-judge test.
2. Deferred grading's `applyGradingError` logged at `error` level even when the evaluator had been aborted, flooding user logs on graceful shutdown.
3. Users with a configured `timeoutMs` or using `_conversation` variables silently fell off the grouped path; there was no way to tell grouping was disabled.
4. If `flushGroupedRows()` threw during post-error cleanup, it would mask the original error.

## Validation
- `nvm use` (Node 24.15.0, npm 11.12.1)
- `npm run l && npm run f` (one pre-existing complexity warning on `runAssertion` unrelated to this PR)
- `npm run tsc`
- `npx vitest run test/evaluator/ test/assertions/contains.test.ts test/matchers/` - 487 tests pass
- New regression tests:
  - `serializes async assert-set judges so grouping survives PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY` — 3 rows × 2 judges in an `assert-set` with async graders, asserts `[judge-one, judge-one, judge-one, judge-two, judge-two, judge-two]`.
  - `does not log error-level message when deferred grading is aborted` — spies on `logger.error`, triggers abort mid-grading, asserts no "Assertion grading failed" message was logged.

## Test plan
- [x] Unit tests pass locally (`npx vitest run test/evaluator/`)
- [x] Type check passes (`npm run tsc`)
- [x] Lint and format pass (`npm run l && npm run f`)
- [ ] CI green

Refs #8391, #8509

🤖 Generated with [Claude Code](https://claude.com/claude-code)