### PR TITLE
test(agent-skills): use python on windows fixtures

### DIFF
--- a/test/agentSkills/promptfooPlugin.test.ts
+++ b/test/agentSkills/promptfooPlugin.test.ts
@@ -49,6 +49,8 @@ const redteamRunFixtureDirs = [
   'redteam-run-local-mixed',
   'redteam-run-local-error',
 ] as const;
+const fixturePythonExecutable =
+  process.env.PROMPTFOO_PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
 
 type MarketplacePlugin = {
   name: string;
@@ -2221,7 +2223,7 @@ describe('promptfoo Codex plugin package', () => {
       const script = readText(absolutePath);
       expect(script, `${context}: ${reference}`).toContain(`def ${functionName}(`);
 
-      const output = execFileSync('python3', [absolutePath], {
+      const output = execFileSync(fixturePythonExecutable, [absolutePath], {
         cwd: path.dirname(absolutePath),
         encoding: 'utf8',
         env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2279,7 +2281,7 @@ describe('promptfoo Codex plugin package', () => {
     expect(configuredEvalResult.output).toContain('PONG topic=config-topic');
     expect(configuredEvalResult.output).toContain('trace id config-trace');
 
-    const evalPythonOutput = execFileSync('python3', ['provider.py'], {
+    const evalPythonOutput = execFileSync(fixturePythonExecutable, ['provider.py'], {
       cwd: path.join(fixtureRoot, 'evals-local-python'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2290,7 +2292,7 @@ describe('promptfoo Codex plugin package', () => {
     expect(evalPythonResult.metadata).toEqual({ topic: 'smoke', trace_id: 'eval-py-123' });
 
     const evalPythonConfigOutput = execFileSync(
-      'python3',
+      fixturePythonExecutable,
       [
         '-c',
         [
@@ -2345,7 +2347,7 @@ describe('promptfoo Codex plugin package', () => {
     expect(configuredResult.output).toBe('PONG local wrapper for qa-config/inv-config');
     expect(configuredResult.metadata).toEqual({ user_id: 'qa-config', invoice_id: 'inv-config' });
 
-    const pythonOutput = execFileSync('python3', ['provider.py'], {
+    const pythonOutput = execFileSync(fixturePythonExecutable, ['provider.py'], {
       cwd: path.join(fixtureRoot, 'provider-setup-local-python'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2414,7 +2416,7 @@ describe('promptfoo Codex plugin package', () => {
     );
     expect((await staticGenerator.callApi()).output).toContain('invoice-owned-by-victim');
 
-    const pythonTargetOutput = execFileSync('python3', ['target.py'], {
+    const pythonTargetOutput = execFileSync(fixturePythonExecutable, ['target.py'], {
       cwd: path.join(fixtureRoot, 'redteam-setup-static-code-python'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2429,7 +2431,7 @@ describe('promptfoo Codex plugin package', () => {
     );
 
     const pythonConfigOutput = execFileSync(
-      'python3',
+      fixturePythonExecutable,
       [
         '-c',
         [
@@ -2459,7 +2461,7 @@ describe('promptfoo Codex plugin package', () => {
       }),
     );
 
-    const pythonGeneratorOutput = execFileSync('python3', ['redteam-generator.py'], {
+    const pythonGeneratorOutput = execFileSync(fixturePythonExecutable, ['redteam-generator.py'], {
       cwd: path.join(fixtureRoot, 'redteam-setup-static-code-python'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2483,7 +2485,7 @@ describe('promptfoo Codex plugin package', () => {
     const passGrader = await loadFixtureProvider('redteam-run-local-pass/grader.mjs');
     expect(parseOutputJson(await passGrader.callApi(String(passResult.output))).pass).toBe(true);
 
-    const pythonRunTargetOutput = execFileSync('python3', ['target.py'], {
+    const pythonRunTargetOutput = execFileSync(fixturePythonExecutable, ['target.py'], {
       cwd: path.join(fixtureRoot, 'redteam-run-local-python-pass'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
@@ -2491,7 +2493,7 @@ describe('promptfoo Codex plugin package', () => {
     const pythonRunTargetResult = JSON.parse(pythonRunTargetOutput) as ProviderResult;
     expect(pythonRunTargetResult.output).toContain('DENIED');
     const pythonRunConfigOutput = execFileSync(
-      'python3',
+      fixturePythonExecutable,
       [
         '-c',
         [
@@ -2512,7 +2514,7 @@ describe('promptfoo Codex plugin package', () => {
     );
     const pythonRunConfigResult = JSON.parse(pythonRunConfigOutput) as ProviderResult;
     expect(pythonRunConfigResult.output).toContain('for qa-py-run-config');
-    const pythonRunGraderOutput = execFileSync('python3', ['grader.py'], {
+    const pythonRunGraderOutput = execFileSync(fixturePythonExecutable, ['grader.py'], {
       cwd: path.join(fixtureRoot, 'redteam-run-local-python-pass'),
       encoding: 'utf8',
       env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },


### PR DESCRIPTION
## Summary
- use a shared fixture Python executable for agent skill contract tests
- honor PROMPTFOO_PYTHON and prefer python on Windows instead of hardcoding python3
- update later Python fixture smoke checks to use the same executable selector

## Validation
- npx vitest test/agentSkills/promptfooPlugin.test.ts --run -t "keeps Python file providers executable" --sequence.shuffle=false
- npx vitest test/agentSkills/promptfooPlugin.test.ts --run --sequence.shuffle=false
- npm run l && npm run f