### PR TITLE
fix(eval): delete traces with eval records

### DIFF
--- a/src/database/evalDeletion.ts
+++ b/src/database/evalDeletion.ts
@@ -1,0 +1,24 @@
+import { inArray, sql } from 'drizzle-orm';
+import { spansTable, tracesTable } from './tables';
+
+import type { getDb } from './index';
+
+const SQLITE_MAX_BOUND_PARAMETERS = 999;
+
+export function deleteTraceRecordsForEvals(db: ReturnType<typeof getDb>, evalIds: string[]): void {
+  for (let i = 0; i < evalIds.length; i += SQLITE_MAX_BOUND_PARAMETERS) {
+    const evalIdBatch = evalIds.slice(i, i + SQLITE_MAX_BOUND_PARAMETERS);
+
+    db.delete(spansTable)
+      .where(
+        sql`${spansTable.traceId} in (
+          select ${tracesTable.traceId}
+          from ${tracesTable}
+          where ${inArray(tracesTable.evaluationId, evalIdBatch)}
+        )`,
+      )
+      .run();
+
+    db.delete(tracesTable).where(inArray(tracesTable.evaluationId, evalIdBatch)).run();
+  }
+}

--- a/src/database/evalDeletion.ts
+++ b/src/database/evalDeletion.ts
@@ -3,9 +3,25 @@ import { spansTable, tracesTable } from './tables';
 
 import type { getDb } from './index';
 
+// SQLite limits a single statement to 999 bound parameters by default.
 const SQLITE_MAX_BOUND_PARAMETERS = 999;
 
