### PR TITLE
fix(code-scan): honor enable-fork-prs

### DIFF
--- a/code-scan-action/README.md
+++ b/code-scan-action/README.md
@@ -23,6 +23,17 @@ Once merged, the scanner will automatically run on future pull requests. Authent
 
 **[Read the full documentation →](https://promptfoo.dev/docs/code-scanning/github-action)** for configuration options, manual installation, and more.
 
+## Fork Pull Requests
+
+Fork pull request scanning is disabled by default for `pull_request` workflows. A maintainer can trigger a fork PR scan through the Promptfoo Scanner comment flow, or you can opt in to scanning fork PRs automatically:
+
+```yaml
+- name: Run Promptfoo Code Scan
+  uses: promptfoo/code-scan-action@v1
+  with:
+    enable-fork-prs: true
+```
+
 ## Contributing
 
 Please note that this a release-only repository. To contribute, refer to the [associated directory](https://github.com/promptfoo/promptfoo/tree/main/promptfoo/code-scan-action) in the main promptfoo repository.

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -111,11 +111,11 @@ function getCurrentRepositoryFullName(): string {
 }
 
 function isPullRequestFromFork(): boolean {
-  if (github.context.eventName !== 'pull_request') {
+  const pullRequest = github.context.payload.pull_request as PullRequestForkPayload | undefined;
+  if (!pullRequest) {
     return false;
   }
 
-  const pullRequest = github.context.payload.pull_request as PullRequestForkPayload | undefined;
   const headRepoFullName = pullRequest?.head?.repo?.full_name;
   const baseRepoFullName = pullRequest?.base?.repo?.full_name || getCurrentRepositoryFullName();
 

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -29,6 +29,20 @@ interface ActionInputs {
   guidanceText: string;
   guidanceFile: string;
   githubToken: string;
+  enableForkPrs: boolean;
+}
+
+interface PullRequestForkPayload {
+  head?: {
+    repo?: {
+      full_name?: string | null;
+    } | null;
+  } | null;
+  base?: {
+    repo?: {
+      full_name?: string | null;
+    } | null;
+  } | null;
 }
 
 function formatError(error: unknown): string {
@@ -43,6 +57,7 @@ function getActionInputs(): ActionInputs {
     guidanceText: core.getInput('guidance'),
     guidanceFile: core.getInput('guidance-file'),
     githubToken: core.getInput('github-token', { required: true }),
+    enableForkPrs: core.getBooleanInput('enable-fork-prs'),
   };
 }
 
@@ -88,6 +103,34 @@ function isSetupPR(files: FileChange[]): boolean {
     files[0].path === setupWorkflowPath &&
     files[0].status === FileChangeStatus.ADDED
   );
+}
+
+function getCurrentRepositoryFullName(): string {
+  const repository = github.context.payload.repository as { full_name?: string } | undefined;
+  return repository?.full_name || `${github.context.repo.owner}/${github.context.repo.repo}`;
+}
+
+function isPullRequestFromFork(): boolean {
+  if (github.context.eventName !== 'pull_request') {
+    return false;
+  }
+
+  const pullRequest = github.context.payload.pull_request as PullRequestForkPayload | undefined;
+  const headRepoFullName = pullRequest?.head?.repo?.full_name;
+  const baseRepoFullName = pullRequest?.base?.repo?.full_name || getCurrentRepositoryFullName();
+
+  if (!headRepoFullName || !baseRepoFullName) {
+    core.warning(
+      'Unable to determine PR source repository from GitHub event payload; treating it as a fork PR',
+    );
+    return true;
+  }
+
+  return headRepoFullName !== baseRepoFullName;
+}
+
+function shouldSkipForkPullRequest(enableForkPrs: boolean): boolean {
+  return !enableForkPrs && isPullRequestFromFork();
 }
 
 async function authenticateWithOidc(): Promise<void> {
@@ -421,6 +464,14 @@ async function runCodeScan(): Promise<void> {
 
   const context = await getGitHubContext(inputs.githubToken);
   core.info(`📋 Scanning PR #${context.number} in ${context.owner}/${context.repo}`);
+
+  if (shouldSkipForkPullRequest(inputs.enableForkPrs)) {
+    core.info('🔀 Fork PR detected and enable-fork-prs is false; skipping Promptfoo Code Scan');
+    core.info(
+      'A maintainer can trigger a scan by commenting @promptfoo-scanner, or enable fork PR scans with enable-fork-prs: true',
+    );
+    return;
+  }
 
   core.info('🔎 Checking if this is a setup PR...');
   const files = await getPRFiles(inputs.githubToken, context);

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -458,12 +458,6 @@ function cleanupConfig(configPath: string, finalConfigPath: string): void {
 
 async function runCodeScan(): Promise<void> {
   const inputs = getActionInputs();
-  const guidance = loadGuidance(inputs);
-
-  core.info('🔍 Starting Promptfoo Code Scan...');
-
-  const context = await getGitHubContext(inputs.githubToken);
-  core.info(`📋 Scanning PR #${context.number} in ${context.owner}/${context.repo}`);
 
   if (shouldSkipForkPullRequest(inputs.enableForkPrs)) {
     core.info('🔀 Fork PR detected and enable-fork-prs is false; skipping Promptfoo Code Scan');
@@ -472,6 +466,13 @@ async function runCodeScan(): Promise<void> {
     );
     return;
   }
+
+  const guidance = loadGuidance(inputs);
+
+  core.info('🔍 Starting Promptfoo Code Scan...');
+
+  const context = await getGitHubContext(inputs.githubToken);
+  core.info(`📋 Scanning PR #${context.number} in ${context.owner}/${context.repo}`);
 
   core.info('🔎 Checking if this is a setup PR...');
   const files = await getPRFiles(inputs.githubToken, context);

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -342,6 +342,24 @@ describe('code-scan-action main', () => {
       expect(mocks.core.setFailed).not.toHaveBeenCalled();
     });
 
+    it('should skip fork pull_request_target scans by default', async () => {
+      mocks.github.context.eventName = 'pull_request_target';
+      setPullRequestRepos('external-contributor/test-repo');
+
+      await import('../../code-scan-action/src/main');
+
+      await vi.waitFor(() => {
+        expect(mocks.core.info).toHaveBeenCalledWith(
+          '🔀 Fork PR detected and enable-fork-prs is false; skipping Promptfoo Code Scan',
+        );
+      });
+
+      expect(mocks.actionGithub.getPRFiles).not.toHaveBeenCalled();
+      expect(mocks.core.getIDToken).not.toHaveBeenCalled();
+      expect(mocks.exec.exec).not.toHaveBeenCalled();
+      expect(mocks.core.setFailed).not.toHaveBeenCalled();
+    });
+
     it('should scan fork pull_request events when enable-fork-prs is true', async () => {
       setPullRequestRepos('external-contributor/test-repo');
       mocks.core.getBooleanInput.mockReturnValue(true);

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -314,6 +314,18 @@ describe('code-scan-action main', () => {
   describe('fork PR controls', () => {
     it('should skip fork pull_request scans by default before fetching files or starting auth', async () => {
       setPullRequestRepos('external-contributor/test-repo');
+      mocks.core.getInput.mockImplementation((name: string) => {
+        if (name === 'github-token') {
+          return 'fake-token';
+        }
+        if (name === 'min-severity' || name === 'minimum-severity') {
+          return 'medium';
+        }
+        if (name === 'guidance-file') {
+          return '/tmp/missing-guidance.md';
+        }
+        return '';
+      });
 
       await import('../../code-scan-action/src/main');
 
@@ -327,6 +339,7 @@ describe('code-scan-action main', () => {
       expect(mocks.core.getIDToken).not.toHaveBeenCalled();
       expect(mocks.config.generateConfigFile).not.toHaveBeenCalled();
       expect(mocks.exec.exec).not.toHaveBeenCalled();
+      expect(mocks.core.setFailed).not.toHaveBeenCalled();
     });
 
     it('should scan fork pull_request events when enable-fork-prs is true', async () => {

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -10,6 +10,7 @@ import { mockProcessEnv } from '../util/utils';
 const mocks = vi.hoisted(() => {
   const core = {
     getInput: vi.fn(),
+    getBooleanInput: vi.fn(),
     getIDToken: vi.fn(),
     info: vi.fn(),
     warning: vi.fn(),
@@ -23,15 +24,27 @@ const mocks = vi.hoisted(() => {
 
   const github = {
     context: {
+      eventName: 'pull_request',
       repo: {
         owner: 'test-owner',
         repo: 'test-repo',
       },
       payload: {
+        repository: {
+          full_name: 'test-owner/test-repo',
+        },
         pull_request: {
           number: 123,
           head: {
             sha: 'abc123',
+            repo: {
+              full_name: 'test-owner/test-repo',
+            },
+          },
+          base: {
+            repo: {
+              full_name: 'test-owner/test-repo',
+            },
           },
         },
       },
@@ -96,6 +109,31 @@ interface NpmExecCall {
 }
 
 function setupMocks() {
+  mocks.github.context.eventName = 'pull_request';
+  mocks.github.context.repo = {
+    owner: 'test-owner',
+    repo: 'test-repo',
+  };
+  mocks.github.context.payload = {
+    repository: {
+      full_name: 'test-owner/test-repo',
+    },
+    pull_request: {
+      number: 123,
+      head: {
+        sha: 'abc123',
+        repo: {
+          full_name: 'test-owner/test-repo',
+        },
+      },
+      base: {
+        repo: {
+          full_name: 'test-owner/test-repo',
+        },
+      },
+    },
+  };
+
   mocks.core.getInput.mockImplementation((name: string) => {
     if (name === 'github-token') {
       return 'fake-token';
@@ -105,6 +143,7 @@ function setupMocks() {
     }
     return '';
   });
+  mocks.core.getBooleanInput.mockReturnValue(false);
   mocks.core.getIDToken.mockResolvedValue('fake-oidc-token');
 
   mocks.exec.exec.mockImplementation(
@@ -203,6 +242,11 @@ function expectSanitizedExecEnv(options: PromptfooExecCall['options'] | NpmExecC
   expect(options?.env?.npm_config_before).toBeUndefined();
 }
 
+function setPullRequestRepos(headRepoFullName: string, baseRepoFullName = 'test-owner/test-repo') {
+  mocks.github.context.payload.pull_request.head.repo.full_name = headRepoFullName;
+  mocks.github.context.payload.pull_request.base.repo.full_name = baseRepoFullName;
+}
+
 describe('code-scan-action main', () => {
   let restoreEnv: () => void;
 
@@ -264,6 +308,54 @@ describe('code-scan-action main', () => {
       const { options } = await importActionAndGetNpmInstallCall();
 
       expectSanitizedExecEnv(options);
+    });
+  });
+
+  describe('fork PR controls', () => {
+    it('should skip fork pull_request scans by default before fetching files or starting auth', async () => {
+      setPullRequestRepos('external-contributor/test-repo');
+
+      await import('../../code-scan-action/src/main');
+
+      await vi.waitFor(() => {
+        expect(mocks.core.info).toHaveBeenCalledWith(
+          '🔀 Fork PR detected and enable-fork-prs is false; skipping Promptfoo Code Scan',
+        );
+      });
+
+      expect(mocks.actionGithub.getPRFiles).not.toHaveBeenCalled();
+      expect(mocks.core.getIDToken).not.toHaveBeenCalled();
+      expect(mocks.config.generateConfigFile).not.toHaveBeenCalled();
+      expect(mocks.exec.exec).not.toHaveBeenCalled();
+    });
+
+    it('should scan fork pull_request events when enable-fork-prs is true', async () => {
+      setPullRequestRepos('external-contributor/test-repo');
+      mocks.core.getBooleanInput.mockReturnValue(true);
+
+      const { args } = await importActionAndGetPromptfooCall();
+
+      expectCliArg(args, '--github-pr', 'test-owner/test-repo#123');
+      expect(mocks.actionGithub.getPRFiles).toHaveBeenCalled();
+      expect(mocks.core.getIDToken).toHaveBeenCalled();
+    });
+
+    it('should allow workflow_dispatch scans when enable-fork-prs is false', async () => {
+      mocks.github.context.eventName = 'workflow_dispatch';
+      mocks.github.context.payload = {
+        repository: {
+          full_name: 'test-owner/test-repo',
+        },
+        inputs: {
+          pr_number: '123',
+        },
+      };
+
+      const { args } = await importActionAndGetPromptfooCall();
+
+      expectCliArg(args, '--github-pr', 'test-owner/test-repo#123');
+      expect(mocks.actionGithub.getPRFiles).toHaveBeenCalled();
+      expect(mocks.core.getIDToken).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the code scan action so the documented `enable-fork-prs` input is enforced client-side.

The action now reads `enable-fork-prs` as a boolean input and skips fork-origin `pull_request` events by default before it enumerates PR files, attempts OIDC auth, generates config, installs promptfoo, or invokes `promptfoo code-scans run`. `workflow_dispatch` remains allowed so maintainer-triggered scans, including the Promptfoo Scanner comment flow, can still run without requiring repository-wide fork PR scanning.

Also updates the action README with the fork PR default and opt-in snippet.

## Tests

- `npm run l`
- `npm run f`
- `npx vitest run test/code-scan-action`
- `npm --prefix code-scan-action run tsc`
- `npm --prefix code-scan-action run build`
