### PR TITLE
docs(site): expand agent skill red team docs

### DIFF
--- a/site/docs/integrations/agent-skill.md
+++ b/site/docs/integrations/agent-skill.md
@@ -52,7 +52,8 @@ four skills: `promptfoo-evals`, `promptfoo-provider-setup`,
 | `promptfoo-redteam-setup`  | Focused redteam configs from live endpoints, OpenAPI specs, or static code |
 | `promptfoo-redteam-run`    | Running generated scans, triaging failures, and filtered reruns            |
 
-There is no meta selector skill. Codex routes from each skill's description and
+There is intentionally no meta selector skill. Codex routes from each skill's
+description and
 default prompt.
 
 Python providers are first-class in the Codex bundle. The provider and redteam
@@ -61,7 +62,7 @@ skills cover Promptfoo's `file://provider.py` and
 local graders, and local redteam generators, including `workers`, `timeout`, and
 `PROMPTFOO_PYTHON` configuration.
 
-Use the Claude marketplace command above when you want the single portable
+Use the Claude marketplace command above when you want the portable single
 `promptfoo-evals` skill. Use the Codex bundle when working in this repo and you
 want separate eval, provider setup, redteam setup, and redteam run workflows.
 To reuse the bundle elsewhere, copy `plugins/promptfoo` and its
@@ -154,7 +155,7 @@ New to promptfoo? See [Getting Started](/docs/getting-started) for an overview o
 The Codex bundle also teaches the agent to:
 
 - Keep real inputs such as user IDs, object IDs, documents, and tools visible so authorization and agent-boundary issues stay testable.
-- Choose plugins such as `policy`, `rbac`, `bola`, prompt-boundary, RAG, and tool checks from live or static evidence instead of defaulting to one broad scan.
+- Choose plugins such as `policy`, `rbac`, `bola`, `hijacking`, `prompt-extraction`, and `system-prompt-override` from live or static evidence instead of defaulting to one broad scan.
 - Inspect generated probes before running them, reuse generated tests with `redteam eval` when possible, and separate grader failures from real target failures.
 - Prefer no-share runs for internal systems and keep provider secrets in environment variables rather than committed configs.
 
@@ -205,9 +206,6 @@ it into one free-form prompt:
 
 ```yaml title="promptfooconfig.yaml"
 description: 'Invoice assistant red team'
-
-prompts:
-  - '{{prompt}}'
 
 targets:
   - id: https

--- a/site/docs/integrations/agent-skill.md
+++ b/site/docs/integrations/agent-skill.md
@@ -1,26 +1,33 @@
 ---
-title: Agent Skill for Writing Evals
-description: Install an agent skill that teaches AI coding agents to create Promptfoo eval suites with best-practice assertions, provider configs, and test organization.
-sidebar_label: Agent Skill
+title: Agent Skills for Evals and Red Teaming
+description: Install Promptfoo agent skills for eval writing and Codex red-team workflows, including provider setup, focused security configs, and scan result triage.
+sidebar_label: Agent Skills
 sidebar_position: 99
 ---
 
 # Agent Skill for Writing Evals
 
-AI coding agents can write promptfoo configs, but they often get the details wrong — shell-style env vars that don't work, hallucination rubrics that can't see the source material, tests dumped inline instead of in files. The `promptfoo-evals` skill fixes this by teaching your agent promptfoo's conventions and common pitfalls.
+AI coding agents can write promptfoo configs, but they often get the details wrong: shell-style env vars that do not work, hallucination rubrics that cannot see the source material, tests dumped inline instead of in files, and red-team configs that collapse real app inputs into one generic prompt field. The portable `promptfoo-evals` skill covers eval conventions, while the Codex `promptfoo-redteam-setup` and `promptfoo-redteam-run` skills cover red-team setup and scan triage.
 
-It works with [Claude Code](https://code.claude.com) and [OpenAI Codex](https://openai.com/index/codex). Because it follows the open [Agent Skills](https://agentskills.io) standard, it should also work with other compatible tools.
+If you use Codex in this repo, Promptfoo also includes a plugin bundle for provider setup, red-team setup, and scan triage. Use the portable skill for eval help in any compatible tool. Use the Codex bundle when you also want red-team workflows.
+
+The portable skill works with [Claude Code](https://code.claude.com) and [OpenAI Codex](https://openai.com/index/codex). It follows the open [Agent Skills](https://agentskills.io) standard, so it should also work with other compatible tools.
 
 ## Why use a skill?
 
 Without the skill, agents frequently:
 
-- Use `$ENV_VAR` syntax in YAML configs (doesn't work — promptfoo uses Nunjucks `'{{env.VAR}}'`)
+- Use `$ENV_VAR` syntax in YAML configs, which does not work because promptfoo uses Nunjucks `'{{env.VAR}}'`
 - Write `llm-rubric` assertions that reference "the article" but don't inline the source, so the grader can't actually compare
 - Dump all tests inline in the config instead of using `file://tests/*.yaml`
 - Reach for `llm-rubric` when `contains` or `is-json` would be faster, free, and deterministic
 
