### PR TITLE
refactor(providers): lazy request timeout env lookup

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,7 +8,7 @@ import { KeyvFile } from 'keyv-file';
 import { getEnvBool, getEnvInt, getEnvString } from './envars';
 import { cloudConfig } from './globalConfig/cloud';
 import logger from './logger';
-import { REQUEST_TIMEOUT_MS } from './providers/shared';
+import { getRequestTimeoutMs } from './providers/shared';
 import { getConfigDirectoryPath } from './util/config/manage';
 import { sha256 } from './util/createHash';
 import { isTransientConnectionError } from './util/fetch/errors';
@@ -492,7 +492,7 @@ async function prepareFetchResponse(
 export async function fetchWithCache<T = unknown>(
   url: RequestInfo,
   options: RequestInit = {},
-  timeout: number = REQUEST_TIMEOUT_MS,
+  timeout: number = getRequestTimeoutMs(),
   format: 'json' | 'text' = 'json',
   bust: boolean = false,
   maxRetries?: number,

--- a/src/providers/ai21.ts
+++ b/src/providers/ai21.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
-import { calculateCost, parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+import { calculateCost, getRequestTimeoutMs, parseChatPrompt } from './shared';
 
 import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';
@@ -168,7 +168,7 @@ export class AI21ChatCompletionProvider implements ApiProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as { data: any; cached: boolean });
     } catch (err) {
       return {

--- a/src/providers/aimlapi.ts
+++ b/src/providers/aimlapi.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
@@ -35,7 +35,7 @@ export async function fetchAimlApiModels(env?: EnvOverrides): Promise<AimlApiMod
     const { data } = await fetchWithCache<any>(
       'https://api.aimlapi.com/models',
       { headers },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     const models = data?.data || data?.models || data;

--- a/src/providers/azure/assistant.ts
+++ b/src/providers/azure/assistant.ts
@@ -7,7 +7,7 @@ import invariant from '../../util/invariant';
 import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
-import { REQUEST_TIMEOUT_MS, toTitleCase } from '../shared';
+import { getRequestTimeoutMs, toTitleCase } from '../shared';
 import { AzureGenericProvider } from './generic';
 
 import type {
@@ -432,7 +432,7 @@ export class AzureAssistantProvider extends AzureGenericProvider {
    * Helper method to make HTTP requests using fetchWithCache
    */
   private async makeRequest<T>(url: string, options: RequestInit): Promise<T> {
-    const timeoutMs = this.assistantConfig.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    const timeoutMs = this.assistantConfig.timeoutMs ?? getRequestTimeoutMs();
     const retries = this.assistantConfig.retryOptions?.maxRetries ?? 4;
 
     // These operations should never be cached

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -18,7 +18,7 @@ import { isClaudeOpus47Model } from '../anthropic/util';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS, transformTools } from '../shared';
+import { getRequestTimeoutMs, parseChatPrompt, transformTools } from '../shared';
 import { DEFAULT_AZURE_API_VERSION } from './defaults';
 import { AzureGenericProvider } from './generic';
 import { calculateAzureCost } from './util';
@@ -353,7 +353,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         context?.bustCache ?? context?.debug,
       );

--- a/src/providers/azure/completion.ts
+++ b/src/providers/azure/completion.ts
@@ -3,7 +3,7 @@ import { getEnvFloat, getEnvInt, getEnvString } from '../../envars';
 import logger from '../../logger';
 import { normalizeFinishReason } from '../../util/finishReason';
 import invariant from '../../util/invariant';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { DEFAULT_AZURE_API_VERSION } from './defaults';
 import { AzureGenericProvider } from './generic';
 import { calculateAzureCost } from './util';
@@ -64,7 +64,7 @@ export class AzureCompletionProvider extends AzureGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         context?.bustCache ?? context?.debug,
       )) as any);

--- a/src/providers/azure/embedding.ts
+++ b/src/providers/azure/embedding.ts
@@ -1,6 +1,6 @@
 import { fetchWithCache } from '../../cache';
 import invariant from '../../util/invariant';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { DEFAULT_AZURE_API_VERSION } from './defaults';
 import { AzureGenericProvider } from './generic';
 
@@ -34,7 +34,7 @@ export class AzureEmbeddingProvider extends AzureGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       return {

--- a/src/providers/azure/moderation.ts
+++ b/src/providers/azure/moderation.ts
@@ -4,7 +4,7 @@ import { getCache, isCacheEnabled } from '../../cache';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import { fetchWithProxy } from '../../util/fetch/index';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { AzureGenericProvider } from './generic';
 
 import type { EnvVarKey } from '../../envars';
@@ -271,7 +271,7 @@ export class AzureModerationProvider extends AzureGenericProvider implements Api
       };
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      const timeoutId = setTimeout(() => controller.abort(), getRequestTimeoutMs());
 
       const response = await fetchWithProxy(url, {
         method: 'POST',

--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -9,7 +9,7 @@ import {
 import invariant from '../../util/invariant';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
-import { LONG_RUNNING_MODEL_TIMEOUT_MS, REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs, LONG_RUNNING_MODEL_TIMEOUT_MS } from '../shared';
 import { AzureGenericProvider } from './generic';
 import { calculateAzureCost } from './util';
 
@@ -259,7 +259,7 @@ export class AzureResponsesProvider extends AzureGenericProvider {
 
     // Calculate timeout for deep research models
     const isDeepResearchModel = this.deploymentName.includes('deep-research');
-    let timeout = REQUEST_TIMEOUT_MS;
+    let timeout = getRequestTimeoutMs();
     if (isDeepResearchModel) {
       const evalTimeout = getEnvInt('PROMPTFOO_EVAL_TIMEOUT_MS', 0);
       timeout = evalTimeout > 0 ? evalTimeout : LONG_RUNNING_MODEL_TIMEOUT_MS;

--- a/src/providers/cohere.ts
+++ b/src/providers/cohere.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -185,7 +185,7 @@ export class CohereChatCompletionProvider implements ApiProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as { data: any; cached: boolean });
 
       if (data.message) {
@@ -287,7 +287,7 @@ export class CohereEmbeddingProvider implements ApiEmbeddingProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       logger.error(`API call error: ${err}`);

--- a/src/providers/cometapi.ts
+++ b/src/providers/cometapi.ts
@@ -5,7 +5,7 @@ import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
 import { OpenAiImageProvider } from './openai/image';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
@@ -38,7 +38,7 @@ export async function fetchCometApiModels(env?: EnvOverrides): Promise<CometApiM
     const { data } = await fetchWithCache<any>(
       'https://api.cometapi.com/v1/models',
       { headers },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     const raw = data?.data || data?.models || data;

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -4,7 +4,7 @@ import logger from '../../logger';
 import { maybeLoadFromExternalFile } from '../../util/file';
 import { renderVarsInObject } from '../../util/index';
 import { getNunjucksEngine } from '../../util/templates';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs, parseChatPrompt } from '../shared';
 import { GoogleGenericProvider, type GoogleProviderOptions } from './base';
 import { CHAT_MODELS } from './shared';
 import {
@@ -293,7 +293,7 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
           body: JSON.stringify(body),
           ...(authDiscriminator && { _authHash: authDiscriminator }),
         } as RequestInit,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         shouldBustCache(context),
       )) as unknown as { data: any; cached: boolean });
@@ -443,7 +443,7 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
           body: JSON.stringify(body),
           ...(authDiscriminator && { _authHash: authDiscriminator }),
         } as RequestInit,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         shouldBustCache(context),
       )) as {
@@ -625,7 +625,7 @@ export class AIStudioEmbeddingProvider
           body: JSON.stringify(body),
           ...(authDiscriminator && { _authHash: authDiscriminator }),
         } as RequestInit,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
       )) as unknown as { data: any; cached: boolean });
     } catch (err) {

--- a/src/providers/google/base.ts
+++ b/src/providers/google/base.ts
@@ -24,7 +24,7 @@ import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { getNunjucksEngine } from '../../util/templates';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToGoogle } from '../mcp/transform';
-import { REQUEST_TIMEOUT_MS, transformTools } from '../shared';
+import { getRequestTimeoutMs, transformTools } from '../shared';
 import { GoogleAuthManager } from './auth';
 import { normalizeTools } from './util';
 
