### PR TITLE
fix(vertex): align VertexEmbeddingProvider constructor with ProviderOptions

### DIFF
--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -42,7 +42,12 @@ import type {
   ProviderResponse,
   TokenUsage,
 } from '../../types/index';
-import type { ClaudeRequest, ClaudeResponse, ClaudeThinkingConfig } from './types';
+import type {
+  ClaudeRequest,
+  ClaudeResponse,
+  ClaudeThinkingConfig,
+  GoogleProviderConfig,
+} from './types';
 import type {
   GeminiApiResponse,
   GeminiErrorResponse,
@@ -53,6 +58,21 @@ import type {
 
 // Type for Google API errors - using 'any' to avoid gaxios dependency
 type GaxiosError = any;
+
+type VertexEmbeddingPredictResponse = {
+  predictions?: Array<{
+    embeddings?: {
+      values?: number[];
+      statistics?: {
+        token_count?: number;
+      };
+    };
+  }>;
+};
+
+type VertexEmbeddingProviderConfig = GoogleProviderConfig & {
+  autoTruncate?: boolean;
+};
 
 function getVertexApiHost(
   region: string,
@@ -1068,13 +1088,13 @@ export class VertexChatProvider extends GoogleGenericProvider {
 
 export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
   modelName: string;
-  config: any;
-  env?: any;
+  config: VertexEmbeddingProviderConfig;
+  env?: EnvOverrides;
 
-  constructor(modelName: string, config: any = {}, env?: any) {
+  constructor(modelName: string, options: GoogleProviderOptions = {}) {
     this.modelName = modelName;
-    this.config = config;
-    this.env = env;
+    this.config = options.config || {};
+    this.env = options.env;
   }
 
   /**
@@ -1124,7 +1144,7 @@ export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
       },
     };
 
-    let data: any;
+    let data: VertexEmbeddingPredictResponse = {};
     try {
       const client = await this.getClientWithCredentials();
       const projectId = await this.getProjectId();
@@ -1136,7 +1156,7 @@ export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
         method: 'POST',
         data: body,
       });
-      data = res.data;
+      data = res.data as VertexEmbeddingPredictResponse;
     } catch (err) {
       logger.error(`Vertex API call error: ${err}`);
       throw err;

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -811,6 +811,17 @@ describe('loadApiProvider', () => {
     expect(provider.id()).toBe('vertex:vertex-embedding-model');
   });
 
+  it('vertex:embedding forwards providerOptions.config to this.config', async () => {
+    const provider = (await loadApiProvider('vertex:embedding:gemini-embedding-001', {
+      options: {
+        config: { autoTruncate: true, region: 'us-west1' },
+      },
+    })) as VertexEmbeddingProvider;
+    expect(provider).toBeInstanceOf(VertexEmbeddingProvider);
+    expect(provider.config.autoTruncate).toBe(true);
+    expect(provider.config.region).toBe('us-west1');
+  });
+
   it('loadApiProvider with google:embedding', async () => {
     const provider = await loadApiProvider('google:embedding:gemini-embedding-001');
     expect(provider).toBeInstanceOf(AIStudioEmbeddingProvider);


### PR DESCRIPTION
## Summary

The `VertexEmbeddingProvider` constructor accepted `(modelName, config, env)`, but `src/providers/registry.ts` has been calling it as `(modelName, providerOptions)` for a long time. That meant:

- `this.config` was being set to the full `ProviderOptions` object (not the nested `config`)
- `this.env` was always `undefined` when created through the registry
- `autoTruncate` and any other Vertex embedding config supplied via `providerOptions.config` silently had no effect

This PR aligns the constructor with the call site and with sibling `VertexChatProvider`:

- `constructor(modelName: string, options: GoogleProviderOptions = {})`
- Type `this.config` as `GoogleProviderConfig & { autoTruncate?: boolean }` instead of `any`
- Type the Vertex `:predict` response shape instead of leaving `data: any`

**BREAKING CHANGE**: External callers instantiating `VertexEmbeddingProvider` directly with `(modelName, config, env)` must switch to `(modelName, { config, env })`. All in-tree callers already use the new form.

Split out of #8842 (which bundled this with an unrelated TLS default change).

## Tests
- [x] `npx tsc --noEmit`
- [x] `npx vitest run test/providers/google/vertex.test.ts test/providers/index.test.ts` — 247/247 pass
- [x] `npm run l && npm run f`