### PR TITLE
fix(eval): honor sharing disable for blob uploads

### DIFF
--- a/src/blobs/remoteUpload.ts
+++ b/src/blobs/remoteUpload.ts
@@ -5,7 +5,12 @@ import logger from '../logger';
 
 import type { BlobStoreResult } from './types';
 
-function buildRemoteUrl(): string | null {
+interface RemoteBlobUploadTarget {
+  url: string;
+  apiKey: string;
+}
+
+function buildRemoteUploadTarget(): RemoteBlobUploadTarget | null {
   if (getEnvBool('PROMPTFOO_DISABLE_SHARING')) {
     return null;
   }
@@ -19,7 +24,7 @@ function buildRemoteUrl(): string | null {
 
   try {
     const url = new URL('/api/blobs', baseUrl);
-    return url.toString();
+    return { url: url.toString(), apiKey };
   } catch (error) {
     logger.debug('[RemoteBlob] Invalid remote blob URL', {
       error: error instanceof Error ? error.message : String(error),
@@ -30,7 +35,7 @@ function buildRemoteUrl(): string | null {
 }
 
 export function shouldAttemptRemoteBlobUpload(): boolean {
-  return buildRemoteUrl() !== null;
+  return buildRemoteUploadTarget() !== null;
 }
 
 export async function uploadBlobRemote(
@@ -44,23 +49,18 @@ export async function uploadBlobRemote(
     kind?: string;
   },
 ): Promise<BlobStoreResult | null> {
-  const url = buildRemoteUrl();
-  if (!url) {
-    return null;
-  }
-
-  const apiKey = cloudConfig.getApiKey();
-  if (!apiKey) {
+  const target = buildRemoteUploadTarget();
+  if (!target) {
     return null;
   }
 
   try {
     const { fetchWithProxy } = await import('../util/fetch');
-    const response = await fetchWithProxy(url, {
+    const response = await fetchWithProxy(target.url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${target.apiKey}`,
       },
       body: JSON.stringify({
         data: buffer.toString('base64'),

--- a/src/blobs/remoteUpload.ts
+++ b/src/blobs/remoteUpload.ts
@@ -1,3 +1,4 @@
+import { getEnvBool } from '../envars';
 import { isLoggedIntoCloud } from '../globalConfig/accounts';
 import { cloudConfig } from '../globalConfig/cloud';
 import logger from '../logger';
@@ -5,6 +6,10 @@ import logger from '../logger';
 import type { BlobStoreResult } from './types';
 
 function buildRemoteUrl(): string | null {
+  if (getEnvBool('PROMPTFOO_DISABLE_SHARING')) {
+    return null;
+  }
+
   const baseUrl = cloudConfig.getApiHost();
   const apiKey = cloudConfig.getApiKey();
 
@@ -40,8 +45,12 @@ export async function uploadBlobRemote(
   },
 ): Promise<BlobStoreResult | null> {
   const url = buildRemoteUrl();
+  if (!url) {
+    return null;
+  }
+
   const apiKey = cloudConfig.getApiKey();
-  if (!url || !apiKey) {
+  if (!apiKey) {
     return null;
   }
 

--- a/test/blobs/remoteUpload.test.ts
+++ b/test/blobs/remoteUpload.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { shouldAttemptRemoteBlobUpload, uploadBlobRemote } from '../../src/blobs/remoteUpload';
 import { getEnvBool } from '../../src/envars';
 import { isLoggedIntoCloud } from '../../src/globalConfig/accounts';
@@ -46,6 +46,10 @@ describe('remote blob upload', () => {
         },
       }),
     } as Response);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
   });
 
   it('attempts remote upload when sharing is enabled and Cloud auth is configured', () => {

--- a/test/blobs/remoteUpload.test.ts
+++ b/test/blobs/remoteUpload.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { shouldAttemptRemoteBlobUpload, uploadBlobRemote } from '../../src/blobs/remoteUpload';
+import { getEnvBool } from '../../src/envars';
+import { isLoggedIntoCloud } from '../../src/globalConfig/accounts';
+import { cloudConfig } from '../../src/globalConfig/cloud';
+import { fetchWithProxy } from '../../src/util/fetch';
+
+vi.mock('../../src/envars', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/envars')>();
+  return {
+    ...actual,
+    getEnvBool: vi.fn(),
+  };
+});
+
+vi.mock('../../src/globalConfig/accounts', () => ({
+  isLoggedIntoCloud: vi.fn(),
+}));
+
+vi.mock('../../src/globalConfig/cloud', () => ({
+  cloudConfig: {
+    getApiHost: vi.fn(),
+    getApiKey: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/util/fetch', () => ({
+  fetchWithProxy: vi.fn(),
+}));
+
+describe('remote blob upload', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getEnvBool).mockReturnValue(false);
+    vi.mocked(isLoggedIntoCloud).mockReturnValue(true);
+    vi.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+    vi.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key');
+    vi.mocked(fetchWithProxy).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        ref: {
+          uri: 'promptfoo://blob/abc123',
+          hash: 'abc123',
+        },
+      }),
+    } as Response);
+  });
+
+  it('attempts remote upload when sharing is enabled and Cloud auth is configured', () => {
+    expect(shouldAttemptRemoteBlobUpload()).toBe(true);
+  });
+
+  it('does not attempt remote upload when PROMPTFOO_DISABLE_SHARING is set', async () => {
+    vi.mocked(getEnvBool).mockImplementation((key) => key === 'PROMPTFOO_DISABLE_SHARING');
+
+    expect(shouldAttemptRemoteBlobUpload()).toBe(false);
+
+    const result = await uploadBlobRemote(Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'eval-123',
+      location: 'response.output',
+      kind: 'image',
+    });
+
+    expect(result).toBeNull();
+    expect(cloudConfig.getApiHost).not.toHaveBeenCalled();
+    expect(cloudConfig.getApiKey).not.toHaveBeenCalled();
+    expect(fetchWithProxy).not.toHaveBeenCalled();
+  });
+
+  it('posts blobs to the Cloud blob endpoint when allowed', async () => {
+    await uploadBlobRemote(Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'eval-123',
+      location: 'response.output',
+      kind: 'image',
+    });
+
+    expect(fetchWithProxy).toHaveBeenCalledWith(
+      'https://api.example.com/api/blobs',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-api-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+});

--- a/test/blobs/remoteUpload.test.ts
+++ b/test/blobs/remoteUpload.test.ts
@@ -50,6 +50,8 @@ describe('remote blob upload', () => {
 
   it('attempts remote upload when sharing is enabled and Cloud auth is configured', () => {
     expect(shouldAttemptRemoteBlobUpload()).toBe(true);
+    expect(cloudConfig.getApiHost).toHaveBeenCalledTimes(1);
+    expect(cloudConfig.getApiKey).toHaveBeenCalledTimes(1);
   });
 
   it('does not attempt remote upload when PROMPTFOO_DISABLE_SHARING is set', async () => {
@@ -86,5 +88,7 @@ describe('remote blob upload', () => {
         }),
       }),
     );
+    expect(cloudConfig.getApiHost).toHaveBeenCalledTimes(1);
+    expect(cloudConfig.getApiKey).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Gate remote blob uploads on `PROMPTFOO_DISABLE_SHARING` before Cloud URL/auth resolution.
- Add regression coverage for disabled sharing blocking `/api/blobs` fetches while allowed uploads still post to Cloud.

## Verification
- `npx vitest run test/blobs/remoteUpload.test.ts test/blobs/extractor.test.ts --sequence.shuffle=false`
- `npx @biomejs/biome check --write src/blobs/remoteUpload.ts test/blobs/remoteUpload.test.ts`
- `npm run tsc`
- Two-pass `npm run local -- eval` proof with a temp media provider and local fake Cloud API: disabled run produced `remoteBlobUploads: 0` and `blobRefs: 1`; enabled run produced `remoteBlobUploads: 1` and `blobRefs: 1`.
