### PR TITLE
test(release): cover release-please history bounds

### DIFF
--- a/test/release-please.test.ts
+++ b/test/release-please.test.ts
@@ -4,15 +4,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MAX_COMMIT_BATCH_SIZE = 25;
 const MIN_RELEASE_PLEASE_MAJOR = 5;
+const RELEASE_PLEASE_ACTION = 'googleapis/release-please-action';
 
 type ReleasePleaseConfig = {
   'commit-batch-size'?: unknown;
   'last-release-sha'?: unknown;
+};
+
+type WorkflowStep = { uses?: unknown };
+type ReleasePleaseWorkflow = {
+  jobs?: { 'release-please'?: { steps?: WorkflowStep[] } };
 };
 
 function readRepoFile(relativePath: string) {
@@ -58,18 +65,33 @@ describe('release-please automation', () => {
     expect(batchSize).toBeLessThanOrEqual(MAX_COMMIT_BATCH_SIZE);
   });
 
-  it('pins release-please-action to a SHA on the v5+ family', () => {
-    const workflow = readRepoFile('.github/workflows/release-please.yml');
+  it('pins the release-please job action to a SHA on the v5+ family', () => {
+    const workflowYaml = readRepoFile('.github/workflows/release-please.yml');
+    const workflow = yaml.load(workflowYaml) as ReleasePleaseWorkflow;
 
-    // Match the SHA pin alongside the `# vN.x.x` version comment Renovate maintains.
-    // SHAs alone are opaque, so the comment is the only stable signal of the major.
-    const match = workflow.match(
-      /uses:\s*googleapis\/release-please-action@([0-9a-f]{40})\s*#\s*v(\d+)/,
+    // Scope to the actual step in the release-please job so the assertion can't
+    // be satisfied by a stray match elsewhere (other job, commented-out line).
+    const releaseStep = workflow.jobs?.['release-please']?.steps?.find(
+      (step) => typeof step.uses === 'string' && step.uses.startsWith(`${RELEASE_PLEASE_ACTION}@`),
     );
     assert(
-      match !== null,
-      'release-please-action must be SHA-pinned with a `# vN` version comment',
+      releaseStep && typeof releaseStep.uses === 'string',
+      `release-please job must include a ${RELEASE_PLEASE_ACTION} step`,
     );
-    expect(Number.parseInt(match[2], 10)).toBeGreaterThanOrEqual(MIN_RELEASE_PLEASE_MAJOR);
+
+    expect(releaseStep.uses).toMatch(new RegExp(`^${RELEASE_PLEASE_ACTION}@[0-9a-f]{40}$`));
+
+    // Major comes from the `# vN.x.x` comment Renovate maintains alongside the
+    // SHA pin — SHAs alone are opaque, so the comment is the only stable signal.
+    const usesLine = workflowYaml
+      .split('\n')
+      .find((line) => line.includes(`uses: ${releaseStep.uses}`));
+    assert(usesLine, 'release-please-action `uses:` line missing in raw YAML');
+    const versionMatch = usesLine.match(/#\s*v(\d+)/);
+    assert(
+      versionMatch !== null,
+      'release-please-action `uses:` must carry a `# vN` version comment',
+    );
+    expect(Number.parseInt(versionMatch[1], 10)).toBeGreaterThanOrEqual(MIN_RELEASE_PLEASE_MAJOR);
   });
 });

--- a/test/release-please.test.ts
+++ b/test/release-please.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+const RELEASE_PLEASE_ACTION_V5_SHA = '45996ed1f6d02564a971a2fa1b5860e934307cf7';
+
+type ReleasePleaseConfig = {
+  'commit-batch-size'?: unknown;
+  'last-release-sha'?: unknown;
+};
+
+type WorkflowStep = {
+  uses?: unknown;
+};
+
+type GithubWorkflow = {
+  jobs?: {
+    'release-please'?: {
+      steps?: WorkflowStep[];
+    };
+  };
+};
+
+function readRootFile(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+describe('release-please automation', () => {
+  it('keeps the release history scan bounded', () => {
+    const config = JSON.parse(readRootFile('release-please-config.json')) as ReleasePleaseConfig;
+
+    expect(config['commit-batch-size']).toBe(1);
+    expect(config['last-release-sha']).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('uses release-please action v5 for history scan controls', () => {
+    const workflow = yaml.load(
+      readRootFile('.github/workflows/release-please.yml'),
+    ) as GithubWorkflow;
+    const releaseStep = workflow.jobs?.['release-please']?.steps?.find(
+      (step) =>
+        typeof step.uses === 'string' && step.uses.startsWith('googleapis/release-please-action@'),
+    );
+
+    expect(releaseStep?.uses).toBe(
+      `googleapis/release-please-action@${RELEASE_PLEASE_ACTION_V5_SHA}`,
+    );
+  });
+});

--- a/test/release-please.test.ts
+++ b/test/release-please.test.ts
@@ -1,51 +1,75 @@
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 
-const RELEASE_PLEASE_ACTION_V5_SHA = '45996ed1f6d02564a971a2fa1b5860e934307cf7';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MAX_COMMIT_BATCH_SIZE = 25;
+const MIN_RELEASE_PLEASE_MAJOR = 5;
 
 type ReleasePleaseConfig = {
   'commit-batch-size'?: unknown;
   'last-release-sha'?: unknown;
 };
 
-type WorkflowStep = {
-  uses?: unknown;
-};
-
-type GithubWorkflow = {
-  jobs?: {
-    'release-please'?: {
-      steps?: WorkflowStep[];
-    };
-  };
-};
-
-function readRootFile(relativePath: string) {
-  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+function readRepoFile(relativePath: string) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
 }
 
-describe('release-please automation', () => {
-  it('keeps the release history scan bounded', () => {
-    const config = JSON.parse(readRootFile('release-please-config.json')) as ReleasePleaseConfig;
+function readReleasePleaseConfig(): ReleasePleaseConfig {
+  return JSON.parse(readRepoFile('release-please-config.json')) as ReleasePleaseConfig;
+}
 
-    expect(config['commit-batch-size']).toBe(1);
-    expect(config['last-release-sha']).toMatch(/^[0-9a-f]{40}$/);
+function isShallowClone(): boolean {
+  const result = spawnSync('git', ['rev-parse', '--is-shallow-repository'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  return result.stdout.trim() === 'true';
+}
+
+// Regression coverage for ccf46b849 ("ci(release): harden release-please history scan").
+// Without these bounds, release-please re-scans the full git history on every run and
+// either times out or emits a giant changelog when something perturbs the prior tag.
+describe('release-please automation', () => {
+  it('pins last-release-sha to a 40-char commit SHA', () => {
+    const sha = readReleasePleaseConfig()['last-release-sha'];
+    assert(typeof sha === 'string', 'last-release-sha must be a string');
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+
+    // CI uses fetch-depth: 2, so the pinned SHA isn't reachable there. Only enforce
+    // reachability in full local clones, which catches typos before they ship.
+    if (!isShallowClone()) {
+      const result = spawnSync('git', ['cat-file', '-e', sha], {
+        cwd: REPO_ROOT,
+        stdio: 'ignore',
+      });
+      expect(result.status).toBe(0);
+    }
   });
 
-  it('uses release-please action v5 for history scan controls', () => {
-    const workflow = yaml.load(
-      readRootFile('.github/workflows/release-please.yml'),
-    ) as GithubWorkflow;
-    const releaseStep = workflow.jobs?.['release-please']?.steps?.find(
-      (step) =>
-        typeof step.uses === 'string' && step.uses.startsWith('googleapis/release-please-action@'),
-    );
+  it('caps commit-batch-size to a small value', () => {
+    const batchSize = readReleasePleaseConfig()['commit-batch-size'];
+    assert(typeof batchSize === 'number', 'commit-batch-size must be a number');
+    expect(batchSize).toBeGreaterThanOrEqual(1);
+    expect(batchSize).toBeLessThanOrEqual(MAX_COMMIT_BATCH_SIZE);
+  });
 
-    expect(releaseStep?.uses).toBe(
-      `googleapis/release-please-action@${RELEASE_PLEASE_ACTION_V5_SHA}`,
+  it('pins release-please-action to a SHA on the v5+ family', () => {
+    const workflow = readRepoFile('.github/workflows/release-please.yml');
+
+    // Match the SHA pin alongside the `# vN.x.x` version comment Renovate maintains.
+    // SHAs alone are opaque, so the comment is the only stable signal of the major.
+    const match = workflow.match(
+      /uses:\s*googleapis\/release-please-action@([0-9a-f]{40})\s*#\s*v(\d+)/,
     );
+    assert(
+      match !== null,
+      'release-please-action must be SHA-pinned with a `# vN` version comment',
+    );
+    expect(Number.parseInt(match[2], 10)).toBeGreaterThanOrEqual(MIN_RELEASE_PLEASE_MAJOR);
   });
 });


### PR DESCRIPTION
## Summary
- Add a focused regression test for release-please history-scan hardening
- Assert the config keeps commit batching bounded and has a pinned last-release SHA
- Assert the release workflow uses the pinned release-please v5 action that supports those controls

## Tests
- npx vitest run test/release-please.test.ts --sequence.shuffle=false
- npm run l
- npm run f