### PR TITLE
test(agent-skills): parallelize Python provider executions

### DIFF
--- a/test/agentSkills/promptfooPlugin.test.ts
+++ b/test/agentSkills/promptfooPlugin.test.ts
@@ -1,11 +1,14 @@
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
 
 const repoRoot = path.resolve(__dirname, '../..');
 const pluginRoot = path.join(repoRoot, 'plugins', 'promptfoo');
@@ -2183,7 +2186,7 @@ describe('promptfoo Codex plugin package', () => {
     }
   });
 
-  it('keeps Python file providers executable and on the promptfoo function contract', () => {
+  it('keeps Python file providers executable and on the promptfoo function contract', async () => {
     const configPaths = listFiles(fixtureRoot, (filePath) =>
       ['promptfooconfig.yaml', 'redteam.yaml'].includes(path.basename(filePath)),
     );
@@ -2219,22 +2222,29 @@ describe('promptfoo Codex plugin package', () => {
       'redteam-setup-static-code-python/target.py:invoice_redteam_target',
     ]);
 
-    for (const { absolutePath, context, functionName, reference } of pythonReferences.values()) {
-      const script = readText(absolutePath);
-      expect(script, `${context}: ${reference}`).toContain(`def ${functionName}(`);
+    const pythonEnv = { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' };
+    await Promise.all(
+      [...pythonReferences.values()].map(
+        async ({ absolutePath, context, functionName, reference }) => {
+          const script = readText(absolutePath);
+          expect(script, `${context}: ${reference}`).toContain(`def ${functionName}(`);
 
-      const output = execFileSync(fixturePythonExecutable, [absolutePath], {
-        cwd: path.dirname(absolutePath),
-        encoding: 'utf8',
-        env: { ...process.env, OAIPKG_DISABLE_META_MISSING: '1' },
-      });
-      const parsed = JSON.parse(output) as ProviderResult;
-      expect(typeof parsed.output, `${absolutePath} should print JSON with output`).toBe('string');
-      expect(
-        String(parsed.output).length,
-        `${absolutePath} output should be non-empty`,
-      ).toBeGreaterThan(0);
-    }
+          const { stdout } = await execFileAsync(fixturePythonExecutable, [absolutePath], {
+            cwd: path.dirname(absolutePath),
+            encoding: 'utf8',
+            env: pythonEnv,
+          });
+          const parsed = JSON.parse(stdout) as ProviderResult;
+          expect(typeof parsed.output, `${absolutePath} should print JSON with output`).toBe(
+            'string',
+          );
+          expect(
+            String(parsed.output).length,
+            `${absolutePath} output should be non-empty`,
+          ).toBeGreaterThan(0);
+        },
+      ),
+    );
   });
 
   it('keeps packaged configs and fixtures free of literal secrets', () => {


### PR DESCRIPTION
## Summary

- Fixes a flaky Windows CI failure in `test/agentSkills/promptfooPlugin.test.ts` where the test `keeps Python file providers executable and on the promptfoo function contract` timed out at 30s (observed 32839ms).
- The test ran 6 `execFileSync` Python invocations sequentially. Python cold-start on Windows under CI shard load pushed total runtime over the default vitest timeout. The whole 121-test suite is ~25s on a passing Windows shard, so this single test sits right at the boundary.
- Run all Python invocations in parallel via `execFile` + `Promise.all`. Wall-clock now equals the slowest single invocation rather than the sum, with no timeout bump (per `test/AGENTS.md`: never increase test timeouts — fix the slow test).

Example failure: https://github.com/promptfoo/promptfoo/actions/runs/25090548470 (CI / Test on Node 22.22 and windows-latest, shard 3/3).

## Test plan

- [x] `npx vitest run test/agentSkills/promptfooPlugin.test.ts` — 121/121 pass in ~3.6s locally
- [x] `npx biome check test/agentSkills/promptfooPlugin.test.ts`
- [ ] CI passes on Windows shard 3/3