### PR TITLE
test(vertex): cover default embedding provider model

### DIFF
--- a/test/providers/google/vertex.defaults.test.ts
+++ b/test/providers/google/vertex.defaults.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DefaultEmbeddingProvider,
+  DefaultGradingProvider,
+} from '../../../src/providers/google/vertex';
+
+describe('Google Vertex default providers', () => {
+  describe('DefaultEmbeddingProvider', () => {
+    it('should use the current Gemini embedding model', () => {
+      expect(DefaultEmbeddingProvider.modelName).toBe('gemini-embedding-001');
+      expect(DefaultEmbeddingProvider.id()).toBe('vertex:gemini-embedding-001');
+    });
+  });
+
+  describe('DefaultGradingProvider', () => {
+    it('should use the current Gemini grading model', () => {
+      expect(DefaultGradingProvider.modelName).toBe('gemini-2.5-pro');
+      expect(DefaultGradingProvider.id()).toBe('vertex:gemini-2.5-pro');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused coverage for Google Vertex default provider model ids
- lock the Vertex embedding default to gemini-embedding-001 after the recent default-model update

## Tests
- npx vitest run test/providers/google/vertex.defaults.test.ts --sequence.shuffle=false
- npm run l
- npm run f