### PR TITLE
ci(release): harden release-please history scan

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
           app-id: ${{ vars.PROMPTFOOBOT_APP_ID }}
           private-key: ${{ secrets.PROMPTFOOBOT_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
+  "last-release-sha": "195df77800b749679f73ed3f258d858d33d55b48",
   "separate-pull-requests": true,
   "packages": {
     ".": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
+  "commit-batch-size": 1,
   "last-release-sha": "195df77800b749679f73ed3f258d858d33d55b48",
   "separate-pull-requests": true,
   "packages": {


### PR DESCRIPTION
## Summary
- update release-please-action to v5.0.0, which runs release-please 17.6.x
- add a release-please baseline at the already-merged 0.121.9 release commit
- shrink release-please commit history batches to one commit so it stops before the GitHub GraphQL history page that is currently returning internal errors

## Testing
- `npx prettier --check release-please-config.json .github/workflows/release-please.yml`
- `npx release-please@17.6.0 release-pr --repo-url promptfoo/promptfoo --target-branch mdangelo/codex/release-please-baseline-0-121-9 --dry-run --debug` -> would open 0 pull requests
- confirmed `npm view promptfoo@0.121.9 version` is still E404 before cleanup/retry