### PR TITLE
fix(api): make modelAudit safeRespond fire-safe under parse failures

### DIFF
--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -296,8 +296,12 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
           : ModelAuditSchemas.Scan.ErrorResponse.parse(body);
         res.status(statusCode).json(parsed);
       } catch (parseError) {
+        // Match the existing logging style in this file (e.g.
+        // `logger.error('Failed to parse model scan output', { parseError, ... })`)
+        // by passing the raw error value so the logger sanitizer can preserve
+        // the stack and other diagnostic context.
         logger.error('safeRespond DTO parse failed; sending fallback envelope', {
-          parseError: parseError instanceof Error ? parseError.message : String(parseError),
+          parseError,
           statusCode,
         });
         // A parse failure on either branch means the response cannot be trusted.

--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -276,17 +276,39 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
     let stderr = '';
     let responded = false; // Prevent double-response
 
-    // Helper to safely send response (prevents double-response if both error and close fire)
+    // Helper to safely send response (prevents double-response if both error and close fire).
+    //
+    // Mark `responded = true` BEFORE running the schema parse: this runs inside
+    // child-process event callbacks where a thrown ZodError would propagate as
+    // an unhandled exception and leave `responded = false`, allowing a second
+    // emitter (e.g. `close` after `error`) to fire and double-send. If the
+    // parse fails, fall back to a hand-built error envelope so the client
+    // still receives a valid response.
     const safeRespond = (statusCode: number, body: object) => {
       if (responded) {
         return;
       }
-      const responseBody =
-        statusCode >= 200 && statusCode < 300
+      responded = true;
+      const isSuccess = statusCode >= 200 && statusCode < 300;
+      try {
+        const parsed = isSuccess
           ? ModelAuditSchemas.Scan.Response.parse(body)
           : ModelAuditSchemas.Scan.ErrorResponse.parse(body);
-      responded = true;
-      res.status(statusCode).json(responseBody);
+        res.status(statusCode).json(parsed);
+      } catch (parseError) {
+        logger.error('safeRespond DTO parse failed; sending fallback envelope', {
+          parseError: parseError instanceof Error ? parseError.message : String(parseError),
+          statusCode,
+        });
+        // A parse failure on either branch means the response cannot be trusted.
+        // Always degrade to 500 with a deterministic envelope so clients see a
+        // clear failure instead of an empty body or a stack trace from Express.
+        const fallbackError =
+          !isSuccess && 'error' in body && typeof body.error === 'string'
+            ? body.error
+            : 'Error processing scan results';
+        res.status(500).json({ error: fallbackError });
+      }
     };
 
     // Clean up child process if client disconnects

--- a/test/server/routes/modelAudit.test.ts
+++ b/test/server/routes/modelAudit.test.ts
@@ -334,10 +334,10 @@ describe('Model Audit Routes', () => {
       const testFilePath = path.join(os.tmpdir(), 'test-model-audit-double-respond.pkl');
       fs.writeFileSync(testFilePath, 'test data');
 
-      // Capture how many times `res.status(...).json(...)` actually writes a body.
-      // The historical bug was: parse throws inside safeRespond *before* the
-      // `responded = true` flag is set, so a second emitter (close after error)
-      // re-enters safeRespond and double-fires the response.
+      // Race `error` then `close` so both fire and both call into safeRespond.
+      // Under the pre-fix code, parse threw *before* `responded = true` was
+      // set, so the close emitter could re-enter safeRespond and write a
+      // second body.
       const errorThenClose = {
         on: vi.fn().mockImplementation(function (
           this: object,
@@ -358,9 +358,10 @@ describe('Model Audit Routes', () => {
       mockProc.on = errorThenClose.on as never;
       mockedSpawn.mockReturnValue(asMockChildProcess(mockProc));
 
-      // Force the error-branch parse to throw on first call; the existing
-      // pre-fix code would leave `responded = false` and the close emitter
-      // would attempt to send a second response.
+      // Force the error-branch parse to throw on the first call. Under the
+      // post-fix code `responded` flips to `true` before parse runs, so the
+      // close emitter that fires next observes `responded === true` and
+      // returns without entering parse a second time.
       const errorParseSpy = vi
         .spyOn(ModelAuditSchemas.Scan.ErrorResponse, 'parse')
         .mockImplementationOnce(() => {
@@ -373,12 +374,13 @@ describe('Model Audit Routes', () => {
           .timeout({ deadline: 1000 })
           .send({ paths: [testFilePath], options: { persist: false } });
 
-        // The parse fallback degrades the error envelope to a 500 with a
-        // deterministic message. The client receives exactly one body — the
-        // close emitter that fires next must observe `responded === true`
-        // and silently no-op.
         expect(response.status).toBe(500);
         expect(typeof response.body.error).toBe('string');
+        // `safeRespond` calls `Scan.ErrorResponse.parse` exactly once per
+        // *entered* invocation. If `responded` were not flipped before parse,
+        // the close emitter would re-enter and trigger a second parse call —
+        // so this single-call assertion is the proxy for "exactly one body
+        // was written to the response stream".
         expect(errorParseSpy).toHaveBeenCalledTimes(1);
       } finally {
         errorParseSpy.mockRestore();

--- a/test/server/routes/modelAudit.test.ts
+++ b/test/server/routes/modelAudit.test.ts
@@ -328,6 +328,64 @@ describe('Model Audit Routes', () => {
       }
     });
 
+    it('should not double-respond when both error and close events fire after a parse-throw', async () => {
+      mockedCheckModelAuditInstalled.mockResolvedValue({ installed: true, version: '0.2.30' });
+
+      const testFilePath = path.join(os.tmpdir(), 'test-model-audit-double-respond.pkl');
+      fs.writeFileSync(testFilePath, 'test data');
+
+      // Capture how many times `res.status(...).json(...)` actually writes a body.
+      // The historical bug was: parse throws inside safeRespond *before* the
+      // `responded = true` flag is set, so a second emitter (close after error)
+      // re-enters safeRespond and double-fires the response.
+      const errorThenClose = {
+        on: vi.fn().mockImplementation(function (
+          this: object,
+          event: string,
+          callback: (...args: unknown[]) => void,
+        ) {
+          if (event === 'error') {
+            setImmediate(() => callback(new Error('boom')));
+          } else if (event === 'close') {
+            // Fire close immediately after error so both safeRespond paths race.
+            setImmediate(() => setImmediate(() => callback(1)));
+          }
+          return this;
+        }),
+      };
+
+      const mockProc = createMockChildProcess({ exitCode: 1 });
+      mockProc.on = errorThenClose.on as never;
+      mockedSpawn.mockReturnValue(asMockChildProcess(mockProc));
+
+      // Force the error-branch parse to throw on first call; the existing
+      // pre-fix code would leave `responded = false` and the close emitter
+      // would attempt to send a second response.
+      const errorParseSpy = vi
+        .spyOn(ModelAuditSchemas.Scan.ErrorResponse, 'parse')
+        .mockImplementationOnce(() => {
+          throw new Error('forced error-branch parse failure');
+        });
+
+      try {
+        const response = await request(app)
+          .post('/api/model-audit/scan')
+          .timeout({ deadline: 1000 })
+          .send({ paths: [testFilePath], options: { persist: false } });
+
+        // The parse fallback degrades the error envelope to a 500 with a
+        // deterministic message. The client receives exactly one body — the
+        // close emitter that fires next must observe `responded === true`
+        // and silently no-op.
+        expect(response.status).toBe(500);
+        expect(typeof response.body.error).toBe('string');
+        expect(errorParseSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        errorParseSpy.mockRestore();
+        fs.unlinkSync(testFilePath);
+      }
+    });
+
     it('should fall back to a 500 response when scan success DTO parsing fails', async () => {
       mockedCheckModelAuditInstalled.mockResolvedValue({ installed: true, version: '0.2.30' });
 


### PR DESCRIPTION
## Summary

`safeRespond` in `POST /api/model-audit/scan` ran the DTO schema parse *before* flipping `responded = true`. A thrown ZodError inside a child-process event callback would:

1. Propagate as an unhandled exception (no try/catch around `modelAudit.on('error', ...)` or several `close`-branch call sites).
2. Leave `responded = false`, so a racing emitter (e.g. `close` firing right after `error`) could re-enter `safeRespond` and attempt a second `res.json()` on the same response — usually crashing the request handler.

Today this is theoretical because `errorDetails` only spreads enum-typed strings, but the surface is fragile: any future contributor adding a non-string `details` value, or any drift between `ScanErrorResponseSchema` and what the scanner emits, becomes an unhandled-exception bug instead of a clean 500.

## Changes

`src/server/routes/modelAudit.ts`:
- Set `responded = true` immediately on entry — before parse — so a throw cannot leave the latch open.
- Wrap the `Scan.Response` / `Scan.ErrorResponse` parse in `try/catch`.
- On parse failure, log structured context and degrade to a deterministic `500 { error: 'Error processing scan results' }` envelope (preserves the body's own error string when the original branch was already an error). The client always receives exactly one well-formed response.

`test/server/routes/modelAudit.test.ts`:
- New regression: race `error` + `close` events with the error-branch parse forced to throw on first call. Pre-fix, this would write a second body. Post-fix, `responded` latches and the second emitter no-ops.
- Existing "scan success DTO parsing fails" test still asserts the `Error processing scan results` message — behavior preserved.

## Test plan
- [x] `npx vitest run test/server/routes/modelAudit.test.ts` — 46 tests pass (1 new).
- [x] `npx vitest run test/server/` — 467 tests pass.
- [x] `npm run l && npm run f` (the residual cognitive-complexity warning on the existing `close` handler is pre-existing and out of scope.)