### PR TITLE
fix(assertions): support indexed XML paths

### DIFF
--- a/src/assertions/xml.ts
+++ b/src/assertions/xml.ts
@@ -293,8 +293,22 @@ function hasElementPath(value: unknown, path: string[]): boolean {
   let current = value;
 
   for (const key of path) {
-    if (current === null || typeof current !== 'object' || Array.isArray(current)) {
+    if (current === null || typeof current !== 'object') {
       return false;
+    }
+
+    if (Array.isArray(current)) {
+      const index = Number(key);
+      if (!Number.isInteger(index) || index < 0 || String(index) !== key) {
+        return false;
+      }
+
+      if (current[index] === undefined) {
+        return false;
+      }
+
+      current = current[index];
+      continue;
     }
 
     const record = current as Record<string, unknown>;

--- a/test/assertions/xml.test.ts
+++ b/test/assertions/xml.test.ts
@@ -105,6 +105,18 @@ describe('validateXml', () => {
     });
   });
 
+  it('should validate indexed required elements within repeated siblings', () => {
+    expect(
+      validateXml('<root><item><name>First</name></item><item><name>Second</name></item></root>', [
+        'root.item.0.name',
+        'root.item.1.name',
+      ]),
+    ).toEqual({
+      isValid: true,
+      reason: 'XML is valid and contains all required elements',
+    });
+  });
+
   it('should handle XML with CDATA sections', () => {
     expect(
       validateXml('<root><child><![CDATA[<p>This is CDATA content</p>]]></child></root>', [
@@ -179,6 +191,13 @@ describe('containsXml', () => {
   it('should validate required elements', () => {
     const input = 'Text <root><child>Content</child></root> more';
     const result = containsXml(input, ['root.child']);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should validate indexed required elements within extracted XML', () => {
+    const input =
+      'Text <root><item><name>First</name></item><item><name>Second</name></item></root> more';
+    const result = containsXml(input, ['root.item.1.name']);
     expect(result.isValid).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- restore required-element traversal through repeated XML nodes using numeric array indices
- add regression coverage for indexed paths in both `validateXml` and `containsXml`

## Test plan
- `npx vitest run test/assertions/xml.test.ts`
- `npm run tsc`
- `npm run l`
- `npm run f`
- `npm run build`