### PR TITLE
test: migrate 10 legacy sleep-wait tests off setTimeout-based waits

### DIFF
--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -973,9 +973,7 @@ describe('fetchWithTimeout', () => {
   });
 
   it('should reject when request times out', async () => {
-    vi.mocked(global.fetch).mockImplementationOnce(
-      () => new Promise((resolve) => setTimeout(resolve, 6000)),
-    );
+    vi.mocked(global.fetch).mockImplementationOnce(() => new Promise(() => {}));
 
     const fetchPromise = fetchWithTimeout('https://example.com', {}, 5000);
     vi.advanceTimersByTime(5000);

--- a/test/providers/google/base.test.ts
+++ b/test/providers/google/base.test.ts
@@ -153,10 +153,9 @@ describe('GoogleGenericProvider', () => {
       });
 
       // Wait for MCP initialization
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Verify initialization was called on the mock instance
-      expect(mockMcpInstance.initialize).toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(mockMcpInstance.initialize).toHaveBeenCalled();
+      });
     });
 
     it('should not initialize MCP when not configured', () => {
@@ -289,7 +288,9 @@ describe('GoogleGenericProvider', () => {
       });
 
       // Wait for MCP initialization to complete
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await vi.waitFor(() => {
+        expect(mockMcpInstance.initialize).toHaveBeenCalled();
+      });
 
       const tools = await provider['getAllTools']();
 
@@ -426,7 +427,9 @@ describe('GoogleGenericProvider', () => {
       });
 
       // Wait for MCP initialization
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await vi.waitFor(() => {
+        expect(mockMcpInstance.initialize).toHaveBeenCalled();
+      });
 
       await provider.cleanup();
 

--- a/test/providers/httpTransforms.test.ts
+++ b/test/providers/httpTransforms.test.ts
@@ -187,7 +187,7 @@ describe('createTransformRequest', () => {
 
   it('should handle async function-based transform', async () => {
     const transform = await createTransformRequest(async (prompt: string) => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await Promise.resolve();
       return { transformed: prompt.toUpperCase() };
     });
     const result = await transform('hello', {} as any);

--- a/test/providers/openai/moderation.test.ts
+++ b/test/providers/openai/moderation.test.ts
@@ -569,8 +569,9 @@ describe('OpenAiModerationProvider', () => {
       const first = provider.callModerationApi('user', 'same sensitive text');
       const second = provider.callModerationApi('user', 'same sensitive text');
 
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(fetchWithCache).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(fetchWithCache).toHaveBeenCalledTimes(1);
+      });
 
       resolveFetch!({
         data: mockResponse,
@@ -617,8 +618,9 @@ describe('OpenAiModerationProvider', () => {
       const first = provider.callModerationApi('user', 'same sensitive text');
       const second = provider.callModerationApi('user', 'same sensitive text');
 
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(fetchWithCache).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => {
+        expect(fetchWithCache).toHaveBeenCalledTimes(2);
+      });
 
       for (const resolveFetch of resolvers) {
         resolveFetch({

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -407,8 +407,9 @@ describe('Python Utils', () => {
     describe('concurrent validation', () => {
       it('should share validation promise between concurrent calls', async () => {
         mockExecFileAsync.mockImplementation(async () => {
-          // Add delay to simulate slow execution
-          await new Promise((resolve) => setTimeout(resolve, 100));
+          // Yield control so concurrent callers can register on the shared
+          // validation promise before resolution.
+          await Promise.resolve();
           return { stdout: 'Python 3.8.10\n', stderr: '' };
         });
 
@@ -433,8 +434,9 @@ describe('Python Utils', () => {
         pythonUtils.state.cachedPythonPath = null;
 
         mockExecFileAsync.mockImplementation(async () => {
-          // Delay to simulate slow execution
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          // Yield control so concurrent callers can race onto the shared
+          // validation promise before resolution.
+          await Promise.resolve();
           return { stdout: 'Python 3.8.10\n', stderr: '' };
         });
 

--- a/test/python/wrapper.test.ts
+++ b/test/python/wrapper.test.ts
@@ -118,16 +118,15 @@ describe('wrapper', () => {
       state.cachedPythonPath = null;
       state.validationPromise = null;
 
-      // Configure the module-level mocks with realistic delays to simulate Windows behavior
-      // This is critical for testing race conditions that only appear under slow I/O
+      // Yield once before resolving so concurrent callers can race onto the
+      // shared validation promise — this is the same race condition the test
+      // is exercising; wall-clock delay isn't needed.
       vi.mocked(tryPath).mockImplementation(async (_path: string) => {
-        // Simulate slow Windows process spawning and antivirus scanning
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await Promise.resolve();
         return '/usr/bin/python3';
       });
       vi.mocked(getSysExecutable).mockImplementation(async () => {
-        // Simulate slow Windows 'where' command and py launcher
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await Promise.resolve();
         return '/usr/bin/python3';
       });
     });

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -3188,11 +3188,10 @@ describe('redteam generate command with target option', () => {
       'test-output.yaml',
     ]);
 
-    // Allow async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
     // Verify getConfigFromCloud was called with both config and target
-    expect(getConfigFromCloud).toHaveBeenCalledWith(configUUID, targetUUID);
+    await vi.waitFor(() => {
+      expect(getConfigFromCloud).toHaveBeenCalledWith(configUUID, targetUUID);
+    });
   });
 
   it('should handle backwards compatibility with empty targets', async () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -203,10 +203,11 @@ describe('Telemetry', () => {
     const _telemetry = new Telemetry();
     _telemetry.record('feature_used', { test: 'value' });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await vi.waitFor(() => {
+      expect(fetchWithProxySpy.mock.calls.length).toBeGreaterThan(0);
+    });
 
     const fetchCalls = fetchWithProxySpy.mock.calls;
-    expect(fetchCalls.length).toBeGreaterThan(0);
 
     let foundExpectedProperties = false;
 

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -139,21 +139,11 @@ const legacySleepPromiseFiles = new Set<string>([
   'evaluator/execution.test.ts',
   'evaluator/gradingConcurrency.test.ts',
   'evaluator/runEval.test.ts',
-  'fetch.test.ts',
   'providers/bedrock/nova-reel.test.ts',
-  'providers/google/base.test.ts',
   'providers/http/auth.test.ts',
-  'providers/httpTransforms.test.ts',
-  'providers/openai/moderation.test.ts',
   'providers/xai/video.test.ts',
-  'python/pythonUtils.test.ts',
-  'python/wrapper.test.ts',
-  'redteam/commands/generate.test.ts',
   'redteam/strategies/gcg.test.ts',
   'smoke/resume.test.ts',
-  'telemetry.test.ts',
-  'tracing/providerInstrumentation.test.ts',
-  'util/agent/agentClient.test.ts',
 ]);
 
 const legacyModuleScopePersistentMockFiles = new Set<string>([

--- a/test/tracing/providerInstrumentation.test.ts
+++ b/test/tracing/providerInstrumentation.test.ts
@@ -400,8 +400,7 @@ describe('Phase 5: Provider Instrumentation Validation', () => {
           withGenAISpan(
             { system, operationName: 'chat', model, providerId: `${system}:${model}` },
             async () => {
-              // Simulate API latency
-              await new Promise((resolve) => setTimeout(resolve, Math.random() * 50));
+              await Promise.resolve();
               return { output: `Response from ${system}` };
             },
           ),

--- a/test/util/agent/agentClient.test.ts
+++ b/test/util/agent/agentClient.test.ts
@@ -160,11 +160,13 @@ describe('createAgentClient', () => {
     await promise;
     expect(resolveCount).toBe(1);
 
-    // Reconnect — should NOT cause a second resolution
+    // Reconnect — should NOT cause a second resolution. Flush several
+    // microtask rounds to give any (buggy) re-resolve handler a chance to fire.
     fakeSocket._simulateDisconnect('transport close');
     fakeSocket._simulateConnect();
-
-    await new Promise((r) => setTimeout(r, 50));
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
     expect(resolveCount).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

Stacked on top of #8949 (which adds the rule). Migrates 10 of the 20 legacy sleep-wait files off the setTimeout-based wait pattern, shrinking the allowlist by half.

Replaces \`await new Promise(r => setTimeout(r, ms))\` with deterministic alternatives:

| File | Pattern | Replacement |
| --- | --- | --- |
| \`providers/openai/moderation.test.ts\` (×2) | flush microtasks before asserting in-flight dedup count | \`vi.waitFor(() => expect(fetchWithCache).toHaveBeenCalledTimes(N))\` |
| \`redteam/commands/generate.test.ts\` | flush microtasks before asserting cloud-config call | \`vi.waitFor()\` on the assertion |
| \`util/agent/agentClient.test.ts\` | wait 50ms post-reconnect to ensure no second resolve | tight microtask-flush loop |
| \`providers/httpTransforms.test.ts\` | 10ms delay inside async transform | \`await Promise.resolve()\` (test only needs async-ness) |
| \`python/pythonUtils.test.ts\` (×2) | sleep in mock so concurrent callers can race on validation | \`await Promise.resolve()\` — yields once, sufficient |
| \`python/wrapper.test.ts\` (×2) | same Windows mock pattern | same yield-once fix |
| \`tracing/providerInstrumentation.test.ts\` | \`Math.random()*50\` latency simulation in mock | \`await Promise.resolve()\` — trace test verifies attributes, not timing |
| \`providers/google/base.test.ts\` (×3) | wait for MCP \`initialize\` to be called | \`vi.waitFor(() => expect(mockMcpInstance.initialize).toHaveBeenCalled())\` |
| \`telemetry.test.ts\` | wait for fire-and-forget POST | \`vi.waitFor()\` on \`fetchWithProxySpy.mock.calls.length\` |
| \`fetch.test.ts\` | 6000ms setTimeout to keep fetch in-flight while fake timers fire the 5000ms timeout | \`new Promise(() => {})\` — the fake-timer timeout path is what's under test |

## Remaining (10 files)

Left for follow-up because they need real timing semantics or a more careful migration:

- Concurrency observation: \`evaluator/gradingConcurrency.test.ts\`, \`evaluator/runEval.test.ts\`, \`evaluator/execution.test.ts\`, \`commands/mcp/lib/performance.test.ts\`, \`redteam/strategies/gcg.test.ts\`
- Real timer pass-through under \`vi.useFakeTimers()\`: \`providers/bedrock/nova-reel.test.ts\`, \`providers/xai/video.test.ts\`, \`providers/http/auth.test.ts\` (token refresh races)
- Wall-clock pacing: \`smoke/resume.test.ts\` (CLI subprocess), \`database.test.ts\` (Windows fs lock release)

## Test plan

- [x] Each migrated file's tests pass individually
- [x] All migrated files + \`test-hygiene.test.ts\` pass together (455 tests, 11 files)
- [x] \`legacySleepPromiseFiles\` allowlist shrunk from 20 → 10
- [x] Stale-allowlist self-check still passes
- [x] \`npm run l && npm run f\` clean