### PR TITLE
fix(providers): claude-agent-sdk returns main agent result, not first sub-agent result

### DIFF
--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -34,6 +34,7 @@ import type {
   PermissionResult,
   Options as QueryOptions,
   SandboxSettings,
+  SDKResultMessage,
   SettingSource,
   Settings,
   SpawnedProcess,
@@ -1350,6 +1351,16 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
             toolStartTimes.clear();
           };
 
+          // The Claude Agent SDK interleaves a `result` message for each background
+          // sub-agent (Task tool with run_in_background: true) into the parent
+          // session's stream before the main agent's terminal `result` arrives.
+          // SDKResultMessage has no parent_tool_use_id, so the only signal that a
+          // result is the main agent's is its position: the main agent's result is
+          // always last. Stash the latest result and process it after the stream
+          // closes — otherwise we'd return the first sub-agent's summary and skip
+          // the main agent's actual final response.
+          let lastResultMsg: SDKResultMessage | undefined;
+
           for await (const msg of res) {
             if (msg.type === 'assistant') {
               // Extract tool_use content blocks from assistant messages
@@ -1386,100 +1397,106 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
                 }
               }
             } else if (msg.type === 'result') {
-              const raw = JSON.stringify(msg);
-              const tokenUsage: ProviderResponse['tokenUsage'] = {
-                prompt: msg.usage?.input_tokens,
-                completion: msg.usage?.output_tokens,
-                total:
-                  msg.usage?.input_tokens && msg.usage?.output_tokens
-                    ? msg.usage?.input_tokens + msg.usage?.output_tokens
-                    : undefined,
-              };
-              const cost = msg.total_cost_usd ?? 0;
-              const sessionId = msg.session_id;
-
-              const toolCallsArray = Array.from(toolCallsMap.values());
-              const skillCalls = deriveSkillCalls(toolCallsArray);
-
-              // The stream is about to close; emit any orphan tool spans first so
-              // abort/hook-stop runs don't silently drop them.
-              drainOrphans();
-
-              // Aborted terminal reasons mean the agent stopped unexpectedly mid-run.
-              // Mark the provider span ERROR directly — without poisoning the
-              // response's `output`/`error` contract, since any produced output is
-              // still useful and downstream assertions may depend on it.
-              const abortedTerminalReason =
-                typeof msg.terminal_reason === 'string' &&
-                (msg.terminal_reason.startsWith('aborted_') ||
-                  msg.terminal_reason === 'hook_stopped')
-                  ? msg.terminal_reason
-                  : undefined;
-              if (abortedTerminalReason) {
-                otelTrace.getActiveSpan()?.setStatus({
-                  code: SpanStatusCode.ERROR,
-                  message: `aborted: ${abortedTerminalReason}`,
-                });
-              }
-
-              if (msg.subtype === 'success') {
-                logger.debug(`Claude Agent SDK response: ${raw}`);
-                // When structured output is enabled and available, use it as the output
-                // Otherwise fall back to the text result
-                const output =
-                  msg.structured_output === undefined ? msg.result : msg.structured_output;
-                const response: ProviderResponse = {
-                  output,
-                  tokenUsage,
-                  cost,
-                  raw,
-                  sessionId,
-                  metadata: {
-                    skillCalls,
-                    toolCalls: toolCallsArray,
-                    numTurns: msg.num_turns,
-                    durationMs: msg.duration_ms,
-                    durationApiMs: msg.duration_api_ms,
-                    modelUsage: msg.modelUsage,
-                    permissionDenials: msg.permission_denials,
-                    ...(msg.terminal_reason === undefined
-                      ? {}
-                      : { terminalReason: msg.terminal_reason }),
-                    ...(msg.structured_output === undefined
-                      ? {}
-                      : { structuredOutput: msg.structured_output }),
-                  },
-                };
-
-                // Cache the response using shared utilities
-                await cacheResponse(cacheResult, response, 'Claude Agent SDK');
-                return response;
-              } else {
-                return {
-                  error: `Claude Agent SDK call failed: ${msg.subtype}`,
-                  tokenUsage,
-                  cost,
-                  raw,
-                  sessionId,
-                  metadata: {
-                    skillCalls,
-                    toolCalls: toolCallsArray,
-                    numTurns: msg.num_turns,
-                    durationMs: msg.duration_ms,
-                    durationApiMs: msg.duration_api_ms,
-                    modelUsage: msg.modelUsage,
-                    permissionDenials: msg.permission_denials,
-                    ...(msg.terminal_reason === undefined
-                      ? {}
-                      : { terminalReason: msg.terminal_reason }),
-                  },
-                };
-              }
+              lastResultMsg = msg;
             }
           }
 
