### PR TITLE
refactor: use fs/promises for file IO

### DIFF
--- a/scripts/generate-blog-image.cjs
+++ b/scripts/generate-blog-image.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const path = require('path');
 const https = require('https');
 // Load environment variables from .env file
@@ -121,7 +122,7 @@ async function downloadImage(url, filepath) {
         });
       })
       .on('error', (error) => {
-        fs.unlink(filepath, () => {}); // Delete the file on error
+        fsPromises.unlink(filepath).catch(() => {}); // Delete the file on error
         reject(error);
       });
   });
@@ -134,7 +135,7 @@ async function main() {
       // If we get base64 data, save it directly
       const outputPath = path.join(__dirname, '..', 'site', 'static', 'img', outputDir, filename);
       const buffer = Buffer.from(imageData.b64_json, 'base64');
-      fs.writeFileSync(outputPath, buffer);
+      await fsPromises.writeFile(outputPath, buffer);
       console.log(`Image saved to: ${outputPath}`);
     } else if (imageData.url) {
       // If we get a URL, download the image

--- a/scripts/generate-blog-image.cjs
+++ b/scripts/generate-blog-image.cjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const fsPromises = require('fs/promises');
+const fs = require('fs/promises');
 const path = require('path');
 const https = require('https');
 // Load environment variables from .env file
@@ -112,20 +111,31 @@ async function generateImage() {
   });
 }
 async function downloadImage(url, filepath) {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(filepath);
+  const buffer = await new Promise((resolve, reject) => {
     https
       .get(url, (response) => {
-        response.pipe(file);
-        file.on('finish', () => {
-          file.close(resolve);
+        if (response.statusCode && response.statusCode >= 400) {
+          response.resume();
+          reject(new Error(`Failed to download image: ${response.statusCode}`));
+          return;
+        }
+        const chunks = [];
+        response.on('data', (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         });
+        response.on('end', () => {
+          resolve(Buffer.concat(chunks));
+        });
+        response.on('error', reject);
       })
-      .on('error', (error) => {
-        fsPromises.unlink(filepath).catch(() => {}); // Delete the file on error
-        reject(error);
-      });
+      .on('error', reject);
   });
+  try {
+    await fs.writeFile(filepath, buffer);
+  } catch (error) {
+    await fs.unlink(filepath).catch(() => {}); // Delete the file on error
+    throw error;
+  }
 }
 async function main() {
   try {
@@ -135,7 +145,7 @@ async function main() {
       // If we get base64 data, save it directly
       const outputPath = path.join(__dirname, '..', 'site', 'static', 'img', outputDir, filename);
       const buffer = Buffer.from(imageData.b64_json, 'base64');
-      await fsPromises.writeFile(outputPath, buffer);
+      await fs.writeFile(outputPath, buffer);
       console.log(`Image saved to: ${outputPath}`);
     } else if (imageData.url) {
       // If we get a URL, download the image

--- a/scripts/generate-event-images.cjs
+++ b/scripts/generate-event-images.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const path = require('path');
 const https = require('https');
 const { execSync } = require('child_process');
@@ -449,7 +450,7 @@ async function downloadImage(url, filepath) {
         });
       })
       .on('error', (error) => {
-        fs.unlink(filepath, () => {});
+        fsPromises.unlink(filepath).catch(() => {});
         reject(error);
       });
   });