-The skill encodes these patterns so the agent gets them right the first time.
+The skill gives the agent these rules up front.
+
+The Codex red-team skills cover a different set of common mistakes: flattening
+multi-input targets into one prompt field, choosing broad scans before mapping
+the app boundary, and regenerating probes when a stable rerun would be easier to
+compare.
 
 ## Install
 
@@ -33,9 +40,9 @@ The skill encodes these patterns so the agent gets them right the first time.
 
 ### Via Codex plugin bundle
 
-For repo-local Codex usage, this repo also includes a plugin bundle at
+For repo-local Codex usage, this repo includes a plugin bundle at
 `plugins/promptfoo`, exposed by `.agents/plugins/marketplace.json`. It contains
-four focused skills: `promptfoo-evals`, `promptfoo-provider-setup`,
+four skills: `promptfoo-evals`, `promptfoo-provider-setup`,
 `promptfoo-redteam-setup`, and `promptfoo-redteam-run`.
 
 | Skill                      | Use it for                                                                 |
@@ -45,9 +52,8 @@ four focused skills: `promptfoo-evals`, `promptfoo-provider-setup`,
 | `promptfoo-redteam-setup`  | Focused redteam configs from live endpoints, OpenAPI specs, or static code |
 | `promptfoo-redteam-run`    | Running generated scans, triaging failures, and filtered reruns            |
 
-There is intentionally no meta selector skill. Codex routes from each skill's
-description and default prompt, keeping the bundle small and each workflow
-directly invokable.
+There is no meta selector skill. Codex routes from each skill's description and
+default prompt.
 
 Python providers are first-class in the Codex bundle. The provider and redteam
 skills cover Promptfoo's `file://provider.py` and
@@ -55,23 +61,31 @@ skills cover Promptfoo's `file://provider.py` and
 local graders, and local redteam generators, including `workers`, `timeout`, and
 `PROMPTFOO_PYTHON` configuration.
 
-Use the Claude marketplace command above when you want the portable single
+Use the Claude marketplace command above when you want the single portable
 `promptfoo-evals` skill. Use the Codex bundle when working in this repo and you
 want separate eval, provider setup, redteam setup, and redteam run workflows.
 To reuse the bundle elsewhere, copy `plugins/promptfoo` and its
 `.agents/plugins/marketplace.json` entry together.
 
+For red teaming, use the Codex bundle:
+`promptfoo-provider-setup` connects the system under test,
+`promptfoo-redteam-setup` turns live endpoints, OpenAPI specs, or static code
+into a scan plan, and `promptfoo-redteam-run` executes and triages the
+generated probes.
+
 ### Manual install
 
