### PR TITLE
test(providers): cover AI Studio embedding errors

### DIFF
--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -1939,6 +1939,7 @@ describe('AIStudioChatProvider', () => {
 describe('AIStudioEmbeddingProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(cache.fetchWithCache).mockReset();
     mockProcessEnv({ GOOGLE_API_KEY: 'test-key' });
   });
 
@@ -2013,6 +2014,24 @@ describe('AIStudioEmbeddingProvider', () => {
     const response = await provider.callEmbeddingApi('hello');
     expect(response.error).toContain('Google API key is not set');
     expect(cache.fetchWithCache).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string embedding inputs before making a request', async () => {
+    const provider = new AIStudioEmbeddingProvider('gemini-embedding-001');
+    const response = await provider.callEmbeddingApi(123 as any);
+
+    expect(response.error).toContain('Invalid input type for embedding API');
+    expect(cache.fetchWithCache).not.toHaveBeenCalled();
+  });
+
+  it('surfaces fetch failures as API call errors', async () => {
+    vi.mocked(cache.fetchWithCache).mockRejectedValue(new Error('network down'));
+
+    const provider = new AIStudioEmbeddingProvider('gemini-embedding-001');
+    const response = await provider.callEmbeddingApi('hello');
+
+    expect(response.embedding).toBeUndefined();
+    expect(response.error).toContain('API call error: Error: network down');
   });
 
   it('surfaces a descriptive error when the response has no values', async () => {


### PR DESCRIPTION
## Summary
Add focused negative-path coverage for the new Google AI Studio embedding provider.

The recent `google:embedding:*` provider change added runtime guards for invalid embedding input types and upstream request failures, but those paths were not exercised in `test/providers/google/ai.studio.test.ts`. This PR adds narrow regressions for both cases and resets the mocked cache fetch between tests so the new failures stay isolated under Vitest's randomized order.

## Testing
- `./node_modules/.bin/vitest run test/providers/google/ai.studio.test.ts`
- `./node_modules/.bin/biome check test/providers/google/ai.studio.test.ts`
