### PR TITLE
chore(deps): limit postcss renovate updates to monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -341,6 +341,13 @@
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "bump",
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "postcss: monthly updates to reduce noise from frequent patch releases",
+      "matchPackageNames": ["postcss"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate `packageRules` entry restricting `postcss` updates to once per month, following the existing pattern used for `undici`, `framer-motion`, `satori`, and Storybook.
- Motivated by frequent low-impact patch PRs (e.g. #8982 bumping postcss 8.5.10 → 8.5.12) creating review churn.

## Test plan
- [x] `renovate-config-validator renovate.json` passes
- [ ] Confirm next Renovate run does not open a separate postcss PR until the first of the month