@@ -466,7 +467,7 @@ async function processEvent(event) {
 
     if (imageData.b64_json) {
       const buffer = Buffer.from(imageData.b64_json, 'base64');
-      fs.writeFileSync(pngPath, buffer);
+      await fsPromises.writeFile(pngPath, buffer);
       console.log(`[${event.filename}] PNG saved`);
     } else if (imageData.url) {
       await downloadImage(imageData.url, pngPath);
@@ -481,14 +482,14 @@ async function processEvent(event) {
       console.log(`[${event.filename}] Converted to JPEG`);
 
       // Remove PNG after successful conversion
-      fs.unlinkSync(pngPath);
+      await fsPromises.unlink(pngPath);
       console.log(`[${event.filename}] Cleaned up PNG`);
     } catch (_convertError) {
       // Try ImageMagick as fallback
       try {
         execSync(`convert "${pngPath}" -quality 85 "${jpgPath}"`, { stdio: 'pipe' });
         console.log(`[${event.filename}] Converted to JPEG (ImageMagick)`);
-        fs.unlinkSync(pngPath);
+        await fsPromises.unlink(pngPath);
       } catch {
         console.log(`[${event.filename}] Could not convert to JPEG, keeping PNG`);
       }

--- a/scripts/generate-event-images.cjs
+++ b/scripts/generate-event-images.cjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const fsPromises = require('fs/promises');
+const fs = require('fs/promises');
 const path = require('path');
 const https = require('https');
 const { execSync } = require('child_process');
@@ -440,20 +439,31 @@ async function generateImage(prompt) {
 }
 
 async function downloadImage(url, filepath) {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(filepath);
+  const buffer = await new Promise((resolve, reject) => {
     https
       .get(url, (response) => {
-        response.pipe(file);
-        file.on('finish', () => {
-          file.close(resolve);
+        if (response.statusCode && response.statusCode >= 400) {
+          response.resume();
+          reject(new Error(`Failed to download image: ${response.statusCode}`));
+          return;
+        }
+        const chunks = [];
+        response.on('data', (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         });
+        response.on('end', () => {
+          resolve(Buffer.concat(chunks));
+        });
+        response.on('error', reject);
       })
-      .on('error', (error) => {
-        fsPromises.unlink(filepath).catch(() => {});
-        reject(error);
-      });
+      .on('error', reject);
   });
+  try {
+    await fs.writeFile(filepath, buffer);
+  } catch (error) {
+    await fs.unlink(filepath).catch(() => {});
+    throw error;
+  }
 }
 
 async function processEvent(event) {
@@ -467,7 +477,7 @@ async function processEvent(event) {
 
     if (imageData.b64_json) {
       const buffer = Buffer.from(imageData.b64_json, 'base64');
-      await fsPromises.writeFile(pngPath, buffer);
+      await fs.writeFile(pngPath, buffer);
       console.log(`[${event.filename}] PNG saved`);
     } else if (imageData.url) {
       await downloadImage(imageData.url, pngPath);
@@ -482,14 +492,14 @@ async function processEvent(event) {
       console.log(`[${event.filename}] Converted to JPEG`);
 
       // Remove PNG after successful conversion
-      await fsPromises.unlink(pngPath);
+      await fs.unlink(pngPath);
       console.log(`[${event.filename}] Cleaned up PNG`);
     } catch (_convertError) {
       // Try ImageMagick as fallback
       try {
         execSync(`convert "${pngPath}" -quality 85 "${jpgPath}"`, { stdio: 'pipe' });
         console.log(`[${event.filename}] Converted to JPEG (ImageMagick)`);
-        await fsPromises.unlink(pngPath);
+        await fs.unlink(pngPath);
       } catch {
         console.log(`[${event.filename}] Could not convert to JPEG, keeping PNG`);
       }

--- a/scripts/generateCitation.ts
+++ b/scripts/generateCitation.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -96,11 +96,11 @@ export const updateCitation = async (): Promise<void> => {
   const packageJsonPath: string = path.join(__dirname, '../package.json');
   const citationPath: string = path.join(__dirname, '../CITATION.cff');
 
-  const packageJson: PackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const packageJson: PackageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
   let citation: Citation;
   try {
-    citation = yaml.load(fs.readFileSync(citationPath, 'utf8')) as Citation;
+    citation = yaml.load(await fs.readFile(citationPath, 'utf8')) as Citation;
   } catch {
     citation = createDefaultCitation(packageJson);
   }
@@ -109,7 +109,7 @@ export const updateCitation = async (): Promise<void> => {
   const releaseDate = await getReleaseDate(packageJson.version);
   citation['date-released'] = releaseDate || new Date().toISOString().slice(0, 10);
 
-  fs.writeFileSync(citationPath, yaml.dump(citation, { lineWidth: -1 }));
+  await fs.writeFile(citationPath, yaml.dump(citation, { lineWidth: -1 }));
 
   console.log('CITATION.cff file has been updated.');
 };

--- a/site/scripts/fetch-stats.mjs
+++ b/site/scripts/fetch-stats.mjs
@@ -6,7 +6,7 @@
  * Always exits 0 — build never fails due to stats fetching.
  */
 
-import { writeFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -103,7 +103,7 @@ async function main() {
     }
   });
 
-  writeFileSync(OUTPUT_PATH, JSON.stringify(stats, null, 2) + '\n');
+  await writeFile(OUTPUT_PATH, JSON.stringify(stats, null, 2) + '\n');
 
   const keys = Object.keys(stats);
   if (keys.length > 0) {

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import async from 'async';
@@ -768,7 +768,7 @@ export async function runCompareAssertion(
 
 export async function readAssertions(filePath: string): Promise<Assertion[]> {
   try {
-    const assertions = yaml.load(fs.readFileSync(filePath, 'utf-8')) as Assertion[];
+    const assertions = yaml.load(await fs.readFile(filePath, 'utf-8')) as Assertion[];
     if (!Array.isArray(assertions) || assertions[0]?.type === undefined) {
       throw new Error('Assertions file must be an array of assertion objects');
     }

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 import * as os from 'os';
 
 import chalk from 'chalk';
@@ -47,7 +47,13 @@ async function doDebug(options: DebugOptions): Promise<void> {
 
   // Try to load config if available
   const configPath = options.config || options.defaultConfigPath;
-  if (configPath && fs.existsSync(configPath)) {
+  const configExists = configPath
+    ? await fs
+        .access(configPath)
+        .then(() => true)
+        .catch(() => false)
+    : false;
+  if (configPath && configExists) {
     debugInfo.configInfo.configExists = true;
     try {
       const resolved = await resolveConfigs(

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import * as path from 'path';
 
 import chalk from 'chalk';
@@ -158,7 +158,8 @@ export async function doEval(
     if (cmdObj.config !== undefined) {
       const configPaths: string[] = Array.isArray(cmdObj.config) ? cmdObj.config : [cmdObj.config];
       for (const configPath of configPaths) {
-        if (fs.existsSync(configPath) && fs.statSync(configPath).isDirectory()) {
+        const configStats = await fs.stat(configPath).catch(() => undefined);
+        if (configStats?.isDirectory()) {
           const { defaultConfig: dirConfig, defaultConfigPath: newConfigPath } =
             await loadDefaultConfig(configPath);
           if (newConfigPath) {

--- a/src/commands/generate/assertions.ts
+++ b/src/commands/generate/assertions.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 
 import chalk from 'chalk';
 import { InvalidArgumentError } from 'commander';
@@ -73,7 +73,7 @@ export async function doGenerateAssertions(options: DatasetGenerateOptions): Pro
   if (options.output) {
     // Should the output be written as a YAML or CSV?
     if (options.output.endsWith('.yaml')) {
-      fs.writeFileSync(options.output, yamlString);
+      await fs.writeFile(options.output, yamlString);
     } else {
       throw new Error(`Unsupported output file type: ${options.output}`);
     }
@@ -89,7 +89,9 @@ export async function doGenerateAssertions(options: DatasetGenerateOptions): Pro
 
   printBorder();
   if (options.write && configPath) {
-    const existingConfig = yaml.load(fs.readFileSync(configPath, 'utf8')) as Partial<UnifiedConfig>;
+    const existingConfig = yaml.load(
+      await fs.readFile(configPath, 'utf8'),
+    ) as Partial<UnifiedConfig>;
     // Handle the union type for tests (string | TestGeneratorConfig | Array<...>)
     const existingDefaultTest =
       typeof existingConfig.defaultTest === 'object' ? existingConfig.defaultTest : {};
@@ -97,7 +99,7 @@ export async function doGenerateAssertions(options: DatasetGenerateOptions): Pro
       ...existingDefaultTest,
       assert: [...(existingDefaultTest?.assert || []), ...configAddition.assert],
     };
-    fs.writeFileSync(configPath, yaml.dump(existingConfig));
+    await fs.writeFile(configPath, yaml.dump(existingConfig));
     logger.info(`Wrote ${results.length} new test cases to ${configPath}`);
     const runCommand = promptfooCommand('eval');
     logger.info(chalk.green(`Run ${chalk.bold(runCommand)} to run the generated assertions`));

--- a/src/commands/generate/dataset.ts
+++ b/src/commands/generate/dataset.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 
 import chalk from 'chalk';
 import yaml from 'js-yaml';
@@ -71,9 +71,9 @@ export async function doGenerateDataset(options: DatasetGenerateOptions): Promis
   if (options.output) {
     // Should the output be written as a YAML or CSV?
     if (options.output.endsWith('.csv')) {
-      fs.writeFileSync(options.output, serializeObjectArrayAsCSV(results));
+      await fs.writeFile(options.output, serializeObjectArrayAsCSV(results));
     } else if (options.output.endsWith('.yaml')) {
-      fs.writeFileSync(options.output, yamlString);
+      await fs.writeFile(options.output, yamlString);
     } else {
       throw new Error(`Unsupported output file type: ${options.output}`);
     }
@@ -89,7 +89,9 @@ export async function doGenerateDataset(options: DatasetGenerateOptions): Promis
 
   printBorder();
   if (options.write && configPath) {
-    const existingConfig = yaml.load(fs.readFileSync(configPath, 'utf8')) as Partial<UnifiedConfig>;
+    const existingConfig = yaml.load(
+      await fs.readFile(configPath, 'utf8'),
+    ) as Partial<UnifiedConfig>;
     // Handle the union type for tests (string | TestGeneratorConfig | Array<...>)
     const existingTests = existingConfig.tests;
     let testsArray: any[] = [];
@@ -99,7 +101,7 @@ export async function doGenerateDataset(options: DatasetGenerateOptions): Promis
       testsArray = [existingTests];
     }
     existingConfig.tests = [...testsArray, ...configAddition.tests];
-    fs.writeFileSync(configPath, yaml.dump(existingConfig));
+    await fs.writeFile(configPath, yaml.dump(existingConfig));
     logger.info(`Wrote ${results.length} new test cases to ${configPath}`);
     const runCommand = promptfooCommand('eval');
     logger.info(chalk.green(`Run ${chalk.bold(runCommand)} to run the generated tests`));

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { getDb } from '../database/index';
 import { evalsTable } from '../database/tables';
@@ -72,7 +72,7 @@ export function importCommand(program: Command) {
       const db = getDb();
       let evalId: string;
       try {
-        const fileContent = fs.readFileSync(file, 'utf-8');
+        const fileContent = await fs.readFile(file, 'utf-8');
         const evalData = JSON.parse(fileContent);
 
         // Extract fields from correct locations (v3 export format)

--- a/src/commands/mcp/tools/generateDataset.ts
+++ b/src/commands/mcp/tools/generateDataset.ts
@@ -99,10 +99,10 @@ export function registerGenerateDatasetTool(server: McpServer) {
 
         // Save to file if outputPath is provided
         if (outputPath) {
-          const fs = await import('fs');
+          const fs = await import('fs/promises');
           const yaml = await import('js-yaml');
           const yamlContent = yaml.dump({ tests: dataset });
-          fs.writeFileSync(outputPath, yamlContent);
+          await fs.writeFile(outputPath, yamlContent);
         }
 
         // Extract useful information from the result

--- a/src/commands/mcp/tools/generateTestCases.ts
+++ b/src/commands/mcp/tools/generateTestCases.ts
@@ -147,10 +147,10 @@ export function registerGenerateTestCasesTool(server: McpServer) {
 
         // Save to file if outputPath is provided
         if (outputPath) {
-          const fs = await import('fs');
+          const fs = await import('fs/promises');
           const yaml = await import('js-yaml');
           const yamlContent = yaml.dump({ tests });
-          fs.writeFileSync(outputPath, yamlContent);
+          await fs.writeFile(outputPath, yamlContent);
         }
 
         // Analyze the generated test cases

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 import * as path from 'path';
 
 import yaml from 'js-yaml';
@@ -36,7 +36,7 @@ export async function extractTextFromPDF(pdfPath: string): Promise<string> {
   logger.debug(`Extracting text from PDF: ${pdfPath}`);
   try {
     const { PDFParse } = await import('pdf-parse');
-    const dataBuffer = fs.readFileSync(pdfPath);
+    const dataBuffer = await fs.readFile(pdfPath);
     const parser = new PDFParse({ data: dataBuffer });
     const result = await parser.getText();
     await parser.destroy();
@@ -296,7 +296,7 @@ export async function renderPrompt(
         vars[varName] = pythonScriptOutput.output.trim();
       } else if (fileExtension === 'yaml' || fileExtension === 'yml') {
         vars[varName] = JSON.stringify(
-          yaml.load(fs.readFileSync(filePath, 'utf8')) as string | object,
+          yaml.load(await fs.readFile(filePath, 'utf8')) as string | object,
         );
       } else if (fileExtension === 'pdf' && !getEnvBool('PROMPTFOO_DISABLE_PDF_AS_TEXT')) {
         telemetry.record('feature_used', {
@@ -319,7 +319,7 @@ export async function renderPrompt(
 
         logger.debug(`Loading ${fileType} as base64: ${filePath}`);
         try {
-          const fileBuffer = fs.readFileSync(filePath);
+          const fileBuffer = await fs.readFile(filePath);
           const base64Data = fileBuffer.toString('base64');
 
           if (fileType === 'image') {
@@ -357,7 +357,7 @@ export async function renderPrompt(
           );
         }
       } else {
-        vars[varName] = fs.readFileSync(filePath, 'utf8').trim();
+        vars[varName] = (await fs.readFile(filePath, 'utf8')).trim();
       }
     } else if (isPackagePath(value)) {
       const basePath = cliState.basePath || '';

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { loadFromJavaScriptFile } from '../assertions/utils';
@@ -63,10 +63,14 @@ export async function loadRubricPrompt(
       // to allow Nunjucks templating before JSON/YAML parsing.
       // This fixes the issue where .json files with Nunjucks templates
       // would fail to parse before rendering.
-      if (!fs.existsSync(resolvedPath)) {
-        throw new Error(`File does not exist: ${resolvedPath}`);
+      try {
+        rubricPrompt = await fs.readFile(resolvedPath, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(`File does not exist: ${resolvedPath}`);
+        }
+        throw error;
       }
-      rubricPrompt = fs.readFileSync(resolvedPath, 'utf8');
     }
   } else {
     // Load from external file if needed (for non file:// references)

--- a/src/microsoftSharepoint.ts
+++ b/src/microsoftSharepoint.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { getEnvString } from './envars';
 import logger from './logger';
@@ -92,7 +92,7 @@ async function getConfidentialClient(): Promise<ConfidentialClientApplication> {
 
     let pemContent: string;
     try {
-      pemContent = fs.readFileSync(certPath, 'utf8');
+      pemContent = await fs.readFile(certPath, 'utf8');
     } catch (error) {
       throw new Error(`Failed to read certificate from path: ${certPath}. Error: ${error}`);
     }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import confirm from '@inquirer/confirm';
@@ -327,7 +327,9 @@ async function askForPermissionToOverwrite({
   relativePath: string;
   required: boolean;
 }): Promise<boolean> {
-  if (!fs.existsSync(absolutePath)) {
+  try {
+    await fs.access(absolutePath);
+  } catch {
     return true;
   }
 
@@ -373,7 +375,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
       }
     }
 
-    fs.writeFileSync(absolutePath, contents);
+    await fs.writeFile(absolutePath, contents);
     logger.info(`📝 Wrote ${relativePath}`);
   }
 
@@ -382,9 +384,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
   let action: string;
   let language: string;
 
-  if (!fs.existsSync(outDirAbsolute)) {
-    fs.mkdirSync(outDirAbsolute, { recursive: true });
-  }
+  await fs.mkdir(outDirAbsolute, { recursive: true });
 
   if (interactive) {
     recordOnboardingStep('start');

--- a/src/providers/agentic-utils.ts
+++ b/src/providers/agentic-utils.ts
@@ -7,7 +7,7 @@
  */
 
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import dedent from 'dedent';
@@ -34,23 +34,23 @@ const FINGERPRINT_TIMEOUT_MS = 2000;
  * @throws Error if fingerprinting times out or directory is inaccessible
  */
 export async function getWorkingDirFingerprint(workingDir: string): Promise<string> {
-  const dirStat = fs.statSync(workingDir);
+  const dirStat = await fs.stat(workingDir);
   const dirMtime = dirStat.mtimeMs;
 
   const startTime = Date.now();
 
   // Recursively get all files
-  const getAllFiles = (dir: string, files: string[] = []): string[] => {
+  const getAllFiles = async (dir: string, files: string[] = []): Promise<string[]> => {
     if (Date.now() - startTime > FINGERPRINT_TIMEOUT_MS) {
       throw new Error('Working directory fingerprint timed out');
     }
 
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const entries = await fs.readdir(dir, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        getAllFiles(fullPath, files);
+        await getAllFiles(fullPath, files);
       } else if (entry.isFile()) {
         files.push(fullPath);
       }
@@ -58,16 +58,18 @@ export async function getWorkingDirFingerprint(workingDir: string): Promise<stri
     return files;
   };
 
-  const allFiles = getAllFiles(workingDir);
+  const allFiles = await getAllFiles(workingDir);
 
   // Create fingerprint from directory mtime + all file mtimes
-  const fileMtimes = allFiles
-    .map((file: string) => {
-      const stat = fs.statSync(file);
-      const relativePath = path.relative(workingDir, file);
-      return `${relativePath}:${stat.mtimeMs}`;
-    })
-    .sort(); // Sort for consistent ordering
+  const fileMtimes = (
+    await Promise.all(
+      allFiles.map(async (file: string) => {
+        const stat = await fs.stat(file);
+        const relativePath = path.relative(workingDir, file);
+        return `${relativePath}:${stat.mtimeMs}`;
+      }),
+    )
+  ).sort(); // Sort for consistent ordering
 
   const fingerprintData = `dir:${dirMtime};files:${fileMtimes.join(',')}`;
   const fingerprint = crypto.createHash('sha256').update(fingerprintData).digest('hex');

--- a/src/providers/agentic-utils.ts
+++ b/src/providers/agentic-utils.ts
@@ -21,6 +21,7 @@ import type { ProviderResponse } from '../types/index';
  * Prevents hanging on extremely large directories
  */
 const FINGERPRINT_TIMEOUT_MS = 2000;
+const STAT_BATCH_SIZE = 32;
 
 /**
  * Get a fingerprint for a working directory to use as a cache key.
@@ -61,15 +62,23 @@ export async function getWorkingDirFingerprint(workingDir: string): Promise<stri
   const allFiles = await getAllFiles(workingDir);
 
   // Create fingerprint from directory mtime + all file mtimes
-  const fileMtimes = (
-    await Promise.all(
-      allFiles.map(async (file: string) => {
+  const fileMtimes: string[] = [];
+  for (let i = 0; i < allFiles.length; i += STAT_BATCH_SIZE) {
+    if (Date.now() - startTime > FINGERPRINT_TIMEOUT_MS) {
+      throw new Error('Working directory fingerprint timed out');
+    }
+
+    const batch = allFiles.slice(i, i + STAT_BATCH_SIZE);
+    const batchMtimes = await Promise.all(
+      batch.map(async (file: string) => {
         const stat = await fs.stat(file);
         const relativePath = path.relative(workingDir, file);
         return `${relativePath}:${stat.mtimeMs}`;
       }),
-    )
-  ).sort(); // Sort for consistent ordering
+    );
+    fileMtimes.push(...batchMtimes);
+  }
+  fileMtimes.sort(); // Sort for consistent ordering
 
   const fingerprintData = `dir:${dirMtime};files:${fileMtimes.join(',')}`;
   const fingerprint = crypto.createHash('sha256').update(fingerprintData).digest('hex');

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1,6 +1,7 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import type { Stats } from 'node:fs';
 
 import { trace as otelTrace, SpanStatusCode } from '@opentelemetry/api';
 import dedent from 'dedent';
@@ -1140,9 +1141,9 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
 
     if (workingDir) {
       // verify the working dir exists and is a directory
-      let stats: fs.Stats;
+      let stats: Stats;
       try {
-        stats = fs.statSync(workingDir);
+        stats = await fs.stat(workingDir);
       } catch (err: any) {
         throw new Error(
           `Working dir ${config.working_dir} does not exist or isn't accessible: ${err.message}`,
@@ -1153,7 +1154,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       }
     } else if (isTempDir) {
       // use a temp dir
-      workingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-claude-agent-sdk-'));
+      workingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'promptfoo-claude-agent-sdk-'));
     }
 
     // Make sure we didn't already abort
@@ -1477,7 +1478,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
     } finally {
       if (isTempDir && workingDir) {
         // Clean up the temp dir
-        fs.rmSync(workingDir, { recursive: true, force: true });
+        await fs.rm(workingDir, { recursive: true, force: true });
       }
       if (callOptions?.abortSignal && abortHandler) {
         callOptions.abortSignal.removeEventListener('abort', abortHandler);

--- a/src/providers/elevenlabs/stt/index.ts
+++ b/src/providers/elevenlabs/stt/index.ts
@@ -9,7 +9,7 @@
  */
 
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { getCache, isCacheEnabled } from '../../../cache';
@@ -241,7 +241,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
   private async readAudioFile(filePath: string): Promise<Buffer> {
     try {
       const resolvedPath = path.resolve(filePath);
-      return await fs.promises.readFile(resolvedPath);
+      return await fs.readFile(resolvedPath);
     } catch (error) {
       throw new Error(
         `Failed to read audio file: ${error instanceof Error ? error.message : String(error)}`,
@@ -303,7 +303,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
   /**
    * Generate cache key for audio file
    */
-  private getCacheKey(audioFilePath: string): string {
+  private async getCacheKey(audioFilePath: string): Promise<string> {
     const configHash = crypto
       .createHash('sha256')
       .update(
@@ -318,7 +318,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
       .slice(0, 16);
 
     // Include file modification time in cache key
-    const stats = fs.statSync(audioFilePath);
+    const stats = await fs.stat(audioFilePath);
     const mtime = stats.mtime.getTime();
 
     const fileHash = crypto
@@ -336,7 +336,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
   private async getCachedResponse(audioFilePath: string): Promise<ProviderResponse | null> {
     try {
       const cache = await getCache();
-      const cacheKey = this.getCacheKey(audioFilePath);
+      const cacheKey = await this.getCacheKey(audioFilePath);
       const cached = await cache.get(cacheKey);
 
       if (cached) {
@@ -360,7 +360,7 @@ export class ElevenLabsSTTProvider implements ApiProvider {
   private async cacheResponse(audioFilePath: string, response: ProviderResponse): Promise<void> {
     try {
       const cache = await getCache();
-      const cacheKey = this.getCacheKey(audioFilePath);
+      const cacheKey = await this.getCacheKey(audioFilePath);
       await cache.set(cacheKey, response);
 
       logger.debug('[ElevenLabs STT] Response cached', { audioFilePath });

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process';
-import fs from 'fs';
+import * as fsSync from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import util from 'util';
@@ -55,7 +56,7 @@ export class GolangProvider implements ApiProvider {
   private findModuleRoot(startPath: string): string {
     let currentPath = startPath;
     while (currentPath !== path.dirname(currentPath)) {
-      if (fs.existsSync(path.join(currentPath, 'go.mod'))) {
+      if (fsSync.existsSync(path.join(currentPath, 'go.mod'))) {
         return currentPath;
       }
       currentPath = path.dirname(currentPath);
@@ -72,7 +73,7 @@ export class GolangProvider implements ApiProvider {
     const moduleRoot = this.findModuleRoot(path.dirname(absPath));
     logger.debug(`Found module root at ${moduleRoot}`);
     logger.debug(`Computing file hash for script ${absPath}`);
-    const fileHash = sha256(fs.readFileSync(absPath, 'utf-8'));
+    const fileHash = sha256(await fs.readFile(absPath, 'utf-8'));
     const cacheKey = `golang:${this.scriptPath}:${apiType}:${fileHash}:${prompt}:${JSON.stringify(
       this.options,
     )}:${JSON.stringify(context?.vars)}`;
@@ -106,33 +107,33 @@ export class GolangProvider implements ApiProvider {
       let tempDir: string | undefined;
       try {
         // Create temp directory
-        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'golang-provider-'));
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'golang-provider-'));
 
         // Helper function to copy directory recursively
-        const copyDir = (src: string, dest: string) => {
-          fs.mkdirSync(dest, { recursive: true });
-          const entries = fs.readdirSync(src, { withFileTypes: true });
+        const copyDir = async (src: string, dest: string): Promise<void> => {
+          await fs.mkdir(dest, { recursive: true });
+          const entries = await fs.readdir(src, { withFileTypes: true });
           for (const entry of entries) {
             const srcPath = path.join(src, entry.name);
             const destPath = path.join(dest, entry.name);
             if (entry.isDirectory()) {
-              copyDir(srcPath, destPath);
+              await copyDir(srcPath, destPath);
             } else {
-              fs.copyFileSync(srcPath, destPath);
+              await fs.copyFile(srcPath, destPath);
             }
           }
         };
 
         // Copy the entire module structure
-        copyDir(moduleRoot, tempDir);
+        await copyDir(moduleRoot, tempDir);
 
         const relativeScriptPath = path.relative(moduleRoot, absPath);
         const scriptDir = path.dirname(path.join(tempDir, relativeScriptPath));
 
         // Copy wrapper.go to the same directory as the script
         const tempWrapperPath = path.join(scriptDir, 'wrapper.go');
-        fs.mkdirSync(scriptDir, { recursive: true });
-        fs.copyFileSync(path.join(getWrapperDir('golang'), 'wrapper.go'), tempWrapperPath);
+        await fs.mkdir(scriptDir, { recursive: true });
+        await fs.copyFile(path.join(getWrapperDir('golang'), 'wrapper.go'), tempWrapperPath);
 
         const executablePath = path.join(tempDir, 'golang_wrapper');
         const tempScriptPath = path.join(tempDir, relativeScriptPath);
@@ -172,7 +173,7 @@ export class GolangProvider implements ApiProvider {
       } finally {
         // Clean up temporary directory
         if (tempDir) {
-          fs.rmSync(tempDir, { recursive: true, force: true });
+          await fs.rm(tempDir, { recursive: true, force: true });
         }
       }
     }

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -312,10 +312,15 @@ function isBase64(str: string): boolean {
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
-  return fs
-    .access(filePath)
-    .then(() => true)
-    .catch(() => false);
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs/promises';
 import http from 'http';
 import https from 'https';
 import path from 'path';
@@ -311,6 +311,13 @@ function isBase64(str: string): boolean {
   return str.length % 4 === 0 && base64Regex.test(str) && str.length > 100;
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+  return fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+}
+
 /**
  * Generate signature using different certificate types
  */
@@ -340,7 +347,7 @@ export async function generateSignature(
       case 'pem': {
         if (signatureAuth.privateKeyPath) {
           const resolvedPath = safeResolve(cliState.basePath || '', signatureAuth.privateKeyPath);
-          privateKey = fs.readFileSync(resolvedPath, 'utf8');
+          privateKey = await fs.readFile(resolvedPath, 'utf8');
         } else if (signatureAuth.privateKey) {
           privateKey = signatureAuth.privateKey;
         } else if (signatureAuth.certificateContent) {
@@ -384,7 +391,7 @@ export async function generateSignature(
         } else if (signatureAuth.keystorePath) {
           // Use file path (existing behavior)
           const resolvedPath = safeResolve(cliState.basePath || '', signatureAuth.keystorePath);
-          keystoreData = fs.readFileSync(resolvedPath);
+          keystoreData = await fs.readFile(resolvedPath);
         } else {
           throw new Error(
             'JKS keystore content or path is required. Provide keystoreContent/certificateContent or keystorePath',
@@ -480,7 +487,7 @@ export async function generateSignature(
               const resolvedPath = safeResolve(cliState.basePath || '', signatureAuth.pfxPath);
               logger.debug(`[Signature Auth] Loading PFX file: ${resolvedPath}`);
               try {
-                const stat = await fs.promises.stat(resolvedPath);
+                const stat = await fs.stat(resolvedPath);
                 logger.debug(`[Signature Auth][PFX] PFX file size: ${stat.size} bytes`);
               } catch (e) {
                 logger.debug(`[Signature Auth][PFX] Could not stat PFX file: ${String(e)}`);
@@ -543,14 +550,14 @@ export async function generateSignature(
               );
 
               // Read the private key directly from the key file
-              if (!fs.existsSync(resolvedKeyPath)) {
+              if (!(await fileExists(resolvedKeyPath))) {
                 throw new Error(`Key file not found: ${resolvedKeyPath}`);
               }
-              if (!fs.existsSync(resolvedCertPath)) {
+              if (!(await fileExists(resolvedCertPath))) {
                 throw new Error(`Certificate file not found: ${resolvedCertPath}`);
               }
 
-              privateKey = fs.readFileSync(resolvedKeyPath, 'utf8');
+              privateKey = await fs.readFile(resolvedKeyPath, 'utf8');
               logger.debug(
                 `[Signature Auth][PFX] Loaded key file characters: ${privateKey.length}`,
               );
@@ -1369,7 +1376,7 @@ async function createHttpsAgent(tlsConfig: z.infer<typeof TlsCertificateSchema>)
     tlsOptions.ca = tlsConfig.ca;
   } else if (tlsConfig.caPath) {
     const resolvedPath = safeResolve(cliState.basePath || '', tlsConfig.caPath);
-    tlsOptions.ca = fs.readFileSync(resolvedPath, 'utf8');
+    tlsOptions.ca = await fs.readFile(resolvedPath, 'utf8');
     logger.debug(`[HTTP Provider] Loaded CA certificate from ${resolvedPath}`);
   }
 
@@ -1403,7 +1410,7 @@ async function createHttpsAgent(tlsConfig: z.infer<typeof TlsCertificateSchema>)
         // Use file path
         const resolvedPath = safeResolve(cliState.basePath || '', (tlsConfig as any).jksPath);
         logger.debug(`[HTTP Provider] Loading JKS from file for TLS: ${resolvedPath}`);
-        keystoreData = fs.readFileSync(resolvedPath);
+        keystoreData = await fs.readFile(resolvedPath);
       } else {
         throw new Error('JKS content or path is required');
       }
@@ -1452,7 +1459,7 @@ async function createHttpsAgent(tlsConfig: z.infer<typeof TlsCertificateSchema>)
       tlsOptions.cert = tlsConfig.cert;
     } else if (tlsConfig.certPath) {
       const resolvedPath = safeResolve(cliState.basePath || '', tlsConfig.certPath);
-      tlsOptions.cert = fs.readFileSync(resolvedPath, 'utf8');
+      tlsOptions.cert = await fs.readFile(resolvedPath, 'utf8');
       logger.debug(`[HTTP Provider] Loaded client certificate from ${resolvedPath}`);
     }
 
@@ -1461,7 +1468,7 @@ async function createHttpsAgent(tlsConfig: z.infer<typeof TlsCertificateSchema>)
       tlsOptions.key = tlsConfig.key;
     } else if (tlsConfig.keyPath) {
       const resolvedPath = safeResolve(cliState.basePath || '', tlsConfig.keyPath);
-      tlsOptions.key = fs.readFileSync(resolvedPath, 'utf8');
+      tlsOptions.key = await fs.readFile(resolvedPath, 'utf8');
       logger.debug(`[HTTP Provider] Loaded private key from ${resolvedPath}`);
     }
   }
@@ -1486,7 +1493,7 @@ async function createHttpsAgent(tlsConfig: z.infer<typeof TlsCertificateSchema>)
     }
   } else if (tlsConfig.pfxPath) {
     const resolvedPath = safeResolve(cliState.basePath || '', tlsConfig.pfxPath);
-    tlsOptions.pfx = fs.readFileSync(resolvedPath);
+    tlsOptions.pfx = await fs.readFile(resolvedPath);
     logger.debug(`[HTTP Provider] Loaded PFX certificate from ${resolvedPath}`);
   }
 

--- a/src/providers/openai/transcription.ts
+++ b/src/providers/openai/transcription.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { fetchWithCache } from '../../cache';
@@ -78,15 +78,9 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
     // The prompt should be a file path to an audio file
     const audioFilePath = prompt.trim();
 
-    if (!fs.existsSync(audioFilePath)) {
-      return {
-        error: `Audio file not found: ${audioFilePath}`,
-      };
-    }
-
     try {
       // Read the audio file and create a File object for native FormData
-      const fileBuffer = fs.readFileSync(audioFilePath);
+      const fileBuffer = await fs.readFile(audioFilePath);
       const fileName = path.basename(audioFilePath);
       const file = new File([fileBuffer], fileName);
 
@@ -247,6 +241,11 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
         },
       };
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {
+          error: `Audio file not found: ${audioFilePath}`,
+        };
+      }
       logger.error('Transcription error', { error: err });
       return {
         error: `Transcription error: ${String(err)}`,

--- a/src/providers/openai/transcription.ts
+++ b/src/providers/openai/transcription.ts
@@ -78,9 +78,19 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
     // The prompt should be a file path to an audio file
     const audioFilePath = prompt.trim();
 
+    let fileBuffer: Awaited<ReturnType<typeof fs.readFile>>;
     try {
-      // Read the audio file and create a File object for native FormData
-      const fileBuffer = await fs.readFile(audioFilePath);
+      fileBuffer = await fs.readFile(audioFilePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { error: `Audio file not found: ${audioFilePath}` };
+      }
+      logger.error('Failed to read audio file', { error: err, audioFilePath });
+      return { error: `Failed to read audio file ${audioFilePath}: ${String(err)}` };
+    }
+
+    try {
+      // Create a File object for native FormData from the loaded buffer
       const fileName = path.basename(audioFilePath);
       const file = new File([fileBuffer], fileName);
 
@@ -241,11 +251,6 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
         },
       };
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-        return {
-          error: `Audio file not found: ${audioFilePath}`,
-        };
-      }
       logger.error('Transcription error', { error: err });
       return {
         error: `Transcription error: ${String(err)}`,

--- a/src/providers/openai/video.ts
+++ b/src/providers/openai/video.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import logger from '../../logger';
 import { getMediaStorage, storeMedia } from '../../storage';
@@ -182,10 +182,13 @@ export class OpenAiVideoProvider extends OpenAiGenericProvider {
       let imageData = config.input_reference;
       if (config.input_reference.startsWith('file://')) {
         const filePath = config.input_reference.slice(7);
-        if (fs.existsSync(filePath)) {
-          const buffer = fs.readFileSync(filePath);
+        try {
+          const buffer = await fs.readFile(filePath);
           imageData = buffer.toString('base64');
-        } else {
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw error;
+          }
           return {
             job: {} as OpenAiVideoJob,
             error: `Input reference file not found: ${filePath}`,

--- a/src/providers/pythonCompletion.ts
+++ b/src/providers/pythonCompletion.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { getCache, isCacheEnabled } from '../cache';
@@ -326,7 +326,7 @@ export class PythonProvider implements ApiProvider {
 
     const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
     logger.debug(`Computing file hash for script ${absPath}`);
-    const fileHash = sha256(fs.readFileSync(absPath, 'utf-8'));
+    const fileHash = sha256(await fs.readFile(absPath, 'utf-8'));
 
     // Create cache key including the function name to ensure different functions don't share caches
     const cacheKey = `python:${this.scriptPath}:${this.functionName || 'default'}:${apiType}:${fileHash}:${prompt}:${JSON.stringify(

--- a/src/providers/rubyCompletion.ts
+++ b/src/providers/rubyCompletion.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { getCache, isCacheEnabled } from '../cache';
@@ -245,7 +245,7 @@ export class RubyProvider implements ApiProvider {
 
     const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
     logger.debug(`Computing file hash for script ${absPath}`);
-    const fileHash = sha256(fs.readFileSync(absPath, 'utf-8'));
+    const fileHash = sha256(await fs.readFile(absPath, 'utf-8'));
 
     // Create cache key including the function name to ensure different functions don't share caches
     const cacheKey = `ruby:${this.scriptPath}:${this.functionName || 'default'}:${apiType}:${fileHash}:${prompt}:${safeJsonStringify(

--- a/src/providers/video/utils.ts
+++ b/src/providers/video/utils.ts
@@ -6,6 +6,7 @@
  */
 import crypto from 'crypto';
 import fs from 'fs';
+import fsPromises from 'fs/promises';
 import path from 'path';
 
 import logger from '../../logger';
@@ -98,12 +99,8 @@ export async function checkVideoCache(
 ): Promise<string | null> {
   const mappingPath = getCacheMappingPath(cacheKey);
 
-  if (!fs.existsSync(mappingPath)) {
-    return null;
-  }
-
   try {
-    const mappingData = fs.readFileSync(mappingPath, 'utf8');
+    const mappingData = await fsPromises.readFile(mappingPath, 'utf8');
     const mapping: VideoCacheMapping = JSON.parse(mappingData);
     // Verify the referenced video file still exists in storage
     if (mapping.videoKey) {
@@ -113,6 +110,9 @@ export async function checkVideoCache(
       }
     }
   } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
     // Mapping file corrupted, treat as cache miss
     logger.debug(`[${providerName}] Cache mapping read failed: ${err}`);
   }

--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
@@ -325,7 +325,7 @@ export async function runPython<T = unknown>(
   };
 
   try {
-    fs.writeFileSync(tempJsonPath, safeJsonStringify(args) as string, 'utf-8');
+    await fs.writeFile(tempJsonPath, safeJsonStringify(args) as string, 'utf-8');
     logger.debug(`Running Python wrapper with args: ${safeJsonStringify(args)}`);
 
     await new Promise<void>((resolve, reject) => {
@@ -352,7 +352,7 @@ export async function runPython<T = unknown>(
       }
     });
 
-    const output = fs.readFileSync(outputPath, 'utf-8');
+    const output = await fs.readFile(outputPath, 'utf-8');
     logger.debug(`Python script ${absPath} returned: ${output}`);
 
     let result: { type: 'final_result'; data: T } | undefined;
@@ -387,12 +387,14 @@ export async function runPython<T = unknown>(
       }`,
     );
   } finally {
-    [tempJsonPath, outputPath].forEach((file) => {
-      try {
-        fs.unlinkSync(file);
-      } catch (error) {
-        logger.error(`Error removing ${file}: ${error}`);
-      }
-    });
+    await Promise.all(
+      [tempJsonPath, outputPath].map(async (file) => {
+        try {
+          await fs.unlink(file);
+        } catch (error) {
+          logger.error(`Error removing ${file}: ${error}`);
+        }
+      }),
+    );
   }
 }

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -129,7 +129,7 @@ export class PythonWorker {
 
     try {
       // Write request
-      fs.writeFileSync(requestFile, safeJsonStringify(args) as string, 'utf-8');
+      await fs.writeFile(requestFile, safeJsonStringify(args) as string, 'utf-8');
 
       // Send CALL command with function name
       // Note: PythonShell.send() adds newline automatically in 'text' mode
@@ -151,7 +151,7 @@ export class PythonWorker {
       // Total max wait: ~18 seconds (handles severe filesystem delays)
       for (let attempt = 0, delay = 1; attempt < 16; attempt++, delay = Math.min(delay * 2, 5000)) {
         try {
-          responseData = fs.readFileSync(responseFile, 'utf-8');
+          responseData = await fs.readFile(responseFile, 'utf-8');
           if (attempt > 0) {
             logger.debug(`Response file read succeeded on attempt ${attempt + 1} after ${delay}ms`);
           }
@@ -172,7 +172,9 @@ export class PythonWorker {
       if (!responseData!) {
         const tempDir = path.dirname(responseFile);
         try {
-          const files = fs.readdirSync(tempDir).filter((f) => f.startsWith('promptfoo-worker-'));
+          const files = (await fs.readdir(tempDir)).filter((f) =>
+            f.startsWith('promptfoo-worker-'),
+          );
           logger.error(
             `Failed to read response file after 16 attempts (~18s). Expected: ${path.basename(responseFile)}, Found in ${tempDir}: ${files.join(', ')}`,
           );
@@ -191,15 +193,17 @@ export class PythonWorker {
       return response.data;
     } finally {
       // Cleanup temp files
-      [requestFile, responseFile].forEach((file) => {
-        try {
-          if (fs.existsSync(file)) {
-            fs.unlinkSync(file);
+      await Promise.all(
+        [requestFile, responseFile].map(async (file) => {
+          try {
+            await fs.unlink(file);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+              logger.error(`Error removing ${file}: ${error}`);
+            }
           }
-        } catch (error) {
-          logger.error(`Error removing ${file}: ${error}`);
-        }
-      });
+        }),
+      );
     }
   }
 

--- a/src/python/wrapper.ts
+++ b/src/python/wrapper.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -22,7 +22,7 @@ export async function runPythonCode<T = unknown>(
     `temp-python-code-${Date.now()}-${Math.random().toString(16).slice(2)}.py`,
   );
   try {
-    fs.writeFileSync(tempFilePath, code);
+    await fs.writeFile(tempFilePath, code);
     // Necessary to await so temp file doesn't get deleted.
     const result = await runPython<T>(tempFilePath, method, args);
     return result;
@@ -31,7 +31,7 @@ export async function runPythonCode<T = unknown>(
     throw error;
   } finally {
     try {
-      fs.unlinkSync(tempFilePath);
+      await fs.unlink(tempFilePath);
     } catch (error) {
       logger.error(`Error removing temporary file: ${error}`);
     }

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -386,9 +386,7 @@ export function discoverCommand(
             throw new Error(`Config not found at ${args.config}`);
           }
           const message = error instanceof Error ? error.message : String(error);
-          throw new Error(`Unable to access config at ${args.config}: ${message}`, {
-            cause: error,
-          });
+          throw new Error(`Unable to access config at ${args.config}: ${message}`);
         }
 
         config = await readConfig(args.config);

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import * as fs from 'fs';
+import fs from 'fs/promises';
 
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
@@ -379,7 +379,11 @@ export function discoverCommand(
       // If user provides a config, read the target from it:
       if (args.config) {
         // Validate that the config is a valid path:
-        if (!fs.existsSync(args.config)) {
+        const configExists = await fs
+          .access(args.config)
+          .then(() => true)
+          .catch(() => false);
+        if (!configExists) {
           throw new Error(`Config not found at ${args.config}`);
         }
 

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -379,12 +379,16 @@ export function discoverCommand(
       // If user provides a config, read the target from it:
       if (args.config) {
         // Validate that the config is a valid path:
-        const configExists = await fs
-          .access(args.config)
-          .then(() => true)
-          .catch(() => false);
-        if (!configExists) {
-          throw new Error(`Config not found at ${args.config}`);
+        try {
+          await fs.access(args.config);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            throw new Error(`Config not found at ${args.config}`);
+          }
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`Unable to access config at ${args.config}: ${message}`, {
+            cause: error,
+          });
         }
 
         config = await readConfig(args.config);

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import * as fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import chalk from 'chalk';
@@ -106,8 +106,15 @@ function handleFailedPlugins(failedPlugins: FailedPluginInfo[], strict: boolean)
   );
 }
 
-function getConfigHash(configPath: string): string {
-  const content = fs.readFileSync(configPath, 'utf8');
+async function pathExists(filePath: string): Promise<boolean> {
+  return fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function getConfigHash(configPath: string): Promise<string> {
+  const content = await fs.readFile(configPath, 'utf8');
   return createHash('md5').update(`${VERSION}:${content}`).digest('hex');
 }
 
@@ -200,8 +207,8 @@ export async function doGenerateRedteam(
     // Write configFromCloud to a temporary file
     const filename = `redteam-generate-${Date.now()}.yaml`;
     const tmpFile = path.join('', filename);
-    fs.mkdirSync(path.dirname(tmpFile), { recursive: true });
-    fs.writeFileSync(tmpFile, yaml.dump(options.configFromCloud));
+    await fs.mkdir(path.dirname(tmpFile), { recursive: true });
+    await fs.writeFile(tmpFile, yaml.dump(options.configFromCloud));
     configPath = tmpFile;
     logger.debug(`Using Promptfoo Cloud-originated config at ${tmpFile}`);
   }
@@ -211,13 +218,15 @@ export async function doGenerateRedteam(
     !options.force &&
     !options.configFromCloud &&
     !outputPath.endsWith('.burp') &&
-    fs.existsSync(outputPath) &&
+    (await pathExists(outputPath)) &&
     configPath &&
-    fs.existsSync(configPath)
+    (await pathExists(configPath))
   ) {
-    const redteamContent = yaml.load(fs.readFileSync(outputPath, 'utf8')) as Partial<UnifiedConfig>;
+    const redteamContent = yaml.load(
+      await fs.readFile(outputPath, 'utf8'),
+    ) as Partial<UnifiedConfig>;
     const storedHash = redteamContent.metadata?.configHash;
-    const currentHash = getConfigHash(configPath);
+    const currentHash = await getConfigHash(configPath);
 
     if (storedHash === currentHash) {
       logger.warn(
@@ -691,7 +700,7 @@ export async function doGenerateRedteam(
         })
         .filter((line) => line.length > 0)
         .join('\n');
-      fs.writeFileSync(options.output, outputLines);
+      await fs.writeFile(options.output, outputLines);
       logger.info(
         chalk.green(`Wrote ${redteamTests.length} test cases to ${chalk.bold(options.output)}`),
       );
@@ -699,7 +708,7 @@ export async function doGenerateRedteam(
       return {};
     } else if (options.output) {
       const existingYaml = configPath
-        ? (yaml.load(fs.readFileSync(configPath, 'utf8')) as Partial<UnifiedConfig>)
+        ? (yaml.load(await fs.readFile(configPath, 'utf8')) as Partial<UnifiedConfig>)
         : {};
       const existingDefaultTest =
         typeof existingYaml.defaultTest === 'object' ? existingYaml.defaultTest : {};
@@ -719,7 +728,7 @@ export async function doGenerateRedteam(
         metadata: {
           ...(existingYaml.metadata || {}),
           ...(configPath && redteamTests.length > 0
-            ? { configHash: getConfigHash(configPath) }
+            ? { configHash: await getConfigHash(configPath) }
             : { configHash: 'force-regenerate' }),
           ...(pluginSeverityOverridesId ? { pluginSeverityOverridesId } : {}),
         },
@@ -757,7 +766,7 @@ export async function doGenerateRedteam(
       printBorder();
     } else if (options.write && configPath) {
       const existingConfig = yaml.load(
-        fs.readFileSync(configPath, 'utf8'),
+        await fs.readFile(configPath, 'utf8'),
       ) as Partial<UnifiedConfig>;
       const existingTests = existingConfig.tests;
       let testsArray: any[] = [];
@@ -784,7 +793,7 @@ export async function doGenerateRedteam(
       // Add the config hash to metadata
       existingConfig.metadata = {
         ...(existingConfig.metadata || {}),
-        configHash: getConfigHash(configPath),
+        configHash: await getConfigHash(configPath),
       };
       const author = getAuthor();
       const userEmail = getUserEmail();

--- a/src/redteam/commands/init.ts
+++ b/src/redteam/commands/init.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import * as path from 'path';
 
 import checkbox, { Separator } from '@inquirer/checkbox';
@@ -210,8 +210,8 @@ export async function redteamInit(directory: string | undefined) {
   recordOnboardingStep('start');
 
   const projectDir = directory || '.';
-  if (projectDir !== '.' && !fs.existsSync(projectDir)) {
-    fs.mkdirSync(projectDir, { recursive: true });
+  if (projectDir !== '.') {
+    await fs.mkdir(projectDir, { recursive: true });
   }
 
   const configPath = path.join(projectDir, 'promptfooconfig.yaml');
@@ -618,10 +618,10 @@ export async function redteamInit(directory: string | undefined) {
     providers,
     descriptions: subCategoryDescriptions,
   });
-  fs.writeFileSync(configPath, redteamConfig, 'utf8');
+  await fs.writeFile(configPath, redteamConfig, 'utf8');
 
   if (writeChatPy) {
-    fs.writeFileSync(path.join(projectDir, 'chat.py'), CUSTOM_PROVIDER_TEMPLATE, 'utf8');
+    await fs.writeFile(path.join(projectDir, 'chat.py'), CUSTOM_PROVIDER_TEMPLATE, 'utf8');
   }
 
   console.clear();

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -1,4 +1,5 @@
-import * as fs from 'fs';
+import * as fsSync from 'fs';
+import fs from 'fs/promises';
 import * as path from 'path';
 
 import chalk from 'chalk';
@@ -40,11 +41,11 @@ type Document = {
 };
 
 export function getAllFiles(dirPath: string, arrayOfFiles: string[] = []): string[] {
-  const files = fs.readdirSync(dirPath);
+  const files = fsSync.readdirSync(dirPath);
 
   files.forEach((file) => {
     const fullPath = path.join(dirPath, file);
-    if (fs.statSync(fullPath).isDirectory()) {
+    if (fsSync.statSync(fullPath).isDirectory()) {
       arrayOfFiles = getAllFiles(fullPath, arrayOfFiles);
     } else {
       arrayOfFiles.push(fullPath);
@@ -92,7 +93,7 @@ export async function poisonDocument(
   logger.debug(`Poisoning ${JSON.stringify(doc)}`);
 
   try {
-    const documentContent = doc.isFile ? fs.readFileSync(doc.docLike, 'utf-8') : doc.docLike;
+    const documentContent = doc.isFile ? await fs.readFile(doc.docLike, 'utf-8') : doc.docLike;
     const result = await generatePoisonedDocument(documentContent, goal);
 
     if (doc.isFile) {
@@ -110,14 +111,14 @@ export async function poisonDocument(
       outputFilePath = path.join(outputDir, docPath);
 
       // Create necessary subdirectories
-      fs.mkdirSync(path.dirname(outputFilePath), { recursive: true });
+      await fs.mkdir(path.dirname(outputFilePath), { recursive: true });
     } else {
       // Generate a filename for / from the document content
       const hash = Buffer.from(documentContent).toString('base64').slice(0, 8);
       outputFilePath = path.join(outputDir, `poisoned-${hash}.txt`);
     }
 
-    fs.writeFileSync(outputFilePath, result.poisonedDocument);
+    await fs.writeFile(outputFilePath, result.poisonedDocument);
     logger.debug(`Wrote poisoned document to ${outputFilePath}`);
 
     logger.info(chalk.green(`✓ Successfully poisoned ${doc.isFile ? doc.docLike : 'document'}`));
@@ -137,7 +138,7 @@ export async function doPoisonDocuments(options: PoisonOptions) {
   const outputDir = options.outputDir || 'poisoned-documents';
 
   // Always create output directory since we're always using it
-  fs.mkdirSync(outputDir, { recursive: true });
+  await fs.mkdir(outputDir, { recursive: true });
 
   logger.info(chalk.blue('Generating poisoned documents...'));
 
@@ -146,8 +147,8 @@ export async function doPoisonDocuments(options: PoisonOptions) {
 
   for (const doc of options.documents) {
     // Is the document a ∈{file|directory} path or document content?
-    if (fs.existsSync(doc)) {
-      const stat = fs.statSync(doc);
+    const stat = await fs.stat(doc).catch(() => undefined);
+    if (stat) {
       if (stat.isDirectory()) {
         docs = [
           ...docs,
@@ -168,7 +169,7 @@ export async function doPoisonDocuments(options: PoisonOptions) {
   );
 
   // Write summary YAML file
-  fs.writeFileSync(outputPath, yaml.dump({ documents: results }));
+  await fs.writeFile(outputPath, yaml.dump({ documents: results }));
   logger.info(chalk.green(`\nWrote ${results.length} poisoned documents summary to ${outputPath}`));
 }
 

--- a/src/redteam/plugins/donotanswer.ts
+++ b/src/redteam/plugins/donotanswer.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { parse } from 'csv-parse/sync';
 import logger from '../../logger';
@@ -64,7 +64,7 @@ export async function fetchDataset(limit: number): Promise<DoNotAnswerTestCase[]
     } else {
       // Read from local file
       try {
-        csvData = fs.readFileSync(DATASET_URL, 'utf8');
+        csvData = await fs.readFile(DATASET_URL, 'utf8');
       } catch (error) {
         throw new Error(`[DoNotAnswer] Error reading local file: ${error}`);
       }

--- a/src/redteam/plugins/xstest.ts
+++ b/src/redteam/plugins/xstest.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { parse } from 'csv-parse/sync';
 import logger from '../../logger';
@@ -56,7 +56,7 @@ export async function fetchDataset(limit: number): Promise<XSTestTestCase[]> {
     } else {
       // Read from local file
       try {
-        csvData = fs.readFileSync(DATASET_URL, 'utf8');
+        csvData = await fs.readFile(DATASET_URL, 'utf8');
       } catch (error) {
         throw new Error(`[XSTest] Error reading local file: ${error}`);
       }

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -66,8 +66,8 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
     const filename = `redteam-${Date.now()}.yaml`;
     const tmpDir = options.loadedFromCloud ? '' : os.tmpdir();
     const tmpFile = path.join(tmpDir, filename);
-    fs.mkdirSync(path.dirname(tmpFile), { recursive: true });
-    fs.writeFileSync(tmpFile, yaml.dump(options.liveRedteamConfig));
+    await fs.mkdir(path.dirname(tmpFile), { recursive: true });
+    await fs.writeFile(tmpFile, yaml.dump(options.liveRedteamConfig));
     redteamPath = tmpFile;
     // Do not use default config.
     configPath = tmpFile;
@@ -113,7 +113,11 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
   const generationDurationMs = Date.now() - generationStartTime;
 
   // Check if redteam.yaml exists before running evaluation
-  if (!redteamConfig || !fs.existsSync(redteamPath)) {
+  const redteamPathExists = await fs
+    .access(redteamPath)
+    .then(() => true)
+    .catch(() => false);
+  if (!redteamConfig || !redteamPathExists) {
     logger.info('No test cases generated. Skipping scan.');
     if (verboseToggleCleanup) {
       verboseToggleCleanup();

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -113,10 +113,15 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
   const generationDurationMs = Date.now() - generationStartTime;
 
   // Check if redteam.yaml exists before running evaluation
-  const redteamPathExists = await fs
-    .access(redteamPath)
-    .then(() => true)
-    .catch(() => false);
+  let redteamPathExists = false;
+  try {
+    await fs.access(redteamPath);
+    redteamPathExists = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
   if (!redteamConfig || !redteamPathExists) {
     logger.info('No test cases generated. Skipping scan.');
     if (verboseToggleCleanup) {

--- a/src/redteam/strategies/simpleVideo.ts
+++ b/src/redteam/strategies/simpleVideo.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -128,7 +129,7 @@ async function textToVideo(text: string): Promise<string> {
           outputPath,
         ]);
 
-        const videoData = fs.readFileSync(outputPath);
+        const videoData = await fsPromises.readFile(outputPath);
         const base64Video = videoData.toString('base64');
         cleanup();
         return base64Video;
@@ -258,7 +259,7 @@ export async function addVideoToBase64(
 export async function writeVideoFile(base64Video: string, outputFilePath: string): Promise<void> {
   try {
     const videoBuffer = Buffer.from(base64Video, 'base64');
-    fs.writeFileSync(outputFilePath, videoBuffer);
+    await fsPromises.writeFile(outputFilePath, videoBuffer);
     logger.info(`Video file written to: ${outputFilePath}`);
   } catch (error) {
     logger.error(`Failed to write video file: ${error}`);

--- a/src/ruby/rubyUtils.ts
+++ b/src/ruby/rubyUtils.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
@@ -297,7 +297,7 @@ export async function runRuby<T = unknown>(
   const wrapperPath = path.join(getWrapperDir('ruby'), 'wrapper.rb');
 
   try {
-    fs.writeFileSync(tempJsonPath, safeJsonStringify(args) as string, 'utf-8');
+    await fs.writeFile(tempJsonPath, safeJsonStringify(args) as string, 'utf-8');
     logger.debug(`Running Ruby wrapper with args: ${safeJsonStringify(args)}`);
 
     const { stdout, stderr } = await execFileAsync(rubyPath, [
@@ -316,7 +316,7 @@ export async function runRuby<T = unknown>(
       logger.error(stderr.trim());
     }
 
-    const output = fs.readFileSync(outputPath, 'utf-8');
+    const output = await fs.readFile(outputPath, 'utf-8');
     logger.debug(`Ruby script ${absPath} returned: ${output}`);
 
     let result: { type: 'final_result'; data: T } | undefined;
@@ -349,12 +349,14 @@ export async function runRuby<T = unknown>(
       }`,
     );
   } finally {
-    [tempJsonPath, outputPath].forEach((file) => {
-      try {
-        fs.unlinkSync(file);
-      } catch (error) {
-        logger.error(`Error removing ${file}: ${error}`);
-      }
-    });
+    await Promise.all(
+      [tempJsonPath, outputPath].map(async (file) => {
+        try {
+          await fs.unlink(file);
+        } catch (error) {
+          logger.error(`Error removing ${file}: ${error}`);
+        }
+      }),
+    );
   }
 }

--- a/src/ruby/wrapper.ts
+++ b/src/ruby/wrapper.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -22,7 +22,7 @@ export async function runRubyCode<T = unknown>(
     `temp-ruby-code-${Date.now()}-${Math.random().toString(16).slice(2)}.rb`,
   );
   try {
-    fs.writeFileSync(tempFilePath, code);
+    await fs.writeFile(tempFilePath, code);
     // Necessary to await so temp file doesn't get deleted.
     const result = await runRuby<T>(tempFilePath, method, args);
     return result;
@@ -31,7 +31,7 @@ export async function runRubyCode<T = unknown>(
     throw error;
   } finally {
     try {
-      fs.unlinkSync(tempFilePath);
+      await fs.unlink(tempFilePath);
     } catch (error) {
       logger.error(`Error removing temporary file: ${error}`);
     }

--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -159,14 +159,17 @@ modelAuditRouter.post('/check-path', async (req: Request, res: Response): Promis
       ? expandedPath
       : path.resolve(process.cwd(), expandedPath);
 
-    // Check if path exists
-    if (!fs.existsSync(absolutePath)) {
+    let stats;
+    try {
+      stats = await fs.stat(absolutePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
       res.json(ModelAuditSchemas.CheckPath.Response.parse({ exists: false, type: null }));
       return;
     }
 
-    // Get path stats
-    const stats = fs.statSync(absolutePath);
     const type = stats.isDirectory() ? 'directory' : 'file';
 
     res.json(
@@ -220,8 +223,11 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
         ? expandedPath
         : path.resolve(process.cwd(), expandedPath);
 
-      // Check if path exists
-      if (!fs.existsSync(absolutePath)) {
+      const pathExists = await fs
+        .access(absolutePath)
+        .then(() => true)
+        .catch(() => false);
+      if (!pathExists) {
         res
           .status(400)
           .json({ error: `Path does not exist: ${inputPath} (resolved to: ${absolutePath})` });

--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -223,11 +223,12 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
         ? expandedPath
         : path.resolve(process.cwd(), expandedPath);
 
-      const pathExists = await fs
-        .access(absolutePath)
-        .then(() => true)
-        .catch(() => false);
-      if (!pathExists) {
+      try {
+        await fs.access(absolutePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
         res
           .status(400)
           .json({ error: `Path does not exist: ${inputPath} (resolved to: ${absolutePath})` });

--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -159,13 +159,12 @@ modelAuditRouter.post('/check-path', async (req: Request, res: Response): Promis
       ? expandedPath
       : path.resolve(process.cwd(), expandedPath);
 
+    // Treat any access failure (ENOENT, EACCES, EPERM, ELOOP, ...) as not-exists,
+    // matching the historical fs.existsSync behavior the UI depends on.
     let stats;
     try {
       stats = await fs.stat(absolutePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
-      }
+    } catch {
       res.json(ModelAuditSchemas.CheckPath.Response.parse({ exists: false, type: null }));
       return;
     }
@@ -226,12 +225,12 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
       try {
         await fs.access(absolutePath);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw error;
-        }
-        res
-          .status(400)
-          .json({ error: `Path does not exist: ${inputPath} (resolved to: ${absolutePath})` });
+        const code = (error as NodeJS.ErrnoException).code;
+        const message =
+          code === 'ENOENT'
+            ? `Path does not exist: ${inputPath} (resolved to: ${absolutePath})`
+            : `Cannot access path: ${inputPath} (resolved to: ${absolutePath}, ${code ?? 'unknown error'})`;
+        res.status(400).json({ error: message });
         return;
       }
 

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 import process from 'process';
@@ -649,7 +648,7 @@ export async function resolveConfigs(
       process.exit(1);
     }
     const modelOutputs = JSON.parse(
-      fs.readFileSync(path.join(process.cwd(), cmdObj.modelOutputs), 'utf8'),
+      await fsPromises.readFile(path.join(process.cwd(), cmdObj.modelOutputs), 'utf8'),
     ) as string[] | { output: string; tags?: string[] }[];
     const assertions = await readAssertions(cmdObj.assertions);
     fileConfig.prompts = ['{{output}}'];

--- a/src/util/xlsx.ts
+++ b/src/util/xlsx.ts
@@ -40,7 +40,10 @@ export async function parseXlsxFile(filePath: string): Promise<CsvRow[]> {
     // Check if file exists before attempting to read it
     try {
       await fs.access(actualFilePath);
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
       throw new Error(`File not found: ${actualFilePath}`);
     }
 

--- a/src/util/xlsx.ts
+++ b/src/util/xlsx.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs/promises';
 
 import type { CsvRow } from '../types/index';
 
@@ -38,7 +38,9 @@ export async function parseXlsxFile(filePath: string): Promise<CsvRow[]> {
     const [actualFilePath, sheetSpecifier] = filePath.split('#');
 
     // Check if file exists before attempting to read it
-    if (!fs.existsSync(actualFilePath)) {
+    try {
+      await fs.access(actualFilePath);
+    } catch {
       throw new Error(`File not found: ${actualFilePath}`);
     }
 

--- a/test/commands/generate/assertions.test.ts
+++ b/test/commands/generate/assertions.test.ts
@@ -10,7 +10,32 @@ import { resolveConfigs } from '../../../src/util/config/load';
 
 import type { Assertion, TestSuite } from '../../../src/types/index';
 
-vi.mock('fs');
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: fsMocks.readFileSync,
+    writeFile: fsMocks.writeFileSync,
+  },
+  readFile: fsMocks.readFileSync,
+  writeFile: fsMocks.writeFileSync,
+}));
 vi.mock('js-yaml');
 vi.mock('../../../src/assertions/synthesis');
 vi.mock('../../../src/util/config/load', () => ({

--- a/test/commands/generate/dataset.test.ts
+++ b/test/commands/generate/dataset.test.ts
@@ -10,7 +10,32 @@ import { resolveConfigs } from '../../../src/util/config/load';
 
 import type { TestSuite, VarMapping } from '../../../src/types/index';
 
-vi.mock('fs');
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: fsMocks.readFileSync,
+    writeFile: fsMocks.writeFileSync,
+  },
+  readFile: fsMocks.readFileSync,
+  writeFile: fsMocks.writeFileSync,
+}));
 vi.mock('js-yaml');
 vi.mock('../../../src/testCase/synthesis');
 vi.mock('../../../src/util/config/load', () => ({

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -18,8 +18,8 @@ import { mockProcessEnv } from './util/utils';
 import type { Prompt, TestCase, TestSuite } from '../src/types/index';
 
 // Use vi.hoisted to define mocks and helpers that need to be accessible in vi.mock factories
-const { actualPathResolve, dynamicModuleMocks, mockDynamicModule, mockPathResolve } = vi.hoisted(
-  () => {
+const { actualPathResolve, dynamicModuleMocks, fsMocks, mockDynamicModule, mockPathResolve } =
+  vi.hoisted(() => {
     const actualPath = require('path');
     const actualPathResolve = actualPath.resolve.bind(actualPath);
     const mockPathResolve = vi.fn((...paths: string[]) => actualPathResolve(...paths));
@@ -28,9 +28,16 @@ const { actualPathResolve, dynamicModuleMocks, mockDynamicModule, mockPathResolv
       const resolvedPath = actualPathResolve(filePath);
       dynamicModuleMocks.set(resolvedPath, moduleExport);
     };
-    return { actualPathResolve, dynamicModuleMocks, mockDynamicModule, mockPathResolve };
-  },
-);
+    const fsMocks = {
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      statSync: vi.fn(),
+      readdirSync: vi.fn(),
+      existsSync: vi.fn(),
+      mkdirSync: vi.fn(),
+    };
+    return { actualPathResolve, dynamicModuleMocks, fsMocks, mockDynamicModule, mockPathResolve };
+  });
 
 vi.mock('path', async () => {
   const actual = await vi.importActual<typeof import('path')>('path');
@@ -58,15 +65,17 @@ vi.mock('node:module', () => {
 });
 
 vi.mock('fs', () => ({
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
-  statSync: vi.fn(),
-  readdirSync: vi.fn(),
-  existsSync: vi.fn(),
-  mkdirSync: vi.fn(),
+  ...fsMocks,
   promises: {
-    readFile: vi.fn(),
+    readFile: fsMocks.readFileSync,
   },
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: fsMocks.readFileSync,
+  },
+  readFile: fsMocks.readFileSync,
 }));
 
 const mockGetText = vi.fn().mockResolvedValue({ text: 'Extracted PDF text' });

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -30,6 +30,17 @@ const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
   mockReadFileSync: vi.fn(),
 }));
 
+const mockReadFile = vi.hoisted(() =>
+  vi.fn((filePath: string, ...args: unknown[]) => {
+    if (!mockExistsSync(filePath)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), {
+        code: 'ENOENT',
+      });
+    }
+    return mockReadFileSync(filePath, ...args);
+  }),
+);
+
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
@@ -38,6 +49,13 @@ vi.mock('fs', async (importOriginal) => {
     readFileSync: mockReadFileSync,
   };
 });
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: mockReadFile,
+  },
+  readFile: mockReadFile,
+}));
 
 const Grader = new TestGrader();
 

--- a/test/microsoftSharepoint.test.ts
+++ b/test/microsoftSharepoint.test.ts
@@ -14,7 +14,26 @@ vi.mock('../src/envars', () => ({
   getEnvString: vi.fn(),
 }));
 
-vi.mock('fs');
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readFileSync: mockReadFileSync,
+    },
+    readFileSync: mockReadFileSync,
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: mockReadFileSync,
+  },
+  readFile: mockReadFileSync,
+}));
 
 // Mock the MSAL node module
 const mockMsalClient = {

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -14,6 +14,14 @@ const mockFs = vi.hoisted(() => ({
   existsSync: vi.fn(),
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
+  access: vi.fn((path: string) => {
+    if (mockFs.existsSync(path)) {
+      return undefined;
+    }
+    throw Object.assign(new Error(`ENOENT: no such file or directory, access '${path}'`), {
+      code: 'ENOENT',
+    });
+  }),
 }));
 
 vi.mock('fs', () => ({
@@ -22,6 +30,16 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('fs/promises', () => ({
+  default: {
+    access: mockFs.access,
+    writeFile: mockFs.writeFileSync,
+    mkdir: mockFs.mkdirSync,
+    mkdtemp: vi.fn(),
+    rm: vi.fn(),
+  },
+  access: mockFs.access,
+  writeFile: mockFs.writeFileSync,
+  mkdir: mockFs.mkdirSync,
   mkdtemp: vi.fn(),
   rm: vi.fn(),
 }));
@@ -78,6 +96,7 @@ beforeEach(() => {
   mockFs.existsSync.mockReset();
   mockFs.writeFileSync.mockReset();
   mockFs.mkdirSync.mockReset();
+  mockFs.access.mockClear();
 });
 
 describe('reportProviderAPIKeyWarnings', () => {

--- a/test/providers/azure/video.test.ts
+++ b/test/providers/azure/video.test.ts
@@ -29,8 +29,43 @@ const {
   mockGetConfigDirectoryPath: vi.fn(),
 }));
 
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
 // Mock the dependencies
-vi.mock('fs');
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => {
+  const readFile = vi.fn((filePath: any, encoding?: any) => {
+    if (!fsMocks.existsSync(filePath)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), {
+        code: 'ENOENT',
+      });
+    }
+    return encoding === undefined
+      ? fsMocks.readFileSync(filePath)
+      : fsMocks.readFileSync(filePath, encoding);
+  });
+  return {
+    default: {
+      readFile,
+    },
+    readFile,
+  };
+});
 vi.mock('../../../src/storage', () => ({
   storeMedia: mockStoreMedia,
   mediaExists: mockMediaExists,

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -239,6 +239,7 @@ describe('ClaudeCodeSDKProvider', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    Object.values(fsMocks).forEach((mock) => mock.mockReset());
 
     // Setup importModule to return our mockQuery
     vi.mocked(importModule).mockResolvedValue({ query: mockQuery });

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -27,11 +27,28 @@ import type { EnvOverrides } from '../../src/types/env';
 import type { CallApiContextParams } from '../../src/types/index';
 
 const testBasePath = path.resolve('/test/basePath');
+const fsMocks = vi.hoisted(() => ({
+  statSync: vi.fn(),
+  mkdtempSync: vi.fn(),
+  rmSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
 
 vi.mock('../../src/cliState', () => ({
   default: { basePath: '/test/basePath' },
   basePath: '/test/basePath',
 }));
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
 vi.mock('../../src/esm', async (importOriginal) => {
   return {
     ...(await importOriginal()),
@@ -47,6 +64,32 @@ vi.mock('node:module', async (importOriginal) => {
     createRequire: vi.fn(() => ({
       resolve: vi.fn(() => '@anthropic-ai/claude-agent-sdk'),
     })),
+  };
+});
+
+vi.mock('node:fs/promises', () => {
+  const fsPromisesMock = {
+    stat: vi.fn((filePath: any) => fsMocks.statSync(filePath)),
+    mkdtemp: vi.fn((prefix: string) => fsMocks.mkdtempSync(prefix)),
+    rm: vi.fn((filePath: any, options?: any) => fsMocks.rmSync(filePath, options)),
+    readdir: vi.fn((filePath: any, options?: any) => fsMocks.readdirSync(filePath, options)),
+  };
+  return {
+    default: fsPromisesMock,
+    ...fsPromisesMock,
+  };
+});
+
+vi.mock('fs/promises', () => {
+  const fsPromisesMock = {
+    stat: vi.fn((filePath: any) => fsMocks.statSync(filePath)),
+    mkdtemp: vi.fn((prefix: string) => fsMocks.mkdtempSync(prefix)),
+    rm: vi.fn((filePath: any, options?: any) => fsMocks.rmSync(filePath, options)),
+    readdir: vi.fn((filePath: any, options?: any) => fsMocks.readdirSync(filePath, options)),
+  };
+  return {
+    default: fsPromisesMock,
+    ...fsPromisesMock,
   };
 });
 

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -8,6 +8,16 @@ import { GolangProvider } from '../../src/providers/golangCompletion';
 const mockExecFile = vi.hoisted(() => vi.fn());
 const mockGetCache = vi.hoisted(() => vi.fn());
 const mockIsCacheEnabled = vi.hoisted(() => vi.fn());
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  mkdtempSync: vi.fn(),
+  existsSync: vi.fn(),
+  rmSync: vi.fn(),
+  readdirSync: vi.fn(),
+  copyFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -35,7 +45,45 @@ vi.mock('../../src/logger', () => ({
   },
 }));
 
-vi.mock('fs');
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => {
+  const access = vi.fn((filePath: any) => {
+    if (fsMocks.existsSync(filePath)) {
+      return undefined;
+    }
+    throw Object.assign(new Error(`ENOENT: no such file or directory, access '${filePath}'`), {
+      code: 'ENOENT',
+    });
+  });
+  return {
+    default: {
+      readFile: fsMocks.readFileSync,
+      readdir: fsMocks.readdirSync,
+      mkdtemp: fsMocks.mkdtempSync,
+      mkdir: fsMocks.mkdirSync,
+      copyFile: fsMocks.copyFileSync,
+      rm: fsMocks.rmSync,
+      access,
+    },
+    readFile: fsMocks.readFileSync,
+    readdir: fsMocks.readdirSync,
+    mkdtemp: fsMocks.mkdtempSync,
+    mkdir: fsMocks.mkdirSync,
+    copyFile: fsMocks.copyFileSync,
+    rm: fsMocks.rmSync,
+    access,
+  };
+});
 vi.mock('path');
 
 vi.mock('../../src/util', async () => {

--- a/test/providers/http-tls.test.ts
+++ b/test/providers/http-tls.test.ts
@@ -41,6 +41,13 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: mockReadFileSync,
+  },
+  readFile: mockReadFileSync,
+}));
+
 describe('HttpProvider with TLS Configuration', () => {
   const mockFetchWithCache = vi.mocked(fetchWithCache);
 

--- a/test/providers/http/auth.test.ts
+++ b/test/providers/http/auth.test.ts
@@ -2,7 +2,7 @@
 import './setup';
 
 import crypto from 'crypto';
-import fs from 'fs';
+import fsPromises from 'fs/promises';
 import path from 'path';
 
 import dedent from 'dedent';
@@ -15,23 +15,39 @@ import { runPython } from '../../../src/python/pythonUtils';
 import { TOKEN_REFRESH_BUFFER_MS } from '../../../src/util/oauth';
 import { createDeferred, mockProcessEnv } from '../../util/utils';
 
+const fsPromisesMocks = vi.hoisted(() => ({
+  actualReadFile: undefined as typeof import('fs/promises').readFile | undefined,
+  readFile: vi.fn(),
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  fsPromisesMocks.actualReadFile = actual.readFile;
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readFile: fsPromisesMocks.readFile,
+    },
+    readFile: fsPromisesMocks.readFile,
+  };
+});
+
 describe('RSA signature authentication', () => {
   let mockPrivateKey: string;
   let mockSign: MockInstance;
   let mockUpdate: MockInstance;
   let mockEnd: MockInstance;
-  let actualReadFileSync: typeof fs.readFileSync;
 
   beforeEach(() => {
     mockPrivateKey = '-----BEGIN PRIVATE KEY-----\nMOCK_KEY\n-----END PRIVATE KEY-----';
-    actualReadFileSync = fs.readFileSync;
-    vi.spyOn(fs, 'readFileSync').mockImplementation(((path, options) => {
-      if (path === '/path/to/key.pem') {
+    vi.mocked(fsPromises.readFile).mockImplementation((async (filePath, options) => {
+      if (filePath.toString() === '/path/to/key.pem') {
         return mockPrivateKey;
       }
 
-      return actualReadFileSync(path as any, options as any);
-    }) as typeof fs.readFileSync);
+      return fsPromisesMocks.actualReadFile!(filePath as any, options as any);
+    }) as typeof fsPromises.readFile);
 
     mockUpdate = vi.fn();
     mockEnd = vi.fn();
@@ -74,7 +90,7 @@ describe('RSA signature authentication', () => {
     await provider.callApi('test');
 
     // Verify signature generation with specific data
-    expect(fs.readFileSync).toHaveBeenCalledWith('/path/to/key.pem', 'utf8');
+    expect(fsPromises.readFile).toHaveBeenCalledWith('/path/to/key.pem', 'utf8');
     expect(crypto.createSign).toHaveBeenCalledWith('SHA256');
     expect(mockUpdate).toHaveBeenCalledTimes(1);
     expect(mockEnd).toHaveBeenCalledTimes(1);
@@ -196,7 +212,7 @@ describe('RSA signature authentication', () => {
 
     // Verify signature generation using privateKey directly
     const privateKeyFileReads = vi
-      .mocked(fs.readFileSync)
+      .mocked(fsPromises.readFile)
       .mock.calls.filter(([filePath]) => filePath === '/path/to/key.pem');
     expect(privateKeyFileReads).toHaveLength(0);
     expect(crypto.createSign).toHaveBeenCalledWith('SHA256');
@@ -250,10 +266,8 @@ describe('RSA signature authentication', () => {
       },
     });
 
-    // Mock fs.readFileSync to return mock keystore data
-    const readFileSyncSpy = vi
-      .spyOn(fs, 'readFileSync')
-      .mockReturnValue(Buffer.from('mock-keystore-data'));
+    // Mock fs/promises.readFile to return mock keystore data
+    vi.mocked(fsPromises.readFile).mockResolvedValue(Buffer.from('mock-keystore-data'));
 
     const restoreEnv = mockProcessEnv({
       PROMPTFOO_JKS_PASSWORD: 'env-password',
@@ -287,9 +301,6 @@ describe('RSA signature authentication', () => {
       expect(jksMock.toPem).toHaveBeenCalledWith(expect.anything(), 'env-password');
     } finally {
       restoreEnv();
-
-      // Clean up
-      readFileSyncSpy.mockRestore();
     }
   });
 
@@ -302,10 +313,8 @@ describe('RSA signature authentication', () => {
       },
     });
 
-    // Mock fs.readFileSync to return mock keystore data
-    const readFileSyncSpy = vi
-      .spyOn(fs, 'readFileSync')
-      .mockReturnValue(Buffer.from('mock-keystore-data'));
+    // Mock fs/promises.readFile to return mock keystore data
+    vi.mocked(fsPromises.readFile).mockResolvedValue(Buffer.from('mock-keystore-data'));
 
     const restoreEnv = mockProcessEnv({
       PROMPTFOO_JKS_PASSWORD: 'env-password',
@@ -339,9 +348,6 @@ describe('RSA signature authentication', () => {
       expect(jksMock.toPem).toHaveBeenCalledWith(expect.any(Buffer), 'config-password');
     } finally {
       restoreEnv();
-
-      // Clean up
-      readFileSyncSpy.mockRestore();
     }
   });
 
@@ -352,10 +358,8 @@ describe('RSA signature authentication', () => {
       throw new Error('Should not be called');
     });
 
-    // Mock fs.readFileSync to return mock keystore data
-    const readFileSyncSpy = vi
-      .spyOn(fs, 'readFileSync')
-      .mockReturnValue(Buffer.from('mock-keystore-data'));
+    // Mock fs/promises.readFile to return mock keystore data
+    vi.mocked(fsPromises.readFile).mockResolvedValue(Buffer.from('mock-keystore-data'));
 
     const provider = new HttpProvider('http://example.com', {
       config: {
@@ -388,9 +392,6 @@ describe('RSA signature authentication', () => {
       );
     } finally {
       restoreEnv();
-
-      // Clean up
-      readFileSyncSpy.mockRestore();
     }
   });
 });

--- a/test/providers/openai/transcription.test.ts
+++ b/test/providers/openai/transcription.test.ts
@@ -20,7 +20,35 @@ vi.mock('../../../src/logger', () => ({
     error: vi.fn(),
   },
 }));
-vi.mock('fs');
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => {
+  const readFile = vi.fn((filePath: any, encoding?: any) =>
+    encoding === undefined
+      ? fsMocks.readFileSync(filePath)
+      : fsMocks.readFileSync(filePath, encoding),
+  );
+  return {
+    default: {
+      readFile,
+    },
+    readFile,
+  };
+});
 
 class MockFile {
   constructor(
@@ -138,7 +166,7 @@ describe('OpenAiTranscriptionProvider', () => {
 
       const result = await provider.callApi('/path/to/audio.mp3');
 
-      expect(fs.existsSync).toHaveBeenCalledWith('/path/to/audio.mp3');
+      expect(fs.readFileSync).toHaveBeenCalledWith('/path/to/audio.mp3');
       expect(fetchWithCache).toHaveBeenCalledWith(
         expect.stringContaining('/audio/transcriptions'),
         expect.objectContaining({
@@ -357,8 +385,8 @@ describe('OpenAiTranscriptionProvider', () => {
         config: { apiKey: 'test-key' },
       });
 
-      vi.mocked(fs.existsSync).mockImplementation(function () {
-        return false;
+      vi.mocked(fs.readFileSync).mockImplementation(function () {
+        throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
       });
 
       const result = await provider.callApi('/path/to/missing.mp3');
@@ -718,7 +746,7 @@ describe('OpenAiTranscriptionProvider', () => {
 
       await provider.callApi('  /path/to/audio.mp3  ');
 
-      expect(fs.existsSync).toHaveBeenCalledWith('/path/to/audio.mp3');
+      expect(fs.readFileSync).toHaveBeenCalledWith('/path/to/audio.mp3');
     });
   });
 });

--- a/test/providers/openai/video.test.ts
+++ b/test/providers/openai/video.test.ts
@@ -27,8 +27,43 @@ const {
   mockGetConfigDirectoryPath: vi.fn(),
 }));
 
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
 // Mock the dependencies
-vi.mock('fs');
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => {
+  const readFile = vi.fn((filePath: any, encoding?: any) => {
+    if (!fsMocks.existsSync(filePath)) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), {
+        code: 'ENOENT',
+      });
+    }
+    return encoding === undefined
+      ? fsMocks.readFileSync(filePath)
+      : fsMocks.readFileSync(filePath, encoding);
+  });
+  return {
+    default: {
+      readFile,
+    },
+    readFile,
+  };
+});
 vi.mock('../../../src/storage', () => ({
   storeMedia: mockStoreMedia,
   mediaExists: mockMediaExists,

--- a/test/providers/pythonCompletion.fileRef.test.ts
+++ b/test/providers/pythonCompletion.fileRef.test.ts
@@ -1,4 +1,5 @@
-import fs from 'fs';
+import fsSync from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,6 +11,7 @@ import { parsePathOrGlob } from '../../src/util/index';
 import type { Logger } from 'winston';
 
 vi.mock('fs');
+vi.mock('fs/promises');
 vi.mock('path');
 vi.mock('../../src/util/file');
 vi.mock('../../src/logger');
@@ -121,9 +123,10 @@ describe('PythonProvider with file references', () => {
       };
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
+    vi.mocked(fsSync.readFileSync).mockImplementation(function () {
       return 'mock file content';
     });
+    vi.mocked(fs.readFile).mockResolvedValue('mock file content');
   });
 
   afterEach(async () => {

--- a/test/providers/pythonCompletion.test.ts
+++ b/test/providers/pythonCompletion.test.ts
@@ -23,7 +23,30 @@ vi.mock('../../src/logger', () => ({
 
 vi.mock('../../src/python/pythonUtils');
 vi.mock('../../src/cache');
-vi.mock('fs');
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: fsMocks.readFileSync,
+  },
+  readFile: fsMocks.readFileSync,
+}));
 vi.mock('path');
 vi.mock('../../src/util', async () => {
   const actual = await vi.importActual<typeof import('../../src/util')>('../../src/util');

--- a/test/providers/rubyCompletion.test.ts
+++ b/test/providers/rubyCompletion.test.ts
@@ -48,6 +48,13 @@ vi.mock('fs', async () => {
   };
 });
 
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: fsMocks.readFileSync,
+  },
+  readFile: fsMocks.readFileSync,
+}));
+
 vi.mock('path', async () => {
   const actual = await vi.importActual<typeof import('path')>('path');
   return {

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -22,18 +22,30 @@ import { PythonShell } from 'python-shell';
 import { getEnvBool, getEnvString } from '../../src/envars';
 import * as pythonUtils from '../../src/python/pythonUtils';
 
+const fsMock = vi.hoisted(() => ({
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
 // Mock setup
 vi.mock('fs', () => {
-  const fsMock = {
-    writeFileSync: vi.fn(),
-    readFileSync: vi.fn(),
-    unlinkSync: vi.fn(),
-  };
   return {
     ...fsMock,
     default: fsMock,
   };
 });
+
+vi.mock('fs/promises', () => ({
+  default: {
+    writeFile: fsMock.writeFileSync,
+    readFile: fsMock.readFileSync,
+    unlink: fsMock.unlinkSync,
+  },
+  writeFile: fsMock.writeFileSync,
+  readFile: fsMock.readFileSync,
+  unlink: fsMock.unlinkSync,
+}));
 
 vi.mock('../../src/envars', () => ({
   getEnvString: vi.fn(),

--- a/test/python/wrapper.test.ts
+++ b/test/python/wrapper.test.ts
@@ -13,17 +13,29 @@ import { mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/esm');
 vi.mock('python-shell');
+const fsMock = vi.hoisted(() => ({
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
 vi.mock('fs', () => {
-  const fsMock = {
-    writeFileSync: vi.fn(),
-    readFileSync: vi.fn(),
-    unlinkSync: vi.fn(),
-  };
   return {
     ...fsMock,
     default: fsMock,
   };
 });
+
+vi.mock('fs/promises', () => ({
+  default: {
+    writeFile: fsMock.writeFileSync,
+    readFile: fsMock.readFileSync,
+    unlink: fsMock.unlinkSync,
+  },
+  writeFile: fsMock.writeFileSync,
+  readFile: fsMock.readFileSync,
+  unlink: fsMock.unlinkSync,
+}));
 vi.mock('../../src/python/pythonUtils', async () => {
   const originalModule = await vi.importActual<typeof import('../../src/python/pythonUtils')>(
     '../../src/python/pythonUtils',

--- a/test/python/wrapper.test.ts
+++ b/test/python/wrapper.test.ts
@@ -72,6 +72,7 @@ describe('wrapper', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.values(fsMock).forEach((mock) => mock.mockReset());
     vi.mocked(validatePythonPath).mockImplementation(
       (pythonPath: string, _isExplicit: boolean): Promise<string> => {
         state.cachedPythonPath = pythonPath;

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -49,7 +49,48 @@ type SynthesizeMockResult = {
   failedPlugins: FailedPluginInfo[];
 };
 
-vi.mock('node:fs');
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      ...fsMocks,
+    },
+    ...fsMocks,
+  };
+});
+vi.mock('fs/promises', () => {
+  const access = vi.fn((filePath: any) => {
+    if (fsMocks.existsSync(filePath)) {
+      return Promise.resolve();
+    }
+    return Promise.reject(
+      Object.assign(new Error(`ENOENT: no such file or directory, access '${filePath}'`), {
+        code: 'ENOENT',
+      }),
+    );
+  });
+  return {
+    default: {
+      readFile: fsMocks.readFileSync,
+      writeFile: fsMocks.writeFileSync,
+      mkdir: fsMocks.mkdirSync,
+      access,
+    },
+    readFile: fsMocks.readFileSync,
+    writeFile: fsMocks.writeFileSync,
+    mkdir: fsMocks.mkdirSync,
+    access,
+  };
+});
 vi.mock('../../../src/redteam', () => ({
   MAX_MAX_CONCURRENCY: 20,
   synthesize: vi.fn().mockResolvedValue({

--- a/test/redteam/commands/poison.test.ts
+++ b/test/redteam/commands/poison.test.ts
@@ -40,6 +40,19 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: mockFsReadFileSync,
+    mkdir: mockFsMkdirSync,
+    writeFile: mockFsWriteFileSync,
+    stat: vi.fn(async (...args: unknown[]) => mockFsStatSync(...args)),
+  },
+  readFile: mockFsReadFileSync,
+  mkdir: mockFsMkdirSync,
+  writeFile: mockFsWriteFileSync,
+  stat: vi.fn(async (...args: unknown[]) => mockFsStatSync(...args)),
+}));
+
 const mockPathJoin = vi.hoisted(() => vi.fn());
 const mockPathRelative = vi.hoisted(() => vi.fn());
 const mockPathResolve = vi.hoisted(() => vi.fn());

--- a/test/redteam/shared.test.ts
+++ b/test/redteam/shared.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as os from 'os';
 import path from 'path';
 
@@ -103,6 +104,7 @@ vi.mock('../../src/util/config/manage', async (importOriginal) => {
   };
 });
 vi.mock('fs');
+vi.mock('fs/promises');
 vi.mock('js-yaml');
 vi.mock('os');
 
@@ -122,6 +124,9 @@ describe('doRedteamRun', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return true;
     });
+    vi.mocked(fsPromises.access).mockResolvedValue(undefined);
+    vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fsPromises.writeFile).mockResolvedValue();
     vi.mocked(os.tmpdir).mockImplementation(function () {
       return '/tmp';
     });
@@ -198,8 +203,10 @@ describe('doRedteamRun', () => {
       const expectedFilename = `redteam-${mockDate.getTime()}.yaml`;
       const expectedPath = path.join('', expectedFilename);
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(expectedPath), { recursive: true });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, 'mocked-yaml-content');
+      expect(fsPromises.mkdir).toHaveBeenCalledWith(path.dirname(expectedPath), {
+        recursive: true,
+      });
+      expect(fsPromises.writeFile).toHaveBeenCalledWith(expectedPath, 'mocked-yaml-content');
       expect(yaml.dump).toHaveBeenCalledWith(mockConfig);
       expect(doGenerateRedteam).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -219,8 +226,10 @@ describe('doRedteamRun', () => {
       const expectedFilePrefix = path.join('/tmp', 'redteam-');
 
       expect(os.tmpdir).toHaveBeenCalledWith();
-      expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(expectedPath), { recursive: true });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect(fsPromises.mkdir).toHaveBeenCalledWith(path.dirname(expectedPath), {
+        recursive: true,
+      });
+      expect(fsPromises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(expectedFilePrefix),
         'mocked-yaml-content',
       );
@@ -243,8 +252,10 @@ describe('doRedteamRun', () => {
       const expectedFilePrefix = path.join('/tmp', 'redteam-');
 
       expect(os.tmpdir).toHaveBeenCalledWith();
-      expect(fs.mkdirSync).toHaveBeenCalledWith(path.dirname(expectedPath), { recursive: true });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect(fsPromises.mkdir).toHaveBeenCalledWith(path.dirname(expectedPath), {
+        recursive: true,
+      });
+      expect(fsPromises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(expectedFilePrefix),
         'mocked-yaml-content',
       );
@@ -280,8 +291,12 @@ describe('doRedteamRun', () => {
       const secondExpectedPath = path.join('', `redteam-${secondTimestamp}.yaml`);
 
       // Verify different filenames were generated
-      expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, firstExpectedPath, 'mocked-yaml-content');
-      expect(fs.writeFileSync).toHaveBeenNthCalledWith(
+      expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
+        1,
+        firstExpectedPath,
+        'mocked-yaml-content',
+      );
+      expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
         2,
         secondExpectedPath,
         'mocked-yaml-content',

--- a/test/redteam/strategies/simpleVideo.test.ts
+++ b/test/redteam/strategies/simpleVideo.test.ts
@@ -4,7 +4,7 @@
  * Tests core functionality with proper mocks to avoid depending on fs, ffmpeg, etc.
  */
 
-import fs from 'fs';
+import fsPromises from 'fs/promises';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import logger from '../../../src/logger';
@@ -44,6 +44,7 @@ vi.mock('../../../src/cliState', () => ({
 }));
 
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
@@ -53,6 +54,17 @@ vi.mock('fs', async (importOriginal) => {
       writeFileSync: mockWriteFileSync,
     },
     writeFileSync: mockWriteFileSync,
+  };
+});
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFile: mockWriteFile,
+    },
+    writeFile: mockWriteFile,
   };
 });
 
@@ -123,6 +135,7 @@ describe('simpleVideo strategy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWriteFileSync.mockReset();
+    mockWriteFile.mockReset();
     mockVideoGenerator.mockClear();
   });
 
@@ -174,15 +187,13 @@ describe('simpleVideo strategy', () => {
     it('writes a base64 video to a file', async () => {
       await writeVideoFile(DUMMY_VIDEO_BASE64, 'test.mp4');
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith('test.mp4', expect.any(Buffer));
+      expect(fsPromises.writeFile).toHaveBeenCalledWith('test.mp4', expect.any(Buffer));
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Video file written to'));
     });
 
     it('throws an error if writing fails', async () => {
       const mockError = new Error('Write failed');
-      vi.mocked(fs.writeFileSync).mockImplementationOnce(function () {
-        throw mockError;
-      });
+      vi.mocked(fsPromises.writeFile).mockRejectedValueOnce(mockError);
 
       await expect(writeVideoFile(DUMMY_VIDEO_BASE64, 'test.mp4')).rejects.toThrow('Write failed');
       expect(logger.error).toHaveBeenCalledWith(

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -60,18 +60,26 @@ vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
 }));
 
-vi.mock('fs/promises', () => ({
-  // Delegate to fs.readFileSync mock for shared test data
-  readFile: vi.fn((...args: unknown[]) => {
-    try {
-      return Promise.resolve(mockReadFileSync(...args));
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  }),
-  writeFile: vi.fn(),
-  mkdir: vi.fn(),
-}));
+vi.mock('fs/promises', () => {
+  const promisesFs = {
+    // Delegate to fs.readFileSync mock for shared test data
+    readFile: vi.fn((...args: unknown[]) => {
+      try {
+        return Promise.resolve(mockReadFileSync(...args));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+    access: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    ...promisesFs,
+    default: promisesFs,
+  };
+});
 
 vi.mock('../../src/database', () => ({
   getDb: vi.fn(),

--- a/test/util/xlsx.test.ts
+++ b/test/util/xlsx.test.ts
@@ -12,10 +12,28 @@ vi.mock('read-excel-file/node', () => ({
 type SheetData = unknown[][];
 
 const createMockSheet = (sheet: string, data: SheetData = []) => ({ sheet, data });
+const mockExistsSync = vi.hoisted(() => vi.fn((_filePath?: any) => true));
 
 vi.mock('fs', () => ({
-  existsSync: vi.fn(() => true),
+  existsSync: mockExistsSync,
 }));
+
+vi.mock('fs/promises', () => {
+  const access = vi.fn((filePath: any) => {
+    if (mockExistsSync(filePath)) {
+      return undefined;
+    }
+    throw Object.assign(new Error(`ENOENT: no such file or directory, access '${filePath}'`), {
+      code: 'ENOENT',
+    });
+  });
+  return {
+    default: {
+      access,
+    },
+    access,
+  };
+});
 
 describe('parseXlsxFile', () => {
   let fs: any;


### PR DESCRIPTION
## Summary
- Replace easy async-path `fs` callbacks/sync reads with `fs/promises` across CLI, providers, redteam, server, and utility flows.
- Preserve sync `fs` usage where converting would require broader async-chain changes.
- Update Vitest mocks, including HTTP auth PEM/JKS coverage, for `fs/promises` reads.

## Testing
- `source ~/.nvm/nvm.sh && nvm use && npx vitest run test/providers/http/auth.test.ts test/microsoftSharepoint.test.ts test/evaluatorHelpers.test.ts test/matchers/llm-rubric.test.ts test/commands/generate/dataset.test.ts test/commands/generate/assertions.test.ts test/onboarding.test.ts test/providers/http-tls.test.ts test/providers/pythonCompletion.test.ts test/providers/rubyCompletion.test.ts test/providers/golangCompletion.test.ts test/providers/openai/transcription.test.ts test/providers/openai/video.test.ts test/providers/claude-agent-sdk.test.ts test/python/pythonUtils.test.ts test/python/wrapper.test.ts test/util/xlsx.test.ts test/redteam/commands/poison.test.ts test/redteam/commands/generate.test.ts --run`
- `source ~/.nvm/nvm.sh && nvm use && npm run tsc`
- `git diff --check origin/main..HEAD`
- `npx @biomejs/biome check --write test/providers/http/auth.test.ts`
- `npx @biomejs/biome check --write --max-diagnostics=none <changed js/ts files>`
- `npm run l` / `npm run f` attempted; both stop on existing `noExcessiveCognitiveComplexity` diagnostics across legacy touched files plus Biome diagnostic cap.
