### PR TITLE
docs(site): align claude-agent-sdk doc with current provider config

### DIFF
--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -793,7 +793,7 @@ providers:
             allowManagedDomainsOnly: true
 ```
 
-## Tool Configuration
+## Per-Tool Configuration
 
 Customize built-in tool behavior with `tool_config`:
 

--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -148,7 +148,7 @@ prompts:
 | `permission_mode`                    | string           | Permission mode: `default`, `plan`, `acceptEdits`, `bypassPermissions`, `dontAsk`, `auto`                    | `default`                |
 | `allow_dangerously_skip_permissions` | boolean          | Required safety flag when using `bypassPermissions` mode                                                     | false                    |
 | `thinking`                           | object           | Thinking config: `{type: 'adaptive'}`, `{type: 'enabled', budgetTokens: N}`, or `{type: 'disabled'}`         | Model default            |
-| `effort`                             | string           | Response effort level: `low`, `medium`, `high`, `max`                                                        | `high`                   |
+| `effort`                             | string           | Response effort level: `low`, `medium`, `high`, `xhigh` (Opus 4.7+), `max`                                   | `high`                   |
 | `agent`                              | string           | Named agent for the main thread (must be defined in `agents` or settings)                                    | None                     |
 | `session_id`                         | string           | Custom session UUID (cannot be used with `continue`/`resume` unless `fork_session` is set)                   | Auto-generated           |
 | `title`                              | string           | Custom title for a new session (skips auto-generation from the first message)                                | Auto-generated           |
@@ -256,6 +256,7 @@ Control Claude Agent SDK's permissions for modifying files and running system co
 | `acceptEdits`       | Allow file modifications                                              |
 | `bypassPermissions` | No restrictions (requires `allow_dangerously_skip_permissions: true`) |
 | `dontAsk`           | Deny permissions that aren't pre-approved (no prompts)                |
+| `auto`              | Use a model classifier to approve or deny permission prompts          |
 
 :::warning
 Using `bypassPermissions` requires setting `allow_dangerously_skip_permissions: true` as a safety measure:
@@ -336,7 +337,7 @@ providers:
       allow_all_tools: true
 ```
 
-The `tools` option specifies the base set of available built-in tools, while `allowedTools` and `disallowedTools` filter from that base.
+The `tools` option specifies the base set of available built-in tools, while `custom_allowed_tools`/`append_allowed_tools` and `disallowed_tools` filter from that base.
 
 ⚠️ **Security Note**: Some tools allow Claude Agent SDK to modify files, run system commands, search the web, and more. Think carefully about security implications before using these tools.
 


### PR DESCRIPTION
## Summary

Audit pass on `site/docs/providers/claude-agent-sdk.md` against `src/providers/claude-agent-sdk.ts`. Four small corrections:

- **Permission Modes table missing `auto`.** The `permission_mode` parameter row at the top of the page lists 6 modes, but the explanatory table directly below stopped at 5. Added the `auto` row.
- **`effort` parameter missing `xhigh`.** The SDK accepts `low | medium | high | xhigh | max` (`xhigh` was added for Opus 4.7+). Doc previously stopped at `max`.
- **Tool-filter explanation referenced internal camelCase fields.** "while `allowedTools` and `disallowedTools` filter from that base" used the SDK's internal field names. Promptfoo users configure these via `custom_allowed_tools`/`append_allowed_tools`/`disallowed_tools` in YAML.
- **Renamed duplicate "Tool Configuration" heading.** The page had two sections with the same heading — H3 under Tools and Permissions (about which tools to allow) and a standalone H2 (about the `tool_config` option for tweaking built-in tool behavior, e.g. `askUserQuestion.previewFormat`). Docusaurus auto-anchored them as `#tool-configuration` and `#tool-configuration-1`, which is brittle for external linking. Renamed the H2 to "Per-Tool Configuration" to match what it actually documents. The H3 anchor (`#tool-configuration`) is preserved, so existing external links still resolve.

## Test plan

- [x] `SKIP_OG_GENERATION=true npm run build` from `site/` — clean, both commits
- [x] Pre-commit Prettier passed on both commits
- [x] Verified the three table corrections against `src/providers/claude-agent-sdk.ts`
- [x] Site-wide grep for `tool-configuration-1` — no incoming links, so the rename is safe