### PR TITLE
chore: address AI code quality findings

### DIFF
--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -318,6 +318,11 @@ describe('DataTable', () => {
           scrollContainer.scrollTop = 20_000;
           scrollContainer.dispatchEvent(new Event('scroll', { bubbles: true }));
         });
+        // TanStack Virtual debounces scroll-end notification after scroll events.
+        // Let it settle before jsdom teardown so React does not receive a late update.
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
       }
 
       const renderedRows = container.querySelectorAll('tbody tr[data-rowindex]');

--- a/src/app/src/pages/model-audit-setup/ModelAuditSetupPage.test.tsx
+++ b/src/app/src/pages/model-audit-setup/ModelAuditSetupPage.test.tsx
@@ -1,6 +1,6 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { callApi } from '@app/utils/api';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useModelAuditConfigStore, useModelAuditHistoryStore } from '../model-audit/stores';
@@ -435,14 +435,12 @@ describe('ModelAuditSetupPage', () => {
     });
 
     it('should cancel loading if dialog is closed before API response', async () => {
-      // Create a promise that resolves after a delay
+      let resolveResponse!: (response: {
+        ok: boolean;
+        json: () => Promise<{ scanners: Array<{ id: string }> }>;
+      }) => void;
       const delayedResponse = new Promise((resolve) => {
-        setTimeout(() => {
-          resolve({
-            ok: true,
-            json: () => Promise.resolve({ scanners: [{ id: 'test' }] }),
-          });
-        }, 100);
+        resolveResponse = resolve;
       });
 
       mockCallApi.mockReturnValue(delayedResponse as any);
@@ -487,11 +485,14 @@ describe('ModelAuditSetupPage', () => {
         </TooltipProvider>,
       );
 
-      // Wait for the API response to arrive
-      await delayedResponse;
-
-      // Give it time to potentially update state (which it shouldn't due to cancellation)
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await act(async () => {
+        resolveResponse({
+          ok: true,
+          json: () => Promise.resolve({ scanners: [{ id: 'test' }] }),
+        });
+        await delayedResponse;
+        await Promise.resolve();
+      });
 
       // Scanner count should remain at initial value since update was cancelled
       expect(screen.getByTestId('scanner-count')).toHaveTextContent('0');

--- a/src/app/src/pages/model-audit-setup/ModelAuditSetupPage.tsx
+++ b/src/app/src/pages/model-audit-setup/ModelAuditSetupPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { Alert, AlertContent, AlertDescription } from '@app/components/ui/alert';
 import { Card, CardContent } from '@app/components/ui/card';
@@ -44,6 +44,11 @@ export default function ModelAuditSetupPage() {
   const [scannerCatalog, setScannerCatalog] = useState<ScannerCatalogEntry[]>([]);
   const [isLoadingScanners, setIsLoadingScanners] = useState(false);
   const [scannerCatalogError, setScannerCatalogError] = useState<string | null>(null);
+  const isOptionsDialogOpenRef = useRef(showOptionsDialog);
+
+  useLayoutEffect(() => {
+    isOptionsDialogOpenRef.current = showOptionsDialog;
+  }, [showOptionsDialog]);
 
   useEffect(() => {
     useModelAuditConfigStore.persist.rehydrate();
@@ -61,6 +66,8 @@ export default function ModelAuditSetupPage() {
       setIsLoadingScanners(true);
       setScannerCatalogError(null);
 
+      const shouldApplyScannerUpdate = () => !cancelled && isOptionsDialogOpenRef.current;
+
       try {
         const response = await callApi('/model-audit/scanners');
         if (!response.ok) {
@@ -69,18 +76,18 @@ export default function ModelAuditSetupPage() {
         }
 
         const data = (await response.json()) as { scanners?: ScannerCatalogEntry[] };
-        if (!cancelled) {
+        if (shouldApplyScannerUpdate()) {
           setScannerCatalog(Array.isArray(data.scanners) ? data.scanners : []);
         }
       } catch (error) {
-        if (!cancelled) {
+        if (shouldApplyScannerUpdate()) {
           setScannerCatalog([]);
           setScannerCatalogError(
             error instanceof Error ? error.message : 'Unable to load scanners',
           );
         }
       } finally {
-        if (!cancelled) {
+        if (shouldApplyScannerUpdate()) {
           setIsLoadingScanners(false);
         }
       }

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -61,9 +61,9 @@ const DESCRIPTIONS_BY_TAB: Record<string, React.ReactNode> = {
   intents: (
     <p>
       <span>
-        Intents are seed phrases for attack generation, for example "bypass authentication and
-        access admin panel". Promptfoo can apply jailbreak strategies to single-turn intents;
-        multi-step sequences run as authored.
+        Intents are seed phrases for attack generation, for example "teach me how to cook meth".
+        Promptfoo can apply jailbreak strategies to single-turn intents; multi-step sequences run as
+        authored.
       </span>{' '}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -61,9 +61,9 @@ const DESCRIPTIONS_BY_TAB: Record<string, React.ReactNode> = {
   intents: (
     <p>
       <span>
-        Intents are seed phrases for attack generation, for example "teach me how to cook meth".
-        Promptfoo can apply jailbreak strategies to single-turn intents; multi-step sequences run as
-        authored.
+        Intents are seed phrases for attack generation, for example "bypass authentication and
+        access admin panel". Promptfoo can apply jailbreak strategies to single-turn intents;
+        multi-step sequences run as authored.
       </span>{' '}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/test/providers/openai/moderation.test.ts
+++ b/test/providers/openai/moderation.test.ts
@@ -134,6 +134,47 @@ describe('OpenAiModerationProvider', () => {
         flags: [],
       });
     });
+
+    it('should use flagged categories when scores are close together', async () => {
+      const provider = createProvider();
+
+      const mockResponse = {
+        id: 'modr-123',
+        model: 'text-moderation-latest',
+        results: [
+          {
+            flagged: true,
+            categories: {
+              hate: true,
+              'hate/threatening': false,
+            },
+            category_scores: {
+              hate: 0.5,
+              'hate/threatening': 0.49,
+            },
+          },
+        ],
+      };
+
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: mockResponse,
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      });
+
+      const result = await provider.callModerationApi('user input', 'assistant response');
+
+      expect(result).toEqual({
+        flags: [
+          {
+            code: 'hate',
+            description: 'hate',
+            confidence: 0.5,
+          },
+        ],
+      });
+    });
   });
 
   describe('Error handling', () => {
@@ -213,6 +254,61 @@ describe('OpenAiModerationProvider', () => {
         id: 'modr-123',
         model: 'text-moderation-latest',
         results: [], // Empty results array
+      };
+
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: mockResponse,
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      });
+
+      const result = await provider.callModerationApi('user', 'assistant');
+      expect(result).toEqual({ flags: [] });
+    });
+
+    it('should handle non-empty results with no flagged categories', async () => {
+      const provider = createProvider();
+
+      const mockResponse = {
+        id: 'modr-124',
+        model: 'text-moderation-latest',
+        results: [
+          {
+            flagged: false,
+            categories: {
+              hate: false,
+              'hate/threatening': false,
+              harassment: false,
+              'harassment/threatening': false,
+              illicit: false,
+              'illicit/violent': false,
+              'self-harm': false,
+              'self-harm/intent': false,
+              'self-harm/instructions': false,
+              sexual: false,
+              'sexual/minors': false,
+              violence: false,
+              'violence/graphic': false,
+            },
+            category_scores: {
+              hate: 0,
+              'hate/threatening': 0,
+              harassment: 0,
+              'harassment/threatening': 0,
+              illicit: 0,
+              'illicit/violent': 0,
+              'self-harm': 0,
+              'self-harm/intent': 0,
+              'self-harm/instructions': 0,
+              sexual: 0,
+              'sexual/minors': 0,
+              violence: 0,
+              'violence/graphic': 0,
+            },
+            category_applied_input_types: {},
+          },
+        ],
       };
 
       vi.mocked(fetchWithCache).mockResolvedValueOnce({
@@ -444,7 +540,7 @@ describe('OpenAiModerationProvider', () => {
       expect(cacheKeyA).not.toContain('sk-moderation-reload');
     });
 
-    it('should deduplicate in-flight moderation requests without raw fetch cache keys', async () => {
+    it('should deduplicate concurrent moderation requests with identical cache identity', async () => {
       vi.mocked(isCacheEnabled).mockImplementation(function () {
         return true;
       });
@@ -622,7 +718,7 @@ describe('OpenAiModerationProvider', () => {
       );
     });
 
-    it('hashes cached mixed text and image inputs without leaking raw content', async () => {
+    it('should hash cached mixed text and image inputs without leaking raw content', async () => {
       vi.mocked(isCacheEnabled).mockImplementation(function () {
         return true;
       });
@@ -863,6 +959,33 @@ describe('Moderation Utility Functions', () => {
         { type: 'text' as const, text: 'second text' },
       ];
       expect(formatModerationInput(input, false)).toBe('first text second text');
+    });
+
+    it('should handle empty text strings when joining for text-only models', () => {
+      const input = [
+        { type: 'text' as const, text: '' },
+        { type: 'image_url' as const, image_url: { url: 'https://example.com/image.jpg' } },
+        { type: 'text' as const, text: 'second text' },
+      ];
+      expect(formatModerationInput(input, false)).toBe(' second text');
+    });
+
+    it('should preserve leading and trailing whitespace in text inputs when joining', () => {
+      const input = [
+        { type: 'text' as const, text: '  first text  ' },
+        { type: 'image_url' as const, image_url: { url: 'https://example.com/image.jpg' } },
+        { type: 'text' as const, text: 'second text' },
+      ];
+      expect(formatModerationInput(input, false)).toBe('  first text   second text');
+    });
+
+    it('should return single text input unchanged when mixed with images for text-only models', () => {
+      const input = [
+        { type: 'image_url' as const, image_url: { url: 'https://example.com/image-1.jpg' } },
+        { type: 'text' as const, text: 'only text' },
+        { type: 'image_url' as const, image_url: { url: 'https://example.com/image-2.jpg' } },
+      ];
+      expect(formatModerationInput(input, false)).toBe('only text');
     });
   });
 });

--- a/test/providers/watsonx.test.ts
+++ b/test/providers/watsonx.test.ts
@@ -883,7 +883,8 @@ describe('WatsonXProvider', () => {
       expect(typeof response.cost).toBe('number');
       // For class_c1 tier ($0.0001 per 1M tokens)
       // Input: 50 tokens * $0.0001/1M = 0.000005
-      // Output: 50 tokens * $0.0001/1M = 0.000005
+      // Output: (generated_token_count - input_token_count) = (100 - 50) = 50 tokens
+      // Output cost: 50 tokens * $0.0001/1M = 0.000005
       // Total expected: 0.00001
       expect(response.cost).toBeCloseTo(0.00001, 6);
     });
@@ -959,7 +960,9 @@ describe('WatsonXProvider', () => {
 
       expect(response.cost).toBeDefined();
       expect(typeof response.cost).toBe('number');
-      // For class_9 tier ($0.00035 per 1M tokens)
+      // For class_9 tier ($0.00035 per 1M tokens):
+      // input_token_count = 50
+      // generated_token_count = 100, so completion/output tokens = 100 - 50 = 50
       // Input: 50 tokens * $0.00035/1M = 0.0000175
       // Output: 50 tokens * $0.00035/1M = 0.0000175
       // Total expected: 0.000035
@@ -1038,6 +1041,8 @@ describe('WatsonXProvider', () => {
       expect(response.cost).toBeDefined();
       expect(typeof response.cost).toBe('number');
       // For class_c1 tier ($0.0001 per 1M tokens)
+      // input_token_count = 50
+      // generated_token_count = 100, so completion/output tokens = 100 - 50 = 50
       // Input: 50 tokens * $0.0001/1M = 0.000005
       // Output: 50 tokens * $0.0001/1M = 0.000005
       // Total expected: 0.00001

--- a/test/smoke/regression-recent.test.ts
+++ b/test/smoke/regression-recent.test.ts
@@ -170,7 +170,7 @@ describe('Recent Bug Regression Tests', () => {
         const results = parsed.results.results;
 
         expect(results).toHaveLength(2);
-        for (const [index, expectedVar] of ['hello world', 'goodbye moon'].entries()) {
+        for (const [index, expectedValue] of ['hello world', 'goodbye moon'].entries()) {
           const result = results[index];
           const componentResult = result.gradingResult.componentResults[0];
 
@@ -180,11 +180,11 @@ describe('Recent Bug Regression Tests', () => {
             'Does the output correctly reference the input: {{myVar}}?',
           );
           expect(componentResult.metadata.renderedAssertionValue).toBe(
-            `Does the output correctly reference the input: ${expectedVar}?`,
+            `Does the output correctly reference the input: ${expectedValue}?`,
           );
-          expect(componentResult.metadata.renderedGradingPrompt).toContain(expectedVar);
+          expect(componentResult.metadata.renderedGradingPrompt).toContain(expectedValue);
           expect(componentResult.metadata.renderedGradingPrompt).not.toContain('{{myVar}}');
-          expect(componentResult.reason).toContain(expectedVar);
+          expect(componentResult.reason).toContain(expectedValue);
           expect(componentResult.reason).not.toContain('{{myVar}}');
         }
       });
@@ -599,7 +599,7 @@ tests:
         // Look for a definition that has the options properties (prefix, suffix, provider, etc.)
         // and verify it's NOT using the problematic allOf pattern
         let foundOptionsSchema = false;
-        for (const [_key, def] of Object.entries(definitions)) {
+        for (const def of Object.values(definitions)) {
           const defObj = def as Record<string, unknown>;
           const props = defObj.properties as Record<string, unknown> | undefined;
 

--- a/test/validators/testProvider.test.ts
+++ b/test/validators/testProvider.test.ts
@@ -279,6 +279,17 @@ describe('testProviderConnectivity', () => {
     expect(vars).not.toHaveProperty('sessionId');
   });
 
+  it('should set sessionId var when provider has no sessionParser config', async () => {
+    const provider = createMockProvider();
+
+    await testProviderConnectivity({ provider });
+
+    expect(mockEvaluate).toHaveBeenCalled();
+    const callArgs = mockEvaluate.mock.calls[0];
+    const vars = callArgs[0].tests[0].vars;
+    expect(vars).toHaveProperty('sessionId');
+  });
+
   it('should use default prompt when none provided', async () => {
     const provider = createMockProvider();
     await testProviderConnectivity({ provider });


### PR DESCRIPTION
## Summary
- address all 12 currently visible GitHub Code Quality AI findings across 5 files
- replace a sensitive UI example in redteam setup copy
- add targeted OpenAI moderation and testProvider coverage, and clean up test naming/comments/readability

## Validation
- `npm run f`
- `npx vitest run test/providers/openai/moderation.test.ts test/providers/watsonx.test.ts test/validators/testProvider.test.ts`
- `npm run l`
- `npx vitest run test/smoke/regression-recent.test.ts --config vitest.smoke.config.ts`

## Notes
- `npm run build` completed root `tsc --noEmit` and CLI bundling, but the app typecheck failed in this reused local dependency tree because `diff` declarations were unavailable for an existing frontend file.