### PR TITLE
fix(deps): update DOMPurify to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24635,9 +24635,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -31884,9 +31884,9 @@
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -44604,7 +44604,7 @@
         "@mui/system": "^9.0.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.1",
         "react-countup": "^6.5.3",
         "swiper": "^12.1.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31879,7 +31879,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.1",
         "marked": "14.0.0"
       }
     },

--- a/site/package.json
+++ b/site/package.json
@@ -89,7 +89,7 @@
     "@mui/system": "^9.0.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.1",
     "react-countup": "^6.5.3",
     "swiper": "^12.1.2"
   }


### PR DESCRIPTION
## Summary
- update the docs workspace DOMPurify floor to 3.4.1
- update the lockfile DOMPurify entries, including the Monaco nested copy, to 3.4.1
- clear the current DOMPurify audit alerts

## Validation
- `npm run f`
- `npm run l`
- `npm run format:check`
- `npx check-dependency-version-consistency .`
- `npm audit --audit-level=moderate`
- `npm ls dompurify --all`
- `SKIP_OG_GENERATION=true npm run build --prefix site`