### PR TITLE
test: isolate env mutations in root tests

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/assertions/assertionResult.test.ts",
         "!!test/assertions/trace.test.ts",
         "!!test/cache.test.ts",
         "!!test/code-scan-action/main.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/index.test.ts",
         "!!test/providers/litellm.test.ts",
         "!!test/providers/openai-codex-sdk.e2e.test.ts",
         "!!test/providers/openai-codex-sdk.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/constants.test.ts",
         "!!test/database.test.ts",
         "!!test/envars.test.ts",
         "!!test/evaluatorHelpers.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/image.test.ts",
         "!!test/providers/google/live.test.ts",
         "!!test/providers/google/provider.test.ts",
         "!!test/providers/google/video.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/defaults.test.ts",
         "!!test/providers/elevenlabs/agents/index.test.ts",
         "!!test/providers/elevenlabs/alignment/index.test.ts",
         "!!test/providers/elevenlabs/history/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/ai.studio.test.ts",
         "!!test/providers/google/auth.test.ts",
         "!!test/providers/google/gemini-image.test.ts",
         "!!test/providers/google/image.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/redteam/extraction/purpose.test.ts",
         "!!test/redteam/plugins/teenSafety.test.ts",
         "!!test/redteam/providers/shared.test.ts",
         "!!test/sagemaker.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/prompts/index.test.ts",
         "!!test/providers.slack.test.ts",
         "!!test/providers.test.ts",
         "!!test/providers/anthropic/completion.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/commands/modelScan.test.ts",
         "!!test/constants.test.ts",
         "!!test/database.test.ts",
         "!!test/envars.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/litellm.test.ts",
         "!!test/providers/openai-codex-sdk.e2e.test.ts",
         "!!test/providers/openai-codex-sdk.test.ts",
         "!!test/providers/openai/chat.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/azure/completion.test.ts",
         "!!test/providers/azure/responses.test.ts",
         "!!test/providers/bedrock.agents.test.ts",
         "!!test/providers/bedrock/converse.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/transform.test.ts",
         "!!test/util/utils.test.ts"
         // END direct process.env mutation legacy allowlist
       ],

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/bedrock/index.test.ts",
         "!!test/providers/bedrock/knowledgeBase.test.ts",
         "!!test/providers/claude-agent-sdk.test.ts",
         "!!test/providers/cloudflare-ai.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/tracing/evaluatorTracing.test.ts",
         "!!test/util/apiHealth.test.ts",
         "!!test/util/config/load.test.ts",
         "!!test/util/env.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/bedrock/converse.test.ts",
         "!!test/providers/bedrock/index.test.ts",
         "!!test/providers/bedrock/knowledgeBase.test.ts",
         "!!test/providers/claude-agent-sdk.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/config/load.test.ts",
         "!!test/util/env.test.ts",
         "!!test/util/file.test.ts",
         "!!test/util/json.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/fetch.test.ts",
         "!!test/globalConfig/cloud.test.ts",
         "!!test/logger.test.ts",
         "!!test/matchers/utils.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/realtime.test.ts",
         "!!test/providers/openclaw.test.ts",
         "!!test/providers/openrouter.test.ts",
         "!!test/providers/replicate.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/groq/responses.test.ts",
         "!!test/providers/huggingface.test.ts",
         "!!test/providers/hyperbolic.test.ts",
         "!!test/providers/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/hyperbolic.test.ts",
         "!!test/providers/index.test.ts",
         "!!test/providers/litellm.test.ts",
         "!!test/providers/openai-codex-sdk.e2e.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/xai/image.test.ts",
         "!!test/providers/xai/voice.test.ts",
         "!!test/redteam/extraction/entities.test.ts",
         "!!test/redteam/extraction/purpose.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/index.test.ts",
         "!!test/providers/openai/realtime.test.ts",
         "!!test/providers/openclaw.test.ts",
         "!!test/providers/openrouter.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai-codex-sdk.test.ts",
         "!!test/providers/openai/chat.test.ts",
         "!!test/providers/openai/codexDefaults.test.ts",
         "!!test/providers/openai/completion.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/chat.test.ts",
         "!!test/providers/openai/codexDefaults.test.ts",
         "!!test/providers/openai/completion.test.ts",
         "!!test/providers/openai/image.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/anthropic/messages.test.ts",
         "!!test/providers/azure/chat.test.ts",
         "!!test/providers/azure/completion.test.ts",
         "!!test/providers/azure/responses.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai-codex-sdk.e2e.test.ts",
         "!!test/providers/openai-codex-sdk.test.ts",
         "!!test/providers/openai/chat.test.ts",
         "!!test/providers/openai/codexDefaults.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -293,10 +293,9 @@
         "src/app/src/**/*.test.ts",
         "src/app/src/**/*.test.tsx",
         "src/app/src/**/*.spec.ts",
-        "src/app/src/**/*.spec.tsx",
+        "src/app/src/**/*.spec.tsx"
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/utils.test.ts"
         // END direct process.env mutation legacy allowlist
       ],
       "plugins": ["./tools/biome/no-direct-process-env-mutation.grit"]

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/logger.test.ts",
         "!!test/matchers/utils.test.ts",
         "!!test/onboarding.test.ts",
         "!!test/prompts/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/file.test.ts",
         "!!test/util/json.test.ts",
         "!!test/util/promptfooCommand.test.ts",
         "!!test/util/render.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/code-scan-action/main.test.ts",
         "!!test/commands/modelScan.test.ts",
         "!!test/constants.test.ts",
         "!!test/database.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/anthropic/generic.test.ts",
         "!!test/providers/anthropic/messages.test.ts",
         "!!test/providers/azure/chat.test.ts",
         "!!test/providers/azure/completion.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/bedrock/knowledgeBase.test.ts",
         "!!test/providers/claude-agent-sdk.test.ts",
         "!!test/providers/cloudflare-ai.test.ts",
         "!!test/providers/cloudflare-gateway.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/cache.test.ts",
         "!!test/code-scan-action/main.test.ts",
         "!!test/commands/modelScan.test.ts",
         "!!test/constants.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/azure/responses.test.ts",
         "!!test/providers/bedrock.agents.test.ts",
         "!!test/providers/bedrock/converse.test.ts",
         "!!test/providers/bedrock/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/env.test.ts",
         "!!test/util/file.test.ts",
         "!!test/util/json.test.ts",
         "!!test/util/promptfooCommand.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/agents/index.test.ts",
         "!!test/providers/elevenlabs/alignment/index.test.ts",
         "!!test/providers/elevenlabs/history/index.test.ts",
         "!!test/providers/elevenlabs/isolation/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/xai/voice.test.ts",
         "!!test/redteam/extraction/entities.test.ts",
         "!!test/redteam/extraction/purpose.test.ts",
         "!!test/redteam/plugins/teenSafety.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/stt/index.test.ts",
         "!!test/providers/elevenlabs/tts/index.test.ts",
         "!!test/providers/google/ai.studio.test.ts",
         "!!test/providers/google/auth.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers.test.ts",
         "!!test/providers/anthropic/completion.test.ts",
         "!!test/providers/anthropic/generic.test.ts",
         "!!test/providers/anthropic/messages.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/gemini-image.test.ts",
         "!!test/providers/google/image.test.ts",
         "!!test/providers/google/live.test.ts",
         "!!test/providers/google/provider.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/snowflake.test.ts",
         "!!test/providers/truefoundry.test.ts",
         "!!test/providers/xai/image.test.ts",
         "!!test/providers/xai/voice.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openclaw.test.ts",
         "!!test/providers/openrouter.test.ts",
         "!!test/providers/replicate.test.ts",
         "!!test/providers/snowflake.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/azure/chat.test.ts",
         "!!test/providers/azure/completion.test.ts",
         "!!test/providers/azure/responses.test.ts",
         "!!test/providers/bedrock.agents.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/sagemaker.test.ts",
         "!!test/telemetry.test.ts",
         "!!test/tracing/evaluatorTracing.test.ts",
         "!!test/util/apiHealth.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/cloudflare-ai.test.ts",
         "!!test/providers/cloudflare-gateway.test.ts",
         "!!test/providers/databricks.test.ts",
         "!!test/providers/defaults.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/completion.test.ts",
         "!!test/providers/openai/image.test.ts",
         "!!test/providers/openai/index.test.ts",
         "!!test/providers/openai/realtime.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/replicate.test.ts",
         "!!test/providers/snowflake.test.ts",
         "!!test/providers/truefoundry.test.ts",
         "!!test/providers/xai/image.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/assertions/trace.test.ts",
         "!!test/cache.test.ts",
         "!!test/code-scan-action/main.test.ts",
         "!!test/commands/modelScan.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/telemetry.test.ts",
         "!!test/tracing/evaluatorTracing.test.ts",
         "!!test/util/apiHealth.test.ts",
         "!!test/util/config/load.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/promptfooCommand.test.ts",
         "!!test/util/render.test.ts",
         "!!test/util/templates.test.ts",
         "!!test/util/transform.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/matchers/utils.test.ts",
         "!!test/onboarding.test.ts",
         "!!test/prompts/index.test.ts",
         "!!test/providers.slack.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openrouter.test.ts",
         "!!test/providers/replicate.test.ts",
         "!!test/providers/snowflake.test.ts",
         "!!test/providers/truefoundry.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/tts/index.test.ts",
         "!!test/providers/google/ai.studio.test.ts",
         "!!test/providers/google/auth.test.ts",
         "!!test/providers/google/gemini-image.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/databricks.test.ts",
         "!!test/providers/defaults.test.ts",
         "!!test/providers/elevenlabs/agents/index.test.ts",
         "!!test/providers/elevenlabs/alignment/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/claude-agent-sdk.test.ts",
         "!!test/providers/cloudflare-ai.test.ts",
         "!!test/providers/cloudflare-gateway.test.ts",
         "!!test/providers/databricks.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/envars.test.ts",
         "!!test/evaluatorHelpers.test.ts",
         "!!test/fetch.test.ts",
         "!!test/globalConfig/cloud.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/isolation/index.test.ts",
         "!!test/providers/elevenlabs/stt/index.test.ts",
         "!!test/providers/elevenlabs/tts/index.test.ts",
         "!!test/providers/google/ai.studio.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/truefoundry.test.ts",
         "!!test/providers/xai/image.test.ts",
         "!!test/providers/xai/voice.test.ts",
         "!!test/redteam/extraction/entities.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/live.test.ts",
         "!!test/providers/google/provider.test.ts",
         "!!test/providers/google/video.test.ts",
         "!!test/providers/groq/responses.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers.slack.test.ts",
         "!!test/providers.test.ts",
         "!!test/providers/anthropic/completion.test.ts",
         "!!test/providers/anthropic/generic.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/redteam/providers/shared.test.ts",
         "!!test/sagemaker.test.ts",
         "!!test/telemetry.test.ts",
         "!!test/tracing/evaluatorTracing.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/codexDefaults.test.ts",
         "!!test/providers/openai/completion.test.ts",
         "!!test/providers/openai/image.test.ts",
         "!!test/providers/openai/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/provider.test.ts",
         "!!test/providers/google/video.test.ts",
         "!!test/providers/groq/responses.test.ts",
         "!!test/providers/huggingface.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/openai/image.test.ts",
         "!!test/providers/openai/index.test.ts",
         "!!test/providers/openai/realtime.test.ts",
         "!!test/providers/openclaw.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/templates.test.ts",
         "!!test/util/transform.test.ts",
         "!!test/util/utils.test.ts"
         // END direct process.env mutation legacy allowlist

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/redteam/plugins/teenSafety.test.ts",
         "!!test/redteam/providers/shared.test.ts",
         "!!test/sagemaker.test.ts",
         "!!test/telemetry.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/history/index.test.ts",
         "!!test/providers/elevenlabs/isolation/index.test.ts",
         "!!test/providers/elevenlabs/stt/index.test.ts",
         "!!test/providers/elevenlabs/tts/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/cloudflare-gateway.test.ts",
         "!!test/providers/databricks.test.ts",
         "!!test/providers/defaults.test.ts",
         "!!test/providers/elevenlabs/agents/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/render.test.ts",
         "!!test/util/templates.test.ts",
         "!!test/util/transform.test.ts",
         "!!test/util/utils.test.ts"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/auth.test.ts",
         "!!test/providers/google/gemini-image.test.ts",
         "!!test/providers/google/image.test.ts",
         "!!test/providers/google/live.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/bedrock.agents.test.ts",
         "!!test/providers/bedrock/converse.test.ts",
         "!!test/providers/bedrock/index.test.ts",
         "!!test/providers/bedrock/knowledgeBase.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -288,15 +288,18 @@
     },
     {
       "includes": [
-        "test/**/*.test.ts",
-        "test/**/*.spec.ts",
-        "src/app/src/**/*.test.ts",
-        "src/app/src/**/*.test.tsx",
-        "src/app/src/**/*.spec.ts",
-        "src/app/src/**/*.spec.tsx"
-        // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
-        // BEGIN direct process.env mutation legacy allowlist
-        // END direct process.env mutation legacy allowlist
+        "*.js",
+        "*.jsx",
+        "*.ts",
+        "*.tsx",
+        "*.mjs",
+        "*.cjs",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.mjs",
+        "**/*.cjs"
       ],
       "plugins": ["./tools/biome/no-direct-process-env-mutation.grit"]
     },

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/evaluatorHelpers.test.ts",
         "!!test/fetch.test.ts",
         "!!test/globalConfig/cloud.test.ts",
         "!!test/logger.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/google/video.test.ts",
         "!!test/providers/groq/responses.test.ts",
         "!!test/providers/huggingface.test.ts",
         "!!test/providers/hyperbolic.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/redteam/extraction/entities.test.ts",
         "!!test/redteam/extraction/purpose.test.ts",
         "!!test/redteam/plugins/teenSafety.test.ts",
         "!!test/redteam/providers/shared.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/onboarding.test.ts",
         "!!test/prompts/index.test.ts",
         "!!test/providers.slack.test.ts",
         "!!test/providers.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/apiHealth.test.ts",
         "!!test/util/config/load.test.ts",
         "!!test/util/env.test.ts",
         "!!test/util/file.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/anthropic/completion.test.ts",
         "!!test/providers/anthropic/generic.test.ts",
         "!!test/providers/anthropic/messages.test.ts",
         "!!test/providers/azure/chat.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/elevenlabs/alignment/index.test.ts",
         "!!test/providers/elevenlabs/history/index.test.ts",
         "!!test/providers/elevenlabs/isolation/index.test.ts",
         "!!test/providers/elevenlabs/stt/index.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/providers/huggingface.test.ts",
         "!!test/providers/hyperbolic.test.ts",
         "!!test/providers/index.test.ts",
         "!!test/providers/litellm.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/util/json.test.ts",
         "!!test/util/promptfooCommand.test.ts",
         "!!test/util/render.test.ts",
         "!!test/util/templates.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/globalConfig/cloud.test.ts",
         "!!test/logger.test.ts",
         "!!test/matchers/utils.test.ts",
         "!!test/onboarding.test.ts",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -296,7 +296,6 @@
         "src/app/src/**/*.spec.tsx",
         // Keep in sync with legacyDirectProcessEnvMutationFiles in test/test-hygiene.test.ts.
         // BEGIN direct process.env mutation legacy allowlist
-        "!!test/database.test.ts",
         "!!test/envars.test.ts",
         "!!test/evaluatorHelpers.test.ts",
         "!!test/fetch.test.ts",

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -96,7 +96,7 @@ async function authenticateWithOidc(): Promise<void> {
     core.info('🔐 Got OIDC token for server authentication');
 
     // Set as environment variable for CLI to use
-    process.env.GITHUB_OIDC_TOKEN = oidcToken;
+    Object.assign(process.env, { GITHUB_OIDC_TOKEN: oidcToken });
   } catch (error) {
     // OIDC tokens are not available for fork PRs (GitHub security restriction)
     // For fork PRs, the server will use PR-based authentication instead

--- a/src/app/vite.config.ts
+++ b/src/app/vite.config.ts
@@ -62,13 +62,10 @@ const showTestConsoleOutput =
 
 // These environment variables are inherited from the parent process (main promptfoo server)
 // We set VITE_ prefixed variables here so Vite can expose them to the client code
-if (process.env.NODE_ENV === 'development') {
-  process.env.VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL =
-    process.env.PROMPTFOO_REMOTE_API_BASE_URL || `http://localhost:${API_PORT}`;
-} else {
-  process.env.VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL =
-    process.env.PROMPTFOO_REMOTE_API_BASE_URL || '';
-}
+const remoteApiBaseUrl =
+  process.env.PROMPTFOO_REMOTE_API_BASE_URL ||
+  (process.env.NODE_ENV === 'development' ? `http://localhost:${API_PORT}` : '');
+Object.assign(process.env, { VITE_PUBLIC_PROMPTFOO_REMOTE_API_BASE_URL: remoteApiBaseUrl });
 
 // https://vitejs.dev/config/
 // Export a plain object here to avoid CI-only type conflicts from multiple Vite installs in the monorepo.

--- a/src/commands/mcp/server.ts
+++ b/src/commands/mcp/server.ts
@@ -19,6 +19,10 @@ import { registerShareEvaluationTool } from './tools/shareEvaluation';
 import { registerTestProviderTool } from './tools/testProvider';
 import { registerValidatePromptfooConfigTool } from './tools/validatePromptfooConfig';
 
+function setMcpTransport(transport: 'http' | 'stdio'): void {
+  Object.assign(process.env, { MCP_TRANSPORT: transport });
+}
+
 /**
  * Creates an MCP server with tools for interacting with promptfoo
  */
@@ -76,7 +80,7 @@ export async function startHttpMcpServer(port: number): Promise<void> {
   }
 
   // Set transport type for telemetry
-  process.env.MCP_TRANSPORT = 'http';
+  setMcpTransport('http');
 
   const app = express();
   app.use(express.json());
@@ -166,7 +170,7 @@ export async function startHttpMcpServer(port: number): Promise<void> {
  */
 export async function startStdioMcpServer(): Promise<void> {
   // Set transport type for telemetry
-  process.env.MCP_TRANSPORT = 'stdio';
+  setMcpTransport('stdio');
 
   // Disable all console logging in stdio mode to prevent pollution of JSON-RPC communication
   logger.transports.forEach((transport) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ async function main() {
 
   // Set PROMPTFOO_DISABLE_UPDATE=true in CI to prevent hanging on network requests
   if (!process.env.PROMPTFOO_DISABLE_UPDATE && typeof process.env.CI !== 'undefined') {
-    process.env.PROMPTFOO_DISABLE_UPDATE = 'true';
+    Object.assign(process.env, { PROMPTFOO_DISABLE_UPDATE: 'true' });
   }
 
   await checkForUpdates();

--- a/test/assertions/assertionResult.test.ts
+++ b/test/assertions/assertionResult.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssertionsResult, GUARDRAIL_BLOCKED_REASON } from '../../src/assertions/assertionsResult';
+import { mockProcessEnv } from '../util/utils';
 
 import type { AssertionSet, GradingResult } from '../../src/types/index';
 
@@ -27,7 +28,7 @@ describe('AssertionsResult', () => {
   let assertionsResult: AssertionsResult;
 
   beforeEach(() => {
-    delete process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES;
+    mockProcessEnv({ PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES: undefined });
     assertionsResult = new AssertionsResult();
   });
 
@@ -56,7 +57,7 @@ describe('AssertionsResult', () => {
   });
 
   it('handles PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES', () => {
-    process.env.PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES = 'true';
+    mockProcessEnv({ PROMPTFOO_SHORT_CIRCUIT_TEST_FAILURES: 'true' });
     expect(() =>
       assertionsResult.addResult({
         index: 0,

--- a/test/assertions/trace.test.ts
+++ b/test/assertions/trace.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { assertionUsesTrace, runAssertion, runAssertions } from '../../src/assertions/index';
 import cliState from '../../src/cliState';
 import { getTraceStore } from '../../src/tracing/store';
+import { mockProcessEnv } from '../util/utils';
 
 import type {
   Assertion,
@@ -71,9 +72,9 @@ describe('trace assertions', () => {
   const restoreTraceFetchEnv = () => {
     for (const [name, value] of Object.entries(originalTraceFetchEnv)) {
       if (value === undefined) {
-        delete process.env[name];
+        mockProcessEnv({ [name]: undefined });
       } else {
-        process.env[name] = value;
+        mockProcessEnv({ [name]: value });
       }
     }
   };
@@ -82,8 +83,8 @@ describe('trace assertions', () => {
     mockTraceStore.getTrace.mockReset();
     vi.clearAllMocks();
     restoreTraceFetchEnv();
-    process.env.PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS = '0';
-    process.env.PROMPTFOO_TRACE_FETCH_STABLE_POLLS = '1';
+    mockProcessEnv({ PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS: '0' });
+    mockProcessEnv({ PROMPTFOO_TRACE_FETCH_STABLE_POLLS: '1' });
     vi.mocked(getTraceStore).mockReturnValue(
       mockTraceStore as unknown as ReturnType<typeof getTraceStore>,
     );
@@ -165,9 +166,9 @@ describe('trace assertions', () => {
     });
 
     it('should retry until trace spans are available', async () => {
-      process.env.PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS = '3';
-      process.env.PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS = '0';
-      process.env.PROMPTFOO_TRACE_FETCH_STABLE_POLLS = '1';
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS: '3' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS: '0' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_STABLE_POLLS: '1' });
 
       mockTraceStore.getTrace
         .mockResolvedValueOnce({
@@ -193,8 +194,8 @@ describe('trace assertions', () => {
     });
 
     it('should use default retry timing when trace fetch env vars are unset', async () => {
-      delete process.env.PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS;
-      delete process.env.PROMPTFOO_TRACE_FETCH_STABLE_POLLS;
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS: undefined });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_STABLE_POLLS: undefined });
       vi.useFakeTimers();
 
       mockTraceStore.getTrace.mockResolvedValue(mockTraceData);
@@ -217,9 +218,9 @@ describe('trace assertions', () => {
     });
 
     it('should wait for span count to stabilize', async () => {
-      process.env.PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS = '4';
-      process.env.PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS = '0';
-      process.env.PROMPTFOO_TRACE_FETCH_STABLE_POLLS = '2';
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS: '4' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS: '0' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_STABLE_POLLS: '2' });
 
       mockTraceStore.getTrace
         .mockResolvedValueOnce({
@@ -264,9 +265,9 @@ describe('trace assertions', () => {
     });
 
     it('should reuse a preloaded missing trace instead of retrying once per assertion', async () => {
-      process.env.PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS = '2';
-      process.env.PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS = '0';
-      process.env.PROMPTFOO_TRACE_FETCH_STABLE_POLLS = '1';
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_MAX_ATTEMPTS: '2' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_RETRY_DELAY_MS: '0' });
+      mockProcessEnv({ PROMPTFOO_TRACE_FETCH_STABLE_POLLS: '1' });
 
       mockTraceStore.getTrace.mockResolvedValue(null);
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -192,7 +192,7 @@ const mockFetchWithRetriesResponse = (
 };
 
 describe('cache configuration', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
   let mkdirSyncMock: MockInstance;
   let existsSyncMock: MockInstance;
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -20,6 +20,7 @@ import {
   withCacheNamespace,
 } from '../src/cache';
 import { fetchWithRetries } from '../src/util/fetch/index';
+import { mockProcessEnv } from './util/utils';
 
 vi.mock('../src/util/config/manage', () => ({
   getConfigDirectoryPath: vi.fn().mockReturnValue('/mock/config/path'),
@@ -197,21 +198,21 @@ describe('cache configuration', () => {
 
   beforeEach(() => {
     vi.resetModules();
-    process.env = { ...originalEnv };
+    mockProcessEnv({ ...originalEnv }, { clear: true });
     // Clear cache type override from test setup
-    delete process.env.PROMPTFOO_CACHE_TYPE;
+    mockProcessEnv({ PROMPTFOO_CACHE_TYPE: undefined });
     mkdirSyncMock = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
     existsSyncMock = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     mkdirSyncMock.mockRestore();
     existsSyncMock.mockRestore();
   });
 
   it('should use memory cache in test environment', async () => {
-    process.env.NODE_ENV = 'test';
+    mockProcessEnv({ NODE_ENV: 'test' });
     const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
     // In test environment, promptfoo falls back to an in-memory store instead of disk.
@@ -219,7 +220,7 @@ describe('cache configuration', () => {
   });
 
   it('should use disk cache in non-test environment', async () => {
-    process.env.NODE_ENV = 'production';
+    mockProcessEnv({ NODE_ENV: 'production' });
     const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
     // In production, stores array should have at least one store (disk cache)
@@ -227,18 +228,18 @@ describe('cache configuration', () => {
   });
 
   it('should respect custom cache path', async () => {
-    process.env.PROMPTFOO_CACHE_PATH = '/custom/cache/path';
-    process.env.NODE_ENV = 'production';
+    mockProcessEnv({ PROMPTFOO_CACHE_PATH: '/custom/cache/path' });
+    mockProcessEnv({ NODE_ENV: 'production' });
     const cacheModule = await import('../src/cache');
     cacheModule.getCache();
     expect(fs.mkdirSync).toHaveBeenCalledWith('/custom/cache/path', { recursive: true });
   });
 
   it('should respect cache configuration from environment', async () => {
-    process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '100';
-    process.env.PROMPTFOO_CACHE_TTL = '3600';
-    process.env.PROMPTFOO_CACHE_MAX_SIZE = '1000000';
-    process.env.NODE_ENV = 'production';
+    mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '100' });
+    mockProcessEnv({ PROMPTFOO_CACHE_TTL: '3600' });
+    mockProcessEnv({ PROMPTFOO_CACHE_MAX_SIZE: '1000000' });
+    mockProcessEnv({ NODE_ENV: 'production' });
 
     const cacheModule = await import('../src/cache');
     const cache = cacheModule.getCache();
@@ -248,7 +249,7 @@ describe('cache configuration', () => {
 
   it('should handle cache directory creation when it exists', async () => {
     existsSyncMock.mockReturnValue(true);
-    process.env.NODE_ENV = 'production';
+    mockProcessEnv({ NODE_ENV: 'production' });
 
     const cacheModule = await import('../src/cache');
     cacheModule.getCache();

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -223,7 +223,7 @@ describe('code-scan-action main', () => {
 
   describe('CLI args construction', () => {
     it('should pass --base with GITHUB_BASE_REF when set', async () => {
-      process.env.GITHUB_BASE_REF = 'feat/my-feature-branch';
+      mockProcessEnv({ GITHUB_BASE_REF: 'feat/my-feature-branch' });
 
       const { args } = await importActionAndGetPromptfooCall();
 
@@ -231,7 +231,7 @@ describe('code-scan-action main', () => {
     });
 
     it('should pass --base with "main" when GITHUB_BASE_REF is not set', async () => {
-      delete process.env.GITHUB_BASE_REF;
+      mockProcessEnv({ GITHUB_BASE_REF: undefined });
 
       const { args } = await importActionAndGetPromptfooCall();
 
@@ -239,7 +239,7 @@ describe('code-scan-action main', () => {
     });
 
     it('should pass --base for stacked PR base branches', async () => {
-      process.env.GITHUB_BASE_REF = 'feat/openai-sora-video-provider';
+      mockProcessEnv({ GITHUB_BASE_REF: 'feat/openai-sora-video-provider' });
 
       const { args } = await importActionAndGetPromptfooCall();
 
@@ -247,9 +247,9 @@ describe('code-scan-action main', () => {
     });
 
     it('should not pass NPM_CONFIG_BEFORE to the promptfoo scan command', async () => {
-      process.env.GITHUB_BASE_REF = 'main';
-      process.env.NPM_CONFIG_BEFORE = '2026-03-29T00:00:00.000Z';
-      process.env.npm_config_before = '2026-03-29T00:00:00.000Z';
+      mockProcessEnv({ GITHUB_BASE_REF: 'main' });
+      mockProcessEnv({ NPM_CONFIG_BEFORE: '2026-03-29T00:00:00.000Z' });
+      mockProcessEnv({ npm_config_before: '2026-03-29T00:00:00.000Z' });
 
       const { options } = await importActionAndGetPromptfooCall();
 
@@ -257,9 +257,9 @@ describe('code-scan-action main', () => {
     });
 
     it('should not pass NPM_CONFIG_BEFORE to npm install', async () => {
-      process.env.GITHUB_BASE_REF = 'main';
-      process.env.NPM_CONFIG_BEFORE = '2026-03-29T00:00:00.000Z';
-      process.env.npm_config_before = '2026-03-29T00:00:00.000Z';
+      mockProcessEnv({ GITHUB_BASE_REF: 'main' });
+      mockProcessEnv({ NPM_CONFIG_BEFORE: '2026-03-29T00:00:00.000Z' });
+      mockProcessEnv({ npm_config_before: '2026-03-29T00:00:00.000Z' });
 
       const { options } = await importActionAndGetNpmInstallCall();
 

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } from 'vitest';
 import { checkModelAuditInstalled, modelScanCommand } from '../../src/commands/modelScan';
 import logger from '../../src/logger';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('child_process');
 vi.mock('../../src/logger');
@@ -1060,7 +1061,7 @@ describe('Sharing behavior', () => {
   afterEach(() => {
     mockExit.mockRestore();
     process.exitCode = 0;
-    delete process.env.PROMPTFOO_DISABLE_SHARING;
+    mockProcessEnv({ PROMPTFOO_DISABLE_SHARING: undefined });
   });
 
   // Helper to create a mock scan process that returns valid JSON results
@@ -1097,7 +1098,7 @@ describe('Sharing behavior', () => {
   }
 
   it('should not share when PROMPTFOO_DISABLE_SHARING env var is set', async () => {
-    process.env.PROMPTFOO_DISABLE_SHARING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_SHARING: 'true' });
     cloudConfigIsEnabledMock.mockReturnValue(true);
     isModelAuditSharingEnabledMock.mockReturnValue(true);
 

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -49,7 +49,7 @@ describe('constants', () => {
     });
 
     it('should return PROMPTFOO_REMOTE_API_BASE_URL if set', () => {
-      process.env.PROMPTFOO_REMOTE_API_BASE_URL = 'https://remote.api.com';
+      mockProcessEnv({ PROMPTFOO_REMOTE_API_BASE_URL: 'https://remote.api.com' });
       expect(getShareApiBaseUrl()).toBe('https://remote.api.com');
     });
   });
@@ -60,7 +60,7 @@ describe('constants', () => {
     });
 
     it('should return PROMPTFOO_SHARING_APP_BASE_URL if set', () => {
-      process.env.PROMPTFOO_SHARING_APP_BASE_URL = 'https://custom.share.com';
+      mockProcessEnv({ PROMPTFOO_SHARING_APP_BASE_URL: 'https://custom.share.com' });
       expect(getDefaultShareViewBaseUrl()).toBe('https://custom.share.com');
     });
   });
@@ -71,7 +71,7 @@ describe('constants', () => {
     });
 
     it('should return PROMPTFOO_REMOTE_APP_BASE_URL if set', () => {
-      process.env.PROMPTFOO_REMOTE_APP_BASE_URL = 'https://remote.app.com';
+      mockProcessEnv({ PROMPTFOO_REMOTE_APP_BASE_URL: 'https://remote.app.com' });
       expect(getShareViewBaseUrl()).toBe('https://remote.app.com');
     });
   });
@@ -82,12 +82,12 @@ describe('constants', () => {
     });
 
     it('should return API_PORT if set', () => {
-      process.env.API_PORT = '3000';
+      mockProcessEnv({ API_PORT: '3000' });
       expect(getDefaultPort()).toBe(3000);
     });
 
     it('should handle invalid API_PORT value', () => {
-      process.env.API_PORT = 'invalid';
+      mockProcessEnv({ API_PORT: 'invalid' });
       expect(getDefaultPort()).toBe(15500);
     });
   });

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockProcessEnv } from './util/utils';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -12,15 +13,15 @@ describe('database WAL mode', () => {
 
   beforeEach(() => {
     vi.resetModules();
-    process.env = { ...ORIGINAL_ENV };
+    mockProcessEnv({ ...ORIGINAL_ENV }, { clear: true });
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-dbtest-'));
-    process.env.PROMPTFOO_CONFIG_DIR = tempDir;
-    delete process.env.IS_TESTING;
-    delete process.env.PROMPTFOO_DISABLE_WAL_MODE;
+    mockProcessEnv({ PROMPTFOO_CONFIG_DIR: tempDir });
+    mockProcessEnv({ IS_TESTING: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_WAL_MODE: undefined });
   });
 
   afterEach(async () => {
-    process.env = ORIGINAL_ENV;
+    mockProcessEnv(ORIGINAL_ENV, { clear: true });
     // Close the database connection if it exists
     try {
       const database = await import('../src/database');
@@ -73,7 +74,7 @@ describe('database WAL mode', () => {
   });
 
   it('skips WAL mode when PROMPTFOO_DISABLE_WAL_MODE is set', async () => {
-    process.env.PROMPTFOO_DISABLE_WAL_MODE = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_WAL_MODE: 'true' });
 
     const database = await import('../src/database');
     database.getDb();
@@ -92,7 +93,7 @@ describe('database WAL mode', () => {
   });
 
   it('does not enable WAL mode for in-memory databases', async () => {
-    process.env.IS_TESTING = 'true';
+    mockProcessEnv({ IS_TESTING: 'true' });
 
     const database = await import('../src/database');
     const db = database.getDb();

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -13,7 +13,7 @@ import { mockProcessEnv } from './util/utils';
 import type { EnvVarKey } from '../src/envars';
 
 describe('envars', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
   const originalCliState = { ...cliState };
 
   beforeEach(() => {

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -8,6 +8,7 @@ import {
   getMaxEvalTimeMs,
   isCI,
 } from '../src/envars';
+import { mockProcessEnv } from './util/utils';
 
 import type { EnvVarKey } from '../src/envars';
 
@@ -17,7 +18,7 @@ describe('envars', () => {
 
   beforeEach(() => {
     vi.resetModules();
-    process.env = { ...originalEnv };
+    mockProcessEnv({ ...originalEnv }, { clear: true });
     // Reset cliState to empty for each test
     Object.keys(cliState).forEach((key) => {
       delete cliState[key as keyof typeof cliState];
@@ -25,7 +26,7 @@ describe('envars', () => {
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     // Restore original cliState
     Object.keys(cliState).forEach((key) => {
       delete cliState[key as keyof typeof cliState];
@@ -35,7 +36,7 @@ describe('envars', () => {
 
   describe('getEnvar', () => {
     it('should return the value of an existing environment variable', () => {
-      process.env.PROMPTFOO_AUTHOR = 'test value';
+      mockProcessEnv({ PROMPTFOO_AUTHOR: 'test value' });
       expect(getEnvString('PROMPTFOO_AUTHOR')).toBe('test value');
     });
 
@@ -48,7 +49,7 @@ describe('envars', () => {
     });
 
     it('should prioritize cliState.config.env over process.env', () => {
-      process.env.OPENAI_API_KEY = 'process-env-key';
+      mockProcessEnv({ OPENAI_API_KEY: 'process-env-key' });
       cliState.config = {
         env: {
           OPENAI_API_KEY: 'config-env-key',
@@ -71,23 +72,23 @@ describe('envars', () => {
     });
 
     it('should handle HTTP proxy environment variables', () => {
-      process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
-      process.env.HTTPS_PROXY = 'https://proxy.example.com:8443';
+      mockProcessEnv({ HTTP_PROXY: 'http://proxy.example.com:8080' });
+      mockProcessEnv({ HTTPS_PROXY: 'https://proxy.example.com:8443' });
 
       expect(getEnvString('HTTP_PROXY')).toBe('http://proxy.example.com:8080');
       expect(getEnvString('HTTPS_PROXY')).toBe('https://proxy.example.com:8443');
     });
 
     it('should handle provider-specific environment variables', () => {
-      process.env.CDP_DOMAIN = 'custom.domain';
-      process.env.PORTKEY_API_BASE_URL = 'https://api.portkey.example.com';
+      mockProcessEnv({ CDP_DOMAIN: 'custom.domain' });
+      mockProcessEnv({ PORTKEY_API_BASE_URL: 'https://api.portkey.example.com' });
 
       expect(getEnvString('CDP_DOMAIN')).toBe('custom.domain');
       expect(getEnvString('PORTKEY_API_BASE_URL')).toBe('https://api.portkey.example.com');
     });
 
     it('should handle arbitrary string keys not defined in EnvVars type', () => {
-      process.env.CUSTOM_ENV_VAR = 'custom value';
+      mockProcessEnv({ CUSTOM_ENV_VAR: 'custom value' });
       expect(getEnvString('CUSTOM_ENV_VAR' as EnvVarKey)).toBe('custom value');
     });
   });
@@ -95,14 +96,14 @@ describe('envars', () => {
   describe('getEnvBool', () => {
     it('should return true for truthy string values', () => {
       ['1', 'true', 'yes', 'yup', 'yeppers'].forEach((value) => {
-        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: value });
         expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(true);
       });
     });
 
     it('should return false for falsy string values', () => {
       ['0', 'false', 'no', 'nope'].forEach((value) => {
-        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: value });
         expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
       });
     });
@@ -114,35 +115,35 @@ describe('envars', () => {
 
     it('should return true for uppercase truthy string values', () => {
       ['TRUE', 'YES', 'YUP', 'YEPPERS'].forEach((value) => {
-        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: value });
         expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(true);
       });
     });
 
     it('should return false for any other string values', () => {
       ['maybe', 'enabled', 'on'].forEach((value) => {
-        process.env.PROMPTFOO_CACHE_ENABLED = value;
+        mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: value });
         expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
       });
     });
 
     it('should return true when the environment variable is set to "1"', () => {
-      process.env.PROMPTFOO_CACHE_ENABLED = '1';
+      mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: '1' });
       expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(true);
     });
 
     it('should return false when the environment variable is set to "0"', () => {
-      process.env.PROMPTFOO_CACHE_ENABLED = '0';
+      mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: '0' });
       expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
     });
 
     it('should return false when no default value is provided and the environment variable is not set', () => {
-      delete process.env.PROMPTFOO_CACHE_ENABLED;
+      mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: undefined });
       expect(getEnvBool('PROMPTFOO_CACHE_ENABLED')).toBe(false);
     });
 
     it('should prioritize cliState.config.env over process.env for boolean values', () => {
-      process.env.PROMPTFOO_CACHE_ENABLED = 'false';
+      mockProcessEnv({ PROMPTFOO_CACHE_ENABLED: 'false' });
       cliState.config = {
         env: {
           PROMPTFOO_CACHE_ENABLED: true as any,
@@ -153,17 +154,17 @@ describe('envars', () => {
     });
 
     it('should handle arbitrary string keys for boolean values', () => {
-      process.env.CUSTOM_BOOL_VAR = 'true';
+      mockProcessEnv({ CUSTOM_BOOL_VAR: 'true' });
       expect(getEnvBool('CUSTOM_BOOL_VAR' as EnvVarKey)).toBe(true);
     });
 
     it('should handle PROMPTFOO_DISABLE_OBJECT_STRINGIFY environment variable', () => {
       expect(getEnvBool('PROMPTFOO_DISABLE_OBJECT_STRINGIFY')).toBe(false);
 
-      process.env.PROMPTFOO_DISABLE_OBJECT_STRINGIFY = 'true';
+      mockProcessEnv({ PROMPTFOO_DISABLE_OBJECT_STRINGIFY: 'true' });
       expect(getEnvBool('PROMPTFOO_DISABLE_OBJECT_STRINGIFY')).toBe(true);
 
-      process.env.PROMPTFOO_DISABLE_OBJECT_STRINGIFY = 'false';
+      mockProcessEnv({ PROMPTFOO_DISABLE_OBJECT_STRINGIFY: 'false' });
       expect(getEnvBool('PROMPTFOO_DISABLE_OBJECT_STRINGIFY')).toBe(false);
 
       cliState.config = {
@@ -177,12 +178,12 @@ describe('envars', () => {
 
   describe('getEnvInt', () => {
     it('should return the integer value of an existing environment variable', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '42';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '42' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(42);
     });
 
     it('should return undefined for a non-numeric environment variable', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = 'not a number';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: 'not a number' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBeUndefined();
     });
 
@@ -191,32 +192,32 @@ describe('envars', () => {
     });
 
     it('should floor a floating-point number in the environment variable', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '42.7';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '42.7' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(42);
     });
 
     it('should handle negative numbers', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '-42';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '-42' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(-42);
     });
 
     it('should return undefined for empty string', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBeUndefined();
     });
 
     it('should return the default value when the environment variable is undefined', () => {
-      delete process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT;
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: undefined });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT', 100)).toBe(100);
     });
 
     it('should return undefined when no default value is provided and the environment variable is not set', () => {
-      delete process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT;
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: undefined });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBeUndefined();
     });
 
     it('should prioritize cliState.config.env over process.env for integer values', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '100';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '100' });
       cliState.config = {
         env: {
           PROMPTFOO_CACHE_MAX_FILE_COUNT: 42 as any,
@@ -227,29 +228,29 @@ describe('envars', () => {
     });
 
     it('should handle arbitrary string keys for integer values', () => {
-      process.env.CUSTOM_INT_VAR = '123';
+      mockProcessEnv({ CUSTOM_INT_VAR: '123' });
       expect(getEnvInt('CUSTOM_INT_VAR' as EnvVarKey)).toBe(123);
     });
 
     it('should return 0 when environment variable is set to "0"', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '0';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '0' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT')).toBe(0);
     });
 
     it('should return 0 instead of default when environment variable is "0"', () => {
-      process.env.PROMPTFOO_CACHE_MAX_FILE_COUNT = '0';
+      mockProcessEnv({ PROMPTFOO_CACHE_MAX_FILE_COUNT: '0' });
       expect(getEnvInt('PROMPTFOO_CACHE_MAX_FILE_COUNT', 100)).toBe(0);
     });
   });
 
   describe('getEnvFloat', () => {
     it('should return the float value of an existing environment variable', () => {
-      process.env.OPENAI_TEMPERATURE = '3.14';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '3.14' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(3.14);
     });
 
     it('should return undefined for a non-numeric environment variable', () => {
-      process.env.OPENAI_TEMPERATURE = 'not a number';
+      mockProcessEnv({ OPENAI_TEMPERATURE: 'not a number' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
     });
 
@@ -258,42 +259,42 @@ describe('envars', () => {
     });
 
     it('should handle integer values', () => {
-      process.env.OPENAI_TEMPERATURE = '42';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '42' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(42);
     });
 
     it('should handle negative numbers', () => {
-      process.env.OPENAI_TEMPERATURE = '-3.14';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '-3.14' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(-3.14);
     });
 
     it('should return undefined for empty string', () => {
-      process.env.OPENAI_TEMPERATURE = '';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
     });
 
     it('should return the default value when the environment variable is undefined', () => {
-      delete process.env.OPENAI_TEMPERATURE;
+      mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
       expect(getEnvFloat('OPENAI_TEMPERATURE', 2.718)).toBe(2.718);
     });
 
     it('should return undefined when no default value is provided and the environment variable is not set', () => {
-      delete process.env.OPENAI_TEMPERATURE;
+      mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBeUndefined();
     });
 
     it('should return 0 when environment variable is set to "0"', () => {
-      process.env.OPENAI_TEMPERATURE = '0';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '0' });
       expect(getEnvFloat('OPENAI_TEMPERATURE')).toBe(0);
     });
 
     it('should return 0 instead of default when environment variable is "0"', () => {
-      process.env.OPENAI_TEMPERATURE = '0';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '0' });
       expect(getEnvFloat('OPENAI_TEMPERATURE', 0.7)).toBe(0);
     });
 
     it('should prioritize cliState.config.env over process.env for float values', () => {
-      process.env.OPENAI_TEMPERATURE = '1.0';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '1.0' });
       cliState.config = {
         env: {
           OPENAI_TEMPERATURE: 0.7 as any,
@@ -304,7 +305,7 @@ describe('envars', () => {
     });
 
     it('should handle arbitrary string keys for float values', () => {
-      process.env.CUSTOM_FLOAT_VAR = '3.14159';
+      mockProcessEnv({ CUSTOM_FLOAT_VAR: '3.14159' });
       expect(getEnvFloat('CUSTOM_FLOAT_VAR' as EnvVarKey)).toBe(3.14159);
     });
   });
@@ -328,7 +329,7 @@ describe('envars', () => {
 
     beforeEach(() => {
       // Clear all CI-related environment variables before each test
-      ciEnvironments.forEach((env) => delete process.env[env]);
+      ciEnvironments.forEach((env) => mockProcessEnv({ [env]: undefined }));
     });
 
     it('should return false when no CI environment variables are set', () => {
@@ -337,24 +338,24 @@ describe('envars', () => {
 
     ciEnvironments.forEach((env) => {
       it(`should return true when ${env} is set to 'true'`, () => {
-        process.env[env] = 'true';
+        mockProcessEnv({ [env]: 'true' });
         expect(isCI()).toBe(true);
       });
 
       it(`should return false when ${env} is set to 'false'`, () => {
-        process.env[env] = 'false';
+        mockProcessEnv({ [env]: 'false' });
         expect(isCI()).toBe(false);
       });
     });
 
     it('should return true if any CI environment variable is set to true', () => {
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.TRAVIS = 'false';
+      mockProcessEnv({ GITHUB_ACTIONS: 'true' });
+      mockProcessEnv({ TRAVIS: 'false' });
       expect(isCI()).toBe(true);
     });
 
     it('should prioritize cliState.config.env over process.env for CI detection', () => {
-      process.env.CI = 'false';
+      mockProcessEnv({ CI: 'false' });
       cliState.config = {
         env: {
           CI: 'true',
@@ -372,17 +373,17 @@ describe('envars', () => {
     });
 
     it('should return parsed integer value from environment variable', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = '10000';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: '10000' });
       expect(getMaxEvalTimeMs()).toBe(10000);
     });
 
     it('should handle invalid values', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = 'invalid';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: 'invalid' });
       expect(getMaxEvalTimeMs(5000)).toBe(5000);
     });
 
     it('should prioritize cliState.config.env over process.env', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = '5000';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: '5000' });
       cliState.config = {
         env: {
           PROMPTFOO_MAX_EVAL_TIME_MS: 10000 as any,
@@ -392,17 +393,17 @@ describe('envars', () => {
     });
 
     it('should floor floating point values', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = '1234.56';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: '1234.56' });
       expect(getMaxEvalTimeMs()).toBe(1234);
     });
 
     it('should handle negative values', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = '-1000';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: '-1000' });
       expect(getMaxEvalTimeMs()).toBe(-1000);
     });
 
     it('should handle empty string', () => {
-      process.env.PROMPTFOO_MAX_EVAL_TIME_MS = '';
+      mockProcessEnv({ PROMPTFOO_MAX_EVAL_TIME_MS: '' });
       expect(getMaxEvalTimeMs(1000)).toBe(1000);
     });
   });

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/evaluatorHelpers';
 import { transform } from '../src/util/transform';
 import { createMockProvider } from './factories/provider';
+import { mockProcessEnv } from './util/utils';
 
 import type { Prompt, TestCase, TestSuite } from '../src/types/index';
 
@@ -165,8 +166,8 @@ describe('evaluatorHelpers', () => {
 
   describe('renderPrompt', () => {
     beforeEach(() => {
-      delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
-      delete process.env.PROMPTFOO_DISABLE_JSON_AUTOESCAPE;
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
+      mockProcessEnv({ PROMPTFOO_DISABLE_JSON_AUTOESCAPE: undefined });
     });
 
     it('should render a prompt with a single variable', async () => {
@@ -217,19 +218,19 @@ describe('evaluatorHelpers', () => {
     });
 
     it('should render environment variables in JSON prompts', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       const prompt = toPrompt('{"text": "{{ env.TEST_ENV_VAR }}"}');
       const renderedPrompt = await renderPrompt(prompt, {}, {});
       expect(renderedPrompt).toBe(JSON.stringify({ text: 'env_value' }, null, 2));
-      delete process.env.TEST_ENV_VAR;
+      mockProcessEnv({ TEST_ENV_VAR: undefined });
     });
 
     it('should render environment variables in non-JSON prompts', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       const prompt = toPrompt('Test prompt {{ env.TEST_ENV_VAR }}');
       const renderedPrompt = await renderPrompt(prompt, {}, {});
       expect(renderedPrompt).toBe('Test prompt env_value');
-      delete process.env.TEST_ENV_VAR;
+      mockProcessEnv({ TEST_ENV_VAR: undefined });
     });
 
     it('should handle complex variable substitutions in JSON prompts', async () => {
@@ -376,11 +377,11 @@ describe('evaluatorHelpers', () => {
 
     describe('with PROMPTFOO_DISABLE_TEMPLATING', () => {
       beforeEach(() => {
-        process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+        mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
       });
 
       afterEach(() => {
-        delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+        mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
       });
 
       it('should return raw prompt when templating is disabled', async () => {
@@ -391,11 +392,11 @@ describe('evaluatorHelpers', () => {
     });
 
     it('should render normally when templating is enabled', async () => {
-      process.env.PROMPTFOO_DISABLE_TEMPLATING = 'false';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'false' });
       const prompt = toPrompt('Test prompt {{ var1 }}');
       const renderedPrompt = await renderPrompt(prompt, { var1: 'value1' }, {});
       expect(renderedPrompt).toBe('Test prompt value1');
-      delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
     });
 
     it('should respect Nunjucks raw tags when variable is provided as a string', async () => {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -114,13 +114,13 @@ vi.mock('../src/envars', () => {
     }),
     getEnvBool: vi.fn().mockImplementation((key: string, defaultValue: boolean = false) => {
       if (key === 'PROMPTFOO_RETRY_5XX_ENABLED') {
-        return process.env.PROMPTFOO_RETRY_5XX_ENABLED === 'true' || false;
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX_ENABLED === 'true' || false;
       }
       if (key === 'PROMPTFOO_INSECURE_SSL') {
-        return process.env.PROMPTFOO_INSECURE_SSL === 'true' || false;
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_INSECURE_SSL === 'true' || false;
       }
       if (key === 'PROMPTFOO_RETRY_5XX') {
-        return process.env.PROMPTFOO_RETRY_5XX === 'true' || false;
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX === 'true' || false;
       }
       return defaultValue;
     }),
@@ -336,8 +336,8 @@ describe('fetchWithProxy', () => {
     const mockCertContent = 'mock-cert-content';
     const mockProxyUrl = 'http://proxy.example.com';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.PROMPTFOO_CA_CERT_PATH = mockCertPath;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ PROMPTFOO_CA_CERT_PATH: mockCertPath });
 
     vi.mocked(getEnvString).mockImplementation((key: string, defaultValue: string = '') => {
       if (key === 'PROMPTFOO_CA_CERT_PATH') {
@@ -392,8 +392,8 @@ describe('fetchWithProxy', () => {
     const mockCertPath = path.normalize('/path/to/nonexistent.pem');
     const mockProxyUrl = 'http://proxy.example.com';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.PROMPTFOO_CA_CERT_PATH = mockCertPath;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ PROMPTFOO_CA_CERT_PATH: mockCertPath });
 
     vi.mocked(getEnvString).mockImplementation((key: string, defaultValue: string = '') => {
       if (key === 'PROMPTFOO_CA_CERT_PATH') {
@@ -443,8 +443,8 @@ describe('fetchWithProxy', () => {
   it('should disable SSL verification when PROMPTFOO_INSECURE_SSL is true', async () => {
     const mockProxyUrl = 'http://proxy.example.com';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.PROMPTFOO_INSECURE_SSL = 'true';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ PROMPTFOO_INSECURE_SSL: 'true' });
 
     vi.mocked(getEnvString).mockImplementation((key: string, defaultValue: string = '') => {
       if (key === 'HTTPS_PROXY') {
@@ -489,8 +489,8 @@ describe('fetchWithProxy', () => {
     const mockCertContent = 'mock-cert-content';
     const mockProxyUrl = 'http://proxy.example.com';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.PROMPTFOO_CA_CERT_PATH = mockCertPath;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ PROMPTFOO_CA_CERT_PATH: mockCertPath });
 
     cliState.basePath = mockBasePath;
 
@@ -613,7 +613,7 @@ describe('fetchWithProxy', () => {
       clearProxyEnv();
 
       Object.entries(testCase.env).forEach(([key, value]) => {
-        process.env[key] = value;
+        mockProcessEnv({ [key]: value });
       });
 
       await fetchWithProxy('http://example.com');
@@ -653,7 +653,7 @@ describe('fetchWithProxy', () => {
       clearProxyEnv();
 
       Object.entries(testCase.env).forEach(([key, value]) => {
-        process.env[key] = value;
+        mockProcessEnv({ [key]: value });
       });
 
       await fetchWithProxy('https://example.com');
@@ -690,8 +690,8 @@ describe('fetchWithProxy', () => {
   it('should use proxy for domains not in NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,internal.example.com';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,internal.example.com' });
 
     await fetchWithProxy('https://api.example.com/v1');
 
@@ -765,7 +765,7 @@ describe('fetchWithProxy', () => {
 
   it('should create a dedicated ProxyAgent dispatcher per proxy URL and maxConcurrency value', async () => {
     const mockProxyUrl = 'http://proxy.example.com';
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
 
     cliState.maxConcurrency = 2;
     await fetchWithProxy('https://example.com/api/low');
@@ -1401,8 +1401,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should respect NO_PROXY for localhost URLs', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost' });
 
     await fetchWithProxy('http://localhost:3000/api');
 
@@ -1412,8 +1412,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should respect NO_PROXY for 127.0.0.1', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = '127.0.0.1';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: '127.0.0.1' });
 
     await fetchWithProxy('http://127.0.0.1:3000/api');
 
@@ -1424,27 +1424,27 @@ describe('fetchWithProxy with NO_PROXY', () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
     const noProxyList = 'example.org,localhost,internal.example.com';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = noProxyList;
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: noProxyList });
 
     await fetchWithProxy('http://localhost:3000/api');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = noProxyList;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: noProxyList });
     await fetchWithProxy('https://example.org/api');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = noProxyList;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: noProxyList });
     await fetchWithProxy('https://internal.example.com/api');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = noProxyList;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: noProxyList });
     await fetchWithProxy('https://example.com/api');
     expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1460,8 +1460,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should use proxy for domains not in NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,internal.example.com';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,internal.example.com' });
 
     await fetchWithProxy('https://api.example.com/v1');
 
@@ -1479,19 +1479,19 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should handle wildcard patterns in NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = '*.example.org,localhost';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: '*.example.org,localhost' });
 
     await fetchWithProxy('https://api.example.org/v1');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
     await fetchWithProxy('https://subdomain.api.example.org/v1');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
     await fetchWithProxy('https://example.com/v1');
     expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1503,24 +1503,24 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should handle domain suffix patterns in NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = '.example.org,localhost';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: '.example.org,localhost' });
 
     await fetchWithProxy('https://api.example.org/v1');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
     await fetchWithProxy('https://subdomain.api.example.org/v1');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
     await fetchWithProxy('https://abc.example.org/v1');
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    process.env.HTTPS_PROXY = mockProxyUrl;
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
     await fetchWithProxy('https://abc.example.com/v1');
     expect(ProxyAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1532,8 +1532,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should handle URLs without schemes', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,example.org';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,example.org' });
 
     await fetchWithProxy('localhost:3000');
     expect(ProxyAgent).not.toHaveBeenCalled();
@@ -1546,8 +1546,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should properly parse URLs with credentials when checking against NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'api.example.org';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'api.example.org' });
 
     await fetchWithProxy('https://username:password@api.example.org/v1');
 
@@ -1565,9 +1565,9 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should handle bad URL inputs gracefully when checking NO_PROXY', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost' });
 
     await fetchWithProxy(':::not-a-valid-url:::');
 
@@ -1577,8 +1577,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should use lowercase for NO_PROXY checks', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'LOCALHOST,API.EXAMPLE.ORG';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'LOCALHOST,API.EXAMPLE.ORG' });
 
     await fetchWithProxy('http://localhost:3000');
     expect(ProxyAgent).not.toHaveBeenCalled();
@@ -1591,8 +1591,8 @@ describe('fetchWithProxy with NO_PROXY', () => {
   it('should handle URL objects and Request objects', async () => {
     const mockProxyUrl = 'http://proxy.example.com:8080';
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,example.org';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,example.org' });
 
     const urlObj = new URL('http://localhost:3000');
     await fetchWithProxy(urlObj.toString());
@@ -1600,16 +1600,16 @@ describe('fetchWithProxy with NO_PROXY', () => {
 
     vi.clearAllMocks();
 
-    process.env.HTTPS_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,example.org';
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,example.org' });
     const request = new Request('https://example.org/api');
     await fetchWithProxy(request);
     expect(ProxyAgent).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
 
-    process.env.HTTP_PROXY = mockProxyUrl;
-    process.env.NO_PROXY = 'localhost,example.org';
+    mockProcessEnv({ HTTP_PROXY: mockProxyUrl });
+    mockProcessEnv({ NO_PROXY: 'localhost,example.org' });
     const otherRequest = new Request('http://example.com/api');
     await fetchWithProxy(otherRequest);
     expect(ProxyAgent).toHaveBeenCalledWith(

--- a/test/globalConfig/cloud.test.ts
+++ b/test/globalConfig/cloud.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { API_HOST, CloudConfig, cloudConfig } from '../../src/globalConfig/cloud';
 import { readGlobalConfig, writeGlobalConfigPartial } from '../../src/globalConfig/globalConfig';
 import { fetchWithProxy } from '../../src/util/fetch/index';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/util/fetch/index');
 vi.mock('../../src/logger');
@@ -288,9 +289,9 @@ describe('CloudConfig', () => {
 
     afterEach(() => {
       if (originalEnv === undefined) {
-        delete process.env.PROMPTFOO_API_KEY;
+        mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       } else {
-        process.env.PROMPTFOO_API_KEY = originalEnv;
+        mockProcessEnv({ PROMPTFOO_API_KEY: originalEnv });
       }
     });
 
@@ -299,7 +300,7 @@ describe('CloudConfig', () => {
         id: 'test-id',
         cloud: { apiKey: 'config-key' },
       });
-      delete process.env.PROMPTFOO_API_KEY;
+      mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       const config = new CloudConfig();
       expect(config.getApiKey()).toBe('config-key');
     });
@@ -308,7 +309,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      process.env.PROMPTFOO_API_KEY = 'env-key';
+      mockProcessEnv({ PROMPTFOO_API_KEY: 'env-key' });
       const config = new CloudConfig();
       expect(config.getApiKey()).toBe('env-key');
     });
@@ -318,7 +319,7 @@ describe('CloudConfig', () => {
         id: 'test-id',
         cloud: { apiKey: 'config-key' },
       });
-      process.env.PROMPTFOO_API_KEY = 'env-key';
+      mockProcessEnv({ PROMPTFOO_API_KEY: 'env-key' });
       const config = new CloudConfig();
       expect(config.getApiKey()).toBe('config-key');
     });
@@ -327,7 +328,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      delete process.env.PROMPTFOO_API_KEY;
+      mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       const config = new CloudConfig();
       expect(config.getApiKey()).toBeUndefined();
     });
@@ -338,9 +339,9 @@ describe('CloudConfig', () => {
 
     afterEach(() => {
       if (originalEnv === undefined) {
-        delete process.env.PROMPTFOO_API_KEY;
+        mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       } else {
-        process.env.PROMPTFOO_API_KEY = originalEnv;
+        mockProcessEnv({ PROMPTFOO_API_KEY: originalEnv });
       }
     });
 
@@ -349,7 +350,7 @@ describe('CloudConfig', () => {
         id: 'test-id',
         cloud: { apiKey: 'config-key' },
       });
-      delete process.env.PROMPTFOO_API_KEY;
+      mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       const config = new CloudConfig();
       expect(config.isEnabled()).toBe(true);
     });
@@ -358,7 +359,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      process.env.PROMPTFOO_API_KEY = 'env-key';
+      mockProcessEnv({ PROMPTFOO_API_KEY: 'env-key' });
       const config = new CloudConfig();
       expect(config.isEnabled()).toBe(true);
     });
@@ -367,7 +368,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      delete process.env.PROMPTFOO_API_KEY;
+      mockProcessEnv({ PROMPTFOO_API_KEY: undefined });
       const config = new CloudConfig();
       expect(config.isEnabled()).toBe(false);
     });
@@ -378,9 +379,9 @@ describe('CloudConfig', () => {
 
     afterEach(() => {
       if (originalEnv === undefined) {
-        delete process.env.PROMPTFOO_CLOUD_API_URL;
+        mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: undefined });
       } else {
-        process.env.PROMPTFOO_CLOUD_API_URL = originalEnv;
+        mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: originalEnv });
       }
     });
 
@@ -389,7 +390,7 @@ describe('CloudConfig', () => {
         id: 'test-id',
         cloud: { apiHost: 'https://config-host.example.com' },
       });
-      delete process.env.PROMPTFOO_CLOUD_API_URL;
+      mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: undefined });
       const config = new CloudConfig();
       expect(config.getApiHost()).toBe('https://config-host.example.com');
     });
@@ -398,7 +399,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      process.env.PROMPTFOO_CLOUD_API_URL = 'https://env-host.example.com';
+      mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: 'https://env-host.example.com' });
       const config = new CloudConfig();
       expect(config.getApiHost()).toBe('https://env-host.example.com');
     });
@@ -408,7 +409,7 @@ describe('CloudConfig', () => {
         id: 'test-id',
         cloud: { apiHost: 'https://config-host.example.com' },
       });
-      process.env.PROMPTFOO_CLOUD_API_URL = 'https://env-host.example.com';
+      mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: 'https://env-host.example.com' });
       const config = new CloudConfig();
       expect(config.getApiHost()).toBe('https://config-host.example.com');
     });
@@ -417,7 +418,7 @@ describe('CloudConfig', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
       });
-      delete process.env.PROMPTFOO_CLOUD_API_URL;
+      mockProcessEnv({ PROMPTFOO_CLOUD_API_URL: undefined });
       const config = new CloudConfig();
       expect(config.getApiHost()).toBe(API_HOST);
     });

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -11,6 +11,7 @@ import {
   type MockInstance,
   vi,
 } from 'vitest';
+import { mockProcessEnv } from './util/utils';
 import type { Logger } from 'winston';
 import type Transport from 'winston-transport';
 
@@ -570,7 +571,7 @@ describe('logger', () => {
     it('should only call install once across concurrent and repeated invocations', async () => {
       // Save and clear LOG_LEVEL to prevent auto-initialization during import
       const originalLogLevel = process.env.LOG_LEVEL;
-      delete process.env.LOG_LEVEL;
+      mockProcessEnv({ LOG_LEVEL: undefined });
 
       try {
         // Reset modules and set up fresh mocks
@@ -598,7 +599,7 @@ describe('logger', () => {
       } finally {
         // Restore LOG_LEVEL
         if (originalLogLevel !== undefined) {
-          process.env.LOG_LEVEL = originalLogLevel;
+          mockProcessEnv({ LOG_LEVEL: originalLogLevel });
         }
         vi.resetModules();
       }
@@ -607,7 +608,7 @@ describe('logger', () => {
     it('should handle errors gracefully when source-map-support fails', async () => {
       // Save and clear LOG_LEVEL
       const originalLogLevel = process.env.LOG_LEVEL;
-      delete process.env.LOG_LEVEL;
+      mockProcessEnv({ LOG_LEVEL: undefined });
 
       try {
         vi.resetModules();
@@ -624,7 +625,7 @@ describe('logger', () => {
       } finally {
         // Restore LOG_LEVEL
         if (originalLogLevel !== undefined) {
-          process.env.LOG_LEVEL = originalLogLevel;
+          mockProcessEnv({ LOG_LEVEL: originalLogLevel });
         }
         vi.resetModules();
       }

--- a/test/matchers/utils.test.ts
+++ b/test/matchers/utils.test.ts
@@ -6,6 +6,7 @@ import {
   DefaultGradingProvider,
 } from '../../src/providers/openai/defaults';
 import { createMockProvider } from '../factories/provider';
+import { mockProcessEnv } from '../util/utils';
 
 import type { ProviderTypeMap } from '../../src/types/index';
 
@@ -361,12 +362,12 @@ describe('tryParse and renderLlmRubricPrompt', () => {
 describe('PROMPTFOO_DISABLE_OBJECT_STRINGIFY environment variable', () => {
   afterEach(() => {
     // Clean up environment variable after each test
-    delete process.env.PROMPTFOO_DISABLE_OBJECT_STRINGIFY;
+    mockProcessEnv({ PROMPTFOO_DISABLE_OBJECT_STRINGIFY: undefined });
   });
 
   describe('Default behavior (PROMPTFOO_DISABLE_OBJECT_STRINGIFY=false)', () => {
     beforeEach(() => {
-      process.env.PROMPTFOO_DISABLE_OBJECT_STRINGIFY = 'false';
+      mockProcessEnv({ PROMPTFOO_DISABLE_OBJECT_STRINGIFY: 'false' });
     });
 
     it('should stringify objects to prevent [object Object] issues', async () => {
@@ -394,7 +395,7 @@ describe('PROMPTFOO_DISABLE_OBJECT_STRINGIFY environment variable', () => {
 
   describe('Object access enabled (PROMPTFOO_DISABLE_OBJECT_STRINGIFY=true)', () => {
     beforeEach(() => {
-      process.env.PROMPTFOO_DISABLE_OBJECT_STRINGIFY = 'true';
+      mockProcessEnv({ PROMPTFOO_DISABLE_OBJECT_STRINGIFY: 'true' });
     });
 
     it('should allow direct object property access', async () => {

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -127,7 +127,7 @@ describe('reportProviderAPIKeyWarnings', () => {
     );
   });
   it('should produce only warnings for applicable providers if the env keys are not set', () => {
-    process.env.OPENAI_API_KEY = '<my-api-key>';
+    mockProcessEnv({ OPENAI_API_KEY: '<my-api-key>' });
     expect(reportProviderAPIKeyWarnings([openaiID, anthropicID])).toEqual(
       expect.arrayContaining([
         expect.stringContaining('ANTHROPIC_API_KEY environment variable is not set'),

--- a/test/prompts/index.test.ts
+++ b/test/prompts/index.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importModule } from '../../src/esm';
 import { processPrompts, readPrompts, readProviderPromptMap } from '../../src/prompts/index';
 import { maybeFilePath } from '../../src/prompts/utils';
+import { mockProcessEnv } from '../util/utils';
 
 import type {
   ApiProvider,
@@ -51,7 +52,7 @@ describe('readPrompts', () => {
     vi.clearAllMocks();
   });
   afterEach(() => {
-    delete process.env.PROMPTFOO_STRICT_FILES;
+    mockProcessEnv({ PROMPTFOO_STRICT_FILES: undefined });
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(fs.statSync).mockReset();
     vi.mocked(globSync).mockReset();
@@ -73,7 +74,7 @@ describe('readPrompts', () => {
   });
 
   it('should throw an error when PROMPTFOO_STRICT_FILES is true and the file does not exist', async () => {
-    process.env.PROMPTFOO_STRICT_FILES = 'true';
+    mockProcessEnv({ PROMPTFOO_STRICT_FILES: 'true' });
     vi.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     vi.mocked(fs.readFileSync).mockImplementationOnce(() => {
       throw new Error("ENOENT: no such file or directory, stat 'non-existent-file.txt'");
@@ -91,7 +92,7 @@ describe('readPrompts', () => {
     vi.mocked(fs.readFileSync).mockReturnValueOnce('');
     vi.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     vi.mocked(maybeFilePath).mockReturnValueOnce(true);
-    process.env.PROMPTFOO_STRICT_FILES = 'true';
+    mockProcessEnv({ PROMPTFOO_STRICT_FILES: 'true' });
     await expect(readPrompts(['prompts.txt'])).rejects.toThrow(
       'There are no prompts in "prompts.txt"',
     );
@@ -101,7 +102,7 @@ describe('readPrompts', () => {
   it('should throw an error for an unsupported file format', async () => {
     vi.mocked(fs.statSync).mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
     vi.mocked(maybeFilePath).mockReturnValueOnce(true);
-    process.env.PROMPTFOO_STRICT_FILES = 'true';
+    mockProcessEnv({ PROMPTFOO_STRICT_FILES: 'true' });
     await expect(readPrompts(['unsupported.for.mat'])).rejects.toThrow(
       'There are no prompts in "unsupported.for.mat"',
     );

--- a/test/providers.slack.test.ts
+++ b/test/providers.slack.test.ts
@@ -1,6 +1,7 @@
 import { WebClient } from '@slack/web-api';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SlackProvider } from '../src/providers/slack';
+import { mockProcessEnv } from './util/utils';
 
 import type { ApiProvider } from '../src/types/index';
 
@@ -23,7 +24,7 @@ describe('SlackProvider', () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     slackMocks.webClientImpl.mockReset();
-    process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
+    mockProcessEnv({ SLACK_BOT_TOKEN: 'xoxb-test-token' });
 
     mockWebClient = {
       chat: {
@@ -40,12 +41,12 @@ describe('SlackProvider', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
-    delete process.env.SLACK_BOT_TOKEN;
+    mockProcessEnv({ SLACK_BOT_TOKEN: undefined });
   });
 
   describe('constructor', () => {
     it('should throw error if no token is provided', () => {
-      delete process.env.SLACK_BOT_TOKEN;
+      mockProcessEnv({ SLACK_BOT_TOKEN: undefined });
       expect(() => new SlackProvider({ config: { channel: 'C123' } })).toThrow(
         'Slack provider requires a token',
       );

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -16,6 +16,7 @@ import { ScriptCompletionProvider } from '../src/providers/scriptCompletion';
 import { WebSocketProvider } from '../src/providers/websocket';
 import { getCloudDatabaseId, getProviderFromCloud, isCloudProvider } from '../src/util/cloud';
 import * as fileUtil from '../src/util/file';
+import { mockProcessEnv } from './util/utils';
 
 import type { ProviderOptions } from '../src/types/index';
 
@@ -788,14 +789,14 @@ describe('loadApiProvider', () => {
   });
 
   it('should handle provider with custom label template', async () => {
-    process.env.CUSTOM_LABEL = 'my-label';
+    mockProcessEnv({ CUSTOM_LABEL: 'my-label' });
     const provider = await loadApiProvider('echo', {
       options: {
         label: '{{ env.CUSTOM_LABEL }}',
       },
     });
     expect(provider.label).toBe('my-label');
-    delete process.env.CUSTOM_LABEL;
+    mockProcessEnv({ CUSTOM_LABEL: undefined });
   });
 
   it('should throw error when file provider array is loaded with loadApiProvider', async () => {
@@ -818,7 +819,7 @@ describe('loadApiProvider', () => {
   });
 
   it('should handle file provider with environment variables', async () => {
-    process.env.OPENAI_API_KEY = 'test-key-from-env';
+    mockProcessEnv({ OPENAI_API_KEY: 'test-key-from-env' });
     const yamlContent: ProviderOptions = {
       id: 'openai:chat:gpt-4',
       config: {
@@ -848,7 +849,7 @@ describe('loadApiProvider', () => {
         }),
       }),
     );
-    delete process.env.OPENAI_API_KEY;
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
   });
 
   it('should load multiple providers from yaml file using loadApiProviders', async () => {

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -13,7 +13,7 @@ vi.mock('proxy-agent', async (importOriginal) => {
   };
 });
 
-const originalEnv = process.env;
+const originalEnv = { ...process.env };
 const TEST_API_KEY = 'test-api-key';
 
 describe('AnthropicCompletionProvider', () => {

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache, disableCache, enableCache } from '../../../src/cache';
 import { AnthropicCompletionProvider } from '../../../src/providers/anthropic/completion';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('proxy-agent', async (importOriginal) => {
   return {
@@ -17,14 +18,14 @@ const TEST_API_KEY = 'test-api-key';
 
 describe('AnthropicCompletionProvider', () => {
   beforeEach(() => {
-    process.env = { ...originalEnv, ANTHROPIC_API_KEY: TEST_API_KEY };
+    mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: TEST_API_KEY }, { clear: true });
   });
 
   afterEach(async () => {
     vi.clearAllMocks();
     await clearCache();
     enableCache();
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   describe('callApi', () => {
@@ -117,7 +118,7 @@ describe('AnthropicCompletionProvider', () => {
     });
 
     it('should preserve an explicit max_tokens_to_sample value of 0', async () => {
-      process.env.ANTHROPIC_MAX_TOKENS = '1024';
+      mockProcessEnv({ ANTHROPIC_MAX_TOKENS: '1024' });
 
       const provider = new AnthropicCompletionProvider('claude-2.1', {
         config: { max_tokens_to_sample: 0 },
@@ -147,7 +148,7 @@ describe('AnthropicCompletionProvider', () => {
       // `AnthropicCompletionOptions` type which deliberately does not expose
       // the field — this test documents the runtime guard for anyone who
       // bypasses the type system.
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       const provider = new AnthropicCompletionProvider('claude-2.1', {
         config: { apiKeyRequired: false } as never,
       });

--- a/test/providers/anthropic/generic.test.ts
+++ b/test/providers/anthropic/generic.test.ts
@@ -86,19 +86,19 @@ describe('AnthropicGenericProvider', () => {
     it('should use environment variables if no config key is provided', () => {
       // Mock process.env
       const originalEnv = process.env;
-      process.env = { ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' };
+      mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' }, { clear: true });
 
       const provider = new AnthropicGenericProvider('claude-3-5-sonnet-20241022');
       expect(provider.getApiKey()).toBe('env-test-key');
 
       // Restore process.env
-      process.env = originalEnv;
+      mockProcessEnv(originalEnv, { clear: true });
     });
 
     it('should prefer config over environment variables', () => {
       // Mock process.env
       const originalEnv = process.env;
-      process.env = { ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' };
+      mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' }, { clear: true });
 
       const provider = new AnthropicGenericProvider('claude-3-5-sonnet-20241022', {
         config: { apiKey: 'config-test-key' },
@@ -107,7 +107,7 @@ describe('AnthropicGenericProvider', () => {
       expect(provider.getApiKey()).toBe('config-test-key');
 
       // Restore process.env
-      process.env = originalEnv;
+      mockProcessEnv(originalEnv, { clear: true });
     });
   });
 
@@ -123,13 +123,16 @@ describe('AnthropicGenericProvider', () => {
     it('should use environment variables if no config URL is provided', () => {
       // Mock process.env
       const originalEnv = process.env;
-      process.env = { ...originalEnv, ANTHROPIC_BASE_URL: 'https://env.anthropic.api' };
+      mockProcessEnv(
+        { ...originalEnv, ANTHROPIC_BASE_URL: 'https://env.anthropic.api' },
+        { clear: true },
+      );
 
       const provider = new AnthropicGenericProvider('claude-3-5-sonnet-20241022');
       expect(provider.getApiBaseUrl()).toBe('https://env.anthropic.api');
 
       // Restore process.env
-      process.env = originalEnv;
+      mockProcessEnv(originalEnv, { clear: true });
     });
   });
 

--- a/test/providers/anthropic/generic.test.ts
+++ b/test/providers/anthropic/generic.test.ts
@@ -85,7 +85,7 @@ describe('AnthropicGenericProvider', () => {
 
     it('should use environment variables if no config key is provided', () => {
       // Mock process.env
-      const originalEnv = process.env;
+      const originalEnv = { ...process.env };
       mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' }, { clear: true });
 
       const provider = new AnthropicGenericProvider('claude-3-5-sonnet-20241022');
@@ -97,7 +97,7 @@ describe('AnthropicGenericProvider', () => {
 
     it('should prefer config over environment variables', () => {
       // Mock process.env
-      const originalEnv = process.env;
+      const originalEnv = { ...process.env };
       mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: 'env-test-key' }, { clear: true });
 
       const provider = new AnthropicGenericProvider('claude-3-5-sonnet-20241022', {
@@ -122,7 +122,7 @@ describe('AnthropicGenericProvider', () => {
 
     it('should use environment variables if no config URL is provided', () => {
       // Mock process.env
-      const originalEnv = process.env;
+      const originalEnv = { ...process.env };
       mockProcessEnv(
         { ...originalEnv, ANTHROPIC_BASE_URL: 'https://env.anthropic.api' },
         { clear: true },

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -6,6 +6,7 @@ import logger from '../../../src/logger';
 import { AnthropicMessagesProvider } from '../../../src/providers/anthropic/messages';
 import { MCPClient } from '../../../src/providers/mcp/client';
 import { maybeLoadResponseFormatFromExternalFile } from '../../../src/util/file';
+import { mockProcessEnv } from '../../util/utils';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { Mocked, MockedFunction } from 'vitest';
 
@@ -91,7 +92,7 @@ describe('AnthropicMessagesProvider', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    process.env = { ...originalEnv, ANTHROPIC_API_KEY: TEST_API_KEY };
+    mockProcessEnv({ ...originalEnv, ANTHROPIC_API_KEY: TEST_API_KEY }, { clear: true });
     mockMCPClient = undefined;
     mcpMocks.instances.length = 0;
     mcpMocks.initialize.mockReset();
@@ -104,7 +105,7 @@ describe('AnthropicMessagesProvider', () => {
   afterEach(async () => {
     vi.clearAllMocks();
     await clearCache();
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     mcpMocks.instances.length = 0;
   });
 
@@ -2158,7 +2159,7 @@ describe('AnthropicMessagesProvider', () => {
       }) as Anthropic.Messages.Message;
 
     it('throws with guidance when no API key and no Claude Code credential are available', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(null);
       const oauthProvider = createProvider('claude-sonnet-4-6');
 
@@ -2168,7 +2169,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('injects the Claude Code identity block and beta headers when constructed with apiKeyRequired: false', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: { apiKeyRequired: false },
@@ -2196,7 +2197,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('adds the Claude Code identity block even when no user system prompt is provided', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: { apiKeyRequired: false },
@@ -2215,7 +2216,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('does not inject the Claude Code identity block for API-key authenticated calls', async () => {
-      process.env.ANTHROPIC_API_KEY = TEST_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: TEST_API_KEY });
       const apiKeyProvider = createProvider('claude-sonnet-4-6');
       expect(apiKeyProvider.usingClaudeCodeOAuth).toBe(false);
 
@@ -2234,7 +2235,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('throws at request time when the Claude Code credential is expired', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue({
         accessToken: 'sk-ant-oat-expired',
         expiresAt: Date.now() - 1000,
@@ -2249,7 +2250,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('preserves user config.beta entries alongside the Claude Code beta features', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: {
@@ -2272,7 +2273,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('merges user-supplied config.headers[anthropic-beta] with OAuth beta flags', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: {
@@ -2296,7 +2297,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('deduplicates Claude Code beta features when the user also supplies them', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: {
@@ -2318,7 +2319,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('forces the Claude Code user-agent even when config.headers tries to override it', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: {
@@ -2340,7 +2341,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('injects the Claude Code identity block and beta headers on the streaming path', async () => {
-      delete process.env.ANTHROPIC_API_KEY;
+      mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
       claudeCodeAuthMocks.loadClaudeCodeCredential.mockReturnValue(validCredential());
       const oauthProvider = createProvider('claude-sonnet-4-6', {
         config: { apiKeyRequired: false, stream: true },

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -71,7 +71,7 @@ const mockMaybeLoadResponseFormatFromExternalFile =
   >;
 
 const TEST_API_KEY = 'test-api-key';
-const originalEnv = process.env;
+const originalEnv = { ...process.env };
 let mockMCPClient: Mocked<MCPClient> | undefined;
 
 const createProvider = (

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import logger from '../../../src/logger';
 import { AzureChatCompletionProvider } from '../../../src/providers/azure/chat';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -28,12 +29,12 @@ const originalOpenAiFrequencyPenalty = process.env.OPENAI_FREQUENCY_PENALTY;
 describe('AzureChatCompletionProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.OPENAI_TEMPERATURE;
-    delete process.env.OPENAI_MAX_TOKENS;
-    delete process.env.OPENAI_MAX_COMPLETION_TOKENS;
-    delete process.env.OPENAI_TOP_P;
-    delete process.env.OPENAI_PRESENCE_PENALTY;
-    delete process.env.OPENAI_FREQUENCY_PENALTY;
+    mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
+    mockProcessEnv({ OPENAI_MAX_TOKENS: undefined });
+    mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: undefined });
+    mockProcessEnv({ OPENAI_TOP_P: undefined });
+    mockProcessEnv({ OPENAI_PRESENCE_PENALTY: undefined });
+    mockProcessEnv({ OPENAI_FREQUENCY_PENALTY: undefined });
     vi.spyOn(AzureChatCompletionProvider.prototype as any, 'getAuthHeaders').mockResolvedValue({
       'api-key': 'test-key',
     });
@@ -42,34 +43,34 @@ describe('AzureChatCompletionProvider', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     if (originalOpenAiTemperature === undefined) {
-      delete process.env.OPENAI_TEMPERATURE;
+      mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
     } else {
-      process.env.OPENAI_TEMPERATURE = originalOpenAiTemperature;
+      mockProcessEnv({ OPENAI_TEMPERATURE: originalOpenAiTemperature });
     }
     if (originalOpenAiMaxTokens === undefined) {
-      delete process.env.OPENAI_MAX_TOKENS;
+      mockProcessEnv({ OPENAI_MAX_TOKENS: undefined });
     } else {
-      process.env.OPENAI_MAX_TOKENS = originalOpenAiMaxTokens;
+      mockProcessEnv({ OPENAI_MAX_TOKENS: originalOpenAiMaxTokens });
     }
     if (originalOpenAiMaxCompletionTokens === undefined) {
-      delete process.env.OPENAI_MAX_COMPLETION_TOKENS;
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: undefined });
     } else {
-      process.env.OPENAI_MAX_COMPLETION_TOKENS = originalOpenAiMaxCompletionTokens;
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: originalOpenAiMaxCompletionTokens });
     }
     if (originalOpenAiTopP === undefined) {
-      delete process.env.OPENAI_TOP_P;
+      mockProcessEnv({ OPENAI_TOP_P: undefined });
     } else {
-      process.env.OPENAI_TOP_P = originalOpenAiTopP;
+      mockProcessEnv({ OPENAI_TOP_P: originalOpenAiTopP });
     }
     if (originalOpenAiPresencePenalty === undefined) {
-      delete process.env.OPENAI_PRESENCE_PENALTY;
+      mockProcessEnv({ OPENAI_PRESENCE_PENALTY: undefined });
     } else {
-      process.env.OPENAI_PRESENCE_PENALTY = originalOpenAiPresencePenalty;
+      mockProcessEnv({ OPENAI_PRESENCE_PENALTY: originalOpenAiPresencePenalty });
     }
     if (originalOpenAiFrequencyPenalty === undefined) {
-      delete process.env.OPENAI_FREQUENCY_PENALTY;
+      mockProcessEnv({ OPENAI_FREQUENCY_PENALTY: undefined });
     } else {
-      process.env.OPENAI_FREQUENCY_PENALTY = originalOpenAiFrequencyPenalty;
+      mockProcessEnv({ OPENAI_FREQUENCY_PENALTY: originalOpenAiFrequencyPenalty });
     }
   });
 
@@ -267,11 +268,11 @@ describe('AzureChatCompletionProvider', () => {
     });
 
     it('should use env defaults with omitDefaults when OPENAI env vars are set', async () => {
-      process.env.OPENAI_TEMPERATURE = '0.5';
-      process.env.OPENAI_MAX_TOKENS = '2048';
-      process.env.OPENAI_TOP_P = '0.9';
-      process.env.OPENAI_PRESENCE_PENALTY = '0.1';
-      process.env.OPENAI_FREQUENCY_PENALTY = '0.2';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '0.5' });
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
+      mockProcessEnv({ OPENAI_TOP_P: '0.9' });
+      mockProcessEnv({ OPENAI_PRESENCE_PENALTY: '0.1' });
+      mockProcessEnv({ OPENAI_FREQUENCY_PENALTY: '0.2' });
 
       provider = new AzureChatCompletionProvider('test-deployment', {
         config: {
@@ -759,8 +760,8 @@ describe('AzureChatCompletionProvider', () => {
     });
 
     it('should prefer OPENAI_MAX_COMPLETION_TOKENS over OPENAI_MAX_TOKENS for reasoning models', async () => {
-      process.env.OPENAI_MAX_COMPLETION_TOKENS = '4096';
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: '4096' });
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureChatCompletionProvider('test-deployment', {
         config: {
@@ -776,7 +777,7 @@ describe('AzureChatCompletionProvider', () => {
     });
 
     it('should fall back to OPENAI_MAX_TOKENS for reasoning models when OPENAI_MAX_COMPLETION_TOKENS is unset', async () => {
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureChatCompletionProvider('test-deployment', {
         config: {

--- a/test/providers/azure/completion.test.ts
+++ b/test/providers/azure/completion.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { AzureCompletionProvider } from '../../../src/providers/azure/completion';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -25,14 +26,14 @@ describe('AzureCompletionProvider', () => {
     vi.spyOn(AzureCompletionProvider.prototype as any, 'getAuthHeaders').mockResolvedValue({
       'api-key': 'test-key',
     });
-    delete process.env.OPENAI_STOP;
-    process.env.AZURE_API_HOST = 'test.azure.com';
-    process.env.AZURE_API_KEY = 'test-key';
+    mockProcessEnv({ OPENAI_STOP: undefined });
+    mockProcessEnv({ AZURE_API_HOST: 'test.azure.com' });
+    mockProcessEnv({ AZURE_API_KEY: 'test-key' });
   });
 
   afterEach(() => {
-    delete process.env.AZURE_API_HOST;
-    delete process.env.AZURE_API_KEY;
+    mockProcessEnv({ AZURE_API_HOST: undefined });
+    mockProcessEnv({ AZURE_API_KEY: undefined });
     vi.restoreAllMocks();
     vi.clearAllMocks();
   });
@@ -172,7 +173,7 @@ describe('AzureCompletionProvider', () => {
   });
 
   it('should handle invalid OPENAI_STOP env var', async () => {
-    process.env.OPENAI_STOP = '{invalid json}';
+    mockProcessEnv({ OPENAI_STOP: '{invalid json}' });
 
     const provider = new AzureCompletionProvider('test', {
       config: { apiHost: 'test.azure.com' },
@@ -183,7 +184,7 @@ describe('AzureCompletionProvider', () => {
       /OPENAI_STOP is not a valid JSON string/,
     );
 
-    delete process.env.OPENAI_STOP;
+    mockProcessEnv({ OPENAI_STOP: undefined });
   });
 
   it('should handle missing output and finish_reason not content_filter', async () => {

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { AzureResponsesProvider } from '../../../src/providers/azure/responses';
 import { maybeLoadResponseFormatFromExternalFile } from '../../../src/util/file';
+import { mockProcessEnv } from '../../util/utils';
 import type { MockedFunction } from 'vitest';
 
 // Mock external dependencies
@@ -21,33 +22,33 @@ const originalOpenAiMaxCompletionTokens = process.env.OPENAI_MAX_COMPLETION_TOKE
 describe('AzureResponsesProvider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    delete process.env.OPENAI_TEMPERATURE;
-    delete process.env.OPENAI_MAX_TOKENS;
-    delete process.env.OPENAI_MAX_COMPLETION_TOKENS;
+    mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
+    mockProcessEnv({ OPENAI_MAX_TOKENS: undefined });
+    mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: undefined });
 
     // Mock environment variables
-    process.env.AZURE_API_KEY = 'test-key';
-    process.env.AZURE_API_HOST = 'test.openai.azure.com';
+    mockProcessEnv({ AZURE_API_KEY: 'test-key' });
+    mockProcessEnv({ AZURE_API_HOST: 'test.openai.azure.com' });
     authHeadersValue = { 'api-key': 'test-key' };
   });
 
   afterEach(() => {
-    delete process.env.AZURE_API_KEY;
-    delete process.env.AZURE_API_HOST;
+    mockProcessEnv({ AZURE_API_KEY: undefined });
+    mockProcessEnv({ AZURE_API_HOST: undefined });
     if (originalOpenAiTemperature === undefined) {
-      delete process.env.OPENAI_TEMPERATURE;
+      mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
     } else {
-      process.env.OPENAI_TEMPERATURE = originalOpenAiTemperature;
+      mockProcessEnv({ OPENAI_TEMPERATURE: originalOpenAiTemperature });
     }
     if (originalOpenAiMaxTokens === undefined) {
-      delete process.env.OPENAI_MAX_TOKENS;
+      mockProcessEnv({ OPENAI_MAX_TOKENS: undefined });
     } else {
-      process.env.OPENAI_MAX_TOKENS = originalOpenAiMaxTokens;
+      mockProcessEnv({ OPENAI_MAX_TOKENS: originalOpenAiMaxTokens });
     }
     if (originalOpenAiMaxCompletionTokens === undefined) {
-      delete process.env.OPENAI_MAX_COMPLETION_TOKENS;
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: undefined });
     } else {
-      process.env.OPENAI_MAX_COMPLETION_TOKENS = originalOpenAiMaxCompletionTokens;
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: originalOpenAiMaxCompletionTokens });
     }
     delete (AzureResponsesProvider.prototype as any).authHeaders;
   });
@@ -245,8 +246,8 @@ describe('AzureResponsesProvider', () => {
     });
 
     it('should use env defaults with omitDefaults when OPENAI env vars are set', async () => {
-      process.env.OPENAI_TEMPERATURE = '0.5';
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '0.5' });
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureResponsesProvider('gpt-4.1-test', {
         config: { omitDefaults: true },
@@ -261,8 +262,8 @@ describe('AzureResponsesProvider', () => {
     });
 
     it('should prefer OPENAI_MAX_COMPLETION_TOKENS over OPENAI_MAX_TOKENS for reasoning models', async () => {
-      process.env.OPENAI_MAX_COMPLETION_TOKENS = '4096';
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_MAX_COMPLETION_TOKENS: '4096' });
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureResponsesProvider('o1-preview', {
         config: { omitDefaults: true },
@@ -275,7 +276,7 @@ describe('AzureResponsesProvider', () => {
     });
 
     it('should fall back to OPENAI_MAX_TOKENS for reasoning models when OPENAI_MAX_COMPLETION_TOKENS is unset', async () => {
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureResponsesProvider('o1-preview', {
         config: { omitDefaults: true },
@@ -288,7 +289,7 @@ describe('AzureResponsesProvider', () => {
     });
 
     it('should use OPENAI_MAX_TOKENS for reasoning models when omitDefaults is false and OPENAI_MAX_COMPLETION_TOKENS is unset', async () => {
-      process.env.OPENAI_MAX_TOKENS = '2048';
+      mockProcessEnv({ OPENAI_MAX_TOKENS: '2048' });
 
       const provider = new AzureResponsesProvider('o1-preview');
 

--- a/test/providers/bedrock.agents.test.ts
+++ b/test/providers/bedrock.agents.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AwsBedrockAgentsProvider } from '../../src/providers/bedrock/agents';
+import { mockProcessEnv } from '../util/utils';
 
 // Hoisted mocks for AWS SDK
 const mockSend = vi.hoisted(() => vi.fn());
@@ -61,20 +62,20 @@ const ORIGINAL_HTTPS_PROXY = process.env.HTTPS_PROXY;
 describe('AwsBedrockAgentsProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.HTTP_PROXY = '';
-    process.env.HTTPS_PROXY = '';
+    mockProcessEnv({ HTTP_PROXY: '' });
+    mockProcessEnv({ HTTPS_PROXY: '' });
   });
 
   afterEach(() => {
     if (ORIGINAL_HTTP_PROXY === undefined) {
-      delete process.env.HTTP_PROXY;
+      mockProcessEnv({ HTTP_PROXY: undefined });
     } else {
-      process.env.HTTP_PROXY = ORIGINAL_HTTP_PROXY;
+      mockProcessEnv({ HTTP_PROXY: ORIGINAL_HTTP_PROXY });
     }
     if (ORIGINAL_HTTPS_PROXY === undefined) {
-      delete process.env.HTTPS_PROXY;
+      mockProcessEnv({ HTTPS_PROXY: undefined });
     } else {
-      process.env.HTTPS_PROXY = ORIGINAL_HTTPS_PROXY;
+      mockProcessEnv({ HTTPS_PROXY: ORIGINAL_HTTPS_PROXY });
     }
   });
 
@@ -150,7 +151,7 @@ describe('AwsBedrockAgentsProvider', () => {
     });
 
     it('should create runtime client with proxy agent when proxy is configured', async () => {
-      process.env.HTTPS_PROXY = 'http://proxy.example:8080';
+      mockProcessEnv({ HTTPS_PROXY: 'http://proxy.example:8080' });
 
       const provider = new AwsBedrockAgentsProvider('test-agent-123', {
         config: {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import * as genaiTracer from '../../../src/tracing/genaiTracer';
+import { mockProcessEnv } from '../../util/utils';
 import type { ContentBlock, StopReason } from '@aws-sdk/client-bedrock-runtime';
 
 // Define mock module type
@@ -164,12 +165,12 @@ describe('AwsBedrockConverseProvider', () => {
   beforeEach(() => {
     // Only reset mockSend, not all mocks (which would break the mock implementations)
     mockSend.mockReset();
-    delete process.env.AWS_BEDROCK_MAX_TOKENS;
-    delete process.env.AWS_BEDROCK_TEMPERATURE;
-    delete process.env.AWS_BEDROCK_TOP_P;
-    delete process.env.AWS_BEDROCK_STOP;
-    delete process.env.HTTP_PROXY;
-    delete process.env.HTTPS_PROXY;
+    mockProcessEnv({ AWS_BEDROCK_MAX_TOKENS: undefined });
+    mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: undefined });
+    mockProcessEnv({ AWS_BEDROCK_TOP_P: undefined });
+    mockProcessEnv({ AWS_BEDROCK_STOP: undefined });
+    mockProcessEnv({ HTTP_PROXY: undefined });
+    mockProcessEnv({ HTTPS_PROXY: undefined });
   });
 
   afterEach(() => {
@@ -217,7 +218,7 @@ describe('AwsBedrockConverseProvider', () => {
 
     it('should return default region when not specified', () => {
       const originalEnv = process.env.AWS_BEDROCK_REGION;
-      delete process.env.AWS_BEDROCK_REGION;
+      mockProcessEnv({ AWS_BEDROCK_REGION: undefined });
 
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {},
@@ -225,13 +226,13 @@ describe('AwsBedrockConverseProvider', () => {
       expect(provider.getRegion()).toBe('us-east-1');
 
       if (originalEnv) {
-        process.env.AWS_BEDROCK_REGION = originalEnv;
+        mockProcessEnv({ AWS_BEDROCK_REGION: originalEnv });
       }
     });
 
     it('should return region from environment variable', () => {
       const originalEnv = process.env.AWS_BEDROCK_REGION;
-      process.env.AWS_BEDROCK_REGION = 'ap-northeast-1';
+      mockProcessEnv({ AWS_BEDROCK_REGION: 'ap-northeast-1' });
 
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {},
@@ -239,9 +240,9 @@ describe('AwsBedrockConverseProvider', () => {
       expect(provider.getRegion()).toBe('ap-northeast-1');
 
       if (originalEnv) {
-        process.env.AWS_BEDROCK_REGION = originalEnv;
+        mockProcessEnv({ AWS_BEDROCK_REGION: originalEnv });
       } else {
-        delete process.env.AWS_BEDROCK_REGION;
+        mockProcessEnv({ AWS_BEDROCK_REGION: undefined });
       }
     });
 
@@ -265,7 +266,7 @@ describe('AwsBedrockConverseProvider', () => {
 
     it('should return undefined credentials when API key is used', async () => {
       const originalEnv = process.env.AWS_BEARER_TOKEN_BEDROCK;
-      process.env.AWS_BEARER_TOKEN_BEDROCK = 'bearer-token-123';
+      mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'bearer-token-123' });
 
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: { region: 'us-east-1' },
@@ -275,9 +276,9 @@ describe('AwsBedrockConverseProvider', () => {
       expect(credentials).toBeUndefined();
 
       if (originalEnv) {
-        process.env.AWS_BEARER_TOKEN_BEDROCK = originalEnv;
+        mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: originalEnv });
       } else {
-        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+        mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
       }
     });
 
@@ -816,8 +817,8 @@ Third line`;
     });
 
     it('should use environment variables as fallback', async () => {
-      process.env.AWS_BEDROCK_MAX_TOKENS = '4096';
-      process.env.AWS_BEDROCK_TEMPERATURE = '0.8';
+      mockProcessEnv({ AWS_BEDROCK_MAX_TOKENS: '4096' });
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: '0.8' });
 
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: { region: 'us-east-1' },
@@ -869,8 +870,8 @@ Third line`;
     });
 
     it('should preserve explicit zero-valued inference parameters over env fallbacks', async () => {
-      process.env.AWS_BEDROCK_MAX_TOKENS = '4096';
-      process.env.AWS_BEDROCK_TOP_P = '0.8';
+      mockProcessEnv({ AWS_BEDROCK_MAX_TOKENS: '4096' });
+      mockProcessEnv({ AWS_BEDROCK_TOP_P: '0.8' });
 
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {
@@ -966,7 +967,7 @@ Third line`;
     });
 
     it('omits temperature for Opus 4.7 via AWS_BEDROCK_TEMPERATURE env fallback', async () => {
-      process.env.AWS_BEDROCK_TEMPERATURE = '0.7';
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: '0.7' });
 
       const provider = new AwsBedrockConverseProvider('global.anthropic.claude-opus-4-7', {
         config: { region: 'us-east-1', max_tokens: 1024 },
@@ -984,7 +985,7 @@ Third line`;
       )?.[0] as { inferenceConfig?: Record<string, unknown> };
       expect(call?.inferenceConfig?.temperature).toBeUndefined();
 
-      delete process.env.AWS_BEDROCK_TEMPERATURE;
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: undefined });
     });
 
     it('still forwards temperature for Opus 4.6 on Bedrock (regression)', async () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -20,6 +20,7 @@ import {
   LlamaVersion,
   parseValue,
 } from '../../../src/providers/bedrock/index';
+import { mockProcessEnv } from '../../util/utils';
 
 import type {
   BedrockAI21GenerationOptions,
@@ -124,14 +125,14 @@ describe('AwsBedrockGenericProvider', () => {
     vi.clearAllMocks();
     credentialProviderSsoFactory.fromSSO.mockReset();
     credentialProviderSsoFactory.fromSSO.mockReturnValue('sso-provider');
-    delete process.env.AWS_BEDROCK_MAX_RETRIES;
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    mockProcessEnv({ AWS_BEDROCK_MAX_RETRIES: undefined });
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
     // Ensure proxy environment variables do not force proxy-specific code paths
     // when running tests. The container sets HTTP_PROXY by default which causes
     // getBedrockInstance to require optional dependencies that are not
     // installed in the test environment.
-    process.env.HTTP_PROXY = '';
-    process.env.HTTPS_PROXY = '';
+    mockProcessEnv({ HTTP_PROXY: '' });
+    mockProcessEnv({ HTTPS_PROXY: '' });
 
     nodeHttpHandlerFactory.setHandlerFactory(function () {
       return { handle: vi.fn() };
@@ -140,16 +141,16 @@ describe('AwsBedrockGenericProvider', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
     if (ORIGINAL_HTTP_PROXY === undefined) {
-      delete process.env.HTTP_PROXY;
+      mockProcessEnv({ HTTP_PROXY: undefined });
     } else {
-      process.env.HTTP_PROXY = ORIGINAL_HTTP_PROXY;
+      mockProcessEnv({ HTTP_PROXY: ORIGINAL_HTTP_PROXY });
     }
     if (ORIGINAL_HTTPS_PROXY === undefined) {
-      delete process.env.HTTPS_PROXY;
+      mockProcessEnv({ HTTPS_PROXY: undefined });
     } else {
-      process.env.HTTPS_PROXY = ORIGINAL_HTTPS_PROXY;
+      mockProcessEnv({ HTTPS_PROXY: ORIGINAL_HTTPS_PROXY });
     }
   });
 
@@ -221,7 +222,7 @@ describe('AwsBedrockGenericProvider', () => {
   });
 
   it('should respect AWS_BEDROCK_MAX_RETRIES environment variable', async () => {
-    process.env.AWS_BEDROCK_MAX_RETRIES = '10';
+    mockProcessEnv({ AWS_BEDROCK_MAX_RETRIES: '10' });
     const provider = new (class extends AwsBedrockGenericProvider {
       constructor() {
         super('test-model', { config: { region: 'us-east-1' } });
@@ -271,7 +272,7 @@ describe('AwsBedrockGenericProvider', () => {
   });
 
   it('should create custom request handler when AWS_BEARER_TOKEN_BEDROCK env var is set', async () => {
-    process.env.AWS_BEARER_TOKEN_BEDROCK = 'test-env-api-key';
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'test-env-api-key' });
     const mockHandler = {
       handle: vi.fn(),
     };
@@ -296,7 +297,7 @@ describe('AwsBedrockGenericProvider', () => {
       requestHandler,
     });
 
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
   });
 
   it('should add Authorization header with Bearer token to requests when using API key', async () => {
@@ -824,21 +825,21 @@ describe('AwsBedrockGenericProvider', () => {
     });
 
     it('should return undefined for API key authentication when AWS_BEARER_TOKEN_BEDROCK env var is set', async () => {
-      process.env.AWS_BEARER_TOKEN_BEDROCK = 'test-env-api-key';
+      mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'test-env-api-key' });
       const provider = new TestBedrockProvider({});
       const credentials = await provider.getCredentials();
       expect(credentials).toBeUndefined();
-      delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
     });
 
     it('should prioritize config apiKey over environment variable', async () => {
-      process.env.AWS_BEARER_TOKEN_BEDROCK = 'test-env-api-key';
+      mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'test-env-api-key' });
       const provider = new TestBedrockProvider({
         apiKey: 'test-config-api-key',
       });
       const credentials = await provider.getCredentials();
       expect(credentials).toBeUndefined(); // API key auth returns undefined for credentials
-      delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
     });
 
     it('should prioritize explicit credentials over API key', async () => {
@@ -875,10 +876,10 @@ describe('addConfigParam', () => {
 
   it('should add env value if config value is not provided', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = 'envValue';
+    mockProcessEnv({ TEST_ENV_KEY: 'envValue' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY);
     expect(params.key).toBe('envValue');
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should add default value if neither config nor env value is provided', async () => {
@@ -889,26 +890,26 @@ describe('addConfigParam', () => {
 
   it('should prioritize config value over env and default values', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = 'envValue';
+    mockProcessEnv({ TEST_ENV_KEY: 'envValue' });
     addConfigParam(params, 'key', 'configValue', process.env.TEST_ENV_KEY, 'defaultValue');
     expect(params.key).toBe('configValue');
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should prioritize env value over default value if config value is not provided', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = 'envValue';
+    mockProcessEnv({ TEST_ENV_KEY: 'envValue' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY, 'defaultValue');
     expect(params.key).toBe('envValue');
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should parse env value if default value is a number', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = '42';
+    mockProcessEnv({ TEST_ENV_KEY: '42' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY, 0);
     expect(params.key).toBe(42);
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should handle undefined config, env, and default values gracefully', async () => {
@@ -919,18 +920,18 @@ describe('addConfigParam', () => {
 
   it('should correctly parse non-number string values', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = 'nonNumberString';
+    mockProcessEnv({ TEST_ENV_KEY: 'nonNumberString' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY, 0);
     expect(params.key).toBe(0);
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should correctly parse empty string values', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = '';
+    mockProcessEnv({ TEST_ENV_KEY: '' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY, 'defaultValue');
     expect(params.key).toBe('');
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 
   it('should handle env value not set', async () => {
@@ -955,10 +956,10 @@ describe('addConfigParam', () => {
 
   it('should handle special characters in env values', async () => {
     const params: any = {};
-    process.env.TEST_ENV_KEY = '!@#$%^&*()_+';
+    mockProcessEnv({ TEST_ENV_KEY: '!@#$%^&*()_+' });
     addConfigParam(params, 'key', undefined, process.env.TEST_ENV_KEY, 'defaultValue');
     expect(params.key).toBe('!@#$%^&*()_+');
-    delete process.env.TEST_ENV_KEY;
+    mockProcessEnv({ TEST_ENV_KEY: undefined });
   });
 });
 
@@ -2302,9 +2303,9 @@ describe('BEDROCK_MODEL DEEPSEEK', () => {
     });
 
     it('should respect environment variables', async () => {
-      process.env.AWS_BEDROCK_MAX_TOKENS = '2000';
-      process.env.AWS_BEDROCK_TEMPERATURE = '0.5';
-      process.env.AWS_BEDROCK_TOP_P = '0.9';
+      mockProcessEnv({ AWS_BEDROCK_MAX_TOKENS: '2000' });
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: '0.5' });
+      mockProcessEnv({ AWS_BEDROCK_TOP_P: '0.9' });
 
       const config = {};
       const prompt = 'Test with env vars';
@@ -2318,9 +2319,9 @@ describe('BEDROCK_MODEL DEEPSEEK', () => {
         top_p: 0.9,
       });
 
-      delete process.env.AWS_BEDROCK_MAX_TOKENS;
-      delete process.env.AWS_BEDROCK_TEMPERATURE;
-      delete process.env.AWS_BEDROCK_TOP_P;
+      mockProcessEnv({ AWS_BEDROCK_MAX_TOKENS: undefined });
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: undefined });
+      mockProcessEnv({ AWS_BEDROCK_TOP_P: undefined });
     });
   });
 
@@ -3240,8 +3241,8 @@ describe('BEDROCK_MODEL.QWEN', () => {
     });
 
     it('should use environment variables for defaults', async () => {
-      process.env.AWS_BEDROCK_TEMPERATURE = '0.5';
-      process.env.AWS_BEDROCK_TOP_P = '0.8';
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: '0.5' });
+      mockProcessEnv({ AWS_BEDROCK_TOP_P: '0.8' });
 
       const config = {};
       const prompt = 'Test prompt';
@@ -3251,8 +3252,8 @@ describe('BEDROCK_MODEL.QWEN', () => {
       expect(result.temperature).toBe(0.5);
       expect(result.top_p).toBe(0.8);
 
-      delete process.env.AWS_BEDROCK_TEMPERATURE;
-      delete process.env.AWS_BEDROCK_TOP_P;
+      mockProcessEnv({ AWS_BEDROCK_TEMPERATURE: undefined });
+      mockProcessEnv({ AWS_BEDROCK_TOP_P: undefined });
     });
   });
 

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -4,6 +4,7 @@ import logger from '../../../src/logger';
 import { AwsBedrockKnowledgeBaseProvider } from '../../../src/providers/bedrock/knowledgeBase';
 import { sha256 } from '../../../src/util/createHash';
 import { createEmptyTokenUsage } from '../../../src/util/tokenUsageUtils';
+import { mockProcessEnv } from '../../util/utils';
 
 const mockSend = vi.fn();
 const mockBedrockClient = {
@@ -126,29 +127,29 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     mockGet.mockReset();
     mockSet.mockReset();
     mockIsCacheEnabled.mockReset().mockReturnValue(false);
-    delete process.env.AWS_BEDROCK_MAX_RETRIES;
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.npm_config_https_proxy;
-    delete process.env.npm_config_http_proxy;
-    delete process.env.npm_config_proxy;
-    delete process.env.all_proxy;
+    mockProcessEnv({ AWS_BEDROCK_MAX_RETRIES: undefined });
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+    mockProcessEnv({ HTTPS_PROXY: undefined });
+    mockProcessEnv({ https_proxy: undefined });
+    mockProcessEnv({ HTTP_PROXY: undefined });
+    mockProcessEnv({ http_proxy: undefined });
+    mockProcessEnv({ npm_config_https_proxy: undefined });
+    mockProcessEnv({ npm_config_http_proxy: undefined });
+    mockProcessEnv({ npm_config_proxy: undefined });
+    mockProcessEnv({ all_proxy: undefined });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.npm_config_https_proxy;
-    delete process.env.npm_config_http_proxy;
-    delete process.env.npm_config_proxy;
-    delete process.env.all_proxy;
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+    mockProcessEnv({ HTTPS_PROXY: undefined });
+    mockProcessEnv({ https_proxy: undefined });
+    mockProcessEnv({ HTTP_PROXY: undefined });
+    mockProcessEnv({ http_proxy: undefined });
+    mockProcessEnv({ npm_config_https_proxy: undefined });
+    mockProcessEnv({ npm_config_http_proxy: undefined });
+    mockProcessEnv({ npm_config_proxy: undefined });
+    mockProcessEnv({ all_proxy: undefined });
   });
 
   it('should throw an error if knowledgeBaseId is not provided', () => {
@@ -226,7 +227,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
   });
 
   it('should respect AWS_BEDROCK_MAX_RETRIES environment variable', async () => {
-    process.env.AWS_BEDROCK_MAX_RETRIES = '5';
+    mockProcessEnv({ AWS_BEDROCK_MAX_RETRIES: '5' });
     const provider = new AwsBedrockKnowledgeBaseProvider(
       'us.anthropic.claude-3-7-sonnet-20241022-v2:0',
       {
@@ -725,7 +726,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
   });
 
   it('should create knowledge base client with API key authentication from environment', async () => {
-    process.env.AWS_BEARER_TOKEN_BEDROCK = 'test-env-api-key';
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'test-env-api-key' });
 
     const provider = new AwsBedrockKnowledgeBaseProvider(
       'us.anthropic.claude-3-7-sonnet-20241022-v2:0',
@@ -746,7 +747,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
       requestHandler: expect.any(Object),
     });
 
-    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
   });
 
   it('should prioritize explicit credentials over API key for knowledge base', async () => {

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -14,6 +14,7 @@ import {
 import { transformMCPConfigToClaudeCode } from '../../src/providers/mcp/transform';
 import * as genaiTracer from '../../src/tracing/genaiTracer';
 import { checkProviderApiKeys } from '../../src/util/provider';
+import { mockProcessEnv } from '../util/utils';
 import type {
   NonNullableUsage,
   Query,
@@ -444,9 +445,9 @@ describe('ClaudeCodeSDKProvider', () => {
 
       it('should return error when API key is missing', async () => {
         // ensure process env won't provide the key or any other Claude Agent SDK env vars
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
-        delete process.env.CLAUDE_CODE_USE_VERTEX;
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
 
         const provider = new ClaudeCodeSDKProvider();
         await expect(provider.callApi('Test prompt')).rejects.toThrow(
@@ -475,44 +476,44 @@ describe('ClaudeCodeSDKProvider', () => {
         const provider = new ClaudeCodeSDKProvider();
 
         // Set the env var in process.env for the test
-        process.env.CLAUDE_CODE_USE_BEDROCK = 'true';
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: 'true' });
 
         const result = await provider.callApi('Test prompt');
 
         expect(result.error).toBeUndefined();
         expect(result.output).toBe('Response');
 
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
       });
     });
 
     describe('checkProviderApiKeys pre-check', () => {
       it('should not report missing key when CLAUDE_CODE_USE_VERTEX is set in process.env', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        process.env.CLAUDE_CODE_USE_VERTEX = 'true';
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: 'true' });
 
         const provider = new ClaudeCodeSDKProvider();
         const result = checkProviderApiKeys([provider]);
         expect(result.size).toBe(0);
 
-        delete process.env.CLAUDE_CODE_USE_VERTEX;
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
       });
 
       it('should not report missing key when CLAUDE_CODE_USE_BEDROCK is set in process.env', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        process.env.CLAUDE_CODE_USE_BEDROCK = 'true';
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: 'true' });
 
         const provider = new ClaudeCodeSDKProvider();
         const result = checkProviderApiKeys([provider]);
         expect(result.size).toBe(0);
 
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
       });
 
       it('should report missing key when no Vertex/Bedrock env is set', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.CLAUDE_CODE_USE_VERTEX;
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
 
         const provider = new ClaudeCodeSDKProvider();
         const result = checkProviderApiKeys([provider]);
@@ -521,9 +522,9 @@ describe('ClaudeCodeSDKProvider', () => {
       });
 
       it('should not report missing key when apiKeyRequired is false', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.CLAUDE_CODE_USE_VERTEX;
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
 
         const provider = new ClaudeCodeSDKProvider({
           config: { apiKeyRequired: false },
@@ -535,8 +536,8 @@ describe('ClaudeCodeSDKProvider', () => {
 
     describe('provider-level env overrides via loadApiProvider', () => {
       it('should pass provider-level env through to the provider', async () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.CLAUDE_CODE_USE_VERTEX;
+        mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+        mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
 
         const provider = new ClaudeCodeSDKProvider({
           env: { CLAUDE_CODE_USE_VERTEX: 'true' } as EnvOverrides,

--- a/test/providers/cloudflare-ai.test.ts
+++ b/test/providers/cloudflare-ai.test.ts
@@ -8,6 +8,7 @@ import {
   createCloudflareAiProvider,
 } from '../../src/providers/cloudflare-ai';
 import { loadApiProviders } from '../../src/providers/index';
+import { mockProcessEnv } from '../util/utils';
 
 import type { ProviderOptionsMap } from '../../src/types/index';
 
@@ -211,8 +212,8 @@ describe('CloudflareAi Provider', () => {
     });
 
     it('Uses environment variables when config not provided', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account-id';
-      process.env.CLOUDFLARE_API_KEY = 'env-api-key';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account-id' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'env-api-key' });
 
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {});
 
@@ -220,8 +221,8 @@ describe('CloudflareAi Provider', () => {
       expect(provider.toString()).toBe(`[Cloudflare AI chat Provider ${testModelName}]`);
 
       // Clean up
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('Should use custom API base URL when provided', async () => {
@@ -374,8 +375,8 @@ describe('CloudflareAi Provider', () => {
     });
 
     it('Should use custom environment variable names', () => {
-      process.env.CUSTOM_CF_ACCOUNT = 'custom-account-id';
-      process.env.CUSTOM_CF_KEY = 'custom-api-key';
+      mockProcessEnv({ CUSTOM_CF_ACCOUNT: 'custom-account-id' });
+      mockProcessEnv({ CUSTOM_CF_KEY: 'custom-api-key' });
 
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {
         config: {
@@ -387,8 +388,8 @@ describe('CloudflareAi Provider', () => {
       expect(provider.getApiKey()).toBe('custom-api-key');
 
       // Clean up
-      delete process.env.CUSTOM_CF_ACCOUNT;
-      delete process.env.CUSTOM_CF_KEY;
+      mockProcessEnv({ CUSTOM_CF_ACCOUNT: undefined });
+      mockProcessEnv({ CUSTOM_CF_KEY: undefined });
     });
 
     it('requires API key', () => {
@@ -401,8 +402,8 @@ describe('CloudflareAi Provider', () => {
     });
 
     it('uses accountIdEnvar when accountId not provided', () => {
-      process.env.CUSTOM_ACCOUNT_VAR = 'env-account-from-custom-var';
-      process.env.CLOUDFLARE_API_KEY = 'default-api-key';
+      mockProcessEnv({ CUSTOM_ACCOUNT_VAR: 'env-account-from-custom-var' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'default-api-key' });
 
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {
         config: {
@@ -413,8 +414,8 @@ describe('CloudflareAi Provider', () => {
       expect(provider.id()).toBe(`cloudflare-ai:chat:${testModelName}`);
 
       // Clean up
-      delete process.env.CUSTOM_ACCOUNT_VAR;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CUSTOM_ACCOUNT_VAR: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('throws error when account ID environment variable does not exist', () => {
@@ -442,8 +443,8 @@ describe('CloudflareAi Provider', () => {
     });
 
     it('prioritizes explicit config over environment variables', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account';
-      process.env.CLOUDFLARE_API_KEY = 'env-key';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'env-key' });
 
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {
         config: {
@@ -455,13 +456,13 @@ describe('CloudflareAi Provider', () => {
       expect(provider.getApiKey()).toBe('explicit-key');
 
       // Clean up
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('handles missing config gracefully with environment fallback', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'fallback-account';
-      process.env.CLOUDFLARE_API_KEY = 'fallback-key';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'fallback-account' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'fallback-key' });
 
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {});
 
@@ -469,14 +470,14 @@ describe('CloudflareAi Provider', () => {
       expect(provider.id()).toBe(`cloudflare-ai:chat:${testModelName}`);
 
       // Clean up
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('throws error when no configuration and no environment variables', () => {
       // Ensure environment variables are not set
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
 
       expect(() => new CloudflareAiChatCompletionProvider(testModelName, {})).toThrow(
         'Cloudflare API token required',
@@ -791,27 +792,27 @@ describe('CloudflareAi Provider', () => {
     });
 
     it('works with undefined options when environment variables are set', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account';
-      process.env.CLOUDFLARE_API_KEY = 'env-key';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'env-key' });
 
       const provider = createCloudflareAiProvider('cloudflare-ai:chat:test-model', undefined);
       expect(provider).toBeInstanceOf(CloudflareAiChatCompletionProvider);
 
       // Clean up
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('works with empty options object when environment variables are set', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account';
-      process.env.CLOUDFLARE_API_KEY = 'env-key';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account' });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: 'env-key' });
 
       const provider = createCloudflareAiProvider('cloudflare-ai:chat:test-model', {});
       expect(provider).toBeInstanceOf(CloudflareAiChatCompletionProvider);
 
       // Clean up
-      delete process.env.CLOUDFLARE_ACCOUNT_ID;
-      delete process.env.CLOUDFLARE_API_KEY;
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: undefined });
+      mockProcessEnv({ CLOUDFLARE_API_KEY: undefined });
     });
 
     it('passes through provider options correctly', () => {

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -580,7 +580,7 @@ describe('CloudflareGateway Provider', () => {
   });
 
   describe('Environment Variable Support', () => {
-    const originalEnv = process.env;
+    const originalEnv = { ...process.env };
 
     beforeEach(() => {
       vi.resetModules();

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -7,6 +7,7 @@ import {
   createCloudflareGatewayProvider,
 } from '../../src/providers/cloudflare-gateway';
 import { loadApiProviders } from '../../src/providers/index';
+import { mockProcessEnv } from '../util/utils';
 
 import type { ProviderOptionsMap } from '../../src/types/index';
 
@@ -583,16 +584,16 @@ describe('CloudflareGateway Provider', () => {
 
     beforeEach(() => {
       vi.resetModules();
-      process.env = { ...originalEnv };
+      mockProcessEnv({ ...originalEnv }, { clear: true });
     });
 
     afterEach(() => {
-      process.env = originalEnv;
+      mockProcessEnv(originalEnv, { clear: true });
     });
 
     it('should use environment variables for account ID and gateway ID', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account-id';
-      process.env.CLOUDFLARE_GATEWAY_ID = 'env-gateway-id';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account-id' });
+      mockProcessEnv({ CLOUDFLARE_GATEWAY_ID: 'env-gateway-id' });
 
       const provider = createCloudflareGatewayProvider('cloudflare-gateway:openai:gpt-4o', {
         config: { apiKey: 'test-key' },
@@ -602,8 +603,8 @@ describe('CloudflareGateway Provider', () => {
     });
 
     it('should prefer config values over environment variables', () => {
-      process.env.CLOUDFLARE_ACCOUNT_ID = 'env-account-id';
-      process.env.CLOUDFLARE_GATEWAY_ID = 'env-gateway-id';
+      mockProcessEnv({ CLOUDFLARE_ACCOUNT_ID: 'env-account-id' });
+      mockProcessEnv({ CLOUDFLARE_GATEWAY_ID: 'env-gateway-id' });
 
       const provider = new CloudflareGatewayOpenAiProvider('openai', 'gpt-4o', {
         config: {
@@ -617,8 +618,8 @@ describe('CloudflareGateway Provider', () => {
     });
 
     it('should support custom environment variable names', () => {
-      process.env.CUSTOM_ACCOUNT = 'custom-account-id';
-      process.env.CUSTOM_GATEWAY = 'custom-gateway-id';
+      mockProcessEnv({ CUSTOM_ACCOUNT: 'custom-account-id' });
+      mockProcessEnv({ CUSTOM_GATEWAY: 'custom-gateway-id' });
 
       const provider = createCloudflareGatewayProvider('cloudflare-gateway:openai:gpt-4o', {
         config: {
@@ -658,7 +659,7 @@ describe('CloudflareGateway Provider', () => {
     it('should require API key for azure-openai', () => {
       // Clear the environment variable to ensure validation triggers
       const originalAzureKey = process.env.AZURE_OPENAI_API_KEY;
-      delete process.env.AZURE_OPENAI_API_KEY;
+      mockProcessEnv({ AZURE_OPENAI_API_KEY: undefined });
 
       try {
         expect(() =>
@@ -675,7 +676,7 @@ describe('CloudflareGateway Provider', () => {
       } finally {
         // Restore the environment variable
         if (originalAzureKey !== undefined) {
-          process.env.AZURE_OPENAI_API_KEY = originalAzureKey;
+          mockProcessEnv({ AZURE_OPENAI_API_KEY: originalAzureKey });
         }
       }
     });

--- a/test/providers/databricks.test.ts
+++ b/test/providers/databricks.test.ts
@@ -9,7 +9,7 @@ import type { DatabricksMosaicAiProviderOptions } from '../../src/providers/data
 vi.mock('../../src/logger');
 
 describe('Databricks Foundation Model APIs Provider', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
   const workspaceUrl = 'https://test-workspace.cloud.databricks.com';
   const defaultOptions: DatabricksMosaicAiProviderOptions = {
     config: {

--- a/test/providers/databricks.test.ts
+++ b/test/providers/databricks.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache } from '../../src/cache';
 import { DatabricksMosaicAiChatCompletionProvider } from '../../src/providers/databricks';
 import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+import { mockProcessEnv } from '../util/utils';
 
 import type { DatabricksMosaicAiProviderOptions } from '../../src/providers/databricks';
 
@@ -18,14 +19,14 @@ describe('Databricks Foundation Model APIs Provider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = { ...originalEnv };
-    delete process.env.DATABRICKS_WORKSPACE_URL;
-    delete process.env.DATABRICKS_TOKEN;
+    mockProcessEnv({ ...originalEnv }, { clear: true });
+    mockProcessEnv({ DATABRICKS_WORKSPACE_URL: undefined });
+    mockProcessEnv({ DATABRICKS_TOKEN: undefined });
   });
 
   afterEach(async () => {
     await clearCache();
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   describe('DatabricksMosaicAiChatCompletionProvider', () => {
@@ -58,7 +59,7 @@ describe('Databricks Foundation Model APIs Provider', () => {
     });
 
     it('should create provider with workspace URL from environment variable', () => {
-      process.env.DATABRICKS_WORKSPACE_URL = workspaceUrl;
+      mockProcessEnv({ DATABRICKS_WORKSPACE_URL: workspaceUrl });
 
       const options: DatabricksMosaicAiProviderOptions = {
         config: {},

--- a/test/providers/defaults.test.ts
+++ b/test/providers/defaults.test.ts
@@ -32,6 +32,7 @@ import {
   DefaultSuggestionsProvider as OpenAiSuggestionsProvider,
 } from '../../src/providers/openai/defaults';
 import { providerRegistry } from '../../src/providers/providerRegistry';
+import { mockProcessEnv } from '../util/utils';
 
 import type { EnvOverrides } from '../../src/types/env';
 import type { ApiProvider } from '../../src/types/index';
@@ -70,26 +71,26 @@ describe('Provider override tests', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    mockProcessEnv({ ...originalEnv }, { clear: true });
     setDefaultCompletionProviders(undefined as any);
     setDefaultEmbeddingProviders(undefined as any);
     vi.mocked(hasGoogleDefaultCredentials).mockResolvedValue(false);
     vi.mocked(hasCodexDefaultCredentials).mockReturnValue(false);
     clearCodexDefaultProvidersForTesting();
-    delete process.env.OPENAI_API_KEY;
-    delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.MISTRAL_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.PALM_API_KEY;
-    delete process.env.AZURE_OPENAI_API_KEY;
-    delete process.env.AZURE_API_KEY;
-    delete process.env.AZURE_DEPLOYMENT_NAME;
-    delete process.env.AZURE_OPENAI_DEPLOYMENT_NAME;
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+    mockProcessEnv({ MISTRAL_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ PALM_API_KEY: undefined });
+    mockProcessEnv({ AZURE_OPENAI_API_KEY: undefined });
+    mockProcessEnv({ AZURE_API_KEY: undefined });
+    mockProcessEnv({ AZURE_DEPLOYMENT_NAME: undefined });
+    mockProcessEnv({ AZURE_OPENAI_DEPLOYMENT_NAME: undefined });
   });
 
   afterEach(async () => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     clearCodexDefaultProvidersForTesting();
     await providerRegistry.shutdownAll();
     vi.resetAllMocks();
@@ -141,7 +142,7 @@ describe('Provider override tests', () => {
   });
 
   it('should use AzureModerationProvider when AZURE_CONTENT_SAFETY_ENDPOINT is set', async () => {
-    process.env.AZURE_CONTENT_SAFETY_ENDPOINT = 'https://test-endpoint.com';
+    mockProcessEnv({ AZURE_CONTENT_SAFETY_ENDPOINT: 'https://test-endpoint.com' });
 
     const providers = await getDefaultProviders();
 
@@ -152,7 +153,7 @@ describe('Provider override tests', () => {
   });
 
   it('should use DefaultModerationProvider when AZURE_CONTENT_SAFETY_ENDPOINT is not set', async () => {
-    delete process.env.AZURE_CONTENT_SAFETY_ENDPOINT;
+    mockProcessEnv({ AZURE_CONTENT_SAFETY_ENDPOINT: undefined });
 
     const providers = await getDefaultProviders();
     expect(providers.moderationProvider).toBe(DefaultModerationProvider);
@@ -188,7 +189,7 @@ describe('Provider override tests', () => {
   });
 
   it('should use Mistral providers when MISTRAL_API_KEY is set', async () => {
-    process.env.MISTRAL_API_KEY = 'test-key';
+    mockProcessEnv({ MISTRAL_API_KEY: 'test-key' });
 
     const providers = await getDefaultProviders();
 
@@ -216,7 +217,7 @@ describe('Provider override tests', () => {
   });
 
   it('should prefer OpenAI API defaults over Codex SDK defaults when OPENAI_API_KEY exists', async () => {
-    process.env.OPENAI_API_KEY = 'test-openai-key';
+    mockProcessEnv({ OPENAI_API_KEY: 'test-openai-key' });
     vi.mocked(hasCodexDefaultCredentials).mockReturnValue(true);
 
     const providers = await getDefaultProviders();
@@ -228,7 +229,7 @@ describe('Provider override tests', () => {
   });
 
   it('should prefer Mistral defaults over Codex SDK defaults when MISTRAL_API_KEY exists', async () => {
-    process.env.MISTRAL_API_KEY = 'test-mistral-key';
+    mockProcessEnv({ MISTRAL_API_KEY: 'test-mistral-key' });
     vi.mocked(hasCodexDefaultCredentials).mockReturnValue(true);
 
     const providers = await getDefaultProviders();
@@ -248,9 +249,9 @@ describe('Provider override tests', () => {
   });
 
   it('should not probe Google default credentials when Azure is preferred', async () => {
-    process.env.AZURE_OPENAI_API_KEY = 'azure-key';
-    process.env.AZURE_DEPLOYMENT_NAME = 'azure-chat';
-    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'azure-chat';
+    mockProcessEnv({ AZURE_OPENAI_API_KEY: 'azure-key' });
+    mockProcessEnv({ AZURE_DEPLOYMENT_NAME: 'azure-chat' });
+    mockProcessEnv({ AZURE_OPENAI_DEPLOYMENT_NAME: 'azure-chat' });
 
     await getDefaultProviders();
 
@@ -272,8 +273,8 @@ describe('Provider override tests', () => {
   });
 
   it('should not use Mistral providers when OpenAI credentials exist', async () => {
-    process.env.MISTRAL_API_KEY = 'test-key';
-    process.env.OPENAI_API_KEY = 'test-key';
+    mockProcessEnv({ MISTRAL_API_KEY: 'test-key' });
+    mockProcessEnv({ OPENAI_API_KEY: 'test-key' });
 
     const providers = await getDefaultProviders();
 
@@ -285,8 +286,8 @@ describe('Provider override tests', () => {
   });
 
   it('should not use Mistral providers when Anthropic credentials exist', async () => {
-    process.env.MISTRAL_API_KEY = 'test-key';
-    process.env.ANTHROPIC_API_KEY = 'test-key';
+    mockProcessEnv({ MISTRAL_API_KEY: 'test-key' });
+    mockProcessEnv({ ANTHROPIC_API_KEY: 'test-key' });
 
     const providers = await getDefaultProviders();
 
@@ -299,7 +300,7 @@ describe('Provider override tests', () => {
 
   describe('Google AI Studio provider selection', () => {
     it('should use Google AI Studio providers when GEMINI_API_KEY is set', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
+      mockProcessEnv({ GEMINI_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 
@@ -312,7 +313,7 @@ describe('Provider override tests', () => {
     });
 
     it('should use Google AI Studio providers when GOOGLE_API_KEY is set', async () => {
-      process.env.GOOGLE_API_KEY = 'test-key';
+      mockProcessEnv({ GOOGLE_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 
@@ -325,7 +326,7 @@ describe('Provider override tests', () => {
     });
 
     it('should use Google AI Studio providers when PALM_API_KEY is set', async () => {
-      process.env.PALM_API_KEY = 'test-key';
+      mockProcessEnv({ PALM_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 
@@ -353,8 +354,8 @@ describe('Provider override tests', () => {
     });
 
     it('should not use Google AI Studio providers when OpenAI credentials exist', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
-      process.env.OPENAI_API_KEY = 'test-key';
+      mockProcessEnv({ GEMINI_API_KEY: 'test-key' });
+      mockProcessEnv({ OPENAI_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 
@@ -365,8 +366,8 @@ describe('Provider override tests', () => {
     });
 
     it('should not use Google AI Studio providers when Anthropic credentials exist', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
-      process.env.ANTHROPIC_API_KEY = 'test-key';
+      mockProcessEnv({ GEMINI_API_KEY: 'test-key' });
+      mockProcessEnv({ ANTHROPIC_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 
@@ -377,7 +378,7 @@ describe('Provider override tests', () => {
     });
 
     it('should prefer Google AI Studio over Vertex when both credentials are available', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
+      mockProcessEnv({ GEMINI_API_KEY: 'test-key' });
       // hasGoogleDefaultCredentials is mocked to return false, but in practice
       // AI Studio should be preferred over Vertex in the provider selection order
 
@@ -390,8 +391,8 @@ describe('Provider override tests', () => {
     });
 
     it('should prefer Google AI Studio over Mistral when both credentials are available', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
-      process.env.MISTRAL_API_KEY = 'test-key';
+      mockProcessEnv({ GEMINI_API_KEY: 'test-key' });
+      mockProcessEnv({ MISTRAL_API_KEY: 'test-key' });
 
       const providers = await getDefaultProviders();
 

--- a/test/providers/defaults.test.ts
+++ b/test/providers/defaults.test.ts
@@ -143,6 +143,7 @@ describe('Provider override tests', () => {
 
   it('should use AzureModerationProvider when AZURE_CONTENT_SAFETY_ENDPOINT is set', async () => {
     mockProcessEnv({ AZURE_CONTENT_SAFETY_ENDPOINT: 'https://test-endpoint.com' });
+    mockProcessEnv({ AZURE_API_KEY: 'test-api-key' });
 
     const providers = await getDefaultProviders();
 
@@ -161,6 +162,7 @@ describe('Provider override tests', () => {
 
   it('should use AzureModerationProvider when AZURE_CONTENT_SAFETY_ENDPOINT is provided via env overrides', async () => {
     const envOverrides: EnvOverrides = {
+      AZURE_API_KEY: 'test-api-key',
       AZURE_CONTENT_SAFETY_ENDPOINT: 'https://test-endpoint.com',
     } as EnvOverrides;
 
@@ -174,6 +176,7 @@ describe('Provider override tests', () => {
 
   it('should use Azure moderation provider with custom configuration', async () => {
     const envOverrides: EnvOverrides = {
+      AZURE_API_KEY: 'test-api-key',
       AZURE_CONTENT_SAFETY_ENDPOINT: 'https://test-endpoint.com',
       AZURE_CONTENT_SAFETY_API_KEY: 'test-api-key',
       AZURE_CONTENT_SAFETY_API_VERSION: '2024-01-01',

--- a/test/providers/defaults.test.ts
+++ b/test/providers/defaults.test.ts
@@ -68,7 +68,7 @@ class MockProvider implements ApiProvider {
 }
 
 describe('Provider override tests', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     mockProcessEnv({ ...originalEnv }, { clear: true });

--- a/test/providers/elevenlabs/agents/index.test.ts
+++ b/test/providers/elevenlabs/agents/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsAgentsProvider } from '../../../../src/providers/elevenlabs/agents';
+import { mockProcessEnv } from '../../../util/utils';
 
 import type { AgentSimulationResponse } from '../../../../src/providers/elevenlabs/agents/types';
 
@@ -30,11 +31,11 @@ vi.mock('../../../../src/providers/elevenlabs/cost-tracker', () => {
 describe('ElevenLabsAgentsProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
     vi.resetAllMocks();
   });
 
@@ -47,7 +48,7 @@ describe('ElevenLabsAgentsProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsAgentsProvider('elevenlabs:agent')).toThrow(
         'ELEVENLABS_API_KEY environment variable is not set',
@@ -99,7 +100,7 @@ describe('ElevenLabsAgentsProvider', () => {
     });
 
     it('should respect environment variable overrides', () => {
-      process.env.CUSTOM_API_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_API_KEY: 'custom-key' });
       const provider = new ElevenLabsAgentsProvider('elevenlabs:agent', {
         config: {
           apiKeyEnvar: 'CUSTOM_API_KEY',
@@ -107,7 +108,7 @@ describe('ElevenLabsAgentsProvider', () => {
       });
 
       expect(provider).toBeDefined();
-      delete process.env.CUSTOM_API_KEY;
+      mockProcessEnv({ CUSTOM_API_KEY: undefined });
     });
   });
 

--- a/test/providers/elevenlabs/alignment/index.test.ts
+++ b/test/providers/elevenlabs/alignment/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsAlignmentProvider } from '../../../../src/providers/elevenlabs/alignment';
+import { mockProcessEnv } from '../../../util/utils';
 
 import type { CallApiContextParams } from '../../../../src/types/providers';
 
@@ -23,11 +24,11 @@ describe('ElevenLabsAlignmentProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockReadFile.mockReset();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -39,7 +40,7 @@ describe('ElevenLabsAlignmentProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsAlignmentProvider('elevenlabs:alignment')).toThrow(
         'ELEVENLABS_API_KEY environment variable is not set',
@@ -98,7 +99,7 @@ describe('ElevenLabsAlignmentProvider', () => {
     });
 
     it('should support custom API key environment variable', () => {
-      process.env.CUSTOM_ELEVENLABS_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: 'custom-key' });
 
       const provider = new ElevenLabsAlignmentProvider('elevenlabs:alignment', {
         config: { apiKeyEnvar: 'CUSTOM_ELEVENLABS_KEY' },
@@ -106,7 +107,7 @@ describe('ElevenLabsAlignmentProvider', () => {
 
       expect(provider).toBeDefined();
 
-      delete process.env.CUSTOM_ELEVENLABS_KEY;
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: undefined });
     });
   });
 
@@ -350,7 +351,7 @@ describe('ElevenLabsAlignmentProvider', () => {
 
   describe('error handling', () => {
     it('should throw meaningful error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsAlignmentProvider('elevenlabs:alignment')).toThrow(
         /ELEVENLABS_API_KEY/i,

--- a/test/providers/elevenlabs/history/index.test.ts
+++ b/test/providers/elevenlabs/history/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsHistoryProvider } from '../../../../src/providers/elevenlabs/history';
+import { mockProcessEnv } from '../../../util/utils';
 
 import type { CallApiContextParams } from '../../../../src/types/providers';
 
@@ -9,11 +10,11 @@ vi.mock('../../../../src/providers/elevenlabs/client');
 describe('ElevenLabsHistoryProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -25,7 +26,7 @@ describe('ElevenLabsHistoryProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsHistoryProvider('elevenlabs:history')).toThrow(
         'ELEVENLABS_API_KEY environment variable is not set',
@@ -95,7 +96,7 @@ describe('ElevenLabsHistoryProvider', () => {
     });
 
     it('should support custom API key environment variable', () => {
-      process.env.CUSTOM_ELEVENLABS_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: 'custom-key' });
 
       const provider = new ElevenLabsHistoryProvider('elevenlabs:history', {
         config: { apiKeyEnvar: 'CUSTOM_ELEVENLABS_KEY' },
@@ -103,7 +104,7 @@ describe('ElevenLabsHistoryProvider', () => {
 
       expect(provider).toBeDefined();
 
-      delete process.env.CUSTOM_ELEVENLABS_KEY;
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: undefined });
     });
   });
 
@@ -299,7 +300,7 @@ describe('ElevenLabsHistoryProvider', () => {
 
   describe('error handling', () => {
     it('should throw meaningful error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsHistoryProvider('elevenlabs:history')).toThrow(
         /ELEVENLABS_API_KEY/i,

--- a/test/providers/elevenlabs/isolation/index.test.ts
+++ b/test/providers/elevenlabs/isolation/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsIsolationProvider } from '../../../../src/providers/elevenlabs/isolation';
+import { mockProcessEnv } from '../../../util/utils';
 
 import type { CallApiContextParams } from '../../../../src/types/providers';
 
@@ -30,11 +31,11 @@ describe('ElevenLabsIsolationProvider', () => {
     vi.clearAllMocks();
     mockReadFile.mockReset();
     mockEncodeAudio.mockReset();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -46,7 +47,7 @@ describe('ElevenLabsIsolationProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsIsolationProvider('elevenlabs:isolation')).toThrow(
         'ELEVENLABS_API_KEY environment variable is not set',
@@ -107,7 +108,7 @@ describe('ElevenLabsIsolationProvider', () => {
     });
 
     it('should support custom API key environment variable', () => {
-      process.env.CUSTOM_ELEVENLABS_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: 'custom-key' });
 
       const provider = new ElevenLabsIsolationProvider('elevenlabs:isolation', {
         config: { apiKeyEnvar: 'CUSTOM_ELEVENLABS_KEY' },
@@ -115,7 +116,7 @@ describe('ElevenLabsIsolationProvider', () => {
 
       expect(provider).toBeDefined();
 
-      delete process.env.CUSTOM_ELEVENLABS_KEY;
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: undefined });
     });
   });
 
@@ -209,7 +210,7 @@ describe('ElevenLabsIsolationProvider', () => {
 
   describe('error handling', () => {
     it('should throw meaningful error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsIsolationProvider('elevenlabs:isolation')).toThrow(
         /ELEVENLABS_API_KEY/i,

--- a/test/providers/elevenlabs/stt/index.test.ts
+++ b/test/providers/elevenlabs/stt/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsSTTProvider } from '../../../../src/providers/elevenlabs/stt';
+import { mockProcessEnv } from '../../../util/utils';
 
 // Mock dependencies
 vi.mock('../../../../src/providers/elevenlabs/client');
@@ -9,11 +10,11 @@ vi.mock('../../../../src/providers/elevenlabs/cost-tracker');
 describe('ElevenLabsSTTProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -25,7 +26,7 @@ describe('ElevenLabsSTTProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsSTTProvider('elevenlabs:stt')).toThrow(
         'ElevenLabs API key not found',
@@ -151,7 +152,7 @@ describe('ElevenLabsSTTProvider', () => {
     });
 
     it('should support custom API key environment variable', () => {
-      process.env.CUSTOM_ELEVENLABS_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: 'custom-key' });
 
       const provider = new ElevenLabsSTTProvider('elevenlabs:stt', {
         config: { apiKeyEnvar: 'CUSTOM_ELEVENLABS_KEY' },
@@ -159,13 +160,13 @@ describe('ElevenLabsSTTProvider', () => {
 
       expect(provider).toBeDefined();
 
-      delete process.env.CUSTOM_ELEVENLABS_KEY;
+      mockProcessEnv({ CUSTOM_ELEVENLABS_KEY: undefined });
     });
   });
 
   describe('error handling', () => {
     it('should throw meaningful error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsSTTProvider('elevenlabs:stt')).toThrow(/ELEVENLABS_API_KEY/i);
     });

--- a/test/providers/elevenlabs/tts/index.test.ts
+++ b/test/providers/elevenlabs/tts/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsTTSProvider } from '../../../../src/providers/elevenlabs/tts';
+import { mockProcessEnv } from '../../../util/utils';
 
 // Mock dependencies
 vi.mock('../../../../src/providers/elevenlabs/client');
@@ -9,11 +10,11 @@ vi.mock('../../../../src/providers/elevenlabs/cost-tracker');
 describe('ElevenLabsTTSProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+    mockProcessEnv({ ELEVENLABS_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
-    delete process.env.ELEVENLABS_API_KEY;
+    mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -31,7 +32,7 @@ describe('ElevenLabsTTSProvider', () => {
     });
 
     it('should throw error when API key is missing', () => {
-      delete process.env.ELEVENLABS_API_KEY;
+      mockProcessEnv({ ELEVENLABS_API_KEY: undefined });
 
       expect(() => new ElevenLabsTTSProvider('elevenlabs:tts')).toThrow(
         'ELEVENLABS_API_KEY environment variable is not set',

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -6,6 +6,7 @@ import { AIStudioChatProvider } from '../../../src/providers/google/ai.studio';
 import * as util from '../../../src/providers/google/util';
 import { getNunjucksEngineForFilePath } from '../../../src/util/file';
 import * as templates from '../../../src/util/templates';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -122,9 +123,9 @@ describe('AIStudioChatProvider', () => {
       expect(mockRenderString).toHaveBeenCalledWith('env-key', {});
 
       // No API key
-      delete process.env.GEMINI_API_KEY;
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.PALM_API_KEY;
+      mockProcessEnv({ GEMINI_API_KEY: undefined });
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ PALM_API_KEY: undefined });
       const providerWithNoKey = new AIStudioChatProvider('gemini-pro');
       expect(providerWithNoKey.getApiKey()).toBeUndefined();
     });
@@ -200,9 +201,9 @@ describe('AIStudioChatProvider', () => {
 
   describe('error handling', () => {
     it('should throw error when API key is not set', async () => {
-      delete process.env.GEMINI_API_KEY;
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.PALM_API_KEY;
+      mockProcessEnv({ GEMINI_API_KEY: undefined });
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ PALM_API_KEY: undefined });
       provider = new AIStudioChatProvider('gemini-pro', {});
       await expect(provider.callApi('test')).rejects.toThrow(
         'Google API key is not set. Set the GOOGLE_API_KEY or GEMINI_API_KEY environment variable or add `apiKey` to the provider config.',

--- a/test/providers/google/auth.test.ts
+++ b/test/providers/google/auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GoogleAuthManager } from '../../../src/providers/google/auth';
+import { mockProcessEnv } from '../../util/utils';
 
 // Mock dependencies
 vi.mock('../../../src/envars', () => ({
@@ -45,13 +46,13 @@ describe('GoogleAuthManager', () => {
     mockGoogleAuthInstance.getProjectId.mockClear().mockResolvedValue('detected-project');
     mockGoogleAuthInstance.fromJSON.mockClear().mockResolvedValue({});
     // Clear environment variables
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.VERTEX_API_KEY;
-    delete process.env.PALM_API_KEY;
-    delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GOOGLE_CLOUD_LOCATION;
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ VERTEX_API_KEY: undefined });
+    mockProcessEnv({ PALM_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_GENAI_USE_VERTEXAI: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_LOCATION: undefined });
   });
 
   afterEach(() => {

--- a/test/providers/google/gemini-image.test.ts
+++ b/test/providers/google/gemini-image.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { GeminiImageProvider } from '../../../src/providers/google/gemini-image';
 import * as googleUtil from '../../../src/providers/google/util';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', () => ({
   fetchWithCache: vi.fn(),
@@ -31,11 +32,11 @@ describe('GeminiImageProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.GOOGLE_API_KEY = 'test-api-key';
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
+    mockProcessEnv({ GOOGLE_API_KEY: 'test-api-key' });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
 
     mockLoadCredentials.mockImplementation((creds) => {
       if (typeof creds === 'object') {
@@ -47,11 +48,11 @@ describe('GeminiImageProvider', () => {
   });
 
   afterEach(() => {
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
   });
 
   it('should construct with model name', () => {
@@ -120,10 +121,10 @@ describe('GeminiImageProvider', () => {
   });
 
   it('should return error when both project ID and API key are missing', async () => {
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
     const provider = new GeminiImageProvider('gemini-3-pro-image-preview');
 
     const result = await provider.callApi('Test prompt');
@@ -142,7 +143,7 @@ describe('GeminiImageProvider', () => {
 
   describe('Vertex AI', () => {
     beforeEach(() => {
-      process.env.GOOGLE_PROJECT_ID = 'test-project';
+      mockProcessEnv({ GOOGLE_PROJECT_ID: 'test-project' });
     });
 
     it('should use OAuth authentication for Vertex AI', async () => {
@@ -732,8 +733,8 @@ describe('GeminiImageProvider', () => {
 
   describe('API key handling', () => {
     it('should support GEMINI_API_KEY environment variable', async () => {
-      delete process.env.GOOGLE_API_KEY;
-      process.env.GEMINI_API_KEY = 'gemini-key';
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ GEMINI_API_KEY: 'gemini-key' });
 
       const provider = new GeminiImageProvider('gemini-3-pro-image-preview');
 
@@ -777,7 +778,7 @@ describe('GeminiImageProvider', () => {
     });
 
     it('should use apiKey from config', async () => {
-      delete process.env.GOOGLE_API_KEY;
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
 
       const provider = new GeminiImageProvider('gemini-3-pro-image-preview', {
         config: {

--- a/test/providers/google/image.test.ts
+++ b/test/providers/google/image.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { GoogleImageProvider } from '../../../src/providers/google/image';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -28,11 +29,11 @@ describe('GoogleImageProvider', async () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.GOOGLE_API_KEY = 'test-api-key';
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
+    mockProcessEnv({ GOOGLE_API_KEY: 'test-api-key' });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
 
     // Set up default mock behaviors
     mockLoadCredentials.mockImplementation(function (creds) {
@@ -42,11 +43,11 @@ describe('GoogleImageProvider', async () => {
   });
 
   afterEach(() => {
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
   });
 
   it('should construct with model name', () => {
@@ -56,7 +57,7 @@ describe('GoogleImageProvider', async () => {
   });
 
   it('should use Google AI Studio when project ID is missing but API key is available', async () => {
-    delete process.env.GOOGLE_PROJECT_ID;
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
     const provider = new GoogleImageProvider('imagen-3.0-generate-001');
 
     mockFetchWithCache.mockResolvedValueOnce({
@@ -91,10 +92,10 @@ describe('GoogleImageProvider', async () => {
   });
 
   it('should return error when both project ID and API key are missing', async () => {
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    delete process.env.GEMINI_API_KEY;
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
     const provider = new GoogleImageProvider('imagen-3.0-generate-001');
 
     const result = await provider.callApi('Test prompt');
@@ -106,7 +107,7 @@ describe('GoogleImageProvider', async () => {
 
   describe('Vertex AI', () => {
     beforeEach(() => {
-      process.env.GOOGLE_PROJECT_ID = 'test-project';
+      mockProcessEnv({ GOOGLE_PROJECT_ID: 'test-project' });
     });
 
     it('should use OAuth authentication for Vertex AI', async () => {
@@ -253,8 +254,8 @@ describe('GoogleImageProvider', async () => {
 
   describe('Google AI Studio', () => {
     beforeEach(() => {
-      delete process.env.GOOGLE_PROJECT_ID;
-      process.env.GOOGLE_API_KEY = 'test-api-key';
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+      mockProcessEnv({ GOOGLE_API_KEY: 'test-api-key' });
     });
 
     it('should make correct API request to Google AI Studio', async () => {
@@ -341,9 +342,9 @@ describe('GoogleImageProvider', async () => {
     });
 
     it('should handle missing API key for Google AI Studio', async () => {
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      delete process.env.GEMINI_API_KEY;
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ GOOGLE_GENERATIVE_AI_API_KEY: undefined });
+      mockProcessEnv({ GEMINI_API_KEY: undefined });
       const provider = new GoogleImageProvider('imagen-3.0-generate-001');
 
       const result = await provider.callApi('Test prompt');
@@ -352,8 +353,8 @@ describe('GoogleImageProvider', async () => {
     });
 
     it('should support different API key environment variables', async () => {
-      delete process.env.GOOGLE_API_KEY;
-      process.env.GEMINI_API_KEY = 'gemini-key';
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ GEMINI_API_KEY: 'gemini-key' });
 
       const provider = new GoogleImageProvider('imagen-3.0-generate-001');
 

--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -7,6 +7,7 @@ import cliState from '../../../src/cliState';
 import { importModule } from '../../../src/esm';
 import { fetchJson, GoogleLiveProvider, tryGetThenPost } from '../../../src/providers/google/live';
 import * as fetchModule from '../../../src/util/fetch/index';
+import { mockProcessEnv } from '../../util/utils';
 
 const mockFetchWithProxy = vi.mocked(fetchModule.fetchWithProxy);
 
@@ -411,18 +412,18 @@ describe('GoogleLiveProvider', () => {
 
     const originalGoogleApiKey = process.env.GOOGLE_API_KEY;
     const originalGeminiApiKey = process.env.GEMINI_API_KEY;
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GEMINI_API_KEY;
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
 
     await expect(providerWithoutKey.callApi('test prompt')).rejects.toThrow(
       'Google authentication is not configured',
     );
 
     if (originalGoogleApiKey) {
-      process.env.GOOGLE_API_KEY = originalGoogleApiKey;
+      mockProcessEnv({ GOOGLE_API_KEY: originalGoogleApiKey });
     }
     if (originalGeminiApiKey) {
-      process.env.GEMINI_API_KEY = originalGeminiApiKey;
+      mockProcessEnv({ GEMINI_API_KEY: originalGeminiApiKey });
     }
   });
 
@@ -851,7 +852,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should use the PROMPTFOO_PYTHON env variable when available', async () => {
       const originalEnv = process.env.PROMPTFOO_PYTHON;
-      process.env.PROMPTFOO_PYTHON = '/env/python3';
+      mockProcessEnv({ PROMPTFOO_PYTHON: '/env/python3' });
 
       const mockSpawn = vi.mocked((await import('child_process')).spawn);
       const validatePythonPathMock = vi.mocked(
@@ -893,9 +894,9 @@ describe('GoogleLiveProvider', () => {
         ]);
       } finally {
         if (originalEnv) {
-          process.env.PROMPTFOO_PYTHON = originalEnv;
+          mockProcessEnv({ PROMPTFOO_PYTHON: originalEnv });
         } else {
-          delete process.env.PROMPTFOO_PYTHON;
+          mockProcessEnv({ PROMPTFOO_PYTHON: undefined });
         }
       }
     });

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -7,6 +7,7 @@ import * as util from '../../../src/providers/google/util';
 import * as fetchUtil from '../../../src/util/fetch/index';
 import { getNunjucksEngineForFilePath } from '../../../src/util/file';
 import * as templates from '../../../src/util/templates';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -265,15 +266,15 @@ describe('GoogleProvider', () => {
 
     it('should throw error when API key is missing in AI Studio mode', async () => {
       // Delete all possible API key env vars
-      delete process.env.GEMINI_API_KEY;
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.PALM_API_KEY;
-      delete process.env.VERTEX_API_KEY;
+      mockProcessEnv({ GEMINI_API_KEY: undefined });
+      mockProcessEnv({ GOOGLE_API_KEY: undefined });
+      mockProcessEnv({ PALM_API_KEY: undefined });
+      mockProcessEnv({ VERTEX_API_KEY: undefined });
       // Also delete project-related env vars that would trigger Vertex mode detection
-      delete process.env.GOOGLE_PROJECT_ID;
-      delete process.env.VERTEX_PROJECT_ID;
-      delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+      mockProcessEnv({ VERTEX_PROJECT_ID: undefined });
+      mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+      mockProcessEnv({ GOOGLE_GENAI_USE_VERTEXAI: undefined });
 
       // Explicitly set vertexai: false to ensure AI Studio mode regardless of env vars
       const noKeyProvider = new GoogleProvider('gemini-pro', {

--- a/test/providers/google/video.test.ts
+++ b/test/providers/google/video.test.ts
@@ -8,6 +8,7 @@ import {
   validateDuration,
   validateResolution,
 } from '../../../src/providers/google/video';
+import { mockProcessEnv } from '../../util/utils';
 
 // Mock the Google client
 const mockRequest = vi.fn();
@@ -79,11 +80,11 @@ describe('GoogleVideoProvider', () => {
           process.env.GOOGLE_PROJECT_ID,
       );
     });
-    process.env.GOOGLE_PROJECT_ID = 'test-project';
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.VERTEX_PROJECT_ID;
+    mockProcessEnv({ GOOGLE_PROJECT_ID: 'test-project' });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ VERTEX_PROJECT_ID: undefined });
 
     // Default mock for blob storage
     mockStoreBlob.mockResolvedValue({
@@ -99,11 +100,11 @@ describe('GoogleVideoProvider', () => {
   });
 
   afterEach(() => {
-    delete process.env.GOOGLE_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GOOGLE_PROJECT_ID;
-    delete process.env.VERTEX_PROJECT_ID;
+    mockProcessEnv({ GOOGLE_API_KEY: undefined });
+    mockProcessEnv({ GEMINI_API_KEY: undefined });
+    mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+    mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+    mockProcessEnv({ VERTEX_PROJECT_ID: undefined });
     // Reset fs mocks to prevent leakage between tests
     vi.mocked(fs.existsSync).mockReset();
     vi.mocked(fs.readFileSync).mockReset();
@@ -240,8 +241,8 @@ describe('GoogleVideoProvider', () => {
 
   describe('callApi', () => {
     it('should return error when Google AI Studio API key is missing', async () => {
-      delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GOOGLE_PROJECT_ID;
+      mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
       mockResolveProjectId.mockRejectedValue(new Error('No project ID found'));
       const provider = new GoogleVideoProvider('veo-3.1-generate-preview');
 
@@ -252,8 +253,8 @@ describe('GoogleVideoProvider', () => {
     });
 
     it('should return error when Vertex project ID is missing and ADC fails', async () => {
-      delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GOOGLE_PROJECT_ID;
+      mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
       mockResolveProjectId.mockRejectedValue(new Error('No project ID found'));
       const provider = new GoogleVideoProvider('veo-3.1-generate-preview', {
         config: {
@@ -268,8 +269,8 @@ describe('GoogleVideoProvider', () => {
     });
 
     it('should resolve project ID from ADC when not explicitly set', async () => {
-      delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GOOGLE_PROJECT_ID;
+      mockProcessEnv({ GOOGLE_CLOUD_PROJECT: undefined });
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
       // ADC can resolve the project ID
       mockResolveProjectId.mockResolvedValue('adc-resolved-project');
 
@@ -395,8 +396,8 @@ describe('GoogleVideoProvider', () => {
     });
 
     it('should create and poll Veo jobs through Google AI Studio with an API key', async () => {
-      delete process.env.GOOGLE_PROJECT_ID;
-      process.env.GOOGLE_API_KEY = 'test-api-key';
+      mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });
+      mockProcessEnv({ GOOGLE_API_KEY: 'test-api-key' });
 
       const operationName = 'models/veo-3.1-generate-preview/operations/test-op';
       const videoUri = 'https://generativelanguage.googleapis.com/v1beta/files/test-video';

--- a/test/providers/groq/responses.test.ts
+++ b/test/providers/groq/responses.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache } from '../../../src/cache';
 import { GroqResponsesProvider } from '../../../src/providers/groq/index';
 import * as fetchModule from '../../../src/util/fetch/index';
+import { mockProcessEnv } from '../../util/utils';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1';
 
@@ -11,11 +12,11 @@ describe('GroqResponsesProvider', () => {
   const mockedFetchWithRetries = vi.mocked(fetchModule.fetchWithRetries);
 
   beforeEach(() => {
-    process.env.GROQ_API_KEY = 'test-key';
+    mockProcessEnv({ GROQ_API_KEY: 'test-key' });
   });
 
   afterEach(async () => {
-    delete process.env.GROQ_API_KEY;
+    mockProcessEnv({ GROQ_API_KEY: undefined });
     await clearCache();
     vi.clearAllMocks();
   });
@@ -236,9 +237,9 @@ describe('GroqResponsesProvider', () => {
     });
 
     it('should handle missing API key', async () => {
-      delete process.env.GROQ_API_KEY;
+      mockProcessEnv({ GROQ_API_KEY: undefined });
       const originalOpenAIKey = process.env.OPENAI_API_KEY;
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         const provider = new GroqResponsesProvider('openai/gpt-oss-120b', {});
@@ -246,7 +247,7 @@ describe('GroqResponsesProvider', () => {
       } finally {
         // Restore OPENAI_API_KEY if it was set
         if (originalOpenAIKey) {
-          process.env.OPENAI_API_KEY = originalOpenAIKey;
+          mockProcessEnv({ OPENAI_API_KEY: originalOpenAIKey });
         }
       }
     });

--- a/test/providers/huggingface.test.ts
+++ b/test/providers/huggingface.test.ts
@@ -5,6 +5,7 @@ import {
   HuggingfaceTextGenerationProvider,
 } from '../../src/providers/huggingface';
 import { loadApiProvider } from '../../src/providers/index';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('proxy-agent', async (importOriginal) => {
   return {
@@ -83,14 +84,14 @@ function mockErrorResponse(statusCode: number, errorMessage: string) {
 
 describe('HuggingfaceChatCompletionProvider', () => {
   beforeEach(() => {
-    process.env.HF_TOKEN = 'test-hf-token';
+    mockProcessEnv({ HF_TOKEN: 'test-hf-token' });
   });
 
   afterEach(async () => {
     vi.clearAllMocks();
     await clearCache();
-    delete process.env.HF_TOKEN;
-    delete process.env.HF_API_TOKEN;
+    mockProcessEnv({ HF_TOKEN: undefined });
+    mockProcessEnv({ HF_API_TOKEN: undefined });
   });
 
   describe('constructor and identity', () => {
@@ -147,21 +148,21 @@ describe('HuggingfaceChatCompletionProvider', () => {
     });
 
     it('falls back to HF_TOKEN env var', () => {
-      process.env.HF_TOKEN = 'env-hf-token';
+      mockProcessEnv({ HF_TOKEN: 'env-hf-token' });
       const provider = new HuggingfaceChatCompletionProvider('test-model');
       expect(provider.getApiKey()).toBe('env-hf-token');
     });
 
     it('falls back to HF_API_TOKEN env var', () => {
-      delete process.env.HF_TOKEN;
-      process.env.HF_API_TOKEN = 'env-hf-api-token';
+      mockProcessEnv({ HF_TOKEN: undefined });
+      mockProcessEnv({ HF_API_TOKEN: 'env-hf-api-token' });
       const provider = new HuggingfaceChatCompletionProvider('test-model');
       expect(provider.getApiKey()).toBe('env-hf-api-token');
     });
 
     it('uses provider-level env overrides for HF_TOKEN', () => {
-      delete process.env.HF_TOKEN;
-      delete process.env.HF_API_TOKEN;
+      mockProcessEnv({ HF_TOKEN: undefined });
+      mockProcessEnv({ HF_API_TOKEN: undefined });
       const provider = new HuggingfaceChatCompletionProvider('test-model', {
         env: { HF_TOKEN: 'env-override-token' },
       });
@@ -169,8 +170,8 @@ describe('HuggingfaceChatCompletionProvider', () => {
     });
 
     it('uses provider-level env overrides for HF_API_TOKEN', () => {
-      delete process.env.HF_TOKEN;
-      delete process.env.HF_API_TOKEN;
+      mockProcessEnv({ HF_TOKEN: undefined });
+      mockProcessEnv({ HF_API_TOKEN: undefined });
       const provider = new HuggingfaceChatCompletionProvider('test-model', {
         env: { HF_API_TOKEN: 'env-override-api-token' },
       });
@@ -178,8 +179,8 @@ describe('HuggingfaceChatCompletionProvider', () => {
     });
 
     it('returns undefined when no key is set', () => {
-      delete process.env.HF_TOKEN;
-      delete process.env.HF_API_TOKEN;
+      mockProcessEnv({ HF_TOKEN: undefined });
+      mockProcessEnv({ HF_API_TOKEN: undefined });
       const provider = new HuggingfaceChatCompletionProvider('test-model');
       expect(provider.getApiKey()).toBeUndefined();
     });
@@ -273,7 +274,7 @@ describe('HuggingfaceChatCompletionProvider', () => {
     });
 
     it('sends Authorization header with HF token', async () => {
-      process.env.HF_TOKEN = 'my-secret-token';
+      mockProcessEnv({ HF_TOKEN: 'my-secret-token' });
       mockFetch.mockResolvedValue(mockChatResponse('response'));
       const provider = new HuggingfaceChatCompletionProvider('test-model');
       await provider.callApi('test');
@@ -329,13 +330,13 @@ describe('HuggingfaceChatCompletionProvider', () => {
 
 describe('HuggingfaceTextGenerationProvider chat delegation', () => {
   beforeEach(() => {
-    process.env.HF_TOKEN = 'test-hf-token';
+    mockProcessEnv({ HF_TOKEN: 'test-hf-token' });
   });
 
   afterEach(async () => {
     vi.clearAllMocks();
     await clearCache();
-    delete process.env.HF_TOKEN;
+    mockProcessEnv({ HF_TOKEN: undefined });
   });
 
   it('auto-detects chat completion format from /v1/chat URL', async () => {

--- a/test/providers/hyperbolic.test.ts
+++ b/test/providers/hyperbolic.test.ts
@@ -3,6 +3,7 @@ import { HyperbolicAudioProvider } from '../../src/providers/hyperbolic/audio';
 import { calculateHyperbolicCost, HyperbolicProvider } from '../../src/providers/hyperbolic/chat';
 import { HyperbolicImageProvider } from '../../src/providers/hyperbolic/image';
 import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/logger', () => ({
   default: {
@@ -18,11 +19,11 @@ describe('HyperbolicProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.HYPERBOLIC_API_KEY = mockApiKey;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: mockApiKey });
   });
 
   afterEach(() => {
-    delete process.env.HYPERBOLIC_API_KEY;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -159,11 +160,11 @@ describe('HyperbolicImageProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.HYPERBOLIC_API_KEY = mockApiKey;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: mockApiKey });
   });
 
   afterEach(() => {
-    delete process.env.HYPERBOLIC_API_KEY;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: undefined });
   });
 
   describe('constructor', () => {
@@ -211,11 +212,11 @@ describe('HyperbolicAudioProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.HYPERBOLIC_API_KEY = mockApiKey;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: mockApiKey });
   });
 
   afterEach(() => {
-    delete process.env.HYPERBOLIC_API_KEY;
+    mockProcessEnv({ HYPERBOLIC_API_KEY: undefined });
   });
 
   describe('constructor', () => {

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -55,6 +55,7 @@ import RedteamImageIterativeProvider from '../../src/redteam/providers/iterative
 import RedteamIterativeTreeProvider from '../../src/redteam/providers/iterativeTree';
 import { checkProviderApiKeys } from '../../src/util/provider';
 import { createMockProvider } from '../factories/provider';
+import { mockProcessEnv } from '../util/utils';
 
 import type { ProviderFunction, ProviderOptionsMap } from '../../src/types/index';
 
@@ -185,15 +186,15 @@ beforeEach(() => {
 describe('call provider apis', () => {
   beforeEach(() => {
     // Set Azure environment variables for Azure provider tests
-    process.env.AZURE_API_HOST = 'test.openai.azure.com';
-    process.env.AZURE_API_KEY = 'test-api-key';
+    mockProcessEnv({ AZURE_API_HOST: 'test.openai.azure.com' });
+    mockProcessEnv({ AZURE_API_KEY: 'test-api-key' });
   });
 
   afterEach(async () => {
     vi.clearAllMocks();
     await clearCache();
-    delete process.env.AZURE_API_HOST;
-    delete process.env.AZURE_API_KEY;
+    mockProcessEnv({ AZURE_API_HOST: undefined });
+    mockProcessEnv({ AZURE_API_KEY: undefined });
   });
 
   it('AzureOpenAiCompletionProvider callApi', async () => {
@@ -528,7 +529,7 @@ describe('loadApiProvider', () => {
       'TEST_MISSING_VAR_7079',
     ];
     for (const key of keysToClean) {
-      delete process.env[key];
+      mockProcessEnv({ [key]: undefined });
     }
   });
 
@@ -1155,8 +1156,8 @@ describe('loadApiProvider', () => {
   });
 
   it('supports templating in provider URL', async () => {
-    process.env.MY_HOST = 'api.example.com';
-    process.env.MY_PORT = '8080';
+    mockProcessEnv({ MY_HOST: 'api.example.com' });
+    mockProcessEnv({ MY_PORT: '8080' });
 
     const provider = await loadApiProvider('https://{{ env.MY_HOST }}:{{ env.MY_PORT }}/query', {
       options: {
@@ -1166,8 +1167,8 @@ describe('loadApiProvider', () => {
       },
     });
     expect(provider.id()).toBe('https://api.example.com:8080/query');
-    delete process.env.MY_HOST;
-    delete process.env.MY_PORT;
+    mockProcessEnv({ MY_HOST: undefined });
+    mockProcessEnv({ MY_PORT: undefined });
   });
 
   it('supports templating in provider URL with context env overrides', async () => {
@@ -1187,11 +1188,11 @@ describe('loadApiProvider', () => {
   });
 
   it('resolves env templates in provider IDs loaded from file references', async () => {
-    process.env.TEST_TENANT_7079 = 'tenant-a';
-    process.env.TEST_APPLICATION_7079 = 'myapp';
-    process.env.TEST_BASE_URL_7079 = 'example.com';
-    process.env.TEST_SERVICE_7079 = 'users';
-    process.env.TEST_VERSION_7079 = 'v3';
+    mockProcessEnv({ TEST_TENANT_7079: 'tenant-a' });
+    mockProcessEnv({ TEST_APPLICATION_7079: 'myapp' });
+    mockProcessEnv({ TEST_BASE_URL_7079: 'example.com' });
+    mockProcessEnv({ TEST_SERVICE_7079: 'users' });
+    mockProcessEnv({ TEST_VERSION_7079: 'v3' });
 
     const mockYamlContent = dedent`
       id: 'https://{{env.TEST_TENANT_7079}}-{{env.TEST_APPLICATION_7079}}.{{env.TEST_BASE_URL_7079}}/api/{{env.TEST_SERVICE_7079}}/{{env.TEST_VERSION_7079}}'
@@ -1204,16 +1205,16 @@ describe('loadApiProvider', () => {
     expect(providers).toHaveLength(1);
     expect(providers[0].id()).toBe('https://tenant-a-myapp.example.com/api/users/v3');
 
-    delete process.env.TEST_TENANT_7079;
-    delete process.env.TEST_APPLICATION_7079;
-    delete process.env.TEST_BASE_URL_7079;
-    delete process.env.TEST_SERVICE_7079;
-    delete process.env.TEST_VERSION_7079;
+    mockProcessEnv({ TEST_TENANT_7079: undefined });
+    mockProcessEnv({ TEST_APPLICATION_7079: undefined });
+    mockProcessEnv({ TEST_BASE_URL_7079: undefined });
+    mockProcessEnv({ TEST_SERVICE_7079: undefined });
+    mockProcessEnv({ TEST_VERSION_7079: undefined });
   });
 
   it('preserves undefined env templates in provider IDs loaded from file references', async () => {
-    process.env.TEST_APPLICATION_7079 = 'myapp';
-    process.env.TEST_BASE_URL_7079 = 'example.com';
+    mockProcessEnv({ TEST_APPLICATION_7079: 'myapp' });
+    mockProcessEnv({ TEST_BASE_URL_7079: 'example.com' });
 
     const mockYamlContent = dedent`
       id: 'https://{{env.TEST_APPLICATION_7079}}-{{env.TEST_MISSING_VAR_7079}}.{{env.TEST_BASE_URL_7079}}/api'
@@ -1226,13 +1227,13 @@ describe('loadApiProvider', () => {
     expect(providers).toHaveLength(1);
     expect(providers[0].id()).toBe('https://myapp-{{env.TEST_MISSING_VAR_7079}}.example.com/api');
 
-    delete process.env.TEST_APPLICATION_7079;
-    delete process.env.TEST_BASE_URL_7079;
+    mockProcessEnv({ TEST_APPLICATION_7079: undefined });
+    mockProcessEnv({ TEST_BASE_URL_7079: undefined });
   });
 
   it('resolves env templates when file:// providers are pre-resolved via resolveProviderConfigs', async () => {
-    process.env.TEST_APP_7079_RESOLVED = 'myapp';
-    process.env.TEST_URL_7079_RESOLVED = 'example.com';
+    mockProcessEnv({ TEST_APP_7079_RESOLVED: 'myapp' });
+    mockProcessEnv({ TEST_URL_7079_RESOLVED: 'example.com' });
 
     const mockYamlContent = dedent`
       id: 'https://{{env.TEST_APP_7079_RESOLVED}}.{{env.TEST_URL_7079_RESOLVED}}/api/v1'
@@ -1250,16 +1251,16 @@ describe('loadApiProvider', () => {
     expect(providers).toHaveLength(1);
     expect(providers[0].id()).toBe('https://myapp.example.com/api/v1');
 
-    delete process.env.TEST_APP_7079_RESOLVED;
-    delete process.env.TEST_URL_7079_RESOLVED;
+    mockProcessEnv({ TEST_APP_7079_RESOLVED: undefined });
+    mockProcessEnv({ TEST_URL_7079_RESOLVED: undefined });
   });
 
   it('resolves env templates in HTTP provider URL and config from file reference (#7079)', async () => {
-    process.env.TEST_APP_7079_HTTP = 'myapp';
-    process.env.TEST_BASE_7079_HTTP = 'example.com';
-    process.env.TEST_SVC_7079_HTTP = 'users';
-    process.env.TEST_VER_7079_HTTP = 'v3';
-    process.env.TEST_SESSION_7079_HTTP = 'abc123';
+    mockProcessEnv({ TEST_APP_7079_HTTP: 'myapp' });
+    mockProcessEnv({ TEST_BASE_7079_HTTP: 'example.com' });
+    mockProcessEnv({ TEST_SVC_7079_HTTP: 'users' });
+    mockProcessEnv({ TEST_VER_7079_HTTP: 'v3' });
+    mockProcessEnv({ TEST_SESSION_7079_HTTP: 'abc123' });
 
     const mockYamlContent = dedent`
       id: 'https://{{env.TEST_APP_7079_HTTP}}.{{env.TEST_BASE_7079_HTTP}}/api/{{env.TEST_SVC_7079_HTTP}}/{{env.TEST_VER_7079_HTTP}}'
@@ -1274,11 +1275,11 @@ describe('loadApiProvider', () => {
     expect(provider.id()).toBe('https://myapp.example.com/api/users/v3');
     expect(provider.config.headers?.Cookie).toBe('SESSION=abc123');
 
-    delete process.env.TEST_APP_7079_HTTP;
-    delete process.env.TEST_BASE_7079_HTTP;
-    delete process.env.TEST_SVC_7079_HTTP;
-    delete process.env.TEST_VER_7079_HTTP;
-    delete process.env.TEST_SESSION_7079_HTTP;
+    mockProcessEnv({ TEST_APP_7079_HTTP: undefined });
+    mockProcessEnv({ TEST_BASE_7079_HTTP: undefined });
+    mockProcessEnv({ TEST_SVC_7079_HTTP: undefined });
+    mockProcessEnv({ TEST_VER_7079_HTTP: undefined });
+    mockProcessEnv({ TEST_SESSION_7079_HTTP: undefined });
   });
 
   it('lets explicit env overrides win for providers loaded from file references', async () => {
@@ -1341,8 +1342,8 @@ describe('loadApiProvider', () => {
   it('preserves merged env overrides for Abliteration providers', async () => {
     const originalAblitKey = process.env.ABLIT_KEY;
     const originalAblitApiBaseUrl = process.env.ABLIT_API_BASE_URL;
-    delete process.env.ABLIT_KEY;
-    delete process.env.ABLIT_API_BASE_URL;
+    mockProcessEnv({ ABLIT_KEY: undefined });
+    mockProcessEnv({ ABLIT_API_BASE_URL: undefined });
 
     try {
       const provider = (await loadApiProvider('abliteration:abliterated-model', {
@@ -1362,15 +1363,15 @@ describe('loadApiProvider', () => {
       expect(provider.getApiKey()).toBe('provider-key');
     } finally {
       if (originalAblitKey === undefined) {
-        delete process.env.ABLIT_KEY;
+        mockProcessEnv({ ABLIT_KEY: undefined });
       } else {
-        process.env.ABLIT_KEY = originalAblitKey;
+        mockProcessEnv({ ABLIT_KEY: originalAblitKey });
       }
 
       if (originalAblitApiBaseUrl === undefined) {
-        delete process.env.ABLIT_API_BASE_URL;
+        mockProcessEnv({ ABLIT_API_BASE_URL: undefined });
       } else {
-        process.env.ABLIT_API_BASE_URL = originalAblitApiBaseUrl;
+        mockProcessEnv({ ABLIT_API_BASE_URL: originalAblitApiBaseUrl });
       }
     }
   });
@@ -1401,8 +1402,8 @@ describe('loadApiProvider', () => {
   });
 
   it('passes provider env overrides through the registry to Claude Agent SDK providers', async () => {
-    delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.CLAUDE_CODE_USE_VERTEX;
+    mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+    mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
 
     const provider = await loadApiProvider('anthropic:claude-agent-sdk', {
       options: {
@@ -1610,7 +1611,7 @@ describe('loadApiProvider', () => {
   });
 
   it('renders label using Nunjucks', async () => {
-    process.env.someVariable = 'foo';
+    mockProcessEnv({ someVariable: 'foo' });
     const providerOptions = {
       id: 'openai:chat:gpt-4o',
       config: {},
@@ -1621,9 +1622,9 @@ describe('loadApiProvider', () => {
   });
 
   it('renders environment variables in provider config while preserving runtime vars', async () => {
-    process.env.MY_DEPLOYMENT = 'test-deployment';
-    process.env.AZURE_ENDPOINT = 'test.openai.azure.com';
-    process.env.API_VERSION = '2024-02-15';
+    mockProcessEnv({ MY_DEPLOYMENT: 'test-deployment' });
+    mockProcessEnv({ AZURE_ENDPOINT: 'test.openai.azure.com' });
+    mockProcessEnv({ API_VERSION: '2024-02-15' });
 
     const providerOptions = {
       config: {
@@ -1647,9 +1648,9 @@ describe('loadApiProvider', () => {
       message: '{{ vars.userMessage }}',
     });
 
-    delete process.env.MY_DEPLOYMENT;
-    delete process.env.AZURE_ENDPOINT;
-    delete process.env.API_VERSION;
+    mockProcessEnv({ MY_DEPLOYMENT: undefined });
+    mockProcessEnv({ AZURE_ENDPOINT: undefined });
+    mockProcessEnv({ API_VERSION: undefined });
   });
 
   it('loadApiProvider with xai', async () => {

--- a/test/providers/litellm.test.ts
+++ b/test/providers/litellm.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
 import { createLiteLLMProvider, LiteLLMProvider } from '../../src/providers/litellm';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/cache', async (importOriginal) => {
   return {
@@ -28,7 +29,7 @@ const originalOpenAiTemperature = process.env.OPENAI_TEMPERATURE;
 describe('LiteLLM Provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.OPENAI_TEMPERATURE;
+    mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
   });
 
   afterEach(() => {
@@ -36,9 +37,9 @@ describe('LiteLLM Provider', () => {
     mockFetch.mockReset();
     vi.unstubAllEnvs();
     if (originalOpenAiTemperature === undefined) {
-      delete process.env.OPENAI_TEMPERATURE;
+      mockProcessEnv({ OPENAI_TEMPERATURE: undefined });
     } else {
-      process.env.OPENAI_TEMPERATURE = originalOpenAiTemperature;
+      mockProcessEnv({ OPENAI_TEMPERATURE: originalOpenAiTemperature });
     }
   });
   describe('createLiteLLMProvider', () => {
@@ -102,7 +103,7 @@ describe('LiteLLM Provider', () => {
 
     it('should work with LITELLM_API_KEY environment variable', () => {
       const originalEnv = process.env.LITELLM_API_KEY;
-      process.env.LITELLM_API_KEY = 'test-litellm-key';
+      mockProcessEnv({ LITELLM_API_KEY: 'test-litellm-key' });
 
       try {
         const provider = createLiteLLMProvider('litellm:gpt-4', {
@@ -122,9 +123,9 @@ describe('LiteLLM Provider', () => {
         expect(wrappedProvider.getApiKey()).toBe('test-litellm-key');
       } finally {
         if (originalEnv === undefined) {
-          delete process.env.LITELLM_API_KEY;
+          mockProcessEnv({ LITELLM_API_KEY: undefined });
         } else {
-          process.env.LITELLM_API_KEY = originalEnv;
+          mockProcessEnv({ LITELLM_API_KEY: originalEnv });
         }
       }
     });
@@ -440,7 +441,7 @@ describe('LiteLLM Provider', () => {
 
     it('should use OPENAI_TEMPERATURE env var when set', async () => {
       mockFetchWithCache.mockResolvedValue(mockResponse);
-      process.env.OPENAI_TEMPERATURE = '0.5';
+      mockProcessEnv({ OPENAI_TEMPERATURE: '0.5' });
 
       const provider = createLiteLLMProvider('litellm:chat:gpt-4', {
         config: {

--- a/test/providers/openai-codex-sdk.e2e.test.ts
+++ b/test/providers/openai-codex-sdk.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mockProcessEnv } from '../util/utils';
+
 /**
  * End-to-End tests for OpenAI Codex SDK Provider
  * These tests use the real @openai/codex-sdk package (must be installed)
@@ -40,21 +42,21 @@ const originalCodexApiKey = process.env.CODEX_API_KEY;
 // vitest.setup.ts installs a dummy OPENAI_API_KEY for unit tests. Ignore that value for E2E runs,
 // and only restore a real key when one is explicitly provided.
 if (e2eApiKey) {
-  process.env.OPENAI_API_KEY = e2eApiKey;
-  process.env.CODEX_API_KEY = e2eApiKey;
+  mockProcessEnv({ OPENAI_API_KEY: e2eApiKey });
+  mockProcessEnv({ CODEX_API_KEY: e2eApiKey });
 }
 
 afterAll(() => {
   if (originalOpenAiApiKey === undefined) {
-    delete process.env.OPENAI_API_KEY;
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
   } else {
-    process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+    mockProcessEnv({ OPENAI_API_KEY: originalOpenAiApiKey });
   }
 
   if (originalCodexApiKey === undefined) {
-    delete process.env.CODEX_API_KEY;
+    mockProcessEnv({ CODEX_API_KEY: undefined });
   } else {
-    process.env.CODEX_API_KEY = originalCodexApiKey;
+    mockProcessEnv({ CODEX_API_KEY: originalCodexApiKey });
   }
 });
 

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -1,25 +1,15 @@
 import fs from 'fs';
 import path from 'path';
 
-import { createDeferred, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 import { clearCache } from '../../src/cache';
 import cliState from '../../src/cliState';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  importModule,
-  it,
-  MockInstance,
-  mockProcessEnv,
-  resolvePackageEntryPoint,
-} from '../../src/esm';
+import { getDirectory, importModule, resolvePackageEntryPoint } from '../../src/esm';
 import logger from '../../src/logger';
 import { OpenAICodexSDKProvider } from '../../src/providers/openai/codex-sdk';
 import { providerRegistry } from '../../src/providers/providerRegistry';
 import { checkProviderApiKeys } from '../../src/util/provider';
-import { getDirectory } from '../util/utils';
+import { createDeferred, mockProcessEnv } from '../util/utils';
 
 import type { CallApiContextParams } from '../../src/types/index';
 

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -1,15 +1,25 @@
 import fs from 'fs';
 import path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { createDeferred, vi } from 'vitest';
 import { clearCache } from '../../src/cache';
 import cliState from '../../src/cliState';
-import { getDirectory, importModule, resolvePackageEntryPoint } from '../../src/esm';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  importModule,
+  it,
+  MockInstance,
+  mockProcessEnv,
+  resolvePackageEntryPoint,
+} from '../../src/esm';
 import logger from '../../src/logger';
 import { OpenAICodexSDKProvider } from '../../src/providers/openai/codex-sdk';
 import { providerRegistry } from '../../src/providers/providerRegistry';
 import { checkProviderApiKeys } from '../../src/util/provider';
-import { createDeferred } from '../util/utils';
+import { getDirectory } from '../util/utils';
 
 import type { CallApiContextParams } from '../../src/types/index';
 
@@ -71,9 +81,9 @@ const createMockResponse = (
 
 function restoreEnvVar(name: 'OPENAI_API_KEY' | 'CODEX_API_KEY', value: string | undefined) {
   if (value === undefined) {
-    delete process.env[name];
+    mockProcessEnv({ [name]: undefined });
   } else {
-    process.env[name] = value;
+    mockProcessEnv({ [name]: value });
   }
 }
 
@@ -362,8 +372,8 @@ describe('OpenAICodexSDKProvider', () => {
       });
 
       it('should allow SDK-managed auth when API key is missing', async () => {
-        delete process.env.OPENAI_API_KEY;
-        delete process.env.CODEX_API_KEY;
+        mockProcessEnv({ OPENAI_API_KEY: undefined });
+        mockProcessEnv({ CODEX_API_KEY: undefined });
         mockRun.mockResolvedValue(createMockResponse('Login-backed response'));
 
         const provider = new OpenAICodexSDKProvider();
@@ -379,8 +389,8 @@ describe('OpenAICodexSDKProvider', () => {
       });
 
       it('should skip missing API key preflight for SDK-managed auth', () => {
-        delete process.env.OPENAI_API_KEY;
-        delete process.env.CODEX_API_KEY;
+        mockProcessEnv({ OPENAI_API_KEY: undefined });
+        mockProcessEnv({ CODEX_API_KEY: undefined });
 
         const provider = new OpenAICodexSDKProvider();
         const result = checkProviderApiKeys([provider]);
@@ -690,8 +700,8 @@ describe('OpenAICodexSDKProvider', () => {
       it('should infer skillCalls from USERPROFILE .codex skill directories on Windows', async () => {
         const originalHome = process.env.HOME;
         const originalUserProfile = process.env.USERPROFILE;
-        delete process.env.HOME;
-        process.env.USERPROFILE = 'C:\\Users\\promptfoo';
+        mockProcessEnv({ HOME: undefined });
+        mockProcessEnv({ USERPROFILE: 'C:\\Users\\promptfoo' });
 
         mockRun.mockResolvedValue(
           createMockResponse('USERPROFILE-SKILL', undefined, [
@@ -723,15 +733,15 @@ describe('OpenAICodexSDKProvider', () => {
           });
         } finally {
           if (originalHome === undefined) {
-            delete process.env.HOME;
+            mockProcessEnv({ HOME: undefined });
           } else {
-            process.env.HOME = originalHome;
+            mockProcessEnv({ HOME: originalHome });
           }
 
           if (originalUserProfile === undefined) {
-            delete process.env.USERPROFILE;
+            mockProcessEnv({ USERPROFILE: undefined });
           } else {
-            process.env.USERPROFILE = originalUserProfile;
+            mockProcessEnv({ USERPROFILE: originalUserProfile });
           }
         }
       });
@@ -1799,7 +1809,7 @@ describe('OpenAICodexSDKProvider', () => {
     describe('environment variables', () => {
       it('should use a minimal shell env by default instead of inheriting all process variables', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
-        process.env.PROMPTFOO_TEST_EXISTING = 'present';
+        mockProcessEnv({ PROMPTFOO_TEST_EXISTING: 'present' });
 
         try {
           const provider = new OpenAICodexSDKProvider({
@@ -1826,7 +1836,7 @@ describe('OpenAICodexSDKProvider', () => {
             }),
           );
         } finally {
-          delete process.env.PROMPTFOO_TEST_EXISTING;
+          mockProcessEnv({ PROMPTFOO_TEST_EXISTING: undefined });
         }
       });
 
@@ -1890,7 +1900,7 @@ describe('OpenAICodexSDKProvider', () => {
 
       it('should use custom cli_env', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
-        process.env.PROMPTFOO_TEST_EXISTING = 'present';
+        mockProcessEnv({ PROMPTFOO_TEST_EXISTING: 'present' });
 
         try {
           const provider = new OpenAICodexSDKProvider({
@@ -1925,7 +1935,7 @@ describe('OpenAICodexSDKProvider', () => {
             }),
           );
         } finally {
-          delete process.env.PROMPTFOO_TEST_EXISTING;
+          mockProcessEnv({ PROMPTFOO_TEST_EXISTING: undefined });
         }
       });
 
@@ -1988,14 +1998,14 @@ describe('OpenAICodexSDKProvider', () => {
 
     describe('API key priority', () => {
       beforeEach(() => {
-        delete process.env.OPENAI_API_KEY;
-        delete process.env.CODEX_API_KEY;
+        mockProcessEnv({ OPENAI_API_KEY: undefined });
+        mockProcessEnv({ CODEX_API_KEY: undefined });
       });
 
       it('should prioritize config apiKey over env vars', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
 
-        process.env.OPENAI_API_KEY = 'env-key';
+        mockProcessEnv({ OPENAI_API_KEY: 'env-key' });
         const provider = new OpenAICodexSDKProvider({
           config: { apiKey: 'config-key' },
         });
@@ -2016,7 +2026,7 @@ describe('OpenAICodexSDKProvider', () => {
       it('should use prompt config apiKey over provider and process env vars', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
 
-        process.env.OPENAI_API_KEY = 'process-env-key';
+        mockProcessEnv({ OPENAI_API_KEY: 'process-env-key' });
         const provider = new OpenAICodexSDKProvider({
           env: { OPENAI_API_KEY: 'provider-env-key' },
         });
@@ -2105,7 +2115,7 @@ describe('OpenAICodexSDKProvider', () => {
       it('should merge cli_env with inherited process env when inherit_process_env is enabled', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
 
-        process.env.PROMPTFOO_TEST_EXISTING = 'present';
+        mockProcessEnv({ PROMPTFOO_TEST_EXISTING: 'present' });
         try {
           const provider = new OpenAICodexSDKProvider({
             config: {
@@ -2127,7 +2137,7 @@ describe('OpenAICodexSDKProvider', () => {
             }),
           );
         } finally {
-          delete process.env.PROMPTFOO_TEST_EXISTING;
+          mockProcessEnv({ PROMPTFOO_TEST_EXISTING: undefined });
         }
       });
 
@@ -2135,7 +2145,7 @@ describe('OpenAICodexSDKProvider', () => {
         const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
         mockRun.mockResolvedValue(createMockResponse('Response'));
         const originalCodexHome = process.env.CODEX_HOME;
-        process.env.CODEX_HOME = '/tmp/process-codex-home';
+        mockProcessEnv({ CODEX_HOME: '/tmp/process-codex-home' });
 
         try {
           const provider = new OpenAICodexSDKProvider({
@@ -2153,9 +2163,9 @@ describe('OpenAICodexSDKProvider', () => {
           );
         } finally {
           if (originalCodexHome === undefined) {
-            delete process.env.CODEX_HOME;
+            mockProcessEnv({ CODEX_HOME: undefined });
           } else {
-            process.env.CODEX_HOME = originalCodexHome;
+            mockProcessEnv({ CODEX_HOME: originalCodexHome });
           }
           warnSpy.mockRestore();
         }
@@ -2165,7 +2175,7 @@ describe('OpenAICodexSDKProvider', () => {
         const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
         mockRun.mockResolvedValue(createMockResponse('Response'));
         const originalSshAuthSock = process.env.SSH_AUTH_SOCK;
-        process.env.SSH_AUTH_SOCK = '/tmp/ssh-agent.sock';
+        mockProcessEnv({ SSH_AUTH_SOCK: '/tmp/ssh-agent.sock' });
 
         try {
           const provider = new OpenAICodexSDKProvider({
@@ -2187,9 +2197,9 @@ describe('OpenAICodexSDKProvider', () => {
           );
         } finally {
           if (originalSshAuthSock === undefined) {
-            delete process.env.SSH_AUTH_SOCK;
+            mockProcessEnv({ SSH_AUTH_SOCK: undefined });
           } else {
-            process.env.SSH_AUTH_SOCK = originalSshAuthSock;
+            mockProcessEnv({ SSH_AUTH_SOCK: originalSshAuthSock });
           }
           warnSpy.mockRestore();
         }
@@ -2199,7 +2209,7 @@ describe('OpenAICodexSDKProvider', () => {
         const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
         mockRun.mockResolvedValue(createMockResponse('Response'));
         const originalSshAuthSock = process.env.SSH_AUTH_SOCK;
-        process.env.SSH_AUTH_SOCK = '/tmp/ssh-agent.sock';
+        mockProcessEnv({ SSH_AUTH_SOCK: '/tmp/ssh-agent.sock' });
 
         try {
           const provider = new OpenAICodexSDKProvider({
@@ -2220,9 +2230,9 @@ describe('OpenAICodexSDKProvider', () => {
           );
         } finally {
           if (originalSshAuthSock === undefined) {
-            delete process.env.SSH_AUTH_SOCK;
+            mockProcessEnv({ SSH_AUTH_SOCK: undefined });
           } else {
-            process.env.SSH_AUTH_SOCK = originalSshAuthSock;
+            mockProcessEnv({ SSH_AUTH_SOCK: originalSshAuthSock });
           }
           warnSpy.mockRestore();
         }

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -6,6 +6,7 @@ import cliState from '../../../src/cliState';
 import { importModule } from '../../../src/esm';
 import logger from '../../../src/logger';
 import { OpenAiChatCompletionProvider } from '../../../src/providers/openai/chat';
+import { mockProcessEnv } from '../../util/utils';
 import { getOpenAiMissingApiKeyMessage } from './shared';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
@@ -41,21 +42,21 @@ describe('OpenAI Provider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     disableCache();
-    process.env.OPENAI_API_KEY = 'test-api-key';
-    process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+    mockProcessEnv({ OPENAI_API_KEY: 'test-api-key' });
+    mockProcessEnv({ DEEPSEEK_API_KEY: 'test-deepseek-key' });
   });
 
   afterEach(() => {
     enableCache();
     if (originalOpenAiApiKey) {
-      process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+      mockProcessEnv({ OPENAI_API_KEY: originalOpenAiApiKey });
     } else {
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
     }
     if (originalDeepseekApiKey) {
-      process.env.DEEPSEEK_API_KEY = originalDeepseekApiKey;
+      mockProcessEnv({ DEEPSEEK_API_KEY: originalDeepseekApiKey });
     } else {
-      delete process.env.DEEPSEEK_API_KEY;
+      mockProcessEnv({ DEEPSEEK_API_KEY: undefined });
     }
   });
 
@@ -2297,7 +2298,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
     it('should use generic error message with fallback when apiKeyEnvar is undefined', async () => {
       // Clear any existing API key environment variables
       const originalEnv = process.env.OPENAI_API_KEY;
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
@@ -2308,7 +2309,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       } finally {
         // Restore original environment
         if (originalEnv) {
-          process.env.OPENAI_API_KEY = originalEnv;
+          mockProcessEnv({ OPENAI_API_KEY: originalEnv });
         }
       }
     });
@@ -2317,8 +2318,8 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       // Clear any existing API key environment variables
       const originalEnv = process.env.OPENAI_API_KEY;
       const originalCustomEnv = process.env.CUSTOM_API_KEY;
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
+      mockProcessEnv({ CUSTOM_API_KEY: undefined });
 
       try {
         const provider = new OpenAiChatCompletionProvider('gpt-4o-mini', {
@@ -2331,10 +2332,10 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       } finally {
         // Restore original environment
         if (originalEnv) {
-          process.env.OPENAI_API_KEY = originalEnv;
+          mockProcessEnv({ OPENAI_API_KEY: originalEnv });
         }
         if (originalCustomEnv) {
-          process.env.CUSTOM_API_KEY = originalCustomEnv;
+          mockProcessEnv({ CUSTOM_API_KEY: originalCustomEnv });
         }
       }
     });
@@ -2359,8 +2360,8 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       // Clear environment variables
       const originalEnv = process.env.OPENAI_API_KEY;
       const originalCustomEnv = process.env.CUSTOM_PROVIDER_API_KEY;
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_PROVIDER_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
+      mockProcessEnv({ CUSTOM_PROVIDER_API_KEY: undefined });
 
       try {
         const provider = new CustomProvider('custom-model');
@@ -2375,10 +2376,10 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       } finally {
         // Restore original environment
         if (originalEnv) {
-          process.env.OPENAI_API_KEY = originalEnv;
+          mockProcessEnv({ OPENAI_API_KEY: originalEnv });
         }
         if (originalCustomEnv) {
-          process.env.CUSTOM_PROVIDER_API_KEY = originalCustomEnv;
+          mockProcessEnv({ CUSTOM_PROVIDER_API_KEY: originalCustomEnv });
         }
       }
     });
@@ -2488,7 +2489,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
 
     it('should work with apiKeyRequired: false and API key from environment', () => {
       const originalEnv = process.env.CUSTOM_LOCAL_API_KEY;
-      process.env.CUSTOM_LOCAL_API_KEY = 'test-local-key';
+      mockProcessEnv({ CUSTOM_LOCAL_API_KEY: 'test-local-key' });
 
       try {
         const provider = new OpenAiChatCompletionProvider('local-model', {
@@ -2506,9 +2507,9 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
         expect(provider.requiresApiKey()).toBe(false);
       } finally {
         if (originalEnv === undefined) {
-          delete process.env.CUSTOM_LOCAL_API_KEY;
+          mockProcessEnv({ CUSTOM_LOCAL_API_KEY: undefined });
         } else {
-          process.env.CUSTOM_LOCAL_API_KEY = originalEnv;
+          mockProcessEnv({ CUSTOM_LOCAL_API_KEY: originalEnv });
         }
       }
     });
@@ -2517,8 +2518,8 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       // Ensure no API key is set in the environment
       const originalCustomEnv = process.env.CUSTOM_LOCAL_API_KEY;
       const originalOpenAIEnv = process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_LOCAL_API_KEY;
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ CUSTOM_LOCAL_API_KEY: undefined });
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         const provider = new OpenAiChatCompletionProvider('local-model', {
@@ -2562,10 +2563,10 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
         expect(headers.Authorization).toBeUndefined();
       } finally {
         if (originalCustomEnv !== undefined) {
-          process.env.CUSTOM_LOCAL_API_KEY = originalCustomEnv;
+          mockProcessEnv({ CUSTOM_LOCAL_API_KEY: originalCustomEnv });
         }
         if (originalOpenAIEnv !== undefined) {
-          process.env.OPENAI_API_KEY = originalOpenAIEnv;
+          mockProcessEnv({ OPENAI_API_KEY: originalOpenAIEnv });
         }
       }
     });

--- a/test/providers/openai/codexDefaults.test.ts
+++ b/test/providers/openai/codexDefaults.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { providerRegistry } from '../../../src/providers/providerRegistry';
+import { mockProcessEnv } from '../../util/utils';
 
 import type { OpenAICodexSDKProvider } from '../../../src/providers/openai/codex-sdk';
 
@@ -34,11 +35,11 @@ describe('Codex default providers', () => {
     originalCodexApiKey = process.env.CODEX_API_KEY;
     originalCodexHome = process.env.CODEX_HOME;
     originalOpenAiApiKey = process.env.OPENAI_API_KEY;
-    delete process.env.CODEX_API_KEY;
-    delete process.env.OPENAI_API_KEY;
+    mockProcessEnv({ CODEX_API_KEY: undefined });
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
 
     codexHome = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-codex-defaults-'));
-    process.env.CODEX_HOME = codexHome;
+    mockProcessEnv({ CODEX_HOME: codexHome });
 
     const { clearCodexDefaultProvidersForTesting } = await import(
       '../../../src/providers/openai/codexDefaults'
@@ -57,26 +58,26 @@ describe('Codex default providers', () => {
     fs.rmSync(codexHome, { force: true, recursive: true });
 
     if (originalCodexApiKey === undefined) {
-      delete process.env.CODEX_API_KEY;
+      mockProcessEnv({ CODEX_API_KEY: undefined });
     } else {
-      process.env.CODEX_API_KEY = originalCodexApiKey;
+      mockProcessEnv({ CODEX_API_KEY: originalCodexApiKey });
     }
 
     if (originalCodexHome === undefined) {
-      delete process.env.CODEX_HOME;
+      mockProcessEnv({ CODEX_HOME: undefined });
     } else {
-      process.env.CODEX_HOME = originalCodexHome;
+      mockProcessEnv({ CODEX_HOME: originalCodexHome });
     }
 
     if (originalOpenAiApiKey === undefined) {
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
     } else {
-      process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+      mockProcessEnv({ OPENAI_API_KEY: originalOpenAiApiKey });
     }
   });
 
   it('returns true when CODEX_API_KEY exists and the Codex SDK package can be resolved', async () => {
-    process.env.CODEX_API_KEY = 'test-codex-key';
+    mockProcessEnv({ CODEX_API_KEY: 'test-codex-key' });
 
     const { hasCodexDefaultCredentials } = await import(
       '../../../src/providers/openai/codexDefaults'
@@ -171,10 +172,10 @@ describe('Codex default providers', () => {
       '../../../src/providers/openai/codexDefaults'
     );
 
-    process.env.CODEX_API_KEY = 'first-codex-key';
+    mockProcessEnv({ CODEX_API_KEY: 'first-codex-key' });
     const firstProviders = getCodexDefaultProviders();
 
-    process.env.CODEX_API_KEY = 'second-codex-key';
+    mockProcessEnv({ CODEX_API_KEY: 'second-codex-key' });
     const secondProviders = getCodexDefaultProviders();
 
     expect(secondProviders).toBe(firstProviders);

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { disableCache, enableCache, fetchWithCache } from '../../../src/cache';
 import logger from '../../../src/logger';
 import { OpenAiCompletionProvider } from '../../../src/providers/openai/completion';
+import { mockProcessEnv } from '../../util/utils';
 import { getOpenAiMissingApiKeyMessage, restoreEnvVar } from './shared';
 
 vi.mock('../../../src/cache');
@@ -14,7 +15,7 @@ describe('OpenAI Provider', () => {
     vi.resetAllMocks();
     disableCache();
     // Set a default API key for tests unless explicitly testing missing key
-    process.env.OPENAI_API_KEY = 'test-api-key';
+    mockProcessEnv({ OPENAI_API_KEY: 'test-api-key' });
   });
 
   afterEach(() => {
@@ -77,7 +78,7 @@ describe('OpenAI Provider', () => {
     it('should handle missing API key', async () => {
       // Save the original env var and clear it for this test
       const originalApiKey = process.env.OPENAI_API_KEY;
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         const provider = new OpenAiCompletionProvider('text-davinci-003', {
@@ -100,8 +101,8 @@ describe('OpenAI Provider', () => {
     it('should use custom apiKeyEnvar in missing API key errors', async () => {
       const originalApiKey = process.env.OPENAI_API_KEY;
       const originalCustomApiKey = process.env.CUSTOM_OPENAI_KEY;
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_OPENAI_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
+      mockProcessEnv({ CUSTOM_OPENAI_KEY: undefined });
 
       try {
         const provider = new OpenAiCompletionProvider('text-davinci-003', {
@@ -235,7 +236,7 @@ describe('OpenAI Provider', () => {
     });
 
     it('should handle invalid OPENAI_STOP env var', async () => {
-      process.env.OPENAI_STOP = '{invalid json}';
+      mockProcessEnv({ OPENAI_STOP: '{invalid json}' });
 
       const provider = new OpenAiCompletionProvider('text-davinci-003', {
         config: {
@@ -247,7 +248,7 @@ describe('OpenAI Provider', () => {
         /OPENAI_STOP is not a valid JSON string/,
       );
 
-      delete process.env.OPENAI_STOP;
+      mockProcessEnv({ OPENAI_STOP: undefined });
     });
   });
 });

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { OpenAiImageProvider } from '../../../src/providers/openai/image';
+import { mockProcessEnv } from '../../util/utils';
 import { getOpenAiMissingApiKeyMessage, restoreEnvVar } from './shared';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
@@ -144,7 +145,7 @@ describe('OpenAiImageProvider', () => {
       // Save original environment variable
       const originalEnv = process.env.OPENAI_API_KEY;
       // Clear the environment variable so we can test the error
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         // Create provider with no API key in config or environment
@@ -167,8 +168,8 @@ describe('OpenAiImageProvider', () => {
     it('should use custom apiKeyEnvar in missing API key errors', async () => {
       const originalEnv = process.env.OPENAI_API_KEY;
       const originalCustomEnv = process.env.CUSTOM_IMAGE_API_KEY;
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_IMAGE_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
+      mockProcessEnv({ CUSTOM_IMAGE_API_KEY: undefined });
 
       try {
         const provider = new OpenAiImageProvider('dall-e-3', {

--- a/test/providers/openai/index.test.ts
+++ b/test/providers/openai/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { OpenAiGenericProvider } from '../../../src/providers/openai/index';
+import { mockProcessEnv } from '../../util/utils';
 
 describe('OpenAI Provider', () => {
   describe('OpenAiGenericProvider', () => {
@@ -11,7 +12,7 @@ describe('OpenAI Provider', () => {
     });
 
     beforeEach(() => {
-      process.env = {};
+      mockProcessEnv({}, { clear: true });
     });
 
     it('should generate correct API URL', () => {
@@ -37,7 +38,7 @@ describe('OpenAI Provider', () => {
     });
 
     it('should get organization from env', () => {
-      process.env.OPENAI_ORGANIZATION = 'env-org';
+      mockProcessEnv({ OPENAI_ORGANIZATION: 'env-org' });
       const envProvider = new OpenAiGenericProvider('test-model');
       expect(envProvider.getOrganization()).toBe('env-org');
     });
@@ -47,13 +48,13 @@ describe('OpenAI Provider', () => {
     });
 
     it('should get API key from env', () => {
-      process.env.OPENAI_API_KEY = 'env-key';
+      mockProcessEnv({ OPENAI_API_KEY: 'env-key' });
       const envProvider = new OpenAiGenericProvider('test-model');
       expect(envProvider.getApiKey()).toBe('env-key');
     });
 
     it('should get API key from custom env var', () => {
-      process.env.CUSTOM_API_KEY = 'custom-key';
+      mockProcessEnv({ CUSTOM_API_KEY: 'custom-key' });
       const customProvider = new OpenAiGenericProvider('test-model', {
         config: { apiKeyEnvar: 'CUSTOM_API_KEY' },
       });

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -3,6 +3,7 @@ import WebSocket from 'ws';
 import { disableCache, enableCache } from '../../../src/cache';
 import logger from '../../../src/logger';
 import { OpenAiRealtimeProvider } from '../../../src/providers/openai/realtime';
+import { mockProcessEnv } from '../../util/utils';
 import { getOpenAiMissingApiKeyMessage, restoreEnvVar } from './shared';
 
 import type { OpenAiRealtimeOptions } from '../../../src/providers/openai/realtime';
@@ -33,9 +34,9 @@ describe('OpenAI Realtime Provider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     disableCache();
-    process.env.OPENAI_API_KEY = 'test-api-key';
-    delete process.env.OPENAI_API_BASE_URL;
-    delete process.env.OPENAI_BASE_URL;
+    mockProcessEnv({ OPENAI_API_KEY: 'test-api-key' });
+    mockProcessEnv({ OPENAI_API_BASE_URL: undefined });
+    mockProcessEnv({ OPENAI_BASE_URL: undefined });
     mockHandlers = {
       open: [],
       message: [],
@@ -119,7 +120,7 @@ describe('OpenAI Realtime Provider', () => {
     });
 
     it('should use default missing API key error message', async () => {
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
       const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
         env: {
           OPENAI_API_KEY: undefined,
@@ -130,8 +131,8 @@ describe('OpenAI Realtime Provider', () => {
     });
 
     it('should use custom apiKeyEnvar in missing API key errors', async () => {
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.CUSTOM_REALTIME_API_KEY;
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
+      mockProcessEnv({ CUSTOM_REALTIME_API_KEY: undefined });
       const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview', {
         config: {
           apiKeyEnvar: 'CUSTOM_REALTIME_API_KEY',

--- a/test/providers/openai/shared.ts
+++ b/test/providers/openai/shared.ts
@@ -4,9 +4,9 @@ export function getOpenAiMissingApiKeyMessage(envVar = 'OPENAI_API_KEY'): string
 
 export function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
-    delete process.env[name];
+    Reflect.deleteProperty(process.env, name);
     return;
   }
 
-  process.env[name] = value;
+  Object.assign(process.env, { [name]: value });
 }

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -15,6 +15,7 @@ import {
   resolveGatewayUrl,
   resolveGatewayWsUrl,
 } from '../../src/providers/openclaw';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/envars', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/envars')>();
@@ -100,19 +101,19 @@ describe('OpenClaw Provider', () => {
       nonce: params.nonce,
     }));
     deviceAuthMocks.loadOpenClawDeviceAuthToken.mockReturnValue(undefined);
-    process.env = { ...originalEnv };
-    delete process.env.CLAWDBOT_GATEWAY_PASSWORD;
-    delete process.env.CLAWDBOT_GATEWAY_TOKEN;
-    delete process.env.CLAWDBOT_GATEWAY_URL;
-    delete process.env.OPENCLAW_CONFIG_PATH;
-    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
-    delete process.env.OPENCLAW_GATEWAY_PORT;
-    delete process.env.OPENCLAW_GATEWAY_URL;
-    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    mockProcessEnv({ ...originalEnv }, { clear: true });
+    mockProcessEnv({ CLAWDBOT_GATEWAY_PASSWORD: undefined });
+    mockProcessEnv({ CLAWDBOT_GATEWAY_TOKEN: undefined });
+    mockProcessEnv({ CLAWDBOT_GATEWAY_URL: undefined });
+    mockProcessEnv({ OPENCLAW_CONFIG_PATH: undefined });
+    mockProcessEnv({ OPENCLAW_GATEWAY_PASSWORD: undefined });
+    mockProcessEnv({ OPENCLAW_GATEWAY_PORT: undefined });
+    mockProcessEnv({ OPENCLAW_GATEWAY_URL: undefined });
+    mockProcessEnv({ OPENCLAW_GATEWAY_TOKEN: undefined });
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     vi.restoreAllMocks();
   });
 
@@ -123,7 +124,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should respect OPENCLAW_CONFIG_PATH when set', () => {
-      process.env.OPENCLAW_CONFIG_PATH = '/tmp/custom-openclaw.json';
+      mockProcessEnv({ OPENCLAW_CONFIG_PATH: '/tmp/custom-openclaw.json' });
       const existsSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
       readOpenClawConfig();
@@ -356,12 +357,12 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should use environment variable second', () => {
-      process.env.OPENCLAW_GATEWAY_URL = 'http://env-host:8888';
+      mockProcessEnv({ OPENCLAW_GATEWAY_URL: 'http://env-host:8888' });
       expect(resolveGatewayUrl()).toBe('http://env-host:8888');
     });
 
     it('should fall back to legacy CLAWDBOT gateway URL environment variable', () => {
-      process.env.CLAWDBOT_GATEWAY_URL = 'http://legacy-host:8888';
+      mockProcessEnv({ CLAWDBOT_GATEWAY_URL: 'http://legacy-host:8888' });
       expect(resolveGatewayUrl()).toBe('http://legacy-host:8888');
     });
 
@@ -444,7 +445,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should use OPENCLAW_GATEWAY_PORT for local auto-detection', () => {
-      process.env.OPENCLAW_GATEWAY_PORT = '19999';
+      mockProcessEnv({ OPENCLAW_GATEWAY_PORT: '19999' });
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
       vi.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs: 10210 } as fs.Stats);
       vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ gateway: { port: 20000 } }));
@@ -453,14 +454,14 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should use OPENCLAW_GATEWAY_PORT for default local URLs', () => {
-      process.env.OPENCLAW_GATEWAY_PORT = '19999';
+      mockProcessEnv({ OPENCLAW_GATEWAY_PORT: '19999' });
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
       expect(resolveGatewayUrl()).toBe('http://127.0.0.1:19999');
     });
 
     it('should ignore malformed OPENCLAW_GATEWAY_PORT values', () => {
-      process.env.OPENCLAW_GATEWAY_PORT = '19999x';
+      mockProcessEnv({ OPENCLAW_GATEWAY_PORT: '19999x' });
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
       expect(resolveGatewayUrl()).toBe('http://127.0.0.1:18789');
@@ -489,7 +490,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should prefer per-provider env override over process env', () => {
-      process.env.OPENCLAW_GATEWAY_URL = 'http://process-env:8888';
+      mockProcessEnv({ OPENCLAW_GATEWAY_URL: 'http://process-env:8888' });
       expect(resolveGatewayUrl(undefined, { OPENCLAW_GATEWAY_URL: 'http://override:7777' })).toBe(
         'http://override:7777',
       );
@@ -538,7 +539,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should use OPENCLAW_GATEWAY_PORT for default local websocket URLs', () => {
-      process.env.OPENCLAW_GATEWAY_PORT = '19999';
+      mockProcessEnv({ OPENCLAW_GATEWAY_PORT: '19999' });
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
       expect(resolveGatewayWsUrl()).toBe('ws://127.0.0.1:19999');
@@ -566,12 +567,12 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should use environment variable second', () => {
-      process.env.OPENCLAW_GATEWAY_TOKEN = 'env-token';
+      mockProcessEnv({ OPENCLAW_GATEWAY_TOKEN: 'env-token' });
       expect(resolveAuthToken()).toBe('env-token');
     });
 
     it('should use password environment variable when token is unset', () => {
-      process.env.OPENCLAW_GATEWAY_PASSWORD = 'env-password';
+      mockProcessEnv({ OPENCLAW_GATEWAY_PASSWORD: 'env-password' });
       expect(resolveAuthToken()).toBe('env-password');
     });
 
@@ -646,7 +647,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should prefer per-provider env override over process env', () => {
-      process.env.OPENCLAW_GATEWAY_TOKEN = 'process-token';
+      mockProcessEnv({ OPENCLAW_GATEWAY_TOKEN: 'process-token' });
       expect(resolveAuthToken(undefined, { OPENCLAW_GATEWAY_TOKEN: 'override-token' })).toBe(
         'override-token',
       );
@@ -657,7 +658,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should fall back to legacy CLAWDBOT token environment variables', () => {
-      process.env.CLAWDBOT_GATEWAY_TOKEN = 'legacy-token';
+      mockProcessEnv({ CLAWDBOT_GATEWAY_TOKEN: 'legacy-token' });
       expect(resolveAuthToken()).toBe('legacy-token');
     });
 
@@ -748,13 +749,13 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should not fall back to OPENAI_API_KEY', () => {
-      process.env.OPENAI_API_KEY = 'sk-openai-key';
+      mockProcessEnv({ OPENAI_API_KEY: 'sk-openai-key' });
       const provider = new OpenClawChatProvider('main', {});
       expect(provider.getApiKey()).toBeUndefined();
     });
 
     it('should not fall back to OPENAI_BASE_URL', () => {
-      process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1';
+      mockProcessEnv({ OPENAI_BASE_URL: 'https://api.openai.com/v1' });
       const provider = new OpenClawChatProvider('main', {});
       expect(provider.getApiUrl()).toBe('http://127.0.0.1:18789/v1');
     });
@@ -859,13 +860,13 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should not fall back to OPENAI_API_KEY', () => {
-      process.env.OPENAI_API_KEY = 'sk-openai-key';
+      mockProcessEnv({ OPENAI_API_KEY: 'sk-openai-key' });
       const provider = new OpenClawResponsesProvider('main', {});
       expect(provider.getApiKey()).toBeUndefined();
     });
 
     it('should not fall back to OPENAI_BASE_URL', () => {
-      process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1';
+      mockProcessEnv({ OPENAI_BASE_URL: 'https://api.openai.com/v1' });
       const provider = new OpenClawResponsesProvider('main', {});
       expect(provider.getApiUrl()).toBe('http://127.0.0.1:18789/v1');
     });
@@ -928,7 +929,7 @@ describe('OpenClaw Provider', () => {
     });
 
     it('should not fall back to OPENAI_API_KEY', () => {
-      process.env.OPENAI_API_KEY = 'sk-openai-key';
+      mockProcessEnv({ OPENAI_API_KEY: 'sk-openai-key' });
       const provider = new OpenClawEmbeddingProvider('main', {});
       expect(provider.getApiKey()).toBeUndefined();
     });

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache } from '../../src/cache';
 import { OpenRouterProvider } from '../../src/providers/openrouter';
 import * as fetchModule from '../../src/util/fetch/index';
+import { mockProcessEnv } from '../util/utils';
 
 const OPENROUTER_API_BASE = 'https://openrouter.ai/api/v1';
 
@@ -61,11 +62,11 @@ describe('OpenRouter', () => {
 
     describe('Thinking tokens handling', () => {
       beforeEach(() => {
-        process.env.OPENROUTER_API_KEY = 'test-key';
+        mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
       });
 
       afterEach(() => {
-        delete process.env.OPENROUTER_API_KEY;
+        mockProcessEnv({ OPENROUTER_API_KEY: undefined });
       });
 
       it('should handle reasoning field correctly when both reasoning and content are present', async () => {
@@ -806,11 +807,11 @@ describe('OpenRouter', () => {
 
     describe('JSON schema response format handling', () => {
       beforeEach(() => {
-        process.env.OPENROUTER_API_KEY = 'test-key';
+        mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
       });
 
       afterEach(() => {
-        delete process.env.OPENROUTER_API_KEY;
+        mockProcessEnv({ OPENROUTER_API_KEY: undefined });
       });
 
       it('should parse JSON output when response_format.type is json_schema', async () => {

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -13,6 +13,7 @@ import {
   ReplicateProvider,
 } from '../../src/providers/replicate';
 import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/cache');
 
@@ -66,8 +67,8 @@ describe('ReplicateProvider', () => {
   it('should preserve explicit zero-valued config instead of replacing it with env defaults', async () => {
     const originalTemperature = process.env.REPLICATE_TEMPERATURE;
     const originalSeed = process.env.REPLICATE_SEED;
-    process.env.REPLICATE_TEMPERATURE = '0.9';
-    process.env.REPLICATE_SEED = '123';
+    mockProcessEnv({ REPLICATE_TEMPERATURE: '0.9' });
+    mockProcessEnv({ REPLICATE_SEED: '123' });
 
     mockedFetchWithCache.mockResolvedValue({
       data: {
@@ -98,15 +99,15 @@ describe('ReplicateProvider', () => {
       expect(body.input.seed).toBe(0);
     } finally {
       if (originalTemperature === undefined) {
-        delete process.env.REPLICATE_TEMPERATURE;
+        mockProcessEnv({ REPLICATE_TEMPERATURE: undefined });
       } else {
-        process.env.REPLICATE_TEMPERATURE = originalTemperature;
+        mockProcessEnv({ REPLICATE_TEMPERATURE: originalTemperature });
       }
 
       if (originalSeed === undefined) {
-        delete process.env.REPLICATE_SEED;
+        mockProcessEnv({ REPLICATE_SEED: undefined });
       } else {
-        process.env.REPLICATE_SEED = originalSeed;
+        mockProcessEnv({ REPLICATE_SEED: originalSeed });
       }
     }
   });

--- a/test/providers/snowflake.test.ts
+++ b/test/providers/snowflake.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache, fetchWithCache } from '../../src/cache';
 import { SnowflakeCortexProvider } from '../../src/providers/snowflake';
+import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/cache', async (importOriginal) => {
   return {
@@ -19,8 +20,8 @@ describe('Snowflake Cortex Provider', () => {
   afterEach(async () => {
     await clearCache();
     vi.clearAllMocks();
-    delete process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER;
-    delete process.env.SNOWFLAKE_API_KEY;
+    mockProcessEnv({ SNOWFLAKE_ACCOUNT_IDENTIFIER: undefined });
+    mockProcessEnv({ SNOWFLAKE_API_KEY: undefined });
   });
 
   describe('initialization', () => {
@@ -38,7 +39,7 @@ describe('Snowflake Cortex Provider', () => {
     });
 
     it('should initialize with accountIdentifier from environment', () => {
-      process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER = 'myorg-myaccount';
+      mockProcessEnv({ SNOWFLAKE_ACCOUNT_IDENTIFIER: 'myorg-myaccount' });
 
       const provider = new SnowflakeCortexProvider('claude-3-5-sonnet', {
         config: {
@@ -95,8 +96,8 @@ describe('Snowflake Cortex Provider', () => {
 
   describe('callApi', () => {
     beforeEach(() => {
-      process.env.SNOWFLAKE_ACCOUNT_IDENTIFIER = 'myorg-myaccount';
-      process.env.SNOWFLAKE_API_KEY = 'test-key';
+      mockProcessEnv({ SNOWFLAKE_ACCOUNT_IDENTIFIER: 'myorg-myaccount' });
+      mockProcessEnv({ SNOWFLAKE_API_KEY: 'test-key' });
     });
 
     it('should call Snowflake Cortex API with correct endpoint', async () => {

--- a/test/providers/truefoundry.test.ts
+++ b/test/providers/truefoundry.test.ts
@@ -6,6 +6,7 @@ import {
   TrueFoundryProvider,
 } from '../../src/providers/truefoundry';
 import * as fetchModule from '../../src/util/fetch/index';
+import { mockProcessEnv } from '../util/utils';
 
 const TRUEFOUNDRY_API_BASE = 'https://llm-gateway.truefoundry.com';
 
@@ -170,11 +171,11 @@ describe('TrueFoundry', () => {
 
     describe('callApi', () => {
       beforeEach(() => {
-        process.env.TRUEFOUNDRY_API_KEY = 'test-key';
+        mockProcessEnv({ TRUEFOUNDRY_API_KEY: 'test-key' });
       });
 
       afterEach(() => {
-        delete process.env.TRUEFOUNDRY_API_KEY;
+        mockProcessEnv({ TRUEFOUNDRY_API_KEY: undefined });
       });
 
       it('should call TrueFoundry API and return output with correct structure', async () => {
@@ -429,11 +430,11 @@ describe('TrueFoundry', () => {
     const embeddingProvider = new TrueFoundryEmbeddingProvider('openai/text-embedding-3-large', {});
 
     beforeEach(() => {
-      process.env.TRUEFOUNDRY_API_KEY = 'test-key';
+      mockProcessEnv({ TRUEFOUNDRY_API_KEY: 'test-key' });
     });
 
     afterEach(() => {
-      delete process.env.TRUEFOUNDRY_API_KEY;
+      mockProcessEnv({ TRUEFOUNDRY_API_KEY: undefined });
     });
 
     it('should initialize with correct model name', () => {

--- a/test/providers/xai/image.test.ts
+++ b/test/providers/xai/image.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { callOpenAiImageApi } from '../../../src/providers/openai/image';
 import { REQUEST_TIMEOUT_MS } from '../../../src/providers/shared';
 import { createXAIImageProvider, XAIImageProvider } from '../../../src/providers/xai/image';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/logger');
 vi.mock('../../../src/providers/openai/image', async () => {
@@ -212,8 +213,8 @@ describe('XAI Image Provider', () => {
       const originalOpenAiKey = process.env.OPENAI_API_KEY;
 
       // Clear all possible API key environment variables
-      delete process.env.XAI_API_KEY;
-      delete process.env.OPENAI_API_KEY;
+      mockProcessEnv({ XAI_API_KEY: undefined });
+      mockProcessEnv({ OPENAI_API_KEY: undefined });
 
       try {
         // Create provider with no API key in config or environment
@@ -226,10 +227,10 @@ describe('XAI Image Provider', () => {
       } finally {
         // Restore the original environment variables
         if (originalXaiKey) {
-          process.env.XAI_API_KEY = originalXaiKey;
+          mockProcessEnv({ XAI_API_KEY: originalXaiKey });
         }
         if (originalOpenAiKey) {
-          process.env.OPENAI_API_KEY = originalOpenAiKey;
+          mockProcessEnv({ OPENAI_API_KEY: originalOpenAiKey });
         }
       }
     });

--- a/test/providers/xai/voice.test.ts
+++ b/test/providers/xai/voice.test.ts
@@ -9,6 +9,7 @@ import {
   type XAIFunctionCallOutput,
   XAIVoiceProvider,
 } from '../../../src/providers/xai/voice';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/logger');
 
@@ -139,7 +140,7 @@ describe('XAI Voice Provider', () => {
   describe('API key handling', () => {
     it('returns error when API key is not set', async () => {
       const originalKey = process.env.XAI_API_KEY;
-      delete process.env.XAI_API_KEY;
+      mockProcessEnv({ XAI_API_KEY: undefined });
 
       try {
         const provider = new XAIVoiceProvider('grok-3');
@@ -150,7 +151,7 @@ describe('XAI Voice Provider', () => {
         );
       } finally {
         if (originalKey) {
-          process.env.XAI_API_KEY = originalKey;
+          mockProcessEnv({ XAI_API_KEY: originalKey });
         }
       }
     });
@@ -373,14 +374,14 @@ describe('XAI Voice Provider', () => {
 
     beforeEach(() => {
       originalEnvValue = process.env.XAI_API_BASE_URL;
-      delete process.env.XAI_API_BASE_URL;
+      mockProcessEnv({ XAI_API_BASE_URL: undefined });
     });
 
     afterEach(() => {
       if (originalEnvValue === undefined) {
-        delete process.env.XAI_API_BASE_URL;
+        mockProcessEnv({ XAI_API_BASE_URL: undefined });
       } else {
-        process.env.XAI_API_BASE_URL = originalEnvValue;
+        mockProcessEnv({ XAI_API_BASE_URL: originalEnvValue });
       }
     });
 
@@ -445,14 +446,14 @@ describe('XAI Voice Provider', () => {
     });
 
     it('uses XAI_API_BASE_URL environment variable', () => {
-      process.env.XAI_API_BASE_URL = 'https://env-proxy.com/v1';
+      mockProcessEnv({ XAI_API_BASE_URL: 'https://env-proxy.com/v1' });
       const provider = new TestableXAIVoiceProvider('grok-3');
       expect(provider.getApiUrl()).toBe('https://env-proxy.com/v1');
       expect(provider.getWebSocketUrl()).toBe('wss://env-proxy.com/v1/realtime');
     });
 
     it('config apiBaseUrl takes priority over environment variable', () => {
-      process.env.XAI_API_BASE_URL = 'https://env-proxy.com/v1';
+      mockProcessEnv({ XAI_API_BASE_URL: 'https://env-proxy.com/v1' });
       const provider = new TestableXAIVoiceProvider('grok-3', {
         config: { apiBaseUrl: 'https://config-proxy.com/v1' },
       });
@@ -468,7 +469,7 @@ describe('XAI Voice Provider', () => {
     });
 
     it('env overrides take priority over environment variable', () => {
-      process.env.XAI_API_BASE_URL = 'https://env-proxy.com/v1';
+      mockProcessEnv({ XAI_API_BASE_URL: 'https://env-proxy.com/v1' });
       const provider = new TestableXAIVoiceProvider('grok-3', {
         env: { XAI_API_BASE_URL: 'https://override-proxy.com/v1' },
       });

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -9,6 +9,7 @@ import {
   createProviderResponse,
   type MockApiProvider,
 } from '../../factories/provider';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -50,8 +51,8 @@ describe('Entities Extractor', () => {
   });
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;
+    mockProcessEnv({ ...originalEnv }, { clear: true });
+    mockProcessEnv({ PROMPTFOO_REMOTE_GENERATION_URL: undefined });
     provider = createMockProvider({
       response: createProviderResponse({ output: 'Entity: Apple\nEntity: Google' }),
     });
@@ -62,12 +63,12 @@ describe('Entities Extractor', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   it('should use remote generation when enabled', async () => {
-    process.env.OPENAI_API_KEY = undefined;
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
     vi.mocked(fetchWithCache).mockResolvedValue({
       data: { task: 'entities', result: ['Apple', 'Google'] },
       status: 200,
@@ -95,8 +96,8 @@ describe('Entities Extractor', () => {
   });
 
   it('should not fall back to local extraction when remote generation fails', async () => {
-    process.env.OPENAI_API_KEY = undefined;
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
     vi.mocked(fetchWithCache).mockRejectedValue(new Error('Remote generation failed'));
 
     const result = await extractEntities(provider, ['prompt1', 'prompt2']);
@@ -109,7 +110,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should use local extraction when remote generation is disabled', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
 
     const result = await extractEntities(provider, ['prompt']);
 
@@ -119,7 +120,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should log debug message when no entities are found', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     vi.mocked(provider.callApi).mockResolvedValue({ output: 'No entities found' });
 
     const result = await extractEntities(provider, ['prompt']);
@@ -128,7 +129,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should ignore Nunjucks template variables in double curly braces', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     vi.mocked(provider.callApi).mockResolvedValue({
       output: 'Entity: John Smith\nEntity: {{image}}\nEntity: Google\nEntity: {{prompt}}',
     });
@@ -142,7 +143,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should properly extract real entities while ignoring template variables', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
 
     // Currently our extraction simply returns whatever the AI returns as entities
     // We need to fix this to properly filter template variables
@@ -161,7 +162,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should handle complex Nunjucks variables with spaces and special characters', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     vi.mocked(provider.callApi).mockResolvedValue({
       output:
         'Entity: Microsoft\nEntity: {{ complex_variable with spaces }}\nEntity: {{nested.variable}}',
@@ -176,7 +177,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should handle empty prompts array', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
 
     const result = await extractEntities(provider, []);
 
@@ -185,7 +186,7 @@ describe('Entities Extractor', () => {
   });
 
   it('should handle errors in local extraction', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     vi.mocked(provider.callApi).mockRejectedValue(new Error('API call failed'));
 
     const result = await extractEntities(provider, ['prompt']);

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -47,7 +47,7 @@ describe('Entities Extractor', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeAll(() => {
-    originalEnv = process.env;
+    originalEnv = { ...process.env };
   });
 
   beforeEach(() => {

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -34,7 +34,7 @@ describe('System Purpose Extractor', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeAll(() => {
-    originalEnv = process.env;
+    originalEnv = { ...process.env };
   });
 
   beforeEach(() => {

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -8,6 +8,7 @@ import {
   createProviderResponse,
   type MockApiProvider,
 } from '../../factories/provider';
+import { mockProcessEnv } from '../../util/utils';
 
 vi.mock('../../../src/logger', () => ({
   default: {
@@ -37,8 +38,8 @@ describe('System Purpose Extractor', () => {
   });
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;
+    mockProcessEnv({ ...originalEnv }, { clear: true });
+    mockProcessEnv({ PROMPTFOO_REMOTE_GENERATION_URL: undefined });
     provider = createMockProvider({
       response: createProviderResponse({
         output: '<Purpose>Extracted system purpose</Purpose>',
@@ -51,12 +52,12 @@ describe('System Purpose Extractor', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   it('should use remote generation when enabled', async () => {
-    process.env.OPENAI_API_KEY = undefined;
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
     vi.mocked(fetchWithCache).mockResolvedValue({
       data: { task: 'purpose', result: 'Remote extracted purpose' },
       status: 200,
@@ -84,19 +85,19 @@ describe('System Purpose Extractor', () => {
   });
 
   it('should not fall back to local extraction when remote generation fails', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'false';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
     const originalOpenaiKey = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = undefined;
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
     vi.mocked(fetchWithCache).mockRejectedValue(new Error('Remote generation failed'));
     const result = await extractSystemPurpose(provider, ['prompt1', 'prompt2']);
 
     expect(result).toBe('');
     expect(provider.callApi).not.toHaveBeenCalled();
-    process.env.OPENAI_API_KEY = originalOpenaiKey;
+    mockProcessEnv({ OPENAI_API_KEY: originalOpenaiKey });
   });
 
   it('should use local extraction when remote generation is disabled', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
 
     const result = await extractSystemPurpose(provider, ['prompt']);
 
@@ -106,7 +107,7 @@ describe('System Purpose Extractor', () => {
   });
 
   it('should extract system purpose when returned without xml tags', async () => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     vi.mocked(provider.callApi).mockResolvedValue({ output: 'Extracted system purpose' });
 
     const result = await extractSystemPurpose(provider, ['prompt1', 'prompt2']);

--- a/test/redteam/plugins/teenSafety.test.ts
+++ b/test/redteam/plugins/teenSafety.test.ts
@@ -9,13 +9,14 @@ import {
   createProviderResponse,
   type MockApiProvider,
 } from '../../factories/provider';
+import { mockProcessEnv } from '../../util/utils';
 
 describe('teen safety plugins', () => {
   const originalDisableRemoteGeneration = process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION;
   let provider: MockApiProvider;
 
   beforeEach(() => {
-    process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
 
     provider = createMockProvider({
       id: 'mock-provider',
@@ -27,9 +28,11 @@ describe('teen safety plugins', () => {
 
   afterEach(() => {
     if (originalDisableRemoteGeneration === undefined) {
-      delete process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION;
+      mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: undefined });
     } else {
-      process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = originalDisableRemoteGeneration;
+      mockProcessEnv({
+        PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: originalDisableRemoteGeneration,
+      });
     }
   });
 

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../src/redteam/providers/shared';
 import { sleep } from '../../../src/util/time';
 import { createMockProvider } from '../../factories/provider';
+import { mockProcessEnv } from '../../util/utils';
 
 import type {
   ApiProvider,
@@ -991,14 +992,14 @@ describe('shared redteam provider utilities', () => {
 
     afterEach(() => {
       if (originalEnv === undefined) {
-        delete process.env.PROMPTFOO_ENABLE_UNBLOCKING;
+        mockProcessEnv({ PROMPTFOO_ENABLE_UNBLOCKING: undefined });
       } else {
-        process.env.PROMPTFOO_ENABLE_UNBLOCKING = originalEnv;
+        mockProcessEnv({ PROMPTFOO_ENABLE_UNBLOCKING: originalEnv });
       }
     });
 
     it('short-circuits by default when PROMPTFOO_ENABLE_UNBLOCKING is not set', async () => {
-      delete process.env.PROMPTFOO_ENABLE_UNBLOCKING;
+      mockProcessEnv({ PROMPTFOO_ENABLE_UNBLOCKING: undefined });
 
       const result = await tryUnblocking({
         messages: [],
@@ -1013,7 +1014,7 @@ describe('shared redteam provider utilities', () => {
     });
 
     it('checks server support when PROMPTFOO_ENABLE_UNBLOCKING=true', async () => {
-      process.env.PROMPTFOO_ENABLE_UNBLOCKING = 'true';
+      mockProcessEnv({ PROMPTFOO_ENABLE_UNBLOCKING: 'true' });
       mockedCheckServerFeatureSupport.mockResolvedValue(false);
 
       const result = await tryUnblocking({

--- a/test/sagemaker.test.ts
+++ b/test/sagemaker.test.ts
@@ -4,6 +4,7 @@ import {
   SageMakerCompletionProvider,
   SageMakerEmbeddingProvider,
 } from '../src/providers/sagemaker';
+import { mockProcessEnv } from './util/utils';
 
 import type { LoadApiProviderContext } from '../src/types/index';
 
@@ -244,7 +245,7 @@ describe('SageMakerCompletionProvider', () => {
   });
 
   it('should initialize with correct region from environment', () => {
-    process.env.AWS_REGION = 'us-east-2';
+    mockProcessEnv({ AWS_REGION: 'us-east-2' });
     const provider = new SageMakerCompletionProvider('test-endpoint', {
       id: 'sagemaker:test-endpoint',
       config: {
@@ -252,7 +253,7 @@ describe('SageMakerCompletionProvider', () => {
       },
     });
     expect(provider.getRegion()).toBe('us-east-2');
-    delete process.env.AWS_REGION;
+    mockProcessEnv({ AWS_REGION: undefined });
   });
 
   it('should use credential options from config', async () => {
@@ -919,7 +920,7 @@ describe('SageMakerCompletionProvider - Payload Formatting', () => {
     it('should format JumpStart payload with do_sample false when temperature is 0', () => {
       // Ensure no environment variable overrides the temperature
       const originalTemp = process.env.AWS_SAGEMAKER_TEMPERATURE;
-      delete process.env.AWS_SAGEMAKER_TEMPERATURE;
+      mockProcessEnv({ AWS_SAGEMAKER_TEMPERATURE: undefined });
 
       const provider = new SageMakerCompletionProvider('jumpstart-endpoint', {
         id: 'sagemaker:jumpstart-endpoint',
@@ -940,7 +941,7 @@ describe('SageMakerCompletionProvider - Payload Formatting', () => {
 
       // Restore environment variable
       if (originalTemp) {
-        process.env.AWS_SAGEMAKER_TEMPERATURE = originalTemp;
+        mockProcessEnv({ AWS_SAGEMAKER_TEMPERATURE: originalTemp });
       }
     });
 
@@ -1014,9 +1015,9 @@ describe('SageMakerCompletionProvider - Payload Formatting', () => {
 
     it('should use environment variables for default parameters', () => {
       // Set environment variables
-      process.env.AWS_SAGEMAKER_MAX_TOKENS = '2048';
-      process.env.AWS_SAGEMAKER_TEMPERATURE = '0.9';
-      process.env.AWS_SAGEMAKER_TOP_P = '0.95';
+      mockProcessEnv({ AWS_SAGEMAKER_MAX_TOKENS: '2048' });
+      mockProcessEnv({ AWS_SAGEMAKER_TEMPERATURE: '0.9' });
+      mockProcessEnv({ AWS_SAGEMAKER_TOP_P: '0.95' });
 
       const provider = new SageMakerCompletionProvider('test-endpoint', {
         id: 'sagemaker:test-endpoint',
@@ -1033,9 +1034,9 @@ describe('SageMakerCompletionProvider - Payload Formatting', () => {
       expect(parsedPayload.top_p).toBe(0.95);
 
       // Clean up environment variables
-      delete process.env.AWS_SAGEMAKER_MAX_TOKENS;
-      delete process.env.AWS_SAGEMAKER_TEMPERATURE;
-      delete process.env.AWS_SAGEMAKER_TOP_P;
+      mockProcessEnv({ AWS_SAGEMAKER_MAX_TOKENS: undefined });
+      mockProcessEnv({ AWS_SAGEMAKER_TEMPERATURE: undefined });
+      mockProcessEnv({ AWS_SAGEMAKER_TOP_P: undefined });
     });
 
     it('should handle malformed JSON gracefully for message-based formats', () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -12,6 +12,7 @@ import {
 import * as envars from '../src/envars';
 import { Telemetry } from '../src/telemetry';
 import { fetchWithProxy, fetchWithTimeout } from '../src/util/fetch/index';
+import { mockProcessEnv } from './util/utils';
 
 vi.mock('../src/util/fetch/index.ts', () => ({
   fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
@@ -50,10 +51,13 @@ vi.mock('../src/envars', async () => {
     ...actual,
     getEnvBool: vi.fn().mockImplementation((key) => {
       if (key === 'PROMPTFOO_DISABLE_TELEMETRY') {
-        return process.env.PROMPTFOO_DISABLE_TELEMETRY === '1';
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_DISABLE_TELEMETRY === '1';
       }
       if (key === 'IS_TESTING') {
-        return process.env.IS_TESTING === 'true' || process.env.IS_TESTING === '1';
+        return (
+          (process.env as NodeJS.ProcessEnv).IS_TESTING === 'true' ||
+          (process.env as NodeJS.ProcessEnv).IS_TESTING === '1'
+        );
       }
       return false;
     }),
@@ -98,8 +102,8 @@ describe('Telemetry', () => {
 
   beforeEach(() => {
     originalEnv = process.env;
-    process.env = { ...originalEnv };
-    process.env.PROMPTFOO_POSTHOG_KEY = 'test-key';
+    mockProcessEnv({ ...originalEnv }, { clear: true });
+    mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-key' });
 
     // Get the mocked fetchWithProxy function
     fetchWithProxySpy = fetchWithProxy as MockedFunction<typeof fetchWithProxy>;
@@ -112,7 +116,7 @@ describe('Telemetry', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -122,14 +126,14 @@ describe('Telemetry', () => {
   });
 
   it('should not track events with PostHog when telemetry is disabled', () => {
-    process.env.PROMPTFOO_DISABLE_TELEMETRY = '1';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
     const _telemetry = new Telemetry();
     _telemetry.record('eval_ran', { foo: 'bar' });
     expect(sendEventSpy).not.toHaveBeenCalledWith('eval_ran', expect.anything());
   });
 
   it('should include version in telemetry events', () => {
-    process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
     const _telemetry = new Telemetry();
     _telemetry.record('eval_ran', { foo: 'bar' });
 
@@ -162,8 +166,8 @@ describe('Telemetry', () => {
   it('should include version and CI status in telemetry events', async () => {
     vi.useRealTimers(); // Temporarily use real timers for this test
 
-    process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-    delete process.env.IS_TESTING; // Clear IS_TESTING to allow fetch calls
+    mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+    mockProcessEnv({ IS_TESTING: undefined }); // Clear IS_TESTING to allow fetch calls
 
     const isCIMock = vi.mocked(envars.isCI);
     const originalMockValue = isCIMock.getMockImplementation();
@@ -211,7 +215,7 @@ describe('Telemetry', () => {
     } else {
       isCIMock.mockReturnValue(false);
     }
-    process.env.IS_TESTING = 'true'; // Reset IS_TESTING
+    mockProcessEnv({ IS_TESTING: 'true' }); // Reset IS_TESTING
     vi.useFakeTimers(); // Restore fake timers
   });
 
@@ -254,7 +258,7 @@ describe('Telemetry', () => {
   });
 
   it('should not send user events when telemetry is disabled', async () => {
-    process.env.PROMPTFOO_DISABLE_TELEMETRY = '1';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
 
     vi.resetModules();
 
@@ -283,9 +287,9 @@ describe('Telemetry', () => {
 
   describe('PostHog client initialization', () => {
     it('should initialize PostHog client when telemetry is enabled and POSTHOG_KEY is present', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const mockPostHog = vi.fn().mockImplementation(() => ({
         identify: vi.fn(),
@@ -318,9 +322,9 @@ describe('Telemetry', () => {
     });
 
     it('should handle PostHog initialization errors gracefully', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const mockPostHog = vi.fn().mockImplementation(() => {
         throw new Error('PostHog initialization failed');
@@ -392,10 +396,13 @@ describe('Telemetry', () => {
           ...actual,
           getEnvBool: vi.fn().mockImplementation((key: string) => {
             if (key === 'PROMPTFOO_DISABLE_TELEMETRY') {
-              return process.env.PROMPTFOO_DISABLE_TELEMETRY === '1';
+              return (process.env as NodeJS.ProcessEnv).PROMPTFOO_DISABLE_TELEMETRY === '1';
             }
             if (key === 'IS_TESTING') {
-              return process.env.IS_TESTING === 'true' || process.env.IS_TESTING === '1';
+              return (
+                (process.env as NodeJS.ProcessEnv).IS_TESTING === 'true' ||
+                (process.env as NodeJS.ProcessEnv).IS_TESTING === '1'
+              );
             }
             return false;
           }),
@@ -444,9 +451,9 @@ describe('Telemetry', () => {
     });
 
     it('should call PostHog identify when telemetry is enabled', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const telemetryModule = await import('../src/telemetry');
       const _telemetry = new telemetryModule.Telemetry();
@@ -466,9 +473,9 @@ describe('Telemetry', () => {
     });
 
     it('should handle PostHog identify errors gracefully', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       mockPostHogInstance.identify.mockImplementation(() => {
         throw new Error('Identify failed');
@@ -484,9 +491,9 @@ describe('Telemetry', () => {
     });
 
     it('should call PostHog capture when sending events', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const telemetryModule = await import('../src/telemetry');
       const _telemetry = new telemetryModule.Telemetry();
@@ -506,9 +513,9 @@ describe('Telemetry', () => {
     });
 
     it('should handle PostHog capture errors gracefully', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       mockPostHogInstance.capture.mockImplementation(() => {
         throw new Error('Capture failed');
@@ -524,9 +531,9 @@ describe('Telemetry', () => {
     });
 
     it('should handle PostHog flush errors silently', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       mockPostHogInstance.flush.mockRejectedValue(new Error('Flush failed'));
 
@@ -537,9 +544,9 @@ describe('Telemetry', () => {
     });
 
     it('should call PostHog shutdown when telemetry shutdown is called', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       mockPostHogInstance.shutdown = vi.fn().mockResolvedValue(undefined);
 
@@ -552,9 +559,9 @@ describe('Telemetry', () => {
     });
 
     it('should handle PostHog shutdown errors gracefully', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '0';
-      delete process.env.IS_TESTING;
-      process.env.PROMPTFOO_POSTHOG_KEY = 'test-posthog-key';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      mockProcessEnv({ IS_TESTING: undefined });
+      mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       mockPostHogInstance.shutdown = vi.fn().mockRejectedValue(new Error('Shutdown failed'));
 
@@ -568,7 +575,7 @@ describe('Telemetry', () => {
     });
 
     it('should handle shutdown when PostHog client is not initialized', async () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '1';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
 
       const telemetryModule = await import('../src/telemetry');
       const _telemetry = new telemetryModule.Telemetry();
@@ -579,7 +586,7 @@ describe('Telemetry', () => {
 
   describe('telemetry disabled recording', () => {
     it('should record telemetry disabled event only once', () => {
-      process.env.PROMPTFOO_DISABLE_TELEMETRY = '1';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
       const _telemetry = new Telemetry();
 
       _telemetry.record('eval_ran', { foo: 'bar' });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -101,7 +101,7 @@ describe('Telemetry', () => {
   let sendEventSpy: MockInstance;
 
   beforeEach(() => {
-    originalEnv = process.env;
+    originalEnv = { ...process.env };
     mockProcessEnv({ ...originalEnv }, { clear: true });
     mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-key' });
 

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/completion.test.ts',
   'providers/openai/image.test.ts',
   'providers/openai/index.test.ts',
   'providers/openai/realtime.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai-codex-sdk.test.ts',
   'providers/openai/chat.test.ts',
   'providers/openai/codexDefaults.test.ts',
   'providers/openai/completion.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/truefoundry.test.ts',
   'providers/xai/image.test.ts',
   'providers/xai/voice.test.ts',
   'redteam/extraction/entities.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/gemini-image.test.ts',
   'providers/google/image.test.ts',
   'providers/google/live.test.ts',
   'providers/google/provider.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/bedrock.agents.test.ts',
   'providers/bedrock/converse.test.ts',
   'providers/bedrock/index.test.ts',
   'providers/bedrock/knowledgeBase.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/azure/responses.test.ts',
   'providers/bedrock.agents.test.ts',
   'providers/bedrock/converse.test.ts',
   'providers/bedrock/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/bedrock/converse.test.ts',
   'providers/bedrock/index.test.ts',
   'providers/bedrock/knowledgeBase.test.ts',
   'providers/claude-agent-sdk.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/live.test.ts',
   'providers/google/provider.test.ts',
   'providers/google/video.test.ts',
   'providers/groq/responses.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/ai.studio.test.ts',
   'providers/google/auth.test.ts',
   'providers/google/gemini-image.test.ts',
   'providers/google/image.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -120,10 +120,7 @@ const allowedSkippedTests: AllowedSkip[] = [
 
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
-const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/transform.test.ts',
-  'util/utils.test.ts',
-]);
+const legacyDirectProcessEnvMutationFiles = new Set(['util/utils.test.ts']);
 
 const hoistedMockPattern = /\bvi\.hoisted\s*\(/;
 const persistentMockMethods = [

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/cloudflare-ai.test.ts',
   'providers/cloudflare-gateway.test.ts',
   'providers/databricks.test.ts',
   'providers/defaults.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -30,10 +30,21 @@ const biomeConfigPath = path.join(repoRoot, 'biome.jsonc');
 const thisFile = fileURLToPath(import.meta.url);
 const testFilePattern = /\.(?:test|spec)\.(?:ts|tsx)$/;
 const testApiNames = new Set(['describe', 'it', 'suite', 'test']);
-const biomeDirectProcessEnvMutationAllowlistStart =
-  '// BEGIN direct process.env mutation legacy allowlist';
-const biomeDirectProcessEnvMutationAllowlistEnd =
-  '// END direct process.env mutation legacy allowlist';
+const directProcessEnvMutationPluginPath = './tools/biome/no-direct-process-env-mutation.grit';
+const directProcessEnvMutationPluginIncludes = [
+  '*.js',
+  '*.jsx',
+  '*.ts',
+  '*.tsx',
+  '*.mjs',
+  '*.cjs',
+  '**/*.js',
+  '**/*.jsx',
+  '**/*.ts',
+  '**/*.tsx',
+  '**/*.mjs',
+  '**/*.cjs',
+];
 
 const allowedSkippedTests: AllowedSkip[] = [
   {
@@ -187,19 +198,31 @@ function findFilesMatchingPolicy(predicate: (source: string) => boolean): string
     .sort();
 }
 
-function findBiomeLegacyDirectProcessEnvMutationExclusions(): string[] {
+function findBiomeDirectProcessEnvMutationPluginIncludes(): string[] {
   const source = readFileSync(biomeConfigPath, 'utf8');
-  const start = source.indexOf(biomeDirectProcessEnvMutationAllowlistStart);
-  const end = source.indexOf(biomeDirectProcessEnvMutationAllowlistEnd);
+  const pluginIndex = source.indexOf(`"${directProcessEnvMutationPluginPath}"`);
 
-  if (start === -1 || end === -1 || end < start) {
-    throw new Error('Biome process.env mutation allowlist markers are missing or out of order');
+  if (pluginIndex === -1) {
+    throw new Error('Biome process.env mutation plugin is not configured');
+  }
+
+  const includesKeyStart = source.slice(0, pluginIndex).lastIndexOf('"includes": [');
+  const includesStart = source.indexOf('[', includesKeyStart);
+  const includesEnd = source.indexOf(']', includesStart);
+
+  if (
+    includesKeyStart === -1 ||
+    includesStart === -1 ||
+    includesEnd === -1 ||
+    includesEnd > pluginIndex
+  ) {
+    throw new Error('Biome process.env mutation plugin includes are missing or out of order');
   }
 
   return Array.from(
-    source.slice(start, end).matchAll(/"!!test\/([^"]+)"/g),
-    ([, file]) => file,
-  ).sort();
+    source.slice(includesStart, includesEnd).matchAll(/"([^"]+)"/g),
+    ([, glob]) => glob,
+  );
 }
 
 function isTestControlKind(name: string): name is TestControlKind {
@@ -446,9 +469,9 @@ describe('root test hygiene', () => {
     expect(staleFiles).toEqual([]);
   });
 
-  it('keeps Biome process.env mutation exclusions in sync with the hygiene allowlist', () => {
-    expect(findBiomeLegacyDirectProcessEnvMutationExclusions()).toEqual(
-      Array.from(legacyDirectProcessEnvMutationFiles).sort(),
+  it('applies the Biome process.env mutation rule to repo TypeScript and JavaScript files', () => {
+    expect(findBiomeDirectProcessEnvMutationPluginIncludes()).toEqual(
+      directProcessEnvMutationPluginIncludes,
     );
   });
 });

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/alignment/index.test.ts',
   'providers/elevenlabs/history/index.test.ts',
   'providers/elevenlabs/isolation/index.test.ts',
   'providers/elevenlabs/stt/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/anthropic/completion.test.ts',
   'providers/anthropic/generic.test.ts',
   'providers/anthropic/messages.test.ts',
   'providers/azure/chat.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers.slack.test.ts',
   'providers.test.ts',
   'providers/anthropic/completion.test.ts',
   'providers/anthropic/generic.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/litellm.test.ts',
   'providers/openai-codex-sdk.e2e.test.ts',
   'providers/openai-codex-sdk.test.ts',
   'providers/openai/chat.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -144,16 +144,7 @@ const persistentMockImplementationPattern = new RegExp(
   `\\.(?:${persistentMockMethods.join('|')})\\s*\\(`,
 );
 const mockImplementationResetPattern = /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\s*\()/;
-const envKeyPattern = String.raw`[A-Za-z_][A-Za-z0-9_]*`;
-const processEnvPropertyAccessPattern = String.raw`\bprocess\.env(?:\.${envKeyPattern}|\[['"]${envKeyPattern}['"]\])`;
-const processEnvObjectAssignmentPattern = String.raw`\bprocess\.env\s*=`;
-const processEnvPropertyAssignmentPattern = String.raw`${processEnvPropertyAccessPattern}\s*=`;
-const processEnvPropertyDeletePattern = String.raw`\bdelete\s+${processEnvPropertyAccessPattern}`;
-const directProcessEnvMutationPattern = new RegExp(
-  `(?:${processEnvObjectAssignmentPattern}|${processEnvPropertyAssignmentPattern}|${processEnvPropertyDeletePattern})`,
-);
-const processEnvReferenceSnapshotPattern =
-  /\b(?:const|let|var)\s+[^=\n]*\boriginal[A-Za-z0-9_]*\s*=\s*process\.env\s*;|\boriginal[A-Za-z0-9_]*\s*=\s*process\.env\s*;/i;
+const processEnvSnapshotIdentifierPattern = /^original[A-Za-z0-9_]*$/i;
 
 function findTestFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -184,24 +175,155 @@ function hasHoistedPersistentMockWithoutReset(source: string) {
   );
 }
 
-function hasDirectProcessEnvMutation(source: string) {
-  return source.split(/\r?\n/).some((line) => {
-    const trimmed = line.trim();
-    return (
-      trimmed.length > 0 && !trimmed.startsWith('//') && directProcessEnvMutationPattern.test(line)
-    );
+function isProcessIdentifier(node: ts.Node): node is ts.Identifier {
+  return ts.isIdentifier(node) && node.text === 'process';
+}
+
+function isEnvStringLiteral(node: ts.Node): boolean {
+  return (
+    (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) && node.text === 'env'
+  );
+}
+
+function isProcessEnvExpression(
+  node: ts.Node,
+): node is ts.PropertyAccessExpression | ts.ElementAccessExpression {
+  return (
+    (ts.isPropertyAccessExpression(node) &&
+      node.name.text === 'env' &&
+      isProcessIdentifier(node.expression)) ||
+    (ts.isElementAccessExpression(node) &&
+      isProcessIdentifier(node.expression) &&
+      isEnvStringLiteral(node.argumentExpression))
+  );
+}
+
+function isProcessEnvMemberExpression(
+  node: ts.Node,
+): node is ts.PropertyAccessExpression | ts.ElementAccessExpression {
+  return (
+    (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+    isProcessEnvExpression(node.expression)
+  );
+}
+
+function containsProcessEnvMutationTarget(node: ts.Node): boolean {
+  if (isProcessEnvExpression(node) || isProcessEnvMemberExpression(node)) {
+    return true;
+  }
+
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    found ||= containsProcessEnvMutationTarget(child);
   });
+  return found;
+}
+
+function isProcessEnvMutationCall(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression) || node.arguments.length === 0) {
+    return false;
+  }
+
+  const target = node.arguments[0];
+  const receiver = node.expression.expression;
+  const method = node.expression.name.text;
+
+  return (
+    ts.isIdentifier(receiver) &&
+    isProcessEnvExpression(target) &&
+    ((receiver.text === 'Object' &&
+      ['assign', 'defineProperties', 'defineProperty'].includes(method)) ||
+      (receiver.text === 'Reflect' && ['defineProperty', 'deleteProperty', 'set'].includes(method)))
+  );
+}
+
+function hasDirectProcessEnvMutation(source: string) {
+  const sourceFile = ts.createSourceFile('fixture.test.ts', source, ts.ScriptTarget.Latest, true);
+  let found = false;
+
+  function visit(node: ts.Node) {
+    if (found) {
+      return;
+    }
+
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment &&
+      containsProcessEnvMutationTarget(node.left)
+    ) {
+      found = true;
+      return;
+    }
+
+    if (
+      ts.isDeleteExpression(node) &&
+      (isProcessEnvExpression(node.expression) || isProcessEnvMemberExpression(node.expression))
+    ) {
+      found = true;
+      return;
+    }
+
+    if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken ||
+        node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      isProcessEnvMemberExpression(node.operand)
+    ) {
+      found = true;
+      return;
+    }
+
+    if (ts.isCallExpression(node) && isProcessEnvMutationCall(node)) {
+      found = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
 }
 
 function hasProcessEnvReferenceSnapshot(source: string) {
-  return source.split(/\r?\n/).some((line) => {
-    const trimmed = line.trim();
-    return (
-      trimmed.length > 0 &&
-      !trimmed.startsWith('//') &&
-      processEnvReferenceSnapshotPattern.test(line)
-    );
-  });
+  const sourceFile = ts.createSourceFile('fixture.test.ts', source, ts.ScriptTarget.Latest, true);
+  let found = false;
+
+  function isSnapshotIdentifier(node: ts.Node): boolean {
+    return ts.isIdentifier(node) && processEnvSnapshotIdentifierPattern.test(node.text);
+  }
+
+  function visit(node: ts.Node) {
+    if (found) {
+      return;
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      isSnapshotIdentifier(node.name) &&
+      node.initializer &&
+      isProcessEnvExpression(node.initializer)
+    ) {
+      found = true;
+      return;
+    }
+
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isSnapshotIdentifier(node.left) &&
+      isProcessEnvExpression(node.right)
+    ) {
+      found = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
 }
 
 function findFilesMatchingPolicy(predicate: (source: string) => boolean): string[] {
@@ -425,10 +547,27 @@ describe('root test hygiene', () => {
 
   it.each([
     'process.env.OPENAI_API_KEY = "test-key";',
+    'process.env.OPENAI_API_KEY += "-suffix";',
+    'process.env.OPENAI_API_KEY ||= "test-key";',
     'process.env["OPENAI_API_KEY"] = "test-key";',
+    'process.env["OPENAI_API_KEY"] ??= "test-key";',
+    'process.env[key] &&= "test-key";',
+    'process["env"].OPENAI_API_KEY = "test-key";',
+    'process["env"]["OPENAI_API_KEY"] = "test-key";',
+    'process.env.OPENAI_API_KEY++;',
+    '++process.env["OPENAI_API_KEY"];',
     'delete process.env.OPENAI_API_KEY;',
     'delete process.env["OPENAI_API_KEY"];',
+    'delete process["env"].OPENAI_API_KEY;',
+    'delete process.env;',
     'process.env = { ...process.env, OPENAI_API_KEY: "test-key" };',
+    'Object.assign(process.env, { OPENAI_API_KEY: "test-key" });',
+    'Object.assign(process["env"], { OPENAI_API_KEY: "test-key" });',
+    'Object.defineProperty(process.env, "OPENAI_API_KEY", { value: "test-key" });',
+    'Object.defineProperties(process.env, { OPENAI_API_KEY: { value: "test-key" } });',
+    'Reflect.defineProperty(process.env, "OPENAI_API_KEY", { value: "test-key" });',
+    'Reflect.deleteProperty(process.env, "OPENAI_API_KEY");',
+    'Reflect.set(process.env, "OPENAI_API_KEY", "test-key");',
   ])('detects direct process.env mutation in %s', (source) => {
     expect(hasDirectProcessEnvMutation(source)).toBe(true);
   });
@@ -437,6 +576,11 @@ describe('root test hygiene', () => {
     'const restoreEnv = mockProcessEnv({ OPENAI_API_KEY: "test-key" });',
     'vi.stubEnv("OPENAI_API_KEY", "test-key");',
     'const env = { ...process.env, NO_COLOR: "1" };',
+    'const current = process.env[key];',
+    'const current = process["env"][key];',
+    'if (process.env.OPENAI_API_KEY === "test-key") {}',
+    'Object.assign(env, { OPENAI_API_KEY: "test-key" });',
+    'Reflect.set(env, "OPENAI_API_KEY", "test-key");',
     '// process.env.OPENAI_API_KEY = "test-key";',
   ])('allows scoped or read-only environment handling in %s', (source) => {
     expect(hasDirectProcessEnvMutation(source)).toBe(false);
@@ -444,6 +588,7 @@ describe('root test hygiene', () => {
 
   it.each([
     'const originalEnv = process.env;',
+    'const originalEnv = process["env"];',
     'originalEnv = process.env;',
     'const ORIGINAL_ENV = process.env;',
   ])('detects process.env reference snapshots in %s', (source) => {

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/defaults.test.ts',
   'providers/elevenlabs/agents/index.test.ts',
   'providers/elevenlabs/alignment/index.test.ts',
   'providers/elevenlabs/history/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openclaw.test.ts',
   'providers/openrouter.test.ts',
   'providers/replicate.test.ts',
   'providers/snowflake.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/provider.test.ts',
   'providers/google/video.test.ts',
   'providers/groq/responses.test.ts',
   'providers/huggingface.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'tracing/evaluatorTracing.test.ts',
   'util/apiHealth.test.ts',
   'util/config/load.test.ts',
   'util/env.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'redteam/extraction/purpose.test.ts',
   'redteam/plugins/teenSafety.test.ts',
   'redteam/providers/shared.test.ts',
   'sagemaker.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'assertions/assertionResult.test.ts',
   'assertions/trace.test.ts',
   'cache.test.ts',
   'code-scan-action/main.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/render.test.ts',
   'util/templates.test.ts',
   'util/transform.test.ts',
   'util/utils.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/snowflake.test.ts',
   'providers/truefoundry.test.ts',
   'providers/xai/image.test.ts',
   'providers/xai/voice.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'commands/modelScan.test.ts',
   'constants.test.ts',
   'database.test.ts',
   'envars.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers.test.ts',
   'providers/anthropic/completion.test.ts',
   'providers/anthropic/generic.test.ts',
   'providers/anthropic/messages.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'fetch.test.ts',
   'globalConfig/cloud.test.ts',
   'logger.test.ts',
   'matchers/utils.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/hyperbolic.test.ts',
   'providers/index.test.ts',
   'providers/litellm.test.ts',
   'providers/openai-codex-sdk.e2e.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/isolation/index.test.ts',
   'providers/elevenlabs/stt/index.test.ts',
   'providers/elevenlabs/tts/index.test.ts',
   'providers/google/ai.studio.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/agents/index.test.ts',
   'providers/elevenlabs/alignment/index.test.ts',
   'providers/elevenlabs/history/index.test.ts',
   'providers/elevenlabs/isolation/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/databricks.test.ts',
   'providers/defaults.test.ts',
   'providers/elevenlabs/agents/index.test.ts',
   'providers/elevenlabs/alignment/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/replicate.test.ts',
   'providers/snowflake.test.ts',
   'providers/truefoundry.test.ts',
   'providers/xai/image.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'redteam/plugins/teenSafety.test.ts',
   'redteam/providers/shared.test.ts',
   'sagemaker.test.ts',
   'telemetry.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'telemetry.test.ts',
   'tracing/evaluatorTracing.test.ts',
   'util/apiHealth.test.ts',
   'util/config/load.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -152,6 +152,8 @@ const processEnvPropertyDeletePattern = String.raw`\bdelete\s+${processEnvProper
 const directProcessEnvMutationPattern = new RegExp(
   `(?:${processEnvObjectAssignmentPattern}|${processEnvPropertyAssignmentPattern}|${processEnvPropertyDeletePattern})`,
 );
+const processEnvReferenceSnapshotPattern =
+  /\b(?:const|let|var)\s+[^=\n]*\boriginal[A-Za-z0-9_]*\s*=\s*process\.env\s*;|\boriginal[A-Za-z0-9_]*\s*=\s*process\.env\s*;/i;
 
 function findTestFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -187,6 +189,17 @@ function hasDirectProcessEnvMutation(source: string) {
     const trimmed = line.trim();
     return (
       trimmed.length > 0 && !trimmed.startsWith('//') && directProcessEnvMutationPattern.test(line)
+    );
+  });
+}
+
+function hasProcessEnvReferenceSnapshot(source: string) {
+  return source.split(/\r?\n/).some((line) => {
+    const trimmed = line.trim();
+    return (
+      trimmed.length > 0 &&
+      !trimmed.startsWith('//') &&
+      processEnvReferenceSnapshotPattern.test(line)
     );
   });
 }
@@ -429,6 +442,23 @@ describe('root test hygiene', () => {
     expect(hasDirectProcessEnvMutation(source)).toBe(false);
   });
 
+  it.each([
+    'const originalEnv = process.env;',
+    'originalEnv = process.env;',
+    'const ORIGINAL_ENV = process.env;',
+  ])('detects process.env reference snapshots in %s', (source) => {
+    expect(hasProcessEnvReferenceSnapshot(source)).toBe(true);
+  });
+
+  it.each([
+    'const originalEnv = { ...process.env };',
+    'const originalApiKey = process.env.OPENAI_API_KEY;',
+    'const envReference = process.env;',
+    '// const originalEnv = process.env;',
+  ])('allows copied snapshots or read-only env access in %s', (source) => {
+    expect(hasProcessEnvReferenceSnapshot(source)).toBe(false);
+  });
+
   it('keeps new root tests from adding hoisted persistent mocks without reset', () => {
     const unapprovedFiles = findFilesMatchingPolicy(hasHoistedPersistentMockWithoutReset)
       .filter((file) => !legacyHoistedPersistentMockFiles.has(file))
@@ -456,6 +486,14 @@ describe('root test hygiene', () => {
         (file) =>
           `${file}: use mockProcessEnv() or vi.stubEnv() instead of direct process.env mutation`,
       );
+
+    expect(unapprovedFiles).toEqual([]);
+  });
+
+  it('keeps new root tests from snapshotting process.env by reference', () => {
+    const unapprovedFiles = findFilesMatchingPolicy(hasProcessEnvReferenceSnapshot).map(
+      (file) => `${file}: snapshot process.env with { ...process.env } instead of by reference`,
+    );
 
     expect(unapprovedFiles).toEqual([]);
   });

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/file.test.ts',
   'util/json.test.ts',
   'util/promptfooCommand.test.ts',
   'util/render.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'logger.test.ts',
   'matchers/utils.test.ts',
   'onboarding.test.ts',
   'prompts/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/image.test.ts',
   'providers/openai/index.test.ts',
   'providers/openai/realtime.test.ts',
   'providers/openclaw.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/bedrock/knowledgeBase.test.ts',
   'providers/claude-agent-sdk.test.ts',
   'providers/cloudflare-ai.test.ts',
   'providers/cloudflare-gateway.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/azure/chat.test.ts',
   'providers/azure/completion.test.ts',
   'providers/azure/responses.test.ts',
   'providers/bedrock.agents.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/groq/responses.test.ts',
   'providers/huggingface.test.ts',
   'providers/hyperbolic.test.ts',
   'providers/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/index.test.ts',
   'providers/openai/realtime.test.ts',
   'providers/openclaw.test.ts',
   'providers/openrouter.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/huggingface.test.ts',
   'providers/hyperbolic.test.ts',
   'providers/index.test.ts',
   'providers/litellm.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'globalConfig/cloud.test.ts',
   'logger.test.ts',
   'matchers/utils.test.ts',
   'onboarding.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/image.test.ts',
   'providers/google/live.test.ts',
   'providers/google/provider.test.ts',
   'providers/google/video.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'cache.test.ts',
   'code-scan-action/main.test.ts',
   'commands/modelScan.test.ts',
   'constants.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/xai/voice.test.ts',
   'redteam/extraction/entities.test.ts',
   'redteam/extraction/purpose.test.ts',
   'redteam/plugins/teenSafety.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/realtime.test.ts',
   'providers/openclaw.test.ts',
   'providers/openrouter.test.ts',
   'providers/replicate.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'code-scan-action/main.test.ts',
   'commands/modelScan.test.ts',
   'constants.test.ts',
   'database.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'redteam/extraction/entities.test.ts',
   'redteam/extraction/purpose.test.ts',
   'redteam/plugins/teenSafety.test.ts',
   'redteam/providers/shared.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/cloudflare-gateway.test.ts',
   'providers/databricks.test.ts',
   'providers/defaults.test.ts',
   'providers/elevenlabs/agents/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/codexDefaults.test.ts',
   'providers/openai/completion.test.ts',
   'providers/openai/image.test.ts',
   'providers/openai/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/config/load.test.ts',
   'util/env.test.ts',
   'util/file.test.ts',
   'util/json.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'prompts/index.test.ts',
   'providers.slack.test.ts',
   'providers.test.ts',
   'providers/anthropic/completion.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -120,7 +120,7 @@ const allowedSkippedTests: AllowedSkip[] = [
 
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
-const legacyDirectProcessEnvMutationFiles = new Set(['util/utils.test.ts']);
+const legacyDirectProcessEnvMutationFiles = new Set<string>();
 
 const hoistedMockPattern = /\bvi\.hoisted\s*\(/;
 const persistentMockMethods = [

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/json.test.ts',
   'util/promptfooCommand.test.ts',
   'util/render.test.ts',
   'util/templates.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/azure/completion.test.ts',
   'providers/azure/responses.test.ts',
   'providers/bedrock.agents.test.ts',
   'providers/bedrock/converse.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai-codex-sdk.e2e.test.ts',
   'providers/openai-codex-sdk.test.ts',
   'providers/openai/chat.test.ts',
   'providers/openai/codexDefaults.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'database.test.ts',
   'envars.test.ts',
   'evaluatorHelpers.test.ts',
   'fetch.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/claude-agent-sdk.test.ts',
   'providers/cloudflare-ai.test.ts',
   'providers/cloudflare-gateway.test.ts',
   'providers/databricks.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/history/index.test.ts',
   'providers/elevenlabs/isolation/index.test.ts',
   'providers/elevenlabs/stt/index.test.ts',
   'providers/elevenlabs/tts/index.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/apiHealth.test.ts',
   'util/config/load.test.ts',
   'util/env.test.ts',
   'util/file.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'onboarding.test.ts',
   'prompts/index.test.ts',
   'providers.slack.test.ts',
   'providers.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/stt/index.test.ts',
   'providers/elevenlabs/tts/index.test.ts',
   'providers/google/ai.studio.test.ts',
   'providers/google/auth.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/auth.test.ts',
   'providers/google/gemini-image.test.ts',
   'providers/google/image.test.ts',
   'providers/google/live.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'sagemaker.test.ts',
   'telemetry.test.ts',
   'tracing/evaluatorTracing.test.ts',
   'util/apiHealth.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'matchers/utils.test.ts',
   'onboarding.test.ts',
   'prompts/index.test.ts',
   'providers.slack.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/env.test.ts',
   'util/file.test.ts',
   'util/json.test.ts',
   'util/promptfooCommand.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/anthropic/messages.test.ts',
   'providers/azure/chat.test.ts',
   'providers/azure/completion.test.ts',
   'providers/azure/responses.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/elevenlabs/tts/index.test.ts',
   'providers/google/ai.studio.test.ts',
   'providers/google/auth.test.ts',
   'providers/google/gemini-image.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'redteam/providers/shared.test.ts',
   'sagemaker.test.ts',
   'telemetry.test.ts',
   'tracing/evaluatorTracing.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'envars.test.ts',
   'evaluatorHelpers.test.ts',
   'fetch.test.ts',
   'globalConfig/cloud.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/google/video.test.ts',
   'providers/groq/responses.test.ts',
   'providers/huggingface.test.ts',
   'providers/hyperbolic.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'evaluatorHelpers.test.ts',
   'fetch.test.ts',
   'globalConfig/cloud.test.ts',
   'logger.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/anthropic/generic.test.ts',
   'providers/anthropic/messages.test.ts',
   'providers/azure/chat.test.ts',
   'providers/azure/completion.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/templates.test.ts',
   'util/transform.test.ts',
   'util/utils.test.ts',
 ]);

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'util/promptfooCommand.test.ts',
   'util/render.test.ts',
   'util/templates.test.ts',
   'util/transform.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openai/chat.test.ts',
   'providers/openai/codexDefaults.test.ts',
   'providers/openai/completion.test.ts',
   'providers/openai/image.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'assertions/trace.test.ts',
   'cache.test.ts',
   'code-scan-action/main.test.ts',
   'commands/modelScan.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/xai/image.test.ts',
   'providers/xai/voice.test.ts',
   'redteam/extraction/entities.test.ts',
   'redteam/extraction/purpose.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/openrouter.test.ts',
   'providers/replicate.test.ts',
   'providers/snowflake.test.ts',
   'providers/truefoundry.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/index.test.ts',
   'providers/litellm.test.ts',
   'providers/openai-codex-sdk.e2e.test.ts',
   'providers/openai-codex-sdk.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'providers/bedrock/index.test.ts',
   'providers/bedrock/knowledgeBase.test.ts',
   'providers/claude-agent-sdk.test.ts',
   'providers/cloudflare-ai.test.ts',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -121,7 +121,6 @@ const allowedSkippedTests: AllowedSkip[] = [
 const legacyHoistedPersistentMockFiles = new Set<string>();
 
 const legacyDirectProcessEnvMutationFiles = new Set([
-  'constants.test.ts',
   'database.test.ts',
   'envars.test.ts',
   'evaluatorHelpers.test.ts',

--- a/test/tracing/evaluatorTracing.test.ts
+++ b/test/tracing/evaluatorTracing.test.ts
@@ -9,6 +9,7 @@ import {
   resetTracingState,
   startOtlpReceiverIfNeeded,
 } from '../../src/tracing/evaluatorTracing';
+import { mockProcessEnv } from '../util/utils';
 
 import type { TestCase, TestSuite } from '../../src/types/index';
 
@@ -43,7 +44,7 @@ describe('evaluatorTracing', () => {
     mockStartOTLPReceiver.mockResolvedValue(undefined);
     resetTracingState();
     // Reset environment variables
-    delete process.env.PROMPTFOO_TRACING_ENABLED;
+    mockProcessEnv({ PROMPTFOO_TRACING_ENABLED: undefined });
   });
 
   describe('generateTraceId', () => {
@@ -124,7 +125,7 @@ describe('evaluatorTracing', () => {
     });
 
     it('should generate trace context when tracing is enabled via environment', async () => {
-      process.env.PROMPTFOO_TRACING_ENABLED = 'true';
+      mockProcessEnv({ PROMPTFOO_TRACING_ENABLED: 'true' });
       const test: TestCase = {
         vars: { foo: 'bar' },
       };
@@ -172,7 +173,7 @@ describe('evaluatorTracing', () => {
     });
 
     it('should return true when environment variable is set', () => {
-      process.env.PROMPTFOO_TRACING_ENABLED = 'true';
+      mockProcessEnv({ PROMPTFOO_TRACING_ENABLED: 'true' });
       const test: TestCase = { vars: {} };
       expect(isTracingEnabled(test)).toBe(true);
     });

--- a/test/util/apiHealth.test.ts
+++ b/test/util/apiHealth.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getRemoteHealthUrl } from '../../src/redteam/remoteGeneration';
 import { checkRemoteHealth } from '../../src/util/apiHealth';
 import { fetchWithTimeout } from '../../src/util/fetch/index';
+import { mockProcessEnv } from './utils';
 
 // Mock fetchWithTimeout module
 vi.mock('../../src/util/fetch/index', () => ({
@@ -30,8 +31,8 @@ const mockedFetchWithTimeout = vi.mocked(fetchWithTimeout);
 describe('API Health Utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION;
-    delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: undefined });
+    mockProcessEnv({ PROMPTFOO_REMOTE_GENERATION_URL: undefined });
 
     mockIsEnabled.mockReset();
     mockGetApiHost.mockReset();
@@ -41,12 +42,12 @@ describe('API Health Utilities', () => {
 
   describe('getRemoteHealthUrl', () => {
     it('should return null when remote generation is disabled', () => {
-      process.env.PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION = 'true';
+      mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
       expect(getRemoteHealthUrl()).toBeNull();
     });
 
     it('should use custom URL when provided', () => {
-      process.env.PROMPTFOO_REMOTE_GENERATION_URL = 'https://custom-api.example.com/task';
+      mockProcessEnv({ PROMPTFOO_REMOTE_GENERATION_URL: 'https://custom-api.example.com/task' });
       expect(getRemoteHealthUrl()).toBe('https://custom-api.example.com/health');
     });
 

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -23,6 +23,7 @@ import { maybeLoadFromExternalFile } from '../../../src/util/file';
 import { isRunningUnderNpx } from '../../../src/util/promptfooCommand';
 import { readTests } from '../../../src/util/testCaseReader';
 import { createMockProvider } from '../../factories/provider';
+import { mockProcessEnv } from '../utils';
 
 vi.mock('../../../src/database', () => ({
   getDb: vi.fn(),
@@ -2307,15 +2308,15 @@ describe('readConfig with environment variable substitution', () => {
     // Restore or delete environment variables to prevent test pollution
     for (const varName of testEnvVars) {
       if (originalEnv[varName] === undefined) {
-        delete process.env[varName];
+        mockProcessEnv({ [varName]: undefined });
       } else {
-        process.env[varName] = originalEnv[varName];
+        mockProcessEnv({ [varName]: originalEnv[varName] });
       }
     }
   });
 
   it('should substitute environment variables in prompts paths', async () => {
-    process.env.TEST_PROMPT_PATH = '/custom/prompts';
+    mockProcessEnv({ TEST_PROMPT_PATH: '/custom/prompts' });
     const mockConfig = {
       description: 'Test config with env vars',
       providers: ['openai:gpt-4o'],
@@ -2330,7 +2331,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in providers paths', async () => {
-    process.env.TEST_PROVIDER_PATH = '/custom/providers';
+    mockProcessEnv({ TEST_PROVIDER_PATH: '/custom/providers' });
     const mockConfig = {
       description: 'Test config with env vars',
       providers: ['{{ env.TEST_PROVIDER_PATH }}/custom_provider.js'],
@@ -2345,7 +2346,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in nested config values', async () => {
-    process.env.MY_API_KEY = 'sk-test-12345';
+    mockProcessEnv({ MY_API_KEY: 'sk-test-12345' });
     const mockConfig = {
       description: 'Test config with env vars',
       providers: [
@@ -2367,7 +2368,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should preserve env templates in static _conversation vars', async () => {
-    process.env.MY_API_KEY = 'sk-test-12345';
+    mockProcessEnv({ MY_API_KEY: 'sk-test-12345' });
     const mockConfig = {
       description: 'Test config with _conversation vars',
       providers: ['{{ env.MY_API_KEY }}'],
@@ -2407,7 +2408,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in assertion paths', async () => {
-    process.env.TEST_ASSERTION_PATH = '/custom/assertions';
+    mockProcessEnv({ TEST_ASSERTION_PATH: '/custom/assertions' });
     const mockConfig = {
       description: 'Test config with env vars',
       providers: ['openai:gpt-4o'],
@@ -2435,7 +2436,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should preserve runtime templates like {{ vars.x }}', async () => {
-    process.env.TEST_PROMPT_PATH = '/custom/prompts';
+    mockProcessEnv({ TEST_PROMPT_PATH: '/custom/prompts' });
     const mockConfig = {
       description: 'Test config with mixed templates',
       providers: ['openai:gpt-4o'],
@@ -2496,7 +2497,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in JavaScript config files', async () => {
-    process.env.TEST_PROMPT_PATH = '/js/prompts';
+    mockProcessEnv({ TEST_PROMPT_PATH: '/js/prompts' });
     const mockConfig = {
       description: 'JS config with env vars',
       providers: ['openai:gpt-4o'],
@@ -2512,7 +2513,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in YAML config files', async () => {
-    process.env.TEST_PROMPT_PATH = '/yaml/prompts';
+    mockProcessEnv({ TEST_PROMPT_PATH: '/yaml/prompts' });
     const mockConfig = {
       description: 'YAML config with env vars',
       providers: ['openai:gpt-4o'],
@@ -2527,8 +2528,8 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute multiple environment variables in a single string', async () => {
-    process.env.TEST_BASE_PATH = '/base';
-    process.env.TEST_SUB_PATH = 'prompts';
+    mockProcessEnv({ TEST_BASE_PATH: '/base' });
+    mockProcessEnv({ TEST_SUB_PATH: 'prompts' });
     const mockConfig = {
       description: 'Test config with multiple env vars',
       providers: ['openai:gpt-4o'],
@@ -2543,7 +2544,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables using bracket notation', async () => {
-    process.env['TEST-PATH-WITH-DASHES'] = '/dashed/path';
+    mockProcessEnv({ ['TEST-PATH-WITH-DASHES']: '/dashed/path' });
     const mockConfig = {
       description: 'Test config with bracket notation',
       providers: ['openai:gpt-4o'],
@@ -2558,7 +2559,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in defaultTest options', async () => {
-    process.env.TEST_GRADER_PROVIDER = 'openai:gpt-4-turbo';
+    mockProcessEnv({ TEST_GRADER_PROVIDER: 'openai:gpt-4-turbo' });
     const mockConfig = {
       description: 'Test config with env vars in defaultTest',
       providers: ['openai:gpt-4o'],
@@ -2578,7 +2579,7 @@ describe('readConfig with environment variable substitution', () => {
   });
 
   it('should substitute environment variables in env config field', async () => {
-    process.env.EXTERNAL_API_KEY = 'external-key-123';
+    mockProcessEnv({ EXTERNAL_API_KEY: 'external-key-123' });
     const mockConfig = {
       description: 'Test config with env vars in env field',
       providers: ['openai:gpt-4o'],
@@ -2601,7 +2602,7 @@ describe('readConfig with environment variable substitution', () => {
 
   describe('security edge cases', () => {
     it('should handle empty string environment variables', async () => {
-      process.env.EMPTY_VAR = '';
+      mockProcessEnv({ EMPTY_VAR: '' });
       const mockConfig = {
         description: 'Test config with empty env var',
         providers: ['openai:gpt-4o'],
@@ -2617,7 +2618,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should safely handle env vars containing template-like syntax', async () => {
-      process.env.PROMPT_TEXT = 'Hello {{ vars.name }}';
+      mockProcessEnv({ PROMPT_TEXT: 'Hello {{ vars.name }}' });
       const mockConfig = {
         description: 'Test config with template-like env var',
         providers: ['openai:gpt-4o'],
@@ -2633,7 +2634,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should safely handle env vars containing Nunjucks statement syntax', async () => {
-      process.env.EVIL_VAR = '{% for i in range(100) %}x{% endfor %}';
+      mockProcessEnv({ EVIL_VAR: '{% for i in range(100) %}x{% endfor %}' });
       const mockConfig = {
         description: 'Test config with statement syntax in env var',
         providers: ['openai:gpt-4o'],
@@ -2649,7 +2650,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should handle env vars containing special regex characters', async () => {
-      process.env.SPECIAL_PATH = '/path/with/$pecial/chars.*[test]';
+      mockProcessEnv({ SPECIAL_PATH: '/path/with/$pecial/chars.*[test]' });
       const mockConfig = {
         description: 'Test config with special chars in env var',
         providers: ['openai:gpt-4o'],
@@ -2666,7 +2667,7 @@ describe('readConfig with environment variable substitution', () => {
     it('should handle potential path traversal in env vars', async () => {
       // Note: This test demonstrates that path traversal is possible if env vars are controlled by attackers
       // File validation should happen at file load time, not in the template renderer
-      process.env.TRAVERSAL_PATH = '../../etc';
+      mockProcessEnv({ TRAVERSAL_PATH: '../../etc' });
       const mockConfig = {
         description: 'Test config with path traversal',
         providers: ['openai:gpt-4o'],
@@ -2697,7 +2698,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should handle malformed template syntax gracefully', async () => {
-      process.env.MY_VAR = 'test-value';
+      mockProcessEnv({ MY_VAR: 'test-value' });
       const mockConfig = {
         description: 'Test config with malformed templates',
         providers: ['openai:gpt-4o'],
@@ -2722,7 +2723,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should handle env vars with newlines and special whitespace', async () => {
-      process.env.MULTILINE_VAR = 'line1\nline2\ttab';
+      mockProcessEnv({ MULTILINE_VAR: 'line1\nline2\ttab' });
       const mockConfig = {
         description: 'Test config with multiline env var',
         providers: ['openai:gpt-4o'],
@@ -2737,7 +2738,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should handle deeply nested objects with env vars', async () => {
-      process.env.DEEP_VAR = 'nested-value';
+      mockProcessEnv({ DEEP_VAR: 'nested-value' });
       const mockConfig = {
         description: 'Test config with deeply nested env vars',
         providers: ['openai:gpt-4o'],
@@ -2775,10 +2776,10 @@ describe('readConfig with environment variable substitution', () => {
 
   describe('provider ID with env variables (regression test for #7079)', () => {
     it('should substitute process.env variables in provider ID URLs', async () => {
-      process.env.TEST_APPLICATION = 'myapp';
-      process.env.TEST_BASE_URL = 'example.com';
-      process.env.TEST_SERVICE_NAME = 'api';
-      process.env.TEST_SERVICE_VERSION = 'v1';
+      mockProcessEnv({ TEST_APPLICATION: 'myapp' });
+      mockProcessEnv({ TEST_BASE_URL: 'example.com' });
+      mockProcessEnv({ TEST_SERVICE_NAME: 'api' });
+      mockProcessEnv({ TEST_SERVICE_VERSION: 'v1' });
       const mockConfig = {
         description: 'Test config with env vars in provider ID',
         providers: [
@@ -2828,7 +2829,7 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should handle mixed defined and undefined env vars in provider ID', async () => {
-      process.env.TEST_DEFINED_VAR = 'defined-value';
+      mockProcessEnv({ TEST_DEFINED_VAR: 'defined-value' });
       const mockConfig = {
         description: 'Test config with mixed env vars',
         providers: [
@@ -2854,8 +2855,8 @@ describe('readConfig with environment variable substitution', () => {
     });
 
     it('should substitute env vars in provider config headers', async () => {
-      process.env.TEST_SESSION = 'session-123';
-      process.env.TEST_TOKEN = 'token-456';
+      mockProcessEnv({ TEST_SESSION: 'session-123' });
+      mockProcessEnv({ TEST_TOKEN: 'token-456' });
       const mockConfig = {
         description: 'Test config with env vars in headers',
         providers: [
@@ -2976,7 +2977,7 @@ describe('readConfig with environment variable substitution', () => {
     it('should handle nested templates in config.env values (two-pass rendering)', async () => {
       // This test verifies that config.env values can reference process.env variables
       // and the two-pass rendering correctly resolves them before using as overrides
-      process.env.TEST_BASE_URL = 'api.example.com';
+      mockProcessEnv({ TEST_BASE_URL: 'api.example.com' });
       const mockConfig = {
         description: 'Test config with nested templates in env section',
         env: {

--- a/test/util/env.test.ts
+++ b/test/util/env.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import dotenv from 'dotenv';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { setupEnv } from '../../src/util/env';
+import { mockProcessEnv } from './utils';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -21,7 +22,7 @@ describe('setupEnv', () => {
   beforeEach(() => {
     originalEnv = { ...process.env };
     // Ensure NODE_ENV is not set at the start of each test
-    delete process.env.NODE_ENV;
+    mockProcessEnv({ NODE_ENV: undefined });
     // Spy on dotenv.config to verify it's called with the right parameters
     dotenvConfigSpy = vi.spyOn(dotenv, 'config').mockImplementation(() => ({ parsed: {} }));
     // Mock file existence check - default to true for backward compat with existing tests
@@ -29,7 +30,7 @@ describe('setupEnv', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
     vi.resetAllMocks();
   });
 
@@ -58,14 +59,14 @@ describe('setupEnv', () => {
     dotenvConfigSpy.mockImplementation((options?: dotenv.DotenvConfigOptions) => {
       if (options?.path === '.env.production') {
         if (options.override) {
-          process.env.NODE_ENV = 'production';
+          mockProcessEnv({ NODE_ENV: 'production' });
         } else if (!process.env.NODE_ENV) {
-          process.env.NODE_ENV = 'production';
+          mockProcessEnv({ NODE_ENV: 'production' });
         }
       } else {
         // Default .env file
         if (!process.env.NODE_ENV) {
-          process.env.NODE_ENV = 'development';
+          mockProcessEnv({ NODE_ENV: 'development' });
         }
       }
       return { parsed: {} };

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -22,6 +22,7 @@ import {
   isJavascriptFile,
   isVideoFile,
 } from '../../src/util/fileExtensions';
+import { mockProcessEnv } from './utils';
 
 vi.mock('proxy-agent', () => ({
   ProxyAgent: vi.fn().mockImplementation(() => ({})),
@@ -323,7 +324,7 @@ describe('file utilities', () => {
     });
 
     it('should handle a path with environment variables in Nunjucks template', () => {
-      process.env.TEST_ROOT_PATH = '/root/dir';
+      mockProcessEnv({ TEST_ROOT_PATH: '/root/dir' });
       const input = 'file://{{ env.TEST_ROOT_PATH }}/test.txt';
 
       const expectedPath = path.resolve(`${process.env.TEST_ROOT_PATH}/test.txt`);
@@ -331,7 +332,7 @@ describe('file utilities', () => {
 
       expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, 'utf8');
 
-      delete process.env.TEST_ROOT_PATH;
+      mockProcessEnv({ TEST_ROOT_PATH: undefined });
     });
 
     it('should ignore basePath when file path is absolute', () => {
@@ -1650,12 +1651,12 @@ describe('file utilities', () => {
     });
 
     it('should throw an error for non-existent file path when PROMPTFOO_STRICT_FILES is true', async () => {
-      process.env.PROMPTFOO_STRICT_FILES = 'true';
+      mockProcessEnv({ PROMPTFOO_STRICT_FILES: 'true' });
       vi.spyOn(fs, 'statSync').mockImplementation(() => {
         throw new Error('File does not exist');
       });
       expect(() => parsePathOrGlob('/base', 'nonexistent.js')).toThrow('File does not exist');
-      delete process.env.PROMPTFOO_STRICT_FILES;
+      mockProcessEnv({ PROMPTFOO_STRICT_FILES: undefined });
     });
 
     it('should properly test file existence when function name in the path', async () => {
@@ -1686,14 +1687,14 @@ describe('file utilities', () => {
 
     it('should handle paths with environment variables', async () => {
       vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
-      process.env.FILE_PATH = 'file.txt';
+      mockProcessEnv({ FILE_PATH: 'file.txt' });
       expect(parsePathOrGlob('/base', process.env.FILE_PATH)).toEqual({
         extension: '.txt',
         functionName: undefined,
         isPathPattern: false,
         filePath: path.join('/base', 'file.txt'),
       });
-      delete process.env.FILE_PATH;
+      mockProcessEnv({ FILE_PATH: undefined });
     });
 
     it('should handle glob patterns in file path', async () => {

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -1688,7 +1688,8 @@ describe('file utilities', () => {
     it('should handle paths with environment variables', async () => {
       vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as fs.Stats);
       mockProcessEnv({ FILE_PATH: 'file.txt' });
-      expect(parsePathOrGlob('/base', process.env.FILE_PATH)).toEqual({
+      const filePath = process.env.FILE_PATH as string;
+      expect(parsePathOrGlob('/base', filePath)).toEqual({
         extension: '.txt',
         functionName: undefined,
         isPathPattern: false,

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -14,22 +14,23 @@ import {
 } from '../../src/util/json';
 import { createEvaluateResult } from '../factories/eval';
 import { createAtomicTestCase, createPrompt } from '../factories/testSuite';
+import { mockProcessEnv } from './utils';
 
 import type { EvaluateResult } from '../../src/types/index';
 
 describe('json utilities', () => {
   describe('getAjv', () => {
     beforeAll(() => {
-      process.env.NODE_ENV = 'test';
+      mockProcessEnv({ NODE_ENV: 'test' });
     });
 
     beforeEach(() => {
-      delete process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE;
+      mockProcessEnv({ PROMPTFOO_DISABLE_AJV_STRICT_MODE: undefined });
       resetAjv();
     });
 
     afterEach(() => {
-      delete process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE;
+      mockProcessEnv({ PROMPTFOO_DISABLE_AJV_STRICT_MODE: undefined });
     });
 
     it('should create an Ajv instance with default options', () => {
@@ -39,7 +40,7 @@ describe('json utilities', () => {
     });
 
     it('should disable strict mode when PROMPTFOO_DISABLE_AJV_STRICT_MODE is set', () => {
-      process.env.PROMPTFOO_DISABLE_AJV_STRICT_MODE = 'true';
+      mockProcessEnv({ PROMPTFOO_DISABLE_AJV_STRICT_MODE: 'true' });
       const ajv = getAjv();
       expect(ajv.opts.strictSchema).toBe(false);
     });
@@ -66,10 +67,10 @@ describe('json utilities', () => {
     it('should only allow resetAjv to be called in test environment', () => {
       const originalNodeEnv = process.env.NODE_ENV;
       try {
-        process.env.NODE_ENV = 'production';
+        mockProcessEnv({ NODE_ENV: 'production' });
         expect(() => resetAjv()).toThrow('resetAjv can only be called in test environment');
       } finally {
-        process.env.NODE_ENV = originalNodeEnv;
+        mockProcessEnv({ NODE_ENV: originalNodeEnv });
       }
     });
   });

--- a/test/util/promptfooCommand.test.ts
+++ b/test/util/promptfooCommand.test.ts
@@ -10,7 +10,7 @@ describe('nextCommand', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
-    originalEnv = process.env;
+    originalEnv = { ...process.env };
     mockProcessEnv({ ...originalEnv }, { clear: true });
   });
 

--- a/test/util/promptfooCommand.test.ts
+++ b/test/util/promptfooCommand.test.ts
@@ -4,27 +4,28 @@ import {
   isRunningUnderNpx,
   promptfooCommand,
 } from '../../src/util/promptfooCommand';
+import { mockProcessEnv } from './utils';
 
 describe('nextCommand', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     originalEnv = process.env;
-    process.env = { ...originalEnv };
+    mockProcessEnv({ ...originalEnv }, { clear: true });
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   describe('detectInstaller', () => {
     it('should detect npx from npm_execpath', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(detectInstaller()).toBe('npx');
     });
 
     it('should detect npx from npm_lifecycle_script', () => {
-      process.env.npm_lifecycle_script = 'npx some-command';
+      mockProcessEnv({ npm_lifecycle_script: 'npx some-command' });
       expect(detectInstaller()).toBe('npx');
     });
 
@@ -44,12 +45,12 @@ describe('nextCommand', () => {
     });
 
     it('should detect npx from npm_config_user_agent', () => {
-      process.env.npm_config_user_agent = 'npx/10.5.0 npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_config_user_agent: 'npx/10.5.0 npm/10.8.2 node/v18.20.4' });
       expect(detectInstaller()).toBe('npx');
     });
 
     it('should detect brew from npm_config_prefix', () => {
-      process.env.npm_config_prefix = '/usr/local/Homebrew/Cellar/node/20.0.0/bin';
+      mockProcessEnv({ npm_config_prefix: '/usr/local/Homebrew/Cellar/node/20.0.0/bin' });
       expect(detectInstaller()).toBe('brew');
     });
 
@@ -69,118 +70,118 @@ describe('nextCommand', () => {
     });
 
     it('should detect npm-global from npm_config_user_agent', () => {
-      process.env.npm_config_user_agent = 'npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_config_user_agent: 'npm/10.8.2 node/v18.20.4' });
       expect(detectInstaller()).toBe('npm-global');
     });
 
     it('should return unknown for unrecognized patterns', () => {
-      process.env.npm_config_user_agent = 'yarn/1.22.0';
+      mockProcessEnv({ npm_config_user_agent: 'yarn/1.22.0' });
       expect(detectInstaller()).toBe('unknown');
     });
 
     it('should prioritize npm_execpath over user agent', () => {
-      process.env.npm_execpath = '/path/to/npx';
-      process.env.npm_config_user_agent = 'npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
+      mockProcessEnv({ npm_config_user_agent: 'npm/10.8.2 node/v18.20.4' });
       expect(detectInstaller()).toBe('npx');
     });
 
     it('should prioritize npm_lifecycle_script over user agent', () => {
-      process.env.npm_lifecycle_script = 'npx some-command';
-      process.env.npm_config_user_agent = 'npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_lifecycle_script: 'npx some-command' });
+      mockProcessEnv({ npm_config_user_agent: 'npm/10.8.2 node/v18.20.4' });
       expect(detectInstaller()).toBe('npx');
     });
 
     it('should handle empty environment variables', () => {
-      delete process.env.npm_execpath;
-      delete process.env.npm_lifecycle_script;
-      delete process.env.npm_config_prefix;
-      delete process.env.npm_config_user_agent;
+      mockProcessEnv({ npm_execpath: undefined });
+      mockProcessEnv({ npm_lifecycle_script: undefined });
+      mockProcessEnv({ npm_config_prefix: undefined });
+      mockProcessEnv({ npm_config_user_agent: undefined });
       expect(detectInstaller()).toBe('unknown');
     });
 
     it('should handle case insensitive homebrew detection', () => {
-      process.env.npm_config_prefix = '/usr/local/homebrew/cellar/node/20.0.0/bin';
+      mockProcessEnv({ npm_config_prefix: '/usr/local/homebrew/cellar/node/20.0.0/bin' });
       expect(detectInstaller()).toBe('brew');
     });
 
     it('should detect brew with Windows-style paths', () => {
-      process.env.npm_config_prefix = 'C:\\Users\\user\\homebrew\\Cellar\\node\\20.0.0\\bin';
+      mockProcessEnv({ npm_config_prefix: 'C:\\Users\\user\\homebrew\\Cellar\\node\\20.0.0\\bin' });
       expect(detectInstaller()).toBe('brew');
     });
   });
 
   describe('promptfooCommand', () => {
     it('should return npx command for npx installer', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(promptfooCommand('eval')).toBe('npx promptfoo@latest eval');
     });
 
     it('should return regular command for brew installer', () => {
-      process.env.npm_config_prefix = '/usr/local/Homebrew/Cellar/node/20.0.0/bin';
+      mockProcessEnv({ npm_config_prefix: '/usr/local/Homebrew/Cellar/node/20.0.0/bin' });
       expect(promptfooCommand('eval')).toBe('promptfoo eval');
     });
 
     it('should return regular command for npm-global installer', () => {
-      process.env.npm_config_user_agent = 'npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_config_user_agent: 'npm/10.8.2 node/v18.20.4' });
       expect(promptfooCommand('eval')).toBe('promptfoo eval');
     });
 
     it('should return regular command for unknown installer', () => {
-      process.env.npm_config_user_agent = 'yarn/1.22.0';
+      mockProcessEnv({ npm_config_user_agent: 'yarn/1.22.0' });
       expect(promptfooCommand('eval')).toBe('promptfoo eval');
     });
 
     it('should handle complex subcommands', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(promptfooCommand('redteam init')).toBe('npx promptfoo@latest redteam init');
     });
 
     it('should handle subcommands with flags', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(promptfooCommand('eval -c config.yaml')).toBe(
         'npx promptfoo@latest eval -c config.yaml',
       );
     });
 
     it('should handle empty subcommand for npx', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(promptfooCommand('')).toBe('npx promptfoo@latest');
     });
 
     it('should handle empty subcommand for non-npx', () => {
-      process.env.npm_config_prefix = '/usr/local/Homebrew/Cellar/node/20.0.0/bin';
+      mockProcessEnv({ npm_config_prefix: '/usr/local/Homebrew/Cellar/node/20.0.0/bin' });
       expect(promptfooCommand('')).toBe('promptfoo');
     });
   });
 
   describe('isRunningUnderNpx (legacy compatibility)', () => {
     it('should return true for npx installer', () => {
-      process.env.npm_execpath = '/path/to/npx';
+      mockProcessEnv({ npm_execpath: '/path/to/npx' });
       expect(isRunningUnderNpx()).toBe(true);
     });
 
     it('should return false for non-npx installers', () => {
-      process.env.npm_config_prefix = '/usr/local/Homebrew/Cellar/node/20.0.0/bin';
+      mockProcessEnv({ npm_config_prefix: '/usr/local/Homebrew/Cellar/node/20.0.0/bin' });
       expect(isRunningUnderNpx()).toBe(false);
     });
   });
 
   describe('edge cases', () => {
     it('should handle partial matches in strings', () => {
-      process.env.npm_execpath = '/some/path/with-npx-in-middle/but-not-npx';
+      mockProcessEnv({ npm_execpath: '/some/path/with-npx-in-middle/but-not-npx' });
       expect(detectInstaller()).toBe('npx'); // Should still match because contains 'npx'
     });
 
     it('should handle npm_config_user_agent with multiple patterns', () => {
-      process.env.npm_config_user_agent = 'npx/10.5.0 npm/10.8.2 node/v18.20.4';
+      mockProcessEnv({ npm_config_user_agent: 'npx/10.5.0 npm/10.8.2 node/v18.20.4' });
       expect(detectInstaller()).toBe('npx'); // Should detect npx, not npm
     });
 
     it('should handle undefined environment variables gracefully', () => {
-      delete process.env.npm_execpath;
-      delete process.env.npm_lifecycle_script;
-      delete process.env.npm_config_prefix;
-      delete process.env.npm_config_user_agent;
+      mockProcessEnv({ npm_execpath: undefined });
+      mockProcessEnv({ npm_lifecycle_script: undefined });
+      mockProcessEnv({ npm_config_prefix: undefined });
+      mockProcessEnv({ npm_config_user_agent: undefined });
 
       expect(() => detectInstaller()).not.toThrow();
       expect(detectInstaller()).toBe('unknown');

--- a/test/util/render.test.ts
+++ b/test/util/render.test.ts
@@ -1,18 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderEnvOnlyInObject, renderVarsInObject } from '../../src/util/render';
+import { mockProcessEnv } from './utils';
 
 describe('renderVarsInObject', () => {
   beforeEach(() => {
-    delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
   });
 
   afterEach(() => {
-    delete process.env.TEST_ENV_VAR;
-    delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+    mockProcessEnv({ TEST_ENV_VAR: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
   });
 
   it('should render environment variables in objects', async () => {
-    process.env.TEST_ENV_VAR = 'env_value';
+    mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
     const obj = { text: '{{ env.TEST_ENV_VAR }}' };
     const rendered = renderVarsInObject(obj, {});
     expect(rendered).toEqual({ text: 'env_value' });
@@ -32,7 +33,7 @@ describe('renderVarsInObject', () => {
   });
 
   it('should return object unchanged when PROMPTFOO_DISABLE_TEMPLATING is true', async () => {
-    process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
     const obj = { text: '{{ variable }}' };
     const vars = { variable: 'test_value' };
     const rendered = renderVarsInObject(obj, vars);
@@ -182,47 +183,47 @@ describe('renderVarsInObject', () => {
 
 describe('renderEnvOnlyInObject', () => {
   beforeEach(() => {
-    delete process.env.TEST_ENV_VAR;
-    delete process.env.AZURE_ENDPOINT;
-    delete process.env.API_VERSION;
-    delete process.env.PORT;
-    delete process.env.API_HOST;
-    delete process.env.BASE_URL;
-    delete process.env.EMPTY_VAR;
-    delete process.env.SPECIAL_CHARS;
-    delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+    mockProcessEnv({ TEST_ENV_VAR: undefined });
+    mockProcessEnv({ AZURE_ENDPOINT: undefined });
+    mockProcessEnv({ API_VERSION: undefined });
+    mockProcessEnv({ PORT: undefined });
+    mockProcessEnv({ API_HOST: undefined });
+    mockProcessEnv({ BASE_URL: undefined });
+    mockProcessEnv({ EMPTY_VAR: undefined });
+    mockProcessEnv({ SPECIAL_CHARS: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
   });
 
   afterEach(() => {
-    delete process.env.TEST_ENV_VAR;
-    delete process.env.AZURE_ENDPOINT;
-    delete process.env.API_VERSION;
-    delete process.env.PORT;
-    delete process.env.API_HOST;
-    delete process.env.BASE_URL;
-    delete process.env.EMPTY_VAR;
-    delete process.env.SPECIAL_CHARS;
-    delete process.env.PROMPTFOO_DISABLE_TEMPLATING;
+    mockProcessEnv({ TEST_ENV_VAR: undefined });
+    mockProcessEnv({ AZURE_ENDPOINT: undefined });
+    mockProcessEnv({ API_VERSION: undefined });
+    mockProcessEnv({ PORT: undefined });
+    mockProcessEnv({ API_HOST: undefined });
+    mockProcessEnv({ BASE_URL: undefined });
+    mockProcessEnv({ EMPTY_VAR: undefined });
+    mockProcessEnv({ SPECIAL_CHARS: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: undefined });
   });
 
   describe('Basic rendering', () => {
     it('should render simple dot notation env vars', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       expect(renderEnvOnlyInObject('{{ env.TEST_ENV_VAR }}')).toBe('env_value');
     });
 
     it('should render bracket notation with single quotes', async () => {
-      process.env['VAR-WITH-DASH'] = 'dash_value';
+      mockProcessEnv({ ['VAR-WITH-DASH']: 'dash_value' });
       expect(renderEnvOnlyInObject("{{ env['VAR-WITH-DASH'] }}")).toBe('dash_value');
     });
 
     it('should render bracket notation with double quotes', async () => {
-      process.env['VAR_NAME'] = 'value';
+      mockProcessEnv({ ['VAR_NAME']: 'value' });
       expect(renderEnvOnlyInObject('{{ env["VAR_NAME"] }}')).toBe('value');
     });
 
     it('should handle whitespace variations', async () => {
-      process.env.TEST = 'value';
+      mockProcessEnv({ TEST: 'value' });
       expect(renderEnvOnlyInObject('{{env.TEST}}')).toBe('value');
       expect(renderEnvOnlyInObject('{{  env.TEST  }}')).toBe('value');
       expect(renderEnvOnlyInObject('{{ env.TEST}}')).toBe('value');
@@ -230,12 +231,12 @@ describe('renderEnvOnlyInObject', () => {
     });
 
     it('should render empty string env vars', async () => {
-      process.env.EMPTY_VAR = '';
+      mockProcessEnv({ EMPTY_VAR: '' });
       expect(renderEnvOnlyInObject('{{ env.EMPTY_VAR }}')).toBe('');
     });
 
     it('should render env vars with special characters in value', async () => {
-      process.env.SPECIAL_CHARS = 'value with spaces & $pecial chars!';
+      mockProcessEnv({ SPECIAL_CHARS: 'value with spaces & $pecial chars!' });
       expect(renderEnvOnlyInObject('{{ env.SPECIAL_CHARS }}')).toBe(
         'value with spaces & $pecial chars!',
       );
@@ -244,34 +245,34 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Filters and expressions (NEW functionality)', () => {
     it('should support default filter with fallback', async () => {
-      process.env.EXISTING = 'exists';
+      mockProcessEnv({ EXISTING: 'exists' });
       expect(renderEnvOnlyInObject("{{ env.EXISTING | default('fallback') }}")).toBe('exists');
       // NEW: When env var doesn't exist but has default filter, Nunjucks renders it
       expect(renderEnvOnlyInObject("{{ env.NONEXISTENT | default('fallback') }}")).toBe('fallback');
     });
 
     it('should support upper filter', async () => {
-      process.env.LOWERCASE = 'lowercase';
+      mockProcessEnv({ LOWERCASE: 'lowercase' });
       expect(renderEnvOnlyInObject('{{ env.LOWERCASE | upper }}')).toBe('LOWERCASE');
     });
 
     it('should support lower filter', async () => {
-      process.env.UPPERCASE = 'UPPERCASE';
+      mockProcessEnv({ UPPERCASE: 'UPPERCASE' });
       expect(renderEnvOnlyInObject('{{ env.UPPERCASE | lower }}')).toBe('uppercase');
     });
 
     it('should support chained filters', async () => {
-      process.env.TEST = 'test';
+      mockProcessEnv({ TEST: 'test' });
       expect(renderEnvOnlyInObject("{{ env.TEST | default('x') | upper }}")).toBe('TEST');
     });
 
     it('should support complex filter expressions', async () => {
-      process.env.PORT = '8080';
+      mockProcessEnv({ PORT: '8080' });
       expect(renderEnvOnlyInObject('{{ env.PORT | int }}')).toBe('8080');
     });
 
     it('should handle filter with closing brace in argument', async () => {
-      process.env.VAR = 'value';
+      mockProcessEnv({ VAR: 'value' });
       // This is a tricky case: the default value contains }
       expect(renderEnvOnlyInObject("{{ env.VAR | default('}') }}")).toBe('value');
     });
@@ -279,21 +280,21 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Preservation of non-env templates', () => {
     it('should preserve vars templates', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       expect(renderEnvOnlyInObject('{{ env.TEST_ENV_VAR }}, {{ vars.myVar }}')).toBe(
         'env_value, {{ vars.myVar }}',
       );
     });
 
     it('should preserve prompt templates', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       expect(renderEnvOnlyInObject('{{ env.TEST_ENV_VAR }}, {{ prompt }}')).toBe(
         'env_value, {{ prompt }}',
       );
     });
 
     it('should preserve multiple non-env templates', async () => {
-      process.env.API_HOST = 'api.example.com';
+      mockProcessEnv({ API_HOST: 'api.example.com' });
       const template =
         'Host: {{ env.API_HOST }}, Message: {{ vars.msg }}, Context: {{ context }}, Prompt: {{ prompt }}';
       const expected =
@@ -308,7 +309,7 @@ describe('renderEnvOnlyInObject', () => {
     });
 
     it('should preserve env templates in _conversation runtime vars', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       const config = {
         tests: [
           {
@@ -355,8 +356,8 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Complex data structures', () => {
     it('should work with nested objects', async () => {
-      process.env.LEVEL1 = 'value1';
-      process.env.LEVEL2 = 'value2';
+      mockProcessEnv({ LEVEL1: 'value1' });
+      mockProcessEnv({ LEVEL2: 'value2' });
       const obj = {
         level1: {
           level2: {
@@ -378,14 +379,14 @@ describe('renderEnvOnlyInObject', () => {
     });
 
     it('should work with arrays', async () => {
-      process.env.ENV1 = 'value1';
-      process.env.ENV2 = 'value2';
+      mockProcessEnv({ ENV1: 'value1' });
+      mockProcessEnv({ ENV2: 'value2' });
       const arr = ['{{ env.ENV1 }}', '{{ vars.test }}', '{{ env.ENV2 }}', 42];
       expect(renderEnvOnlyInObject(arr)).toEqual(['value1', '{{ vars.test }}', 'value2', 42]);
     });
 
     it('should work with mixed nested structures', async () => {
-      process.env.API_KEY = 'secret123';
+      mockProcessEnv({ API_KEY: 'secret123' });
       const config = {
         api: {
           key: '{{ env.API_KEY }}',
@@ -431,7 +432,7 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Error handling', () => {
     it('should preserve template on Nunjucks render error', async () => {
-      process.env.TEST = 'value';
+      mockProcessEnv({ TEST: 'value' });
       // Malformed filter that would cause Nunjucks error
       const template = '{{ env.TEST | nonexistent_filter }}';
       const rendered = renderEnvOnlyInObject(template);
@@ -442,14 +443,14 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('PROMPTFOO_DISABLE_TEMPLATING flag', () => {
     it('should return unchanged when flag is set', async () => {
-      process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       expect(renderEnvOnlyInObject('{{ env.TEST_ENV_VAR }}')).toBe('{{ env.TEST_ENV_VAR }}');
     });
 
     it('should return unchanged objects when flag is set', async () => {
-      process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
-      process.env.TEST = 'value';
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
+      mockProcessEnv({ TEST: 'value' });
       const obj = { key: '{{ env.TEST }}' };
       expect(renderEnvOnlyInObject(obj)).toEqual({ key: '{{ env.TEST }}' });
     });
@@ -457,8 +458,8 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Real-world scenarios', () => {
     it('should handle Azure provider config with mixed templates', async () => {
-      process.env.AZURE_ENDPOINT = 'test.openai.azure.com';
-      process.env.API_VERSION = '2024-02-15';
+      mockProcessEnv({ AZURE_ENDPOINT: 'test.openai.azure.com' });
+      mockProcessEnv({ API_VERSION: '2024-02-15' });
       const config = {
         apiHost: '{{ env.AZURE_ENDPOINT }}',
         apiVersion: '{{ env.API_VERSION }}',
@@ -478,7 +479,7 @@ describe('renderEnvOnlyInObject', () => {
     });
 
     it('should handle HTTP provider with runtime vars', async () => {
-      process.env.BASE_URL = 'https://api.example.com';
+      mockProcessEnv({ BASE_URL: 'https://api.example.com' });
       const config = {
         url: '{{ env.BASE_URL }}/query',
         method: 'POST',
@@ -507,8 +508,8 @@ describe('renderEnvOnlyInObject', () => {
     });
 
     it('should handle complex provider config with filters', async () => {
-      process.env.API_HOST = 'api.example.com';
-      process.env.PORT = '8080';
+      mockProcessEnv({ API_HOST: 'api.example.com' });
+      mockProcessEnv({ PORT: '8080' });
       const config = {
         baseUrl: "{{ env.API_HOST | default('localhost') }}:{{ env.PORT }}",
         timeout: '{{ env.TIMEOUT | default(30000) }}',
@@ -529,18 +530,18 @@ describe('renderEnvOnlyInObject', () => {
 
   describe('Edge cases', () => {
     it('should handle multiple env vars in same string', async () => {
-      process.env.HOST = 'example.com';
-      process.env.PORT = '8080';
+      mockProcessEnv({ HOST: 'example.com' });
+      mockProcessEnv({ PORT: '8080' });
       expect(renderEnvOnlyInObject('{{ env.HOST }}:{{ env.PORT }}')).toBe('example.com:8080');
     });
 
     it('should handle env vars in middle of text', async () => {
-      process.env.NAME = 'World';
+      mockProcessEnv({ NAME: 'World' });
       expect(renderEnvOnlyInObject('Hello {{ env.NAME }}!')).toBe('Hello World!');
     });
 
     it('should handle templates with newlines', async () => {
-      process.env.VAR = 'value';
+      mockProcessEnv({ VAR: 'value' });
       expect(
         renderEnvOnlyInObject(`Line 1: {{ env.VAR }}
 Line 2: {{ vars.test }}`),
@@ -549,7 +550,7 @@ Line 2: {{ vars.test }}`);
     });
 
     it('should render env vars in strings longer than 50000 chars', async () => {
-      process.env.TEST_ENV_VAR = 'env_value';
+      mockProcessEnv({ TEST_ENV_VAR: 'env_value' });
       const padding = 'x'.repeat(60000);
       const template = `${padding} {{ env.TEST_ENV_VAR }} ${padding}`;
       expect(template.length).toBeGreaterThan(50000);
@@ -563,7 +564,7 @@ Line 2: {{ vars.test }}`);
     });
 
     it('should handle long strings with mixed env and non-env templates', async () => {
-      process.env.HOST = 'example.com';
+      mockProcessEnv({ HOST: 'example.com' });
       const padding = 'x'.repeat(60000);
       const template = `${padding} {{ env.HOST }} {{ vars.test }} ${padding}`;
       expect(renderEnvOnlyInObject(template)).toBe(
@@ -577,7 +578,7 @@ Line 2: {{ vars.test }}`);
     });
 
     it('should not confuse env in other contexts', async () => {
-      process.env.TEST = 'value';
+      mockProcessEnv({ TEST: 'value' });
       // Should not match "environment" or other words containing "env"
       expect(renderEnvOnlyInObject('environment {{ vars.test }}')).toBe(
         'environment {{ vars.test }}',

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -304,7 +304,7 @@ describe('analyzeTemplateReference', () => {
 });
 
 describe('getNunjucksEngine', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.resetModules();

--- a/test/util/templates.test.ts
+++ b/test/util/templates.test.ts
@@ -8,6 +8,7 @@ import {
   getNunjucksEngine,
   templateReferencesVariable,
 } from '../../src/util/templates';
+import { mockProcessEnv } from './utils';
 
 describe('extractVariablesFromTemplate', () => {
   it('should extract simple variables', () => {
@@ -307,11 +308,11 @@ describe('getNunjucksEngine', () => {
 
   beforeEach(() => {
     vi.resetModules();
-    process.env = { ...originalEnv };
+    mockProcessEnv({ ...originalEnv }, { clear: true });
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    mockProcessEnv(originalEnv, { clear: true });
   });
 
   it('should return a nunjucks environment by default', () => {
@@ -321,20 +322,20 @@ describe('getNunjucksEngine', () => {
   });
 
   it('should return a simple render function when PROMPTFOO_DISABLE_TEMPLATING is set', () => {
-    process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
     const engine = getNunjucksEngine();
     expect(engine.renderString('Hello {{ name }}', { name: 'World' })).toBe('Hello {{ name }}');
   });
 
   it('should return a nunjucks environment when isGrader is true, regardless of PROMPTFOO_DISABLE_TEMPLATING', () => {
-    process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
     const engine = getNunjucksEngine({}, false, true);
     expect(engine).toBeInstanceOf(nunjucks.Environment);
     expect(engine.renderString('Hello {{ name }}', { name: 'Grader' })).toBe('Hello Grader');
   });
 
   it('should use nunjucks when isGrader is true, even if PROMPTFOO_DISABLE_TEMPLATING is set', () => {
-    process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
     const engine = getNunjucksEngine({}, false, true);
     expect(engine).toBeInstanceOf(nunjucks.Environment);
     expect(engine.renderString('Hello {{ name }}', { name: 'Grader' })).toBe('Hello Grader');
@@ -372,7 +373,7 @@ describe('getNunjucksEngine', () => {
   });
 
   it('should add environment variables as globals under "env"', () => {
-    process.env.TEST_VAR = 'test_value';
+    mockProcessEnv({ TEST_VAR: 'test_value' });
     const engine = getNunjucksEngine();
     expect(engine.renderString('{{ env.TEST_VAR }}', {})).toBe('test_value');
   });
@@ -392,7 +393,7 @@ describe('getNunjucksEngine', () => {
   });
 
   it('should respect all parameters when provided', () => {
-    process.env.PROMPTFOO_DISABLE_TEMPLATING = 'true';
+    mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATING: 'true' });
     const customFilters = {
       double: (n: number) => (n * 2).toString(),
     };
@@ -406,7 +407,7 @@ describe('getNunjucksEngine', () => {
 
   describe('environment variables as globals', () => {
     it('should add environment variables as globals by default', () => {
-      process.env.TEST_VAR = 'test_value';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
       const engine = getNunjucksEngine();
       expect(engine.renderString('{{ env.TEST_VAR }}', {})).toBe('test_value');
     });
@@ -428,20 +429,20 @@ describe('getNunjucksEngine', () => {
     });
 
     it('should handle undefined cliState.config', () => {
-      process.env.TEST_VAR = 'test_value';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
       const engine = getNunjucksEngine();
       expect(engine.renderString('{{ env.TEST_VAR }}', {})).toBe('test_value');
     });
 
     it('should handle undefined cliState.config.env', () => {
-      process.env.TEST_VAR = 'test_value';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
       const engine = getNunjucksEngine();
       expect(engine.renderString('{{ env.TEST_VAR }}', {})).toBe('test_value');
     });
 
     it('should disable process.env but allow config env variables when PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS is true', () => {
-      process.env.TEST_VAR = 'test_value';
-      process.env.PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS = 'true';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
+      mockProcessEnv({ PROMPTFOO_DISABLE_TEMPLATE_ENV_VARS: 'true' });
       const initialConfig = { ...cliState.config };
       cliState.config = {
         env: {
@@ -455,8 +456,8 @@ describe('getNunjucksEngine', () => {
     });
 
     it('should disable process.env but allow config env variables when PROMPTFOO_SELF_HOSTED is true', () => {
-      process.env.TEST_VAR = 'test_value';
-      process.env.PROMPTFOO_SELF_HOSTED = 'true';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
+      mockProcessEnv({ PROMPTFOO_SELF_HOSTED: 'true' });
       const initialConfig = { ...cliState.config };
       cliState.config = {
         env: {
@@ -470,7 +471,7 @@ describe('getNunjucksEngine', () => {
     });
 
     it('should handle empty config env object', () => {
-      process.env.TEST_VAR = 'test_value';
+      mockProcessEnv({ TEST_VAR: 'test_value' });
       const initialConfig = { ...cliState.config };
       cliState.config = {
         env: {},
@@ -481,7 +482,7 @@ describe('getNunjucksEngine', () => {
     });
 
     it('should prioritize config env variables over process.env when both exist', () => {
-      process.env.SHARED_VAR = 'process_value';
+      mockProcessEnv({ SHARED_VAR: 'process_value' });
       const initialConfig = { ...cliState.config };
       cliState.config = {
         env: {

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -324,7 +324,8 @@ describe('util', () => {
         const context = { vars: {}, prompt: {} };
         const transformFunction = `
           // process.env should still work
-          return typeof (process.env as NodeJS.ProcessEnv) === 'object' ? 'env-works' : 'env-broken';
+          const env = process.env;
+          return typeof env === 'object' ? 'env-works' : 'env-broken';
         `;
         const result = await transform(transformFunction, output, context);
         expect(result).toBe('env-works');

--- a/test/util/transform.test.ts
+++ b/test/util/transform.test.ts
@@ -324,7 +324,7 @@ describe('util', () => {
         const context = { vars: {}, prompt: {} };
         const transformFunction = `
           // process.env should still work
-          return typeof process.env === 'object' ? 'env-works' : 'env-broken';
+          return typeof (process.env as NodeJS.ProcessEnv) === 'object' ? 'env-works' : 'env-broken';
         `;
         const result = await transform(transformFunction, output, context);
         expect(result).toBe('env-works');

--- a/test/util/utils.test.ts
+++ b/test/util/utils.test.ts
@@ -14,9 +14,9 @@ function restoreTestEnv(): void {
   for (const key of envKeys) {
     const value = originalEnv[key];
     if (value === undefined) {
-      delete process.env[key];
+      mockProcessEnv({ [key]: undefined });
     } else {
-      process.env[key] = value;
+      mockProcessEnv({ [key]: value });
     }
   }
 }
@@ -29,14 +29,14 @@ afterEach(() => {
 
 describe('mockProcessEnv', () => {
   it('applies overrides and restores the previous environment snapshot', () => {
-    process.env.PROMPTFOO_TEST_UTIL_ORIGINAL = 'original';
+    mockProcessEnv({ PROMPTFOO_TEST_UTIL_ORIGINAL: 'original' });
 
     const restoreEnv = mockProcessEnv({
       PROMPTFOO_TEST_UTIL_ORIGINAL: 'override',
       PROMPTFOO_TEST_UTIL_OVERRIDE: 'set',
     });
 
-    process.env.PROMPTFOO_TEST_UTIL_CREATED = 'created-by-test';
+    mockProcessEnv({ PROMPTFOO_TEST_UTIL_CREATED: 'created-by-test' });
 
     expect(process.env.PROMPTFOO_TEST_UTIL_ORIGINAL).toBe('override');
     expect(process.env.PROMPTFOO_TEST_UTIL_OVERRIDE).toBe('set');
@@ -49,7 +49,7 @@ describe('mockProcessEnv', () => {
   });
 
   it('can start from an empty environment without replacing the process.env object', () => {
-    process.env.PROMPTFOO_TEST_UTIL_ORIGINAL = 'original';
+    mockProcessEnv({ PROMPTFOO_TEST_UTIL_ORIGINAL: 'original' });
     const envReference = process.env;
 
     const restoreEnv = mockProcessEnv(

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -87,7 +87,7 @@ export function mockConsole(
 
 function replaceProcessEnv(nextEnv: Record<string, string | undefined>): void {
   for (const key of Object.keys(process.env)) {
-    delete process.env[key];
+    Reflect.deleteProperty(process.env, key);
   }
   Object.assign(process.env, nextEnv);
 }
@@ -104,9 +104,9 @@ export function mockProcessEnv(
 
   for (const [key, value] of Object.entries(overrides)) {
     if (value === undefined) {
-      delete process.env[key];
+      Reflect.deleteProperty(process.env, key);
     } else {
-      process.env[key] = value;
+      Object.assign(process.env, { [key]: value });
     }
   }
 
@@ -134,7 +134,7 @@ export const PROXY_ENV_KEYS = [
 
 export function clearProxyEnv(): void {
   for (const key of PROXY_ENV_KEYS) {
-    delete process.env[key];
+    Reflect.deleteProperty(process.env, key);
   }
 }
 

--- a/tools/biome/no-direct-process-env-mutation.grit
+++ b/tools/biome/no-direct-process-env-mutation.grit
@@ -5,10 +5,172 @@ or {
   `process.env = $value` as $match where {
     register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
   },
+  `process.env += $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env -= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env *= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env /= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env %= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env **= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env <<= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env >>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env >>>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env &= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env |= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env ^= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env ||= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env &&= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env ??= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
   `process.env.$name = $value` as $match where {
     register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
   },
+  `process.env.$name += $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name -= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name *= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name /= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name %= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name **= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name <<= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name >>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name >>>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name &= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name |= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name ^= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name ||= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name &&= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name ??= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name++` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env.$name--` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `++process.env.$name` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `--process.env.$name` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
   `process.env[$name] = $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] += $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] -= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] *= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] /= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] %= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] **= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] <<= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] >>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] >>>= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] &= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] |= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] ^= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] ||= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] &&= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name] ??= $value` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name]++` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `process.env[$name]--` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `++process.env[$name]` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `--process.env[$name]` as $match where {
+    register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
+  },
+  `delete process.env` as $match where {
     register_diagnostic(span=$match, message="Use mockProcessEnv() or vi.stubEnv() instead of mutating process.env.", severity="error")
   },
   `delete process.env.$name` as $match where {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -12,23 +12,27 @@ import { afterAll, afterEach, vi } from 'vitest';
 const TEST_CONFIG_DIR = path.join('.local', 'vitest', 'config', `worker-${process.pid}`);
 
 // Set up test environment variables
-process.env.NODE_ENV = 'test';
-process.env.CODEX_HOME = './.local/vitest/codex-home';
-process.env.PROMPTFOO_CACHE_TYPE = 'memory';
-process.env.IS_TESTING = 'true';
-process.env.PROMPTFOO_CONFIG_DIR = TEST_CONFIG_DIR;
+Object.assign(process.env, {
+  NODE_ENV: 'test',
+  CODEX_HOME: './.local/vitest/codex-home',
+  PROMPTFOO_CACHE_TYPE: 'memory',
+  IS_TESTING: 'true',
+  PROMPTFOO_CONFIG_DIR: TEST_CONFIG_DIR,
+});
 
 // Set mock API keys to prevent authentication errors during tests
 // These are dummy values that allow provider instantiation without real credentials
-process.env.ANTHROPIC_API_KEY = 'test-anthropic-api-key';
-process.env.AZURE_OPENAI_API_HOST = 'test.openai.azure.com';
-process.env.AZURE_OPENAI_API_KEY = 'test-azure-api-key';
-process.env.AZURE_API_KEY = 'test-azure-api-key';
-process.env.HF_API_TOKEN = 'test-hf-token';
-process.env.OPENAI_API_KEY = 'test-openai-api-key';
+Object.assign(process.env, {
+  ANTHROPIC_API_KEY: 'test-anthropic-api-key',
+  AZURE_OPENAI_API_HOST: 'test.openai.azure.com',
+  AZURE_OPENAI_API_KEY: 'test-azure-api-key',
+  AZURE_API_KEY: 'test-azure-api-key',
+  HF_API_TOKEN: 'test-hf-token',
+  OPENAI_API_KEY: 'test-openai-api-key',
+});
 
 // Clean up any remote generation URL
-delete process.env.PROMPTFOO_REMOTE_GENERATION_URL;
+Reflect.deleteProperty(process.env, 'PROMPTFOO_REMOTE_GENERATION_URL');
 
 /**
  * Global cleanup after each test to prevent memory leaks.


### PR DESCRIPTION
## Summary

- Replaced every legacy direct `process.env` mutation in root test files with `mockProcessEnv()` or equivalent non-mutating read patterns.
- Emptied `legacyDirectProcessEnvMutationFiles` in `test/test-hygiene.test.ts` and removed the matching Biome exclusions.
- Hardened the root hygiene guard from regex matching to TypeScript AST matching so it catches compound/logical assignments, updates, `process["env"]`, mutating `Object`/`Reflect` calls, and reference snapshots without matching comments or strings.
- Expanded the Biome Grit plugin to block alternate direct `process.env` mutation syntax, including compound/logical assignments, update operators, dynamic keys, and `delete process.env`.

## Validation

- `npm run l`
- `npm run f`
- `npx vitest run test/test-hygiene.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `npm run lint:tests`
- Temporary Biome negative fixtures confirmed the plugin reports alternate mutation forms.
- `npx vitest run $(git diff --name-only --diff-filter=ACMRTUXB origin/main -- "test/**/*.test.ts" "test/*.test.ts") --sequence.shuffle=false`

All local checks passed. `npm run lint:tests` exits successfully with the existing complexity warnings in `test/assertions/meteor.test.ts` and `test/providers/google/gemini-mcp-integration.test.ts`.
