### PR TITLE
feat(app): humanize per-cell latency in eval results table

### DIFF
--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -1156,9 +1156,50 @@ describe('EvalOutputCell', () => {
       },
     };
     renderWithProviders(<EvalOutputCell {...props} />);
-    expect(
-      screen.getByLabelText('1,234 ms — original duration; served from cache'),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText('1,234 ms (cached response)')).toBeInTheDocument();
+  });
+
+  it('renders sub-millisecond latency without rounding away precision', () => {
+    const props = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 0.123,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+    expect(screen.getByLabelText('0.123 ms')).toBeInTheDocument();
+  });
+
+  it('falls back to raw ms when latency is non-finite or negative', () => {
+    const cases: { latencyMs: number; expected: string }[] = [
+      { latencyMs: Number.POSITIVE_INFINITY, expected: '∞ ms' },
+      { latencyMs: -1234, expected: '-1,234 ms' },
+    ];
+    for (const { latencyMs, expected } of cases) {
+      const { unmount } = renderWithProviders(
+        <EvalOutputCell
+          {...defaultProps}
+          output={{ ...defaultProps.output, latencyMs, response: {} }}
+        />,
+      );
+      expect(screen.getByLabelText(expected)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('renders an exact-hour latency without trailing minutes', () => {
+    const props = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 129_600_000,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+    expect(screen.getByText('36h')).toBeInTheDocument();
   });
 
   it('displays large latency values in human-readable format (minutes/hours)', () => {

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -944,6 +944,25 @@ describe('EvalOutputCell', () => {
     renderWithProviders(<EvalOutputCell {...propsWithStandardTokens} />);
 
     expect(screen.getByText('33 (11+22)')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('11 prompt tokens + 22 completion tokens = 33 total'),
+    ).toBeInTheDocument();
+  });
+
+  it('italicizes the (cached) suffix on cached token usage', () => {
+    const props: MockEvalOutputCellProps = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        tokenUsage: { cached: 42 },
+      },
+    };
+
+    renderWithProviders(<EvalOutputCell {...props} />);
+
+    const cachedSuffix = screen.getByText('(cached)');
+    expect(cachedSuffix).toBeInTheDocument();
+    expect(cachedSuffix).toHaveClass('italic');
   });
 
   it('renders JSON diffs with added and removed fragments when showDiffs is enabled', () => {
@@ -1078,7 +1097,7 @@ describe('EvalOutputCell', () => {
       },
     };
     renderWithProviders(<EvalOutputCell {...props} />);
-    const latencyElement = screen.getByText('123 ms');
+    const latencyElement = screen.getByText('123ms');
     expect(latencyElement).toBeInTheDocument();
 
     const props2 = {
@@ -1090,7 +1109,7 @@ describe('EvalOutputCell', () => {
       },
     };
     renderWithProviders(<EvalOutputCell {...props2} />);
-    const latencyElement2 = screen.getByText('456 ms');
+    const latencyElement2 = screen.getByText('456ms');
     expect(latencyElement2).toBeInTheDocument();
   });
 
@@ -1108,8 +1127,75 @@ describe('EvalOutputCell', () => {
 
     renderWithProviders(<EvalOutputCell {...props} />);
 
-    const latencyElement = screen.getByText('0 ms (cached)');
-    expect(latencyElement).toBeInTheDocument();
+    expect(screen.getByText('0ms')).toBeInTheDocument();
+    const cachedSuffix = screen.getByText('(cached)');
+    expect(cachedSuffix).toBeInTheDocument();
+    expect(cachedSuffix).toHaveClass('italic');
+  });
+
+  it('exposes precise milliseconds via aria-label on the latency trigger', () => {
+    const props = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 3_789_665,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+    expect(screen.getByLabelText('3,789,665 ms')).toBeInTheDocument();
+  });
+
+  it('clarifies cached latency in the aria-label', () => {
+    const props = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 1234,
+        response: { cached: true },
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+    expect(
+      screen.getByLabelText('1,234 ms — original duration; served from cache'),
+    ).toBeInTheDocument();
+  });
+
+  it('displays large latency values in human-readable format (minutes/hours)', () => {
+    const propsMinutes = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 255_718,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...propsMinutes} />);
+    expect(screen.getByText('4m 16s')).toBeInTheDocument();
+
+    const propsHours = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 3_789_665,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...propsHours} />);
+    expect(screen.getByText('1h 3m')).toBeInTheDocument();
+  });
+
+  it('displays seconds for sub-minute latencies', () => {
+    const props = {
+      ...defaultProps,
+      output: {
+        ...defaultProps.output,
+        latencyMs: 2300,
+        response: {},
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+    expect(screen.getByText('2.3s')).toBeInTheDocument();
   });
 
   it('handles searchText containing complex regex special characters', () => {

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tool
 import useCloudConfig from '@app/hooks/useCloudConfig';
 import { useEvalOperations } from '@app/hooks/useEvalOperations';
 import { useShiftKey } from '@app/hooks/useShiftKey';
+import { formatDuration } from '@app/utils/date';
 import {
   normalizeMediaText,
   resolveAudioSource,
@@ -723,6 +724,8 @@ function getCommentTextToDisplay(comment?: string): string | undefined {
   return comment?.startsWith('!highlight') ? comment.slice('!highlight'.length).trim() : comment;
 }
 
+const WHOLE_NUMBER_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
 function formatTokenUsageDisplay(
   tokenUsage:
     | EvaluateTableOutput['tokenUsage']
@@ -732,8 +735,8 @@ function formatTokenUsageDisplay(
   if (tokenUsage?.cached) {
     return (
       <span>
-        {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(tokenUsage.cached ?? 0)}{' '}
-        (cached)
+        {WHOLE_NUMBER_FORMATTER.format(tokenUsage.cached ?? 0)}
+        <span className="italic"> (cached)</span>
       </span>
     );
   }
@@ -742,18 +745,12 @@ function formatTokenUsageDisplay(
     return undefined;
   }
 
-  const promptTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-    tokenUsage.prompt ?? 0,
-  );
-  const completionTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-    tokenUsage.completion ?? 0,
-  );
-  const totalTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
-    tokenUsage.total ?? 0,
-  );
+  const promptTokens = WHOLE_NUMBER_FORMATTER.format(tokenUsage.prompt ?? 0);
+  const completionTokens = WHOLE_NUMBER_FORMATTER.format(tokenUsage.completion ?? 0);
+  const totalTokens = WHOLE_NUMBER_FORMATTER.format(tokenUsage.total ?? 0);
 
   if (tokenUsage.completionDetails?.reasoning) {
-    const reasoningTokens = Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+    const reasoningTokens = WHOLE_NUMBER_FORMATTER.format(
       tokenUsage.completionDetails.reasoning ?? 0,
     );
     const tooltipText = `${promptTokens} prompt tokens + ${completionTokens} completion tokens & ${reasoningTokens} reasoning tokens = ${totalTokens} total`;
@@ -773,16 +770,17 @@ function formatTokenUsageDisplay(
     );
   }
 
+  const plainTooltipText = `${promptTokens} prompt tokens + ${completionTokens} completion tokens = ${totalTokens} total`;
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span>
+        <span aria-label={plainTooltipText}>
           {totalTokens}
           {(promptTokens !== '0' || completionTokens !== '0') &&
             ` (${promptTokens}+${completionTokens})`}
         </span>
       </TooltipTrigger>
-      <TooltipContent>{`${promptTokens} prompt tokens + ${completionTokens} completion tokens = ${totalTokens} total`}</TooltipContent>
+      <TooltipContent>{plainTooltipText}</TooltipContent>
     </Tooltip>
   );
 }
@@ -792,11 +790,25 @@ function getLatencyDisplay(output: EvaluateTableOutput): React.ReactNode | undef
     return undefined;
   }
 
+  const formatted = formatDuration(output.latencyMs);
+  if (formatted === null) {
+    return undefined;
+  }
+
+  const cached = !!output.response?.cached;
+  const exactMs = `${WHOLE_NUMBER_FORMATTER.format(output.latencyMs)} ms`;
+  const tooltipContent = cached ? `${exactMs} — original duration; served from cache` : exactMs;
+
   return (
-    <span>
-      {Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(output.latencyMs)} ms
-      {output.response?.cached ? ' (cached)' : ''}
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span aria-label={tooltipContent}>
+          {formatted}
+          {cached && <span className="italic"> (cached)</span>}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipContent}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -815,9 +827,7 @@ function getTokensPerSecondDisplay({
   }
 
   const tokPerSec = tokenUsage.completion / (latencyMs / 1000);
-  return (
-    <span>{Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(tokPerSec)}</span>
-  );
+  return <span>{WHOLE_NUMBER_FORMATTER.format(tokPerSec)}</span>;
 }
 
 function getCostDisplay(cost?: number): React.ReactNode | undefined {

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -724,7 +724,12 @@ function getCommentTextToDisplay(comment?: string): string | undefined {
   return comment?.startsWith('!highlight') ? comment.slice('!highlight'.length).trim() : comment;
 }
 
+// Module-scoped to avoid Intl.NumberFormat construction on every per-cell render.
 const WHOLE_NUMBER_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+// Sub-millisecond precision for raw latency values (some providers report fractional ms).
+const LATENCY_PRECISION_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 3,
+});
 
 function formatTokenUsageDisplay(
   tokenUsage:
@@ -786,18 +791,16 @@ function formatTokenUsageDisplay(
 }
 
 function getLatencyDisplay(output: EvaluateTableOutput): React.ReactNode | undefined {
-  if (!output.latencyMs) {
-    return undefined;
-  }
-
-  const formatted = formatDuration(output.latencyMs);
-  if (formatted === null) {
+  if (output.latencyMs == null) {
     return undefined;
   }
 
   const cached = !!output.response?.cached;
-  const exactMs = `${WHOLE_NUMBER_FORMATTER.format(output.latencyMs)} ms`;
-  const tooltipContent = cached ? `${exactMs} — original duration; served from cache` : exactMs;
+  const exactMs = `${LATENCY_PRECISION_FORMATTER.format(output.latencyMs)} ms`;
+  // Fall back to the raw ms string when latency is non-finite/negative, so corrupt
+  // upstream data is still visible in the cell (matches the column-aggregate footer).
+  const formatted = formatDuration(output.latencyMs) ?? exactMs;
+  const tooltipContent = cached ? `${exactMs} (cached response)` : exactMs;
 
   return (
     <Tooltip>

--- a/src/app/src/pages/eval/components/ResultsTable.css
+++ b/src/app/src/pages/eval/components/ResultsTable.css
@@ -194,7 +194,8 @@ table.results-table,
 .results-table tr .stat-item {
   font-weight: normal;
   font-size: 0.75rem;
-  color: #888;
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
 }
 
 /* Remove default button styling - but not for MUI IconButton */
@@ -280,7 +281,8 @@ table.results-table,
   row-gap: 0.25rem;
 
   font-size: 0.75rem;
-  color: #888;
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
   margin-top: auto; /* Floats element to the bottom of the container */
 }
 

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -2629,6 +2629,11 @@ describe('ResultsTable Filtered Metrics Display', () => {
     expect(filteredTokensElement).toHaveStyle('font-size: 0.9em');
     expect(filteredTokensElement).toHaveStyle('color: #666');
     expect(filteredTokensElement).toHaveStyle('margin-left: 4px');
+
+    expect(screen.getByText('Avg Latency:')).toBeInTheDocument();
+    const filteredLatencyElement = screen.getByText('(200ms filtered)');
+    expect(filteredLatencyElement).toBeInTheDocument();
+    expect(filteredLatencyElement).toHaveStyle('font-size: 0.9em');
   });
 });
 

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -2631,6 +2631,8 @@ describe('ResultsTable Filtered Metrics Display', () => {
     expect(filteredTokensElement).toHaveStyle('margin-left: 4px');
 
     expect(screen.getByText('Avg Latency:')).toBeInTheDocument();
+    expect(screen.getByText('200ms')).toBeInTheDocument();
+    expect(screen.getByLabelText('200 ms')).toBeInTheDocument();
     const filteredLatencyElement = screen.getByText('(200ms filtered)');
     expect(filteredLatencyElement).toBeInTheDocument();
     expect(filteredLatencyElement).toHaveStyle('font-size: 0.9em');
@@ -2713,6 +2715,10 @@ describe('ResultsTable - No Filters Applied', () => {
 
     expect(screen.getByText('Total Tokens:')).toBeInTheDocument();
     expect(screen.getByText('1,000')).toBeInTheDocument();
+
+    expect(screen.getByText('Avg Latency:')).toBeInTheDocument();
+    expect(screen.getByText('200ms')).toBeInTheDocument();
+    expect(screen.getByLabelText('200 ms')).toBeInTheDocument();
 
     const filteredMetricElements = screen.queryAllByTestId('filtered-metric');
     expect(filteredMetricElements.length).toBe(0);

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -630,12 +630,12 @@ function renderLatencyMetric({
 
   const totalAverage = testCount?.total ? metrics.totalLatencyMs / testCount.total : 0;
   const filteredAverage =
-    filteredMetrics?.totalLatencyMs && testCount?.filtered
+    filteredMetrics?.totalLatencyMs != null && testCount?.filtered
       ? filteredMetrics.totalLatencyMs / testCount.filtered
       : undefined;
 
   const formatLatency = (ms: number) => formatDuration(ms) ?? `${formatMetricValue(ms)} ms`;
-  const exactTotalMs = `${formatMetricValue(totalAverage)} ms`;
+  const exactTotalMs = `${formatMetricValue(totalAverage, { maximumFractionDigits: 3 })} ms`;
 
   return (
     <div>

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -16,6 +16,7 @@ import { EVAL_ROUTES, ROUTES } from '@app/constants/routes';
 import { useToast } from '@app/hooks/useToast';
 import { cn } from '@app/lib/utils';
 import { callApi } from '@app/utils/api';
+import { formatDuration } from '@app/utils/date';
 import { normalizeMediaText, resolveAudioSource, resolveImageSource } from '@app/utils/media';
 import { getActualPrompt } from '@app/utils/providerResponse';
 import { FILE_METADATA_KEY, HUMAN_ASSERTION_TYPE } from '@promptfoo/providers/constants';
@@ -567,7 +568,7 @@ function renderCostMetric({
       <strong>Total Cost:</strong>{' '}
       <Tooltip>
         <TooltipTrigger asChild>
-          <span style={{ cursor: 'help' }}>${totalCost}</span>
+          <span className="cursor-help">${totalCost}</span>
         </TooltipTrigger>
         <TooltipContent>{`Average: $${averageCost} per test`}</TooltipContent>
       </Tooltip>
@@ -633,12 +634,21 @@ function renderLatencyMetric({
       ? filteredMetrics.totalLatencyMs / testCount.filtered
       : undefined;
 
+  const formatLatency = (ms: number) => formatDuration(ms) ?? `${formatMetricValue(ms)} ms`;
+  const exactTotalMs = `${formatMetricValue(totalAverage)} ms`;
+
   return (
     <div>
-      <strong>Avg Latency:</strong> {formatMetricValue(totalAverage)} ms
-      {filteredAverage
-        ? renderFilteredSuffix(formatMetricValue(filteredAverage), 'ms filtered')
-        : null}
+      <strong>Avg Latency:</strong>{' '}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="cursor-help" aria-label={exactTotalMs}>
+            {formatLatency(totalAverage)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{exactTotalMs}</TooltipContent>
+      </Tooltip>
+      {filteredAverage === undefined ? null : renderFilteredSuffix(formatLatency(filteredAverage))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Per-cell **Latency** and column-aggregate **Avg Latency** now render via the same `formatDuration` helper that already powers the top-of-page **DURATION** chip — `1h 3m` / `4m 16s` / `2.3s` / `247ms`. Each value is wrapped in a Radix `Tooltip` exposing the precise raw ms (cached rows clarify that the displayed duration is the *original* pre-cache execution time), and triggers carry an `aria-label` so screen readers receive the exact value rather than guessing at `"1h 3m"`.

While addressing the reported asymmetry, a small batch of design-system polish lands in the same surface:

- Italicize the `(cached)` qualifier on both latency and tokens (was inline parens at full weight, now a clear meta-qualifier)
- Replace hardcoded `#888` on `.stat-item` and `.prompt-detail` with `hsl(var(--muted-foreground))` so contrast respects light/dark theme tokens
- Add `font-variant-numeric: tabular-nums` to both rows so columns of digits scan vertically — directly serves the issue's stated outlier-spotting goal
- Swap inline `style={{ cursor: 'help' }}` for the `cursor-help` Tailwind class on the column-aggregate triggers (matching `renderCostMetric`)
- Cache a single module-level `Intl.NumberFormat` instance for use across the per-cell display helpers instead of constructing one per call (hot path: hundreds of cells)

### Scope decisions vs. the issue

The issue also proposed `15,176 → 15.2k (2.2k↑ + 15k↓)` for tokens and `4 → 4 tok/s` for the Tokens/Sec metric. We intentionally did **not** ship those:

- The compact `15.2k` notation rounds away granularity that's actually useful when comparing similar tests, and the `↑↓` arrow notation is a screen-reader hazard. The current `15,176 (2,225+14,951)` already breaks down precisely with thousands-separators.
- The `Tokens/Sec:` row label already names the unit; adding `tok/s` after the value would duplicate it.

The core ask — closing the readability gap between humanized DURATION and raw-ms cells — is fully addressed.

Closes #8974

## Test plan

- [x] `npm run test:app -- src/pages/eval --run` — 1426 / 1426 pass (added 8 new tests covering humanized output across s / m / h, the `aria-label` precision, cached aria-label clarification, italicized cached suffix on both latency and tokens, and the filtered-latency suffix)
- [x] `npm run l && npm run f` clean
- [x] `tsc --noEmit` clean
- [ ] Visual: open an eval with a mix of sub-second, minute-range, hour-range, and cached rows — confirm Latency cells render humanized, hover reveals exact ms, cached rows show italic `(cached)` and a clarifying tooltip
- [ ] Light + dark theme: muted-foreground tokens render with adequate contrast in both

## Screenshots

### Before
![Before: raw millisecond latency in the eval results table](https://iili.io/BsWnNEJ.png)

### After
![After: humanized latency in the eval results table](https://iili.io/BsWnv7p.png)
