### PR TITLE
docs(site): clarify JSONL assertion component results

### DIFF
--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -128,6 +128,11 @@ promptfoo eval --output results.jsonl
 {"testIdx": 1, "promptIdx": 0, "output": "Response 2", "success": true, "score": 0.9}
 ```
 
+For assertion-level details, inspect each row's `gradingResult.componentResults` array. The
+top-level `success`, `score`, and `gradingResult` fields describe the aggregate result for the
+test row, while each `componentResults[]` entry contains the pass/fail, score, reason, and
+assertion metadata for one evaluated assertion.
+
 ### XML Format
 
 Structured data for enterprise integrations:

--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -128,10 +128,11 @@ promptfoo eval --output results.jsonl
 {"testIdx": 1, "promptIdx": 0, "output": "Response 2", "success": true, "score": 0.9}
 ```
 
-For assertion-level details, inspect each row's `gradingResult.componentResults` array. The
-top-level `success`, `score`, and `gradingResult` fields describe the aggregate result for the
-test row, while each `componentResults[]` entry contains the pass/fail, score, reason, and
-assertion metadata for one evaluated assertion.
+For assertion-level details, inspect each row's `gradingResult?.componentResults` array when
+present. The top-level `success`, `score`, and `gradingResult` fields describe the aggregate
+result for the row, while each `componentResults[]` entry contains the pass/fail, score,
+reason, and assertion metadata for one evaluated assertion. Both `gradingResult` and
+`componentResults` may be absent on error rows or rows without assertions.
 
 ### XML Format
 


### PR DESCRIPTION
## Summary

This adds a small note to the JSONL output docs explaining where per-assertion details live.

The current section shows the row-level `success` and `score` fields. When consuming JSONL programmatically, it is useful to know that those are aggregate row fields, while individual assertion outcomes are available under `gradingResult.componentResults[]`.

## Change

- Document that `gradingResult.componentResults[]` contains per-assertion pass/fail, score, reason, and assertion metadata.
- Clarify that top-level `success`, `score`, and `gradingResult` are row-level aggregate result fields.

## Validation

Ran `git diff --check`.
