### PR TITLE
fix(providers): use agent_reference for Azure AI Foundry agents

### DIFF
--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -1091,13 +1091,13 @@ Azure AI Foundry Agents let promptfoo run an existing Foundry agent through the 
 
 ### Key Differences from Standard Azure Assistants
 
-| Feature             | Azure Assistant                              | Azure Foundry Agent                                                             |
-| ------------------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
-| **API Type**        | Direct HTTP calls to Azure OpenAI API        | Azure AI Projects SDK (`@azure/ai-projects`) + Responses API agent runtime      |
-| **Authentication**  | API key or Azure credentials                 | `DefaultAzureCredential` (Azure CLI, environment variables, managed identity)   |
-| **Endpoint**        | Azure OpenAI endpoint (`*.openai.azure.com`) | Azure AI Project URL (`*.services.ai.azure.com/api/projects/*`)                 |
-| **Provider Format** | `azure:assistant:<assistant_id>`             | `azure:foundry-agent:<agent-name-or-id>`                                        |
-| **Execution Model** | Threads/messages/runs                        | `responses.create(..., { body: { agent: { name, type: "agent_reference" } } })` |
+| Feature             | Azure Assistant                              | Azure Foundry Agent                                                                       |
+| ------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **API Type**        | Direct HTTP calls to Azure OpenAI API        | Azure AI Projects SDK (`@azure/ai-projects`) + Responses API agent runtime                |
+| **Authentication**  | API key or Azure credentials                 | `DefaultAzureCredential` (Azure CLI, environment variables, managed identity)             |
+| **Endpoint**        | Azure OpenAI endpoint (`*.openai.azure.com`) | Azure AI Project URL (`*.services.ai.azure.com/api/projects/*`)                           |
+| **Provider Format** | `azure:assistant:<assistant_id>`             | `azure:foundry-agent:<agent-name-or-id>`                                                  |
+| **Execution Model** | Threads/messages/runs                        | `responses.create(..., { body: { agent_reference: { name, type: "agent_reference" } } })` |
 
 ### Setup
 

--- a/src/providers/azure/foundry-agent.ts
+++ b/src/providers/azure/foundry-agent.ts
@@ -431,10 +431,9 @@ export class AzureFoundryAgentProvider extends AzureGenericProvider {
   }
 
   private getAgentReference(agent: FoundryAgent): FoundryResponseCreateOptions {
-    // Azure AI Foundry deprecated the top-level `agent` field in the responses
-    // create body in favor of `agent_reference`. Sending `agent` now returns a
-    // 400 from the service: "The 'agent' property is deprecated. Use
-    // 'agent_reference' instead."
+    // Azure AI Foundry replaced the top-level `agent` field in the responses
+    // create body with `agent_reference`. Sending `agent` returns a 400 similar
+    // to: "The 'agent' property is deprecated. Use 'agent_reference' instead."
     return {
       body: {
         agent_reference: {

--- a/src/providers/azure/foundry-agent.ts
+++ b/src/providers/azure/foundry-agent.ts
@@ -43,7 +43,7 @@ interface AgentReferenceOption {
 
 interface FoundryResponseCreateOptions {
   body?: {
-    agent?: AgentReferenceOption;
+    agent_reference?: AgentReferenceOption;
   };
 }
 
@@ -431,9 +431,13 @@ export class AzureFoundryAgentProvider extends AzureGenericProvider {
   }
 
   private getAgentReference(agent: FoundryAgent): FoundryResponseCreateOptions {
+    // Azure AI Foundry deprecated the top-level `agent` field in the responses
+    // create body in favor of `agent_reference`. Sending `agent` now returns a
+    // 400 from the service: "The 'agent' property is deprecated. Use
+    // 'agent_reference' instead."
     return {
       body: {
-        agent: {
+        agent_reference: {
           name: agent.name,
           type: 'agent_reference',
         },

--- a/test/providers/azure/foundry-agent.test.ts
+++ b/test/providers/azure/foundry-agent.test.ts
@@ -184,7 +184,7 @@ describe('AzureFoundryAgentProvider', () => {
         }),
         {
           body: {
-            agent: {
+            agent_reference: {
               name: 'weather-agent',
               type: 'agent_reference',
             },
@@ -216,7 +216,7 @@ describe('AzureFoundryAgentProvider', () => {
       expect(mockListAgents).toHaveBeenCalledTimes(1);
       expect(mockResponsesCreate).toHaveBeenCalledWith(expect.any(Object), {
         body: {
-          agent: {
+          agent_reference: {
             name: 'weather-agent',
             type: 'agent_reference',
           },
@@ -322,7 +322,7 @@ describe('AzureFoundryAgentProvider', () => {
         },
         {
           body: {
-            agent: {
+            agent_reference: {
               name: 'weather-agent',
               type: 'agent_reference',
             },

--- a/test/providers/azure/foundry-agent.test.ts
+++ b/test/providers/azure/foundry-agent.test.ts
@@ -191,6 +191,10 @@ describe('AzureFoundryAgentProvider', () => {
           },
         },
       );
+      // Guard against regressing to the deprecated `agent` key, which the
+      // Foundry Responses API now rejects with a 400.
+      const responseOptions = mockResponsesCreate.mock.calls[0][1];
+      expect(responseOptions.body).not.toHaveProperty('agent');
       expect(result.output).toBe('Test response');
     });
 


### PR DESCRIPTION
## Summary

- Closes #8959. Azure AI Foundry's Responses API stopped accepting the deprecated top-level `agent` field; calls now fail with `400 The 'agent' property is deprecated. Use 'agent_reference' instead.`
- Rename the body key sent through `openai.responses.create` from `agent` to `agent_reference` (the inner `type: 'agent_reference'` discriminator stays the same), per current Microsoft Foundry agent runtime docs.
- Update unit tests and the `azure.md` execution-model snippet to match.

## Test plan

- [x] `npx vitest run test/providers/azure/foundry-agent.test.ts` — 14/14 pass
- [x] `npm run l` and `npm run tsc` clean
- [x] Real end-to-end eval against a freshly created Azure AI Foundry agent (`gpt-4.1`, `promptfoo-deployment-1` project): both test cases pass with live model output (`Bonjour, comment ça va ?` / `Hola, ¿cómo estás hoy?`)
- [x] Reproduced the original 400 by reverting just the body-key change, then confirmed the fixed build clears it