@@ -398,7 +398,7 @@ export abstract class GoogleGenericProvider implements ApiProvider {
    * Get the request timeout in milliseconds.
    */
   protected getTimeout(): number {
-    return this.config.timeoutMs || REQUEST_TIMEOUT_MS;
+    return this.config.timeoutMs || getRequestTimeoutMs();
   }
 }
 

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from '../../cache';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import { toDataUri } from '../../util/dataUrl';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import {
   createAuthCacheDiscriminator,
   geminiFormatAndSystemInstructions,
@@ -155,7 +155,7 @@ export class GeminiImageProvider implements ApiProvider {
           body: JSON.stringify(body),
           ...(authDiscriminator && { _authHash: authDiscriminator }),
         } as RequestInit,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         false,
       )) as { data: any; cached: boolean };
@@ -216,7 +216,7 @@ export class GeminiImageProvider implements ApiProvider {
           ...(this.config.headers || {}),
         },
         data: body,
-        timeout: REQUEST_TIMEOUT_MS,
+        timeout: getRequestTimeoutMs(),
       });
       const latencyMs = Date.now() - startTime;
 

--- a/src/providers/google/image.ts
+++ b/src/providers/google/image.ts
@@ -3,7 +3,7 @@ import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import { toDataUri } from '../../util/dataUrl';
 import { sleep } from '../../util/time';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import {
   createAuthCacheDiscriminator,
   getGoogleClient,
@@ -176,7 +176,7 @@ export class GoogleImageProvider implements ApiProvider {
               ...(this.config.headers || {}),
             },
             data: body,
-            timeout: REQUEST_TIMEOUT_MS,
+            timeout: getRequestTimeoutMs(),
           }),
         'Vertex AI API call',
       )) as { data: ImageGenerationResponse };
@@ -246,7 +246,7 @@ export class GoogleImageProvider implements ApiProvider {
               body: JSON.stringify(body),
               ...(authDiscriminator && { _authHash: authDiscriminator }),
             } as RequestInit,
-            REQUEST_TIMEOUT_MS,
+            getRequestTimeoutMs(),
             'json',
           ),
         'Google AI Studio API call',

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -19,7 +19,7 @@ import { fetchWithProxy } from '../../util/fetch/index';
 import { maybeLoadFromExternalFile } from '../../util/file';
 import { renderVarsInObject } from '../../util/index';
 import { getNunjucksEngine } from '../../util/templates';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { GoogleGenericProvider, type GoogleProviderOptions } from './base';
 import {
   calculateGoogleCost,
@@ -362,7 +362,7 @@ export class GoogleProvider extends GoogleGenericProvider {
           url,
           method: 'POST',
           data: body,
-          timeout: REQUEST_TIMEOUT_MS,
+          timeout: getRequestTimeoutMs(),
         });
         data = res.data as GeminiApiResponse;
       } else if (this.isVertexMode && this.isExpressMode()) {
@@ -374,7 +374,7 @@ export class GoogleProvider extends GoogleGenericProvider {
           method: 'POST',
           headers: await this.getAuthHeaders(),
           body: JSON.stringify(body),
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          signal: AbortSignal.timeout(getRequestTimeoutMs()),
         });
 
         if (!res.ok) {
@@ -400,7 +400,7 @@ export class GoogleProvider extends GoogleGenericProvider {
             // Include auth discriminator in cache key to prevent cross-tenant cache sharing
             ...(authDiscriminator && { _authHash: authDiscriminator }),
           } as RequestInit,
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           false,
         );

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -18,7 +18,7 @@ import {
   outputFromMessage,
   parseMessages,
 } from '../anthropic/util';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs, parseChatPrompt } from '../shared';
 import { GoogleGenericProvider, type GoogleProviderOptions } from './base';
 import {
   calculateGoogleCost,
@@ -345,7 +345,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
           'Content-Type': 'application/json; charset=utf-8',
         },
         data: body,
-        timeout: REQUEST_TIMEOUT_MS,
+        timeout: getRequestTimeoutMs(),
       });
 
       data = res.data as ClaudeResponse;
@@ -550,7 +550,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
             method: 'POST',
             headers: await this.getAuthHeaders(),
             body: JSON.stringify(body),
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(getRequestTimeoutMs()),
           });
 
           if (!res.ok) {
@@ -573,7 +573,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
             url,
             method: 'POST',
             data: body,
-            timeout: REQUEST_TIMEOUT_MS,
+            timeout: getRequestTimeoutMs(),
           });
           data = res.data as GeminiApiResponse;
         }
@@ -882,7 +882,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
           'Content-Type': 'application/json',
         },
         data: body,
-        timeout: REQUEST_TIMEOUT_MS,
+        timeout: getRequestTimeoutMs(),
       });
       data = res.data as Palm2ApiResponse;
     } catch (err) {
@@ -1025,7 +1025,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
           'Content-Type': 'application/json; charset=utf-8',
         },
         data: body,
-        timeout: REQUEST_TIMEOUT_MS,
+        timeout: getRequestTimeoutMs(),
       });
 
       data = res.data as LlamaResponse;

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -40,7 +40,12 @@ import {
   createTransformResponse,
   type TransformResponseContext,
 } from './httpTransforms';
