### PR TITLE
ci(release): split release-please pull requests

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- set `separate-pull-requests: true` for release-please so root package releases use the package-specific release branch/title again
- avoid the merged grouped-release PR path that left #8713 labeled `autorelease: pending` and prevented new release PRs from opening

## Validation
- repaired live release state by creating the missing GitHub release/tag `0.121.6` at `74f0dd27dc52d0eadbd07871e7d27333dbe6b503`
- moved #8713 from `autorelease: pending` to `autorelease: tagged`
- release-please dry-run now sees root `0.121.6`, scans 134 commits, and would open the next `0.121.7` release PR
- `npm run l`
- `npm run f`