### PR TITLE
docs(site): add JSONL assertion component parsing example

### DIFF
--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -138,10 +138,14 @@ To parse assertion-level component results from JSONL:
 
 ```ts
 import fs from 'node:fs';
+import readline from 'node:readline';
 
-const lines = fs.readFileSync('results.jsonl', 'utf8').split('\n');
+const rl = readline.createInterface({
+  input: fs.createReadStream('results.jsonl', { encoding: 'utf8' }),
+  crlfDelay: Infinity,
+});
 
-for (const line of lines) {
+for await (const line of rl) {
   if (!line.trim()) {
     continue;
   }

--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -134,6 +134,33 @@ result for the row, while each `componentResults[]` entry contains the pass/fail
 reason, and assertion metadata for one evaluated assertion. Both `gradingResult` and
 `componentResults` may be absent on error rows or rows without assertions.
 
+To parse assertion-level component results from JSONL:
+
+```ts
+import fs from 'node:fs';
+
+const lines = fs.readFileSync('results.jsonl', 'utf8').split('\n');
+
+for (const line of lines) {
+  if (!line.trim()) {
+    continue;
+  }
+
+  const row = JSON.parse(line);
+  const components = row.gradingResult?.componentResults ?? [];
+
+  for (const component of components) {
+    console.log({
+      pass: component.pass,
+      score: component.score,
+      reason: component.reason,
+    });
+  }
+}
+```
+
+The `?? []` fallback handles rows without assertions or component results.
+
 ### XML Format
 
 Structured data for enterprise integrations:

--- a/site/docs/configuration/outputs.md
+++ b/site/docs/configuration/outputs.md
@@ -124,8 +124,8 @@ promptfoo eval --output results.jsonl
 **Use when:** Working with very large evaluations or when JSON export fails with memory errors.
 
 ```jsonl
-{"testIdx": 0, "promptIdx": 0, "output": "Response 1", "success": true, "score": 1.0}
-{"testIdx": 1, "promptIdx": 0, "output": "Response 2", "success": true, "score": 0.9}
+{"testIdx":0,"promptIdx":0,"success":true,"score":1.0,"response":{"output":"Response 1"},"gradingResult":{"pass":true,"score":1.0,"reason":"All assertions passed","componentResults":[{"pass":true,"score":1.0,"reason":"Expected output to contain \"hello\"","assertion":{"type":"contains","value":"hello"}}]}}
+{"testIdx":1,"promptIdx":0,"success":false,"score":0.0,"response":{"output":"Response 2"},"gradingResult":null}
 ```
 
 For assertion-level details, inspect each row's `gradingResult?.componentResults` array when
@@ -134,7 +134,7 @@ result for the row, while each `componentResults[]` entry contains the pass/fail
 reason, and assertion metadata for one evaluated assertion. Both `gradingResult` and
 `componentResults` may be absent on error rows or rows without assertions.
 
-To parse assertion-level component results from JSONL:
+To stream a JSONL file and read each row's component results:
 
 ```ts
 import fs from 'node:fs';
@@ -149,12 +149,10 @@ for await (const line of rl) {
   if (!line.trim()) {
     continue;
   }
-
   const row = JSON.parse(line);
-  const components = row.gradingResult?.componentResults ?? [];
-
-  for (const component of components) {
+  for (const component of row.gradingResult?.componentResults ?? []) {
     console.log({
+      type: component.assertion?.type,
       pass: component.pass,
       score: component.score,
       reason: component.reason,
@@ -163,7 +161,8 @@ for await (const line of rl) {
 }
 ```
 
-The `?? []` fallback handles rows without assertions or component results.
+`?.` and `?? []` together cover the `gradingResult: null` case shown above and rows
+where a single top-level assertion produced no nested `componentResults`.
 
 ### XML Format
 


### PR DESCRIPTION
What changed

Adds a small JSONL parsing example showing how to read assertion-level component results from `gradingResult.componentResults[]`.

Why

#8894 clarified where assertion-level results live in each JSONL row. This follow-up adds a practical example for readers who want to parse those component results in scripts or CI.

Validation

Ran locally:

```bash
git diff --check
```