### PR TITLE
fix(code-scan): resolve code scanning findings

### DIFF
--- a/examples/openai-agents/promptfoo_tracing.py
+++ b/examples/openai-agents/promptfoo_tracing.py
@@ -19,7 +19,6 @@ from agents.tracing.spans import Span
 from agents.tracing.traces import Trace
 
 TRACEPARENT_RE = re.compile(r"^[\da-f]{2}-([\da-f]{32})-([\da-f]{16})-[\da-f]{2}$")
-_CURRENT_PROCESSOR: "PromptfooTracingProcessor | None" = None
 
 
 @dataclass(frozen=True)
@@ -361,6 +360,14 @@ class PromptfooTracingProcessor(TracingProcessor):
                     )
 
 
+class _TracingState:
+    def __init__(self) -> None:
+        self.processor: PromptfooTracingProcessor | None = None
+
+
+_TRACING_STATE = _TracingState()
+
+
 def _parse_traceparent(traceparent: str | None) -> tuple[str, str] | None:
     if not traceparent:
         return None
@@ -392,17 +399,15 @@ def configure_promptfoo_tracing(
 ) -> PromptfooTraceContext | None:
     """Configure the SDK to emit spans into Promptfoo for the current eval case."""
 
-    global _CURRENT_PROCESSOR
-
-    if _CURRENT_PROCESSOR is not None:
+    if _TRACING_STATE.processor is not None:
         try:
-            _CURRENT_PROCESSOR.shutdown()
+            _TRACING_STATE.processor.shutdown()
         except Exception as exc:
             print(
                 f"[promptfoo_tracing] Failed to shut down previous processor: {exc}",
                 file=sys.stderr,
             )
-        _CURRENT_PROCESSOR = None
+        _TRACING_STATE.processor = None
 
     parsed = _active_otel_parent() or _parse_traceparent(context.get("traceparent"))
     if parsed is None:
@@ -424,7 +429,7 @@ def configure_promptfoo_tracing(
     )
     set_trace_processors([processor])
     set_tracing_disabled(False)
