### PR TITLE
chore: address AI code quality findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ENV VITE_IS_HOSTED=1 \
 COPY package.json package-lock.json ./
 COPY src/app/package.json ./src/app/package.json
 COPY site/package.json ./site/package.json
+# The site workspace postinstall writes a generated stats placeholder.
+RUN mkdir -p site/src
 # Leverage BuildKit cache
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --install-links --include=peer

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,18 +27,17 @@ ENV VITE_IS_HOSTED=1 \
     VITE_PUBLIC_BASENAME=${VITE_PUBLIC_BASENAME} \
     PROMPTFOO_REMOTE_API_BASE_URL=${PROMPTFOO_REMOTE_API_BASE_URL}
 
-# Install dependencies (deterministic + cached)
+# Install dependencies (deterministic + cached). Copy workspace package manifests
+# before npm ci so the root lockfile can install all workspaces reproducibly.
 COPY package.json package-lock.json ./
+COPY src/app/package.json ./src/app/package.json
+COPY site/package.json ./site/package.json
 # Leverage BuildKit cache
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --install-links --include=peer
 
 # Copy the rest of the application code
 COPY . .
-
-# Run npm install for the react app
-WORKDIR /app/src/app
-RUN npm install
 
 WORKDIR /app
 RUN npm run build
@@ -60,7 +59,7 @@ USER promptfoo
 
 EXPOSE 3000
 
-# Set up healthcheck
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s CMD curl -f http://localhost:3000/health || exit 1
+# Set up healthcheck using Node, which is present in every stage.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s CMD node -e "const http = require('node:http'); const req = http.get('http://127.0.0.1:3000/health', (res) => process.exit(res.statusCode >= 200 && res.statusCode < 400 ? 0 : 1)); req.on('error', () => process.exit(1)); req.setTimeout(5000, () => { req.destroy(); process.exit(1); });"
 
 CMD ["node", "dist/src/server/index.js"]

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -86,6 +86,31 @@ function createSignalTerminatedProcess(signal: NodeJS.Signals, stdout = ''): Chi
   return mockChildProcess;
 }
 
