### PR TITLE
fix(auth): log file auth refresh lifecycle

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1017,6 +1017,15 @@ function parseFileAuthReference(filePath: string): { filePath: string; functionN
   return filePath.startsWith('file://') ? parseFileUrl(filePath) : { filePath };
 }
 
+function formatFileAuthFreshness(expiration?: number | null): string {
+  if (expiration == null) {
+    return 'never expires';
+  }
+
+  const freshForSeconds = Math.max(0, Math.ceil((expiration - Date.now()) / 1000));
+  return `expires in ${freshForSeconds} seconds`;
+}
+
 export async function createSessionParser(
   parser: string | Function | undefined,
 ): Promise<(data: SessionParserData) => string> {
@@ -1786,15 +1795,20 @@ export class HttpProvider implements ApiProvider {
     return false;
   }
 
-  private async refreshTokenWithLock(refreshToken: () => Promise<void>): Promise<void> {
+  private async refreshTokenWithLock(
+    refreshToken: () => Promise<void>,
+    onLockAcquired?: () => void,
+  ): Promise<void> {
     while (this.tokenRefreshLock != null) {
       if (await this.waitForInFlightTokenRefresh()) {
         return;
       }
     }
 
-    const refreshLock = { promise: refreshToken() };
+    const refreshLock = { promise: Promise.resolve() as Promise<void> };
     this.tokenRefreshLock = refreshLock;
+    onLockAcquired?.();
+    refreshLock.promise = refreshToken();
 
     try {
       await refreshLock.promise;
@@ -1822,7 +1836,12 @@ export class HttpProvider implements ApiProvider {
     }
 
     logger.debug('[HTTP Provider Auth]: Starting or waiting for file auth token refresh');
-    await this.refreshTokenWithLock(() => this.performFileTokenRefresh(prompt, vars, context));
+    await this.refreshTokenWithLock(
+      () => this.performFileTokenRefresh(prompt, vars, context),
+      () => {
+        logger.debug('[HTTP Provider Auth]: Acquired file auth refresh lock');
+      },
+    );
   }
 
   private async performFileTokenRefresh(
@@ -1841,6 +1860,9 @@ export class HttpProvider implements ApiProvider {
     };
 
     try {
+      logger.debug(
+        `[HTTP Provider Auth]: Invoking file auth function ${filePath}#${functionName ?? defaultFunctionName}`,
+      );
       const authFn = await loadFunction<
         (authContext: CallApiContextParams) => Promise<FileAuthResult> | FileAuthResult
       >({
@@ -1851,7 +1873,9 @@ export class HttpProvider implements ApiProvider {
       const result = FileAuthResultSchema.parse(await authFn(authContext));
       this.lastToken = result.token;
       this.lastTokenExpiresAt = result.expiration ?? undefined;
-      logger.debug('[HTTP Provider Auth]: Successfully refreshed file auth token');
+      logger.info(
+        `[HTTP Provider Auth]: Successfully refreshed file auth token (${formatFileAuthFreshness(result.expiration)})`,
+      );
     } catch (err) {
       logger.error(`[HTTP Provider Auth]: Failed to refresh file auth token: ${String(err)}`);
       throw new Error(`Failed to refresh file auth token: ${String(err)}`);

--- a/test/providers/http/auth.test.ts
+++ b/test/providers/http/auth.test.ts
@@ -1350,6 +1350,7 @@ describe('HttpProvider - File Auth', () => {
       };
     });
     vi.mocked(importModule).mockImplementation(async () => ({ default: authFn }));
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
     const provider = new HttpProvider(mockUrl, {
       config: {
@@ -1391,6 +1392,28 @@ describe('HttpProvider - File Auth', () => {
         }),
       );
     }
+    expect(debugSpy).toHaveBeenCalledWith('[HTTP Provider Auth]: Acquired file auth refresh lock');
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[HTTP Provider Auth]: Invoking file auth function ./auth/get-token.js#default',
+    );
+    expect(
+      debugSpy.mock.calls.filter(
+        ([message]) => message === '[HTTP Provider Auth]: Acquired file auth refresh lock',
+      ),
+    ).toHaveLength(1);
+    expect(
+      debugSpy.mock.calls.filter(
+        ([message]) =>
+          message ===
+          '[HTTP Provider Auth]: Invoking file auth function ./auth/get-token.js#default',
+      ),
+    ).toHaveLength(1);
+    expect(
+      debugSpy.mock.calls.filter(
+        ([message]) =>
+          message === '[HTTP Provider Auth]: Token refresh already in progress, waiting...',
+      ).length,
+    ).toBeGreaterThan(0);
   });
 
   it('should make file auth values available to transformRequest before the request is rendered', async () => {
@@ -1522,6 +1545,68 @@ describe('HttpProvider - File Auth', () => {
           session: 'session-123',
         }),
       }),
+    );
+  });
+
+  it('should log how many seconds a refreshed file auth token stays fresh', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const authFn = vi.fn().mockResolvedValue({
+      token: 'expiring-token',
+      expiration: 43_000,
+    });
+    vi.mocked(importModule).mockImplementation(async () => ({ default: authFn }));
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+
+    const provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer {{token}}',
+        },
+        auth: {
+          type: 'file',
+          path: './auth/get-token.js',
+        },
+      },
+    });
+
+    await provider.callApi('test prompt', {
+      prompt: { raw: 'test prompt', label: 'test prompt' },
+      vars: {},
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[HTTP Provider Auth]: Successfully refreshed file auth token (expires in 42 seconds)',
+    );
+  });
+
+  it('should log when a refreshed file auth token never expires', async () => {
+    const authFn = vi.fn().mockResolvedValue({
+      token: 'non-expiring-token',
+    });
+    vi.mocked(importModule).mockImplementation(async () => ({ default: authFn }));
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+
+    const provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer {{token}}',
+        },
+        auth: {
+          type: 'file',
+          path: './auth/get-token.js',
+        },
+      },
+    });
+
+    await provider.callApi('test prompt', {
+      prompt: { raw: 'test prompt', label: 'test prompt' },
+      vars: {},
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[HTTP Provider Auth]: Successfully refreshed file auth token (never expires)',
     );
   });
 


### PR DESCRIPTION
## Summary
- log when file auth acquires the refresh lock and invokes the auth function
- include a plain-language freshness message when file auth returns a token successfully
- add HTTP auth tests covering the new lock and success logging behavior

## Testing
- npm run l
- npm run f
- npx vitest run test/providers/http/auth.test.ts