### PR TITLE
chore(deps): apply min-release-age to npm overrides in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -276,6 +276,12 @@
       "matchDepTypes": ["optionalDependencies"],
       "minimumReleaseAge": "2 days"
     },
+    {
+      "description": "npm overrides/resolutions: wait 2 days to match .npmrc min-release-age floor",
+      "matchDatasources": ["npm"],
+      "matchDepTypes": ["overrides", "pnpm.overrides", "resolutions"],
+      "minimumReleaseAge": "2 days"
+    },
 
     {
       "description": "@opencode-ai/sdk: weekly updates to reduce noise from daily releases",


### PR DESCRIPTION
## Summary

- The existing `minimumReleaseAge` rules in `renovate.json` only match `dependencies`, `devDependencies`, and `optionalDependencies`, so packages reached only via `package.json#overrides` slip past the 2-day floor.
- Result: Renovate opened #8994 (`chevrotain-allstar` 0.4.2) ~1 hour after publish, which then failed every CI `Install Dependencies` step against the repo's `.npmrc` `min-release-age=2` policy.
- Add an explicit rule covering `overrides`, `pnpm.overrides`, and `resolutions` depTypes with `minimumReleaseAge: "2 days"`, so override bumps honor the same floor as devDependencies and `.npmrc`.

Validated locally with `renovate-config-validator`.

## Test plan

- [x] `jq . renovate.json` parses
- [x] `npx renovate-config-validator renovate.json` reports `Config validated successfully`
- [ ] Confirm via Renovate's next dry-run / dashboard that override-only updates now respect the 2-day floor