### PR TITLE
test(app): cover data table header action layout

### DIFF
--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -953,6 +953,51 @@ describe('DataTable', () => {
     expect(headerCells[3].className).toContain('overflow-hidden');
   });
 
+  it('should reserve inline space for sortable header actions without absolute positioning', () => {
+    const layoutColumns: ColumnDef<TestRow>[] = [
+      {
+        accessorKey: 'id',
+        header: 'Identifier',
+        size: 96,
+      },
+      {
+        accessorKey: 'name',
+        header: 'Right Aligned Header',
+        size: 128,
+        meta: {
+          align: 'right',
+        },
+      },
+    ];
+    const data: TestRow[] = [{ id: '1', name: 'Long header row' }];
+
+    render(<DataTable columns={layoutColumns} data={data} />);
+
+    const assertHeaderLayout = (headerText: string, shouldBeRightAligned = false) => {
+      const headerLabel = screen.getByText(headerText);
+      const headerContent = headerLabel.closest('div');
+      expect(headerContent).not.toBeNull();
+      expect(headerContent).toHaveClass('flex', 'min-w-0', 'items-center', 'gap-1');
+      expect(headerContent).toHaveClass('overflow-hidden');
+
+      if (shouldBeRightAligned) {
+        expect(headerContent).toHaveClass('flex-row-reverse');
+      } else {
+        expect(headerContent).not.toHaveClass('flex-row-reverse');
+      }
+
+      expect(headerLabel).toHaveClass('block', 'min-w-0', 'flex-1', 'truncate');
+
+      const actionGroup = headerContent?.querySelector('button')?.closest('span');
+      expect(actionGroup).toBeInTheDocument();
+      expect(actionGroup).toHaveClass('flex', 'shrink-0', 'items-center');
+      expect(actionGroup).not.toHaveClass('absolute', 'left-0', 'right-0');
+    };
+
+    assertHeaderLayout('Identifier');
+    assertHeaderLayout('Right Aligned Header', true);
+  });
+
   describe('cell content wrapper', () => {
     it('should wrap data cell content in a div with overflow-hidden but not select cells', () => {
       const data: TestRow[] = [{ id: '1', name: 'Test Item' }];


### PR DESCRIPTION
## Summary
- add regression coverage for DataTable sortable header action layout
- verify default and right-aligned headers reserve inline space for action controls instead of relying on absolute positioning

## Tests
- npm run test:app -- src/components/data-table/data-table.test.tsx --run
- npm run l && npm run f