### PR TITLE
test(redteam): cover non-string best-of-n candidates

### DIFF
--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -143,6 +143,34 @@ describe('BestOfNProvider - Runtime Behavior', () => {
   });
 
   it.each([
+    42,
+    true,
+    null,
+    { prompt: 'candidate 0' },
+  ])('should skip non-string candidate prompt from remote generation: %j', async (invalidPrompt) => {
+    const provider = new BestOfNProvider({
+      injectVar: 'input',
+    });
+    const context = createMockContext(mockTargetProvider);
+
+    mockFetchWithProxy.mockResolvedValue({
+      json: async () => ({
+        modifiedPrompts: [invalidPrompt, 'candidate 2'],
+      }),
+    });
+
+    await provider.callApi('test prompt', context);
+
+    expect(mockRenderPrompt).toHaveBeenCalledTimes(1);
+    expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(mockTargetProvider.callApi).toHaveBeenCalledWith(
+      'candidate 2',
+      expect.any(Object),
+      undefined,
+    );
+  });
+
+  it.each([
     'file://etc/passwd',
     ' FILE://etc/passwd',
     '\tFiLe://etc/passwd',


### PR DESCRIPTION
## Summary
Add regression coverage for the recent `BestOfNProvider` guard that skips malformed non-string candidate prompts returned by remote generation.

## Why
The production path now defends against malformed `modifiedPrompts` entries, but the runtime test file only covered unsafe string schemes like `file://` and `package:`. That left the non-string branch untested.

## Root cause
Remote generation responses are JSON and can contain malformed values. Without a regression test, a future change could accidentally start forwarding numbers, booleans, `null`, or objects to `renderPrompt` and the target provider.

## Fix
Add a focused parameterized test in `test/redteam/providers/bestOfN.test.ts` that feeds non-string candidates alongside a valid fallback candidate and asserts only the valid string candidate is rendered and executed.

## Validation
- `npx vitest run test/redteam/providers/bestOfN.test.ts`
- `npm run l`
- `npm run f`