### PR TITLE
build: tighten GitHub Actions permissions

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -4,6 +4,10 @@ on:
     branches: ['main']
     paths:
       - 'src/app/**' # Only trigger on changes to frontend code
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,14 +43,13 @@ env:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - name: Free disk space
@@ -181,6 +180,9 @@ jobs:
     runs-on: ${{ matrix.platforms.runner }}
     timeout-minutes: 60
     needs: [test]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -239,6 +241,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-docker-and-push-digests]
+    permissions:
+      packages: write
     outputs:
       manifest_digest: ${{ steps.inspect.outputs.digest }}
     steps:

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -8,6 +8,10 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
+
+permissions:
+  contents: read
+
 jobs:
   build:
     # Only run on Pull Requests within the same repository, and not from forks.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  checks: write
-  id-token: write # Required for OIDC authentication with Codecov
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +69,10 @@ jobs:
     name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}${{ matrix.shard && format(' (shard {0}/3)', matrix.shard) || '' }}
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
+      id-token: write # Required for OIDC authentication with Codecov
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.ci-config.outputs.test-matrix) }}
@@ -369,6 +370,10 @@ jobs:
     name: Site tests
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      id-token: write # Required for OIDC authentication with Codecov
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -403,6 +408,10 @@ jobs:
     name: webui tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      id-token: write # Required for OIDC authentication with Codecov
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -9,6 +9,9 @@ on:
         description: 'PR number to scan'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- tighten workflow-level `GITHUB_TOKEN` defaults to read-only across the GitHub Actions workflows we touched
- move elevated scopes to the specific jobs that actually need them, especially Codecov upload and Docker publish/attestation jobs
- keep existing behavior intact for release, deploy, image compression, and code-scan workflows while making the permission model explicit

## Why
The workflows were mostly already using reasonable permissions, but several files still relied on broader workflow defaults or implicit repository defaults. This makes the least-privilege model explicit and reduces the chance that future jobs inherit write scopes they do not need.

## Impact
- no product behavior changes
- lower default `GITHUB_TOKEN` privileges for CI/CD jobs
- clearer job-by-job permission boundaries for future workflow edits

## Validation
- `actionlint .github/workflows/*.yml`
- manual review of each touched workflow to confirm required scopes still match usage
