### PR TITLE
ci(docker): publish images for release backfills

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,15 +2,16 @@
 # runs the Docker container, performs a health check to ensure the application
 # is running correctly, and then publishes the image to GitHub Container Registry
 # if all checks pass. This action is triggered by the release-please workflow,
-# workflow dispatch, pull requests to main that modify the Dockerfile, and pushes to main.
+# published human-created releases, workflow dispatch, pull requests to main that
+# modify the Dockerfile, and pushes to main.
 
 name: Test and Publish Multi-arch Docker Image
 run-name: |
-  ${{ inputs.tag_name && 'Release' ||
+  ${{ (inputs.tag_name || github.event.release.tag_name) && 'Release' ||
       github.event_name == 'workflow_dispatch' && 'Manual' ||
       github.event_name == 'pull_request' && 'PR' ||
       'Push' }}
-  Docker build for ${{ inputs.tag_name || github.ref_name }}
+  Docker build for ${{ inputs.tag_name || github.event.release.tag_name || github.ref_name }}
   ${{ github.event_name == 'pull_request' && format('(PR #{0})', github.event.number) || '' }}
   by @${{ github.actor }}
 
@@ -22,6 +23,14 @@ on:
         required: true
         type: string
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Optional release tag to publish (e.g., 0.121.6)'
+        required: false
+        type: string
+  release:
+    types:
+      - published
   pull_request:
     branches:
       - main
@@ -40,12 +49,20 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  RELEASE_TAG: ${{ inputs.tag_name || github.event.release.tag_name || '' }}
+  SOURCE_REF: ${{ inputs.tag_name || github.event.release.tag_name || github.ref }}
+  BUILD_VERSION: ${{ inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+  BUILD_DATE: ${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
 
 permissions:
   contents: read
 
 jobs:
   test:
+    # Release-please-created releases are already handled by release-please.yml
+    # after npm publish. The release event path is for human-published releases
+    # and backfills where release-please did not emit release_created=true.
+    if: github.event_name != 'release' || github.event.release.author.login != 'promptfoobot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -64,6 +81,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -81,8 +100,8 @@ jobs:
           tags: local-test-image:latest
           platforms: linux/amd64
           build-args: |
-            BUILD_VERSION=${{ inputs.tag_name || github.ref_name }}
-            BUILD_DATE=${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
+            BUILD_VERSION=${{ env.BUILD_VERSION }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
             GIT_SHA=${{ github.sha }}
 
       - name: Run Docker container for testing
@@ -186,6 +205,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -217,8 +238,8 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BUILD_VERSION=${{ inputs.tag_name || github.ref_name }}
-            BUILD_DATE=${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
+            BUILD_VERSION=${{ env.BUILD_VERSION }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
             GIT_SHA=${{ github.sha }}
           outputs: |
             type=image,push-by-digest=true,name-canonical=true,push=true,annotation-index.org.opencontainers.image.description=promptfoo is a tool for testing evaluating and red-teaming LLM apps.
@@ -274,8 +295,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=${{ inputs.tag_name }},enable=${{ inputs.tag_name != '' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || inputs.tag_name != '' }}
+            type=raw,value=${{ env.RELEASE_TAG }},enable=${{ env.RELEASE_TAG != '' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || env.RELEASE_TAG != '' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -287,7 +308,7 @@ jobs:
       - name: Inspect image
         id: inspect
         run: |
-          IMAGE_TAG="${{ inputs.tag_name || steps.meta.outputs.version }}"
+          IMAGE_TAG="${{ env.RELEASE_TAG || steps.meta.outputs.version }}"
           IMAGE_REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}"
           # Log full inspection details and extract digest
           INSPECT_OUTPUT=$(docker buildx imagetools inspect "${IMAGE_REF}")

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ env:
   SOURCE_REF: ${{ inputs.tag_name || github.event.release.tag_name || github.ref }}
   BUILD_VERSION: ${{ inputs.tag_name || github.event.release.tag_name || github.ref_name }}
   BUILD_DATE: ${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
+  IS_RELEASE_BACKFILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || github.event_name == 'release' }}
 
 permissions:
   contents: read
@@ -84,6 +85,10 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REF }}
 
+      - name: Resolve source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -102,7 +107,7 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ env.BUILD_VERSION }}
             BUILD_DATE=${{ env.BUILD_DATE }}
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.source.outputs.sha }}
 
       - name: Run Docker container for testing
         run: docker run -d --name promptfoo-container -p 3000:3000 local-test-image:latest
@@ -208,6 +213,10 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REF }}
 
+      - name: Resolve source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -219,6 +228,8 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -240,7 +251,7 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ env.BUILD_VERSION }}
             BUILD_DATE=${{ env.BUILD_DATE }}
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.source.outputs.sha }}
           outputs: |
             type=image,push-by-digest=true,name-canonical=true,push=true,annotation-index.org.opencontainers.image.description=promptfoo is a tool for testing evaluating and red-teaming LLM apps.
 
