### PR TITLE
fix(api): preserve error details and stack traces in shared helpers

### DIFF
--- a/src/server/utils/errors.ts
+++ b/src/server/utils/errors.ts
@@ -4,6 +4,27 @@ import { ErrorResponseSchema } from '../../types/api/common';
 import type { Response } from 'express';
 
 /**
+ * Build a logger-safe context object from an unknown error value.
+ *
+ * The default logger object-context serializer goes through `JSON.stringify`,
+ * which drops `name`, `message`, and `stack` from `Error` instances because they
+ * are non-enumerable. Extract them explicitly so `logger.error` retains the stack.
+ */
+function toLogContext(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+        ...(error.cause === undefined ? {} : { cause: error.cause }),
+      },
+    };
+  }
+  return { error };
+}
+
+/**
  * Send a standardized error response.
  *
  * All error responses use the shape `{ error: string }`.
@@ -15,13 +36,25 @@ export function sendError(
   publicMessage: string,
   internalError?: unknown,
 ): void {
-  if (internalError) {
-    logger.error(publicMessage, { error: internalError });
+  if (internalError !== undefined) {
+    logger.error(publicMessage, toLogContext(internalError));
   }
   res.status(status).json(ErrorResponseSchema.parse({ error: publicMessage }));
 }
 
-/** Reply with a 400 from a Zod safeParse error, formatted via `z.prettifyError`. */
+/**
+ * Reply with a 400 from a Zod safeParse error.
+ *
+ * The human-readable message goes in `error` (formatted via `z.prettifyError`)
+ * so existing clients keep working. The structured Zod issue array is also
+ * exposed in `details` for clients that want to map errors back to fields
+ * programmatically.
+ */
 export function replyValidationError(res: Response, error: z.ZodError): void {
-  res.status(400).json(ErrorResponseSchema.parse({ error: z.prettifyError(error) }));
+  res.status(400).json(
+    ErrorResponseSchema.parse({
+      error: z.prettifyError(error),
+      details: { issues: error.issues },
+    }),
+  );
 }

--- a/src/server/utils/errors.ts
+++ b/src/server/utils/errors.ts
@@ -30,7 +30,13 @@ function serializeError(value: unknown, depth: number, seen: Set<unknown>): unkn
     return { name: value.name, message: value.message };
   }
   seen.add(value);
