### PR TITLE
test(providers): cover xai nested stream deltas

### DIFF
--- a/test/providers/xai/responses.test.ts
+++ b/test/providers/xai/responses.test.ts
@@ -273,6 +273,31 @@ describe('XAIResponsesProvider', () => {
     expect(result.output).toBe('hello');
   });
 
+  it('accumulates nested output_text deltas from streamed Responses API events', async () => {
+    mockFetchWithProxy.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      body: createSSEStream(
+        [
+          'data: {"type":"response.output_text.delta","output_text":{"delta":"hel"}}',
+          '',
+          'data: {"type":"response.output_text.delta","output_text":{"delta":"lo"}}',
+          '',
+          'data: [DONE]',
+          '',
+        ].join('\n'),
+      ),
+    });
+
+    const provider = new XAIResponsesProvider('grok-4.3', {
+      config: { apiKey: 'test-key', stream: true },
+    });
+
+    const result = await provider.callApi('hello');
+
+    expect(result.output).toBe('hello');
+  });
+
   it('returns an error when a streamed response has no output content', async () => {
     mockFetchWithProxy.mockResolvedValueOnce({
       status: 200,


### PR DESCRIPTION
## Summary
- add focused coverage for nested `output_text.delta` SSE chunks in xAI Responses streaming
- lock the fallback accumulation path when no completed response event is present

## Tests
- `source ~/.nvm/nvm.sh && nvm use && ./node_modules/.bin/vitest run test/providers/xai/responses.test.ts`
- `source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/promptfoo-npm-cache npm run l && npm_config_cache=/tmp/promptfoo-npm-cache npm run f`