### PR TITLE
chore(deps): throttle fast-xml-parser to monthly updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -348,6 +348,13 @@
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "bump",
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "fast-xml-parser: monthly updates to reduce noise from frequent patch releases",
+      "matchPackageNames": ["fast-xml-parser"],
+      "schedule": ["before 6am on the first day of the month"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule for `fast-xml-parser` that schedules updates for the first day of the month with a 7-day stabilization window and `rangeStrategy: bump`, mirroring the existing throttles for `postcss`, `undici`, `satori`, etc.
- Caps PR churn for this dependency to at most one per month.

## Test plan
- [x] `npm run l && npm run f` (no changes)
- [ ] Confirm Renovate honors the new rule on next dependency dashboard refresh