### PR TITLE
fix(cli): fail closed on modelaudit signal exits

### DIFF
--- a/src/commands/modelScan.ts
+++ b/src/commands/modelScan.ts
@@ -32,6 +32,7 @@ import type { ModelAuditIssue, ModelAuditScanResults } from '../types/modelAudit
 
 interface SpawnResult {
   code: number | null;
+  signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
 }
@@ -121,17 +122,43 @@ function hasErrorsInResults(results: ModelAuditScanResults): boolean {
 }
 
 /**
- * Check if exit code indicates a process error (signal termination or crash).
+ * Resolve abnormal subprocess termination into a non-zero wrapper exit code.
  *
  * modelaudit exit codes:
  * - 0: Scan completed successfully, no security issues found
  * - 1: Scan completed successfully, security issues were found (NOT an error)
- * - 2+: Fatal errors (e.g., invalid arguments, crash, signal termination)
+ * - 2+: Fatal errors (e.g., invalid arguments)
  *
- * This differs from standard Unix conventions where exit 1 = general failure.
+ * Child processes that terminate by signal report `code === null`, so they must be
+ * handled separately instead of collapsing to a successful wrapper exit.
  */
-function isProcessError(code: number | null): code is number {
-  return code !== null && code > 1;
+function getProcessErrorExitCode(result: Pick<SpawnResult, 'code' | 'signal'>): number | null {
+  if (result.signal !== null) {
+    return 1;
+  }
+
+  if (result.code === null) {
+    return 1;
+  }
+
+  return result.code > 1 ? result.code : null;
+}
+
+function logProcessError(result: Pick<SpawnResult, 'code' | 'signal'>): number | null {
+  const exitCode = getProcessErrorExitCode(result);
+  if (exitCode === null) {
+    return null;
+  }
+
+  if (result.signal !== null) {
+    logger.error(`Model scan process terminated by signal ${result.signal}`);
+  } else if (result.code === null) {
+    logger.error('Model scan process exited without an exit code');
+  } else {
+    logger.error(`Model scan process exited with code ${result.code}`);
+  }
+
+  return exitCode;
 }
 
 /**
@@ -209,17 +236,19 @@ function spawnModelAudit(
     const childProcess = spawn('modelaudit', args, spawnOptions);
 
     // Graceful shutdown - forward SIGINT/SIGTERM to child process
-    const cleanup = () => {
+    const forwardSignal = (signal: NodeJS.Signals) => () => {
       if (!childProcess.killed) {
-        childProcess.kill('SIGTERM');
+        childProcess.kill(signal);
       }
     };
-    process.once('SIGINT', cleanup);
-    process.once('SIGTERM', cleanup);
+    const forwardSigint = forwardSignal('SIGINT');
+    const forwardSigterm = forwardSignal('SIGTERM');
+    process.once('SIGINT', forwardSigint);
+    process.once('SIGTERM', forwardSigterm);
 
     const removeListeners = () => {
-      process.removeListener('SIGINT', cleanup);
-      process.removeListener('SIGTERM', cleanup);
+      process.removeListener('SIGINT', forwardSigint);
+      process.removeListener('SIGTERM', forwardSigterm);
     };
 
     if (options.captureOutput) {
@@ -245,13 +274,13 @@ function spawnModelAudit(
       reject(error);
     });
 
-    childProcess.on('close', (code: number | null) => {
+    childProcess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
       removeListeners();
       if (settled) {
         return;
       }
       settled = true;
-      resolve({ code, stdout, stderr });
+      resolve({ code, signal: signal ?? null, stdout, stderr });
     });
   });
 }
@@ -317,11 +346,17 @@ async function runPassthroughModelAudit(
 ): Promise<void> {
   try {
     const spawnResult = await spawnModelAudit(args, { captureOutput: false, env });
+    const processErrorExitCode = logProcessError(spawnResult);
+    if (processErrorExitCode !== null) {
+      process.exitCode = processErrorExitCode;
+      return;
+    }
+
     const isIssuesExit = treatExitOneAsIssues && spawnResult.code === 1;
     if (spawnResult.code !== null && spawnResult.code !== 0 && !isIssuesExit) {
       logger.error(`Model scan process exited with code ${spawnResult.code}`);
     }
-    process.exitCode = spawnResult.code || 0;
+    process.exitCode = spawnResult.code ?? 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`Failed to start modelaudit: ${message}`);
@@ -720,10 +755,10 @@ async function processScanResultsFromFile(
   };
 
   // Handle process errors (stderr already displayed via inherited stdio)
-  if (isProcessError(spawnResult.code)) {
-    logger.error(`Model scan process exited with code ${spawnResult.code}`);
+  const processErrorExitCode = logProcessError(spawnResult);
+  if (processErrorExitCode !== null) {
     await cleanupTempFile();
-    return spawnResult.code;
+    return processErrorExitCode;
   }
 
   // Read JSON from temp file
@@ -741,7 +776,7 @@ async function processScanResultsFromFile(
 
   return processJsonResults(
     jsonOutput,
-    spawnResult.code || 0,
+    spawnResult.code ?? 0,
     paths,
     options,
     currentScannerVersion,
@@ -761,12 +796,12 @@ async function processScanResultsFromStdout(
   existingAudit: ModelAudit | null,
 ): Promise<number> {
   // Handle process errors
-  if (isProcessError(spawnResult.code)) {
-    logger.error(`Model scan process exited with code ${spawnResult.code}`);
+  const processErrorExitCode = logProcessError(spawnResult);
+  if (processErrorExitCode !== null) {
     if (spawnResult.stderr) {
       logger.error(spawnResult.stderr);
     }
-    return spawnResult.code;
+    return processErrorExitCode;
   }
 
   const jsonOutput = spawnResult.stdout.trim();
@@ -778,7 +813,7 @@ async function processScanResultsFromStdout(
 
   return processJsonResults(
     jsonOutput,
-    spawnResult.code || 0,
+    spawnResult.code ?? 0,
     paths,
     options,
     currentScannerVersion,

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from 'child_process';
+import { writeFileSync } from 'fs';
 
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } from 'vitest';
@@ -45,6 +46,46 @@ vi.mock('../../src/util/huggingfaceMetadata', async (importOriginal) => {
   };
 });
 
+const SIGNAL_TERMINATIONS: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGKILL'];
+const VALID_SCAN_OUTPUT = JSON.stringify({
+  total_checks: 10,
+  passed_checks: 10,
+  failed_checks: 0,
+  files_scanned: 1,
+  bytes_scanned: 1024,
+  duration: 1000,
+  issues: [],
+  checks: [],
+});
+
+function createSignalTerminatedProcess(signal: NodeJS.Signals, stdout = ''): ChildProcess {
+  const mockChildProcess = {
+    stdout: {
+      on: vi.fn().mockImplementation(function (event: string, callback: any) {
+        if (event === 'data' && stdout) {
+          callback(Buffer.from(stdout));
+        }
+        return mockChildProcess.stdout;
+      }),
+    },
+    stderr: {
+      on: vi.fn().mockImplementation(function () {
+        return mockChildProcess.stderr;
+      }),
+    },
+    killed: false,
+    kill: vi.fn(),
+    on: vi.fn().mockImplementation(function (event: string, callback: any) {
+      if (event === 'close') {
+        callback(null, signal);
+      }
+      return mockChildProcess;
+    }),
+  } as unknown as ChildProcess;
+
+  return mockChildProcess;
+}
+
 describe('modelScanCommand', () => {
   let program: Command;
   let mockExit: MockInstance;
@@ -85,6 +126,7 @@ describe('modelScanCommand', () => {
   afterEach(() => {
     mockExit.mockRestore();
     process.exitCode = 0;
+    vi.resetAllMocks();
   });
 
   it('should exit if no paths are provided', async () => {
@@ -438,6 +480,152 @@ describe('modelScanCommand', () => {
     expect(process.exitCode).toBe(2);
 
     loggerErrorSpy.mockRestore();
+  });
+});
+
+describe('Signal termination handling', () => {
+  let program: Command;
+  let mockExit: MockInstance;
+
+  beforeEach(async () => {
+    program = new Command();
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(function () {
+      return undefined as never;
+    });
+    process.exitCode = 0;
+    vi.clearAllMocks();
+
+    vi.mocked(spawn).mockReset();
+    const { getModelAuditCurrentVersion } = await import('../../src/updates');
+    vi.mocked(getModelAuditCurrentVersion).mockReset();
+    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
+
+    const ModelAudit = (await import('../../src/models/modelAudit')).default;
+    vi.mocked(ModelAudit.findByRevision).mockReset();
+    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
+    vi.mocked(ModelAudit.create).mockReset();
+    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
+
+    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
+      '../../src/util/huggingfaceMetadata'
+    );
+    vi.mocked(isHuggingFaceModel).mockReset();
+    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
+    vi.mocked(getHuggingFaceMetadata).mockReset();
+    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
+    vi.mocked(parseHuggingFaceModel).mockReset();
+    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    process.exitCode = 0;
+  });
+
+  it.each(
+    SIGNAL_TERMINATIONS,
+  )('fails closed in --no-write mode when modelaudit terminates via %s', async (signal) => {
+    (spawn as unknown as Mock).mockReturnValue(createSignalTerminatedProcess(signal));
+
+    modelScanCommand(program);
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+
+    await command.parseAsync(['node', 'scan-model', 'model.pkl', '--no-write']);
+
+    expect(logger.error).toHaveBeenCalledWith(`Model scan process terminated by signal ${signal}`);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('forwards parent SIGINT to modelaudit as SIGINT', async () => {
+    let closeHandler: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+    const mockChildProcess = {
+      killed: false,
+      kill: vi.fn(),
+      on: vi.fn().mockImplementation(function (event: string, callback: any) {
+        if (event === 'close') {
+          closeHandler = callback;
+        }
+        return mockChildProcess;
+      }),
+    } as unknown as ChildProcess;
+    (spawn as unknown as Mock).mockReturnValue(mockChildProcess);
+
+    modelScanCommand(program);
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+    const parsePromise = command.parseAsync(['node', 'scan-model', 'model.pkl', '--no-write']);
+
+    await vi.waitFor(() => {
+      expect(closeHandler).toBeDefined();
+    });
+    process.emit('SIGINT');
+    closeHandler?.(null, 'SIGINT');
+    await parsePromise;
+
+    expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGINT');
+    expect(logger.error).toHaveBeenCalledWith('Model scan process terminated by signal SIGINT');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('fails closed when modelaudit closes without an exit code or signal', async () => {
+    const mockChildProcess = {
+      killed: false,
+      kill: vi.fn(),
+      on: vi.fn().mockImplementation(function (event: string, callback: any) {
+        if (event === 'close') {
+          callback(null, null);
+        }
+        return mockChildProcess;
+      }),
+    } as unknown as ChildProcess;
+    (spawn as unknown as Mock).mockReturnValue(mockChildProcess);
+
+    modelScanCommand(program);
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+
+    await command.parseAsync(['node', 'scan-model', 'model.pkl', '--no-write']);
+
+    expect(logger.error).toHaveBeenCalledWith('Model scan process exited without an exit code');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.each(
+    SIGNAL_TERMINATIONS,
+  )('fails closed in stdout-capture mode after JSON output when modelaudit terminates via %s', async (signal) => {
+    (spawn as unknown as Mock).mockReturnValue(
+      createSignalTerminatedProcess(signal, VALID_SCAN_OUTPUT),
+    );
+
+    modelScanCommand(program);
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+    const ModelAudit = (await import('../../src/models/modelAudit')).default;
+
+    await command.parseAsync(['node', 'scan-model', 'model.pkl']);
+
+    expect(logger.error).toHaveBeenCalledWith(`Model scan process terminated by signal ${signal}`);
+    expect(process.exitCode).toBe(1);
+    expect(ModelAudit.create).not.toHaveBeenCalled();
+  });
+
+  it.each(
+    SIGNAL_TERMINATIONS,
+  )('fails closed in temp-output mode after JSON output when modelaudit terminates via %s', async (signal) => {
+    const { getModelAuditCurrentVersion } = await import('../../src/updates');
+    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.20');
+    (spawn as unknown as Mock).mockImplementation((_command: string, args: string[]) => {
+      const outputFlagIndex = args.indexOf('--output');
+      writeFileSync(args[outputFlagIndex + 1], VALID_SCAN_OUTPUT);
+      return createSignalTerminatedProcess(signal);
+    });
+
+    modelScanCommand(program);
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+    const ModelAudit = (await import('../../src/models/modelAudit')).default;
+
+    await command.parseAsync(['node', 'scan-model', 'model.pkl']);
+
+    expect(logger.error).toHaveBeenCalledWith(`Model scan process terminated by signal ${signal}`);
+    expect(process.exitCode).toBe(1);
+    expect(ModelAudit.create).not.toHaveBeenCalled();
   });
 });
 

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -126,7 +126,6 @@ describe('modelScanCommand', () => {
   afterEach(() => {
     mockExit.mockRestore();
     process.exitCode = 0;
-    vi.resetAllMocks();
   });
 
   it('should exit if no paths are provided', async () => {
@@ -520,6 +519,7 @@ describe('Signal termination handling', () => {
   afterEach(() => {
     mockExit.mockRestore();
     process.exitCode = 0;
+    vi.resetAllMocks();
   });
 
   it.each(

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -152,7 +152,6 @@ const legacyModuleScopePersistentMockFiles = new Set<string>([
   'commands/export.test.ts',
   'commands/mcp/server.test.ts',
   'commands/mcp/tools/runEvaluation.test.ts',
-  'commands/modelScan.test.ts',
   'commands/view.test.ts',
   'evaluator.integration.realTransforms.test.ts',
   'evaluatorHelpers.test.ts',


### PR DESCRIPTION
## Summary
- preserve child process signals from delegated `modelaudit` scans instead of collapsing `code === null` into success
- fail closed with explicit diagnostics across passthrough, stdout-capture, and temp-output flows
- preserve parent signal forwarding semantics and add regression coverage for signal exits, null closes, and JSON emitted before abnormal termination

## Testing
- `npx vitest run test/commands/modelScan.test.ts --sequence.shuffle=false`
- `npm run tsc -- --pretty false`
- `npm run l`
- `npm run f`
- live fake-child repro: delegated `modelaudit` emitted JSON, terminated with `SIGTERM`, and `promptfoo scan-model --no-write --format json` exited `1`
