### PR TITLE
ci(release): run Docker publish after npm release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,7 +91,13 @@ jobs:
           PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
 
   docker:
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.release-please.result == 'success' &&
+        needs.publish-npm.result == 'success' &&
+        needs.release-please.outputs.release_created == 'true'
+      }}
     needs: [publish-npm, release-please]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Make the release-please Docker job gate explicit so skipped optional release jobs do not suppress Docker publishing
- Require release-please and npm publish to succeed before invoking the reusable Docker workflow

## Validation
- `actionlint .github/workflows/release-please.yml`
- `npx prettier --check .github/workflows/release-please.yml`

## Follow-up
- Manually dispatched the Docker workflow for `0.121.7` to backfill the image while this fix lands.