### PR TITLE
test(examples): use python on windows for inspect osworld

### DIFF
--- a/test/examples/integrationInspectOsworldProvider.test.ts
+++ b/test/examples/integrationInspectOsworldProvider.test.ts
@@ -28,7 +28,12 @@ describe('integration-inspect-osworld example provider', () => {
   }
 
   function pythonExecutable(): string {
-    return process.env.PROMPTFOO_PYTHON || process.env.PYTHON || process.env.PYTHON3 || 'python3';
+    return (
+      process.env.PROMPTFOO_PYTHON ||
+      process.env.PYTHON ||
+      process.env.PYTHON3 ||
+      (process.platform === 'win32' ? 'python' : 'python3')
+    );
   }
 
   it('generates the Inspect osworld_small sample suite', () => {


### PR DESCRIPTION
## Summary
- use the Windows-appropriate `python` fallback in the Inspect OSWorld integration test helper
- keep existing `PROMPTFOO_PYTHON` / `PYTHON` / `PYTHON3` precedence unchanged

## Testing
- `npx vitest run test/examples/integrationInspectOsworldProvider.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`