### PR TITLE
fix(test): prevent test-hygiene race with parallel fixture writers

### DIFF
--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -147,11 +147,14 @@ const mockImplementationResetPattern = /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\
 const processEnvSnapshotIdentifierPattern = /^original[A-Za-z0-9_]*$/i;
 
 function findTestFiles(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry) => {
-    const fullPath = path.join(dir, entry);
-    const stats = statSync(fullPath);
+  // Use withFileTypes so entry type comes from the directory record itself rather
+  // than a follow-up stat() call. Other test files (e.g. python/workerPool.test.ts)
+  // create and delete fixtures in beforeAll/afterAll, and parallel test execution
+  // can delete an entry between readdir() and stat(), causing a flaky ENOENT.
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
 
-    if (stats.isDirectory()) {
+    if (entry.isDirectory()) {
       return findTestFiles(fullPath);
     }
 


### PR DESCRIPTION
## Summary

`test/test-hygiene.test.ts` walks `test/` recursively with `readdirSync` followed by `statSync` on each entry. Other test files — notably `test/python/workerPool.test.ts` — write fixtures (`pool_multi_api.py`, `counter_provider.py`) into `test/python/fixtures/` in `beforeAll` and delete them in `afterAll`. Vitest runs files in parallel, so a fixture can be unlinked in the gap between `readdir()` and `stat()`, producing a flaky ENOENT:

```
Error: ENOENT: no such file or directory, stat '/home/runner/work/promptfoo/promptfoo/test/python/fixtures/pool_multi_api.py'
 ❯ test/test-hygiene.test.ts:152:19
```

Switching to `readdirSync(dir, { withFileTypes: true })` reads the entry type from the directory record itself, eliminating the second syscall and the race. Python fixtures still get filtered out by `testFilePattern` before any `readFileSync` runs, so non-test files cannot trigger spurious reads either.

Observed flake: https://github.com/promptfoo/promptfoo/actions (CI #38926, Test on Node 24.x and ubuntu-latest).

## Test plan

- [x] `npx vitest run test/test-hygiene.test.ts` — 59 passed
- [x] `npx vitest run test/test-hygiene.test.ts test/python/workerPool.test.ts` (the racing pair) — 66 passed
- [x] `npm run l && npm run f` clean