+/**
+ * Removes spans and traces tied to the given eval ids.
+ *
+ * `traces.evaluation_id -> evals.id` and `spans.trace_id -> traces.trace_id` are
+ * FK-enforced (see `pragma foreign_keys = ON`) without `ON DELETE CASCADE`, so any
+ * eval-deletion path must clear spans before traces before the eval row itself.
+ * No-ops when `evalIds` is empty.
+ *
+ * Spans are removed via a correlated subquery so the query stays within SQLite's
+ * bound-parameter limit even when an eval has many traces.
+ */
 export function deleteTraceRecordsForEvals(db: ReturnType<typeof getDb>, evalIds: string[]): void {
+  if (evalIds.length === 0) {
+    return;
+  }
+
   for (let i = 0; i < evalIds.length; i += SQLITE_MAX_BOUND_PARAMETERS) {
     const evalIdBatch = evalIds.slice(i, i + SQLITE_MAX_BOUND_PARAMETERS);
 

--- a/src/database/evalDeletion.ts
+++ b/src/database/evalDeletion.ts
@@ -12,16 +12,11 @@ const SQLITE_MAX_BOUND_PARAMETERS = 999;
  * `traces.evaluation_id -> evals.id` and `spans.trace_id -> traces.trace_id` are
  * FK-enforced (see `pragma foreign_keys = ON`) without `ON DELETE CASCADE`, so any
  * eval-deletion path must clear spans before traces before the eval row itself.
- * No-ops when `evalIds` is empty.
  *
  * Spans are removed via a correlated subquery so the query stays within SQLite's
  * bound-parameter limit even when an eval has many traces.
  */
 export function deleteTraceRecordsForEvals(db: ReturnType<typeof getDb>, evalIds: string[]): void {
-  if (evalIds.length === 0) {
-    return;
-  }
-
   for (let i = 0; i < evalIds.length; i += SQLITE_MAX_BOUND_PARAMETERS) {
     const evalIdBatch = evalIds.slice(i, i + SQLITE_MAX_BOUND_PARAMETERS);
 

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -1,5 +1,6 @@
-import { and, desc, eq, inArray, type SQL, sql } from 'drizzle-orm';
+import { and, desc, eq, type SQL, sql } from 'drizzle-orm';
 import { DEFAULT_QUERY_LIMIT, HUMAN_ASSERTION_TYPE } from '../constants';
+import { deleteTraceRecordsForEvals } from '../database/evalDeletion';
 import { getDb } from '../database/index';
 import { updateSignalFile } from '../database/signal';
 import {
@@ -10,9 +11,7 @@ import {
   evalsToPromptsTable,
   evalsToTagsTable,
   promptsTable,
-  spansTable,
   tagsTable,
-  tracesTable,
 } from '../database/tables';
 import { getEnvBool } from '../envars';
 import { getAuthor } from '../globalConfig/accounts';
@@ -1403,18 +1402,7 @@ export default class Eval {
   async delete() {
     const db = getDb();
     db.transaction(() => {
-      const traceIds = db
-        .select({ traceId: tracesTable.traceId })
-        .from(tracesTable)
-        .where(eq(tracesTable.evaluationId, this.id))
-        .all()
-        .map(({ traceId }) => traceId);
-
-      if (traceIds.length > 0) {
-        db.delete(spansTable).where(inArray(spansTable.traceId, traceIds)).run();
-      }
-
-      db.delete(tracesTable).where(eq(tracesTable.evaluationId, this.id)).run();
+      deleteTraceRecordsForEvals(db, [this.id]);
       db.delete(evalsToDatasetsTable).where(eq(evalsToDatasetsTable.evalId, this.id)).run();
       db.delete(evalsToPromptsTable).where(eq(evalsToPromptsTable.evalId, this.id)).run();
       db.delete(evalsToTagsTable).where(eq(evalsToTagsTable.evalId, this.id)).run();

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, type SQL, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, type SQL, sql } from 'drizzle-orm';
 import { DEFAULT_QUERY_LIMIT, HUMAN_ASSERTION_TYPE } from '../constants';
 import { getDb } from '../database/index';
 import { updateSignalFile } from '../database/signal';
@@ -10,7 +10,9 @@ import {
   evalsToPromptsTable,
   evalsToTagsTable,
   promptsTable,
+  spansTable,
   tagsTable,
+  tracesTable,
 } from '../database/tables';
 import { getEnvBool } from '../envars';
 import { getAuthor } from '../globalConfig/accounts';
@@ -1401,6 +1403,18 @@ export default class Eval {
   async delete() {
     const db = getDb();
     db.transaction(() => {
+      const traceIds = db
+        .select({ traceId: tracesTable.traceId })
+        .from(tracesTable)
+        .where(eq(tracesTable.evaluationId, this.id))
+        .all()
+        .map(({ traceId }) => traceId);
+
+      if (traceIds.length > 0) {
+        db.delete(spansTable).where(inArray(spansTable.traceId, traceIds)).run();
+      }
+
+      db.delete(tracesTable).where(eq(tracesTable.evaluationId, this.id)).run();
       db.delete(evalsToDatasetsTable).where(eq(evalsToDatasetsTable.evalId, this.id)).run();
       db.delete(evalsToPromptsTable).where(eq(evalsToPromptsTable.evalId, this.id)).run();
       db.delete(evalsToTagsTable).where(eq(evalsToTagsTable.evalId, this.id)).run();

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { LRUCache } from 'lru-cache';
 import { DEFAULT_QUERY_LIMIT } from '../constants';
+import { deleteTraceRecordsForEvals } from '../database/evalDeletion';
 import { getDb } from '../database/index';
 import {
   datasetsTable,
@@ -437,25 +438,6 @@ export async function getEvalFromId(hash: string) {
     }
   }
   return undefined;
-}
-
-function deleteTraceRecordsForEvals(db: ReturnType<typeof getDb>, evalIds: string[]) {
-  if (evalIds.length === 0) {
-    return;
-  }
-
-  const traceIds = db
-    .select({ traceId: tracesTable.traceId })
-    .from(tracesTable)
-    .where(inArray(tracesTable.evaluationId, evalIds))
-    .all()
-    .map(({ traceId }) => traceId);
-
-  if (traceIds.length > 0) {
-    db.delete(spansTable).where(inArray(spansTable.traceId, traceIds)).run();
-  }
-
-  db.delete(tracesTable).where(inArray(tracesTable.evaluationId, evalIds)).run();
 }
 
 export async function deleteEval(evalId: string) {

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -10,7 +10,9 @@ import {
   evalsToPromptsTable,
   evalsToTagsTable,
   promptsTable,
+  spansTable,
   tagsTable,
+  tracesTable,
 } from '../database/tables';
 import { getAuthor } from '../globalConfig/accounts';
 import logger from '../logger';
@@ -437,10 +439,30 @@ export async function getEvalFromId(hash: string) {
   return undefined;
 }
 
+function deleteTraceRecordsForEvals(db: ReturnType<typeof getDb>, evalIds: string[]) {
+  if (evalIds.length === 0) {
+    return;
+  }
+
+  const traceIds = db
+    .select({ traceId: tracesTable.traceId })
+    .from(tracesTable)
+    .where(inArray(tracesTable.evaluationId, evalIds))
+    .all()
+    .map(({ traceId }) => traceId);
+
+  if (traceIds.length > 0) {
+    db.delete(spansTable).where(inArray(spansTable.traceId, traceIds)).run();
+  }
+
+  db.delete(tracesTable).where(inArray(tracesTable.evaluationId, evalIds)).run();
+}
+
 export async function deleteEval(evalId: string) {
   const db = getDb();
   db.transaction(() => {
     // We need to clean up foreign keys first. We don't have onDelete: 'cascade' set on all these relationships.
+    deleteTraceRecordsForEvals(db, [evalId]);
     db.delete(evalsToPromptsTable).where(eq(evalsToPromptsTable.evalId, evalId)).run();
     db.delete(evalsToDatasetsTable).where(eq(evalsToDatasetsTable.evalId, evalId)).run();
     db.delete(evalsToTagsTable).where(eq(evalsToTagsTable.evalId, evalId)).run();
@@ -461,6 +483,7 @@ export async function deleteEval(evalId: string) {
 export function deleteEvals(ids: string[]) {
   const db = getDb();
   db.transaction(() => {
+    deleteTraceRecordsForEvals(db, ids);
     db.delete(evalsToPromptsTable).where(inArray(evalsToPromptsTable.evalId, ids)).run();
     db.delete(evalsToDatasetsTable).where(inArray(evalsToDatasetsTable.evalId, ids)).run();
     db.delete(evalsToTagsTable).where(inArray(evalsToTagsTable.evalId, ids)).run();
@@ -477,6 +500,8 @@ export function deleteEvals(ids: string[]) {
 export async function deleteAllEvals(): Promise<void> {
   const db = getDb();
   db.transaction(() => {
+    db.delete(spansTable).run();
+    db.delete(tracesTable).run();
     db.delete(evalResultsTable).run();
     db.delete(evalsToPromptsTable).run();
     db.delete(evalsToDatasetsTable).run();

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -443,7 +443,9 @@ export async function getEvalFromId(hash: string) {
 export async function deleteEval(evalId: string) {
   const db = getDb();
   db.transaction(() => {
-    // We need to clean up foreign keys first. We don't have onDelete: 'cascade' set on all these relationships.
+    // Clean up FK-referenced rows first; not all relationships have onDelete: 'cascade'.
+    // Spans and traces in particular must be removed before the eval row, otherwise
+    // SQLite raises "FOREIGN KEY constraint failed" (foreign_keys pragma is ON).
     deleteTraceRecordsForEvals(db, [evalId]);
     db.delete(evalsToPromptsTable).where(eq(evalsToPromptsTable.evalId, evalId)).run();
     db.delete(evalsToDatasetsTable).where(eq(evalsToDatasetsTable.evalId, evalId)).run();

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../src/database/index';
 import { updateSignalFile } from '../../src/database/signal';
+import { spansTable, tracesTable } from '../../src/database/tables';
 import { getAuthor } from '../../src/globalConfig/accounts';
 import { runDbMigrations } from '../../src/migrate';
 import Eval, {
@@ -11,6 +12,7 @@ import Eval, {
   escapeJsonPathKey,
   getEvalSummaries,
 } from '../../src/models/eval';
+import { TraceStore } from '../../src/tracing/store';
 import EvalFactory from '../factories/evalFactory';
 
 import type { Prompt } from '../../src/types/index';
@@ -44,6 +46,8 @@ describe('evaluator', () => {
     // Clear all tables before each test
     const db = getDb();
     // Delete related tables first
+    await db.run('DELETE FROM spans');
+    await db.run('DELETE FROM traces');
     await db.run('DELETE FROM eval_results');
     await db.run('DELETE FROM evals_to_datasets');
     await db.run('DELETE FROM evals_to_prompts');
@@ -227,6 +231,30 @@ describe('evaluator', () => {
 
       const eval_2 = await Eval.findById(eval1.id);
       expect(eval_2).toBeUndefined();
+    });
+
+    it('should delete traces and spans for an evaluation', async () => {
+      const eval1 = await EvalFactory.create();
+      const traceStore = new TraceStore();
+      await traceStore.createTrace({
+        traceId: 'trace-to-delete',
+        evaluationId: eval1.id,
+        testCaseId: 'test-case-id',
+      });
+      await traceStore.addSpans('trace-to-delete', [
+        {
+          spanId: 'span-to-delete',
+          name: 'test-span',
+          startTime: 1,
+        },
+      ]);
+
+      await eval1.delete();
+
+      const db = getDb();
+      expect(await Eval.findById(eval1.id)).toBeUndefined();
+      expect(db.select().from(tracesTable).all()).toHaveLength(0);
+      expect(db.select().from(spansTable).all()).toHaveLength(0);
     });
   });
 

--- a/test/util/databaseDelete.test.ts
+++ b/test/util/databaseDelete.test.ts
@@ -95,27 +95,16 @@ describe('database eval deletion', () => {
     expect(await Eval.findById(eval_.id)).toBeUndefined();
   });
 
-  it('deletes evals that share span ids across distinct traces', async () => {
-    const eval1 = await EvalFactory.create();
-    const eval2 = await EvalFactory.create();
-    await addTrace(eval1.id, 'trace-shared-span-1');
-    await addTrace(eval2.id, 'trace-shared-span-2');
-
-    // Each trace already has one span; add another span on eval1's trace to
-    // exercise multi-span cleanup for a single trace.
-    const traceStore = new TraceStore();
-    await traceStore.addSpans('trace-shared-span-1', [
-      {
-        spanId: 'extra-span',
-        name: 'extra',
-        startTime: 2,
-      },
+  it('deletes every span when a trace has multiple spans', async () => {
+    const eval_ = await EvalFactory.create();
+    await addTrace(eval_.id, 'trace-multi-span');
+    await new TraceStore().addSpans('trace-multi-span', [
+      { spanId: 'extra-span', name: 'extra', startTime: 2 },
     ]);
 
-    deleteEvals([eval1.id, eval2.id]);
+    await deleteEval(eval_.id);
 
     const db = getDb();
-    expect(db.select().from(tracesTable).all()).toHaveLength(0);
     expect(db.select().from(spansTable).all()).toHaveLength(0);
   });
 });

--- a/test/util/databaseDelete.test.ts
+++ b/test/util/databaseDelete.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getDb } from '../../src/database/index';
+import { spansTable, tracesTable } from '../../src/database/tables';
+import { runDbMigrations } from '../../src/migrate';
+import Eval from '../../src/models/eval';
+import { TraceStore } from '../../src/tracing/store';
+import { deleteAllEvals, deleteEval, deleteEvals } from '../../src/util/database';
+import EvalFactory from '../factories/evalFactory';
+
+describe('database eval deletion', () => {
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    await db.run('DELETE FROM spans');
+    await db.run('DELETE FROM traces');
+    await db.run('DELETE FROM eval_results');
+    await db.run('DELETE FROM evals_to_datasets');
+    await db.run('DELETE FROM evals_to_prompts');
+    await db.run('DELETE FROM evals_to_tags');
+    await db.run('DELETE FROM evals');
+  });
+
+  async function addTrace(evalId: string, traceId: string) {
+    const traceStore = new TraceStore();
+    await traceStore.createTrace({
+      traceId,
+      evaluationId: evalId,
+      testCaseId: 'test-case-id',
+    });
+    await traceStore.addSpans(traceId, [
+      {
+        spanId: `${traceId}-span`,
+        name: 'test-span',
+        startTime: 1,
+      },
+    ]);
+  }
+
+  it('deletes traces and spans for a single eval', async () => {
+    const eval_ = await EvalFactory.create();
+    await addTrace(eval_.id, 'trace-single');
+
+    await deleteEval(eval_.id);
+
+    const db = getDb();
+    expect(await Eval.findById(eval_.id)).toBeUndefined();
+    expect(db.select().from(tracesTable).all()).toHaveLength(0);
+    expect(db.select().from(spansTable).all()).toHaveLength(0);
+  });
+
+  it('deletes only traces and spans for selected evals', async () => {
+    const eval1 = await EvalFactory.create();
+    const eval2 = await EvalFactory.create();
+    const eval3 = await EvalFactory.create();
+    await addTrace(eval1.id, 'trace-bulk-1');
+    await addTrace(eval2.id, 'trace-bulk-2');
+    await addTrace(eval3.id, 'trace-retained');
+
+    deleteEvals([eval1.id, eval2.id]);
+
+    const db = getDb();
+    expect(await Eval.findById(eval1.id)).toBeUndefined();
+    expect(await Eval.findById(eval2.id)).toBeUndefined();
+    expect(await Eval.findById(eval3.id)).toBeDefined();
+    expect(db.select({ traceId: tracesTable.traceId }).from(tracesTable).all()).toEqual([
+      { traceId: 'trace-retained' },
+    ]);
+    expect(db.select({ traceId: spansTable.traceId }).from(spansTable).all()).toEqual([
+      { traceId: 'trace-retained' },
+    ]);
+  });
+
+  it('deletes traces and spans when deleting all evals', async () => {
+    const eval1 = await EvalFactory.create();
+    const eval2 = await EvalFactory.create();
+    await addTrace(eval1.id, 'trace-all-1');
+    await addTrace(eval2.id, 'trace-all-2');
+
+    await deleteAllEvals();
+
+    const db = getDb();
+    expect(await Eval.getMany()).toHaveLength(0);
+    expect(db.select().from(tracesTable).all()).toHaveLength(0);
+    expect(db.select().from(spansTable).all()).toHaveLength(0);
+  });
+});

--- a/test/util/databaseDelete.test.ts
+++ b/test/util/databaseDelete.test.ts
@@ -86,4 +86,36 @@ describe('database eval deletion', () => {
     expect(db.select().from(tracesTable).all()).toHaveLength(0);
     expect(db.select().from(spansTable).all()).toHaveLength(0);
   });
+
+  it('handles evals with no traces without error', async () => {
+    const eval_ = await EvalFactory.create();
+
+    await deleteEval(eval_.id);
+
+    expect(await Eval.findById(eval_.id)).toBeUndefined();
+  });
+
+  it('deletes evals that share span ids across distinct traces', async () => {
+    const eval1 = await EvalFactory.create();
+    const eval2 = await EvalFactory.create();
+    await addTrace(eval1.id, 'trace-shared-span-1');
+    await addTrace(eval2.id, 'trace-shared-span-2');
+
+    // Each trace already has one span; add another span on eval1's trace to
+    // exercise multi-span cleanup for a single trace.
+    const traceStore = new TraceStore();
+    await traceStore.addSpans('trace-shared-span-1', [
+      {
+        spanId: 'extra-span',
+        name: 'extra',
+        startTime: 2,
+      },
+    ]);
+
+    deleteEvals([eval1.id, eval2.id]);
+
+    const db = getDb();
+    expect(db.select().from(tracesTable).all()).toHaveLength(0);
+    expect(db.select().from(spansTable).all()).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- remove trace spans before trace rows when deleting evals
- cover single, bulk, delete-all, and model-level eval deletion with trace-backed regressions
- keep delete behavior transactional so failed deletes still roll back cleanly

## Testing
- `npx vitest run test/util/databaseDelete.test.ts test/models/eval.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `npm run local -- delete eval <id>` against a throwaway SQLite config dir containing a traced eval

Fixes #8972