-import { REQUEST_TIMEOUT_MS, type ToolFormat, transformToolChoice, transformTools } from './shared';
+import {
+  getRequestTimeoutMs,
+  type ToolFormat,
+  transformToolChoice,
+  transformTools,
+} from './shared';
 
 import type {
   ApiProvider,
@@ -1728,7 +1733,7 @@ export class HttpProvider implements ApiProvider {
       const response = await fetchWithCache(
         oauthConfig.tokenUrl,
         fetchOptions,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text',
         true, // Always bust cache for token requests
         0, // No retries for token requests
@@ -2026,7 +2031,7 @@ export class HttpProvider implements ApiProvider {
     const response = await fetchWithCache(
       url,
       fetchOptions,
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'text',
       true, // Always bust cache for session requests
       this.config.maxRetries,
@@ -2465,7 +2470,7 @@ export class HttpProvider implements ApiProvider {
       } = await fetchWithCache(
         url,
         fetchOptions,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text',
         multipartBody ? true : (context?.bustCache ?? context?.debug),
         this.config.maxRetries,
@@ -2696,7 +2701,7 @@ export class HttpProvider implements ApiProvider {
       } = await fetchWithCache(
         url,
         fetchOptions,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text',
         context?.bustCache ?? context?.debug,
         this.config.maxRetries,

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -3,7 +3,7 @@ import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { OpenAiChatCompletionProvider } from './openai/chat';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type {
   ApiProvider,
@@ -254,7 +254,7 @@ export class HuggingfaceTextGenerationProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       logger.debug('Huggingface Inference API response', { data: response.data });
@@ -335,7 +335,7 @@ export class HuggingfaceTextClassificationProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       if (response.data.error) {
@@ -438,7 +438,7 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       if (typeof response.data === 'object' && 'error' in response.data) {
@@ -533,7 +533,7 @@ export class HuggingfaceSentenceSimilarityProvider implements ApiSimilarityProvi
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       if (typeof response.data === 'object' && 'error' in response.data) {
@@ -623,7 +623,7 @@ export class HuggingfaceTokenExtractionProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       if (typeof response.data === 'object' && 'error' in response.data) {

--- a/src/providers/hyperbolic/audio.ts
+++ b/src/providers/hyperbolic/audio.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../../cache';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 
 import type { EnvOverrides } from '../../types/env';
 import type {
@@ -129,7 +129,7 @@ export class HyperbolicAudioProvider implements ApiProvider {
           headers,
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
 
       if (status < 200 || status >= 300) {

--- a/src/providers/hyperbolic/image.ts
+++ b/src/providers/hyperbolic/image.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../../cache';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 
 import type { EnvOverrides } from '../../types/env';
 import type {
@@ -242,7 +242,7 @@ export class HyperbolicImageProvider implements ApiProvider {
           headers,
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
 
       if (status < 200 || status >= 300) {

--- a/src/providers/llama.ts
+++ b/src/providers/llama.ts
@@ -1,6 +1,6 @@
 import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { ApiProvider, ProviderResponse } from '../types/index';
 
@@ -84,7 +84,7 @@ export class LlamaProvider implements ApiProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
     } catch (err) {
       return {

--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -1,6 +1,6 @@
 import { fetchWithCache } from '../cache';
 import { getEnvFloat, getEnvString } from '../envars';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs, parseChatPrompt } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderEmbeddingResponse, ProviderResponse } from '../types/index';
@@ -78,7 +78,7 @@ export class LocalAiChatProvider extends LocalAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       return {
@@ -115,7 +115,7 @@ export class LocalAiEmbeddingProvider extends LocalAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       return {
@@ -162,7 +162,7 @@ export class LocalAiCompletionProvider extends LocalAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       return {

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -5,7 +5,7 @@ import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { maybeLoadToolsFromExternalFile } from '../util';
-import { calculateCost, parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+import { calculateCost, getRequestTimeoutMs, parseChatPrompt } from './shared';
 
 import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';
@@ -509,7 +509,7 @@ export class MistralChatCompletionProvider implements ApiProvider {
             },
             body: JSON.stringify(params),
           },
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           true,
         )) as unknown as MistralFetchResult;
@@ -701,7 +701,7 @@ export class MistralEmbeddingProvider implements ApiProvider {
               },
               body: JSON.stringify(body),
             },
-            REQUEST_TIMEOUT_MS,
+            getRequestTimeoutMs(),
             'json',
             true,
           )) as unknown as MistralFetchResult;

--- a/src/providers/modelslab.ts
+++ b/src/providers/modelslab.ts
@@ -17,7 +17,7 @@ import { getEnvString } from '../envars';
 import logger from '../logger';
 import { fetchWithProxy } from '../util/fetch';
 import { ellipsize } from '../util/text';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -145,7 +145,7 @@ export class ModelsLabImageProvider implements ApiProvider {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(requestBody),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         true,
       );
@@ -244,7 +244,7 @@ export class ModelsLabImageProvider implements ApiProvider {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ key: this.apiKey }),
           },
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           true,
         );

--- a/src/providers/nscale/image.ts
+++ b/src/providers/nscale/image.ts
@@ -2,7 +2,7 @@ import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import invariant from '../../util/invariant';
 import { callOpenAiImageApi, formatOutput, OpenAiImageProvider } from '../openai/image';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 
 import type { EnvOverrides } from '../../types/env';
 import type {
@@ -188,7 +188,7 @@ export class NscaleImageProvider extends OpenAiImageProvider {
         `${this.getApiUrl()}${endpoint}`,
         body,
         headers,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
       if (status < 200 || status >= 300) {
         return {

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -3,7 +3,7 @@ import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { maybeLoadToolsFromExternalFile } from '../util/index';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS, transformTools } from './shared';
+import { getRequestTimeoutMs, parseChatPrompt, transformTools } from './shared';
 
 import type {
   ApiProvider,
@@ -228,7 +228,7 @@ export class OllamaCompletionProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text',
       );
     } catch (err) {
@@ -385,7 +385,7 @@ export class OllamaChatProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text',
         context?.bustCache ?? context?.debug,
       );
@@ -521,7 +521,7 @@ export class OllamaEmbeddingProvider extends OllamaCompletionProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
       );
     } catch (err) {

--- a/src/providers/openai/assistant.ts
+++ b/src/providers/openai/assistant.ts
@@ -7,7 +7,7 @@ import logger from '../../logger';
 import { isJavascriptFile } from '../../util/fileExtensions';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { sleep } from '../../util/time';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS, toTitleCase } from '../shared';
+import { getRequestTimeoutMs, parseChatPrompt, toTitleCase } from '../shared';
 import { OpenAiGenericProvider } from '.';
 import { failApiCall, getTokenUsage } from './util';
 import type { Metadata } from 'openai/resources/shared';
@@ -234,7 +234,7 @@ export class OpenAiAssistantProvider extends OpenAiGenericProvider {
       organization: this.getOrganization(),
       baseURL: this.getApiUrl(),
       maxRetries: 3,
-      timeout: REQUEST_TIMEOUT_MS,
+      timeout: getRequestTimeoutMs(),
       defaultHeaders: this.assistantConfig.headers,
     });
 

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -21,8 +21,8 @@ import {
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
 import {
+  getRequestTimeoutMs,
   parseChatPrompt,
-  REQUEST_TIMEOUT_MS,
   transformToolChoice,
   transformTools,
 } from '../shared';
@@ -494,7 +494,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         context?.bustCache ?? context?.debug,
         this.config.maxRetries,

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../../envars';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { OpenAiGenericProvider } from '.';
 import {
   calculateOpenAICost,
@@ -88,7 +88,7 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         context?.bustCache ?? context?.debug,
         this.config.maxRetries,

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -1,6 +1,6 @@
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { OpenAiGenericProvider } from '.';
 import { getTokenUsage } from './util';
 
@@ -47,7 +47,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         false,
         this.config.maxRetries,

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
 import { ellipsize } from '../../util/text';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { OpenAiGenericProvider } from '.';
 import { formatOpenAiError } from './util';
 
@@ -847,7 +847,7 @@ export class OpenAiImageProvider extends OpenAiGenericProvider {
         `${this.getApiUrl()}${endpoint}`,
         body,
         headers,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
 
       if (status < 200 || status >= 300) {

--- a/src/providers/openai/moderation.ts
+++ b/src/providers/openai/moderation.ts
@@ -2,7 +2,7 @@ import { createHmac } from 'crypto';
 
 import { fetchWithCache, getCache, getScopedCacheKey, isCacheEnabled } from '../../cache';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { OpenAiGenericProvider } from '.';
 
 import type {
@@ -289,7 +289,7 @@ export class OpenAiModerationProvider
               headers,
               body: requestBody,
             },
-            REQUEST_TIMEOUT_MS,
+            getRequestTimeoutMs(),
             'json',
             true,
             this.config.maxRetries,

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -8,7 +8,7 @@ import {
 } from '../../util/index';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
-import { LONG_RUNNING_MODEL_TIMEOUT_MS, REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs, LONG_RUNNING_MODEL_TIMEOUT_MS } from '../shared';
 import { OpenAiGenericProvider } from '.';
 import { calculateOpenAICost, formatOpenAiError, getTokenUsage } from './util';
 
@@ -415,7 +415,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     }
 
     // Calculate timeout for long-running models (deep research and GPT-5-pro variants)
-    let timeout = REQUEST_TIMEOUT_MS;
+    let timeout = getRequestTimeoutMs();
     const isGpt5ProModel = /(^|\/)gpt-5(?:\.\d+)?-pro(?:-|$)/.test(this.modelName);
     const isLongRunningModel = isDeepResearchModel || isGpt5ProModel;
     if (isLongRunningModel) {

--- a/src/providers/openai/transcription.ts
+++ b/src/providers/openai/transcription.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { OpenAiGenericProvider } from './';
 import { OPENAI_TRANSCRIPTION_MODELS } from './util';
 
@@ -140,7 +140,7 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
             headers,
             body: formData,
           },
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           context?.bustCache ?? context?.debug,
         ));

--- a/src/providers/openclaw/agent.ts
+++ b/src/providers/openclaw/agent.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import WebSocket from 'ws';
 import { VERSION } from '../../constants';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import {
   buildSignedOpenClawDevice,
   clearOpenClawDeviceAuthToken,
@@ -155,7 +155,7 @@ export class OpenClawAgentProvider implements ApiProvider {
     const authSecret = resolveAuthSecret(this.openclawConfig, env);
     this.authKind = authSecret?.kind;
     this.authSecret = authSecret?.value;
-    this.timeoutMs = this.openclawConfig.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.timeoutMs = this.openclawConfig.timeoutMs ?? getRequestTimeoutMs();
     this.scopes = normalizeScopes(this.openclawConfig.scopes);
     this.hasExplicitScopes = this.scopes.length > 0;
     if (!this.hasExplicitScopes) {

--- a/src/providers/openclaw/tools.ts
+++ b/src/providers/openclaw/tools.ts
@@ -1,6 +1,6 @@
 import logger from '../../logger';
 import { fetchWithProxy } from '../../util/fetch/index';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { buildOpenClawContextHeaders, resolveAuthToken, resolveGatewayUrl } from './shared';
 
 import type { ApiProvider, ProviderOptions, ProviderResponse } from '../../types/providers';
@@ -37,7 +37,7 @@ export class OpenClawToolInvokeProvider implements ApiProvider {
     const env = providerOptions.env as Record<string, string | undefined> | undefined;
     this.gatewayUrl = resolveGatewayUrl(this.openclawConfig, env);
     this.authToken = resolveAuthToken(this.openclawConfig, env);
-    this.timeoutMs = this.openclawConfig.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.timeoutMs = this.openclawConfig.timeoutMs ?? getRequestTimeoutMs();
   }
 
   id(): string {

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -4,7 +4,7 @@ import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../t
 import { normalizeFinishReason } from '../util/finishReason';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { calculateOpenAICost, formatOpenAiError, getTokenUsage } from './openai/util';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 import type OpenAI from 'openai';
 
 import type {
@@ -157,7 +157,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
             },
             body: JSON.stringify(body),
           },
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           context?.bustCache ?? context?.debug,
         ));

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -10,7 +10,7 @@ import {
 } from '../redteam/remoteGeneration';
 import { getRemoteMaterializationContextFromVars } from '../redteam/remoteMaterialization';
 import { fetchWithRetries } from '../util/fetch/index';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -218,7 +218,7 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
           body: JSON.stringify(body),
           ...(callApiOptions?.abortSignal && { signal: callApiOptions.abortSignal }),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       const data = await response.json();
@@ -336,7 +336,7 @@ export class PromptfooSimulatedUserProvider implements ApiProvider {
           body: JSON.stringify(body),
           ...(callApiOptions?.abortSignal && { signal: callApiOptions.abortSignal }),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       if (!response.ok) {

--- a/src/providers/quiverai.ts
+++ b/src/providers/quiverai.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { fetchWithProxy } from '../util/fetch';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -154,7 +154,7 @@ export class QuiverAiProvider implements ApiProvider {
         headers: this.getHeaders(),
         body: JSON.stringify(body),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'json',
       context?.bustCache ?? context?.debug,
     );
@@ -182,7 +182,7 @@ export class QuiverAiProvider implements ApiProvider {
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      const timeout = setTimeout(() => controller.abort(), getRequestTimeoutMs());
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
       try {

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -3,7 +3,7 @@ import { createHmac } from 'crypto';
 import { fetchWithCache, getCache, isCacheEnabled } from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';
 import logger from '../logger';
-import { REQUEST_TIMEOUT_MS } from '../providers/shared';
+import { getRequestTimeoutMs } from '../providers/shared';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { safeJsonStringify } from '../util/json';
 import { ellipsize } from '../util/text';
@@ -255,7 +255,7 @@ export class ReplicateProvider implements ApiProvider {
           },
           body: JSON.stringify(data),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
       );
 
@@ -333,7 +333,7 @@ export class ReplicateProvider implements ApiProvider {
             Authorization: `Bearer ${this.apiKey}`,
           },
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         false, // Don't cache polling requests
       );
@@ -505,7 +505,7 @@ export class ReplicateImageProvider extends ReplicateProvider {
           },
           body: JSON.stringify(data),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
       );
 

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -6,7 +6,9 @@ import type { ApiProvider } from '../types/index';
 /**
  * The default timeout for API requests in milliseconds.
  */
-export const REQUEST_TIMEOUT_MS = getEnvInt('REQUEST_TIMEOUT_MS', 300_000);
+export function getRequestTimeoutMs(): number {
+  return getEnvInt('REQUEST_TIMEOUT_MS', 300_000);
+}
 
 /**
  * Extended timeout for long-running models (deep research, gpt-5-pro, etc.) in milliseconds.

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -3,7 +3,7 @@ import logger from '../logger';
 import { normalizeFinishReason } from '../util/finishReason';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { calculateOpenAICost, formatOpenAiError, getTokenUsage } from './openai/util';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 import type OpenAI from 'openai';
 
 import type {
@@ -140,7 +140,7 @@ export class SnowflakeCortexProvider extends OpenAiChatCompletionProvider {
             },
             body: JSON.stringify(body),
           },
-          REQUEST_TIMEOUT_MS,
+          getRequestTimeoutMs(),
           'json',
           context?.bustCache ?? context?.debug,
         ));

--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -4,7 +4,7 @@ import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { sha256 } from '../util/createHash';
-import { parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs, parseChatPrompt } from './shared';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -16,8 +16,6 @@ import type {
   ProviderResponse,
 } from '../types/providers';
 import type { TokenUsage } from '../types/shared';
-
-const DEFAULT_TIMEOUT_MS = REQUEST_TIMEOUT_MS;
 
 /**
  * Message format for chat completions.
@@ -267,7 +265,7 @@ export class VercelAiProvider implements ApiProvider {
    * Handles streaming API calls using streamText().
    */
   private async callApiStreaming(messages: ChatMessage[]): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeout = this.config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout);
 
     try {
@@ -314,7 +312,7 @@ export class VercelAiProvider implements ApiProvider {
    * Handles structured output API calls using generateObject().
    */
   private async callApiStructured(messages: ChatMessage[]): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeout = this.config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout);
 
     try {
@@ -408,7 +406,7 @@ export class VercelAiProvider implements ApiProvider {
    * Handles non-streaming API calls using generateText().
    */
   private async callApiNonStreaming(messages: ChatMessage[]): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeout = this.config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout);
 
     try {
@@ -507,7 +505,7 @@ export class VercelAiEmbeddingProvider implements ApiEmbeddingProvider {
       }
     }
 
-    const timeout = this.config.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeout = this.config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout);
 
     try {

--- a/src/providers/voyage.ts
+++ b/src/providers/voyage.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type {
   ApiEmbeddingProvider,
@@ -92,7 +92,7 @@ export class VoyageEmbeddingProvider implements ApiEmbeddingProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       )) as unknown as any);
     } catch (err) {
       logger.error(`API call error: ${err}`);

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -7,7 +7,7 @@ import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import invariant from '../util/invariant';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
-import { calculateCost, parseChatPrompt, REQUEST_TIMEOUT_MS } from './shared';
+import { calculateCost, getRequestTimeoutMs, parseChatPrompt } from './shared';
 import type { WatsonXAI as WatsonXAIClient } from '@ibm-cloud/watsonx-ai';
 import type { BearerTokenAuthenticator, IamAuthenticator } from 'ibm-cloud-sdk-core';
 
@@ -242,7 +242,7 @@ async function fetchModelSpecs(): Promise<ModelSpec[]> {
           'Content-Type': 'application/json',
         },
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     // Handle string response that needs to be parsed

--- a/src/providers/webhook.ts
+++ b/src/providers/webhook.ts
@@ -1,5 +1,5 @@
 import { fetchWithCache } from '../cache';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type { ApiProvider, ProviderResponse } from '../types/index';
 
@@ -47,7 +47,7 @@ export class WebhookProvider implements ApiProvider {
           },
           body: JSON.stringify(params),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
       ));
     } catch (err) {

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -9,7 +9,7 @@ import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
 import { getNunjucksEngine } from '../util/templates';
-import { REQUEST_TIMEOUT_MS } from './shared';
+import { getRequestTimeoutMs } from './shared';
 
 import type {
   ApiProvider,
@@ -193,7 +193,7 @@ export class WebSocketProvider implements ApiProvider {
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config as WebSocketProviderConfig;
     this.url = this.config.url || url;
-    this.timeoutMs = this.config.timeoutMs || REQUEST_TIMEOUT_MS;
+    this.timeoutMs = this.config.timeoutMs || getRequestTimeoutMs();
     this.transformResponse = createTransformResponse(
       this.config.transformResponse || this.config.responseParser,
     );

--- a/src/providers/xai/image.ts
+++ b/src/providers/xai/image.ts
@@ -7,7 +7,7 @@ import {
   formatOutput,
   OpenAiImageProvider,
 } from '../openai/image';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 
 import type { EnvOverrides } from '../../types/env';
 import type {
@@ -118,7 +118,7 @@ export class XAIImageProvider extends OpenAiImageProvider {
         `${this.getApiUrl()}${endpoint}`,
         body,
         headers,
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       ));
       if (status < 200 || status >= 300) {
         return {

--- a/src/providers/xai/responses.ts
+++ b/src/providers/xai/responses.ts
@@ -7,7 +7,7 @@ import {
 } from '../../util/index';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
-import { REQUEST_TIMEOUT_MS } from '../shared';
+import { getRequestTimeoutMs } from '../shared';
 import { calculateXAICost, GROK_4_MODELS } from './chat';
 
 import type { EnvOverrides } from '../../types/env';
@@ -340,7 +340,7 @@ export class XAIResponsesProvider implements ApiProvider {
           },
           body: JSON.stringify(body),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         context?.bustCache ?? context?.debug,
         this.config.maxRetries,

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { PythonShell } from 'python-shell';
 import { getWrapperDir } from '../esm';
 import logger from '../logger';
-import { REQUEST_TIMEOUT_MS } from '../providers/shared';
+import { getRequestTimeoutMs } from '../providers/shared';
 import { safeJsonStringify } from '../util/json';
 import { validatePythonPath } from './pythonUtils';
 
@@ -26,7 +26,7 @@ export class PythonWorker {
     private scriptPath: string,
     private functionName: string,
     private pythonPath?: string,
-    private timeout: number = REQUEST_TIMEOUT_MS,
+    private timeout: number = getRequestTimeoutMs(),
     private onReady?: () => void,
   ) {}
 

--- a/src/redteam/audio/adversarialProvider.ts
+++ b/src/redteam/audio/adversarialProvider.ts
@@ -13,7 +13,7 @@
 
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { fetchWithProxy } from '../../util/fetch';
 
 /**
@@ -187,7 +187,7 @@ export class HttpAdversarialProvider implements AdversarialAudioProvider {
     supportedAttacks?: (AdversarialAttackType | string)[];
   }) {
     this.endpoint = config.endpoint;
-    this.timeout = config.timeout || REQUEST_TIMEOUT_MS;
+    this.timeout = config.timeout || getRequestTimeoutMs();
     this.headers = config.headers || {};
     this.supportedAttacks = config.supportedAttacks || [
       'noise-injection',

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -5,7 +5,7 @@ import { VERSION } from '../../constants';
 import { getEnvBool } from '../../envars';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { getRemoteGenerationUrl } from '../remoteGeneration';
 
@@ -55,7 +55,7 @@ export async function fetchRemoteGeneration(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'json',
     );
 

--- a/src/redteam/plugins/cyberseceval.ts
+++ b/src/redteam/plugins/cyberseceval.ts
@@ -1,5 +1,5 @@
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { fetchWithTimeout } from '../../util/fetch/index';
 import { RedteamPluginBase } from './base';
 
@@ -36,7 +36,7 @@ async function fetchDataset(
 ): Promise<CyberSecEvalTestCase[]> {
   try {
     const url = isMultilingual ? DATASET_URL_MULTILINGUAL : DATASET_URL;
-    const response = await fetchWithTimeout(url, {}, REQUEST_TIMEOUT_MS);
+    const response = await fetchWithTimeout(url, {}, getRequestTimeoutMs());
     if (!response.ok) {
       throw new Error(`[CyberSecEval] HTTP status: ${response.status} ${response.statusText}`);
     }

--- a/src/redteam/plugins/donotanswer.ts
+++ b/src/redteam/plugins/donotanswer.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { parse } from 'csv-parse/sync';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { fetchWithTimeout } from '../../util/fetch/index';
 import { RedteamPluginBase } from './base';
 
@@ -56,7 +56,7 @@ export async function fetchDataset(limit: number): Promise<DoNotAnswerTestCase[]
     // Check if we're using a local file path or a URL
     if (DATASET_URL.startsWith('http')) {
       // Fetch from URL
-      const response = await fetchWithTimeout(DATASET_URL, {}, REQUEST_TIMEOUT_MS);
+      const response = await fetchWithTimeout(DATASET_URL, {}, getRequestTimeoutMs());
       if (!response.ok) {
         throw new Error(`[DoNotAnswer] HTTP status: ${response.status} ${response.statusText}`);
       }

--- a/src/redteam/plugins/harmbench.ts
+++ b/src/redteam/plugins/harmbench.ts
@@ -1,7 +1,7 @@
 import { parse as csvParse } from 'csv-parse/sync';
 import dedent from 'dedent';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { fetchWithTimeout } from '../../util/fetch/index';
 import { RedteamGraderBase, RedteamPluginBase } from './base';
 
@@ -152,7 +152,7 @@ async function fetchDataset(
   config?: NormalizedHarmbenchPluginConfig,
 ): Promise<HarmbenchInput[]> {
   try {
-    const response = await fetchWithTimeout(DATASET_URL, {}, REQUEST_TIMEOUT_MS);
+    const response = await fetchWithTimeout(DATASET_URL, {}, getRequestTimeoutMs());
     if (!response.ok) {
       throw new Error(`HTTP status: ${response.status} ${response.statusText}`);
     }

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -4,7 +4,7 @@ import { VERSION } from '../../constants';
 import { getEnvBool } from '../../envars';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { checkRemoteHealth } from '../../util/apiHealth';
 import { retryWithDeduplication } from '../../util/generation';
 import invariant from '../../util/invariant';
@@ -390,7 +390,7 @@ async function fetchRemoteTestCases(
         },
         body,
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
     if (status !== 200 || !data || !data.result || !Array.isArray(data.result)) {
       logger.error(`Error generating test cases for ${key}: ${statusText} ${JSON.stringify(data)}`);

--- a/src/redteam/plugins/vlsu.ts
+++ b/src/redteam/plugins/vlsu.ts
@@ -2,7 +2,7 @@ import { parse as csvParse } from 'csv-parse/sync';
 import dedent from 'dedent';
 import { fetchWithCache } from '../../cache';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import {
   ImageDatasetGraderBase,
   ImageDatasetPluginBase,
@@ -294,7 +294,7 @@ export class VLSUDatasetManager extends ImageDatasetManager<VLSUInput> {
       const response = await fetchWithCache(
         VLSU_CSV_URL,
         {},
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'text' as 'json', // Force text response
       );
 

--- a/src/redteam/plugins/xstest.ts
+++ b/src/redteam/plugins/xstest.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { parse } from 'csv-parse/sync';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { fetchWithTimeout } from '../../util/fetch/index';
 import { RedteamPluginBase } from './base';
 
@@ -48,7 +48,7 @@ export async function fetchDataset(limit: number): Promise<XSTestTestCase[]> {
     // Check if we're using a local file path or a URL
     if (DATASET_URL.startsWith('http')) {
       // Fetch from URL
-      const response = await fetchWithTimeout(DATASET_URL, {}, REQUEST_TIMEOUT_MS);
+      const response = await fetchWithTimeout(DATASET_URL, {}, getRequestTimeoutMs());
       if (!response.ok) {
         throw new Error(`[XSTest] HTTP status: ${response.status} ${response.statusText}`);
       }

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -70,7 +70,7 @@ async function generateCitations(
           },
           body: JSON.stringify(payload),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       logger.debug(

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -3,7 +3,7 @@ import { Presets, SingleBar } from 'cli-progress';
 import { fetchWithCache } from '../../cache';
 import { getUserEmail, isLoggedIntoCloud } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -70,7 +70,7 @@ async function generateGcgPrompts(
           },
           body: JSON.stringify(payload),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
         'json',
         true,
       );

--- a/src/redteam/strategies/likert.ts
+++ b/src/redteam/strategies/likert.ts
@@ -3,7 +3,7 @@ import { Presets, SingleBar } from 'cli-progress';
 import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -66,7 +66,7 @@ async function generateLikertPrompts(
           },
           body: JSON.stringify(payload),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       logger.debug(

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { extractFirstJsonObject } from '../../util/json';
 import { redteamProviderManager } from '../providers/shared';
@@ -72,7 +72,7 @@ export async function generateMathPrompt(
           },
           body: JSON.stringify(payload),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       logger.debug(

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -7,7 +7,7 @@ import cliState from '../../cliState';
 import { DEFAULT_MAX_CONCURRENCY } from '../../constants';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { redteamProviderManager } from '../providers/shared';
 import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
@@ -140,7 +140,7 @@ async function processRemoteChunk(
       },
       body: JSON.stringify(payload),
     },
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs(),
   );
   const { data, status, statusText } = resp as any;
   const result = (data as any)?.result;

--- a/src/redteam/strategies/simpleAudio.ts
+++ b/src/redteam/strategies/simpleAudio.ts
@@ -3,7 +3,7 @@ import { fetchWithCache } from '../../cache';
 import { VERSION } from '../../constants';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { isMediaStorageEnabled, storeMedia } from '../../storage';
 import invariant from '../../util/invariant';
 import {
@@ -61,7 +61,7 @@ export async function textToAudio(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     if (data.error || !data.audioBase64) {

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -3,7 +3,7 @@ import { Presets, SingleBar } from 'cli-progress';
 import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -83,7 +83,7 @@ async function generateCompositePrompts(
           },
           body: JSON.stringify(payload),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       logger.debug(

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -1,6 +1,6 @@
 import { fetchWithCache } from '../cache';
 import logger from '../logger';
-import { REQUEST_TIMEOUT_MS } from '../providers/shared';
+import { getRequestTimeoutMs } from '../providers/shared';
 import { type Inputs } from '../types/shared';
 import { safeJsonStringify } from '../util/json';
 import { escapeRegExp } from '../util/text';
@@ -384,7 +384,7 @@ export async function extractGoalFromPrompt(
         },
         body: JSON.stringify(requestBody),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     logger.debug(

--- a/src/remoteGrading.ts
+++ b/src/remoteGrading.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from './cache';
 import { getUserEmail } from './globalConfig/accounts';
 import logger from './logger';
-import { REQUEST_TIMEOUT_MS } from './providers/shared';
+import { getRequestTimeoutMs } from './providers/shared';
 import { getRemoteGenerationUrl } from './redteam/remoteGeneration';
 
 import type { GradingResult } from './types/index';
@@ -27,7 +27,7 @@ export async function doRemoteGrading(
         },
         body,
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
     );
 
     logger.debug(

--- a/src/remoteScoring.ts
+++ b/src/remoteScoring.ts
@@ -1,7 +1,7 @@
 import { fetchWithCache } from './cache';
 import { getEnvString } from './envars';
 import logger from './logger';
-import { REQUEST_TIMEOUT_MS } from './providers/shared';
+import { getRequestTimeoutMs } from './providers/shared';
 
 import type { GradingResult } from './types/index';
 
@@ -59,7 +59,7 @@ export async function doRemoteScoringWithPi(
           },
           body,
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
       return convertPiResultToGradingResult(data, passThreshold);
     } else {

--- a/src/server/services/redteamTestCaseGenerationService.ts
+++ b/src/server/services/redteamTestCaseGenerationService.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
 import { VERSION } from '../../constants';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import {
   DEFAULT_MULTI_TURN_MAX_TURNS,
   type MultiTurnStrategy,
@@ -268,7 +268,7 @@ async function handleGoatStrategy(
       },
       body: JSON.stringify(goatBody),
     },
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs(),
   );
 
   if (!response.ok) {
@@ -324,7 +324,7 @@ async function handleMischievousUserStrategy(
       },
       body: JSON.stringify(mischievousBody),
     },
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs(),
   );
 
   if (!response.ok) {
@@ -438,7 +438,7 @@ async function handleHydraStrategy(
       },
       body: JSON.stringify(hydraBody),
     },
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs(),
   );
 
   if (!response.ok) {
@@ -525,7 +525,7 @@ async function handleCrescendoLikeStrategy(
       },
       body: JSON.stringify(providerRequest),
     },
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs(),
   );
 
   if (!response.ok) {

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -8,7 +8,7 @@ import cliState from '../../cliState';
 import { DEFAULT_MAX_CONCURRENCY, VERSION } from '../../constants';
 import { getEnvBool, getEnvInt, getEnvString } from '../../envars';
 import logger from '../../logger';
-import { REQUEST_TIMEOUT_MS } from '../../providers/shared';
+import { getRequestTimeoutMs } from '../../providers/shared';
 import { parseRateLimitHeaders, parseRetryAfter } from '../../scheduler/headerParser';
 import invariant from '../../util/invariant';
 import { sleep } from '../../util/time';
@@ -74,7 +74,7 @@ function getOrCreateAgent(tlsOptions: ConnectionOptions): Agent {
     return existing;
   }
   const agent = new Agent({
-    headersTimeout: REQUEST_TIMEOUT_MS,
+    headersTimeout: getRequestTimeoutMs(),
     keepAliveTimeout: 30_000,
     keepAliveMaxTimeout: 60_000,
     connections: concurrency,
@@ -99,7 +99,7 @@ function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions):
     uri: proxyUrl,
     proxyTls: tlsOptions,
     requestTls: tlsOptions,
-    headersTimeout: REQUEST_TIMEOUT_MS,
+    headersTimeout: getRequestTimeoutMs(),
     keepAliveTimeout: 30_000,
     keepAliveMaxTimeout: 60_000,
     connections: concurrency,

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -8,7 +8,7 @@ import { DEFAULT_MAX_CONCURRENCY, VERSION } from '../src/constants';
 import { getEnvBool, getEnvString } from '../src/envars';
 import { cloudConfig } from '../src/globalConfig/cloud';
 import logger from '../src/logger';
-import { REQUEST_TIMEOUT_MS } from '../src/providers/shared';
+import { getRequestTimeoutMs } from '../src/providers/shared';
 import {
   clearAgentCache,
   fetchWithProxy,
@@ -444,7 +444,7 @@ describe('fetchWithProxy', () => {
         ca: mockCertContent,
         rejectUnauthorized: true,
       },
-      headersTimeout: REQUEST_TIMEOUT_MS,
+      headersTimeout: getRequestTimeoutMs(),
       keepAliveTimeout: 30_000,
       keepAliveMaxTimeout: 60_000,
       connections: DEFAULT_MAX_CONCURRENCY,
@@ -496,7 +496,7 @@ describe('fetchWithProxy', () => {
       requestTls: {
         rejectUnauthorized: true,
       },
-      headersTimeout: REQUEST_TIMEOUT_MS,
+      headersTimeout: getRequestTimeoutMs(),
       keepAliveTimeout: 30_000,
       keepAliveMaxTimeout: 60_000,
       connections: DEFAULT_MAX_CONCURRENCY,
@@ -539,7 +539,7 @@ describe('fetchWithProxy', () => {
       requestTls: {
         rejectUnauthorized: false,
       },
-      headersTimeout: REQUEST_TIMEOUT_MS,
+      headersTimeout: getRequestTimeoutMs(),
       keepAliveTimeout: 30_000,
       keepAliveMaxTimeout: 60_000,
       connections: DEFAULT_MAX_CONCURRENCY,
@@ -606,7 +606,7 @@ describe('fetchWithProxy', () => {
         ca: mockCertContent,
         rejectUnauthorized: true,
       },
-      headersTimeout: REQUEST_TIMEOUT_MS,
+      headersTimeout: getRequestTimeoutMs(),
       keepAliveTimeout: 30_000,
       keepAliveMaxTimeout: 60_000,
       connections: DEFAULT_MAX_CONCURRENCY,
@@ -693,7 +693,7 @@ describe('fetchWithProxy', () => {
         requestTls: {
           rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
         },
-        headersTimeout: REQUEST_TIMEOUT_MS,
+        headersTimeout: getRequestTimeoutMs(),
         keepAliveTimeout: 30_000,
         keepAliveMaxTimeout: 60_000,
         connections: DEFAULT_MAX_CONCURRENCY,
@@ -733,7 +733,7 @@ describe('fetchWithProxy', () => {
         requestTls: {
           rejectUnauthorized: !getEnvBool('PROMPTFOO_INSECURE_SSL', true),
         },
-        headersTimeout: REQUEST_TIMEOUT_MS,
+        headersTimeout: getRequestTimeoutMs(),
         keepAliveTimeout: 30_000,
         keepAliveMaxTimeout: 60_000,
         connections: DEFAULT_MAX_CONCURRENCY,

--- a/test/providers/http/request.test.ts
+++ b/test/providers/http/request.test.ts
@@ -15,7 +15,7 @@ import {
   estimateTokenCount,
   HttpProvider,
 } from '../../../src/providers/http';
-import { REQUEST_TIMEOUT_MS } from '../../../src/providers/shared';
+import { getRequestTimeoutMs } from '../../../src/providers/shared';
 
 describe('determineRequestBody', () => {
   it('should merge parsed prompt object with config body when content type is JSON', () => {
@@ -307,7 +307,7 @@ describe('request transformation', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ key: 'value', transformed: 'test' }),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'text',
       undefined,
       undefined,
@@ -343,7 +343,7 @@ describe('request transformation', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ key: 'value', transformed: 'TEST' }),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'text',
       undefined,
       undefined,

--- a/test/providers/llama.test.ts
+++ b/test/providers/llama.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
 import { LlamaProvider } from '../../src/providers/llama';
-import { REQUEST_TIMEOUT_MS } from '../../src/providers/shared';
+import { getRequestTimeoutMs } from '../../src/providers/shared';
 
 vi.mock('../../src/cache', async (importOriginal) => {
   return {
@@ -89,7 +89,7 @@ describe('LlamaProvider', () => {
             logit_bias: undefined,
           }),
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
     });
     it('should return the correct response on success', async () => {

--- a/test/providers/quiverai.test.ts
+++ b/test/providers/quiverai.test.ts
@@ -73,6 +73,8 @@ function createSSEStream(events: string, splitAt?: number[]) {
 describe('QuiverAI Provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEnvString).mockReset();
+    vi.mocked(getEnvInt).mockReset();
     vi.mocked(getEnvInt).mockReturnValue(300_000);
   });
 

--- a/test/providers/quiverai.test.ts
+++ b/test/providers/quiverai.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
-import { getEnvString } from '../../src/envars';
+import { getEnvInt, getEnvString } from '../../src/envars';
 import { createQuiverAiProvider, QuiverAiProvider } from '../../src/providers/quiverai';
 import { fetchWithProxy } from '../../src/util/fetch';
 
@@ -73,6 +73,7 @@ function createSSEStream(events: string, splitAt?: number[]) {
 describe('QuiverAI Provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEnvInt).mockReturnValue(300_000);
   });
 
   afterEach(() => {

--- a/test/providers/shared.test.ts
+++ b/test/providers/shared.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getEnvBool } from '../../src/envars';
+import { getEnvBool, getEnvInt } from '../../src/envars';
 import {
   calculateCost,
+  getRequestTimeoutMs,
   isOpenAIToolArray,
   isOpenAIToolChoice,
   isPromptfooSampleTarget,
@@ -26,6 +27,18 @@ describe('Shared Provider Functions', () => {
     vi.resetAllMocks();
     vi.mocked(getEnvBool).mockImplementation(function () {
       return false;
+    });
+    vi.mocked(getEnvInt).mockImplementation(function (_key, defaultValue) {
+      return defaultValue ?? 0;
+    });
+  });
+
+  describe('getRequestTimeoutMs', () => {
+    it('reads REQUEST_TIMEOUT_MS lazily', () => {
+      vi.mocked(getEnvInt).mockReturnValueOnce(12_345);
+
+      expect(getRequestTimeoutMs()).toBe(12_345);
+      expect(getEnvInt).toHaveBeenCalledWith('REQUEST_TIMEOUT_MS', 300_000);
     });
   });
 

--- a/test/providers/xai/image.test.ts
+++ b/test/providers/xai/image.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { callOpenAiImageApi } from '../../../src/providers/openai/image';
-import { REQUEST_TIMEOUT_MS } from '../../../src/providers/shared';
+import { getRequestTimeoutMs } from '../../../src/providers/shared';
 import { createXAIImageProvider, XAIImageProvider } from '../../../src/providers/xai/image';
 import { mockProcessEnv } from '../../util/utils';
 
@@ -117,7 +117,7 @@ describe('XAI Image Provider', () => {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${mockApiKey}`,
         },
-        REQUEST_TIMEOUT_MS,
+        getRequestTimeoutMs(),
       );
 
       expect(result).toEqual({

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { fetchWithCache } from '../../../src/cache';
 import { VERSION } from '../../../src/constants';
 import logger from '../../../src/logger';
-import { REQUEST_TIMEOUT_MS } from '../../../src/providers/shared';
+import { getRequestTimeoutMs } from '../../../src/providers/shared';
 import {
   callExtraction,
   fetchRemoteGeneration,
@@ -86,7 +86,7 @@ describe('fetchRemoteGeneration', () => {
           email: null,
         }),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'json',
     );
   });
@@ -118,7 +118,7 @@ describe('fetchRemoteGeneration', () => {
           email: null,
         }),
       },
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'json',
     );
   });
@@ -173,7 +173,7 @@ describe('fetchRemoteGeneration', () => {
     expect(fetchWithCache).toHaveBeenCalledWith(
       customUrl,
       expect.any(Object),
-      REQUEST_TIMEOUT_MS,
+      getRequestTimeoutMs(),
       'json',
     );
   });

--- a/test/server/services/redteamTestCaseGenerationService.test.ts
+++ b/test/server/services/redteamTestCaseGenerationService.test.ts
@@ -29,7 +29,7 @@ function mockRemoteGeneration(responseBody: unknown, rejectWith?: Error) {
     neverGenerateRemote: vi.fn().mockReturnValue(false),
   }));
   vi.doMock('../../../src/providers/shared', () => ({
-    REQUEST_TIMEOUT_MS,
+    getRequestTimeoutMs: () => REQUEST_TIMEOUT_MS,
   }));
   vi.doMock('../../../src/constants', () => ({
     VERSION: '0.0.0-test',


### PR DESCRIPTION
## Summary

- Replace the top-level `REQUEST_TIMEOUT_MS` export with `getRequestTimeoutMs()`.
- Update provider, fetch/cache, redteam, remote grading/scoring, and server call sites to resolve the timeout at use time.
- Add coverage for lazy timeout reads and adjust affected provider tests for the new lazy mock behavior.

## Why

The tsdown/Rolldown investigation exposed that startup-time env-derived values are risky in bundled output: a widely imported module can force env/config state to be read during module initialization and make chunk evaluation order more fragile. This change removes one high-fanout eager env read from `providers/shared.ts` while preserving the existing default and override behavior.

This is intentionally scoped to Promptfoo's architecture. It does not claim to fix the upstream Rolldown issue by itself; it makes Promptfoo less dependent on top-level env evaluation during startup.

## Validation

- `npm test -- test/providers/shared.test.ts --run`
- `npx vitest run test/providers/quiverai.test.ts --sequence.shuffle=false`
- `npx vitest run test/fetch.test.ts test/providers/llama.test.ts test/providers/xai/image.test.ts test/redteam/extraction/util.test.ts test/server/services/redteamTestCaseGenerationService.test.ts test/providers/http/request.test.ts --sequence.shuffle=false`
- `npm run tsc -- --noEmit`
- `npm run l && npm run f`
- `$pr-review` full multi-agent pass; fixed the QuiverAI lazy-mock regression and follow-up mock-reset policy nit it found