+          // The stream is about to close; emit any orphan tool spans first so
+          // abort/hook-stop runs don't silently drop them.
           drainOrphans();
-          return { error: "Claude Agent SDK call didn't return a result" };
+
+          if (!lastResultMsg) {
+            return { error: "Claude Agent SDK call didn't return a result" };
+          }
+
+          const finalMsg = lastResultMsg;
+          const raw = JSON.stringify(finalMsg);
+          const tokenUsage: ProviderResponse['tokenUsage'] = {
+            prompt: finalMsg.usage?.input_tokens,
+            completion: finalMsg.usage?.output_tokens,
+            total:
+              finalMsg.usage?.input_tokens && finalMsg.usage?.output_tokens
+                ? finalMsg.usage?.input_tokens + finalMsg.usage?.output_tokens
+                : undefined,
+          };
+          const cost = finalMsg.total_cost_usd ?? 0;
+          const sessionId = finalMsg.session_id;
+
+          const toolCallsArray = Array.from(toolCallsMap.values());
+          const skillCalls = deriveSkillCalls(toolCallsArray);
+
+          // Aborted terminal reasons mean the agent stopped unexpectedly mid-run.
+          // Mark the provider span ERROR directly — without poisoning the
+          // response's `output`/`error` contract, since any produced output is
+          // still useful and downstream assertions may depend on it.
+          const abortedTerminalReason =
+            typeof finalMsg.terminal_reason === 'string' &&
+            (finalMsg.terminal_reason.startsWith('aborted_') ||
+              finalMsg.terminal_reason === 'hook_stopped')
+              ? finalMsg.terminal_reason
+              : undefined;
+          if (abortedTerminalReason) {
+            otelTrace.getActiveSpan()?.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: `aborted: ${abortedTerminalReason}`,
+            });
+          }
+
+          if (finalMsg.subtype === 'success') {
+            logger.debug(`Claude Agent SDK response: ${raw}`);
+            // When structured output is enabled and available, use it as the output
+            // Otherwise fall back to the text result
+            const output =
+              finalMsg.structured_output === undefined
+                ? finalMsg.result
+                : finalMsg.structured_output;
+            const response: ProviderResponse = {
+              output,
+              tokenUsage,
+              cost,
+              raw,
+              sessionId,
+              metadata: {
+                skillCalls,
+                toolCalls: toolCallsArray,
+                numTurns: finalMsg.num_turns,
+                durationMs: finalMsg.duration_ms,
+                durationApiMs: finalMsg.duration_api_ms,
+                modelUsage: finalMsg.modelUsage,
+                permissionDenials: finalMsg.permission_denials,
+                ...(finalMsg.terminal_reason === undefined
+                  ? {}
+                  : { terminalReason: finalMsg.terminal_reason }),
+                ...(finalMsg.structured_output === undefined
+                  ? {}
+                  : { structuredOutput: finalMsg.structured_output }),
+              },
+            };
+
+            // Cache the response using shared utilities
+            await cacheResponse(cacheResult, response, 'Claude Agent SDK');
+            return response;
+          }
+
+          return {
+            error: `Claude Agent SDK call failed: ${finalMsg.subtype}`,
+            tokenUsage,
+            cost,
+            raw,
+            sessionId,
+            metadata: {
+              skillCalls,
+              toolCalls: toolCallsArray,
+              numTurns: finalMsg.num_turns,
+              durationMs: finalMsg.duration_ms,
+              durationApiMs: finalMsg.duration_api_ms,
+              modelUsage: finalMsg.modelUsage,
+              permissionDenials: finalMsg.permission_denials,
+              ...(finalMsg.terminal_reason === undefined
+                ? {}
+                : { terminalReason: finalMsg.terminal_reason }),
+            },
+          };
         },
         (response) => {
           const metadata = response.metadata ?? {};

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1414,12 +1414,23 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
 
           const finalMsg = lastResultMsg;
 
-          // If we observed >1 result messages but the last one has no
-          // terminal_reason, the main agent's result may not actually be last
-          // (truncated stream after a sub-agent finished). Surface this so
-          // downstream evals don't silently grade a sub-agent summary as the
+          // If we observed >1 result messages, the last one is a success, and
+          // it has no terminal_reason, the main agent's result may not actually
+          // be last (truncated stream after a sub-agent finished). Surface this
+          // so downstream evals don't silently grade a sub-agent summary as the
           // model's answer.
-          if (resultMsgCount > 1 && finalMsg.terminal_reason === undefined) {
+          //
+          // Gate on subtype === 'success' because non-success subtypes
+          // ('error_during_execution', 'error_max_turns', etc.) are themselves
+          // a definitive terminal signal — they're how the SDK reports the
+          // run ending in error, not a truncation indicator. Warning on those
+          // would be a false positive on every legitimate main-agent failure
+          // that follows a background sub-agent.
+          if (
+            resultMsgCount > 1 &&
+            finalMsg.subtype === 'success' &&
+            finalMsg.terminal_reason === undefined
+          ) {
             logger.warn(
               `[ClaudeAgentSDK] Stream produced ${resultMsgCount} result messages and the last had no terminal_reason; returning it as the main-agent result, but the stream may have been truncated.`,
             );

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1354,12 +1354,14 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
           // The Claude Agent SDK interleaves a `result` message for each background
           // sub-agent (Task tool with run_in_background: true) into the parent
           // session's stream before the main agent's terminal `result` arrives.
-          // SDKResultMessage has no parent_tool_use_id, so the only signal that a
-          // result is the main agent's is its position: the main agent's result is
-          // always last. Stash the latest result and process it after the stream
-          // closes — otherwise we'd return the first sub-agent's summary and skip
-          // the main agent's actual final response.
+          // SDKResultMessage has no parent_tool_use_id, so position is the only
+          // signal we have: in current SDK behavior the main agent's result is
+          // the last `result` message in the stream. Stash the latest one and
+          // process it after the stream closes — otherwise we'd return the first
+          // sub-agent's summary and skip the main agent's actual final response.
+          // See https://github.com/promptfoo/promptfoo/issues/9054.
           let lastResultMsg: SDKResultMessage | undefined;
+          let resultMsgCount = 0;
 
           for await (const msg of res) {
             if (msg.type === 'assistant') {
@@ -1398,6 +1400,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
               }
             } else if (msg.type === 'result') {
               lastResultMsg = msg;
+              resultMsgCount++;
             }
           }
 
@@ -1410,6 +1413,21 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
           }
 
           const finalMsg = lastResultMsg;
+
+          // If we observed >1 result messages but the last one has no
+          // terminal_reason, the main agent's result may not actually be last
+          // (truncated stream after a sub-agent finished). Surface this so
+          // downstream evals don't silently grade a sub-agent summary as the
+          // model's answer.
+          if (resultMsgCount > 1 && finalMsg.terminal_reason === undefined) {
+            logger.warn(
+              `[ClaudeAgentSDK] Stream produced ${resultMsgCount} result messages and the last had no terminal_reason; returning it as the main-agent result, but the stream may have been truncated.`,
+            );
+            otelTrace.getActiveSpan()?.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: 'stream closed without terminal_reason after multiple result messages',
+            });
+          }
           const raw = JSON.stringify(finalMsg);
           const tokenUsage: ProviderResponse['tokenUsage'] = {
             prompt: finalMsg.usage?.input_tokens,

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -776,6 +776,57 @@ describe('ClaudeCodeSDKProvider', () => {
         }
       });
 
