### PR TITLE
docs(site): document PostToolUse updatedToolOutput hook

### DIFF
--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -966,6 +966,35 @@ See the [Claude Agent SDK permissions documentation](https://platform.claude.com
 If you're testing scenarios where the agent asks questions, consider what answer would lead to the most interesting test case. Using `random` behavior can help discover edge cases.
 :::
 
+## Hooks
+
+Promptfoo forwards the `hooks` option to the Claude Agent SDK unchanged, so callbacks receive the SDK's native input shape and return values are honored as documented upstream. Hooks are programmatic-only — define them in a JS/TS provider file rather than YAML.
+
+The `PostToolUse` event lets you rewrite tool output before the model sees it. Return `updatedToolOutput` to replace the result for any tool (built-in or MCP):
+
+```ts title="provider.mjs"
+export default {
+  id: 'anthropic:claude-agent-sdk',
+  config: {
+    hooks: {
+      PostToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: [
+            async (input) => ({
+              hookEventName: 'PostToolUse',
+              updatedToolOutput: redact(input.tool_response),
+            }),
+          ],
+        },
+      ],
+    },
+  },
+};
+```
+
+`updatedMCPToolOutput` (MCP-only) is deprecated in favor of `updatedToolOutput`, which works for every tool. See the [SDK hook reference](https://docs.claude.com/en/docs/claude-code/hooks) for the full list of events and return shapes.
+
 ## Tool Call Tracking
 
 The Claude Agent SDK provider captures all tool calls made during the agentic session and exposes them in `response.metadata.toolCalls`. This allows you to assert on tool usage in your evaluations.


### PR DESCRIPTION
## Summary

`@anthropic-ai/claude-agent-sdk` 0.2.121 (landed in #8991) added `updatedToolOutput` to `PostToolUseHookSpecificOutput`. The new field lets a `PostToolUse` hook rewrite the result of any tool — built-in or MCP — before the model sees it. The previous field, `updatedMCPToolOutput`, only worked for MCP tools and is now deprecated.

Promptfoo's Claude Agent SDK provider already forwards the `hooks` option to the SDK unchanged (`src/providers/claude-agent-sdk.ts:457` declares the type, `:1159` passes it through), so the new field works the moment the dep bump lands. No code changes are needed — but the docs only mentioned `hooks` as a single row in the parameter table, with no example of what a hook callback looks like or what it can return.

This PR adds a `## Hooks` section to `site/docs/providers/claude-agent-sdk.md` (above `## Tool Call Tracking`) that:

- Calls out that `hooks` is a passthrough and is programmatic-only (must live in a JS/TS provider file, not YAML).
- Shows a `PostToolUse` example using `updatedToolOutput` to redact `Bash` output before the model consumes it.
- Notes the `updatedMCPToolOutput` deprecation and links to the upstream SDK hook reference for the full event/return-shape catalog.

29 lines added, doc-only.

## Test plan

- [x] `SKIP_OG_GENERATION=true npm run build` (Docusaurus) succeeds
- [x] `npx prettier --write site/docs/providers/claude-agent-sdk.md` is a no-op
- [x] Pre-commit lint hook passes