### PR TITLE
ci(release): prevent Docker workflow self-cancel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,8 +43,10 @@ on:
       - 'Dockerfile'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Reusable workflow calls inherit the caller's github.workflow value. Keep this
+  # group Docker-specific so release-please callers are not cancelled mid-release.
+  group: ${{ github.event_name == 'pull_request' && format('docker-pr-{0}', github.ref) || format('docker-publish-{0}', github.repository) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- avoid sharing the release-please concurrency group from reusable Docker workflow calls
- keep PR Docker builds cancelable while release/publish Docker jobs serialize without cancellation
- backfilled the missing `ghcr.io/promptfoo/promptfoo:0.121.8` image after the failed release

## Root cause
The Docker workflow used `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. When `release-please.yml` called it as a reusable workflow, `${{ github.workflow }}` resolved to the caller workflow name, so the Docker child run reused the parent release-please concurrency group and cancelled the release after npm publish.

## Validation
- `actionlint .github/workflows/docker.yml .github/workflows/release-please.yml`
- `npm run l`
- `npm run f`
- `gh workflow run docker.yml --ref main -f tag_name=0.121.8`
- Docker backfill run passed: https://github.com/promptfoo/promptfoo/actions/runs/24914946334
- `docker manifest inspect ghcr.io/promptfoo/promptfoo:0.121.8`