+      it('should not warn when the final result is a non-success error subtype after a sub-agent', async () => {
+        // Negative case for the truncation heuristic: a non-success subtype
+        // like 'error_max_turns' is itself a definitive terminal signal — the
+        // SDK is reporting the run ended in error. Warning on this would be
+        // a false positive on every legitimate main-agent failure that
+        // follows a background sub-agent.
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
+        try {
+          const subAgentResult: Partial<SDKMessage> = {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'sub-session',
+            uuid: 'cccc1111-cccc-cccc-cccc-cccccccccccc' as `${string}-${string}-${string}-${string}-${string}`,
+            result: 'Sub-agent finished',
+            usage: createMockUsage(5, 5),
+            total_cost_usd: 0.0005,
+            duration_ms: 200,
+            duration_api_ms: 150,
+            is_error: false,
+            num_turns: 1,
+            permission_denials: [],
+          };
+          const mainAgentError: Partial<SDKMessage> = {
+            type: 'result',
+            subtype: 'error_max_turns',
+            session_id: 'main-session',
+            uuid: 'dddd2222-dddd-dddd-dddd-dddddddddddd' as `${string}-${string}-${string}-${string}-${string}`,
+            usage: createMockUsage(20, 30),
+            total_cost_usd: 0.003,
+            duration_ms: 1500,
+            duration_api_ms: 1200,
+            is_error: true,
+            num_turns: 4,
+            permission_denials: [],
+            // Intentionally no terminal_reason: error subtype is the signal.
+          };
+
+          mockQuery.mockReturnValue(createMockQuery([subAgentResult, mainAgentError]));
+
+          const provider = new ClaudeCodeSDKProvider({
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          const result = await provider.callApi('Test prompt');
+
+          expect(result.error).toBe('Claude Agent SDK call failed: error_max_turns');
+          expect(warnSpy).not.toHaveBeenCalled();
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
       it('should not warn when a single result message has no terminal_reason', async () => {
         // Negative case: a single non-terminal result is the normal pre-fix
         // path, not a truncation signal. We must not spam warnings.

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -487,6 +487,104 @@ describe('ClaudeCodeSDKProvider', () => {
         expect(result.metadata?.structuredOutput).toBeUndefined();
       });
 
+      it('should return main agent result when background sub-agents emit interleaved result messages', async () => {
+        // Reproduces #9054: when the main agent spawns a background sub-agent
+        // (Task tool with run_in_background: true), the SDK interleaves the
+        // sub-agent's `result` message into the parent stream before the main
+        // agent's terminal `result` arrives. SDKResultMessage has no
+        // parent_tool_use_id, so position is the only signal — the main agent's
+        // result is always last.
+        const subAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'sub-session',
+          uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Sub-agent summary that should NOT be surfaced',
+          usage: createMockUsage(5, 5),
+          total_cost_usd: 0.0005,
+          duration_ms: 200,
+          duration_api_ms: 150,
+          is_error: false,
+          num_turns: 1,
+          permission_denials: [],
+        };
+        const mainAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'main-session',
+          uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Main agent final answer',
+          usage: createMockUsage(20, 30),
+          total_cost_usd: 0.003,
+          duration_ms: 1500,
+          duration_api_ms: 1200,
+          is_error: false,
+          num_turns: 4,
+          permission_denials: [],
+          terminal_reason: 'completed',
+        };
+
+        mockQuery.mockReturnValue(createMockQuery([subAgentResult, mainAgentResult]));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('Test prompt');
+
+        expect(result.error).toBeUndefined();
+        expect(result.output).toBe('Main agent final answer');
+        expect(result.sessionId).toBe('main-session');
+        expect(result.cost).toBe(0.003);
+        expect(result.tokenUsage).toEqual({ prompt: 20, completion: 30, total: 50 });
+        expect(result.metadata?.numTurns).toBe(4);
+        expect(result.metadata?.terminalReason).toBe('completed');
+        // Raw should reflect the main agent's result, not the sub-agent's
+        expect(JSON.parse(result.raw as string).session_id).toBe('main-session');
+      });
+
+      it('should surface main agent error when sub-agent succeeds first', async () => {
+        // Inverse of the previous test: sub-agent finishes successfully but the
+        // main agent ultimately errors. The error must win — otherwise we'd
+        // mask main-agent failures behind a green sub-agent summary.
+        const subAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'sub-session',
+          uuid: 'cccccccc-cccc-cccc-cccc-cccccccccccc' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Sub-agent summary',
+          usage: createMockUsage(5, 5),
+          total_cost_usd: 0.0005,
+          duration_ms: 200,
+          duration_api_ms: 150,
+          is_error: false,
+          num_turns: 1,
+          permission_denials: [],
+        };
+        const mainAgentError: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'error_max_turns',
+          session_id: 'main-session',
+          uuid: 'dddddddd-dddd-dddd-dddd-dddddddddddd' as `${string}-${string}-${string}-${string}-${string}`,
+          usage: createMockUsage(20, 30),
+          total_cost_usd: 0.003,
+          duration_ms: 1500,
+          duration_api_ms: 1200,
+          is_error: true,
+          num_turns: 4,
+          permission_denials: [],
+        };
+
+        mockQuery.mockReturnValue(createMockQuery([subAgentResult, mainAgentError]));
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('Test prompt');
+
+        expect(result.error).toBe('Claude Agent SDK call failed: error_max_turns');
+        expect(result.sessionId).toBe('main-session');
+      });
+
       it('should return error when API key is missing', async () => {
         // ensure process env won't provide the key or any other Claude Agent SDK env vars
         mockProcessEnv({ ANTHROPIC_API_KEY: undefined });

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -544,8 +544,9 @@ describe('ClaudeCodeSDKProvider', () => {
 
       it('should surface main agent error when sub-agent succeeds first', async () => {
         // Inverse of the previous test: sub-agent finishes successfully but the
-        // main agent ultimately errors. The error must win — otherwise we'd
-        // mask main-agent failures behind a green sub-agent summary.
+        // main agent ultimately errors. The main agent's outcome must win —
+        // otherwise we'd mask main-agent failures behind a green sub-agent
+        // summary. See https://github.com/promptfoo/promptfoo/issues/9054.
         const subAgentResult: Partial<SDKMessage> = {
           type: 'result',
           subtype: 'success',
@@ -583,6 +584,217 @@ describe('ClaudeCodeSDKProvider', () => {
 
         expect(result.error).toBe('Claude Agent SDK call failed: error_max_turns');
         expect(result.sessionId).toBe('main-session');
+      });
+
+      it('should cache only the main agent response, not interleaved sub-agent results', async () => {
+        // Locks the load-bearing behavioral guarantee of the #9054 fix:
+        // cacheResponse must fire exactly once with the main agent's payload,
+        // never with an intermediate sub-agent result. If a future refactor
+        // re-introduced caching inside the for-await loop, the second call
+        // below would return the sub-agent's summary from cache.
+        const subAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'sub-session',
+          uuid: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Sub-agent summary that must NOT end up in the cache',
+          usage: createMockUsage(5, 5),
+          total_cost_usd: 0.0005,
+          duration_ms: 200,
+          duration_api_ms: 150,
+          is_error: false,
+          num_turns: 1,
+          permission_denials: [],
+        };
+        const mainAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'main-session',
+          uuid: 'ffffffff-ffff-ffff-ffff-ffffffffffff' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Main agent final answer (cached)',
+          usage: createMockUsage(20, 30),
+          total_cost_usd: 0.003,
+          duration_ms: 1500,
+          duration_api_ms: 1200,
+          is_error: false,
+          num_turns: 4,
+          permission_denials: [],
+          terminal_reason: 'completed',
+        };
+
+        mockQuery.mockImplementation(() => createMockQuery([subAgentResult, mainAgentResult]));
+
+        const wasEnabled = isCacheEnabled();
+        enableCache();
+        try {
+          const provider = new ClaudeCodeSDKProvider({
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+
+          const first = await provider.callApi('Cache-once prompt');
+          expect(first.output).toBe('Main agent final answer (cached)');
+          expect(mockQuery).toHaveBeenCalledTimes(1);
+
+          // Cache hit on second call — returns whatever cacheResponse stored.
+          // If the loop had cached the sub-agent's result, we'd see
+          // 'Sub-agent summary…' here. We must see the main agent's payload.
+          const second = await provider.callApi('Cache-once prompt');
+          expect(mockQuery).toHaveBeenCalledTimes(1);
+          expect(second.cached).toBe(true);
+          expect(second.output).toBe('Main agent final answer (cached)');
+          expect(second.sessionId).toBe('main-session');
+        } finally {
+          await clearCache();
+          if (wasEnabled) {
+            enableCache();
+          } else {
+            disableCache();
+          }
+        }
+      });
+
+      it('should return only the last of three or more interleaved result messages', async () => {
+        // Real workloads with multiple run_in_background Task calls produce N+1
+        // result messages in the parent stream. The accumulator must keep the
+        // last one regardless of how many sub-agents finished before it.
+        const buildSubAgent = (i: number): Partial<SDKMessage> => ({
+          type: 'result',
+          subtype: 'success',
+          session_id: `sub-session-${i}`,
+          uuid: `1111111${i}-1111-1111-1111-111111111111` as `${string}-${string}-${string}-${string}-${string}`,
+          result: `Sub-agent ${i} summary`,
+          usage: createMockUsage(2, 2),
+          total_cost_usd: 0.0001,
+          duration_ms: 100,
+          duration_api_ms: 50,
+          is_error: false,
+          num_turns: 1,
+          permission_denials: [],
+        });
+        const mainAgentResult: Partial<SDKMessage> = {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'main-session',
+          uuid: '99999999-9999-9999-9999-999999999999' as `${string}-${string}-${string}-${string}-${string}`,
+          result: 'Main agent final answer (after three sub-agents)',
+          usage: createMockUsage(30, 40),
+          total_cost_usd: 0.005,
+          duration_ms: 2500,
+          duration_api_ms: 2000,
+          is_error: false,
+          num_turns: 6,
+          permission_denials: [],
+          terminal_reason: 'completed',
+        };
+
+        mockQuery.mockReturnValue(
+          createMockQuery([buildSubAgent(1), buildSubAgent(2), buildSubAgent(3), mainAgentResult]),
+        );
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('Test prompt');
+
+        expect(result.error).toBeUndefined();
+        expect(result.output).toBe('Main agent final answer (after three sub-agents)');
+        expect(result.sessionId).toBe('main-session');
+        expect(result.metadata?.numTurns).toBe(6);
+      });
+
+      it('should warn and mark span ERROR when stream has multiple results but no terminal_reason on the last', async () => {
+        // Truncated-stream guard: if we observed multiple result messages but
+        // the last one has no terminal_reason, the stream may have been cut
+        // off after a sub-agent finished. We still return a response (so
+        // downstream evals don't crash), but we surface a warning and mark
+        // the OTEL span ERROR so this isn't graded silently.
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
+        const setStatusSpy = vi.fn();
+        vi.spyOn(otelTrace, 'getActiveSpan').mockReturnValue({
+          setStatus: setStatusSpy,
+          setAttribute: vi.fn(),
+          setAttributes: vi.fn(),
+          addEvent: vi.fn(),
+          recordException: vi.fn(),
+          updateName: vi.fn(),
+          end: vi.fn(),
+          isRecording: () => true,
+          spanContext: () => ({ traceId: 't', spanId: 's', traceFlags: 1 }),
+        } as any);
+
+        try {
+          const subAgentResult: Partial<SDKMessage> = {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'sub-session',
+            uuid: 'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as `${string}-${string}-${string}-${string}-${string}`,
+            result: 'Sub-agent finished',
+            usage: createMockUsage(5, 5),
+            total_cost_usd: 0.0005,
+            duration_ms: 200,
+            duration_api_ms: 150,
+            is_error: false,
+            num_turns: 1,
+            permission_denials: [],
+          };
+          // No terminal_reason — simulates a truncated/cut-off stream.
+          const stragglerResult: Partial<SDKMessage> = {
+            type: 'result',
+            subtype: 'success',
+            session_id: 'unclear-session',
+            uuid: 'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as `${string}-${string}-${string}-${string}-${string}`,
+            result: 'Possibly another sub-agent',
+            usage: createMockUsage(3, 3),
+            total_cost_usd: 0.0003,
+            duration_ms: 100,
+            duration_api_ms: 80,
+            is_error: false,
+            num_turns: 1,
+            permission_denials: [],
+          };
+
+          mockQuery.mockReturnValue(createMockQuery([subAgentResult, stragglerResult]));
+
+          const provider = new ClaudeCodeSDKProvider({
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          const result = await provider.callApi('Test prompt');
+
+          // Still returns a response (we'd rather grade against a possibly-wrong
+          // answer than crash), but flagged via logs and span status.
+          expect(result.error).toBeUndefined();
+          expect(result.output).toBe('Possibly another sub-agent');
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          expect(warnSpy.mock.calls[0]?.[0]).toMatch(/2 result messages/);
+          expect(warnSpy.mock.calls[0]?.[0]).toMatch(/may have been truncated/);
+          expect(setStatusSpy).toHaveBeenCalledWith({
+            code: SpanStatusCode.ERROR,
+            message: expect.stringContaining('terminal_reason'),
+          });
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('should not warn when a single result message has no terminal_reason', async () => {
+        // Negative case: a single non-terminal result is the normal pre-fix
+        // path, not a truncation signal. We must not spam warnings.
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
+        try {
+          mockQuery.mockReturnValue(
+            createMockResponse('Plain response', { input_tokens: 1, output_tokens: 1 }),
+          );
+
+          const provider = new ClaudeCodeSDKProvider({
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+          const result = await provider.callApi('Test prompt');
+
+          expect(result.output).toBe('Plain response');
+          expect(warnSpy).not.toHaveBeenCalled();
+        } finally {
+          warnSpy.mockRestore();
+        }
       });
 
       it('should return error when API key is missing', async () => {
@@ -3936,6 +4148,136 @@ describe('ClaudeCodeSDKProvider', () => {
         expect(toolSpan).toBeDefined();
         expect(toolSpan!.attrs['tool.incomplete']).toBe(true);
         expect(toolSpan!.status?.code).toBe(2); // SpanStatusCode.ERROR
+      });
+
+      it('emits each orphan tool span exactly once across interleaved sub-agent results', async () => {
+        // Pre-fix, drainOrphans() fired inside the result branch and would
+        // execute on each interleaved sub-agent result. Post-fix it runs once
+        // after the for-await loop. This test locks that in so a future
+        // refactor can't silently double-emit orphan spans.
+        const { emittedSpans } = installTracerSpy();
+
+        mockQuery.mockReturnValue(
+          createMockQuery([
+            {
+              type: 'assistant',
+              parent_tool_use_id: null,
+              message: createMockBetaMessage([
+                {
+                  type: 'tool_use',
+                  id: 'orphan-interleaved',
+                  name: 'Read',
+                  input: { file_path: '/y' },
+                },
+              ]),
+              session_id: 'test-session',
+            },
+            // Interleaved sub-agent result: pre-fix this would have triggered
+            // both an early return AND a drainOrphans call.
+            {
+              type: 'result',
+              subtype: 'success',
+              session_id: 'sub-session',
+              uuid: '11111111-1111-1111-1111-111111111111',
+              result: 'sub done',
+              usage: createMockUsage(1, 1),
+              total_cost_usd: 0,
+              duration_ms: 1,
+              duration_api_ms: 1,
+              is_error: false,
+              num_turns: 1,
+              permission_denials: [],
+            },
+            // Main agent's terminal result.
+            {
+              type: 'result',
+              subtype: 'success',
+              session_id: 'main-session',
+              uuid: '22222222-2222-2222-2222-222222222222',
+              result: 'main done',
+              usage: createMockUsage(1, 1),
+              total_cost_usd: 0,
+              duration_ms: 1,
+              duration_api_ms: 1,
+              is_error: false,
+              num_turns: 2,
+              permission_denials: [],
+              terminal_reason: 'completed',
+            },
+          ]),
+        );
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('prompt');
+
+        // Main agent's result wins.
+        expect(result.output).toBe('main done');
+        expect(result.sessionId).toBe('main-session');
+
+        // The orphan tool_use must produce exactly one span — not two.
+        const readSpans = emittedSpans.filter((s) => s.name === 'tool Read');
+        expect(readSpans).toHaveLength(1);
+        expect(readSpans[0].attrs['tool.incomplete']).toBe(true);
+      });
+
+      it('does not flip span status to ERROR when only an interleaved sub-agent has an aborted terminal_reason', async () => {
+        // Pre-fix, the aborted-terminal_reason check ran inside the result
+        // branch and would fire on the FIRST result message. So a sub-agent
+        // that aborted would mark the parent span ERROR even when the main
+        // agent completed normally. Post-fix, only the main agent's
+        // terminal_reason can flip the parent span.
+        const { emittedSpans } = installTracerSpy();
+
+        mockQuery.mockReturnValue(
+          createMockQuery([
+            // Sub-agent reports an aborted terminal_reason.
+            {
+              type: 'result',
+              subtype: 'success',
+              session_id: 'sub-aborted-session',
+              uuid: '33333333-3333-3333-3333-333333333333',
+              result: 'sub aborted',
+              usage: createMockUsage(1, 1),
+              total_cost_usd: 0,
+              duration_ms: 1,
+              duration_api_ms: 1,
+              is_error: false,
+              num_turns: 1,
+              permission_denials: [],
+              terminal_reason: 'aborted_streaming',
+            },
+            // Main agent completes cleanly.
+            {
+              type: 'result',
+              subtype: 'success',
+              session_id: 'main-clean-session',
+              uuid: '44444444-4444-4444-4444-444444444444',
+              result: 'main clean',
+              usage: createMockUsage(1, 1),
+              total_cost_usd: 0,
+              duration_ms: 1,
+              duration_api_ms: 1,
+              is_error: false,
+              num_turns: 2,
+              permission_denials: [],
+              terminal_reason: 'completed',
+            },
+          ]),
+        );
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('prompt');
+
+        expect(result.output).toBe('main clean');
+        expect(result.metadata?.terminalReason).toBe('completed');
+
+        // No emitted span should be ERROR-statused due to the sub-agent's abort.
+        const erroredSpans = emittedSpans.filter((s) => s.status?.code === SpanStatusCode.ERROR);
+        expect(erroredSpans).toHaveLength(0);
       });
 
       it('propagates response.model from modelUsage and finish_reasons from terminal_reason', async () => {


### PR DESCRIPTION
## Summary

Fixes #9054 — the `anthropic:claude-agent-sdk` provider returned early when a background sub-agent emitted a `result` message, surfacing the sub-agent's summary instead of the main agent's final response.

The Claude Agent SDK interleaves a `result`-typed message for each background sub-agent (`Task` tool with `run_in_background: true`) into the parent session's stream before the main agent's terminal `result` arrives. `SDKResultMessage` has no `parent_tool_use_id`, so position-in-stream is the only signal — the main agent's result is always last.

The previous loop returned on the first `result` message it saw, which also caused `cacheResponse`, OTEL span-status, and orphan-tool-span draining to fire against intermediate sub-agent results.

## What changed

- `src/providers/claude-agent-sdk.ts`: stash the latest `SDKResultMessage` while iterating the stream, then process it once after the stream closes. Tool-call / skill-call collection across `assistant`/`user` messages is unchanged — those already attribute via `parent_tool_use_id`.
- `test/providers/claude-agent-sdk.test.ts`: two regression tests
  - sub-agent success → main agent success: asserts main agent's `result`, `sessionId`, and token usage are returned.
  - sub-agent success → main agent error: asserts the main-agent error wins (so failures aren't masked behind a green sub-agent summary).

## Test plan

- [x] `npx vitest run test/providers/claude-agent-sdk.test.ts` — 138/138 passing
- [x] Confirmed the new regression test fails on `main` (returns sub-agent output) and passes with this fix
- [x] `npm run tsc` — clean
- [x] `npm run l` / `npm run f` — no new warnings (pre-existing complexity warnings on the file are unchanged; this PR actually reduces one)
- [x] End-to-end real eval: configured a prompt that uses the `Task` tool with `run_in_background: true` and required the main agent to emit a `MAIN_AGENT_FINAL:` sentinel. Provider returned the sentinel sentence (main agent), not the sub-agent's summary. Tool-call metadata correctly records the `Agent` call with `run_in_background: true`.