### PR TITLE
test(hygiene): tighten module-scope persistent-mock detector

### DIFF
--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -147,6 +147,7 @@ const legacySleepPromiseFiles = new Set<string>([
 ]);
 
 const legacyModuleScopePersistentMockFiles = new Set<string>([
+  'assertions/runAssertion.test.ts',
   'assertions/runAssertions.test.ts',
   'assertions/similar.test.ts',
   'cache.test.ts',
@@ -158,9 +159,11 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'commands/modelScan.test.ts',
   'commands/view.test.ts',
   'evaluator.integration.realTransforms.test.ts',
+  'evaluatorHelpers.test.ts',
   'external/assertions.test.ts',
   'external/conversationRelevancy.test.ts',
   'globalConfig.test.ts',
+  'googleSheets.test.ts',
   'index.test.ts',
   'integration/envPath.test.ts',
   'migrate.test.ts',
@@ -172,6 +175,8 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'providers/bedrock/knowledgeBase.test.ts',
   'providers/bedrock/luma-ray.test.ts',
   'providers/bedrock/nova-reel.test.ts',
+  'providers/bedrock/nova-sonic.test.ts',
+  'providers/browser.test.ts',
   'providers/cloudflare-ai.test.ts',
   'providers/cloudflare-gateway.test.ts',
   'providers/functionCallbackUtils.test.ts',
@@ -189,7 +194,9 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'providers/google/video.test.ts',
   'providers/http-tls.test.ts',
   'providers/huggingface.test.ts',
+  'providers/index.test.ts',
   'providers/mcp/authProvider.test.ts',
+  'providers/openai-codex-sdk.test.ts',
   'providers/openai/chatkit-pool.test.ts',
   'providers/openai/chatkit.test.ts',
   'providers/pythonCompletion.cliState.test.ts',
@@ -199,6 +206,7 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'providers/simulatedUser.test.ts',
   'providers/watsonx.test.ts',
   'redteam/commands/crossSessionLeakGenerate.test.ts',
+  'redteam/commands/generate.test.ts',
   'redteam/commands/report.test.ts',
   'redteam/extraction/entities.test.ts',
   'redteam/extraction/purpose.test.ts',
@@ -206,11 +214,13 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'redteam/plugins/base.test.ts',
   'redteam/plugins/canGenerateRemote.test.ts',
   'redteam/plugins/codingAgent.test.ts',
+  'redteam/plugins/index.test.ts',
   'redteam/plugins/intent.test.ts',
   'redteam/plugins/pliny.test.ts',
   'redteam/plugins/unsafebench.test.ts',
   'redteam/providers/authoritativeMarkupInjection.test.ts',
   'redteam/providers/bestOfN.test.ts',
+  'redteam/providers/crescendo/index.test.ts',
   'redteam/providers/goat.test.ts',
   'redteam/providers/hydra/index.test.ts',
   'redteam/providers/indirectWebPwn.test.ts',
@@ -223,13 +233,18 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'redteam/strategies/simpleVideo.test.ts',
   'sagemaker.test.ts',
   'server/findStaticDir.test.ts',
+  'server/server.test.ts',
+  'telemetry.test.ts',
   'tracing/evaluatorTracing.test.ts',
+  'tracing/integration.test.ts',
   'util/agent/fsOperations.test.ts',
+  'util/config/load.test.ts',
   'util/jsonExport.test.ts',
   'util/jsonlOutput.test.ts',
   'util/sanitizer.test.ts',
   'util/testCaseReader.test.ts',
   'util/transform.test.ts',
+  'validators/testProvider.test.ts',
 ]);
 
 const hoistedMockPattern = /\bvi\.hoisted\s*\(/;
@@ -244,12 +259,14 @@ const persistentMockImplementationPattern = new RegExp(
   `\\.(?:${persistentMockMethods.join('|')})\\s*\\(`,
 );
 const mockImplementationResetPattern = /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\s*\()/;
-// Only the global reset helpers (vi.resetAllMocks/vi.restoreAllMocks) are
-// trusted as a file-level signal that every mock is reset between tests.
+// Only `vi.resetAllMocks()` is trusted as a file-level signal that every
+// `vi.fn()`-style mock has its persistent implementation reset between tests.
 // Per-mock helpers (.mockReset()/.mockRestore()) only reset the specific mock
-// they are called on, so a single .mockReset() in a file does not protect
-// other module-scope persistent setters from leaking across random-order tests.
-const globalMockResetPattern = /\bvi\.(?:resetAllMocks|restoreAllMocks)\s*\(/;
+// they are called on, and `vi.restoreAllMocks()` is documented as targeting
+// `vi.spyOn` mocks specifically — relying on it to reset module-scope
+// `vi.fn().mockReturnValue(...)` defaults is fragile, so it does not count.
+// See https://vitest.dev/api/vi#vi-restoreallmocks.
+const globalMockResetPattern = /\bvi\.resetAllMocks\s*\(/;
 const processEnvSnapshotIdentifierPattern = /^original[A-Za-z0-9_]*$/i;
 
 function findTestFiles(dir: string): string[] {
@@ -285,9 +302,10 @@ function hasHoistedPersistentMockWithoutReset(source: string) {
 }
 
 // Boundaries beyond which a synchronous module-load traversal must not pass.
-// Constructors and class static blocks are included because they only run when
-// the class is instantiated (constructors) or first referenced (static blocks),
-// not when the module is loaded — mocks declared inside them are deferred.
+// Constructors are included because they only run when the class is
+// instantiated. Class static blocks are NOT included: they execute when the
+// class declaration is evaluated (i.e. at module load), so mock setters
+// inside them DO leak across tests if not reset.
 function isFunctionLikeNode(node: ts.Node): boolean {
   return (
     ts.isArrowFunction(node) ||
@@ -296,8 +314,7 @@ function isFunctionLikeNode(node: ts.Node): boolean {
     ts.isMethodDeclaration(node) ||
     ts.isGetAccessorDeclaration(node) ||
     ts.isSetAccessorDeclaration(node) ||
-    ts.isConstructorDeclaration(node) ||
-    ts.isClassStaticBlockDeclaration(node)
+    ts.isConstructorDeclaration(node)
   );
 }
 
@@ -412,15 +429,43 @@ function hasModuleScopePersistentMockWithoutReset(source: string) {
   }
   const sourceFile = ts.createSourceFile('fixture.test.ts', source, ts.ScriptTarget.Latest, true);
 
+  // Build a lookup for module-scope variable / function declarations whose
+  // value is a function literal, so that `vi.mock('x', factory)` with a
+  // factory passed by identifier can be resolved back to its body and scanned.
+  const moduleFactoryByName = new Map<string, ts.Node>();
+  for (const stmt of sourceFile.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.initializer &&
+          (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))
+        ) {
+          moduleFactoryByName.set(decl.name.text, decl.initializer);
+        }
+      }
+    } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      moduleFactoryByName.set(stmt.name.text, stmt);
+    }
+  }
+
+  function resolveViMockFactoryArg(arg: ts.Expression): ts.Node {
+    if (ts.isIdentifier(arg) && moduleFactoryByName.has(arg.text)) {
+      return moduleFactoryByName.get(arg.text) as ts.Node;
+    }
+    return arg;
+  }
+
   for (const stmt of sourceFile.statements) {
     if (ts.isExpressionStatement(stmt)) {
       if (ts.isCallExpression(stmt.expression) && isViMockCall(stmt.expression)) {
-        // vi.mock(path, factory): traverse the factory body, which runs at module load.
-        if (
-          stmt.expression.arguments.length >= 2 &&
-          evaluatesPersistentMockSetter(stmt.expression.arguments[1], { enterRootFunction: true })
-        ) {
-          return true;
+        // vi.mock(path, factory): the factory body runs at module load. Resolve
+        // identifier-style factories back to their declaration first.
+        if (stmt.expression.arguments.length >= 2) {
+          const factoryNode = resolveViMockFactoryArg(stmt.expression.arguments[1]);
+          if (evaluatesPersistentMockSetter(factoryNode, { enterRootFunction: true })) {
+            return true;
+          }
         }
         continue;
       }
@@ -435,6 +480,18 @@ function hasModuleScopePersistentMockWithoutReset(source: string) {
       )
     ) {
       return true;
+    }
+    // Class declarations: static blocks execute at module load when the class
+    // is evaluated, so any persistent setter inside one leaks across tests.
+    if (ts.isClassDeclaration(stmt)) {
+      for (const member of stmt.members) {
+        if (
+          ts.isClassStaticBlockDeclaration(member) &&
+          evaluatesPersistentMockSetter(member.body)
+        ) {
+          return true;
+        }
+      }
     }
   }
 
@@ -988,6 +1045,34 @@ describe('root test hygiene', () => {
     ],
     ['const baseClient = vi.fn().mockReturnValue({ id: "default" });'],
     ['vi.mocked(client).mockResolvedValue({ ok: true });'],
+    // Static blocks execute when the class declaration is evaluated (module
+    // load), so persistent setters inside them DO leak across tests.
+    [
+      [
+        'class Helper {',
+        '  static fn: ReturnType<typeof vi.fn>;',
+        '  static {',
+        '    Helper.fn = vi.fn().mockReturnValue("x");',
+        '  }',
+        '}',
+      ].join('\n'),
+    ],
+    // vi.mock(path, factory) where the factory is passed by identifier — the
+    // factory body still runs at module load and must be scanned.
+    [
+      [
+        "const factory = () => ({ fn: vi.fn().mockReturnValue('default') });",
+        "vi.mock('foo', factory);",
+      ].join('\n'),
+    ],
+    [
+      [
+        'function makeMockModule() {',
+        "  return { fn: vi.fn().mockReturnValue('default') };",
+        '}',
+        "vi.mock('foo', makeMockModule);",
+      ].join('\n'),
+    ],
   ])('detects module-scope persistent mock implementations without reset in %#', (source) => {
     expect(hasModuleScopePersistentMockWithoutReset(source)).toBe(true);
   });
