### PR TITLE
docs(site): clarify grader temperature override pattern

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -73,6 +73,20 @@ defaultTest:
     provider: openai:gpt-5-mini
 ```
 
+To set grader parameters such as `temperature` for repeatability, expand the shorthand into an `id` + `config` block:
+
+```yaml
+assert:
+  - type: g-eval
+    value: 'Ensure response is factually accurate'
+    provider:
+      id: openai:gpt-5-mini
+      config:
+        temperature: 0
+```
+
+See the [llm-rubric grader override docs](/docs/configuration/expected-outputs/model-graded/llm-rubric#setting-grader-parameters-temperature-etc) for more detail.
+
 ## Example
 
 Here's a complete example showing how to use G-Eval to assess multiple aspects of an LLM response:

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -269,7 +269,7 @@ tests:
 This works at every level where a grader can be set — per-assertion (`assertion.provider`), per-test (`test.options.provider`), and globally (`defaultTest.options.provider`).
 
 :::note
-The built-in OpenAI grader already uses `temperature=0` by default, so you only need to set it when overriding the grader with a custom `provider` block that would otherwise inherit a non-zero default. Reasoning models (o1, o3, o5, etc.) ignore `temperature` entirely.
+The built-in OpenAI grader already uses `temperature=0` by default, so you only need to set it when overriding the grader with a custom `provider` block that would otherwise inherit a non-zero default. OpenAI reasoning models (o1, o3, o4, GPT-5, etc.) ignore `temperature` entirely.
 :::
 
 Also note that [custom providers](/docs/providers/custom-api) are supported as well.

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -269,7 +269,7 @@ tests:
 This works at every level where a grader can be set — per-assertion (`assertion.provider`), per-test (`test.options.provider`), and globally (`defaultTest.options.provider`).
 
 :::note
-The built-in OpenAI grader already uses `temperature=0` by default, so you only need to set it when overriding the grader with a custom `provider` block that would otherwise inherit a non-zero default. OpenAI reasoning models (o1, o3, o4, GPT-5, etc.) ignore `temperature` entirely.
+The built-in OpenAI grader already uses `temperature=0` by default, so you only need to set it when overriding the grader with a custom `provider` block that would otherwise inherit a non-zero default. GPT-5 series reasoning models ignore `temperature` entirely.
 :::
 
 Also note that [custom providers](/docs/providers/custom-api) are supported as well.

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -253,14 +253,24 @@ By default, model-graded asserts use `gpt-5` for grading. If you do not have acc
            provider: openai:gpt-5-mini
    ```
 
-Use the `provider.config` field to set custom parameters:
+Use the `provider.config` field to set custom parameters such as `temperature`, `max_tokens`, or API host:
 
 ```yaml
-provider:
-  - id: openai:gpt-5-mini
-    config:
-      temperature: 0
+tests:
+  - assert:
+      - type: llm-rubric
+        value: Is not apologetic and provides a clear, concise answer
+        provider:
+          id: openai:gpt-5-mini
+          config:
+            temperature: 0
 ```
