### PR TITLE
test(webui): cover server-virtualized selection ids

### DIFF
--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -355,6 +355,45 @@ describe('DataTable', () => {
       expect(container.querySelector('tbody tr[aria-busy="true"]')).toBeInTheDocument();
     });
 
+    it('should use virtual row indexes for server-side selection when no getRowId is provided', async () => {
+      const user = userEvent.setup();
+      let capturedSelection: Record<string, boolean> = {};
+      const loadedRows = new Map<number, TestRow>([[25, { id: 'row-25', name: 'Loaded row 25' }]]);
+
+      render(
+        <DataTable
+          columns={columns}
+          data={[]}
+          rowDisplayMode="server-virtualized"
+          maxHeight="400px"
+          virtualRowEstimate={20}
+          virtualOverscan={10}
+          enableRowSelection
+          rowSelection={{}}
+          onRowSelectionChange={(selection) => {
+            capturedSelection = selection;
+          }}
+          serverVirtualization={{
+            rowCount: 100,
+            pageSize: 25,
+            getRow: (index) => loadedRows.get(index),
+            loadRows: vi.fn(),
+            isRowLoading: (index) => !loadedRows.has(index),
+          }}
+        />,
+      );
+
+      await screen.findByText('Loaded row 25');
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(2);
+
+      await user.click(checkboxes[1]);
+
+      expect(capturedSelection).toHaveProperty('25', true);
+      expect(capturedSelection).not.toHaveProperty('0');
+    });
+
     it('should hide no-op filter controls for server-side rows by default', async () => {
       const loadRows = vi.fn();
       render(


### PR DESCRIPTION
## Summary
Adds focused frontend coverage for the server-virtualized `DataTable` row selection path.

The recent shared table virtualization work renders visible server rows through a separate TanStack table instance. This PR verifies that when no custom `getRowId` is provided, selecting a loaded server-side row uses its virtual row index as the selection key instead of the local rendered-slice index.

## Testing
- `npm run test:app -- src/components/data-table/data-table.test.tsx --run`
- `node_modules/.bin/biome check src/app/src/components/data-table/data-table.test.tsx`