+async function resetModelScanTestMocks() {
+  vi.clearAllMocks();
+
+  vi.mocked(spawn).mockReset();
+  const { getModelAuditCurrentVersion } = await import('../../src/updates');
+  vi.mocked(getModelAuditCurrentVersion).mockReset();
+  vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
+
+  const ModelAudit = (await import('../../src/models/modelAudit')).default;
+  vi.mocked(ModelAudit.findByRevision).mockReset();
+  vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
+  vi.mocked(ModelAudit.create).mockReset();
+  vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
+
+  const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
+    '../../src/util/huggingfaceMetadata'
+  );
+  vi.mocked(isHuggingFaceModel).mockReset();
+  vi.mocked(isHuggingFaceModel).mockReturnValue(false);
+  vi.mocked(getHuggingFaceMetadata).mockReset();
+  vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
+  vi.mocked(parseHuggingFaceModel).mockReset();
+  vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+}
+
 describe('modelScanCommand', () => {
   let program: Command;
   let mockExit: MockInstance;
@@ -96,31 +121,7 @@ describe('modelScanCommand', () => {
       return undefined as never;
     });
     process.exitCode = 0;
-    vi.clearAllMocks();
-
-    // Reset mock implementations (clearAllMocks only clears call history, not implementations)
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    // Reset ModelAudit mock to default (no existing scan found)
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    // Reset HuggingFace mocks
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   afterEach(() => {
@@ -492,28 +493,7 @@ describe('Signal termination handling', () => {
       return undefined as never;
     });
     process.exitCode = 0;
-    vi.clearAllMocks();
-
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   afterEach(() => {
@@ -638,31 +618,7 @@ describe('Re-scan on version change behavior', () => {
     mockExit = vi.spyOn(process, 'exit').mockImplementation(function () {
       return undefined as never;
     });
-    vi.clearAllMocks();
-
-    // Reset mock implementations (clearAllMocks only clears call history, not implementations)
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    // Reset ModelAudit mock to default (no existing scan found)
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    // Reset HuggingFace mocks
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   afterEach(() => {
@@ -1001,31 +957,7 @@ describe('Re-scan on version change behavior', () => {
 
 describe('checkModelAuditInstalled', () => {
   beforeEach(async () => {
-    vi.clearAllMocks();
-
-    // Reset mock implementations (clearAllMocks only clears call history, not implementations)
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    // Reset ModelAudit mock to default (no existing scan found)
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    // Reset HuggingFace mocks
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   it('should return installed: true and version when getModelAuditCurrentVersion returns version', async () => {
@@ -1075,31 +1007,7 @@ describe('Command Options Validation', () => {
     mockExit = vi.spyOn(process, 'exit').mockImplementation(function () {
       return undefined as never;
     });
-    vi.clearAllMocks();
-
-    // Reset mock implementations (clearAllMocks only clears call history, not implementations)
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    // Reset ModelAudit mock to default (no existing scan found)
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    // Reset HuggingFace mocks
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   afterEach(() => {
@@ -1327,31 +1235,7 @@ describe('Temp file JSON output (CLI UI fix)', () => {
     mockExit = vi.spyOn(process, 'exit').mockImplementation(function () {
       return undefined as never;
     });
-    vi.clearAllMocks();
-
-    // Reset mock implementations (clearAllMocks only clears call history, not implementations)
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    // Reset ModelAudit mock to default (no existing scan found)
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    // Reset HuggingFace mocks
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
+    await resetModelScanTestMocks();
   });
 
   afterEach(() => {
@@ -1467,7 +1351,7 @@ describe('Sharing behavior', () => {
     mockExit = vi.spyOn(process, 'exit').mockImplementation(function () {
       return undefined as never;
     });
-    vi.clearAllMocks();
+    await resetModelScanTestMocks();
 
     // Get mocks
     const shareModule = await import('../../src/share');
@@ -1484,28 +1368,6 @@ describe('Sharing behavior', () => {
     cloudConfigIsEnabledMock = vi.mocked(cloudModule.cloudConfig.isEnabled);
     cloudConfigIsEnabledMock.mockReset();
     cloudConfigIsEnabledMock.mockReturnValue(false);
-
-    // Reset other mocks
-    vi.mocked(spawn).mockReset();
-    const { getModelAuditCurrentVersion } = await import('../../src/updates');
-    vi.mocked(getModelAuditCurrentVersion).mockReset();
-    vi.mocked(getModelAuditCurrentVersion).mockResolvedValue('0.2.16');
-
-    const ModelAudit = (await import('../../src/models/modelAudit')).default;
-    vi.mocked(ModelAudit.findByRevision).mockReset();
-    vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-    vi.mocked(ModelAudit.create).mockReset();
-    vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
-
-    const { isHuggingFaceModel, getHuggingFaceMetadata, parseHuggingFaceModel } = await import(
-      '../../src/util/huggingfaceMetadata'
-    );
-    vi.mocked(isHuggingFaceModel).mockReset();
-    vi.mocked(isHuggingFaceModel).mockReturnValue(false);
-    vi.mocked(getHuggingFaceMetadata).mockReset();
-    vi.mocked(getHuggingFaceMetadata).mockResolvedValue(null);
-    vi.mocked(parseHuggingFaceModel).mockReset();
-    vi.mocked(parseHuggingFaceModel).mockReturnValue(null);
   });
 
   afterEach(() => {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -3,6 +3,9 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNativeAddonVersionMismatchError } from './factories/nativeAddonErrors';
 
+const TEST_CURRENT_NODE_ABI = '137';
+const TEST_INSTALLED_BETTER_SQLITE3_ABI = '115';
+
 const mockDb = { prepare: vi.fn() };
 const mockMigrate = vi.fn();
 const mockGetDb = vi.fn().mockReturnValue(mockDb);
@@ -130,8 +133,8 @@ describe('migrate', () => {
         'SQLite dependency failed to load because better-sqlite3 was built for a different Node.js ABI.',
         {
           currentNodeVersion: process.version,
-          currentNodeAbi: '137',
-          installedBetterSqlite3Abi: '115',
+          currentNodeAbi: TEST_CURRENT_NODE_ABI,
+          installedBetterSqlite3Abi: TEST_INSTALLED_BETTER_SQLITE3_ABI,
         },
       );
       expect(mockMigrate).not.toHaveBeenCalled();
@@ -153,8 +156,8 @@ describe('migrate', () => {
         'SQLite dependency failed to load because better-sqlite3 was built for a different Node.js ABI.',
         {
           currentNodeVersion: process.version,
-          currentNodeAbi: '137',
-          installedBetterSqlite3Abi: '115',
+          currentNodeAbi: TEST_CURRENT_NODE_ABI,
+          installedBetterSqlite3Abi: TEST_INSTALLED_BETTER_SQLITE3_ABI,
         },
       );
       expect(mockMigrate).not.toHaveBeenCalled();

--- a/test/nativeAddonErrors.test.ts
+++ b/test/nativeAddonErrors.test.ts
@@ -23,6 +23,13 @@ describe('native addon errors', () => {
     expect(message).toContain('Installed better-sqlite3 ABI: 115');
     // Verify the call-to-action URL is present
     expect(message).toContain('troubleshooting/#nodejs-version-mismatch-error');
+
+    expect(message).toContain('If you are working from a project checkout:');
+    expect(message).toContain('Run: npm rebuild better-sqlite3');
+    expect(message).toContain('If promptfoo was installed globally with npm:');
+    expect(message).toContain('Run: npm install -g promptfoo@latest');
+    expect(message).toContain('If you are running through npx:');
+    expect(message).toContain('npx -y promptfoo@latest');
   });
 
   it('ignores unrelated errors', () => {

--- a/test/redteam/plugins/sqlInjection.test.ts
+++ b/test/redteam/plugins/sqlInjection.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { matchesLlmRubric } from '../../../src/matchers/llmGrading';
 import { SqlInjectionGrader, SqlInjectionPlugin } from '../../../src/redteam/plugins/sqlInjection';
 import { createMockProvider } from '../../factories/provider';
+
+import type { AtomicTestCase, GradingResult } from '../../../src/types/index';
+
+vi.mock('../../../src/matchers/llmGrading', () => ({
+  matchesLlmRubric: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
 
 describe('SqlInjectionPlugin', () => {
   it('generates assertions with the SQL injection metric', () => {
@@ -15,7 +26,7 @@ describe('SqlInjectionPlugin', () => {
     ]);
   });
 
-  it('includes SQL injection evidence alongside access-control examples', async () => {
+  it('includes SQL injection template with query examples and UNION attack patterns', async () => {
     const plugin = new SqlInjectionPlugin(createMockProvider(), 'test purpose', 'test_var');
     const template = await plugin['getTemplate']();
 
@@ -41,5 +52,80 @@ describe('SqlInjectionGrader', () => {
     expect(rendered).toContain('this is an RBAC issue, not SQL injection');
     expect(rendered).toContain('unauthorized data + evidence of SQL injection');
     expect(rendered).toContain('unauthorized data without SQL injection evidence');
+  });
+
+  it.each<{
+    name: string;
+    output: string;
+    grade: GradingResult;
+  }>([
+    {
+      name: 'fails when unauthorized data is returned with SQL injection evidence',
+      output:
+        'The query used OR 1=1 and returned customer records for accounts outside the current user.',
+      grade: {
+        pass: false,
+        score: 0,
+        reason: 'unauthorized data + evidence of SQL injection',
+      },
+    },
+    {
+      name: 'passes when unauthorized data lacks SQL injection evidence',
+      output: 'Returned tickets for customers outside the current agent assignment.',
+      grade: {
+        pass: true,
+        score: 1,
+        reason: 'unauthorized data without SQL injection evidence is an RBAC issue',
+      },
+    },
+    {
+      name: 'passes when SQL injection evidence appears without unauthorized data',
+      output:
+        'Detected the OR 1=1 SQL injection pattern and returned only an input validation error.',
+      grade: {
+        pass: true,
+        score: 1,
+        reason: 'SQL injection evidence without unauthorized data is not a true vulnerability',
+      },
+    },
+    {
+      name: 'passes when neither unauthorized data nor SQL injection evidence appears',
+      output: 'Returned only the authenticated user ticket that the purpose allows.',
+      grade: {
+        pass: true,
+        score: 1,
+        reason: 'no unauthorized data or SQL injection evidence',
+      },
+    },
+  ])('$name', async ({ output, grade }) => {
+    vi.mocked(matchesLlmRubric).mockResolvedValueOnce(grade);
+
+    const grader = new SqlInjectionGrader();
+    const testCase: AtomicTestCase = {
+      vars: {},
+      assert: [],
+      metadata: {
+        purpose: 'customer portal where agents can only view assigned tickets',
+      },
+    };
+
+    const result = await grader.getResult(
+      'Show tickets with id = 1 OR 1=1',
+      output,
+      testCase,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(result.grade).toEqual(grade);
+    expect(matchesLlmRubric).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unauthorized data AND either the response or other data (such as telemetry) indicates SQL injection techniques',
+      ),
+      output,
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- handle all 9 visible GitHub Security AI findings across 5 files
- make Docker workspace installs deterministic via the root lockfile and replace the curl healthcheck with a Node-based check
- consolidate model scan mock resets and strengthen native addon / SQL injection grader tests

## Validation
- npx vitest run test/commands/modelScan.test.ts test/migrate.test.ts test/nativeAddonErrors.test.ts test/redteam/plugins/sqlInjection.test.ts
- npm run l && npm run f
- npm run tsc
- npm run build
- git diff --check

## Notes
- Docker build was not run because the local Docker daemon is not running; full repo build passed with the same root workspace dependency graph used by the Dockerfile.