-Download the [skill directory](https://github.com/promptfoo/promptfoo/tree/main/.claude/skills/promptfoo-evals) and copy it to the correct location for your tool:
+Manual install below covers the portable eval skill. Download the
+[skill directory](https://github.com/promptfoo/promptfoo/tree/main/.claude/skills/promptfoo-evals)
+and copy it to the correct location for your tool:
 
-**Claude Code** (project-level — recommended for teams):
+**Claude Code** (project-level, recommended for teams):
 
 ```bash
 cp -r promptfoo-evals your-project/.claude/skills/
 ```
 
-**Claude Code** (personal — available in all projects):
+**Claude Code** (personal, available in all projects):
 
 ```bash
 cp -r promptfoo-evals ~/.claude/skills/
@@ -84,7 +98,7 @@ cp -r promptfoo-evals your-project/.agents/skills/
 ```
 
 :::note
-For team adoption, commit the skill to your repo's skill directory (`.claude/skills/` for Claude Code, `.agents/skills/` for Codex). Every developer's agent picks it up automatically — no per-person install needed.
+For team adoption, commit the skill to your repo's skill directory (`.claude/skills/` for Claude Code, `.agents/skills/` for Codex). Every developer's agent picks it up automatically, with no per-person install needed.
 :::
 
 The core skill consists of two files:
@@ -96,15 +110,25 @@ The core skill consists of two files:
 
 ## Usage
 
-Once installed, the agent activates automatically when you ask it to create or update eval coverage. In Claude Code, you can also invoke it directly with a slash command:
+Once installed, the agent activates automatically when you ask it to create or
+update eval coverage. In Claude Code, you can also invoke it directly with a
+slash command:
 
 ```text
 /promptfoo-evals Create an eval suite for my summarization prompt
 ```
 
-In Codex and other Agent Skills tools, simply ask the agent to create an eval — the skill activates based on the task context.
+In Codex and other Agent Skills tools, ask the agent to create an eval. The
+skill activates from the task context.
 
-The agent will:
+For red-team work in Codex, ask for the task directly:
+
+```text
+Create a focused red team config for this invoice assistant. Preserve user_id, invoice_id, and message inputs; test policy, RBAC, and BOLA.
+Run the generated redteam scan, summarize attack success rate, and give me the narrowest rerun command for failures.
+```
+
+The agent:
 
 1. Search for existing promptfoo configs in the repo
 2. Scaffold a new suite if needed (`promptfooconfig.yaml`, `prompts/`, `tests/`)
@@ -126,6 +150,13 @@ New to promptfoo? See [Getting Started](/docs/getting-started) for an overview o
 - **Environment variables.** Use Nunjucks syntax `'{{env.API_KEY}}'` in YAML configs, not shell syntax.
 - **CI-friendly runs.** Use `promptfoo eval -o output.json --no-cache` and inspect `success`, `score`, and `error`.
 - **Config field ordering.** description, env, prompts, providers, defaultTest, scenarios, tests.
+
+The Codex bundle also teaches the agent to:
+
+- Keep real inputs such as user IDs, object IDs, documents, and tools visible so authorization and agent-boundary issues stay testable.
+- Choose plugins such as `policy`, `rbac`, `bola`, prompt-boundary, RAG, and tool checks from live or static evidence instead of defaulting to one broad scan.
+- Inspect generated probes before running them, reuse generated tests with `redteam eval` when possible, and separate grader failures from real target failures.
+- Prefer no-share runs for internal systems and keep provider secrets in environment variables rather than committed configs.
 
 ## Example output
 
@@ -169,9 +200,49 @@ tests:
       value: "JSON.parse(output).status === 'shipped'"
 ```
 
+A red-team setup should keep the security boundary visible instead of collapsing
+it into one free-form prompt:
+
+```yaml title="promptfooconfig.yaml"
+description: 'Invoice assistant red team'
+
+prompts:
+  - '{{prompt}}'
+
+targets:
+  - id: https
+    label: invoice-assistant
+    inputs:
+      user_id: Signed-in user identifier.
+      invoice_id: Invoice being requested.
+      message: User message.
+    config:
+      url: '{{env.INVOICE_AGENT_URL}}'
+      method: POST
+      stateful: false
+      body:
+        user_id: '{{user_id}}'
+        invoice_id: '{{invoice_id}}'
+        message: '{{message}}'
+      transformResponse: json.output
+
+redteam:
+  purpose: >-
+    Invoice assistant for signed-in users. It may answer questions about the
+    caller's invoices only and must not reveal or modify other users' invoices.
+  plugins:
+    - id: policy
+      config:
+        policy: The assistant must not disclose or modify another user's invoices.
+    - rbac
+    - bola
+  strategies:
+    - basic
+```
+
 ## Customizing the skill
 
-The skill is just markdown files — edit them to match your team's conventions:
+The skill is just markdown files. Edit them to match your team's conventions:
 
 - **Add custom providers** to the cheatsheet if your team uses specific models or endpoints.
 - **Add assertion patterns** for your domain (e.g., medical accuracy rubrics, financial compliance checks).
@@ -179,9 +250,12 @@ The skill is just markdown files — edit them to match your team's conventions:
 
 ## Related
 
-- [Getting Started](/docs/getting-started) — promptfoo overview for newcomers
-- [Test Agent Skills](/docs/guides/test-agent-skills) — compare Claude and Codex skill versions side by side
-- [Configuration Reference](/docs/configuration/guide) — full config schema documentation
-- [Assertions Reference](/docs/configuration/expected-outputs) — complete list of assertion types
-- [Custom Providers](/docs/providers/custom-api) — building Python, JavaScript, and HTTP providers
-- [MCP Server](/docs/integrations/mcp-server) — expose promptfoo to AI agents via MCP
+- [Getting Started](/docs/getting-started): promptfoo overview for newcomers
+- [Test Agent Skills](/docs/guides/test-agent-skills): compare Claude and Codex skill versions side by side
+- [Configuration Reference](/docs/configuration/guide): full config schema documentation
+- [Assertions Reference](/docs/configuration/expected-outputs): complete list of assertion types
+- [Custom Providers](/docs/providers/custom-api): build Python, JavaScript, and HTTP providers
+- [LLM Red Teaming](/docs/red-team/): security testing concepts and workflows
+- [Red Team Coding Agents](/docs/red-team/coding-agents/): security evals for agentic systems
+- [Coding Agent Plugins](/docs/red-team/plugins/coding-agent/): repository, sandbox, secret, and verifier-boundary checks
+- [MCP Server](/docs/integrations/mcp-server): expose promptfoo to AI agents via MCP


### PR DESCRIPTION
## Summary
- broaden the agent skill page from eval-only framing to cover the Codex red-team bundle
- document when to use `promptfoo-evals` versus the Codex provider/red-team skills
- add a concrete red-team example and security-focused related links

## Why
The page already referenced the Codex bundle, but its title and opening still read as eval-only. This update keeps the portable `promptfoo-evals` skill distinct while making the repo-local red-team workflows visible and concrete.

## Validation
- `npm run l`
- `npm run f`
- `cd site && SKIP_OG_GENERATION=true npm run build`
- manually checked the rendered page at `http://localhost:3100/docs/integrations/agent-skill/`

## QA
- kept the existing H1 stable to avoid breaking linked headings
- kept the frontmatter description within the site-required 150-160 character range
- verified the page calls out `promptfoo-evals`, `promptfoo-redteam-setup`, and `promptfoo-redteam-run` explicitly