### PR TITLE
fix(fetch): default PROMPTFOO_INSECURE_SSL to false for proxy TLS

### DIFF
--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -223,7 +223,7 @@ export async function fetchWithProxy(
   }
 
   const tlsOptions: ConnectionOptions = {
-    rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
+    rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
   };
 
   // Support custom CA certificates

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -115,13 +115,20 @@ vi.mock('../src/envars', () => {
     }),
     getEnvBool: vi.fn().mockImplementation((key: string, defaultValue: boolean = false) => {
       if (key === 'PROMPTFOO_RETRY_5XX_ENABLED') {
-        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX_ENABLED === 'true' || false;
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX_ENABLED === 'true';
       }
       if (key === 'PROMPTFOO_INSECURE_SSL') {
-        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_INSECURE_SSL === 'true' || false;
+        const raw = (process.env as NodeJS.ProcessEnv).PROMPTFOO_INSECURE_SSL;
+        if (raw === 'true') {
+          return true;
+        }
+        if (raw === 'false') {
+          return false;
+        }
+        return defaultValue;
       }
       if (key === 'PROMPTFOO_RETRY_5XX') {
-        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX === 'true' || false;
+        return (process.env as NodeJS.ProcessEnv).PROMPTFOO_RETRY_5XX === 'true';
       }
       return defaultValue;
     }),
@@ -507,6 +514,32 @@ describe('fetchWithProxy', () => {
     );
   });
 
+  it('should enable SSL verification by default when PROMPTFOO_INSECURE_SSL is unset', async () => {
+    const mockProxyUrl = 'http://proxy.example.com';
+
+    mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
+
+    vi.mocked(getEnvString).mockImplementation((key: string, defaultValue: string = '') => {
+      if (key === 'HTTPS_PROXY') {
+        return mockProxyUrl;
+      }
+      return defaultValue;
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue(new Response());
+    global.fetch = mockFetch;
+
+    await fetchWithProxy('https://example.com');
+
+    expect(ProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: mockProxyUrl,
+        proxyTls: { rejectUnauthorized: true },
+        requestTls: { rejectUnauthorized: true },
+      }),
+    );
+  });
+
   it('should disable SSL verification when PROMPTFOO_INSECURE_SSL is true', async () => {
     const mockProxyUrl = 'http://proxy.example.com';
 
@@ -688,10 +721,10 @@ describe('fetchWithProxy', () => {
       expect(ProxyAgent).toHaveBeenCalledWith({
         uri: testCase.expected.url,
         proxyTls: {
-          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
+          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
         },
         requestTls: {
-          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
+          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
         },
         headersTimeout: REQUEST_TIMEOUT_MS,
         keepAliveTimeout: 30_000,
@@ -728,10 +761,10 @@ describe('fetchWithProxy', () => {
       expect(ProxyAgent).toHaveBeenCalledWith({
         uri: testCase.expected.url,
         proxyTls: {
-          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
+          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
         },
         requestTls: {
-          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
+          rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', false),
         },
         headersTimeout: REQUEST_TIMEOUT_MS,
         keepAliveTimeout: 30_000,


### PR DESCRIPTION
## Summary

`fetchWithProxy` was computing `rejectUnauthorized` as `!getEnvBool('PROMPTFOO_INSECURE_SSL', true)`, which meant proxy TLS verification was disabled whenever the env var was unset - the opposite of a secure default.

Flip the default so TLS certificate verification is enabled unless the user explicitly sets `PROMPTFOO_INSECURE_SSL=true`, and add a regression test that asserts the literal `rejectUnauthorized: true` on `ProxyAgent` when the env var is not set. The previous test was circular (computing the expectation from the same `getEnvBool` call as production), so it would have kept passing if someone flipped the default back.

The mock for `getEnvBool` is also tightened so it honors the `defaultValue` argument for `PROMPTFOO_INSECURE_SSL`, which is what makes the new literal assertion actually exercise the default.

### Behavior change for users

Anyone who was implicitly relying on the insecure default - for example a local HTTPS proxy with a self-signed certificate and no custom CA configured - will now see TLS rejections. The fix:
- Preferred: supply the CA via `PROMPTFOO_CA_CERT_PATH`.
- Escape hatch: opt in to the old behavior with `PROMPTFOO_INSECURE_SSL=true`.

### Split note

Originally this PR bundled the TLS default flip with an unrelated `VertexEmbeddingProvider` constructor change and some test-only churn. Now scoped to just the TLS fix; the Vertex change moved to #8843. The test-only churn (watsonx comment clarifications, `expectedVar` -> `expectedValue` rename, new `testProviderConnectivity` sessionId test) was dropped and can be reintroduced as a separate `chore(tests)` PR if desired.

## Tests
- [x] `npx vitest run test/fetch.test.ts` - 94/94 pass
- [x] Regression verified: temporarily reverted the source default to `true` and confirmed the new test fails, then restored and confirmed it passes
- [x] `npx tsc --noEmit`
- [x] `npm run l && npm run f`