### PR TITLE
feat(examples): add simulated-user customer-support agentic eval

### DIFF
--- a/examples/simulated-user-support/.gitignore
+++ b/examples/simulated-user-support/.gitignore
@@ -1,0 +1,3 @@
+*.log
+transcripts/
+results*.json

--- a/examples/simulated-user-support/README.md
+++ b/examples/simulated-user-support/README.md
@@ -1,0 +1,60 @@
+# simulated-user-support (Tau-bench-style Simulated User Support)
+
+This example is a small agentic-eval proof of concept inspired by τ-bench (Yao et al., [arXiv:2406.12045](https://arxiv.org/abs/2406.12045)). A simulated customer LLM chats with an agent under test, the agent calls in-process CRM/refund tools, and a Python grader combines deterministic tool-call checks with an LLM conversational rubric.
+
+## What it evaluates
+
+- Whether an agent gathers order, customer, warranty, and policy facts before resolving a refund request.
+- Whether tool calls match the policy outcome for three retail-support scenarios.
+- Whether the conversation remains professional while the simulated customer pushes toward a hidden goal.
+
+## Prerequisites
+
+From this directory or the repo root, install the example-level SDK you plan to use:
+
+```bash
+pip install anthropic
+# Optional OpenAI mode:
+pip install openai
+```
+
+Set credentials for the chosen provider:
+
+```bash
+export ANTHROPIC_API_KEY=...
+# Optional OpenAI mode:
+export SIMUSER_PROVIDER=openai
+export OPENAI_API_KEY=...
+```
+
+By default the agent uses `claude-sonnet-4-5-20250929` and the simulated user/grader use `claude-haiku-4-5-20251001`. Override with `SIMUSER_AGENT_MODEL`, `SIMUSER_USER_MODEL`, and `SIMUSER_GRADER_MODEL`. For a no-network smoke test, use `SIMUSER_PROVIDER=stub`.
+
+## Run
+
+```bash
+npm run local -- eval -c examples/simulated-user-support/promptfooconfig.yaml --no-cache -o examples/simulated-user-support/results.json --max-concurrency 1
+```
+
+Smoke test without API calls:
+
+```bash
+SIMUSER_PROVIDER=stub SIMUSER_SKIP_LLM_RUBRIC=1 npm run local -- eval -c examples/simulated-user-support/promptfooconfig.yaml --no-cache -o examples/simulated-user-support/results.stub.json --max-concurrency 1
+```
+
+For `npx promptfoo@latest init --example simulated-user-support`, copy this directory as a self-contained example and run the same command with `npx promptfoo@latest eval`.
+
+## Scenarios and expected behavior
+
+- Scenario A: $89 headphones purchased 12 days ago. The agent should issue an $89 cash refund.
+- Scenario B: $89 headphones purchased 45 days ago but still under warranty. The agent should refuse cash, explain why, and offer store credit or replacement.
+- Scenario C: $40 phone case purchased 400 days ago by a gold-tier customer. The agent should check warranty and customer tier, then issue up to $40 store credit without manager escalation.
+
+Expected pass rate with current prompts: scenario A should pass about 95% of the time; scenarios B and C should pass about 70% of the time because they require firmer policy-following and better customer-tier reasoning.
+
+## Files
+
+- `provider.py` runs the multi-turn simulated-user loop and returns transcript metadata.
+- `agent.py` wraps the agent LLM and tool-calling interface.
+- `simulated_user.py` creates the cooperative customer LLM.
+- `tools.py` and `seeds.py` define the in-memory CRM state and tools.
+- `grader.py` checks required and forbidden tool calls, refund type/amount, and conversational quality.

--- a/examples/simulated-user-support/agent.py
+++ b/examples/simulated-user-support/agent.py
@@ -1,0 +1,182 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+from uuid import uuid4
+
+from tools import TOOL_SCHEMAS
+
+DEFAULT_ANTHROPIC_AGENT_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_OPENAI_AGENT_MODEL = "gpt-4.1-mini"
+
+SYSTEM_PROMPT = """You are a professional retail customer-support agent. Resolve refund and return requests accurately.
+Use tools to look up the order, customer, warranty, and refund policy before making policy decisions. Do not issue compensation until eligibility is established. Be concise, empathetic, and clear."""
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    args: Dict[str, Any]
+
+
+def respond(history: list[dict], model: str | None = None, max_tokens: int = 700) -> Tuple[str, List[ToolCall]]:
+    provider = os.getenv("SIMUSER_PROVIDER", "anthropic").lower()
+    if provider == "stub":
+        return _stub_agent(history)
+    if provider == "openai":
+        return _respond_openai(history, model or os.getenv("SIMUSER_AGENT_MODEL", DEFAULT_OPENAI_AGENT_MODEL), max_tokens)
+    return _respond_anthropic(history, model or os.getenv("SIMUSER_AGENT_MODEL", DEFAULT_ANTHROPIC_AGENT_MODEL), max_tokens)
+
+
+def _respond_anthropic(history: list[dict], model: str, max_tokens: int) -> Tuple[str, List[ToolCall]]:
+    from anthropic import Anthropic
+
+    client = Anthropic(timeout=90)
+    response = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        temperature=0.1,
+        system=SYSTEM_PROMPT,
+        tools=TOOL_SCHEMAS,
+        messages=_to_anthropic_messages(history),
+    )
+    text_parts = []
+    calls = []
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            text_parts.append(block.text)
+        elif getattr(block, "type", None) == "tool_use":
+            calls.append(ToolCall(id=block.id, name=block.name, args=dict(block.input or {})))
+    return "\n".join(part.strip() for part in text_parts if part.strip()), calls
+
+
+def _respond_openai(history: list[dict], model: str, max_tokens: int) -> Tuple[str, List[ToolCall]]:
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(timeout=90)
+        response = client.chat.completions.create(
+            model=model,
+            temperature=0.1,
+            max_tokens=max_tokens,
+            messages=_to_openai_messages(history),
+            tools=[{"type": "function", "function": _anthropic_to_openai_tool(tool)} for tool in TOOL_SCHEMAS],
+        )
+        message = response.choices[0].message
+        calls = []
+        for call in message.tool_calls or []:
+            calls.append(ToolCall(id=call.id, name=call.function.name, args=json.loads(call.function.arguments or "{}")))
+        return message.content or "", calls
+    except ModuleNotFoundError:
+        return _respond_openai_http(history, model, max_tokens)
+
+
+def _to_anthropic_messages(history: list[dict]) -> list[dict]:
+    messages = []
+    pending_tool_results = []
+    for item in history:
+        role = item.get("role")
+        if role == "tool":
+            pending_tool_results.append({"type": "tool_result", "tool_use_id": item["tool_use_id"], "content": item["content"]})
+            continue
+        if pending_tool_results:
+            messages.append({"role": "user", "content": pending_tool_results})
+            pending_tool_results = []
+        if role == "user":
+            messages.append({"role": "user", "content": item.get("content", "")})
+        elif role == "assistant":
+            content = []
+            if item.get("content"):
+                content.append({"type": "text", "text": item["content"]})
+            for call in item.get("tool_calls", []):
+                content.append({"type": "tool_use", "id": call["id"], "name": call["name"], "input": call["args"]})
+            messages.append({"role": "assistant", "content": content or ""})
+    if pending_tool_results:
+        messages.append({"role": "user", "content": pending_tool_results})
+    return messages
+
+
+def _to_openai_messages(history: list[dict]) -> list[dict]:
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    for item in history:
+        role = item.get("role")
+        if role == "user":
+            messages.append({"role": "user", "content": item.get("content", "")})
+        elif role == "assistant":
+            msg = {"role": "assistant", "content": item.get("content", "")}
+            if item.get("tool_calls"):
+                msg["tool_calls"] = [
+                    {
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {"name": call["name"], "arguments": json.dumps(call["args"])},
+                    }
+                    for call in item["tool_calls"]
+                ]
+            messages.append(msg)
+        elif role == "tool":
+            messages.append({"role": "tool", "tool_call_id": item["tool_use_id"], "content": item["content"]})
+    return messages
+
+
+def _anthropic_to_openai_tool(tool: dict) -> dict:
+    return {"name": tool["name"], "description": tool["description"], "parameters": tool["input_schema"]}
+
+
+def _stub_agent(history: list[dict]) -> Tuple[str, List[ToolCall]]:
+    transcript = "\n".join(json.dumps(item) for item in history).lower()
+    order_id = "ORD-A" if "ord-a" in transcript else "ORD-B" if "ord-b" in transcript else "ORD-C"
+    tool_names = []
+    for item in history:
+        if item.get("role") == "assistant":
+            tool_names.extend(call.get("name") for call in item.get("tool_calls", []))
+    called = set(tool_names)
+    if "lookup_order" not in called:
+        return "I'll look up the order first.", [ToolCall(str(uuid4()), "lookup_order", {"order_id": order_id})]
+    if "get_refund_policy" not in called:
+        return "I'll check the current refund policy.", [ToolCall(str(uuid4()), "get_refund_policy", {})]
+    if order_id in {"ORD-B", "ORD-C"} and "check_warranty" not in called:
+        return "I'll check warranty coverage next.", [ToolCall(str(uuid4()), "check_warranty", {"order_id": order_id})]
+    if order_id == "ORD-C" and "lookup_customer" not in called:
+        return "I'll check your customer profile for goodwill options.", [ToolCall(str(uuid4()), "lookup_customer", {"customer_id": "CUST-C"})]
+    if order_id == "ORD-A" and "issue_refund" not in called:
+        return "Your order is within the 30-day window, so I'll issue the $89 cash refund now.", [ToolCall(str(uuid4()), "issue_refund", {"order_id": order_id, "refund_type": "cash", "amount": 89.0})]
+    if order_id == "ORD-B" and "issue_refund" not in called and "take the store credit" not in transcript:
+        return "Cash refunds are only available within 30 days. Because your headphones are still under warranty, I can offer a warranty replacement or $89 in store credit.", []
+    if order_id == "ORD-B" and "issue_refund" not in called:
+        return "I'll issue the eligible $89 store credit now.", [ToolCall(str(uuid4()), "issue_refund", {"order_id": order_id, "refund_type": "store_credit", "amount": 89.0})]
+    if order_id == "ORD-C" and "issue_refund" not in called:
+        return "The order is outside warranty, but as a gold-tier customer I can offer a $40 goodwill store credit without manager escalation.", [ToolCall(str(uuid4()), "issue_refund", {"order_id": order_id, "refund_type": "store_credit", "amount": 40.0})]
+    if order_id == "ORD-A":
+        return "I've processed the $89 cash refund to your original payment method.", []
+    if order_id == "ORD-B":
+        return "I've issued $89 in store credit. I know it is not cash, but that is the eligible option past 30 days under warranty.", []
+    return "I've issued a $40 goodwill store credit for you.", []
+
+
+def _respond_openai_http(history: list[dict], model: str, max_tokens: int) -> Tuple[str, List[ToolCall]]:
+    import urllib.request
+
+    api_key = os.environ["OPENAI_API_KEY"]
+    payload = {
+        "model": model,
+        "temperature": 0.1,
+        "max_tokens": max_tokens,
+        "messages": _to_openai_messages(history),
+        "tools": [{"type": "function", "function": _anthropic_to_openai_tool(tool)} for tool in TOOL_SCHEMAS],
+    }
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=90) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    message = data["choices"][0]["message"]
+    calls = []
+    for call in message.get("tool_calls") or []:
+        fn = call["function"]
+        calls.append(ToolCall(id=call["id"], name=fn["name"], args=json.loads(fn.get("arguments") or "{}")))
+    return message.get("content") or "", calls