@@ -290,13 +301,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=branch,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
+            type=ref,event=pr,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
             type=raw,value=${{ env.RELEASE_TAG }},enable=${{ env.RELEASE_TAG != '' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || env.RELEASE_TAG != '' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && env.IS_RELEASE_BACKFILL != 'true' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - name: Validate release tag
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+        if: env.RELEASE_TAG != ''
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "::error::RELEASE_TAG is empty or invalid"
+            echo "::error::RELEASE_TAG '$RELEASE_TAG' is empty or invalid"
             exit 1
           fi
 
@@ -218,10 +218,10 @@ jobs:
       packages: write
     steps:
       - name: Validate release tag
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+        if: env.RELEASE_TAG != ''
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "::error::RELEASE_TAG is empty or invalid"
+            echo "::error::RELEASE_TAG '$RELEASE_TAG' is empty or invalid"
             exit 1
           fi
 
@@ -313,12 +313,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      # Fallback release builds publish immutable version tags only so moving aliases stay on normal release paths.
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Fallback release builds publish immutable version tags only so moving aliases stay on normal release paths.
           tags: |
             type=ref,event=branch,enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}
             type=ref,event=pr,enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,23 +53,31 @@ env:
   SOURCE_REF: ${{ inputs.tag_name || github.event.release.tag_name || github.ref }}
   BUILD_VERSION: ${{ inputs.tag_name || github.event.release.tag_name || github.ref_name }}
   BUILD_DATE: ${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
-  IS_RELEASE_BACKFILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || github.event_name == 'release' }}
+  # Fallback release paths build a specific tag outside release-please.yml.
+  IS_RELEASE_FALLBACK: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || github.event_name == 'release' }}
 
 permissions:
   contents: read
 
 jobs:
   test:
-    # Release-please-created releases are already handled by release-please.yml
-    # after npm publish. The release event path is for human-published releases
-    # and backfills where release-please did not emit release_created=true.
-    if: github.event_name != 'release' || github.event.release.author.login != 'promptfoobot[bot]'
+    # Bot-authored releases are already handled by release-please.yml after npm publish.
+    # The release event path is for human-published fallback releases and backfills.
+    if: github.event_name != 'release' || github.event.release.author.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
 
     steps:
+      - name: Validate release tag
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::RELEASE_TAG is empty or invalid"
+            exit 1
+          fi
+
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet
@@ -85,6 +93,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REF }}
 
+      # github.sha is the trigger SHA; SOURCE_REF can point checkout at a different tag.
       - name: Resolve source commit
         id: source
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -208,11 +217,20 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Validate release tag
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::RELEASE_TAG is empty or invalid"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.SOURCE_REF }}
 
+      # github.sha is the trigger SHA; SOURCE_REF can point checkout at a different tag.
       - name: Resolve source commit
         id: source
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -295,19 +313,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      # Fallback release builds publish immutable version tags only so moving aliases stay on normal release paths.
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
-            type=ref,event=pr,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
+            type=ref,event=branch,enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}
+            type=ref,event=pr,enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,enable=${{ env.IS_RELEASE_BACKFILL != 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}
+            type=sha,enable=${{ env.IS_RELEASE_FALLBACK != 'true' }}
             type=raw,value=${{ env.RELEASE_TAG }},enable=${{ env.RELEASE_TAG != '' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && env.IS_RELEASE_BACKFILL != 'true' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && env.IS_RELEASE_FALLBACK != 'true' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -318,8 +337,9 @@ jobs:
 
       - name: Inspect image
         id: inspect
+        env:
+          IMAGE_TAG: ${{ env.RELEASE_TAG || steps.meta.outputs.version }}
         run: |
-          IMAGE_TAG="${{ env.RELEASE_TAG || steps.meta.outputs.version }}"
           IMAGE_REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}"
           # Log full inspection details and extract digest
           INSPECT_OUTPUT=$(docker buildx imagetools inspect "${IMAGE_REF}")

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Validate release tag
-        if: env.RELEASE_TAG != ''
+        if: github.event_name == 'release' || env.RELEASE_TAG != ''
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
             echo "::error::RELEASE_TAG '$RELEASE_TAG' is empty or invalid"
@@ -218,7 +218,7 @@ jobs:
       packages: write
     steps:
       - name: Validate release tag
-        if: env.RELEASE_TAG != ''
+        if: github.event_name == 'release' || env.RELEASE_TAG != ''
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
             echo "::error::RELEASE_TAG '$RELEASE_TAG' is empty or invalid"


### PR DESCRIPTION
## Summary
- add a Docker workflow release-published fallback for human-published releases/backfills
- add a manual `tag_name` dispatch input so missing release images like `0.121.6` can be rebuilt from the tag
- checkout the selected release tag when the workflow is invoked for a release/backfill, and tag GHCR manifests from the selected release tag

Fixes #8849.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker.yml"); puts "yaml ok"'`
- `npx prettier --write .github/workflows/docker.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -oneline .github/workflows/docker.yml`
- `git diff --check`

## Backfill after merge
Run the Docker workflow manually with `tag_name=0.121.6` from `main` to publish the missing GHCR image for the existing release.