+  // Spread enumerable own props first so subclass diagnostics (Node
+  // SystemError `code`/`errno`/`syscall`/`path`, AWS SDK `$metadata`/`$fault`,
+  // node-fetch `code`, custom provider metadata) reach the log. Then overlay
+  // the four standard non-enumerable Error fields so they always win even if
+  // a subclass shadowed them as enumerable.
   return {
+    ...value,
     name: value.name,
     message: value.message,
     stack: value.stack,

--- a/src/server/utils/errors.ts
+++ b/src/server/utils/errors.ts
@@ -3,32 +3,69 @@ import logger from '../../logger';
 import { ErrorResponseSchema } from '../../types/api/common';
 import type { Response } from 'express';
 
+const MAX_CAUSE_DEPTH = 4;
+
 /**
  * Build a logger-safe context object from an unknown error value.
  *
- * The default logger object-context serializer goes through `JSON.stringify`,
- * which drops `name`, `message`, and `stack` from `Error` instances because they
- * are non-enumerable. Extract them explicitly so `logger.error` retains the stack.
+ * Most logger paths serialize context with `JSON.stringify`-equivalent
+ * routines, which drop `name`/`message`/`stack` from `Error` instances
+ * because those properties are non-enumerable. Extract them explicitly so
+ * stack traces survive logging.
+ *
+ * Walk `cause` chains so a wrapped error doesn't re-introduce the same
+ * non-enumerable-fields bug at the next level. A depth cap prevents
+ * runaway cycles (`err.cause = err`) from blowing the stack or making
+ * the logger payload pathological.
  */
 function toLogContext(error: unknown): Record<string, unknown> {
-  if (error instanceof Error) {
-    return {
-      error: {
-        name: error.name,
-        message: error.message,
-        stack: error.stack,
-        ...(error.cause === undefined ? {} : { cause: error.cause }),
-      },
-    };
+  return { error: serializeError(error, 0, new Set()) };
+}
+
+function serializeError(value: unknown, depth: number, seen: Set<unknown>): unknown {
+  if (!(value instanceof Error)) {
+    return value;
   }
-  return { error };
+  if (seen.has(value) || depth >= MAX_CAUSE_DEPTH) {
+    return { name: value.name, message: value.message };
+  }
+  seen.add(value);
+  return {
+    name: value.name,
+    message: value.message,
+    stack: value.stack,
+    ...(value.cause === undefined ? {} : { cause: serializeError(value.cause, depth + 1, seen) }),
+  };
+}
+
+/**
+ * Reply with a parsed `ErrorResponseSchema` envelope, falling back to a
+ * hand-built `{ error }` object if parsing throws (e.g. a future schema
+ * tightening that rejects the input). Otherwise a parse failure inside
+ * this canonical funnel would propagate, escape the caller's try/catch,
+ * and land in Express's default error handler — leaving the client with
+ * an empty 500 and no JSON body.
+ */
+function safeRespond(res: Response, status: number, body: { error: string; details?: unknown }) {
+  let parsed: unknown;
+  try {
+    parsed = ErrorResponseSchema.parse(body);
+  } catch (parseError) {
+    logger.error('ErrorResponseSchema.parse failed; sending hand-built envelope', {
+      parseError: serializeError(parseError, 0, new Set()),
+    });
+    parsed = { error: body.error };
+  }
+  res.status(status).json(parsed);
 }
 
 /**
  * Send a standardized error response.
  *
- * All error responses use the shape `{ error: string }`.
- * Internal details are logged but never exposed to the client.
+ * The wire shape is `{ error: string }` (with optional `details`/
+ * `suggestion`/`success` permitted by `ErrorResponseSchema.passthrough()`,
+ * but this helper only emits `error`). `internalError` is logged but
+ * never returned to the client.
  */
 export function sendError(
   res: Response,
@@ -39,22 +76,25 @@ export function sendError(
   if (internalError !== undefined) {
     logger.error(publicMessage, toLogContext(internalError));
   }
-  res.status(status).json(ErrorResponseSchema.parse({ error: publicMessage }));
+  safeRespond(res, status, { error: publicMessage });
 }
 
 /**
  * Reply with a 400 from a Zod safeParse error.
  *
- * The human-readable message goes in `error` (formatted via `z.prettifyError`)
- * so existing clients keep working. The structured Zod issue array is also
- * exposed in `details` for clients that want to map errors back to fields
- * programmatically.
+ * The human-readable message goes in `error` (formatted via
+ * `z.prettifyError`) so existing clients keep working. The structured Zod
+ * issue array is also exposed in `details` for clients that want to map
+ * errors back to fields programmatically. Zod core issues only contain
+ * paths, codes, and type names — never the user-supplied input value —
+ * so this is safe to expose. If a project schema ever uses a `.refine`
+ * whose message interpolates the failing input, that custom message
+ * would also reach the wire via this field; audit such schemas before
+ * adding.
  */
 export function replyValidationError(res: Response, error: z.ZodError): void {
-  res.status(400).json(
-    ErrorResponseSchema.parse({
-      error: z.prettifyError(error),
-      details: { issues: error.issues },
-    }),
-  );
+  safeRespond(res, 400, {
+    error: z.prettifyError(error),
+    details: { issues: error.issues },
+  });
 }

--- a/test/server/utils/errors.test.ts
+++ b/test/server/utils/errors.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { z } from 'zod';
+import logger from '../../../src/logger';
+import { replyValidationError, sendError } from '../../../src/server/utils/errors';
+import type { Response } from 'express';
+
+vi.mock('../../../src/logger', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function createResponseMock(): {
+  res: Response;
+  status: Mock;
+  json: Mock;
+} {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn(() => ({ json }));
+  return {
+    res: { status, json } as unknown as Response,
+    status: status as unknown as Mock,
+    json,
+  };
+}
+
+describe('server/utils/errors', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('sendError', () => {
+    it('returns the public message and never leaks the internal error', () => {
+      const { res, status, json } = createResponseMock();
+
+      sendError(res, 500, 'Failed to do thing', new Error('secret db password leaked'));
+
+      expect(status).toHaveBeenCalledWith(500);
+      const body = json.mock.calls[0]?.[0];
+      expect(body).toEqual({ error: 'Failed to do thing' });
+      expect(JSON.stringify(body)).not.toContain('secret db password');
+    });
+
+    it('skips logging when no internal error is provided', () => {
+      const { res } = createResponseMock();
+
+      sendError(res, 404, 'Not found');
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('logs Error name, message, and stack as a structured object', () => {
+      const { res } = createResponseMock();
+      const err = new Error('boom');
+      err.stack = 'Error: boom\n    at someFn';
+
+      sendError(res, 500, 'Failed', err);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const [message, context] = (logger.error as unknown as Mock).mock.calls[0];
+      expect(message).toBe('Failed');
+      expect(context).toEqual({
+        error: {
+          name: 'Error',
+          message: 'boom',
+          stack: 'Error: boom\n    at someFn',
+        },
+      });
+    });
+
+    it('preserves Error.cause when present', () => {
+      const { res } = createResponseMock();
+      const cause = new Error('underlying');
+      const err = new Error('wrapper', { cause });
+
+      sendError(res, 500, 'Failed', err);
+
+      const [, context] = (logger.error as unknown as Mock).mock.calls[0];
+      expect((context as { error: { cause: unknown } }).error.cause).toBe(cause);
+    });
+
+    it('passes non-Error values through verbatim', () => {
+      const { res } = createResponseMock();
+
+      sendError(res, 500, 'Failed', 'plain string error');
+
+      const [, context] = (logger.error as unknown as Mock).mock.calls[0];
+      expect(context).toEqual({ error: 'plain string error' });
+    });
+  });
+
+  describe('replyValidationError', () => {
+    let zodError: z.ZodError;
+
+    beforeEach(() => {
+      const schema = z.object({
+        name: z.string(),
+        age: z.number().int().nonnegative(),
+      });
+      const result = schema.safeParse({ name: 42, age: -1 });
+      if (result.success) {
+        throw new Error('expected parse to fail');
+      }
+      zodError = result.error;
+    });
+
+    it('returns a 400 with prettified message in `error`', () => {
+      const { res, status, json } = createResponseMock();
+
+      replyValidationError(res, zodError);
+
+      expect(status).toHaveBeenCalledWith(400);
+      const body = json.mock.calls[0]?.[0] as { error: string };
+      expect(typeof body.error).toBe('string');
+      expect(body.error.length).toBeGreaterThan(0);
+    });
+
+    it('exposes structured Zod issues in `details` for programmatic clients', () => {
+      const { res, json } = createResponseMock();
+
+      replyValidationError(res, zodError);
+
+      const body = json.mock.calls[0]?.[0] as {
+        details: { issues: z.core.$ZodIssue[] };
+      };
+      expect(Array.isArray(body.details.issues)).toBe(true);
+      expect(body.details.issues.length).toBe(zodError.issues.length);
+      const paths = body.details.issues.map((issue) => issue.path.join('.'));
+      expect(paths).toContain('name');
+      expect(paths).toContain('age');
+    });
+  });
+});

--- a/test/server/utils/errors.test.ts
+++ b/test/server/utils/errors.test.ts
@@ -71,15 +71,21 @@ describe('server/utils/errors', () => {
       });
     });
 
-    it('preserves Error.cause when present', () => {
+    it('preserves Error.cause when present, serialized to retain its stack', () => {
       const { res } = createResponseMock();
       const cause = new Error('underlying');
+      cause.stack = 'Error: underlying\n    at someInnerFn';
       const err = new Error('wrapper', { cause });
 
       sendError(res, 500, 'Failed', err);
 
       const [, context] = (logger.error as unknown as Mock).mock.calls[0];
-      expect((context as { error: { cause: unknown } }).error.cause).toBe(cause);
+      const ctx = context as { error: { cause: { name: string; message: string; stack: string } } };
+      expect(ctx.error.cause.name).toBe('Error');
+      expect(ctx.error.cause.message).toBe('underlying');
+      // Stack must survive — serializing the raw Error reference would have
+      // dropped it via JSON.stringify, which is the regression this helper exists to prevent.
+      expect(ctx.error.cause.stack).toContain('someInnerFn');
     });
 
     it('passes non-Error values through verbatim', () => {
@@ -89,6 +95,93 @@ describe('server/utils/errors', () => {
 
       const [, context] = (logger.error as unknown as Mock).mock.calls[0];
       expect(context).toEqual({ error: 'plain string error' });
+    });
+
+    it('logs `null` as a real (no-detail) failure rather than skipping', () => {
+      // Pin current behavior: the guard is `internalError !== undefined`, so
+      // `null` reaches the logger. This is intentional — a future refactor to
+      // `if (internalError)` would silently swallow falsy-but-real signals
+      // (e.g. `0`, `false`, `''`).
+      const { res } = createResponseMock();
+
+      sendError(res, 500, 'Failed', null);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const [, context] = (logger.error as unknown as Mock).mock.calls[0];
+      expect(context).toEqual({ error: null });
+    });
+
+    it('preserves Error subclass name (TypeError, custom subclasses)', () => {
+      const { res } = createResponseMock();
+      class CustomError extends Error {
+        constructor(message: string) {
+          super(message);
+          this.name = 'CustomError';
+        }
+      }
+
+      sendError(res, 500, 'Failed', new TypeError('not a string'));
+      sendError(res, 500, 'Failed', new CustomError('bespoke'));
+
+      const calls = (logger.error as unknown as Mock).mock.calls;
+      expect((calls[0][1] as { error: { name: string } }).error.name).toBe('TypeError');
+      expect((calls[1][1] as { error: { name: string } }).error.name).toBe('CustomError');
+    });
+
+    it('recursively unwraps Error.cause chains so nested stacks survive serialization', () => {
+      const { res } = createResponseMock();
+      const root = new Error('root cause');
+      root.stack = 'Error: root cause\n    at deep';
+      const middle = new Error('middle', { cause: root });
+      middle.stack = 'Error: middle\n    at middle';
+      const top = new Error('top', { cause: middle });
+      top.stack = 'Error: top\n    at top';
+
+      sendError(res, 500, 'Failed', top);
+
+      const [, context] = (logger.error as unknown as Mock).mock.calls[0];
+      const ctx = context as {
+        error: {
+          stack: string;
+          cause: { stack: string; cause: { stack: string } };
+        };
+      };
+      expect(ctx.error.stack).toContain('top');
+      expect(ctx.error.cause.stack).toContain('middle');
+      expect(ctx.error.cause.cause.stack).toContain('deep');
+    });
+
+    it('does not crash on a circular Error.cause', () => {
+      const { res, status } = createResponseMock();
+      const cyclic = new Error('cyclic') as Error & { cause?: unknown };
+      cyclic.cause = cyclic;
+
+      expect(() => sendError(res, 500, 'Failed', cyclic)).not.toThrow();
+      // The response must still ship — cycle detection in serializeError is
+      // the entire reason this canonical 500 funnel doesn't unhandled-throw.
+      expect(status).toHaveBeenCalledWith(500);
+    });
+
+    it('falls back to a hand-built envelope if ErrorResponseSchema.parse throws', async () => {
+      // Force the schema parse to throw, simulating a future tightening that
+      // rejects what `sendError` produces. Without the safeRespond fallback,
+      // the throw would escape the handler's try/catch and land in Express's
+      // default error path (empty 500 with no JSON body).
+      const common = await import('../../../src/types/api/common');
+      const parseSpy = vi.spyOn(common.ErrorResponseSchema, 'parse').mockImplementationOnce(() => {
+        throw new Error('forced schema rejection');
+      });
+
+      try {
+        const { res, status, json } = createResponseMock();
+
+        expect(() => sendError(res, 500, 'Public message')).not.toThrow();
+        expect(status).toHaveBeenCalledWith(500);
+        expect(json.mock.calls[0]?.[0]).toEqual({ error: 'Public message' });
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        parseSpy.mockRestore();
+      }
     });
   });
 

--- a/test/server/utils/errors.test.ts
+++ b/test/server/utils/errors.test.ts
@@ -111,6 +111,43 @@ describe('server/utils/errors', () => {
       expect(context).toEqual({ error: null });
     });
 
+    it('preserves enumerable diagnostic fields on Error subclasses', () => {
+      // Node SystemError carries `code`/`errno`/`syscall`/`path` as enumerable
+      // own props; AWS SDK errors carry `$metadata`/`$fault`; fetch errors
+      // carry `code`/`errno`. Logging the explicit four fields without
+      // spreading would silently drop these — exactly the production-triage
+      // regression flagged by the Codex P2 reviewer on this PR.
+      const { res } = createResponseMock();
+      const sysErr = Object.assign(new Error('ENOENT: no such file or directory, open ...'), {
+        code: 'ENOENT',
+        errno: -2,
+        syscall: 'open',
+        path: '/missing/file',
+      });
+
+      sendError(res, 500, 'Failed', sysErr);
+
+      const [, context] = (logger.error as unknown as Mock).mock.calls[0];
+      const ctx = context as {
+        error: {
+          name: string;
+          message: string;
+          stack: string;
+          code: string;
+          errno: number;
+          syscall: string;
+          path: string;
+        };
+      };
+      expect(ctx.error.name).toBe('Error');
+      expect(ctx.error.code).toBe('ENOENT');
+      expect(ctx.error.errno).toBe(-2);
+      expect(ctx.error.syscall).toBe('open');
+      expect(ctx.error.path).toBe('/missing/file');
+      // Standard fields still win even though the subclass also has its own.
+      expect(typeof ctx.error.stack).toBe('string');
+    });
+
     it('preserves Error subclass name (TypeError, custom subclasses)', () => {
       const { res } = createResponseMock();
       class CustomError extends Error {


### PR DESCRIPTION
## Summary

Two regressions introduced by the recent DTO/error-helper rollout (#8922 et al):

1. **Validation errors lost the structured `details` field.** The pre-DTO telemetry handler returned `{ error: 'Invalid request body', details: z.prettifyError(...) }`. After `replyValidationError` was added, the body became `{ error: '<pretty>' }` only. `ErrorResponseSchema` still declares `details` optional, so the contract said one thing while the helper produced another. Programmatic clients that read `body.details` now see `undefined`.
2. **Stack traces are dropped from server logs.** `sendError` passed raw `Error` instances into the logger's object-context serializer, which goes through `JSON.stringify`. Because `name`, `message`, and `stack` are non-enumerable on `Error`, the serialized payload was effectively `{}`. Now that `sendError` is the canonical funnel for every 500 across `eval`, `providers`, `redteam`, `media`, `traces`, etc., the regression surface is dramatically wider than the old ad-hoc handlers.

## Changes

- `src/server/utils/errors.ts`
  - `replyValidationError` keeps the prettified message in `error` (matching existing test assertions) and additionally exposes `details: { issues: error.issues }` so clients can map failures back to fields.
  - `sendError` now extracts `name`/`message`/`stack`/`cause` from `Error` instances before logging, so stacks survive object-context serialization. Non-Error values pass through verbatim.
- `test/server/utils/errors.test.ts` (new) — covers the public message, no-leak guarantee, structured Error logging, `cause` preservation, the no-internalError path, and the validation `details` shape.

No public API/wire-format break: every existing test that asserts on `response.body.error` continues to pass (the prettified string is unchanged); only the previously-empty `details` field now carries the Zod issue array.

## Test plan
- [x] `npx vitest run test/server/utils/errors.test.ts` (new file, 7 tests)
- [x] `npx vitest run test/server/` (473 tests pass; existing validation tests unchanged)
- [x] `npm run l && npm run f`