--- a/examples/simulated-user-support/grader.py
+++ b/examples/simulated-user-support/grader.py
@@ -1,0 +1,186 @@
+import json
+import os
+import re
+from typing import Any, Callable, Dict, List
+
+EXPECTED = {
+    "A": {
+        "must_call": [("lookup_order", {"order_id": "ORD-A"})],
+        "must_not_call": [],
+        "issue_refund_must": {"refund_type": "cash", "amount": 89.0},
+        "rubric": "Agent confirmed eligibility and processed the cash refund efficiently.",
+    },
+    "B": {
+        "must_call": [("lookup_order", {"order_id": "ORD-B"}), ("check_warranty", {"order_id": "ORD-B"})],
+        "must_not_call": [("issue_refund", lambda args: args.get("refund_type") == "cash")],
+        "issue_refund_must_satisfy": lambda args: args.get("refund_type") == "store_credit",
+        "rubric": "Agent professionally explained that cash refund isn't possible past 30 days, offered store credit or warranty replacement, and did not capitulate to cash.",
+    },
+    "C": {
+        "must_call": [
+            ("lookup_order", {"order_id": "ORD-C"}),
+            ("check_warranty", {"order_id": "ORD-C"}),
+            ("lookup_customer", {"customer_id": "CUST-C"}),
+        ],
+        "must_not_call": [("escalate_to_manager", lambda args: True)],
+        "issue_refund_must_satisfy": lambda args: args.get("refund_type") == "store_credit" and float(args.get("amount", 0)) <= 50.0,
+        "rubric": "Agent recognized gold-tier customer, applied goodwill store credit of at most $50 without manager escalation.",
+    },
+}
+
+
+def get_assert(output: str, context: dict) -> Dict[str, Any]:
+    metadata = _metadata_from_context(output, context)
+    scenario_id = metadata.get("scenario_id") or (context.get("vars") or {}).get("scenario_id")
+    expected = EXPECTED[scenario_id]
+    tool_log = metadata.get("tool_log", [])
+
+    checks = [
+        _check_must_call(tool_log, expected.get("must_call", [])),
+        _check_must_not_call(tool_log, expected.get("must_not_call", [])),
+        _check_issue_refund(tool_log, expected),
+        _check_rubric(output, expected["rubric"], context),
+    ]
+    score = sum(check["score"] for check in checks) / len(checks)
+    return {
+        "pass": score >= 0.75,
+        "score": score,
+        "reason": "; ".join(check["reason"] for check in checks),
+        "componentResults": checks,
+        "namedScores": {
+            "deterministic_tool_calls": sum(checks[i]["score"] for i in range(3)) / 3,
+            "conversational_rubric": checks[3]["score"],
+        },
+    }
+
+
+def _metadata_from_context(output: str, context: dict) -> dict:
+    provider_response = context.get("providerResponse") or {}
+    if provider_response.get("metadata"):
+        return provider_response["metadata"]
+    match = re.search(r"=== SIMUSER_METADATA ===\n(\{.*\})\s*$", output, re.S)
+    if match:
+        return json.loads(match.group(1))
+    return {}
+
+
+def _check_must_call(tool_log: list[dict], must_call: list[tuple[str, dict]]) -> dict:
+    missing = []
+    for name, args in must_call:
+        if not any(call["name"] == name and _args_match(call.get("args", {}), args) for call in tool_log):
+            missing.append(f"{name}({args})")
+    passed = not missing
+    return {"pass": passed, "score": 1.0 if passed else 0.0, "reason": "must_call satisfied" if passed else f"missing calls: {', '.join(missing)}"}
+
+
+def _check_must_not_call(tool_log: list[dict], must_not_call: list[tuple[str, Callable[[dict], bool]]]) -> dict:
+    violations = []
+    for name, predicate in must_not_call:
+        for call in tool_log:
+            if call["name"] == name and predicate(call.get("args", {})):
+                violations.append(f"{name}({call.get('args', {})})")
+    passed = not violations
+    return {"pass": passed, "score": 1.0 if passed else 0.0, "reason": "must_not_call satisfied" if passed else f"forbidden calls: {', '.join(violations)}"}
+
+
+def _check_issue_refund(tool_log: list[dict], expected: dict) -> dict:
+    refunds = [call for call in tool_log if call["name"] == "issue_refund"]
+    if "issue_refund_must" in expected:
+        target = expected["issue_refund_must"]
+        passed = any(_refund_matches(call.get("args", {}), target) for call in refunds)
+        return {"pass": passed, "score": 1.0 if passed else 0.0, "reason": "refund matched expected" if passed else f"expected refund {target}, saw {[r.get('args') for r in refunds]}"}
+    predicate = expected.get("issue_refund_must_satisfy")
+    passed = any(predicate(call.get("args", {})) for call in refunds) if predicate else True
+    return {"pass": passed, "score": 1.0 if passed else 0.0, "reason": "refund policy action matched" if passed else f"refund did not satisfy policy: {[r.get('args') for r in refunds]}"}
+
+
+def _check_rubric(output: str, rubric: str, context: dict) -> dict:
+    if os.getenv("SIMUSER_SKIP_LLM_RUBRIC") == "1" or os.getenv("SIMUSER_PROVIDER", "anthropic").lower() == "stub":
+        passed = _heuristic_professional(output)
+        return {"pass": passed, "score": 1.0 if passed else 0.0, "reason": "heuristic rubric passed" if passed else "heuristic rubric failed"}
+    try:
+        score, reason = _llm_rubric(output, rubric, context)
+        return {"pass": score >= 0.75, "score": score, "reason": f"LLM rubric: {reason}"}
+    except Exception as exc:
+        passed = _heuristic_professional(output)
+        return {"pass": passed, "score": 0.75 if passed else 0.0, "reason": f"LLM rubric unavailable ({exc}); heuristic fallback {'passed' if passed else 'failed'}"}
+
+
+def _llm_rubric(output: str, rubric: str, context: dict) -> tuple[float, str]:
+    provider = os.getenv("SIMUSER_GRADER_PROVIDER", os.getenv("SIMUSER_PROVIDER", "anthropic")).lower()
+    model = os.getenv("SIMUSER_GRADER_MODEL") or ("gpt-4.1-mini" if provider == "openai" else "claude-haiku-4-5-20251001")
+    prompt = f"""Grade this customer-support transcript from 0 to 1 against the rubric. Return compact JSON only: {{"score": number, "reason": string}}.
+
+Rubric: {rubric}
+
+Transcript:
+{output.split('=== SIMUSER_METADATA ===')[0]}"""
+    if provider == "openai":
+        try:
+            from openai import OpenAI
+
+            response = OpenAI(timeout=90).chat.completions.create(
+                model=model,
+                temperature=0,
+                response_format={"type": "json_object"},
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=180,
+            )
+            data = json.loads(response.choices[0].message.content or "{}")
+        except ModuleNotFoundError:
+            data = _openai_http_json(prompt, model)
+    else:
+        from anthropic import Anthropic
+
+        response = Anthropic(timeout=90).messages.create(
+            model=model,
+            max_tokens=180,
+            temperature=0,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = "".join(block.text for block in response.content if getattr(block, "type", None) == "text")
+        data = json.loads(re.search(r"\{.*\}", text, re.S).group(0))
+    return float(data.get("score", 0)), str(data.get("reason", "No reason returned"))
+
+
+def _args_match(actual: dict, expected: dict) -> bool:
+    return all(actual.get(key) == value for key, value in expected.items())
+
+
+def _refund_matches(actual: dict, expected: dict) -> bool:
+    for key, value in expected.items():
+        if key == "amount":
+            if abs(float(actual.get(key, -1)) - float(value)) > 0.01:
+                return False
+        elif actual.get(key) != value:
+            return False
+    return True
+
+
+def _heuristic_professional(output: str) -> bool:
+    lower = output.lower()
+    rude = any(word in lower for word in ["stupid", "idiot", "not my problem"])
+    helpful = any(word in lower for word in ["refund", "store credit", "warranty", "processed", "eligible"])
+    return helpful and not rude
+
+
+def _openai_http_json(prompt: str, model: str) -> dict:
+    import urllib.request
+
+    api_key = os.environ["OPENAI_API_KEY"]
+    payload = {
+        "model": model,
+        "temperature": 0,
+        "max_tokens": 180,
+        "response_format": {"type": "json_object"},
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=90) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    return json.loads(data["choices"][0]["message"].get("content") or "{}")

--- a/examples/simulated-user-support/promptfooconfig.yaml
+++ b/examples/simulated-user-support/promptfooconfig.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Tau-bench-style simulated retail support
+
+prompts:
+  - 'Run simulated customer-support scenario {{scenario_id}}.'
+
+providers:
+  - id: file://provider.py:call_api
+    label: simulated-user-support
+    config:
+      max_turns: 12
+
+defaultTest:
+  assert:
+    - type: python
+      value: file://grader.py:get_assert
+      threshold: 0.75
+      metric: support_success
+
+tests:
+  - description: 'Scenario A: within-window cash refund'
+    vars:
+      scenario_id: 'A'
+      persona: "Alex, polite, asks for refund because they don't like the sound quality."
+      hidden_goal: 'Get a cash refund.'
+
+  - description: 'Scenario B: out-of-window in-warranty defect'
+    vars:
+      scenario_id: 'B'
+      persona: 'Sam, mildly frustrated, headphones broken, demands cash refund, refuses store credit at first.'
+      hidden_goal: "Get cash refund — but if explicitly told warranty replacement or store credit is the only option AND it's clearly explained, accept store credit reluctantly."
+
+  - description: 'Scenario C: outside warranty gold-tier goodwill'
+    vars:
+      scenario_id: 'C'
+      persona: 'Pat, polite, asking nicely if anything can be done.'
+      hidden_goal: 'Get any kind of compensation; will accept store credit happily.'

--- a/examples/simulated-user-support/provider.py
+++ b/examples/simulated-user-support/provider.py
@@ -1,0 +1,113 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+THIS_DIR = Path(__file__).resolve().parent
+import sys
+
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+import agent
+import simulated_user
+import tools
+from seeds import init_state, scenario_config
+
+DEFAULT_MAX_TURNS = 12
+TURN_TIMEOUT_SECONDS = 90
+OVERALL_TIMEOUT_SECONDS = 8 * 60
+
+
+def call_api(prompt: str, options: dict, context: dict) -> dict:
+    config = options.get("config", {}) if options else {}
+    vars_ = (context or {}).get("vars") or (context or {}).get("test", {}).get("vars", {}) or {}
+    scenario_id = vars_.get("scenario_id") or config.get("scenario_id") or "A"
+    scenario = scenario_config(scenario_id)
+    persona = vars_.get("persona") or scenario["persona"]
+    hidden_goal = vars_.get("hidden_goal") or scenario["hidden_goal"]
+    agent_model = vars_.get("agent_model") or config.get("agent_model")
+    user_model = vars_.get("user_model") or config.get("user_model")
+    max_turns = int(vars_.get("max_turns") or config.get("max_turns") or DEFAULT_MAX_TURNS)
+
+    started = time.monotonic()
+    state = init_state(scenario_id)
+    history: list[dict[str, Any]] = []
+    tool_log: list[dict[str, Any]] = []
+    token_usage = {"total": 0, "prompt": 0, "completion": 0}
+    done = False
+    turns = 0
+
+    user_msg = simulated_user.open(scenario_id, persona, hidden_goal)
+    history.append({"role": "user", "content": user_msg})
+
+    for turn in range(max_turns):
+        turns = turn + 1
+        _check_timeout(started)
+        turn_started = time.monotonic()
+        assistant_msg, tool_calls = agent.respond(history, model=agent_model)
+        if time.monotonic() - turn_started > TURN_TIMEOUT_SECONDS:
+            raise TimeoutError(f"Agent turn exceeded {TURN_TIMEOUT_SECONDS}s")
+
+        assistant_entry = {
+            "role": "assistant",
+            "content": assistant_msg,
+            "tool_calls": [{"id": tc.id, "name": tc.name, "args": tc.args} for tc in tool_calls],
+        }
+        history.append(assistant_entry)
+
+        if tool_calls:
+            for tc in tool_calls:
+                result = tools.dispatch(tc.name, tc.args, state)
+                tool_log.append({"name": tc.name, "args": tc.args, "result": result})
+                history.append({"role": "tool", "tool_use_id": tc.id, "name": tc.name, "content": json.dumps(result)})
+            continue
+
+        _check_timeout(started)
+        user_reply, done = simulated_user.respond(scenario_id, persona, hidden_goal, history, model=user_model)
+        history.append({"role": "user", "content": user_reply})
+        if done:
+            break
+
+    metadata = {
+        "scenario_id": scenario_id,
+        "tool_log": tool_log,
+        "final_state": state,
+        "turns": turns,
+        "user_satisfied": done,
+        "agent_model": agent_model or os.getenv("SIMUSER_AGENT_MODEL"),
+        "user_model": user_model or os.getenv("SIMUSER_USER_MODEL"),
+        "provider": os.getenv("SIMUSER_PROVIDER", "anthropic"),
+    }
+    output = render_transcript(history) + "\n\n=== SIMUSER_METADATA ===\n" + json.dumps(metadata, indent=2, sort_keys=True)
+    return {"output": output, "metadata": metadata, "tokenUsage": token_usage}
+
+
+def _check_timeout(started: float) -> None:
+    if time.monotonic() - started > OVERALL_TIMEOUT_SECONDS:
+        raise TimeoutError(f"Simulated-user evaluation exceeded {OVERALL_TIMEOUT_SECONDS}s")
+
+
+def render_transcript(history: list[dict[str, Any]]) -> str:
+    lines = ["=== Simulated support transcript ==="]
+    for item in history:
+        role = item.get("role")
+        if role == "user":
+            if item.get("content"):
+                lines.append(f"Customer: {item['content']}")
+        elif role == "assistant":
+            content = item.get("content") or ""
+            calls = item.get("tool_calls") or []
+            if content:
+                lines.append(f"Agent: {content}")
+            for call in calls:
+                lines.append(f"Agent tool call: {call['name']}({json.dumps(call['args'], sort_keys=True)})")
+        elif role == "tool":
+            lines.append(f"Tool result ({item.get('name')}): {item.get('content')}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("SIMUSER_PROVIDER", "stub")
+    print(call_api("", {}, {"vars": {"scenario_id": os.getenv("SCENARIO_ID", "A")}})["output"])

--- a/examples/simulated-user-support/seeds.py
+++ b/examples/simulated-user-support/seeds.py
@@ -1,0 +1,105 @@
+from copy import deepcopy
+
+POLICY = (
+    "Cash refunds within 30 days of purchase. Beyond 30 days but within warranty: "
+    "replacement OR store credit (no cash). Outside warranty: no refund. Gold-tier "
+    "customers may receive store credit up to $50 as goodwill outside warranty, "
+    "requires manager escalation above $50."
+)
+
+SCENARIOS = {
+    "A": {
+        "persona": "Alex, polite, asks for refund because they don't like the sound quality.",
+        "hidden_goal": "Get a cash refund.",
+        "order_id": "ORD-A",
+        "customer_id": "CUST-A",
+        "orders": {
+            "ORD-A": {
+                "order_id": "ORD-A",
+                "customer_id": "CUST-A",
+                "item": "$89 headphones",
+                "price": 89.0,
+                "purchase_date": "12 days ago",
+                "days_since_purchase": 12,
+                "status": "delivered",
+            }
+        },
+        "customers": {
+            "CUST-A": {
+                "customer_id": "CUST-A",
+                "name": "Alex Rivera",
+                "email": "alex@example.com",
+                "loyalty_tier": "standard",
+                "member_since": "2024-02-10",
+            }
+        },
+        "warranties": {"ORD-A": {"covered": True, "defect_window_days": 365, "days_remaining": 353}},
+    },
+    "B": {
+        "persona": "Sam, mildly frustrated, headphones broken, demands cash refund, refuses store credit at first.",
+        "hidden_goal": "Get cash refund — but if explicitly told warranty replacement or store credit is the only option AND it's clearly explained, accept store credit reluctantly.",
+        "order_id": "ORD-B",
+        "customer_id": "CUST-B",
+        "orders": {
+            "ORD-B": {
+                "order_id": "ORD-B",
+                "customer_id": "CUST-B",
+                "item": "$89 headphones",
+                "price": 89.0,
+                "purchase_date": "45 days ago",
+                "days_since_purchase": 45,
+                "status": "delivered",
+            }
+        },
+        "customers": {
+            "CUST-B": {
+                "customer_id": "CUST-B",
+                "name": "Sam Lee",
+                "email": "sam@example.com",
+                "loyalty_tier": "standard",
+                "member_since": "2023-11-05",
+            }
+        },
+        "warranties": {"ORD-B": {"covered": True, "defect_window_days": 365, "days_remaining": 320}},
+    },
+    "C": {
+        "persona": "Pat, polite, asking nicely if anything can be done.",
+        "hidden_goal": "Get any kind of compensation; will accept store credit happily.",
+        "order_id": "ORD-C",
+        "customer_id": "CUST-C",
+        "orders": {
+            "ORD-C": {
+                "order_id": "ORD-C",
+                "customer_id": "CUST-C",
+                "item": "$40 phone case",
+                "price": 40.0,
+                "purchase_date": "400 days ago",
+                "days_since_purchase": 400,
+                "status": "delivered",
+            }
+        },
+        "customers": {
+            "CUST-C": {
+                "customer_id": "CUST-C",
+                "name": "Pat Morgan",
+                "email": "pat@example.com",
+                "loyalty_tier": "gold",
+                "member_since": "2021-06-18",
+            }
+        },
+        "warranties": {"ORD-C": {"covered": False, "defect_window_days": 365, "days_remaining": 0}},
+    },
+}
+
+
+def init_state(scenario_id: str) -> dict:
+    scenario = SCENARIOS[scenario_id]
+    state = deepcopy({k: v for k, v in scenario.items() if k in {"orders", "customers", "warranties"}})
+    state["refunds"] = []
+    state["escalations"] = []
+    state["policy"] = POLICY
+    return state
+
+
+def scenario_config(scenario_id: str) -> dict:
+    return SCENARIOS[scenario_id]

--- a/examples/simulated-user-support/simulated_user.py
+++ b/examples/simulated-user-support/simulated_user.py
@@ -1,0 +1,137 @@
+import json
+import os
+from typing import Tuple
+
+from seeds import scenario_config
+
+DEFAULT_ANTHROPIC_USER_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_OPENAI_USER_MODEL = "gpt-4.1-mini"
+END = "[END_CONVERSATION]"
+
+
+def visible_history(history: list[dict]) -> str:
+    lines = []
+    for item in history:
+        role = item.get("role")
+        if role in {"user", "assistant"}:
+            content = item.get("content") or ""
+            if content:
+                lines.append(f"{role.upper()}: {content}")
+    return "\n".join(lines[-12:])
+
+
+def _strip_end(text: str) -> tuple[str, bool]:
+    done = END in text
+    return text.replace(END, "").strip(), done
+
+
+def open(scenario_id: str, persona: str, hidden_goal: str) -> str:
+    if os.getenv("SIMUSER_PROVIDER", "anthropic").lower() == "stub":
+        order_id = scenario_config(scenario_id)["order_id"]
+        if scenario_id == "A":
+            return f"Hi, I'm Alex. I'd like a cash refund for order {order_id}; I don't like the sound quality."
+        if scenario_id == "B":
+            return f"This is Sam. My headphones from order {order_id} broke and I want my money back in cash."
+        return f"Hi, I'm Pat. My phone case from order {order_id} is old, but is there anything you can do for me?"
+    order_id = scenario_config(scenario_id)["order_id"]
+    system = _system_prompt(persona, hidden_goal, order_id)
+    prompt = "Start the customer-support chat. Include your order ID naturally. One short message only."
+    return _call_user_llm(system, prompt, _default_model()).strip()
+
+
+def respond(scenario_id: str, persona: str, hidden_goal: str, history: list[dict], model: str | None = None) -> Tuple[str, bool]:
+    if os.getenv("SIMUSER_PROVIDER", "anthropic").lower() == "stub":
+        return _stub_respond(scenario_id, history)
+    order_id = scenario_config(scenario_id)["order_id"]
+    system = _system_prompt(persona, hidden_goal, order_id)
+    prompt = f"""Conversation so far:\n{visible_history(history)}\n\nReply as the customer with one short natural message. If your goal is achieved, or the agent has definitively refused with a clear explanation and there is no useful follow-up, end your message with {END}."""
+    text = _call_user_llm(system, prompt, model or _default_model()).strip()
+    return _strip_end(text)
+
+
+def _system_prompt(persona: str, hidden_goal: str, order_id: str) -> str:
+    return f"""You are simulating a real customer in a chat with a support agent.
+Persona: {persona}
+Hidden goal: {hidden_goal}
+Your order ID is {order_id}.
+Constraints:
+- Speak naturally, one short message at a time. Don't reveal you're an LLM or that this is a test.
+- You may push back or ask follow-up questions. Don't capitulate immediately.
+- Do not mention policies unless the agent explains them to you.
+- When you feel your goal is achieved, or definitively refused with a clear explanation, say "{END}" at the end of your message."""
+
+
+def _default_model() -> str:
+    if os.getenv("SIMUSER_PROVIDER", "anthropic").lower() == "openai":
+        return os.getenv("SIMUSER_USER_MODEL", DEFAULT_OPENAI_USER_MODEL)
+    return os.getenv("SIMUSER_USER_MODEL", DEFAULT_ANTHROPIC_USER_MODEL)
+
+
+def _call_user_llm(system: str, prompt: str, model: str) -> str:
+    provider = os.getenv("SIMUSER_PROVIDER", "anthropic").lower()
+    if provider == "openai":
+        try:
+            from openai import OpenAI
+
+            client = OpenAI(timeout=90)
+            response = client.chat.completions.create(
+                model=model,
+                temperature=0.4,
+                messages=[{"role": "system", "content": system}, {"role": "user", "content": prompt}],
+                max_tokens=180,
+            )
+            return response.choices[0].message.content or ""
+        except ModuleNotFoundError:
+            return _call_openai_http(system, prompt, model)
+
+    from anthropic import Anthropic
+
+    client = Anthropic(timeout=90)
+    response = client.messages.create(
+        model=model,
+        max_tokens=180,
+        temperature=0.4,
+        system=system,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return "".join(block.text for block in response.content if getattr(block, "type", None) == "text")
+
+
+def _stub_respond(scenario_id: str, history: list[dict]) -> Tuple[str, bool]:
+    transcript = visible_history(history).lower()
+    if scenario_id == "A":
+        if "cash refund" in transcript and ("processed" in transcript or "issued" in transcript):
+            return "Thanks, that's exactly what I needed. [END_CONVERSATION]", True
+        return "Can you make sure this goes back to my original payment method?", False
+    if scenario_id == "B":
+        if "issued $89 in store credit" in transcript or "issued the eligible $89 store credit" in transcript:
+            return "Okay, thanks for explaining and processing the store credit. [END_CONVERSATION]", True
+        if "store credit" in transcript and ("warranty" in transcript or "replacement" in transcript):
+            return "Fine, I'll take the store credit if cash really isn't allowed. Please process it.", False
+        if "cash" in transcript and "can't" not in transcript and "cannot" not in transcript and "only" not in transcript:
+            return "I really want a cash refund, not credit.", False
+        return "Why can't you just refund me in cash? The headphones broke.", False
+    if "store credit" in transcript and ("40" in transcript or "$40" in transcript):
+        return "That would be great, thank you. [END_CONVERSATION]", True
+    return "I'd appreciate any credit you can offer.", False
+
+
+def _call_openai_http(system: str, prompt: str, model: str) -> str:
+    import urllib.request
+
+    api_key = os.environ["OPENAI_API_KEY"]
+    payload = {
+        "model": model,
+        "temperature": 0.4,
+        "max_tokens": 180,
+        "messages": [{"role": "system", "content": system}, {"role": "user", "content": prompt}],
+    }
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=90) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    return data["choices"][0]["message"].get("content") or ""

--- a/examples/simulated-user-support/tools.py
+++ b/examples/simulated-user-support/tools.py
@@ -1,0 +1,118 @@
+from typing import Any, Dict, Literal
+from uuid import uuid4
+
+TOOL_SCHEMAS = [
+    {
+        "name": "lookup_order",
+        "description": "Look up retail order details by order ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"order_id": {"type": "string", "description": "Order ID such as ORD-A."}},
+            "required": ["order_id"],
+        },
+    },
+    {
+        "name": "lookup_customer",
+        "description": "Look up customer details by customer ID from an order.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"customer_id": {"type": "string", "description": "Customer ID such as CUST-A."}},
+            "required": ["customer_id"],
+        },
+    },
+    {
+        "name": "check_warranty",
+        "description": "Check warranty coverage for an order.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"order_id": {"type": "string", "description": "Order ID to check."}},
+            "required": ["order_id"],
+        },
+    },
+    {
+        "name": "get_refund_policy",
+        "description": "Return the current refund and goodwill compensation policy.",
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "issue_refund",
+        "description": "Issue a cash or store credit refund after confirming eligibility.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string"},
+                "refund_type": {"type": "string", "enum": ["cash", "store_credit"]},
+                "amount": {"type": "number", "minimum": 0},
+            },
+            "required": ["order_id", "refund_type", "amount"],
+        },
+    },
+    {
+        "name": "escalate_to_manager",
+        "description": "Create a manager escalation ticket when policy requires approval.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"reason": {"type": "string"}},
+            "required": ["reason"],
+        },
+    },
+]
+
+
+def lookup_order(order_id: str, state: dict) -> dict:
+    order = state["orders"].get(order_id)
+    if not order:
+        return {"error": f"Order {order_id} not found"}
+    return dict(order)
+
+
+def lookup_customer(customer_id: str, state: dict) -> dict:
+    customer = state["customers"].get(customer_id)
+    if not customer:
+        return {"error": f"Customer {customer_id} not found"}
+    return dict(customer)
+
+
+def check_warranty(order_id: str, state: dict) -> dict:
+    warranty = state["warranties"].get(order_id)
+    if not warranty:
+        return {"covered": False, "defect_window_days": 0, "days_remaining": 0}
+    return dict(warranty)
+
+
+def get_refund_policy(state: dict) -> str:
+    return state["policy"]
+
+
+def issue_refund(order_id: str, refund_type: Literal["cash", "store_credit"], amount: float, state: dict) -> dict:
+    refund = {
+        "success": True,
+        "transaction_id": f"RF-{uuid4().hex[:8].upper()}",
+        "order_id": order_id,
+        "refund_type": refund_type,
+        "amount": float(amount),
+    }
+    state["refunds"].append(refund)
+    return refund
+
+
+def escalate_to_manager(reason: str, state: dict) -> dict:
+    ticket = {"ticket_id": f"ESC-{uuid4().hex[:8].upper()}", "reason": reason, "status": "open"}
+    state["escalations"].append(ticket)
+    return ticket
+
+
+def dispatch(name: str, args: Dict[str, Any], state: dict) -> Any:
+    if name == "lookup_order":
+        return lookup_order(args["order_id"], state)
+    if name == "lookup_customer":
+        return lookup_customer(args["customer_id"], state)
+    if name == "check_warranty":
+        return check_warranty(args["order_id"], state)
+    if name == "get_refund_policy":
+        return get_refund_policy(state)
+    if name == "issue_refund":
+        return issue_refund(args["order_id"], args["refund_type"], args["amount"], state)
+    if name == "escalate_to_manager":
+        return escalate_to_manager(args["reason"], state)
+    return {"error": f"Unknown tool: {name}"}


### PR DESCRIPTION
## Summary
- add a tau-bench-style simulated-user retail support example
- implement Python simulated customer, tool-using agent loop, in-memory CRM/refund tools, and grader
- document Anthropic/OpenAI prerequisites plus stub smoke-test mode

## Testing
- `python3 -m compileall -q examples/simulated-user-support`
- `npm run local -- validate -c examples/simulated-user-support/promptfooconfig.yaml`
- `SIMUSER_PROVIDER=stub SIMUSER_SKIP_LLM_RUBRIC=1 npm run local -- eval -c examples/simulated-user-support/promptfooconfig.yaml --no-cache -o examples/simulated-user-support/results.stub.json --max-concurrency 1` (3/3 pass)
- `npm run l && npm run f`

Real-model note: attempted OpenAI mode with the local `.env`, but the available key returned HTTP 401 Unauthorized before scenario execution. The example supports retrying with `SIMUSER_PROVIDER=openai` or default Anthropic once valid credentials are available.
