### PR TITLE
fix(assertions): support Vercel AI SDK tool-call spans

### DIFF
--- a/examples/integration-opentelemetry/javascript/README.md
+++ b/examples/integration-opentelemetry/javascript/README.md
@@ -163,6 +163,8 @@ The trajectory-specific config at `promptfooconfig.trajectory.yaml` adds:
 - `trajectory:tool-sequence`
 - `trajectory:step-count`
 
+Promptfoo accepts generic tool span attributes such as `tool.name` and `tool.arguments`, and it also recognizes Vercel AI SDK telemetry attributes such as `ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`.
+
 ## Viewing Traces
 
 After running an evaluation, view traces in the web UI:

--- a/examples/integration-opentelemetry/javascript/promptfooconfig.trajectory.yaml
+++ b/examples/integration-opentelemetry/javascript/promptfooconfig.trajectory.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: Trajectory assertions with OpenTelemetry traces
 
+# Promptfoo accepts generic tool span attributes like tool.name/tool.arguments
+# and Vercel AI SDK telemetry attributes like ai.toolCall.name/ai.toolCall.args.
+
 prompts:
   - 'Explain how {{topic}} works in simple terms'
 

--- a/examples/integration-vercel/ai-sdk/README.md
+++ b/examples/integration-vercel/ai-sdk/README.md
@@ -117,3 +117,8 @@ return {
 
 - [Vercel AI SDK Documentation](https://ai-sdk.dev)
 - [promptfoo Custom Providers](https://promptfoo.dev/docs/providers/custom-api)
+- [Promptfoo tracing and trajectory assertions](https://promptfoo.dev/docs/tracing/)
+
+## Tool Telemetry
+
+If you enable Vercel AI SDK `experimental_telemetry` for tool-calling workflows, Promptfoo trajectory assertions can normalize the SDK's tool-call spans from `ai.toolCall.name` plus the matching `ai.toolCall.args`, `ai.toolCall.arguments`, or `ai.toolCall.input` attributes.

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -683,6 +683,8 @@ The `trajectory:tool-used` assertion checks traced tool steps rather than the mo
 Trajectory assertions require trace data. Enable tracing for the eval and use a provider that emits tool-oriented spans or attributes.
 :::
 
+Promptfoo identifies tool names from attributes such as `tool.name`, `function.name`, and Vercel AI SDK telemetry's `ai.toolCall.name`.
+
 Example:
 
 ```yaml
@@ -740,7 +742,7 @@ tests:
 
 In `partial` mode, object properties are matched recursively as a subset. In `exact` mode, the entire argument payload must match exactly.
 
-Promptfoo looks for tool arguments in span attributes such as `tool.arguments`, `tool.args`, `tool.input`, `function.arguments`, `args`, `arguments`, and `input`. String values are parsed as JSON when possible.
+Promptfoo looks for tool arguments in span attributes such as `tool.arguments`, `tool.args`, `tool.input`, `function.arguments`, `args`, `arguments`, `input`, and Vercel AI SDK telemetry's `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. String values are parsed as JSON when possible.
 
 ### trajectory:tool-sequence {#trajectorytool-sequence}
 

--- a/site/docs/providers/vercel.md
+++ b/site/docs/providers/vercel.md
@@ -9,6 +9,8 @@ description: Access OpenAI, Anthropic, Google, and 20+ AI providers through Verc
 
 [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) provides a unified interface to access AI models from 20+ providers through a single API. This provider uses the official [Vercel AI SDK](https://ai-sdk.dev/).
 
+If you call the Vercel AI SDK directly from a [`file://` custom provider](/docs/providers/custom-api/) and enable `experimental_telemetry`, Promptfoo's [trajectory assertions](/docs/configuration/expected-outputs/deterministic/#trajectorytool-used) can normalize the SDK's tool-call spans from `ai.toolCall.name` plus the matching `ai.toolCall.args`, `ai.toolCall.arguments`, or `ai.toolCall.input` attributes.
+
 ## Setup
 
 1. Enable AI Gateway in your [Vercel Dashboard](https://vercel.com/dashboard)

--- a/site/docs/red-team/llm-agents.md
+++ b/site/docs/red-team/llm-agents.md
@@ -421,7 +421,7 @@ redteam:
     - jailbreak:composite
 ```
 
-For useful trajectories, your agent or provider needs to emit spans that identify internal steps. Add attributes such as `tool.name`, `tool.arguments`, `command`, `search.query`, or guardrail decision fields. Built-in providers emit provider-level GenAI spans automatically, but deeper agent evidence requires instrumenting the agent workflow or using a provider that already streams tool and command spans. Keep `spanFilter` aligned with the span names your agent emits; it uses case-insensitive substring matching, not wildcards or regex, so values like `llm.` and `tool.` will match spans such as `llm.chat.completions` or `tool.database_query`. Overly narrow filters can hide the evidence you want graders or assertions to inspect.
+For useful trajectories, your agent or provider needs to emit spans that identify internal steps. Add attributes such as `tool.name`, `tool.arguments`, Vercel AI SDK `ai.toolCall.name`, `ai.toolCall.args`, `command`, `search.query`, or guardrail decision fields. Built-in providers emit provider-level GenAI spans automatically, but deeper agent evidence requires instrumenting the agent workflow or using a provider that already streams tool and command spans. Keep `spanFilter` aligned with the span names your agent emits; it uses case-insensitive substring matching, not wildcards or regex, so values like `llm.` and `tool.` will match spans such as `llm.chat.completions` or `tool.database_query`. Overly narrow filters can hide the evidence you want graders or assertions to inspect.
 
 #### How Trace Feedback Improves Attacks
 

--- a/site/docs/tracing.md
+++ b/site/docs/tracing.md
@@ -233,7 +233,7 @@ tests:
         provider: openai:gpt-5-mini
 ```
 
-Use trajectory assertions when your spans identify tools, commands, searches, reasoning steps, or messages. Promptfoo also normalizes common command-like tool spans, including OpenAI Agents SDK `exec_command` calls with `cmd` arguments, into command trajectory steps. If you only need raw span counts, durations, or error detection, use [`trace-span-count`](/docs/configuration/expected-outputs/deterministic/#trace-span-count), [`trace-span-duration`](/docs/configuration/expected-outputs/deterministic/#trace-span-duration), or [`trace-error-spans`](/docs/configuration/expected-outputs/deterministic/#trace-error-spans).
+Use trajectory assertions when your spans identify tools, commands, searches, reasoning steps, or messages. Promptfoo also normalizes common command-like tool spans, including OpenAI Agents SDK `exec_command` calls with `cmd` arguments, into command trajectory steps. For traced tool calls, Promptfoo recognizes both generic attributes such as `tool.name` and `tool.arguments` and framework-specific ones such as Vercel AI SDK's `ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. If you only need raw span counts, durations, or error detection, use [`trace-span-count`](/docs/configuration/expected-outputs/deterministic/#trace-span-count), [`trace-span-duration`](/docs/configuration/expected-outputs/deterministic/#trace-span-duration), or [`trace-error-spans`](/docs/configuration/expected-outputs/deterministic/#trace-error-spans).
 
 ## Configuration Reference
 
@@ -309,6 +309,7 @@ Key points:
 - Create child spans for each operation
 - Set appropriate span attributes and status
 - Add tool-oriented attributes like `tool.name` or `function.name` when you want to use trajectory assertions
+- If you use Vercel AI SDK telemetry for tool calls, Promptfoo can normalize `ai.toolCall.name` plus the matching `ai.toolCall.args` / `ai.toolCall.arguments` / `ai.toolCall.input` attributes into trajectory tool steps
 
 ### Python
 

--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -27,15 +27,15 @@ export interface TrajectoryStep {
 }
 
 const TOOL_ARGUMENT_ATTRIBUTE_KEYS = [
-  'ai.toolCall.args',
-  'ai.toolCall.arguments',
-  'ai.toolCall.input',
   'tool.arguments',
   'tool.args',
   'tool.input',
   'tool_arguments',
   'tool_args',
   'tool_input',
+  'ai.toolCall.args',
+  'ai.toolCall.arguments',
+  'ai.toolCall.input',
   'function.arguments',
   'function.args',
   'function.input',
@@ -172,6 +172,20 @@ function extractToolName(span: TraceSpan): string | undefined {
   const directMatch = getToolNameFromAttributes(attributes);
   if (directMatch) {
     return directMatch;
+  }
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value !== 'string' || !value.trim()) {
+      continue;
+    }
+
+    if (/tool.?name|function.?name/i.test(key)) {
+      return value.trim();
+    }
+
+    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output/i.test(key)) {
+      return value.trim();
+    }
   }
 
   if (span.name.startsWith('mcp ')) {

--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -1,4 +1,4 @@
-import { getToolNameFromAttributes } from '../tracing/toolAttributes';
+import { getFirstStringAttribute, getToolNameFromAttributes } from '../tracing/toolAttributes';
 import { matchesPattern } from './traceUtils';
 
 import type { TraceData, TraceSpan } from '../types/tracing';
@@ -27,34 +27,34 @@ export interface TrajectoryStep {
 }
 
 const TOOL_ARGUMENT_ATTRIBUTE_KEYS = [
-  'tool.arguments',
-  'tool.args',
-  'tool.input',
-  'tool_arguments',
-  'tool_args',
-  'tool_input',
+  'agent.tool.args',
+  'agent.tool.arguments',
+  'agent.tool.input',
   'ai.toolCall.args',
   'ai.toolCall.arguments',
   'ai.toolCall.input',
-  'function.arguments',
-  'function.args',
-  'function.input',
-  'function_arguments',
-  'function_args',
-  'gen_ai.tool.arguments',
-  'gen_ai.tool.args',
-  'gen_ai.tool.input',
-  'gen_ai.tool.call.arguments',
-  'gen_ai.tool.call.args',
-  'agent.tool.arguments',
-  'agent.tool.args',
-  'agent.tool.input',
-  'codex.mcp.arguments',
-  'codex.mcp.args',
-  'codex.mcp.input',
-  'arguments',
   'args',
+  'arguments',
+  'codex.mcp.args',
+  'codex.mcp.arguments',
+  'codex.mcp.input',
+  'function.args',
+  'function.arguments',
+  'function.input',
+  'function_args',
+  'function_arguments',
+  'gen_ai.tool.args',
+  'gen_ai.tool.arguments',
+  'gen_ai.tool.call.args',
+  'gen_ai.tool.call.arguments',
+  'gen_ai.tool.input',
   'input',
+  'tool.args',
+  'tool.arguments',
+  'tool.input',
+  'tool_args',
+  'tool_arguments',
+  'tool_input',
 ] as const;
 
 const COMMAND_ATTRIBUTE_KEYS = [
@@ -91,19 +91,6 @@ interface JudgeTrajectoryStep {
 
 interface OmittedJudgeTrajectorySteps {
   omittedCount: number;
-}
-
-function getStringAttribute(
-  attributes: TrajectoryAttributes,
-  keys: readonly string[],
-): string | undefined {
-  for (const key of keys) {
-    const value = attributes[key];
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim();
-    }
-  }
-  return undefined;
 }
 
 function normalizeStructuredAttribute(value: unknown): unknown {
@@ -233,7 +220,7 @@ function extractCommand(
 ): string | undefined {
   const attributes = span.attributes || {};
 
-  const directMatch = getStringAttribute(attributes, COMMAND_ATTRIBUTE_KEYS);
+  const directMatch = getFirstStringAttribute(attributes, COMMAND_ATTRIBUTE_KEYS);
   if (directMatch) {
     return directMatch;
   }
@@ -276,12 +263,12 @@ function extractCommand(
 function extractSearchQuery(span: TraceSpan): string | undefined {
   const attributes = span.attributes || {};
 
-  const directMatch = getStringAttribute(attributes, SEARCH_ATTRIBUTE_KEYS);
+  const directMatch = getFirstStringAttribute(attributes, SEARCH_ATTRIBUTE_KEYS);
   if (directMatch) {
     return directMatch;
   }
 
-  const genericQuery = getStringAttribute(attributes, GENERIC_QUERY_ATTRIBUTE_KEYS);
+  const genericQuery = getFirstStringAttribute(attributes, GENERIC_QUERY_ATTRIBUTE_KEYS);
   if (genericQuery && isSearchLikeSpan(span)) {
     return genericQuery;
   }

--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -1,3 +1,4 @@
+import { getToolNameFromAttributes } from '../tracing/toolAttributes';
 import { matchesPattern } from './traceUtils';
 
 import type { TraceData, TraceSpan } from '../types/tracing';
@@ -25,20 +26,10 @@ export interface TrajectoryStep {
   type: TrajectoryStepType;
 }
 
-const TOOL_ATTRIBUTE_KEYS = [
-  'tool.name',
-  'tool_name',
-  'tool',
-  'function.name',
-  'function_name',
-  'gen_ai.tool.name',
-  'codex.mcp.tool',
-  'agent.tool',
-  'agent.tool_name',
-  'agent.toolName',
-] as const;
-
 const TOOL_ARGUMENT_ATTRIBUTE_KEYS = [
+  'ai.toolCall.args',
+  'ai.toolCall.arguments',
+  'ai.toolCall.input',
   'tool.arguments',
   'tool.args',
   'tool.input',
@@ -178,23 +169,9 @@ function isCommandToolName(toolName: string | undefined): boolean {
 function extractToolName(span: TraceSpan): string | undefined {
   const attributes = span.attributes || {};
 
-  const directMatch = getStringAttribute(attributes, TOOL_ATTRIBUTE_KEYS);
+  const directMatch = getToolNameFromAttributes(attributes);
   if (directMatch) {
     return directMatch;
-  }
-
-  for (const [key, value] of Object.entries(attributes)) {
-    if (typeof value !== 'string' || !value.trim()) {
-      continue;
-    }
-
-    if (/tool.?name|function.?name/i.test(key)) {
-      return value.trim();
-    }
-
-    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output/i.test(key)) {
-      return value.trim();
-    }
   }
 
   if (span.name.startsWith('mcp ')) {

--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -1,4 +1,8 @@
-import { getFirstStringAttribute, getToolNameFromAttributes } from '../tracing/toolAttributes';
+import {
+  getFirstStringAttribute,
+  getToolNameFromAttributes,
+  TOOL_ARGUMENT_ATTRIBUTE_KEYS,
+} from '../tracing/toolAttributes';
 import { matchesPattern } from './traceUtils';
 
 import type { TraceData, TraceSpan } from '../types/tracing';
@@ -25,37 +29,6 @@ export interface TrajectoryStep {
   statusMessage?: string;
   type: TrajectoryStepType;
 }
-
-const TOOL_ARGUMENT_ATTRIBUTE_KEYS = [
-  'agent.tool.args',
-  'agent.tool.arguments',
-  'agent.tool.input',
-  'ai.toolCall.args',
-  'ai.toolCall.arguments',
-  'ai.toolCall.input',
-  'args',
-  'arguments',
-  'codex.mcp.args',
-  'codex.mcp.arguments',
-  'codex.mcp.input',
-  'function.args',
-  'function.arguments',
-  'function.input',
-  'function_args',
-  'function_arguments',
-  'gen_ai.tool.args',
-  'gen_ai.tool.arguments',
-  'gen_ai.tool.call.args',
-  'gen_ai.tool.call.arguments',
-  'gen_ai.tool.input',
-  'input',
-  'tool.args',
-  'tool.arguments',
-  'tool.input',
-  'tool_args',
-  'tool_arguments',
-  'tool_input',
-] as const;
 
 const COMMAND_ATTRIBUTE_KEYS = [
   'codex.command',

--- a/src/redteam/providers/traceFormatting.ts
+++ b/src/redteam/providers/traceFormatting.ts
@@ -1,4 +1,4 @@
-import { TraceContextData, TraceSpan } from '../../tracing/traceContext';
+import { getToolNameFromAttributes, TraceContextData, TraceSpan } from '../../tracing/traceContext';
 
 const DEFAULT_MAX_SPANS = 10;
 
@@ -27,7 +27,7 @@ function formatSpan(span: TraceSpan): string {
     `[${duration}] ${span.name}${span.kind && span.kind !== 'unspecified' ? ` (${span.kind})` : ''}`,
   );
 
-  const tool = span.attributes['tool.name'] || span.attributes['tool_name'];
+  const tool = getToolNameFromAttributes(span.attributes);
   if (tool) {
     parts.push(`tool=${tool}`);
   }

--- a/src/redteam/providers/traceFormatting.ts
+++ b/src/redteam/providers/traceFormatting.ts
@@ -1,4 +1,5 @@
-import { getToolNameFromAttributes, TraceContextData, TraceSpan } from '../../tracing/traceContext';
+import { getToolNameFromAttributes } from '../../tracing/toolAttributes';
+import { TraceContextData, TraceSpan } from '../../tracing/traceContext';
 
 const DEFAULT_MAX_SPANS = 10;
 

--- a/src/tracing/toolAttributes.ts
+++ b/src/tracing/toolAttributes.ts
@@ -42,30 +42,21 @@ const TOOL_ATTRIBUTE_FAMILIES: readonly ToolAttributeFamily[] = [
   },
 ];
 
-const BARE_ARG_KEYS = ['args', 'arguments', 'input'] as const;
-
-function buildFamilyKeys(kind: 'name' | 'arg'): readonly string[] {
-  const keys: string[] = [];
-  for (const family of TOOL_ATTRIBUTE_FAMILIES) {
-    const suffixes = kind === 'name' ? family.nameSuffixes : family.argSuffixes;
-    if (suffixes) {
-      for (const suffix of suffixes) {
-        keys.push(`${family.prefix}${suffix}`);
-      }
-    }
-    const extras = kind === 'name' ? family.extraNameKeys : family.extraArgKeys;
-    if (extras) {
-      keys.push(...extras);
-    }
-  }
-  return keys;
-}
-
-export const TOOL_NAME_ATTRIBUTE_KEYS: readonly string[] = buildFamilyKeys('name');
+export const TOOL_NAME_ATTRIBUTE_KEYS: readonly string[] = TOOL_ATTRIBUTE_FAMILIES.flatMap(
+  (family) => [
+    ...(family.nameSuffixes ?? []).map((suffix) => `${family.prefix}${suffix}`),
+    ...(family.extraNameKeys ?? []),
+  ],
+);
 
 export const TOOL_ARGUMENT_ATTRIBUTE_KEYS: readonly string[] = [
-  ...buildFamilyKeys('arg'),
-  ...BARE_ARG_KEYS,
+  ...TOOL_ATTRIBUTE_FAMILIES.flatMap((family) => [
+    ...(family.argSuffixes ?? []).map((suffix) => `${family.prefix}${suffix}`),
+    ...(family.extraArgKeys ?? []),
+  ]),
+  'args',
+  'arguments',
+  'input',
 ];
 
 export function getFirstStringAttribute(

--- a/src/tracing/toolAttributes.ts
+++ b/src/tracing/toolAttributes.ts
@@ -1,16 +1,72 @@
-const TOOL_NAME_ATTRIBUTE_KEYS = [
-  'tool.name',
-  'tool_name',
-  'ai.toolCall.name',
-  'tool',
-  'function.name',
-  'function_name',
-  'gen_ai.tool.name',
-  'codex.mcp.tool',
-  'agent.tool',
-  'agent.tool_name',
-  'agent.toolName',
-] as const;
+type ToolAttributeFamily = {
+  prefix: string;
+  nameSuffixes?: readonly string[];
+  argSuffixes?: readonly string[];
+  extraNameKeys?: readonly string[];
+  extraArgKeys?: readonly string[];
+};
+
+const TOOL_ATTRIBUTE_FAMILIES: readonly ToolAttributeFamily[] = [
+  {
+    prefix: 'tool',
+    nameSuffixes: ['.name', '_name'],
+    argSuffixes: ['.args', '.arguments', '.input', '_args', '_arguments', '_input'],
+    extraNameKeys: ['tool'],
+  },
+  {
+    prefix: 'function',
+    nameSuffixes: ['.name', '_name'],
+    argSuffixes: ['.args', '.arguments', '.input', '_args', '_arguments'],
+  },
+  {
+    prefix: 'ai.toolCall',
+    nameSuffixes: ['.name'],
+    argSuffixes: ['.args', '.arguments', '.input'],
+  },
+  {
+    prefix: 'gen_ai.tool',
+    nameSuffixes: ['.name'],
+    argSuffixes: ['.args', '.arguments', '.input'],
+    extraArgKeys: ['gen_ai.tool.call.args', 'gen_ai.tool.call.arguments'],
+  },
+  {
+    prefix: 'agent.tool',
+    nameSuffixes: ['_name'],
+    argSuffixes: ['.args', '.arguments', '.input'],
+    extraNameKeys: ['agent.tool', 'agent.toolName'],
+  },
+  {
+    prefix: 'codex.mcp',
+    argSuffixes: ['.args', '.arguments', '.input'],
+    extraNameKeys: ['codex.mcp.tool'],
+  },
+];
+
+const BARE_ARG_KEYS = ['args', 'arguments', 'input'] as const;
+
+function buildFamilyKeys(kind: 'name' | 'arg'): readonly string[] {
+  const keys: string[] = [];
+  for (const family of TOOL_ATTRIBUTE_FAMILIES) {
+    const suffixes = kind === 'name' ? family.nameSuffixes : family.argSuffixes;
+    if (suffixes) {
+      for (const suffix of suffixes) {
+        keys.push(`${family.prefix}${suffix}`);
+      }
+    }
+    const extras = kind === 'name' ? family.extraNameKeys : family.extraArgKeys;
+    if (extras) {
+      keys.push(...extras);
+    }
+  }
+  return keys;
+}
+
+export const TOOL_NAME_ATTRIBUTE_KEYS: readonly string[] = buildFamilyKeys('name');
+
+export const TOOL_ARGUMENT_ATTRIBUTE_KEYS: readonly string[] = [
+  ...buildFamilyKeys('arg'),
+  ...BARE_ARG_KEYS,
+];
 
 export function getFirstStringAttribute(
   attributes: Record<string, unknown> | undefined,

--- a/src/tracing/toolAttributes.ts
+++ b/src/tracing/toolAttributes.ts
@@ -26,19 +26,5 @@ export function getToolNameFromAttributes(
     }
   }
 
-  for (const [key, value] of Object.entries(attributes)) {
-    if (typeof value !== 'string' || !value.trim()) {
-      continue;
-    }
-
-    if (/tool.?name|function.?name/i.test(key)) {
-      return value.trim();
-    }
-
-    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output/i.test(key)) {
-      return value.trim();
-    }
-  }
-
   return undefined;
 }

--- a/src/tracing/toolAttributes.ts
+++ b/src/tracing/toolAttributes.ts
@@ -12,14 +12,15 @@ const TOOL_NAME_ATTRIBUTE_KEYS = [
   'agent.toolName',
 ] as const;
 
-export function getToolNameFromAttributes(
+export function getFirstStringAttribute(
   attributes: Record<string, unknown> | undefined,
+  keys: readonly string[],
 ): string | undefined {
   if (!attributes) {
     return undefined;
   }
 
-  for (const key of TOOL_NAME_ATTRIBUTE_KEYS) {
+  for (const key of keys) {
     const value = attributes[key];
     if (typeof value === 'string' && value.trim()) {
       return value.trim();
@@ -27,4 +28,10 @@ export function getToolNameFromAttributes(
   }
 
   return undefined;
+}
+
+export function getToolNameFromAttributes(
+  attributes: Record<string, unknown> | undefined,
+): string | undefined {
+  return getFirstStringAttribute(attributes, TOOL_NAME_ATTRIBUTE_KEYS);
 }

--- a/src/tracing/toolAttributes.ts
+++ b/src/tracing/toolAttributes.ts
@@ -1,0 +1,44 @@
+const TOOL_NAME_ATTRIBUTE_KEYS = [
+  'tool.name',
+  'tool_name',
+  'ai.toolCall.name',
+  'tool',
+  'function.name',
+  'function_name',
+  'gen_ai.tool.name',
+  'codex.mcp.tool',
+  'agent.tool',
+  'agent.tool_name',
+  'agent.toolName',
+] as const;
+
+export function getToolNameFromAttributes(
+  attributes: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!attributes) {
+    return undefined;
+  }
+
+  for (const key of TOOL_NAME_ATTRIBUTE_KEYS) {
+    const value = attributes[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value !== 'string' || !value.trim()) {
+      continue;
+    }
+
+    if (/tool.?name|function.?name/i.test(key)) {
+      return value.trim();
+    }
+
+    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output/i.test(key)) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}

--- a/src/tracing/traceContext.ts
+++ b/src/tracing/traceContext.ts
@@ -135,8 +135,6 @@ function createTraceSpans(spans: SpanData[]): TraceSpan[] {
   });
 }
 
-export { getToolNameFromAttributes } from './toolAttributes';
-
 function deriveInsights(traceSpans: TraceSpan[]): string[] {
   if (traceSpans.length === 0) {
     return [];

--- a/src/tracing/traceContext.ts
+++ b/src/tracing/traceContext.ts
@@ -1,6 +1,7 @@
 import logger from '../logger';
 import { sleep } from '../util/time';
 import { getTraceStore, type SpanData, type TraceSpanQueryOptions } from './store';
+import { getToolNameFromAttributes } from './toolAttributes';
 
 export interface TraceEvent {
   name: string;
@@ -134,6 +135,8 @@ function createTraceSpans(spans: SpanData[]): TraceSpan[] {
   });
 }
 
+export { getToolNameFromAttributes } from './toolAttributes';
+
 function deriveInsights(traceSpans: TraceSpan[]): string[] {
   if (traceSpans.length === 0) {
     return [];
@@ -147,11 +150,11 @@ function deriveInsights(traceSpans: TraceSpan[]): string[] {
     insights.push(`Error span "${span.name}" (${span.spanId.slice(0, 8)})${statusMessage}`);
   });
 
-  const toolCalls = traceSpans.filter((span) => span.attributes['tool.name']);
-  toolCalls.forEach((span) => {
-    insights.push(
-      `Tool call ${span.attributes['tool.name']} via "${span.name}" (duration ${span.durationMs ?? 0}ms)`,
-    );
+  const toolCalls = traceSpans
+    .map((span) => ({ span, toolName: getToolNameFromAttributes(span.attributes) }))
+    .filter((entry) => entry.toolName);
+  toolCalls.forEach(({ span, toolName }) => {
+    insights.push(`Tool call ${toolName} via "${span.name}" (duration ${span.durationMs ?? 0}ms)`);
   });
 
   const guardrailHits = traceSpans.filter(

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -308,6 +308,34 @@ describe('trajectory utilities', () => {
     expect(steps[0].name).toBe('pwd');
   });
 
+  it('normalizes Vercel AI SDK tool spans that use ai.toolCall attributes', () => {
+    const steps = extractTrajectorySteps({
+      ...mockTraceData,
+      spans: [
+        {
+          spanId: 'vercel-tool-call',
+          name: 'ai.toolCall',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: {
+            'ai.toolCall.name': 'search_orders',
+            'ai.toolCall.args': '{"order_id":"123","include_history":false}',
+            'ai.toolCall.result': '{"status":"ok"}',
+          },
+        },
+      ],
+    });
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].type).toBe('tool');
+    expect(steps[0].name).toBe('search_orders');
+    expect(steps[0].aliases).toEqual(expect.arrayContaining(['ai.toolCall', 'search_orders']));
+    expect(steps[0].args).toEqual({
+      order_id: '123',
+      include_history: false,
+    });
+  });
+
   it('preserves original span order when timestamps are tied', () => {
     const steps = extractTrajectorySteps({
       ...mockTraceData,

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -308,7 +308,11 @@ describe('trajectory utilities', () => {
     expect(steps[0].name).toBe('pwd');
   });
 
-  it('normalizes Vercel AI SDK tool spans that use ai.toolCall attributes', () => {
+  it.each([
+    ['ai.toolCall.args', '{"order_id":"123","include_history":false}'],
+    ['ai.toolCall.arguments', '{"order_id":"123","include_history":false}'],
+    ['ai.toolCall.input', '{"order_id":"123","include_history":false}'],
+  ])('normalizes Vercel AI SDK tool spans with %s', (argKey, argValue) => {
     const steps = extractTrajectorySteps({
       ...mockTraceData,
       spans: [
@@ -319,7 +323,7 @@ describe('trajectory utilities', () => {
           endTime: 1100,
           attributes: {
             'ai.toolCall.name': 'search_orders',
-            'ai.toolCall.args': '{"order_id":"123","include_history":false}',
+            [argKey]: argValue,
             'ai.toolCall.result': '{"status":"ok"}',
           },
         },
@@ -991,6 +995,45 @@ describe('trajectory assertions', () => {
           'Tool "compose_*" matched expected arguments (exact) on tool:compose_reply. Args: {"tone":"friendly","citations":["doc_1","doc_2"]}',
         assertion: params.assertion,
       });
+    });
+
+    it('matches Vercel AI SDK spans end-to-end against expected args', () => {
+      const vercelTrace: TraceData = {
+        ...mockTraceData,
+        spans: [
+          {
+            spanId: 'vercel-span',
+            name: 'ai.toolCall',
+            startTime: 1000,
+            endTime: 1100,
+            attributes: {
+              'ai.toolCall.name': 'lookup_customer',
+              'ai.toolCall.args': '{"customer_id":"cust_1234","include_history":true}',
+              'ai.toolCall.result': '{"plan":"pro"}',
+            },
+          },
+        ],
+      };
+      const params: AssertionParams = {
+        ...defaultParams,
+        assertionValueContext: { ...defaultParams.assertionValueContext, trace: vercelTrace },
+        baseType: 'trajectory:tool-args-match',
+        assertion: {
+          type: 'trajectory:tool-args-match',
+          value: {
+            name: 'lookup_customer',
+            args: { customer_id: 'cust_1234' },
+          },
+        },
+        renderedValue: {
+          name: 'lookup_customer',
+          args: { customer_id: 'cust_1234' },
+        },
+      };
+
+      const result = handleTrajectoryToolArgsMatch(params);
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(1);
     });
 
     it('fails when no matching tool arguments satisfy the expectation', () => {

--- a/test/redteam/providers/traceFormatting.test.ts
+++ b/test/redteam/providers/traceFormatting.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { formatTraceSummary } from '../../../src/redteam/providers/traceFormatting';
+
+import type { TraceContextData } from '../../../src/tracing/traceContext';
+
+describe('formatTraceSummary', () => {
+  it('includes Vercel AI SDK tool names in formatted spans', () => {
+    const trace: TraceContextData = {
+      traceId: '0123456789abcdef',
+      fetchedAt: Date.now(),
+      insights: ['Tool call lookup_customer via "ai.toolCall" (duration 42ms)'],
+      spans: [
+        {
+          spanId: 'span-1',
+          name: 'ai.toolCall',
+          kind: 'internal',
+          startTime: 0,
+          endTime: 42,
+          durationMs: 42,
+          attributes: {
+            'ai.toolCall.name': 'lookup_customer',
+          },
+          status: {
+            code: 'ok',
+          },
+          depth: 0,
+          events: [],
+        },
+      ],
+    };
+
+    const summary = formatTraceSummary(trace);
+
+    expect(summary).toContain('tool=lookup_customer');
+    expect(summary).toContain('Tool call lookup_customer via "ai.toolCall"');
+  });
+});

--- a/test/tracing/toolAttributes.test.ts
+++ b/test/tracing/toolAttributes.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { getToolNameFromAttributes } from '../../src/tracing/traceContext';
+import { getToolNameFromAttributes } from '../../src/tracing/toolAttributes';
 
 describe('getToolNameFromAttributes', () => {
   it('returns undefined when attributes are missing', () => {
     expect(getToolNameFromAttributes(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when no recognized keys are present', () => {
+    expect(getToolNameFromAttributes({ foo: 'bar' })).toBeUndefined();
   });
 
   it('returns Vercel AI SDK tool span names', () => {
@@ -14,7 +18,7 @@ describe('getToolNameFromAttributes', () => {
     ).toBe('lookup_customer');
   });
 
-  it('prefers generic tool.name when present', () => {
+  it('prefers generic tool.name over vendor-specific keys', () => {
     expect(
       getToolNameFromAttributes({
         'tool.name': 'search_orders',
@@ -23,7 +27,7 @@ describe('getToolNameFromAttributes', () => {
     ).toBe('search_orders');
   });
 
-  it('recognizes other common tool-name attributes', () => {
+  it('recognizes function.name', () => {
     expect(
       getToolNameFromAttributes({
         'function.name': 'compose_reply',
@@ -31,21 +35,29 @@ describe('getToolNameFromAttributes', () => {
     ).toBe('compose_reply');
   });
 
-  it('recognizes dynamic function-name-style keys', () => {
+  it('trims whitespace from values', () => {
     expect(
       getToolNameFromAttributes({
-        customFunctionName: 'draft_reply',
+        'tool.name': '  trimmed_tool  ',
       }),
-    ).toBe('draft_reply');
+    ).toBe('trimmed_tool');
   });
 
-  it('recognizes generic tool-like keys and ignores result-only attributes', () => {
+  it('skips empty string values in favor of later recognized keys', () => {
     expect(
       getToolNameFromAttributes({
-        metadata: 42,
-        'tool.result': '{"status":"ok"}',
-        'workflow.tool': 'search_inventory',
+        'tool.name': '   ',
+        'ai.toolCall.name': 'fallback_tool',
       }),
-    ).toBe('search_inventory');
+    ).toBe('fallback_tool');
+  });
+
+  it('skips non-string values', () => {
+    expect(
+      getToolNameFromAttributes({
+        'tool.name': 42 as unknown as string,
+        'ai.toolCall.name': 'fallback_tool',
+      }),
+    ).toBe('fallback_tool');
   });
 });

--- a/test/tracing/toolAttributes.test.ts
+++ b/test/tracing/toolAttributes.test.ts
@@ -55,9 +55,18 @@ describe('getToolNameFromAttributes', () => {
   it('skips non-string values', () => {
     expect(
       getToolNameFromAttributes({
-        'tool.name': 42 as unknown as string,
+        'tool.name': 42,
         'ai.toolCall.name': 'fallback_tool',
       }),
     ).toBe('fallback_tool');
+  });
+
+  it('does not match arbitrary attributes whose keys are not in the allowlist', () => {
+    expect(
+      getToolNameFromAttributes({
+        'workflow.tool': 'should_not_match',
+        'tool.description': 'not a tool name',
+      }),
+    ).toBeUndefined();
   });
 });

--- a/test/tracing/toolAttributes.test.ts
+++ b/test/tracing/toolAttributes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getToolNameFromAttributes } from '../../src/tracing/toolAttributes';
+import {
+  getToolNameFromAttributes,
+  TOOL_ARGUMENT_ATTRIBUTE_KEYS,
+  TOOL_NAME_ATTRIBUTE_KEYS,
+} from '../../src/tracing/toolAttributes';
 
 describe('getToolNameFromAttributes', () => {
   it('returns undefined when attributes are missing', () => {
@@ -68,5 +72,61 @@ describe('getToolNameFromAttributes', () => {
         'tool.description': 'not a tool name',
       }),
     ).toBeUndefined();
+  });
+});
+
+describe('tool attribute key tables', () => {
+  it('exposes the expected set of tool-name keys', () => {
+    expect([...TOOL_NAME_ATTRIBUTE_KEYS].sort()).toEqual([
+      'agent.tool',
+      'agent.toolName',
+      'agent.tool_name',
+      'ai.toolCall.name',
+      'codex.mcp.tool',
+      'function.name',
+      'function_name',
+      'gen_ai.tool.name',
+      'tool',
+      'tool.name',
+      'tool_name',
+    ]);
+  });
+
+  it('exposes the expected set of tool-argument keys', () => {
+    expect([...TOOL_ARGUMENT_ATTRIBUTE_KEYS].sort()).toEqual([
+      'agent.tool.args',
+      'agent.tool.arguments',
+      'agent.tool.input',
+      'ai.toolCall.args',
+      'ai.toolCall.arguments',
+      'ai.toolCall.input',
+      'args',
+      'arguments',
+      'codex.mcp.args',
+      'codex.mcp.arguments',
+      'codex.mcp.input',
+      'function.args',
+      'function.arguments',
+      'function.input',
+      'function_args',
+      'function_arguments',
+      'gen_ai.tool.args',
+      'gen_ai.tool.arguments',
+      'gen_ai.tool.call.args',
+      'gen_ai.tool.call.arguments',
+      'gen_ai.tool.input',
+      'input',
+      'tool.args',
+      'tool.arguments',
+      'tool.input',
+      'tool_args',
+      'tool_arguments',
+      'tool_input',
+    ]);
+  });
+
+  it('has no duplicate keys in either table', () => {
+    expect(new Set(TOOL_NAME_ATTRIBUTE_KEYS).size).toBe(TOOL_NAME_ATTRIBUTE_KEYS.length);
+    expect(new Set(TOOL_ARGUMENT_ATTRIBUTE_KEYS).size).toBe(TOOL_ARGUMENT_ATTRIBUTE_KEYS.length);
   });
 });

--- a/test/tracing/traceContext.test.ts
+++ b/test/tracing/traceContext.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getToolNameFromAttributes } from '../../src/tracing/traceContext';
+
+describe('getToolNameFromAttributes', () => {
+  it('returns Vercel AI SDK tool span names', () => {
+    expect(
+      getToolNameFromAttributes({
+        'ai.toolCall.name': 'lookup_customer',
+      }),
+    ).toBe('lookup_customer');
+  });
+
+  it('prefers generic tool.name when present', () => {
+    expect(
+      getToolNameFromAttributes({
+        'tool.name': 'search_orders',
+        'ai.toolCall.name': 'lookup_customer',
+      }),
+    ).toBe('search_orders');
+  });
+
+  it('recognizes other common tool-name attributes', () => {
+    expect(
+      getToolNameFromAttributes({
+        'function.name': 'compose_reply',
+      }),
+    ).toBe('compose_reply');
+  });
+});

--- a/test/tracing/traceContext.test.ts
+++ b/test/tracing/traceContext.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { getToolNameFromAttributes } from '../../src/tracing/traceContext';
 
 describe('getToolNameFromAttributes', () => {
+  it('returns undefined when attributes are missing', () => {
+    expect(getToolNameFromAttributes(undefined)).toBeUndefined();
+  });
+
   it('returns Vercel AI SDK tool span names', () => {
     expect(
       getToolNameFromAttributes({
@@ -25,5 +29,23 @@ describe('getToolNameFromAttributes', () => {
         'function.name': 'compose_reply',
       }),
     ).toBe('compose_reply');
+  });
+
+  it('recognizes dynamic function-name-style keys', () => {
+    expect(
+      getToolNameFromAttributes({
+        customFunctionName: 'draft_reply',
+      }),
+    ).toBe('draft_reply');
+  });
+
+  it('recognizes generic tool-like keys and ignores result-only attributes', () => {
+    expect(
+      getToolNameFromAttributes({
+        metadata: 42,
+        'tool.result': '{"status":"ok"}',
+        'workflow.tool': 'search_inventory',
+      }),
+    ).toBe('search_inventory');
   });
 });


### PR DESCRIPTION
## Summary

- add support for Vercel AI SDK tool-call telemetry attributes in trajectory extraction
- reuse the same tool-name normalization in trace insights and red-team trace formatting
- update docs and examples to describe the supported `ai.toolCall.*` attributes

## Why

Trajectory assertions did not recognize Vercel AI SDK tool-call spans emitted via `experimental_telemetry`, which made real traced tool usage invisible to `trajectory:tool-used` and `trajectory:tool-args-match` assertions.

## Impact

- trajectory assertions now recognize `ai.toolCall.name` and `ai.toolCall.args` / `ai.toolCall.arguments` / `ai.toolCall.input`
- trace insights and red-team trace summaries stay aligned with the same tool-name normalization rules
- docs and examples now describe the supported telemetry attributes without overstating result matching support

## Validation

- `npm run l`
- `npm run f`
- `npx vitest run test/assertions/trajectory*.test.ts test/tracing/traceContext.test.ts test/redteam/providers/traceFormatting.test.ts`
- `SKIP_OG_GENERATION=true npm run build --prefix site`
- end-to-end eval with a real Vercel AI SDK custom provider using `experimental_telemetry` and `/Users/mdangelo/projects/promptfoo/.env`

## Related

- related to #8799
