### PR TITLE
feat(providers): add GPT-5.5 OpenAI support

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -56,7 +56,7 @@ Note: Quotes around `'{{env.VAR}}'` are required in YAML to prevent parsing issu
 
 Use current model identifiers (see `site/docs/providers/` for full list):
 
-- OpenAI: `openai:chat:gpt-5.4`, `openai:chat:gpt-5.4-mini`, `openai:chat:gpt-5.4-nano`, `openai:responses:gpt-5.4`
+- OpenAI: `openai:chat:gpt-5.5`, `openai:responses:gpt-5.5`, `openai:responses:gpt-5.5-pro`, `openai:chat:gpt-5.4-mini`
 - Anthropic: `anthropic:messages:claude-sonnet-4-6`, `anthropic:messages:claude-haiku-4-5-20251001`
 - Google: `google:gemini-2.0-flash`, `google:gemini-2.5-pro-preview`
 

--- a/examples/config-ts/promptfooconfig-with-schema.ts
+++ b/examples/config-ts/promptfooconfig-with-schema.ts
@@ -44,8 +44,8 @@ Return a JSON response with your translation, confidence level, and any fun cult
 
   providers: [
     {
-      id: 'openai:chat:gpt-5.4-mini',
-      label: 'GPT-5 Mini (structured)',
+      id: 'openai:chat:gpt-5.5',
+      label: 'GPT-5.5 (structured)',
       config: {
         response_format: responseFormat,
       },

--- a/examples/config-ts/promptfooconfig.ts
+++ b/examples/config-ts/promptfooconfig.ts
@@ -6,7 +6,7 @@ const config: UnifiedConfig = {
     'Rephrase this in {{language}}: {{body}}',
     'Translate this to conversational {{language}}: {{body}}',
   ],
-  providers: ['openai:chat:gpt-5.4-mini'],
+  providers: ['openai:chat:gpt-5.5'],
   tests: [
     {
       vars: {

--- a/examples/getting-started/promptfooconfig.yaml
+++ b/examples/getting-started/promptfooconfig.yaml
@@ -8,7 +8,7 @@ prompts:
   - 'Convert the following English text to {{language}}: {{input}}'
 
 providers:
-  - openai:chat:gpt-5.4
+  - openai:chat:gpt-5.5
   - openai:chat:gpt-5.4-mini
   # Or setup models from other providers
   # - anthropic:messages:claude-sonnet-4-6

--- a/examples/openai-codex-app-server/approval-policy/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/approval-policy/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Explain what command you would run to list files. Do not run it.'
 
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       approval_policy: on-request

--- a/examples/openai-codex-app-server/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Return a concise JSON summary of this workspace. Include the main purpose and two likely maintenance risks.'
 
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-app-server/review-diff/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/review-diff/promptfooconfig.yaml
@@ -17,7 +17,7 @@ prompts:
     actionable comments, return an empty comments array.
 
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-app-server/skills/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/skills/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - file://skill-input.json
 
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-responses/README.md
+++ b/examples/openai-responses/README.md
@@ -13,7 +13,7 @@ cd openai-responses
 
 ### Basic Responses API (`promptfooconfig.yaml`)
 
-Basic example showing how to use the Responses API with the GPT-5.4 family (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) and a GPT-4.1 comparison model.
+Basic example showing how to use the Responses API with GPT-5.5, the GPT-5.4 family (`gpt-5.4-mini`, `gpt-5.4-nano`), and a GPT-4.1 comparison model.
 
 ### External Response Format (`promptfooconfig.external-format.yaml`)
 
@@ -67,6 +67,10 @@ Example comparing GPT-5.2 with different reasoning effort levels:
 - **medium**: Balanced reasoning for most tasks
 - **high**: Maximum reasoning for complex problem-solving
 
+### GPT-5.5 (`promptfooconfig.gpt-5.5.yaml`)
+
+Example comparing GPT-5.5 standard and pro models with different Responses API reasoning settings.
+
 ### Image Processing (`promptfooconfig.image.yaml`)
 
 Example demonstrating image input capabilities with vision models.
@@ -118,6 +122,9 @@ npx promptfoo eval -c promptfooconfig.gpt-5.1.yaml
 
 # GPT-5.2 example
 npx promptfoo eval -c promptfooconfig.gpt-5.2.yaml
+
+# GPT-5.5 example
+npx promptfoo eval -c promptfooconfig.gpt-5.5.yaml
 
 ```
 

--- a/examples/openai-responses/promptfooconfig.gpt-5.5.yaml
+++ b/examples/openai-responses/promptfooconfig.gpt-5.5.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: GPT-5.5 Responses API reasoning comparison
+prompts:
+  - |
+    Solve this planning problem and explain your reasoning clearly:
+    {{problem}}
+
+providers:
+  - id: openai:responses:gpt-5.5
+    label: gpt-5.5-low-reasoning
+    config:
+      max_output_tokens: 2048
+      reasoning:
+        effort: 'low'
+      verbosity: 'medium'
+
+  - id: openai:responses:gpt-5.5
+    label: gpt-5.5-high-reasoning
+    config:
+      max_output_tokens: 4096
+      reasoning:
+        effort: 'high'
+      verbosity: 'medium'
+
+  - id: openai:responses:gpt-5.5-pro
+    label: gpt-5.5-pro-xhigh-reasoning
+    config:
+      max_output_tokens: 8192
+      reasoning:
+        effort: 'xhigh'
+      verbosity: 'medium'
+
+tests:
+  - vars:
+      problem: 'A team has 6 engineers, 3 designers, and 2 product managers. Build a two-week launch plan that sequences discovery, implementation, QA, and release readiness without overloading any one function.'
+    assert:
+      - type: icontains
+        value: discovery
+      - type: icontains
+        value: QA
+
+  - vars:
+      problem: 'A support queue has 120 tickets, 30% are billing issues, and 15% require engineering investigation. Propose a triage plan that minimizes customer wait time while preserving escalation quality.'
+    assert:
+      - type: icontains-any
+        value:
+          - triage
+          - prioritize
+      - type: icontains
+        value: escalation

--- a/examples/openai-responses/promptfooconfig.yaml
+++ b/examples/openai-responses/promptfooconfig.yaml
@@ -5,8 +5,8 @@ prompts:
 
 providers:
   # GPT-5 models showcasing latest capabilities
-  - id: openai:responses:gpt-5.4
-    label: gpt-5.4-json-schema
+  - id: openai:responses:gpt-5.5
+    label: gpt-5.5-json-schema
     config:
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@inquirer/input": "^5.0.8",
         "@inquirer/select": "^5.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/agents": "^0.8.3",
+        "@openai/agents": "^0.8.5",
         "@opencode-ai/sdk": "^1.2.19",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.6.0",
@@ -12493,14 +12493,14 @@
       "license": "MIT"
     },
     "node_modules/@openai/agents": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.3.tgz",
-      "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.5.tgz",
+      "integrity": "sha512-OFA7XVV1qXE8lzatvQj080KdSArt8utBExFXRfD5B/R7KT0D+AVaKwg6nLoW3Gxb30vRkIUQf+MaW/Wz+gO3Yg==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
-        "@openai/agents-openai": "0.8.3",
-        "@openai/agents-realtime": "0.8.3",
+        "@openai/agents-core": "0.8.5",
+        "@openai/agents-openai": "0.8.5",
+        "@openai/agents-realtime": "0.8.5",
         "debug": "^4.4.0",
         "openai": "^6.26.0"
       },
@@ -12509,9 +12509,9 @@
       }
     },
     "node_modules/@openai/agents-core": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.3.tgz",
-      "integrity": "sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.5.tgz",
+      "integrity": "sha512-qs9mmN+D+UmqEZo3qrvhhIIXIOgSvJPic0v4a+ruq+eYgcQMk3PY8lLcsdQwJit6zf2Wyfv1q2cX5m3jzWZpKw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -12530,12 +12530,12 @@
       }
     },
     "node_modules/@openai/agents-openai": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.3.tgz",
-      "integrity": "sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.5.tgz",
+      "integrity": "sha512-cGYmyiVy8ecgf2Vch0L/ekeNo3xuZsuWnRsxyv+w9ai9dgxUifdEQ6G3dtsjMLtmXVHRVGoO7mVBr+tKcilntw==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
+        "@openai/agents-core": "0.8.5",
         "debug": "^4.4.0",
         "openai": "^6.26.0"
       },
@@ -12544,12 +12544,12 @@
       }
     },
     "node_modules/@openai/agents-realtime": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.3.tgz",
-      "integrity": "sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.5.tgz",
+      "integrity": "sha512-JqKVsR33OvKtTxRp5Ylhw8WfNvJ49ZIhlhMZlSVKqwR2Ks6JuxqFJ0zM9p7JIbTQDSlAZnmnZJv1qlItaildiQ==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
+        "@openai/agents-core": "0.8.5",
         "@types/ws": "^8.18.1",
         "debug": "^4.4.0",
         "ws": "^8.18.1"

--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
     "@inquirer/input": "^5.0.8",
     "@inquirer/select": "^5.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/agents": "^0.8.3",
+    "@openai/agents": "^0.8.5",
     "@opencode-ai/sdk": "^1.2.19",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.6.0",

--- a/site/docs/providers/openai-codex-app-server.md
+++ b/site/docs/providers/openai-codex-app-server.md
@@ -15,9 +15,9 @@ For CI and straightforward automation, prefer the [OpenAI Codex SDK provider](./
 ```yaml
 providers:
   - openai:codex-app-server
-  - openai:codex-app-server:gpt-5.4
+  - openai:codex-app-server:gpt-5.5
   - openai:codex-desktop
-  - openai:codex-desktop:gpt-5.4
+  - openai:codex-desktop:gpt-5.5
 ```
 
 `openai:codex-desktop` is an alias for the same app-server protocol. Promptfoo starts its own `codex app-server` process; it does not attach to an already-running Codex Desktop app process.
@@ -71,7 +71,7 @@ Promptfoo also accepts `CODEX_API_KEY` or `config.apiKey`. For reproducible eval
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       approval_policy: never
@@ -120,7 +120,7 @@ The provider validates top-level provider config strictly. Prompt-level config i
 | `additional_directories`  | string[]      | Additional directories added to workspace-write sandbox roots.                                                                                                      | None                 |
 | `skip_git_repo_check`     | boolean       | Skip the default Git repository safety check.                                                                                                                       | `false`              |
 | `codex_path_override`     | string        | Path to a specific `codex` binary.                                                                                                                                  | `codex`              |
-| `model`                   | string        | Model id, such as `gpt-5.4`. Can also be set in the provider id.                                                                                                    | Codex default        |
+| `model`                   | string        | Model id, such as `gpt-5.5`. Can also be set in the provider id.                                                                                                    | Codex default        |
 | `model_provider`          | string        | App-server model provider override for `thread/start` and `thread/resume`.                                                                                          | None                 |
 | `service_tier`            | string        | `fast` or `flex`.                                                                                                                                                   | App-server default   |
 | `sandbox_mode`            | string        | `read-only`, `workspace-write`, or `danger-full-access`.                                                                                                            | `read-only`          |
@@ -157,7 +157,7 @@ The provider validates top-level provider config strictly. Prompt-level config i
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       approval_policy:
         granular:
@@ -172,12 +172,12 @@ providers:
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       collaboration_mode:
         mode: plan
         settings:
-          model: gpt-5.4
+          model: gpt-5.5
           reasoning_effort: none
           developer_instructions: null
 ```
@@ -190,7 +190,7 @@ Configure deterministic responses when you intentionally want app-server approva
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: workspace-write
       approval_policy: on-request
@@ -237,7 +237,7 @@ Legacy `execCommandApproval` and `applyPatchApproval` callbacks are also handled
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:codex-app-server:gpt-5.4
+  - id: openai:codex-app-server:gpt-5.5
     config:
       sandbox_mode: read-only
       output_schema:

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -121,7 +121,7 @@ Specify which OpenAI model to use for code generation:
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - openai:codex:gpt-5.4
+  - openai:codex:gpt-5.5
 
 prompts:
   - 'Write a TypeScript function that validates email addresses'
@@ -133,7 +133,7 @@ If you need additional Codex settings, you can still set the model via `config.m
 providers:
   - id: openai:codex-sdk
     config:
-      model: gpt-5.4
+      model: gpt-5.5
 ```
 
 ### With Working Directory
@@ -224,19 +224,21 @@ The `approval_policy` parameter controls when user approval is required:
 
 ## Models
 
-The SDK supports various OpenAI models. Use `gpt-5.4` for the latest frontier model:
+The SDK supports various OpenAI models. Use `gpt-5.5` for the latest frontier model:
 
 ```yaml
 providers:
   - id: openai:codex-sdk
     config:
-      model: gpt-5.4 # Recommended for code tasks
+      model: gpt-5.5 # Recommended for code tasks
 ```
 
 Supported models include:
 
-- **GPT-5.4** - Frontier model for professional work (`gpt-5.4`)
-- **GPT-5.4 Pro** - Higher-capacity variant (`gpt-5.4-pro`)
+- **GPT-5.5** - Latest frontier model for professional work (`gpt-5.5`)
+- **GPT-5.5 Pro** - Higher-capacity variant (`gpt-5.5-pro`)
+- **GPT-5.4** - Previous frontier model for professional work (`gpt-5.4`)
+- **GPT-5.4 Pro** - Previous higher-capacity variant (`gpt-5.4-pro`)
 - **GPT-5.3 Codex** - Latest codex generation (`gpt-5.3-codex`, `gpt-5.3-codex-spark`)
 - **GPT-5.2** - Current GPT-5.2 line (`gpt-5.2`, `gpt-5.2-codex`)
 - **GPT-5.1 Codex** - Optimized for code generation (`gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`)
@@ -244,6 +246,8 @@ Supported models include:
 - **GPT-5** - Base GPT-5 model (`gpt-5`)
 
 If you omit `config.model`, the Codex CLI may choose an internal default model alias and the backend may resolve that alias to a different concrete model. The current Codex SDK turn payload exposed to Promptfoo includes `items`, `finalResponse`, and `usage`, but not the backend-resolved model name, so tracing and cost attribution use the requested `config.model` when present and otherwise fall back to the provider's generic `codex` label with `response.cost: 0`.
+
+GPT-5.5 model IDs are recognized for routing, usage tracking, and standard API cost estimates. Batch and Flex discounts, and Priority processing multipliers, are not automatically inferred from Codex runtime settings.
 
 ### Mini Models
 
@@ -540,15 +544,17 @@ providers:
 
 Available levels vary by model:
 
-| Level     | Description                          | Supported Models                                                               |
-| --------- | ------------------------------------ | ------------------------------------------------------------------------------ |
-| `minimal` | Minimal reasoning overhead           | gpt-5.4, gpt-5.2                                                               |
-| `low`     | Light reasoning, faster responses    | All models                                                                     |
-| `medium`  | Balanced (default)                   | All models                                                                     |
-| `high`    | Thorough reasoning for complex tasks | All models                                                                     |
-| `xhigh`   | Maximum reasoning depth              | gpt-5.4, gpt-5.4-pro, gpt-5.3-codex, gpt-5.2, gpt-5.2-codex, gpt-5.1-codex-max |
+| Level     | Description                          | Supported Models                                                                                     |
+| --------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `minimal` | Minimal reasoning overhead           | gpt-5.4, gpt-5.2                                                                                     |
+| `low`     | Light reasoning, faster responses    | All models                                                                                           |
+| `medium`  | Balanced (default)                   | All models                                                                                           |
+| `high`    | Thorough reasoning for complex tasks | All models                                                                                           |
+| `xhigh`   | Maximum reasoning depth              | gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-pro, gpt-5.3-codex, gpt-5.2, gpt-5.2-codex, gpt-5.1-codex-max |
 
 Promptfoo validates the allowed enum values, but model-specific support is ultimately enforced by the Codex SDK/runtime. If a value is not supported by the selected model, the provider returns a normal provider error row.
+
+For GPT-5.5 API requests, use `none`, `low`, `medium`, `high`, or `xhigh` reasoning where the runtime exposes those values. The current Codex SDK type still exposes `minimal`, `low`, `medium`, `high`, and `xhigh`.
 
 ## Additional Directories
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-description: 'Configure OpenAI models including GPT-5.4, GPT-5.3, GPT-4.1, o-series reasoning, embeddings, and assistants for comprehensive AI evals'
+description: 'Configure OpenAI models including GPT-5.5, GPT-5.4, GPT-4.1, o-series reasoning, embeddings, and assistants for comprehensive AI evals'
 ---
 
 # OpenAI
@@ -32,7 +32,7 @@ The OpenAI provider supports the following model formats:
 - `openai:video:<model name>` - uses Sora video generation models
 - `openai:agents:<agent name>` - runs agentic workflows via OpenAI Agents SDK
 - `openai:chatkit:<workflow_id>` - runs ChatKit workflows
-- `openai:codex-sdk` / `openai:codex` - runs agentic coding workflows via OpenAI Codex SDK, with optional inline model selection like `openai:codex:gpt-5.4`
+- `openai:codex-sdk` / `openai:codex` - runs agentic coding workflows via OpenAI Codex SDK, with optional inline model selection like `openai:codex:gpt-5.5`
 - `openai:codex-app-server` / `openai:codex-desktop` - runs the experimental Codex app-server protocol for rich-client event, approval, sandbox, skill, plugin, and thread lifecycle evals
 
 The `openai:<endpoint>:<model name>` construction is useful if OpenAI releases a new model,
@@ -40,17 +40,17 @@ or if you have a custom model.
 For example, if OpenAI releases `gpt-5` chat completion,
 you could begin using it immediately with `openai:chat:gpt-5`.
 
-```yaml title="GPT-5 only: verbosity and minimal reasoning"
+```yaml title="GPT-5 only: verbosity and lowest reasoning"
 providers:
   - id: openai:chat:gpt-5
     config:
       verbosity: high # low | medium | high
-      reasoning_effort: minimal
+      reasoning_effort: minimal # GPT-5.5 uses none instead
   # For the Responses API, use a nested reasoning object:
   - id: openai:responses:gpt-5
     config:
       reasoning:
-        effort: minimal
+        effort: minimal # GPT-5.5 uses none instead
 ```
 
 The OpenAI provider supports a handful of [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/openai/types.ts#L112-L185), such as `temperature`, `max_tokens`, `max_completion_tokens`, `functions`, and `tools`, which can be used to customize model behavior like so:
@@ -61,7 +61,7 @@ providers:
     config:
       temperature: 0
       max_tokens: 1024
-  - id: openai:chat:gpt-5.4-mini
+  - id: openai:chat:gpt-5.5
     config:
       max_completion_tokens: 1024
 ```
@@ -82,7 +82,7 @@ providers:
     config:
       temperature: 0
       max_tokens: 128
-  - id: openai:chat:gpt-5.4-mini
+  - id: openai:chat:gpt-5.5
     config:
       max_completion_tokens: 128
       apiKey: sk-abc123
@@ -90,42 +90,42 @@ providers:
 
 Supported parameters include:
 
-| Parameter               | Description                                                                                                                                                                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiBaseUrl`            | The base URL of the OpenAI API, please also read `OPENAI_BASE_URL` below.                                                                                                                                                                                                                         |
-| `apiHost`               | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                                                                                                                                                         |
-| `apiKey`                | Your OpenAI API key, equivalent to `OPENAI_API_KEY` environment variable                                                                                                                                                                                                                          |
-| `apiKeyEnvar`           | An environment variable that contains the API key                                                                                                                                                                                                                                                 |
-| `best_of`               | Controls the number of alternative outputs to generate and select from.                                                                                                                                                                                                                           |
-| `frequency_penalty`     | Applies a penalty to frequent tokens, making them less likely to appear in the output.                                                                                                                                                                                                            |
-| `function_call`         | Controls whether the AI should call functions. Can be either 'none', 'auto', or an object with a `name` that specifies the function to call.                                                                                                                                                      |
-| `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                                                                                                                                                                 |
-| `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                                                                                                                              |
-| `headers`               | Additional headers to include in the request.                                                                                                                                                                                                                                                     |
-| `cost`                  | Legacy per-token override applied to both input and output pricing in promptfoo cost estimates.                                                                                                                                                                                                   |
-| `inputCost`             | Override input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                         |
-| `outputCost`            | Override output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                        |
-| `audioCost`             | Legacy per-token override applied to both audio input and audio output pricing in promptfoo cost estimates.                                                                                                                                                                                       |
-| `audioInputCost`        | Override audio input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                   |
-| `audioOutputCost`       | Override audio output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                  |
-| `max_tokens`            | Controls maximum output length for non-reasoning requests. Not used by reasoning-capable models (o-series, `codex-mini-latest`, and GPT-5 family). Use `max_completion_tokens` (Chat Completions) or `max_output_tokens` (Responses API) instead.                                                 |
-| `maxRetries`            | Maximum number of retry attempts for failed API requests. Defaults to 4. Set to 0 to disable retries.                                                                                                                                                                                             |
-| `metadata`              | Key-value pairs for request tagging and organization.                                                                                                                                                                                                                                             |
-| `omitDefaults`          | Omits hardcoded defaults for `temperature` and `max_tokens`/`max_output_tokens` unless values are explicitly set via config or environment variables. Supported by `openai:chat` and `openai:responses`.                                                                                          |
-| `organization`          | Your OpenAI organization key.                                                                                                                                                                                                                                                                     |
-| `passthrough`           | A flexible object that allows passing arbitrary parameters directly to the OpenAI API request body. Useful for experimental, new, or provider-specific parameters not yet explicitly supported in promptfoo. This parameter is merged into the final API request and can override other settings. |
-| `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                                                                                                                                                     |
-| `reasoning`             | Reasoning configuration object for reasoning-capable models. In practice, use this with the Responses API (`openai:responses:*`) for o-series and GPT-5 family models. `effort` supports `none`, `low`, `medium`, `high` (and `minimal` for GPT-5 family), with optional `summary`.               |
-| `response_format`       | Specifies the desired output format, including `json_object` and `json_schema`. Can also be specified in the prompt config. If specified in both, the prompt config takes precedence.                                                                                                             |
-| `seed`                  | Seed used for deterministic output.                                                                                                                                                                                                                                                               |
-| `stop`                  | Defines a list of tokens that signal the end of the output.                                                                                                                                                                                                                                       |
-| `store`                 | Whether to store the conversation for future retrieval (boolean).                                                                                                                                                                                                                                 |
-| `temperature`           | Controls the randomness of the AI's output for non-reasoning models. Promptfoo omits it for reasoning-capable models (o-series, `codex-mini-latest`, and GPT-5 family) because OpenAI ignores it there.                                                                                           |
-| `tool_choice`           | Controls whether the AI should use a tool. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                         |
-| `tools`                 | Allows you to define custom tools. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                                 |
-| `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                                                                                                                                                     |
-| `user`                  | A unique identifier representing your end-user, for tracking and abuse prevention.                                                                                                                                                                                                                |
-| `max_completion_tokens` | Maximum number of tokens for reasoning-capable Chat Completions models (o-series and GPT-5 family). For Responses API, use `max_output_tokens` instead.                                                                                                                                           |
+| Parameter               | Description                                                                                                                                                                                                                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiBaseUrl`            | The base URL of the OpenAI API, please also read `OPENAI_BASE_URL` below.                                                                                                                                                                                                                                  |
+| `apiHost`               | The hostname of the OpenAI API, please also read `OPENAI_API_HOST` below.                                                                                                                                                                                                                                  |
+| `apiKey`                | Your OpenAI API key, equivalent to `OPENAI_API_KEY` environment variable                                                                                                                                                                                                                                   |
+| `apiKeyEnvar`           | An environment variable that contains the API key                                                                                                                                                                                                                                                          |
+| `best_of`               | Controls the number of alternative outputs to generate and select from.                                                                                                                                                                                                                                    |
+| `frequency_penalty`     | Applies a penalty to frequent tokens, making them less likely to appear in the output.                                                                                                                                                                                                                     |
+| `function_call`         | Controls whether the AI should call functions. Can be either 'none', 'auto', or an object with a `name` that specifies the function to call.                                                                                                                                                               |
+| `functions`             | Allows you to define custom functions. Each function should be an object with a `name`, optional `description`, and `parameters`.                                                                                                                                                                          |
+| `functionToolCallbacks` | A map of function tool names to function callbacks. Each callback should accept a string and return a string or a `Promise<string>`.                                                                                                                                                                       |
+| `headers`               | Additional headers to include in the request.                                                                                                                                                                                                                                                              |
+| `cost`                  | Legacy per-token override applied to both input and output pricing in promptfoo cost estimates.                                                                                                                                                                                                            |
+| `inputCost`             | Override input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                                  |
+| `outputCost`            | Override output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                                 |
+| `audioCost`             | Legacy per-token override applied to both audio input and audio output pricing in promptfoo cost estimates.                                                                                                                                                                                                |
+| `audioInputCost`        | Override audio input token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                            |
+| `audioOutputCost`       | Override audio output token pricing in promptfoo cost estimates.                                                                                                                                                                                                                                           |
+| `max_tokens`            | Controls maximum output length for non-reasoning requests. Not used by reasoning-capable models (o-series, `codex-mini-latest`, and GPT-5 family). Use `max_completion_tokens` (Chat Completions) or `max_output_tokens` (Responses API) instead.                                                          |
+| `maxRetries`            | Maximum number of retry attempts for failed API requests. Defaults to 4. Set to 0 to disable retries.                                                                                                                                                                                                      |
+| `metadata`              | Key-value pairs for request tagging and organization.                                                                                                                                                                                                                                                      |
+| `omitDefaults`          | Omits hardcoded defaults for `temperature` and `max_tokens`/`max_output_tokens` unless values are explicitly set via config or environment variables. Supported by `openai:chat` and `openai:responses`.                                                                                                   |
+| `organization`          | Your OpenAI organization key.                                                                                                                                                                                                                                                                              |
+| `passthrough`           | A flexible object that allows passing arbitrary parameters directly to the OpenAI API request body. Useful for experimental, new, or provider-specific parameters not yet explicitly supported in promptfoo. This parameter is merged into the final API request and can override other settings.          |
+| `presence_penalty`      | Applies a penalty to new tokens (tokens that haven't appeared in the input), making them less likely to appear in the output.                                                                                                                                                                              |
+| `reasoning`             | Reasoning configuration object for reasoning-capable models. In practice, use this with the Responses API (`openai:responses:*`) for o-series and GPT-5 family models. `effort` supports `none`, `low`, `medium`, `high`, and model-specific values such as `xhigh` or `minimal`, with optional `summary`. |
+| `response_format`       | Specifies the desired output format, including `json_object` and `json_schema`. Can also be specified in the prompt config. If specified in both, the prompt config takes precedence.                                                                                                                      |
+| `seed`                  | Seed used for deterministic output.                                                                                                                                                                                                                                                                        |
+| `stop`                  | Defines a list of tokens that signal the end of the output.                                                                                                                                                                                                                                                |
+| `store`                 | Whether to store the conversation for future retrieval (boolean).                                                                                                                                                                                                                                          |
+| `temperature`           | Controls the randomness of the AI's output for non-reasoning models. Promptfoo omits it for reasoning-capable models (o-series, `codex-mini-latest`, and GPT-5 family) because OpenAI ignores it there.                                                                                                    |
+| `tool_choice`           | Controls whether the AI should use a tool. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                                  |
+| `tools`                 | Allows you to define custom tools. See [OpenAI Tools documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools)                                                                                                                                                          |
+| `top_p`                 | Controls the nucleus sampling, a method that helps control the randomness of the AI's output.                                                                                                                                                                                                              |
+| `user`                  | A unique identifier representing your end-user, for tracking and abuse prevention.                                                                                                                                                                                                                         |
+| `max_completion_tokens` | Maximum number of tokens for reasoning-capable Chat Completions models (o-series and GPT-5 family). For Responses API, use `max_output_tokens` instead.                                                                                                                                                    |
 
 Use `inputCost` and `outputCost` when a model has different prompt and completion rates.
 The legacy `cost` option remains a shared fallback. For audio-capable models,
@@ -140,7 +140,7 @@ interface OpenAiConfig {
   max_tokens?: number;
   max_completion_tokens?: number;
   reasoning?: {
-    effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | null;
+    effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null;
     summary?: 'auto' | 'concise' | 'detailed' | null;
   };
   top_p?: number;
@@ -506,6 +506,50 @@ providers:
       max_output_tokens: 2048
 ```
 
+### GPT-5.5
+
+GPT-5.5 is a GPT-5 family model for high-capability reasoning, professional work, and agentic workflows.
+
+#### Available Models
+
+| Model                  | Description                   | Pricing (Input / Output) |
+| ---------------------- | ----------------------------- | ------------------------ |
+| gpt-5.5                | Standard GPT-5.5 model        | $5 / $30 per 1M tokens   |
+| gpt-5.5-2026-04-23     | Dated snapshot of gpt-5.5     | $5 / $30 per 1M tokens   |
+| gpt-5.5-pro            | Premium GPT-5.5 pro model     | $30 / $180 per 1M tokens |
+| gpt-5.5-pro-2026-04-23 | Dated snapshot of gpt-5.5-pro | $30 / $180 per 1M tokens |
+
+#### Key Specifications
+
+- **Endpoint support**: `gpt-5.5` supports Chat Completions and Responses API. `gpt-5.5-pro` is Responses API only.
+- **Context window**: `gpt-5.5` supports a 1M-token context window.
+- **Reasoning effort**: `gpt-5.5` supports `none`, `low`, `medium`, `high`, and `xhigh`. In Chat Completions, set `reasoning_effort`; in Responses API, set `reasoning.effort`.
+- **Cost estimates**: Promptfoo includes standard API pricing for GPT-5.5. Batch and Flex discounts, and Priority processing multipliers, are not automatically inferred from `service_tier`.
+- **Long-running requests**: `gpt-5.5-pro` automatically receives the same 10-minute timeout as other GPT-5 pro models.
+
+#### Usage Examples
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: openai:chat:gpt-5.5
+    config:
+      max_completion_tokens: 4096
+      reasoning_effort: 'low'
+      verbosity: 'medium'
+
+  - id: openai:responses:gpt-5.5
+    config:
+      reasoning:
+        effort: 'high'
+      max_output_tokens: 4096
+
+  - id: openai:responses:gpt-5.5-pro
+    config:
+      reasoning:
+        effort: 'xhigh'
+      max_output_tokens: 8192
+```
+
 ### GPT-5.4
 
 GPT-5.4 is a GPT-5 family model for complex professional work, agentic coding, and tool-heavy workflows.
@@ -529,7 +573,7 @@ GPT-5.4 is a GPT-5 family model for complex professional work, agentic coding, a
 - **Long-context pricing**: `gpt-5.4` and `gpt-5.4-pro` use higher long-context rates when prompts exceed 272,000 input tokens.
 - **Max output tokens**: 128,000 tokens
 - **Reasoning effort**: `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` support `none`, `low`, `medium`, `high`, `xhigh`. `gpt-5.4-pro` supports `medium`, `high`, `xhigh`.
-- **Endpoint support**: `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` support Chat Completions and Responses API. `gpt-5.4-pro` is Responses API only. Promptfoo's Codex SDK provider currently supports `gpt-5.4` and `gpt-5.4-pro`.
+- **Endpoint support**: `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` support Chat Completions and Responses API. `gpt-5.4-pro` is Responses API only. Promptfoo's Codex SDK provider supports `gpt-5.4`, `gpt-5.4-pro`, and the newer GPT-5.5 line.
 - **Cached input**: `gpt-5.4` cached input tokens $0.25 per 1M, `gpt-5.4-mini` $0.075 per 1M, and `gpt-5.4-nano` $0.02 per 1M. `gpt-5.4-pro` has no cached-input discount.
 
 #### Usage Examples
@@ -590,7 +634,7 @@ providers:
 Unlike standard models that use `max_tokens`, reasoning models use:
 
 - `max_completion_tokens` to control the total tokens generated (both reasoning and visible output)
-- `reasoning` to control how thoroughly the model thinks before responding (with `effort`: none, low, medium, high; GPT-5 family in Responses API also supports `minimal`)
+- `reasoning` to control how thoroughly the model thinks before responding (with `effort`: none, low, medium, high; some GPT-5 family models also support `minimal` or `xhigh`)
 
 #### How Reasoning Models Work
 
@@ -1848,6 +1892,10 @@ The Responses API supports a wide range of models, including:
 - `gpt-5.4-nano-2026-03-17` - Dated snapshot of gpt-5.4-nano
 - `gpt-5.4-pro` - Premium GPT-5.4 model ($30/$180 per 1M tokens)
 - `gpt-5.4-pro-2026-03-05` - Dated snapshot of gpt-5.4-pro
+- `gpt-5.5` - GPT-5.5 model
+- `gpt-5.5-2026-04-23` - Dated snapshot of gpt-5.5
+- `gpt-5.5-pro` - Premium GPT-5.5 pro model
+- `gpt-5.5-pro-2026-04-23` - Dated snapshot of gpt-5.5-pro
 - `gpt-5` - Earlier GPT-5 family model
 - `gpt-5-chat` - GPT-5 chat alias
 - `gpt-5.1` - GPT-5.1 base model
@@ -2195,7 +2243,7 @@ The `web_search_preview` tool is **required** for deep research models. The prov
 
 ### GPT-5 Pro Timeout Configuration
 
-`gpt-5-pro`, `gpt-5.2-pro`, and `gpt-5.4-pro` are long-running models that often require extended timeouts due to advanced reasoning. Like deep research models, these variants automatically receive a 10-minute timeout (600,000ms) instead of the standard 5-minute timeout.
+`gpt-5-pro`, `gpt-5.2-pro`, `gpt-5.4-pro`, and `gpt-5.5-pro` are long-running models that often require extended timeouts due to advanced reasoning. Like deep research models, these variants automatically receive a 10-minute timeout (600,000ms) instead of the standard 5-minute timeout.
 
 **Automatic timeout behavior:**
 
@@ -2348,13 +2396,13 @@ See the [OpenAI Agents documentation](/docs/providers/openai-agents) for full co
 
 ### Codex SDK
 
-For agentic coding tasks with working directory access and structured JSON output, use the [OpenAI Codex SDK provider](/docs/providers/openai-codex-sdk). This provider supports GPT-5.4 and Codex-optimized GPT-5 models for code generation. You can select a model inline with `openai:codex:gpt-5.4` or via `config.model` when you need additional options:
+For agentic coding tasks with working directory access and structured JSON output, use the [OpenAI Codex SDK provider](/docs/providers/openai-codex-sdk). This provider supports GPT-5.5, GPT-5.4, and Codex-optimized GPT-5 models for code generation. You can select a model inline with `openai:codex:gpt-5.5` or via `config.model` when you need additional options:
 
 ```yaml
 providers:
   - id: openai:codex-sdk
     config:
-      model: gpt-5.4
+      model: gpt-5.5
       working_dir: ./src
       output_schema:
         type: object

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -344,6 +344,9 @@ const COMMON_OPTIONAL_PROCESS_ENV_KEYS = [
 ] as const;
 
 const CODEX_MODEL_PRICING: Record<string, { input: number; output: number; cache_read: number }> = {
+  // GPT-5.5 models. No discounted cached-input API rate is published yet.
+  'gpt-5.5': { input: 5.0, output: 30.0, cache_read: 5.0 },
+  'gpt-5.5-pro': { input: 30.0, output: 180.0, cache_read: 30.0 },
   'gpt-5.4': { input: 2.5, output: 15.0, cache_read: 0.25 },
   'gpt-5.4-pro': { input: 30.0, output: 180.0, cache_read: 30.0 },
   'gpt-5.3-codex': { input: 1.75, output: 14.0, cache_read: 0.175 },
@@ -1532,6 +1535,17 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     this.initializingConnections.add(connection);
     try {
       await connection.initialize(config);
+      const apiKey = this.getApiKey(config);
+      if (apiKey) {
+        await connection.request(
+          'account/login/start',
+          {
+            type: 'apiKey',
+            apiKey,
+          },
+          { timeoutMs: this.getRequestTimeoutMs(config) },
+        );
+      }
       return connection;
     } catch (error) {
       await connection.close().catch((closeError) => {

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -63,6 +63,9 @@ export type ApprovalPolicy = 'never' | 'on-request' | 'on-failure' | 'untrusted'
  *
  * Model support varies:
  * - gpt-5.4: 'minimal', 'low', 'medium', 'high', 'xhigh'
+ * - gpt-5.5: 'none', 'low', 'medium', 'high', 'xhigh' in the OpenAI API;
+ *   the current Codex SDK enum exposes 'minimal', 'low', 'medium', 'high', 'xhigh'
+ * - gpt-5.5-pro: 'medium', 'high', 'xhigh'
  * - gpt-5.4-pro: 'medium', 'high', 'xhigh'
  * - gpt-5.3-codex: 'low', 'medium', 'high', 'xhigh'
  * - gpt-5.3-codex-spark: 'low', 'medium', 'high'
@@ -75,7 +78,7 @@ export type ApprovalPolicy = 'never' | 'on-request' | 'on-failure' | 'untrusted'
  * - 'low': Light reasoning, faster responses
  * - 'medium': Balanced (default)
  * - 'high': Thorough reasoning for complex tasks
- * - 'xhigh': Maximum reasoning depth (gpt-5.4, gpt-5.2, gpt-5.1-codex-max)
+ * - 'xhigh': Maximum reasoning depth (gpt-5.5, gpt-5.4, gpt-5.2, gpt-5.1-codex-max)
  */
 export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
@@ -193,7 +196,7 @@ export interface OpenAICodexSDKConfig {
   codex_path_override?: string;
 
   /**
-   * Model to use (e.g., 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-mini')
+   * Model to use (e.g., 'gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-mini')
    */
   model?: string;
 
@@ -435,6 +438,9 @@ async function loadCodexSDK(): Promise<any> {
 // Pricing per 1M tokens
 // See: https://openai.com/pricing
 const CODEX_MODEL_PRICING: Record<string, { input: number; output: number; cache_read: number }> = {
+  // GPT-5.5 models. No discounted cached-input API rate is published yet.
+  'gpt-5.5': { input: 5.0, output: 30.0, cache_read: 5.0 },
+  'gpt-5.5-pro': { input: 30.0, output: 180.0, cache_read: 30.0 },
   // GPT-5.4 models
   'gpt-5.4': { input: 2.5, output: 15.0, cache_read: 0.25 },
   // gpt-5.4-pro does not have discounted cached-input pricing.
@@ -457,6 +463,9 @@ const CODEX_MODEL_PRICING: Record<string, { input: number; output: number; cache
 
 export class OpenAICodexSDKProvider implements ApiProvider {
   static OPENAI_MODELS = [
+    // GPT-5.5 models
+    'gpt-5.5',
+    'gpt-5.5-pro',
     // GPT-5.4 models
     'gpt-5.4',
     'gpt-5.4-pro',
@@ -1302,9 +1311,11 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     conversationMessages: Array<{ role: string; content: string }>;
   } {
     const agentMessages = state.items.filter((item) => item.type === 'agent_message');
+    const finalAgentMessage = [...agentMessages]
+      .reverse()
+      .find((item) => typeof item.text === 'string');
     return {
-      finalResponse:
-        agentMessages.length > 0 ? agentMessages.map((item) => item.text).join('\n') : '',
+      finalResponse: finalAgentMessage?.text ?? '',
       items: state.items,
       usage: state.usage,
       reasoningTexts: state.reasoningTexts,

--- a/src/providers/openai/defaults.ts
+++ b/src/providers/openai/defaults.ts
@@ -3,7 +3,7 @@ import { OpenAiEmbeddingProvider } from './embedding';
 import { OpenAiModerationProvider } from './moderation';
 import { OpenAiResponsesProvider } from './responses';
 
-const DEFAULT_OPENAI_GRADING_MODEL = 'gpt-5.4-2026-03-05';
+const DEFAULT_OPENAI_GRADING_MODEL = 'gpt-5.5-2026-04-23';
 
 export const DefaultEmbeddingProvider = new OpenAiEmbeddingProvider('text-embedding-3-large');
 export const DefaultGradingProvider = new OpenAiChatCompletionProvider(
@@ -21,7 +21,7 @@ export const DefaultSuggestionsProvider = new OpenAiChatCompletionProvider(
   DEFAULT_OPENAI_GRADING_MODEL,
 );
 export const DefaultModerationProvider = new OpenAiModerationProvider('omni-moderation-latest');
-export const DefaultWebSearchProvider = new OpenAiResponsesProvider('gpt-5.4-2026-03-05', {
+export const DefaultWebSearchProvider = new OpenAiResponsesProvider('gpt-5.5-2026-04-23', {
   config: {
     tools: [{ type: 'web_search_preview' }],
   },

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -88,6 +88,11 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'gpt-5.4-nano-2026-03-17',
     'gpt-5.4-pro',
     'gpt-5.4-pro-2026-03-05',
+    // GPT-5.5 models
+    'gpt-5.5',
+    'gpt-5.5-2026-04-23',
+    'gpt-5.5-pro',
+    'gpt-5.5-pro-2026-04-23',
     // Audio models
     'gpt-audio',
     'gpt-audio-2025-08-28',

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -157,7 +157,7 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
   stop?: string[];
   seed?: number;
   passthrough?: object;
-  reasoning_effort?: ReasoningEffort;
+  reasoning_effort?: GPT5ReasoningEffort;
   reasoning?: Reasoning | GPT5Reasoning;
   service_tier?: ('auto' | 'default' | 'premium') | null;
   modalities?: string[];

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -10,8 +10,25 @@ const ajv = getAjv();
 
 const GPT_5_4_LONG_CONTEXT_THRESHOLD = 272_000;
 
+type OpenAIModelCost = {
+  input: number;
+  output: number;
+  audioInput?: number;
+  audioOutput?: number;
+  longContext?: {
+    threshold: number;
+    input: number;
+    output: number;
+  };
+};
+
+type OpenAIModelInfo = {
+  id: string;
+  cost?: OpenAIModelCost;
+};
+
 // see https://platform.openai.com/docs/models
-export const OPENAI_CHAT_MODELS = [
+export const OPENAI_CHAT_MODELS: OpenAIModelInfo[] = [
   // TTS model (text input + audio output costs)
   ...['gpt-4o-mini-tts', 'gpt-4o-mini-tts-2025-12-15'].map((model) => ({
     id: model,
@@ -367,6 +384,14 @@ export const OPENAI_CHAT_MODELS = [
       output: 1.25 / 1e6,
     },
   })),
+  // GPT-5.5 models
+  ...['gpt-5.5', 'gpt-5.5-2026-04-23'].map((model) => ({
+    id: model,
+    cost: {
+      input: 5 / 1e6,
+      output: 30 / 1e6,
+    },
+  })),
   // gpt-audio models
   ...['gpt-audio', 'gpt-audio-2025-08-28'].map((model) => ({
     id: model,
@@ -397,7 +422,7 @@ export const OPENAI_CHAT_MODELS = [
   })),
 ];
 
-export const OPENAI_RESPONSES_ONLY_MODELS = [
+export const OPENAI_RESPONSES_ONLY_MODELS: OpenAIModelInfo[] = [
   ...['gpt-5.4-pro', 'gpt-5.4-pro-2026-03-05'].map((model) => ({
     id: model,
     cost: {
@@ -410,10 +435,18 @@ export const OPENAI_RESPONSES_ONLY_MODELS = [
       },
     },
   })),
+  // GPT-5.5 Pro is Responses-only
+  ...['gpt-5.5-pro', 'gpt-5.5-pro-2026-04-23'].map((model) => ({
+    id: model,
+    cost: {
+      input: 30 / 1e6,
+      output: 180 / 1e6,
+    },
+  })),
 ];
 
 // Deep research models for Responses API
-export const OPENAI_DEEP_RESEARCH_MODELS = [
+export const OPENAI_DEEP_RESEARCH_MODELS: OpenAIModelInfo[] = [
   ...['o3-deep-research', 'o3-deep-research-2025-06-26'].map((model) => ({
     id: model,
     cost: {
@@ -431,7 +464,7 @@ export const OPENAI_DEEP_RESEARCH_MODELS = [
 ];
 
 // See https://platform.openai.com/docs/models/model-endpoint-compatibility
-export const OPENAI_COMPLETION_MODELS = [
+export const OPENAI_COMPLETION_MODELS: OpenAIModelInfo[] = [
   {
     id: 'gpt-3.5-turbo-instruct',
     cost: {
@@ -448,7 +481,7 @@ export const OPENAI_COMPLETION_MODELS = [
 ];
 
 // Realtime models for WebSocket API
-export const OPENAI_REALTIME_MODELS = [
+export const OPENAI_REALTIME_MODELS: OpenAIModelInfo[] = [
   // GA gpt-realtime models
   ...['gpt-realtime', 'gpt-realtime-2025-08-28', 'gpt-realtime-1.5'].map((model) => ({
     id: model,

--- a/test/providers/github/defaults.test.ts
+++ b/test/providers/github/defaults.test.ts
@@ -74,7 +74,7 @@ describe('GitHub Models Default Providers', () => {
     const providers = await getDefaultProviders();
 
     // Should use OpenAI, not GitHub
-    expect(providers.gradingProvider.id()).toBe('openai:gpt-5.4-2026-03-05');
+    expect(providers.gradingProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
   });
 
   it('should prefer Anthropic over GitHub when Anthropic is available', async () => {

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from 'stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenAICodexAppServerProvider } from '../../src/providers/openai/codex-app-server';
 import { providerRegistry } from '../../src/providers/providerRegistry';
+import { mockProcessEnv } from '../util/utils';
 
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
@@ -102,7 +103,13 @@ async function waitForMessageWithoutTimers(
 }
 
 describe('OpenAICodexAppServerProvider', () => {
+  let originalOpenAiApiKey: string | undefined;
+  let originalCodexApiKey: string | undefined;
+
   beforeEach(() => {
+    originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+    originalCodexApiKey = process.env.CODEX_API_KEY;
+    mockProcessEnv({ OPENAI_API_KEY: undefined, CODEX_API_KEY: undefined });
     vi.clearAllMocks();
     mocks.spawn.mockReset();
   });
@@ -112,6 +119,7 @@ describe('OpenAICodexAppServerProvider', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    mockProcessEnv({ OPENAI_API_KEY: originalOpenAiApiKey, CODEX_API_KEY: originalCodexApiKey });
   });
 
   it('initializes with safe defaults and validates config strictly', () => {
@@ -194,7 +202,7 @@ describe('OpenAICodexAppServerProvider', () => {
       config: {
         apiKey: 'test-api-key',
         codex_path_override: '/usr/local/bin/codex',
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         service_tier: 'fast',
         model_reasoning_effort: 'none',
         reasoning_summary: 'detailed',
@@ -204,7 +212,7 @@ describe('OpenAICodexAppServerProvider', () => {
         collaboration_mode: {
           mode: 'plan',
           settings: {
-            model: 'gpt-5.4',
+            model: 'gpt-5.5',
             reasoning_effort: 'none',
             developer_instructions: null,
           },
@@ -221,6 +229,13 @@ describe('OpenAICodexAppServerProvider', () => {
     server.send({ id: initialize.id, result: { userAgent: 'codex-test' } });
 
     await waitForMessage(server, (message) => message.method === 'initialized');
+    const loginStart = await waitForMessage(
+      server,
+      (message) => message.method === 'account/login/start',
+    );
+    expect(loginStart.params).toEqual({ type: 'apiKey', apiKey: 'test-api-key' });
+    server.send({ id: loginStart.id, result: { type: 'apiKey' } });
+
     const threadStart = await waitForMessage(
       server,
       (message) => message.method === 'thread/start',
@@ -229,7 +244,7 @@ describe('OpenAICodexAppServerProvider', () => {
       approvalPolicy: 'never',
       sandbox: 'read-only',
       ephemeral: true,
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       serviceTier: 'fast',
       baseInstructions: 'You are evaluating repository quality.',
       developerInstructions: 'Return concise, actionable output.',
@@ -251,7 +266,7 @@ describe('OpenAICodexAppServerProvider', () => {
       threadId: 'thr_test',
       input: [{ type: 'text', text: 'Summarize this repo', text_elements: [] }],
       approvalPolicy: 'never',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       serviceTier: 'fast',
       effort: 'none',
       summary: 'detailed',
@@ -259,7 +274,7 @@ describe('OpenAICodexAppServerProvider', () => {
       collaborationMode: {
         mode: 'plan',
         settings: {
-          model: 'gpt-5.4',
+          model: 'gpt-5.5',
           reasoning_effort: 'none',
           developer_instructions: null,
         },
@@ -333,11 +348,11 @@ describe('OpenAICodexAppServerProvider', () => {
       total: 15,
       cached: 2,
     });
-    expect(result.cost).toBeCloseTo(0.000095);
+    expect(result.cost).toBeCloseTo(0.0002);
     expect(result.metadata?.codexAppServer).toMatchObject({
       threadId: 'thr_test',
       turnId: 'turn_test',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       sandboxMode: 'read-only',
       approvalPolicy: 'never',
       itemCounts: { agentMessage: 1 },
@@ -4189,6 +4204,13 @@ describe('OpenAICodexAppServerProvider', () => {
     const spawnEnv = mocks.spawn.mock.calls[0][2].env;
     expect(spawnEnv.OPENAI_BASE_URL).toBe('https://custom.example.com/v1');
     expect(spawnEnv.OPENAI_API_BASE_URL).toBe('https://custom.example.com/v1');
+
+    const loginStart = await waitForMessage(
+      server,
+      (message) => message.method === 'account/login/start',
+    );
+    expect(loginStart.params).toEqual({ type: 'apiKey', apiKey: 'test-key' });
+    server.send({ id: loginStart.id, result: { type: 'apiKey' } });
 
     const threadStart = await waitForMessage(
       server,

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -1563,7 +1563,7 @@ describe('OpenAICodexSDKProvider', () => {
 
         const result = await provider.callApi('Test prompt');
 
-        expect(result.output).toBe('Part 1\nPart 2');
+        expect(result.output).toBe('Part 2');
         expect(result.tokenUsage).toEqual({
           prompt: 10, // cached_input_tokens is already included in input_tokens
           completion: 20,
@@ -2229,7 +2229,23 @@ describe('OpenAICodexSDKProvider', () => {
       });
     });
 
-    describe('GPT-5.2, GPT-5.3, and GPT-5.4 models', () => {
+    describe('GPT-5.2, GPT-5.3, GPT-5.4, and GPT-5.5 models', () => {
+      it('should recognize gpt-5.5 as a known model', () => {
+        const provider = new OpenAICodexSDKProvider({
+          config: { model: 'gpt-5.5' },
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+        expect(provider.config.model).toBe('gpt-5.5');
+      });
+
+      it('should recognize gpt-5.5-pro as a known model', () => {
+        const provider = new OpenAICodexSDKProvider({
+          config: { model: 'gpt-5.5-pro' },
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+        expect(provider.config.model).toBe('gpt-5.5-pro');
+      });
+
       it('should recognize gpt-5.4 as a known model', () => {
         const provider = new OpenAICodexSDKProvider({
           config: { model: 'gpt-5.4' },

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -1589,6 +1589,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
     it('should identify GPT-5 models correctly including prefixed names', async () => {
       // Direct model names
       const gpt5Provider = new OpenAiChatCompletionProvider('gpt-5');
+      const gpt55Provider = new OpenAiChatCompletionProvider('gpt-5.5');
       const gpt54MiniProvider = new OpenAiChatCompletionProvider('gpt-5.4-mini');
       const gpt54NanoProvider = new OpenAiChatCompletionProvider('gpt-5.4-nano');
       const gpt5MiniProvider = new OpenAiChatCompletionProvider('gpt-5-mini');
@@ -1596,6 +1597,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
 
       // Prefixed model names (used by GitHub Models)
       const prefixedGpt5Provider = new OpenAiChatCompletionProvider('openai/gpt-5');
+      const prefixedGpt55Provider = new OpenAiChatCompletionProvider('openai/gpt-5.5');
       const prefixedGpt54MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-mini');
       const prefixedGpt54NanoProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-nano');
       const prefixedGpt5MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5-mini');
@@ -1606,11 +1608,13 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const gpt4oProvider = new OpenAiChatCompletionProvider('openai/gpt-4o');
 
       expect(gpt5Provider['isGPT5Model']()).toBe(true);
+      expect(gpt55Provider['isGPT5Model']()).toBe(true);
       expect(gpt54MiniProvider['isGPT5Model']()).toBe(true);
       expect(gpt54NanoProvider['isGPT5Model']()).toBe(true);
       expect(gpt5MiniProvider['isGPT5Model']()).toBe(true);
       expect(gpt5NanoProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt5Provider['isGPT5Model']()).toBe(true);
+      expect(prefixedGpt55Provider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt54MiniProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt54NanoProvider['isGPT5Model']()).toBe(true);
       expect(prefixedGpt5MiniProvider['isGPT5Model']()).toBe(true);
@@ -1625,6 +1629,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const prefixedO3Provider = new OpenAiChatCompletionProvider('openai/o3-mini');
       const prefixedO4Provider = new OpenAiChatCompletionProvider('openai/o4-mini');
       const prefixedGpt5Provider = new OpenAiChatCompletionProvider('openai/gpt-5');
+      const prefixedGpt55Provider = new OpenAiChatCompletionProvider('openai/gpt-5.5');
       const prefixedGpt54MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-mini');
       const prefixedGpt54NanoProvider = new OpenAiChatCompletionProvider('openai/gpt-5.4-nano');
       const prefixedGpt5MiniProvider = new OpenAiChatCompletionProvider('openai/gpt-5-mini');
@@ -1636,6 +1641,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(prefixedO3Provider['isReasoningModel']()).toBe(true);
       expect(prefixedO4Provider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt5Provider['isReasoningModel']()).toBe(true);
+      expect(prefixedGpt55Provider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt54MiniProvider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt54NanoProvider['isReasoningModel']()).toBe(true);
       expect(prefixedGpt5MiniProvider['isReasoningModel']()).toBe(true);

--- a/test/providers/openai/defaults.test.ts
+++ b/test/providers/openai/defaults.test.ts
@@ -18,16 +18,16 @@ describe('OpenAI default providers', () => {
 
   describe('DefaultGradingProvider', () => {
     it('should use correct model version and configuration', () => {
-      expect(DefaultGradingProvider.modelName).toBe('gpt-5.4-2026-03-05');
-      expect(DefaultGradingProvider.id()).toBe('openai:gpt-5.4-2026-03-05');
+      expect(DefaultGradingProvider.modelName).toBe('gpt-5.5-2026-04-23');
+      expect(DefaultGradingProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
       expect(DefaultGradingProvider.config).toEqual({});
     });
   });
 
   describe('DefaultGradingJsonProvider', () => {
     it('should use correct model version and JSON configuration', () => {
-      expect(DefaultGradingJsonProvider.modelName).toBe('gpt-5.4-2026-03-05');
-      expect(DefaultGradingJsonProvider.id()).toBe('openai:gpt-5.4-2026-03-05');
+      expect(DefaultGradingJsonProvider.modelName).toBe('gpt-5.5-2026-04-23');
+      expect(DefaultGradingJsonProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
       expect(DefaultGradingJsonProvider.config).toEqual({
         response_format: { type: 'json_object' },
       });
@@ -36,8 +36,8 @@ describe('OpenAI default providers', () => {
 
   describe('DefaultSuggestionsProvider', () => {
     it('should use correct model version', () => {
-      expect(DefaultSuggestionsProvider.modelName).toBe('gpt-5.4-2026-03-05');
-      expect(DefaultSuggestionsProvider.id()).toBe('openai:gpt-5.4-2026-03-05');
+      expect(DefaultSuggestionsProvider.modelName).toBe('gpt-5.5-2026-04-23');
+      expect(DefaultSuggestionsProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
       expect(DefaultSuggestionsProvider.config).toEqual({});
     });
   });
@@ -51,8 +51,8 @@ describe('OpenAI default providers', () => {
 
   describe('DefaultWebSearchProvider', () => {
     it('should use correct model snapshot and web search configuration', () => {
-      expect(DefaultWebSearchProvider.modelName).toBe('gpt-5.4-2026-03-05');
-      expect(DefaultWebSearchProvider.id()).toBe('openai:gpt-5.4-2026-03-05');
+      expect(DefaultWebSearchProvider.modelName).toBe('gpt-5.5-2026-04-23');
+      expect(DefaultWebSearchProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
       expect(DefaultWebSearchProvider.config).toEqual({
         tools: [{ type: 'web_search_preview' }],
       });

--- a/test/providers/openai/responses/models.test.ts
+++ b/test/providers/openai/responses/models.test.ts
@@ -34,6 +34,12 @@ describe('OpenAiResponsesProvider model registry', () => {
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
       'gpt-5.4-pro-2026-03-05',
     );
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5-2026-04-23');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5-pro');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.5-pro-2026-04-23',
+    );
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5-nano');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5-mini');
     for (const model of expectedAudioModels) {
@@ -122,6 +128,13 @@ describe('OpenAiResponsesProvider model registry', () => {
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.4-pro');
     expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
       'gpt-5.4-pro-2026-03-05',
+    );
+    // GPT-5.5 models
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5-2026-04-23');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain('gpt-5.5-pro');
+    expect(OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES).toContain(
+      'gpt-5.5-pro-2026-04-23',
     );
     // Audio models
     for (const model of expectedAudioModels) {

--- a/test/providers/openai/responses/reasoning.test.ts
+++ b/test/providers/openai/responses/reasoning.test.ts
@@ -391,6 +391,43 @@ describe('OpenAiResponsesProvider reasoning models', () => {
       );
     });
 
+    it('should use longer timeout for gpt-5.5-pro models', async () => {
+      const mockData = {
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Response complete' }],
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 200 },
+      };
+
+      (cache.fetchWithCache as Mock).mockResolvedValueOnce({
+        data: mockData,
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      });
+
+      const provider = new OpenAiResponsesProvider('gpt-5.5-pro', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      await provider.callApi('Test prompt');
+
+      expect(cache.fetchWithCache).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        LONG_RUNNING_MODEL_TIMEOUT_MS,
+        'json',
+        undefined,
+        undefined,
+      );
+    });
+
     it('should handle reasoning items with empty summary correctly', async () => {
       const mockData = {
         output: [

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -311,13 +311,32 @@ describe('calculateOpenAICost', () => {
     expect(cost).toBeCloseTo((1000 * 30 + 500 * 180) / 1e6, 6);
   });
 
-  it('should keep GPT-5.4 Pro out of Chat Completions routing', () => {
+  it('should recognize GPT-5.5 models with built-in pricing', () => {
+    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5')).toBe(true);
+    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-2026-04-23')).toBe(true);
+    expect(OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.5-pro')).toBe(true);
+    expect(
+      OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.5-pro-2026-04-23'),
+    ).toBe(true);
+    expect(calculateOpenAICost('gpt-5.5', {}, 1000, 500)).toBeCloseTo(
+      (1000 * 5 + 500 * 30) / 1e6,
+      6,
+    );
+    expect(calculateOpenAICost('gpt-5.5-pro', {}, 1000, 500)).toBeCloseTo(
+      (1000 * 30 + 500 * 180) / 1e6,
+      6,
+    );
+  });
+
+  it('should keep GPT-5.4 and GPT-5.5 Pro out of Chat Completions routing', () => {
     expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.4-pro')).toBe(false);
     expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.4-pro-2026-03-05')).toBe(false);
     expect(OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.4-pro')).toBe(true);
     expect(
       OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.4-pro-2026-03-05'),
     ).toBe(true);
+    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-pro')).toBe(false);
+    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-pro-2026-04-23')).toBe(false);
   });
 
   it('should calculate cost correctly for gpt-5-nano', () => {


### PR DESCRIPTION
## Summary
- Add GPT-5.5 and GPT-5.5 Pro model metadata, pricing, defaults, and reasoning support for OpenAI providers
- Update Codex SDK and Codex app-server providers for GPT-5.5 routing, cost tracking, API-key app-server login, and streaming final-output handling
- Refresh OpenAI docs and examples, including a GPT-5.5 Responses example and updated Codex examples

## QA
- `npm run l` (passes with existing Biome complexity warnings in `src/providers/openai/responses.ts`)
- `npm run f` (passes with the same warnings)
- `npm run tsc`
- `npx vitest run test/providers/openai-codex-app-server.test.ts test/providers/openai-codex-sdk.test.ts test/providers/openai/defaults.test.ts test/providers/openai/util.test.ts test/providers/openai/responses/models.test.ts test/providers/openai/responses/reasoning.test.ts test/providers/openai/chat.test.ts`
- `npm run local -- eval -c /tmp/promptfoo-gpt55-codex-qa/codex-sdk-gpt55.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache -o /tmp/promptfoo-gpt55-codex-qa/codex-sdk-output-after-streaming-fix.json`
- `npm run local -- eval -c /tmp/promptfoo-gpt55-codex-qa/codex-sdk-gpt55-no-stream.yaml --no-cache -o /tmp/promptfoo-gpt55-codex-qa/codex-sdk-no-stream-output.json`
- `npm run local -- eval -c /tmp/promptfoo-gpt55-codex-qa/codex-app-server-gpt55-local-bin.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache -o /tmp/promptfoo-gpt55-codex-qa/codex-app-server-local-bin-output-after-pricing-fix.json`

## Live eval results
- `openai:codex:gpt-5.5` streaming: pass, 72,509 tokens, cost `0.372545`
- `openai:codex:gpt-5.5` non-streaming: pass, 72,370 tokens, cost `0.372075`
- `openai:codex-app-server:gpt-5.5`: pass, 37,508 tokens, cost `0.189215`
