### PR TITLE
fix(eval): preserve filter range on resume

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -412,7 +412,7 @@ export async function doEval(
       );
     }
     const filterRange = resumeEval
-      ? (persistedFilterRange ?? commandLineOptions?.filterRange ?? evaluateOptions.filterRange)
+      ? persistedFilterRange
       : (cmdObj.filterRange ?? commandLineOptions?.filterRange ?? evaluateOptions.filterRange);
     const shouldApplyRangeToImplicitDefaultTest =
       filterRange !== undefined && !hasScenarios && !testSuite.tests?.length;

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -406,13 +406,15 @@ export async function doEval(
       typeof resumeRuntimeOptions?.filterRange === 'string'
         ? resumeRuntimeOptions.filterRange
         : undefined;
-    if (resumeEval && cmdObj.filterRange && cmdObj.filterRange !== persistedFilterRange) {
+    const resumeConfigFilterRange = commandLineOptions?.filterRange ?? evaluateOptions.filterRange;
+    const resumeFilterRange = persistedFilterRange ?? resumeConfigFilterRange;
+    if (resumeEval && cmdObj.filterRange && cmdObj.filterRange !== resumeFilterRange) {
       logger.warn(
-        `Ignoring --filter-range ${cmdObj.filterRange}: resuming ${resumeEval.id} with persisted range ${persistedFilterRange ?? '(none)'} to preserve test indices.`,
+        `Ignoring --filter-range ${cmdObj.filterRange}: resuming ${resumeEval.id} with stored range ${resumeFilterRange ?? '(none)'} to preserve test indices.`,
       );
     }
     const filterRange = resumeEval
-      ? persistedFilterRange
+      ? resumeFilterRange
       : (cmdObj.filterRange ?? commandLineOptions?.filterRange ?? evaluateOptions.filterRange);
     const shouldApplyRangeToImplicitDefaultTest =
       filterRange !== undefined && !hasScenarios && !testSuite.tests?.length;

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -652,9 +652,13 @@ describe('evaluateOptions behavior', () => {
       }
     });
 
-    it('should ignore newly configured filterRange defaults when resuming without one persisted', async () => {
+    it.each([
+      ['commandLineOptions', { commandLineOptions: { filterRange: '1:2' } }],
+      ['evaluateOptions', { evaluateOptions: { filterRange: '1:2' } }],
+    ])('should restore legacy %s.filterRange when resuming evals without persisted runtime options', async (_source, legacyConfig) => {
       const resumeEval = new Eval(
         {
+          ...legacyConfig,
           providers: ['echo'],
           prompts: ['Hello {{name}}'],
           tests: [
@@ -666,11 +670,6 @@ describe('evaluateOptions behavior', () => {
         {
           id: 'eval-resume-without-filter-range',
           persisted: true,
-          runtimeOptions: {
-            cache: true,
-            maxConcurrency: 1,
-            repeat: 1,
-          },
         },
       );
       const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValue(resumeEval);
@@ -684,13 +683,13 @@ describe('evaluateOptions behavior', () => {
           {},
           undefined,
           {
-            filterRange: '1:2',
+            filterRange: '0:1',
           },
         );
 
         expect(evaluateMock).toHaveBeenCalled();
         const options = evaluateMock.mock.calls.at(-1)?.[2] as EvaluateOptions;
-        expect(options.filterRange).toBeUndefined();
+        expect(options.filterRange).toBe('1:2');
       } finally {
         findByIdSpy.mockRestore();
       }

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -652,6 +652,50 @@ describe('evaluateOptions behavior', () => {
       }
     });
 
+    it('should ignore newly configured filterRange defaults when resuming without one persisted', async () => {
+      const resumeEval = new Eval(
+        {
+          providers: ['echo'],
+          prompts: ['Hello {{name}}'],
+          tests: [
+            { vars: { name: 'Alice' } },
+            { vars: { name: 'Bob' } },
+            { vars: { name: 'Carol' } },
+          ],
+        },
+        {
+          id: 'eval-resume-without-filter-range',
+          persisted: true,
+          runtimeOptions: {
+            cache: true,
+            maxConcurrency: 1,
+            repeat: 1,
+          },
+        },
+      );
+      const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValue(resumeEval);
+
+      try {
+        await doEval(
+          {
+            table: false,
+            resume: 'eval-resume-without-filter-range',
+          } as any,
+          {},
+          undefined,
+          {
+            filterRange: '1:2',
+          },
+        );
+
+        expect(evaluateMock).toHaveBeenCalled();
+        const options = evaluateMock.mock.calls.at(-1)?.[2] as EvaluateOptions;
+        expect(options.filterRange).toBeUndefined();
+      } finally {
+        findByIdSpy.mockRestore();
+      }
+    });
+
     it('should warn and ignore CLI --filter-range when resuming with a different persisted range', async () => {
       const resumeEval = new Eval(
         {


### PR DESCRIPTION
## Summary
- In the new resume path, eval.ts now computes resume-time filterRange as:
`persistedFilterRange ?? commandLineOptions?.filterRange ?? evaluateOptions.filterRange`
and then passes a range into evaluation whenever `resumeEval` is present. That means an eval originally created with no range can later resume with a newly added config default range, silently changing the test slice even though the surrounding code says resume should preserve test indices.
- preserve the original filter-range contract when resuming persisted evals
- avoid introducing a new config-default range into resumes that were created without one
- add regression coverage for the no-persisted-range resume case

## Test plan
- Verified a local eval with `--filter-range 1:2` still executes only the expected single test case.
- Added and ran focused resume coverage for evals created without a persisted range.