### PR TITLE
test(fs): make fs/promises mocks return real Promises

### DIFF
--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -57,7 +57,9 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 vi.mock('fs/promises', () => {
-  const access = vi.fn((filePath: any) => {
+  // Wrap each sync mock so the corresponding fs/promises export returns a real
+  // Promise (or rejects), matching the actual API contract.
+  const access = vi.fn(async (filePath: any) => {
     if (fsMocks.existsSync(filePath)) {
       return undefined;
     }
@@ -65,24 +67,14 @@ vi.mock('fs/promises', () => {
       code: 'ENOENT',
     });
   });
-  return {
-    default: {
-      readFile: fsMocks.readFileSync,
-      readdir: fsMocks.readdirSync,
-      mkdtemp: fsMocks.mkdtempSync,
-      mkdir: fsMocks.mkdirSync,
-      copyFile: fsMocks.copyFileSync,
-      rm: fsMocks.rmSync,
-      access,
-    },
-    readFile: fsMocks.readFileSync,
-    readdir: fsMocks.readdirSync,
-    mkdtemp: fsMocks.mkdtempSync,
-    mkdir: fsMocks.mkdirSync,
-    copyFile: fsMocks.copyFileSync,
-    rm: fsMocks.rmSync,
-    access,
-  };
+  const readFile = vi.fn(async (...args: any[]) => fsMocks.readFileSync(...args));
+  const readdir = vi.fn(async (...args: any[]) => fsMocks.readdirSync(...args));
+  const mkdtemp = vi.fn(async (...args: any[]) => fsMocks.mkdtempSync(...args));
+  const mkdir = vi.fn(async (...args: any[]) => fsMocks.mkdirSync(...args));
+  const copyFile = vi.fn(async (...args: any[]) => fsMocks.copyFileSync(...args));
+  const rm = vi.fn(async (...args: any[]) => fsMocks.rmSync(...args));
+  const promiseApi = { readFile, readdir, mkdtemp, mkdir, copyFile, rm, access };
+  return { default: promiseApi, ...promiseApi };
 });
 vi.mock('path');
 

--- a/test/providers/http-tls.test.ts
+++ b/test/providers/http-tls.test.ts
@@ -41,12 +41,13 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
-vi.mock('fs/promises', () => ({
-  default: {
-    readFile: mockReadFileSync,
-  },
-  readFile: mockReadFileSync,
-}));
+// Wrap the sync mock so fs/promises.readFile returns a real Promise, matching
+// the actual API contract. (await still unwraps non-Promise values, but tests
+// for Promise-aware callers like Promise.all need the real shape.)
+vi.mock('fs/promises', () => {
+  const readFile = vi.fn(async (...args: any[]) => mockReadFileSync(...args));
+  return { default: { readFile }, readFile };
+});
 
 describe('HttpProvider with TLS Configuration', () => {
   const mockFetchWithCache = vi.mocked(fetchWithCache);

--- a/test/providers/openai/transcription.test.ts
+++ b/test/providers/openai/transcription.test.ts
@@ -37,7 +37,9 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 vi.mock('fs/promises', () => {
-  const readFile = vi.fn((filePath: any, encoding?: any) =>
+  // Async wrapper around the sync mock so the returned value is a real Promise,
+  // matching the actual fs/promises.readFile API.
+  const readFile = vi.fn(async (filePath: any, encoding?: any) =>
     encoding === undefined
       ? fsMocks.readFileSync(filePath)
       : fsMocks.readFileSync(filePath, encoding),

--- a/test/providers/openai/video.test.ts
+++ b/test/providers/openai/video.test.ts
@@ -47,7 +47,9 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 vi.mock('fs/promises', () => {
-  const readFile = vi.fn((filePath: any, encoding?: any) => {
+  // Async wrapper around the sync mock so the returned value is a real Promise,
+  // matching the actual fs/promises.readFile API.
+  const readFile = vi.fn(async (filePath: any, encoding?: any) => {
     if (!fsMocks.existsSync(filePath)) {
       throw Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), {
         code: 'ENOENT',

--- a/test/util/xlsx.test.ts
+++ b/test/util/xlsx.test.ts
@@ -19,7 +19,9 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('fs/promises', () => {
-  const access = vi.fn((filePath: any) => {
+  // Async wrapper so fs/promises.access returns a real Promise (resolves) or
+  // rejects, matching the actual API contract.
+  const access = vi.fn(async (filePath: any) => {
     if (mockExistsSync(filePath)) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

Stacked on top of #8956. After the fs/promises audit, several test mocks delegated \`fs/promises.readFile\` and \`fs/promises.access\` to the underlying sync \`vi.fn()\`, so the mocked methods returned plain values instead of Promises. \`await\` unwraps non-Promise values so the tests still passed, but Promise-aware callers (\`Promise.all\`, \`.then()\`) break against the mock contract — exactly the issue that surfaced when wiring up #8956.

Wraps each export in a thin \`async vi.fn\` that delegates to the existing sync mock, so behavior is preserved while the API shape matches Node's actual \`fs/promises\`.

Files touched:

- \`test/providers/http-tls.test.ts\`
- \`test/providers/openai/transcription.test.ts\`
- \`test/providers/openai/video.test.ts\`
- \`test/providers/golangCompletion.test.ts\`
- \`test/util/xlsx.test.ts\`

## Test plan

- [x] \`npx vitest run test/providers/http-tls.test.ts test/providers/openai/transcription.test.ts test/providers/openai/video.test.ts test/providers/golangCompletion.test.ts test/util/xlsx.test.ts\` — 147/147 pass