### PR TITLE
fix(output): strip nested test case metadata

### DIFF
--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -29,6 +29,25 @@ function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
   }) as ProviderConfig;
 }
 
+function projectTestCase(
+  testCase: AtomicTestCase,
+  options: { stripMetadata: boolean; stripVars: boolean },
+): AtomicTestCase {
+  if (!options.stripMetadata && !options.stripVars) {
+    return testCase;
+  }
+
+  const projectedTestCase = options.stripMetadata
+    ? (({ metadata: _metadata, ...rest }) => rest)(testCase)
+    : { ...testCase };
+
+  if (options.stripVars) {
+    projectedTestCase.vars = undefined;
+  }
+
+  return projectedTestCase;
+}
+
 // Removes circular references from the provider object and ensures consistent format
 export function sanitizeProvider(
   provider: ApiProvider | ProviderOptions | string,
@@ -604,12 +623,10 @@ export default class EvalResult {
         }
       : this.prompt;
 
-    const testCase = shouldStripTestVars
-      ? {
-          ...this.testCase,
-          vars: undefined,
-        }
-      : this.testCase;
+    const testCase = projectTestCase(this.testCase, {
+      stripMetadata: shouldStripMetadata,
+      stripVars: shouldStripTestVars,
+    });
 
     return {
       cost: this.cost,

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -13,6 +13,7 @@ import {
 import { createEvaluateResult } from '../factories/eval';
 import { createMockProvider, createProviderResponse } from '../factories/provider';
 import { createAtomicTestCase, createPrompt } from '../factories/testSuite';
+import { mockProcessEnv } from '../util/utils';
 
 describe('EvalResult', () => {
   beforeAll(async () => {
@@ -840,6 +841,59 @@ describe('EvalResult', () => {
           },
         }),
       );
+    });
+
+    it('should strip nested test-case metadata when metadata stripping is enabled', () => {
+      const restoreEnv = mockProcessEnv({
+        PROMPTFOO_STRIP_METADATA: 'true',
+        PROMPTFOO_STRIP_TEST_VARS: 'true',
+      });
+
+      try {
+        const result = new EvalResult({
+          id: 'test-id',
+          evalId: 'test-eval-id',
+          promptIdx: 0,
+          testIdx: 0,
+          testCase: {
+            ...mockTestCase,
+            vars: {
+              customerEmail: 'secret@example.com',
+            },
+            metadata: {
+              goal: 'goal testcase-secret',
+              pluginConfig: {
+                policy: 'policy testcase-secret',
+              },
+              inputMaterialization: {
+                source: 'source testcase-secret',
+              },
+            },
+          },
+          prompt: mockPrompt,
+          success: true,
+          score: 1,
+          response: {
+            output: 'provider output',
+          },
+          gradingResult: null,
+          provider: mockProvider,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          metadata: {
+            debug: 'top-level-secret',
+          },
+        });
+
+        const evaluateResult = result.toEvaluateResult();
+
+        expect(evaluateResult.metadata).toEqual({});
+        expect(evaluateResult.testCase).not.toHaveProperty('metadata');
+        expect(evaluateResult.testCase.vars).toBeUndefined();
+        expect(JSON.stringify(evaluateResult)).not.toContain('testcase-secret');
+      } finally {
+        restoreEnv();
+      }
     });
   });
 

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -8,7 +8,7 @@ import * as googleSheets from '../../src/googleSheets';
 import Eval from '../../src/models/eval';
 import { type EvaluateResult, ResultFailureReason } from '../../src/types/index';
 import { createOutputMetadata, writeMultipleOutputs, writeOutput } from '../../src/util/output';
-import { mockConsole } from './utils';
+import { mockConsole, mockProcessEnv } from './utils';
 
 vi.mock('../../src/database', () => ({
   getDb: vi.fn(),
@@ -174,6 +174,79 @@ describe('writeOutput', () => {
     expect(parsed.config.providers[0].config.apiKey).toBe('[REDACTED]');
     expect(parsed.config.providers[0].config.max_turns).toBe(2);
     expect(parsed.config.description).toBe('Test config');
+  });
+
+  it.each([
+    {
+      extension: 'json',
+      parse: (value: string) => JSON.parse(value),
+    },
+    {
+      extension: 'yaml',
+      parse: (value: string) => yaml.load(value) as Record<string, any>,
+    },
+  ])('omits test-case metadata from $extension output when metadata stripping is enabled', async ({
+    extension,
+    parse,
+  }) => {
+    const restoreEnv = mockProcessEnv({
+      PROMPTFOO_STRIP_METADATA: 'true',
+      PROMPTFOO_STRIP_TEST_VARS: 'true',
+    });
+
+    try {
+      const eval_ = new Eval({});
+      await eval_.addResult({
+        success: true,
+        failureReason: ResultFailureReason.NONE,
+        score: 1,
+        namedScores: {},
+        latencyMs: 100,
+        provider: { id: 'provider' },
+        prompt: {
+          raw: 'Test prompt',
+          label: 'Test prompt',
+        },
+        response: {
+          output: 'Test output',
+        },
+        vars: {
+          customerEmail: 'secret@example.com',
+        },
+        promptIdx: 0,
+        testIdx: 0,
+        testCase: {
+          vars: {
+            customerEmail: 'secret@example.com',
+          },
+          metadata: {
+            goal: 'goal testcase-secret',
+            pluginConfig: {
+              policy: 'policy testcase-secret',
+            },
+            inputMaterialization: {
+              source: 'source testcase-secret',
+            },
+          },
+        },
+        promptId: 'prompt',
+        metadata: {
+          debug: 'top-level-secret',
+        },
+      });
+
+      await writeOutput(`output.${extension}`, eval_, null);
+
+      const written = vi.mocked(fsPromises.writeFile).mock.calls[0][1] as string;
+      const parsed = parse(written);
+      const result = parsed.results.results[0];
+      expect(result.metadata).toEqual({});
+      expect(result.testCase.metadata).toBeUndefined();
+      expect(result.testCase.vars).toBeUndefined();
+      expect(written).not.toContain('testcase-secret');
+    } finally {
+      restoreEnv();
+    }
   });
 
   it('preserves deep non-secret config fields in JSON output', async () => {


### PR DESCRIPTION
## Summary
- remove nested `testCase.metadata` from exported result summaries when `PROMPTFOO_STRIP_METADATA` is enabled
- centralize test-case export projection so metadata and variable stripping are applied together
- add regression coverage for the model projection plus JSON and YAML exports

## Testing
- `npx vitest run test/models/evalResult.test.ts test/util/output.test.ts`
- `npm run tsc`
- `npm run l && npm run f`