+
+This works at every level where a grader can be set — per-assertion (`assertion.provider`), per-test (`test.options.provider`), and globally (`defaultTest.options.provider`).
+
+:::note
+The built-in OpenAI grader already uses `temperature=0` by default, so you only need to set it when overriding the grader with a custom `provider` block that would otherwise inherit a non-zero default. Reasoning models (o1, o3, o5, etc.) ignore `temperature` entirely.
+:::
 
 Also note that [custom providers](/docs/providers/custom-api) are supported as well.
 

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -122,6 +122,28 @@ By default, `llm-rubric` uses `gpt-5` for grading. You can override this in seve
            // highlight-end
    ```
 
+### Setting grader parameters (temperature, etc.)
+
+To pin `temperature`, `max_tokens`, or other provider-specific parameters on the grader, expand the `provider` shorthand into an object with `id` and `config`. This is the supported way to force deterministic grading when swapping in a custom judge:
+
+```yaml
+assert:
+  - type: llm-rubric
+    value: Is not apologetic and provides a clear, concise answer
+    // highlight-start
+    provider:
+      id: openai:gpt-5-mini
+      config:
+        temperature: 0
+    // highlight-end
+```
+
+The same shape works under `defaultTest.options.provider` and `test.options.provider`.
+
+:::note
+The built-in OpenAI grader already defaults to `temperature=0`, so this override is only needed when you're pointing at a different model or provider whose default differs. Reasoning models (o1, o3, o5, etc.) ignore `temperature` and do not need it set.
+:::
+
 Custom `llm-rubric` providers can also return a `metadata` object in their `ProviderResponse`. promptfoo copies those keys onto the assertion's `GradingResult.metadata` alongside `renderedGradingPrompt`, which makes per-assertion fields such as upload IDs or trace IDs available in hooks like `afterEach`.
 
 ## Customizing the rubric prompt

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -141,7 +141,7 @@ assert:
 The same shape works under `defaultTest.options.provider` and `test.options.provider`.
 
 :::note
-The built-in OpenAI grader already defaults to `temperature=0`, so this override is only needed when you're pointing at a different model or provider whose default differs. Reasoning models (o1, o3, o5, etc.) ignore `temperature` and do not need it set.
+The built-in OpenAI grader already defaults to `temperature=0`, so this override is only needed when you're pointing at a different model or provider whose default differs. OpenAI reasoning models (o1, o3, o4, GPT-5, etc.) ignore `temperature` and do not need it set.
 :::
 
 Custom `llm-rubric` providers can also return a `metadata` object in their `ProviderResponse`. promptfoo copies those keys onto the assertion's `GradingResult.metadata` alongside `renderedGradingPrompt`, which makes per-assertion fields such as upload IDs or trace IDs available in hooks like `afterEach`.

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -141,7 +141,7 @@ assert:
 The same shape works under `defaultTest.options.provider` and `test.options.provider`.
 
 :::note
-The built-in OpenAI grader already defaults to `temperature=0`, so this override is only needed when you're pointing at a different model or provider whose default differs. OpenAI reasoning models (o1, o3, o4, GPT-5, etc.) ignore `temperature` and do not need it set.
+The built-in OpenAI grader already defaults to `temperature=0`, so this override is only needed when you're pointing at a different model or provider whose default differs. GPT-5 series reasoning models ignore `temperature` and do not need it set.
 :::
 
 Custom `llm-rubric` providers can also return a `metadata` object in their `ProviderResponse`. promptfoo copies those keys onto the assertion's `GradingResult.metadata` alongside `renderedGradingPrompt`, which makes per-assertion fields such as upload IDs or trace IDs available in hooks like `afterEach`.

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -124,7 +124,7 @@ By default, `llm-rubric` uses `gpt-5` for grading. You can override this in seve
 
 ### Setting grader parameters (temperature, etc.)
 
-To pin `temperature`, `max_tokens`, or other provider-specific parameters on the grader, expand the `provider` shorthand into an object with `id` and `config`. This is the supported way to force deterministic grading when swapping in a custom judge:
+To pin `temperature`, `max_tokens`, or other provider-specific parameters on the grader, expand the `provider` shorthand into an object with `id` and `config`. This is the supported way to push grading toward reproducibility when swapping in a custom judge:
 
 ```yaml
 assert:


### PR DESCRIPTION
## Summary

Addresses [#8175](https://github.com/promptfoo/promptfoo/issues/8175) with docs rather than a new shorthand.

The existing `provider: { id, config: { temperature } }` pattern already supports pinning `temperature` (and any other provider-specific parameter) on llm-as-a-judge graders — but it was only shown briefly in `model-graded/index.md` and missing from the `llm-rubric` and `g-eval` pages. Users reading those pages would naturally conclude no override exists, which is what #8175 is reacting to.

### Changes

- **`model-graded/index.md`**: Expand the existing example into a realistic per-assertion block, call out that the same shape works at `defaultTest.options.provider` / `test.options.provider` / `assertion.provider`, and add an admonition clarifying (a) the default OpenAI grader already uses `temperature=0` and (b) GPT-5 series reasoning models ignore `temperature`.
- **`model-graded/llm-rubric.md`**: Add a new `### Setting grader parameters (temperature, etc.)` subsection under "Overriding the LLM grader" with the same override example and admonition.
- **`model-graded/g-eval.md`**: Add the override example and a cross-link to the llm-rubric subsection.

### Why docs-only

A dedicated `temperature:` shorthand at the assertion level would:

- Overlap an already-supported path, creating two ways to do the same thing.
- Have to fan out into per-provider mapping (OpenAI `temperature` vs. Bedrock `inferenceConfig.temperature`, etc.).
- Need special-casing for GPT-5 series and other reasoning models that reject/ignore temperature.
- Oversell \"determinism\": temp=0 is not actually deterministic (MoE routing, server-side sampling variance).

The existing `provider.config` path already handles all of this correctly. The gap was purely discoverability.

## Test plan

- [ ] Docs build locally: \`cd site && SKIP_OG_GENERATION=true npm run build\`
- [ ] Verify the cross-page anchor link `/docs/configuration/expected-outputs/model-graded/llm-rubric#setting-grader-parameters-temperature-etc` resolves (Docusaurus auto-slug matches)
- [ ] Claims verified against \`src/providers/openai/chat.ts:193-244\` (default temp=0, reasoning-model guard) and \`src/matchers/providers.ts:73-87\` (\`provider.config\` flows through)