### PR TITLE
fix(eval): stop HuggingFace empty-page loops

### DIFF
--- a/site/docs/configuration/telemetry.md
+++ b/site/docs/configuration/telemetry.md
@@ -19,14 +19,16 @@ pagination_next: null
 
 # Telemetry
 
-`promptfoo` collects basic anonymous telemetry by default. This telemetry helps us decide how to spend time on development.
+`promptfoo` collects basic usage telemetry by default. This telemetry helps us decide how to spend time on development.
 
 An event is recorded when:
 
 - A command is run (e.g. `init`, `eval`, `view`)
 - An assertion is used (along with the type of assertion, e.g. `is-json`, `similar`, `llm-rubric`)
 
-No additional information is collected. The above list is exhaustive.
+Telemetry events include package version and whether the command is running in CI. When account information is present in the local promptfoo config, hosted telemetry also includes the promptfoo user ID, email address, cloud login status, and authentication method.
+
+Telemetry does not include prompts, model outputs, test cases, provider API keys, or full configuration files.
 
 To disable telemetry, set the following environment variable:
 

--- a/site/docs/red-team/troubleshooting/data-handling.md
+++ b/site/docs/red-team/troubleshooting/data-handling.md
@@ -98,13 +98,13 @@ See [Configuring Inference](/docs/red-team/troubleshooting/inference-limit/) for
 
 ## Telemetry
 
-Promptfoo collects anonymous usage telemetry:
+Promptfoo collects usage telemetry:
 
 - Commands run (`redteam generate`, `redteam run`, etc.)
 - Plugin and strategy types used (not content)
 - Assertion types
 
-No prompt content, responses, or personally identifiable information is included.
+Hosted telemetry may include package version, CI status, promptfoo user ID, email address, cloud login status, and authentication method when those values are present in the local promptfoo config. Prompt content, model responses, generated test cases, provider API keys, and full configuration files are not included.
 
 To disable:
 

--- a/src/integrations/huggingfaceDatasets.ts
+++ b/src/integrations/huggingfaceDatasets.ts
@@ -297,6 +297,12 @@ export async function fetchHuggingFaceDataset(
       }
 
       const data = response.data as HuggingFaceResponse;
+      const isDatasetExhausted = offset >= data.num_rows_total;
+      if (data.rows.length === 0 && !isDatasetExhausted) {
+        const error = `[HF Dataset] Received an empty page at offset ${offset} before reaching ${data.num_rows_total} total rows. Aborting to avoid retrying the same page indefinitely.\nFetched ${url}`;
+        logger.error(error);
+        throw new Error(error);
+      }
 
       if (offset === 0) {
         // Smart logging: contextual info with cache status on first successful request

--- a/test/integrations/huggingfaceDatasets.test.ts
+++ b/test/integrations/huggingfaceDatasets.test.ts
@@ -289,6 +289,29 @@ describe('huggingfaceDatasets', () => {
     });
   });
 
+  it('should reject an empty non-final page instead of retrying the same offset', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce({
+        data: {
+          num_rows_total: 2,
+          features: [{ name: 'text', type: { dtype: 'string', _type: 'Value' } }],
+          rows: [],
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      } as any)
+      .mockRejectedValueOnce(new Error('Paginator retried the empty page'));
+
+    await expect(
+      fetchHuggingFaceDataset('huggingface://datasets/test/dataset', 200),
+    ).rejects.toThrow(
+      '[HF Dataset] Received an empty page at offset 0 before reaching 2 total rows',
+    );
+
+    expect(vi.mocked(fetchWithCache)).toHaveBeenCalledTimes(1);
+  });
+
   it('should handle API errors by throwing', async () => {
     vi.mocked(fetchWithCache).mockResolvedValueOnce({
       data: null,


### PR DESCRIPTION
## Summary

- Abort HuggingFace dataset pagination when a successful response returns an empty non-final page, preventing repeated requests to the same offset.
- Add regression coverage for the empty-page pagination failure mode.
- Update telemetry docs to disclose hosted telemetry identity metadata and clarify that prompt/eval content is not sent.

## QA

- Reproduced pre-fix behavior by temporarily restoring the old paginator and running `npx vitest run test/integrations/huggingfaceDatasets.test.ts -t "empty non-final page" --sequence.shuffle=false`; it retried the empty page and failed with `Paginator retried the empty page`.
- `npx vitest run test/integrations/huggingfaceDatasets.test.ts test/telemetry.test.ts --sequence.shuffle=false`
- `PROMPTFOO_CACHE_ENABLED=false PROMPTFOO_DISABLE_TELEMETRY=1 PROMPTFOO_DISABLE_SHARING=1 npm run local -- eval -c /tmp/pf-post-hf-real-eval.yaml --no-cache --no-share -o /tmp/pf-post-hf-real-eval-output.json` using `rajpurkar/squad?split=train&config=plain_text&limit=105`: 105 passed, 0 failed, 0 errors.
- `npm run f`
- `npm run l`
- `npm run tsc`
- `cd site && SKIP_OG_GENERATION=true npm run build`
