### PR TITLE
fix(providers): canonicalize Azure assistant cache keys

### DIFF
--- a/src/providers/azure/assistant.ts
+++ b/src/providers/azure/assistant.ts
@@ -138,9 +138,13 @@ function normalizeAzureAssistantCacheValue(value: unknown, seen = new WeakSet<ob
 }
 
 function hmacAzureAssistantCacheValue(value: unknown) {
-  return createHmac('sha256', AZURE_ASSISTANT_CACHE_KEY_HMAC_KEY)
-    .update(safeJsonStringify(normalizeAzureAssistantCacheValue(value)) ?? '')
-    .digest('hex');
+  const serialized = safeJsonStringify(normalizeAzureAssistantCacheValue(value));
+  invariant(
+    serialized !== undefined,
+    'Azure Assistant cache key input contains values that cannot be serialized',
+  );
+
+  return createHmac('sha256', AZURE_ASSISTANT_CACHE_KEY_HMAC_KEY).update(serialized).digest('hex');
 }
 
 function getAuthHeadersCacheIdentity(authHeaders: Record<string, string>) {

--- a/src/providers/azure/assistant.ts
+++ b/src/providers/azure/assistant.ts
@@ -4,6 +4,7 @@ import { fetchWithCache, getCache, isCacheEnabled } from '../../cache';
 import logger from '../../logger';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import invariant from '../../util/invariant';
+import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { REQUEST_TIMEOUT_MS, toTitleCase } from '../shared';
@@ -101,9 +102,44 @@ interface RunStepsResponse {
 
 const AZURE_ASSISTANT_CACHE_KEY_HMAC_KEY = 'promptfoo-azure-assistant-cache-key-v1';
 
+function normalizeAzureAssistantCacheValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+    const normalized = value.map((item) => normalizeAzureAssistantCacheValue(item, seen));
+    seen.delete(value);
+    return normalized;
+  }
+
+  if (value && typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return value;
+    }
+
+    seen.add(value);
+    const normalized = Object.keys(value)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalizeAzureAssistantCacheValue((value as Record<string, unknown>)[key], seen);
+        return acc;
+      }, {});
+    seen.delete(value);
+    return normalized;
+  }
+
+  return value;
+}
+
 function hmacAzureAssistantCacheValue(value: unknown) {
   return createHmac('sha256', AZURE_ASSISTANT_CACHE_KEY_HMAC_KEY)
-    .update(JSON.stringify(value))
+    .update(safeJsonStringify(normalizeAzureAssistantCacheValue(value)) ?? '')
     .digest('hex');
 }
 
@@ -169,7 +205,7 @@ export class AzureAssistantProvider extends AzureGenericProvider {
       temperature: this.assistantConfig.temperature,
       tool_choice: this.assistantConfig.tool_choice,
       tool_resources: this.assistantConfig.tool_resources,
-      tools: JSON.stringify(loadedTools),
+      tools: loadedTools,
       top_p: this.assistantConfig.top_p,
     })}`;
 

--- a/test/providers/azure/assistant.test.ts
+++ b/test/providers/azure/assistant.test.ts
@@ -243,6 +243,53 @@ describe('Azure Assistant Provider', () => {
       expect(firstCacheKey).not.toContain('Shared assistant prompt');
       expect(firstCacheKey).not.toContain('tenant.azure.com');
     });
+
+    it('should canonicalize nested assistant config order in cache keys', async () => {
+      const cacheGet = vi.fn().mockResolvedValue({ output: 'Cached assistant output' });
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      vi.mocked(getCache).mockResolvedValue({
+        get: cacheGet,
+        set: vi.fn(),
+      } as any);
+
+      provider.assistantConfig.response_format = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'canonical_response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              answer: { type: 'string' },
+              confidence: { type: 'number' },
+            },
+            required: ['answer', 'confidence'],
+            additionalProperties: false,
+          },
+        },
+      };
+      await provider.callApi('Shared canonical assistant prompt');
+
+      provider.assistantConfig.response_format = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'canonical_response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              confidence: { type: 'number' },
+              answer: { type: 'string' },
+            },
+            required: ['answer', 'confidence'],
+            additionalProperties: false,
+          },
+        },
+      };
+      await provider.callApi('Shared canonical assistant prompt');
+
+      expect(cacheGet.mock.calls[0][0]).toBe(cacheGet.mock.calls[1][0]);
+    });
   });
 
   describe('error handling', () => {

--- a/test/providers/azure/assistant.test.ts
+++ b/test/providers/azure/assistant.test.ts
@@ -290,6 +290,32 @@ describe('Azure Assistant Provider', () => {
 
       expect(cacheGet.mock.calls[0][0]).toBe(cacheGet.mock.calls[1][0]);
     });
+
+    it('should reject unserializable assistant cache key inputs', async () => {
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      vi.mocked(getCache).mockResolvedValue({
+        get: vi.fn(),
+        set: vi.fn(),
+      } as any);
+      provider.assistantConfig.response_format = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'unserializable_response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              answer: { type: 'string', default: BigInt(1) },
+            },
+            additionalProperties: false,
+          },
+        },
+      } as any;
+
+      await expect(provider.callApi('prompt with unserializable config')).rejects.toThrow(
+        'Azure Assistant cache key input contains values that cannot be serialized',
+      );
+    });
   });
 
   describe('error handling', () => {


### PR DESCRIPTION
## Summary
- canonicalize nested Azure assistant cache-key inputs before HMAC hashing
- keep loaded tool definitions as structured data for stable hashing
- add a regression for semantically identical response schemas with different property order

## Test
- ./node_modules/.bin/vitest run test/providers/azure/assistant.test.ts --sequence.shuffle=false
- npm run tsc
- npm run l
- npm run f