-    _CURRENT_PROCESSOR = processor
+    _TRACING_STATE.processor = processor
 
     return PromptfooTraceContext(
         trace_id=trace_id,

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -259,12 +259,18 @@ export function maybeLoadConfigFromExternalFile(
       const isVarsField = key === 'vars';
 
       const childContext = isAssertionValue ? 'assertion' : isVarsField ? 'vars' : context;
-      Object.defineProperty(result, key, {
-        value: maybeLoadConfigFromExternalFile(config[key], childContext),
-        enumerable: true,
-        configurable: true,
-        writable: true,
-      });
+      const value = maybeLoadConfigFromExternalFile(config[key], childContext);
+
+      if (key === '__proto__') {
+        Object.defineProperty(result, key, {
+          value,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        result[key] = value;
+      }
     }
     return result;
   }

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -259,7 +259,12 @@ export function maybeLoadConfigFromExternalFile(
       const isVarsField = key === 'vars';
 
       const childContext = isAssertionValue ? 'assertion' : isVarsField ? 'vars' : context;
-      result[key] = maybeLoadConfigFromExternalFile(config[key], childContext);
+      Object.defineProperty(result, key, {
+        value: maybeLoadConfigFromExternalFile(config[key], childContext),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
     return result;
   }

--- a/test/evaluator/gradingConcurrency.test.ts
+++ b/test/evaluator/gradingConcurrency.test.ts
@@ -479,7 +479,7 @@ describeEvaluator('evaluator grading concurrency', () => {
     expect(gradingProvider.callApi).toHaveBeenCalledTimes(4);
   });
 
-  it('serializes async assert-set judges so grouping survives PROMPTFOO_ASSERTIONS_MAX_CONCURRENCY', async () => {
+  it('serializes async assert-set judges when provider call queue is active', async () => {
     // Regression: without forcing assertion concurrency to 1 when the grouping
     // queue is active, async graders inside an assert-set would interleave
     // judges across rows (judge-one row1, judge-two row1, judge-one row2, ...)
@@ -495,8 +495,8 @@ describeEvaluator('evaluator grading concurrency', () => {
     const makeAsyncJudge = (id: string): ApiProvider => ({
       id: vi.fn().mockReturnValue(id),
       callApi: vi.fn(async () => {
-        // Yield to the event loop a few times to expose any interleaving that
-        // `async.forEachOfLimit(ASSERTIONS_MAX_CONCURRENCY)` would produce.
+        // Intentionally yield through both queues so this regression test can
+        // expose the cross-row interleaving that assertion concurrency caused.
         await Promise.resolve();
         await new Promise((resolve) => setTimeout(resolve, 0));
         callOrder.push(id);

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -17,8 +17,7 @@ vi.mock('../../../src/util/fetch/index', () => ({
 }));
 
 vi.mock('../../../src/evaluatorHelpers', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  renderPrompt: (...args: any[]) => mockRenderPrompt(...args),
+  renderPrompt: (...args: unknown[]) => mockRenderPrompt(...args),
 }));
 
 vi.mock('../../../src/globalConfig/accounts', () => ({
@@ -49,10 +48,16 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     vi.mocked(neverGenerateRemote).mockReset();
     vi.mocked(neverGenerateRemote).mockReturnValue(false);
     mockRenderPrompt.mockReset();
-    mockRenderPrompt.mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (_prompt: any, vars: any) => vars.input || 'rendered prompt',
-    );
+    mockRenderPrompt.mockImplementation((_prompt: unknown, vars: unknown) => {
+      const input =
+        typeof vars === 'object' &&
+        vars !== null &&
+        'input' in vars &&
+        typeof (vars as { input?: unknown }).input === 'string'
+          ? (vars as { input: string }).input
+          : undefined;
+      return input || 'rendered prompt';
+    });
 
     // Dynamic import after mocks are set up
     const module = await import('../../../src/redteam/providers/bestOfN');

--- a/test/redteam/strategies/gcg.test.ts
+++ b/test/redteam/strategies/gcg.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchWithCache } from '../../../src/cache';
+import { type FetchWithCacheResult, fetchWithCache } from '../../../src/cache';
 import { getUserEmail, isLoggedIntoCloud } from '../../../src/globalConfig/accounts';
 import logger from '../../../src/logger';
 import {
@@ -10,6 +10,10 @@ import {
 import { addGcgTestCases, CONCURRENCY } from '../../../src/redteam/strategies/gcg';
 
 import type { TestCase } from '../../../src/types/index';
+
+type GcgGenerationResponse = {
+  responses: string[];
+};
 
 vi.mock('../../../src/cache');
 vi.mock('../../../src/globalConfig/accounts');
@@ -197,7 +201,9 @@ describe('gcg strategy', () => {
     let concurrentCalls = 0;
     let maxConcurrentCalls = 0;
 
-    mockFetchWithCache.mockImplementation(async function () {
+    mockFetchWithCache.mockImplementation(async function (): Promise<
+      FetchWithCacheResult<GcgGenerationResponse>
+    > {
       concurrentCalls++;
       maxConcurrentCalls = Math.max(maxConcurrentCalls, concurrentCalls);
       await new Promise((resolve) => setTimeout(resolve, 10));

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -543,8 +543,9 @@ describe('file utilities', () => {
     it('should handle objects with prototype pollution attempts safely', () => {
       vi.mocked(fs.readFileSync).mockReturnValueOnce('malicious content');
 
+      const protoKey = '__proto__';
       const config = {
-        __proto__: 'file://malicious.txt',
+        [protoKey]: 'file://malicious.txt',
         constructor: { normal: 'value' },
         prototype: ['safe', 'array'],
         normal: 'safe value',
@@ -553,11 +554,12 @@ describe('file utilities', () => {
       const result = maybeLoadConfigFromExternalFile(config);
 
       expect(result).toEqual({
-        __proto__: 'malicious content',
+        [protoKey]: 'malicious content',
         constructor: { normal: 'value' },
         prototype: ['safe', 'array'],
         normal: 'safe value',
       });
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
     });
 
     it('should handle very large nested structures efficiently', () => {

--- a/test/util/tokenUsageCompat.test.ts
+++ b/test/util/tokenUsageCompat.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../src/util/tokenUsageCompat';
 
 import type { SpanData } from '../../src/tracing/store';
+import type { TraceData } from '../../src/types/tracing';
 
 // Mock the TraceStore
 vi.mock('../../src/tracing/store', () => ({
@@ -27,20 +28,25 @@ vi.mock('../../src/util/tokenUsage', () => ({
 import { getTraceStore } from '../../src/tracing/store';
 
 describe('tokenUsageCompat', () => {
+  type TraceStoreType = ReturnType<typeof getTraceStore>;
+  type TokenUsageTrackerInstance = ReturnType<typeof TokenUsageTracker.getInstance>;
+
   const mockTraceStore = {
-    getSpans: vi.fn(),
-    getTracesByEvaluation: vi.fn(),
+    getSpans: vi.fn<TraceStoreType['getSpans']>(),
+    getTracesByEvaluation: vi.fn<TraceStoreType['getTracesByEvaluation']>(),
   };
 
   const mockTracker = {
-    getProviderUsage: vi.fn(),
-    getTotalUsage: vi.fn(),
+    getProviderUsage: vi.fn<TokenUsageTrackerInstance['getProviderUsage']>(),
+    getTotalUsage: vi.fn<TokenUsageTrackerInstance['getTotalUsage']>(),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getTraceStore).mockReturnValue(mockTraceStore as any);
-    vi.mocked(TokenUsageTracker.getInstance).mockReturnValue(mockTracker as any);
+    vi.mocked(getTraceStore).mockReturnValue(mockTraceStore as unknown as TraceStoreType);
+    vi.mocked(TokenUsageTracker.getInstance).mockReturnValue(
+      mockTracker as unknown as TokenUsageTrackerInstance,
+    );
   });
 
   afterEach(() => {
@@ -191,7 +197,7 @@ describe('tokenUsageCompat', () => {
         name: 'test',
         startTime: 0,
         attributes: {
-          'gen_ai.usage.input_tokens': 'not-a-number' as any,
+          'gen_ai.usage.input_tokens': 'not-a-number',
           'gen_ai.usage.output_tokens': 50,
         },
       };
@@ -359,9 +365,11 @@ describe('tokenUsageCompat', () => {
 
   describe('getTokenUsageFromEvaluation', () => {
     it('should aggregate usage from all traces in evaluation', async () => {
-      const traces = [
+      const traces: TraceData[] = [
         {
           traceId: 'trace-1',
+          evaluationId: 'eval-456',
+          testCaseId: 'test-1',
           spans: [
             {
               spanId: 'span-1',
@@ -377,6 +385,8 @@ describe('tokenUsageCompat', () => {
         },
         {
           traceId: 'trace-2',
+          evaluationId: 'eval-456',
+          testCaseId: 'test-2',
           spans: [
             {
               spanId: 'span-2',
@@ -430,9 +440,11 @@ describe('tokenUsageCompat', () => {
     });
 
     it('should use OTEL data when evalId is provided', async () => {
-      const traces = [
+      const traces: TraceData[] = [
         {
           traceId: 'trace-1',
+          evaluationId: 'eval-456',
+          testCaseId: 'test-1',
           spans: [
             {
               spanId: 'span-1',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -8,31 +8,24 @@ import { rmSync } from 'node:fs';
 import path from 'node:path';
 
 import { afterAll, afterEach, vi } from 'vitest';
+import { mockProcessEnv } from './test/util/utils';
 
 const TEST_CONFIG_DIR = path.join('.local', 'vitest', 'config', `worker-${process.pid}`);
 
-// Set up test environment variables
-Object.assign(process.env, {
+mockProcessEnv({
   NODE_ENV: 'test',
   CODEX_HOME: './.local/vitest/codex-home',
   PROMPTFOO_CACHE_TYPE: 'memory',
   IS_TESTING: 'true',
   PROMPTFOO_CONFIG_DIR: TEST_CONFIG_DIR,
-});
-
-// Set mock API keys to prevent authentication errors during tests
-// These are dummy values that allow provider instantiation without real credentials
-Object.assign(process.env, {
   ANTHROPIC_API_KEY: 'test-anthropic-api-key',
   AZURE_OPENAI_API_HOST: 'test.openai.azure.com',
   AZURE_OPENAI_API_KEY: 'test-azure-api-key',
   AZURE_API_KEY: 'test-azure-api-key',
   HF_API_TOKEN: 'test-hf-token',
   OPENAI_API_KEY: 'test-openai-api-key',
+  PROMPTFOO_REMOTE_GENERATION_URL: undefined,
 });
-
-// Clean up any remote generation URL
-Reflect.deleteProperty(process.env, 'PROMPTFOO_REMOTE_GENERATION_URL');
 
 /**
  * Global cleanup after each test to prevent memory leaks.


### PR DESCRIPTION
## Summary

- Replace the Python tracing example's unused module-level processor assignment with a small tracing state holder.
- Preserve own `__proto__` config keys as data properties when loading external file references, and update the regression test accordingly.
- Address the reported test quality findings by tightening mock types, clarifying concurrency test wording, and using `mockProcessEnv` in Vitest setup.

## Validation

- `npm run l` (passes with existing complexity warnings in `src/util/file.ts`)
- `npm run f` (passes with existing complexity warnings in `src/util/file.ts`)
- `npm run tsc`
- `npx vitest run test/util/file.test.ts test/evaluator/gradingConcurrency.test.ts test/redteam/providers/bestOfN.test.ts test/redteam/strategies/gcg.test.ts test/util/tokenUsageCompat.test.ts`
- `python3 -m py_compile examples/openai-agents/promptfoo_tracing.py`
- `git diff --check`