@@ -1031,36 +1116,33 @@ describe('root test hygiene', () => {
         '\n',
       ),
     ],
-    // Setters inside class constructor / static block do not run at module load.
+    // Setters inside a class constructor do not run at module load — they
+    // only fire when the class is instantiated.
     [
       [
         'class Helper {',
+        '  fn: ReturnType<typeof vi.fn>;',
         '  constructor() {',
         '    this.fn = vi.fn().mockReturnValue("x");',
         '  }',
         '}',
       ].join('\n'),
     ],
-    [
-      [
-        'class Helper {',
-        '  static {',
-        '    Helper.fn = vi.fn().mockReturnValue("x");',
-        '  }',
-        '}',
-      ].join('\n'),
-    ],
-    // vi.restoreAllMocks() is also a global reset.
-    [
-      [
-        "vi.mock('foo', () => ({ bar: vi.fn().mockReturnValue('default') }));",
-        'afterEach(() => {',
-        '  vi.restoreAllMocks();',
-        '});',
-      ].join('\n'),
-    ],
   ])('allows module-scope persistent mocks when paired with reset or scoped per-test in %#', (source) => {
     expect(hasModuleScopePersistentMockWithoutReset(source)).toBe(false);
+  });
+
+  it('treats vi.restoreAllMocks() as insufficient for module-scope vi.fn() defaults', () => {
+    // vi.restoreAllMocks() is documented as targeting vi.spyOn mocks; relying
+    // on it to reset persistent vi.fn().mockReturnValue(...) defaults is
+    // fragile, so the file should still be flagged.
+    const source = [
+      "vi.mock('foo', () => ({ bar: vi.fn().mockReturnValue('default') }));",
+      'afterEach(() => {',
+      '  vi.restoreAllMocks();',
+      '});',
+    ].join('\n');
+    expect(hasModuleScopePersistentMockWithoutReset(source)).toBe(true);
   });
 
   it('treats per-mock .mockReset() as insufficient at file level', () => {

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -294,12 +294,11 @@ function hasHoistedPersistentMockWithoutReset(source: string) {
   );
 }
 
+// Boundaries beyond which a synchronous module-load traversal must not pass.
+// Constructors and class static blocks are included because they only run when
+// the class is instantiated (constructors) or first referenced (static blocks),
+// not when the module is loaded — mocks declared inside them are deferred.
 function isFunctionLikeNode(node: ts.Node): boolean {
-  // Boundaries beyond which a synchronous module-load traversal must not pass.
-  // Includes constructors and class static blocks, which only execute when the
-  // class is instantiated or initialized (not at module load) — flagging
-  // mocks declared inside them would create false positives for class-based
-  // helpers in test files.
   return (
     ts.isArrowFunction(node) ||
     ts.isFunctionExpression(node) ||
@@ -336,10 +335,11 @@ function evaluatesPersistentMockSetter(
     if (found) {
       return;
     }
-    if (isFunctionLikeNode(current)) {
-      if (!isRoot || !opts.enterRootFunction) {
-        return;
-      }
+    // Stop at function literal boundaries — their bodies don't run at module
+    // load. Exception: when `enterRootFunction` is set, descend into the root
+    // node itself (used for vi.mock(..., factory) factories).
+    if (isFunctionLikeNode(current) && !(isRoot && opts.enterRootFunction)) {
+      return;
     }
     if (
       ts.isCallExpression(current) &&

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -159,40 +159,86 @@ const legacySleepPromiseFiles = new Set<string>([
 const legacyModuleScopePersistentMockFiles = new Set<string>([
   'assertions/runAssertions.test.ts',
   'assertions/similar.test.ts',
+  'cache.test.ts',
+  'codeScans/scanner/request.test.ts',
+  'commands/eval/evaluateOptions.test.ts',
   'commands/export.test.ts',
+  'commands/mcp/server.test.ts',
   'commands/mcp/tools/runEvaluation.test.ts',
+  'commands/modelScan.test.ts',
   'commands/view.test.ts',
   'evaluator.integration.realTransforms.test.ts',
   'external/assertions.test.ts',
   'external/conversationRelevancy.test.ts',
   'globalConfig.test.ts',
+  'index.test.ts',
   'integration/envPath.test.ts',
+  'migrate.test.ts',
+  'prompts/index.test.ts',
   'providers/anthropic/completion.test.ts',
   'providers/anthropic/defaults.test.ts',
+  'providers/bedrock/agents.test.ts',
+  'providers/bedrock/converse.test.ts',
+  'providers/bedrock/knowledgeBase.test.ts',
+  'providers/bedrock/luma-ray.test.ts',
+  'providers/bedrock/nova-reel.test.ts',
   'providers/cloudflare-ai.test.ts',
   'providers/cloudflare-gateway.test.ts',
   'providers/functionCallbackUtils.test.ts',
+  'providers/github/defaults.test.ts',
+  'providers/google/ai.studio.test.ts',
+  'providers/google/auth.test.ts',
+  'providers/google/base.test.ts',
   'providers/google/gemini-image.test.ts',
+  'providers/google/gemini-mcp-integration.test.ts',
   'providers/google/image.test.ts',
+  'providers/google/live.test.ts',
+  'providers/google/provider.test.ts',
+  'providers/google/util.test.ts',
+  'providers/google/vertex.test.ts',
+  'providers/google/video.test.ts',
+  'providers/http-tls.test.ts',
   'providers/huggingface.test.ts',
   'providers/mcp/authProvider.test.ts',
+  'providers/openai/chatkit-pool.test.ts',
   'providers/openai/chatkit.test.ts',
+  'providers/pythonCompletion.cliState.test.ts',
   'providers/registry.test.ts',
   'providers/responses/processor.test.ts',
+  'providers/sagemaker.test.ts',
+  'providers/simulatedUser.test.ts',
   'providers/watsonx.test.ts',
   'redteam/commands/crossSessionLeakGenerate.test.ts',
   'redteam/commands/report.test.ts',
   'redteam/extraction/entities.test.ts',
   'redteam/extraction/purpose.test.ts',
   'redteam/extraction/util.test.ts',
+  'redteam/plugins/base.test.ts',
+  'redteam/plugins/canGenerateRemote.test.ts',
+  'redteam/plugins/codingAgent.test.ts',
   'redteam/plugins/intent.test.ts',
   'redteam/plugins/pliny.test.ts',
+  'redteam/plugins/unsafebench.test.ts',
   'redteam/providers/authoritativeMarkupInjection.test.ts',
+  'redteam/providers/bestOfN.test.ts',
+  'redteam/providers/goat.test.ts',
+  'redteam/providers/hydra/index.test.ts',
+  'redteam/providers/indirectWebPwn.test.ts',
+  'redteam/providers/iterative.test.ts',
+  'redteam/providers/iterativeImage.test.ts',
+  'redteam/providers/multi-turn-empty-response.test.ts',
   'redteam/strategies/citation.test.ts',
   'redteam/strategies/gcg.test.ts',
+  'redteam/strategies/simpleAudio.test.ts',
+  'redteam/strategies/simpleVideo.test.ts',
+  'sagemaker.test.ts',
   'server/findStaticDir.test.ts',
+  'tracing/evaluatorTracing.test.ts',
+  'util/agent/fsOperations.test.ts',
   'util/jsonExport.test.ts',
   'util/jsonlOutput.test.ts',
+  'util/sanitizer.test.ts',
+  'util/testCaseReader.test.ts',
   'util/transform.test.ts',
 ]);
 
@@ -208,8 +254,12 @@ const persistentMockImplementationPattern = new RegExp(
   `\\.(?:${persistentMockMethods.join('|')})\\s*\\(`,
 );
 const mockImplementationResetPattern = /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\s*\()/;
-const fullMockResetPattern =
-  /(?:\.mockReset\s*\(|\bvi\.resetAllMocks\s*\(|\.mockRestore\s*\(|\bvi\.restoreAllMocks\s*\()/;
+// Only the global reset helpers (vi.resetAllMocks/vi.restoreAllMocks) are
+// trusted as a file-level signal that every mock is reset between tests.
+// Per-mock helpers (.mockReset()/.mockRestore()) only reset the specific mock
+// they are called on, so a single .mockReset() in a file does not protect
+// other module-scope persistent setters from leaking across random-order tests.
+const globalMockResetPattern = /\bvi\.(?:resetAllMocks|restoreAllMocks)\s*\(/;
 const processEnvSnapshotIdentifierPattern = /^original[A-Za-z0-9_]*$/i;
 
 function findTestFiles(dir: string): string[] {
@@ -245,13 +295,20 @@ function hasHoistedPersistentMockWithoutReset(source: string) {
 }
 
 function isFunctionLikeNode(node: ts.Node): boolean {
+  // Boundaries beyond which a synchronous module-load traversal must not pass.
+  // Includes constructors and class static blocks, which only execute when the
+  // class is instantiated or initialized (not at module load) — flagging
+  // mocks declared inside them would create false positives for class-based
+  // helpers in test files.
   return (
     ts.isArrowFunction(node) ||
     ts.isFunctionExpression(node) ||
     ts.isFunctionDeclaration(node) ||
     ts.isMethodDeclaration(node) ||
     ts.isGetAccessorDeclaration(node) ||
-    ts.isSetAccessorDeclaration(node)
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isClassStaticBlockDeclaration(node)
   );
 }
 
@@ -266,16 +323,23 @@ function isViMockCall(node: ts.Node): node is ts.CallExpression {
 }
 
 // True if `node` synchronously evaluates a call ending in a persistent mock
-// setter (mockReturnValue/mockResolvedValue/etc). Skips bodies of nested
-// function literals, since their setters only run when the callback fires.
-function evaluatesPersistentMockSetter(node: ts.Node): boolean {
+// setter (mockReturnValue/mockResolvedValue/etc). Skips bodies of function
+// literals — both nested and at the root — since those only run when the
+// callback fires. Pass `enterRootFunction: true` for the body of a vi.mock(...)
+// factory, which IS executed synchronously at module load.
+function evaluatesPersistentMockSetter(
+  node: ts.Node,
+  opts: { enterRootFunction?: boolean } = {},
+): boolean {
   let found = false;
   function visit(current: ts.Node, isRoot: boolean) {
     if (found) {
       return;
     }
-    if (!isRoot && isFunctionLikeNode(current)) {
-      return;
+    if (isFunctionLikeNode(current)) {
+      if (!isRoot || !opts.enterRootFunction) {
+        return;
+      }
     }
     if (
       ts.isCallExpression(current) &&
@@ -353,26 +417,24 @@ function hasSleepPromise(source: string) {
 }
 
 function hasModuleScopePersistentMockWithoutReset(source: string) {
-  if (fullMockResetPattern.test(source)) {
+  if (globalMockResetPattern.test(source)) {
     return false;
   }
   const sourceFile = ts.createSourceFile('fixture.test.ts', source, ts.ScriptTarget.Latest, true);
 
   for (const stmt of sourceFile.statements) {
     if (ts.isExpressionStatement(stmt)) {
-      // vi.mock(path, factory) is detected separately so we don't double-count.
-      if (
-        ts.isCallExpression(stmt.expression) &&
-        isViMockCall(stmt.expression) &&
-        stmt.expression.arguments.length >= 2 &&
-        evaluatesPersistentMockSetter(stmt.expression.arguments[1])
-      ) {
-        return true;
+      if (ts.isCallExpression(stmt.expression) && isViMockCall(stmt.expression)) {
+        // vi.mock(path, factory): traverse the factory body, which runs at module load.
+        if (
+          stmt.expression.arguments.length >= 2 &&
+          evaluatesPersistentMockSetter(stmt.expression.arguments[1], { enterRootFunction: true })
+        ) {
+          return true;
+        }
+        continue;
       }
-      if (
-        !(ts.isCallExpression(stmt.expression) && isViMockCall(stmt.expression)) &&
-        evaluatesPersistentMockSetter(stmt.expression)
-      ) {
+      if (evaluatesPersistentMockSetter(stmt.expression)) {
         return true;
       }
     }
@@ -964,8 +1026,67 @@ describe('root test hygiene', () => {
       ].join('\n'),
     ],
     [['beforeEach(() => {', '  const mock = vi.fn().mockReturnValue("ok");', '});'].join('\n')],
+    // Module-scope helpers that aren't called at module load are deferred —
+    // their persistent setters do not actually run until the helper is invoked.
+    [
+      [
+        'const buildMock = () => vi.fn().mockReturnValue("default");',
+        'beforeEach(() => {',
+        '  const local = buildMock();',
+        '});',
+      ].join('\n'),
+    ],
+    [
+      ['function setupMock() {', '  return vi.fn().mockResolvedValue({ ok: true });', '}'].join(
+        '\n',
+      ),
+    ],
+    // Setters inside class constructor / static block do not run at module load.
+    [
+      [
+        'class Helper {',
+        '  constructor() {',
+        '    this.fn = vi.fn().mockReturnValue("x");',
+        '  }',
+        '}',
+      ].join('\n'),
+    ],
+    [
+      [
+        'class Helper {',
+        '  static {',
+        '    Helper.fn = vi.fn().mockReturnValue("x");',
+        '  }',
+        '}',
+      ].join('\n'),
+    ],
+    // vi.restoreAllMocks() is also a global reset.
+    [
+      [
+        "vi.mock('foo', () => ({ bar: vi.fn().mockReturnValue('default') }));",
+        'afterEach(() => {',
+        '  vi.restoreAllMocks();',
+        '});',
+      ].join('\n'),
+    ],
   ])('allows module-scope persistent mocks when paired with reset or scoped per-test in %#', (source) => {
     expect(hasModuleScopePersistentMockWithoutReset(source)).toBe(false);
+  });
+
+  it('treats per-mock .mockReset() as insufficient at file level', () => {
+    // A single .mockReset() on one mock does not protect other module-scope
+    // persistent setters from leaking — the file should still be flagged.
+    const source = [
+      "vi.mock('foo', () => ({",
+      "  bar: vi.fn().mockReturnValue('bar-default'),",
+      "  baz: vi.fn().mockReturnValue('baz-default'),",
+      '}));',
+      '',
+      'beforeEach(() => {',
+      '  vi.mocked(bar).mockReset();',
+      '});',
+    ].join('\n');
+    expect(hasModuleScopePersistentMockWithoutReset(source)).toBe(true);
   });
 
   it('keeps new root tests from adding unreset module-scope persistent mocks', () => {


### PR DESCRIPTION
## Summary

Addresses three review comments from #8949 (now merged):

| Reviewer | Issue | Fix |
| --- | --- | --- |
| codex P2 | false negatives — any reset token in file silenced detection | Honor only *global* resets (`vi.resetAllMocks`/`vi.restoreAllMocks`). Per-mock `.mockReset()` no longer counts at file level. |
| codex P2 | false positives — module-scope helper functions traversed | Add `enterRootFunction` opt; only enable for `vi.mock(path, factory)` factory body. Other root-level function literals (helpers, `const buildMock = () => ...`, etc.) are now skipped. |
| Copilot | `isFunctionLikeNode` missed constructors / static blocks | Add `ts.isConstructorDeclaration` and `ts.isClassStaticBlockDeclaration`. |

## Effect on the legacy allowlist

The stricter file-level reset rule expands `legacyModuleScopePersistentMockFiles` from 37 → 83 entries. The ratchet self-check stays in place, so the list will shrink as files migrate to a `vi.resetAllMocks()`/`vi.restoreAllMocks()` call in `beforeEach`/`afterEach`.

## New test coverage

- module-scope helper functions (`const buildMock = () => vi.fn().mockReturnValue(...)`)
- class constructor / static block setters
- `vi.restoreAllMocks()` recognized as a global reset
- per-mock `.mockReset()` now correctly flagged as insufficient

## Test plan

- [x] `npx vitest run test/test-hygiene.test.ts` — 86 tests pass (was 80)
- [x] Stale-allowlist self-check passes
- [x] `npm run l && npm run f` clean