### PR TITLE
docs(site): restore loadApiProviders to Node API docs

### DIFF
--- a/site/docs/usage/node-api-examples.md
+++ b/site/docs/usage/node-api-examples.md
@@ -189,23 +189,17 @@ const evalRecord = await evaluate({
 Load multiple providers and evaluate them independently:
 
 ```typescript
-import { assertions, loadApiProvider } from 'promptfoo';
+import { assertions, loadApiProviders } from 'promptfoo';
 
 async function batchTestProviders() {
-  const providerPaths = [
-    'openai:chat:gpt-5.5',
-    'anthropic:messages:claude-opus-4-7',
-    'vertex:claude-opus-4-7',
-  ];
-  const providers = await Promise.all(
-    providerPaths.map((providerPath) =>
-      loadApiProvider(providerPath, {
-        env: {
-          OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-        },
-      }),
-    ),
+  const providers = await loadApiProviders(
+    ['openai:chat:gpt-5.5', 'anthropic:messages:claude-opus-4-7', 'vertex:claude-opus-4-7'],
+    {
+      env: {
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      },
+    },
   );
 
   const testQuestions = [

--- a/site/docs/usage/node-api-quick-reference.md
+++ b/site/docs/usage/node-api-quick-reference.md
@@ -18,6 +18,7 @@ import {
 
   // Providers
   loadApiProvider,
+  loadApiProviders,
 
   // Assertions
   assertions,
@@ -104,11 +105,10 @@ const provider = await loadApiProvider('openai:chat:gpt-5.5', {
 ### Task: Test Multiple Providers
 
 ```typescript
-const providers = await Promise.all(
-  ['openai:chat:gpt-5.5', 'anthropic:messages:claude-opus-4-7'].map((providerPath) =>
-    loadApiProvider(providerPath),
-  ),
-);
+const providers = await loadApiProviders([
+  'openai:chat:gpt-5.5',
+  'anthropic:messages:claude-opus-4-7',
+]);
 
 for (const p of providers) {
   const resp = await p.callApi('test');
@@ -177,9 +177,10 @@ await cache.withCacheNamespace('v1', async () => {
 
 ### Provider Functions
 
-| Function            | Purpose           | Stability |
-| ------------------- | ----------------- | --------- |
-| `loadApiProvider()` | Load one provider | ✅ Stable |
+| Function             | Purpose                 | Stability |
+| -------------------- | ----------------------- | --------- |
+| `loadApiProvider()`  | Load one provider       | ✅ Stable |
+| `loadApiProviders()` | Load multiple providers | ✅ Stable |
 
 ### Cache Functions
 
@@ -315,10 +316,10 @@ await evaluate(testSuite, {
 ### Pattern: Batch Testing Providers
 
 ```typescript
-const providerPaths = ['openai:chat:gpt-5.5', 'anthropic:messages:claude-opus-4-7'];
-const providers = await Promise.all(
-  providerPaths.map((providerPath) => loadApiProvider(providerPath)),
-);
+const providers = await loadApiProviders([
+  'openai:chat:gpt-5.5',
+  'anthropic:messages:claude-opus-4-7',
+]);
 
 for (const p of providers) {
   const result = await p.callApi(prompt);

--- a/site/docs/usage/node-api-reference.md
+++ b/site/docs/usage/node-api-reference.md
@@ -143,16 +143,40 @@ console.log(response.output);
 
 ---
 
-To load several providers for manual testing, call `loadApiProvider()` for each one:
+### `loadApiProviders(providers, options?)`
+
+Load multiple providers in parallel. Accepts the same `ProvidersConfig` shape that `evaluate()` uses internally, so you can mix string identifiers with inline config objects or functions.
 
 ```typescript
-import { loadApiProvider } from 'promptfoo';
+async function loadApiProviders(
+  providers: ProvidersConfig,
+  options?: { env?: Record<string, string> },
+): Promise<ApiProvider[]>;
+```
 
-const providers = await Promise.all(
-  ['openai:chat:gpt-5.5', 'anthropic:messages:claude-opus-4-7'].map((providerPath) =>
-    loadApiProvider(providerPath),
-  ),
-);
+**Parameters:**
+
+- `providers`: Array of provider identifiers or config objects
+- `options`: Optional environment overrides
+
+**Returns:** Array of configured provider instances
+
+**Example:**
+
+```typescript
+import { loadApiProviders } from 'promptfoo';
+
+const providers = await loadApiProviders([
+  'openai:chat:gpt-5.5',
+  'anthropic:messages:claude-opus-4-7',
+  {
+    id: 'custom-provider',
+    config: {
+      model: 'my-model',
+      temperature: 0.7,
+    },
+  },
+]);
 
 for (const provider of providers) {
   const result = await provider.callApi('Test');
@@ -866,13 +890,12 @@ const evalRecord = await evaluate({
 Load providers and test in parallel:
 
 ```typescript
-import { assertions, loadApiProvider } from 'promptfoo';
+import { assertions, loadApiProviders } from 'promptfoo';
 
-const providers = await Promise.all(
-  ['openai:chat:gpt-5.5', 'anthropic:messages:claude-opus-4-7'].map((providerPath) =>
-    loadApiProvider(providerPath),
-  ),
-);
+const providers = await loadApiProviders([
+  'openai:chat:gpt-5.5',
+  'anthropic:messages:claude-opus-4-7',
+]);
 
 const testCases = ['2+2=?', 'What is AI?'];
 
@@ -975,7 +998,7 @@ import type {
 ### Stable APIs (Safe for production)
 
 - `evaluate()`
-- `loadApiProvider()`
+- `loadApiProvider()`, `loadApiProviders()`
 - `assertions.runAssertion()`, `assertions.runAssertions()`
 - Cache namespace functions
 - Guardrails namespace


### PR DESCRIPTION
## Summary
Follow-up to #9063. The batch loader `loadApiProviders` is still exported from `src/index.ts` and asserted by the export contract test (`test/index.test.ts:101`), but #9063 removed it from the docs in favor of `Promise.all([...].map(loadApiProvider))`. This restores it because:

- The single call is more ergonomic than `Promise.all` + `.map`.
- `loadApiProviders` accepts the full `ProvidersConfig` shape (strings, functions, or inline `{ id, config }` objects) — the same shape `evaluate()` uses internally (`src/index.ts:290`). The `Promise.all`-based pattern only handles plain string IDs and silently loses the config-object use case.
- The reference page previously had an awkward header-less paragraph wedged between two `---` rules where the H3 used to live. The restored section gets a proper `### loadApiProviders(providers, options?)` header that matches the rest of the API reference.

Refreshed model IDs and the `azure-openai:` → `azure:` fix from #9063 are preserved.

## Changes
- `site/docs/usage/node-api-reference.md` — restore `### loadApiProviders` section; add `loadApiProviders()` back to the Stable APIs list; switch Pattern 3 (Batch Provider Testing) back to `loadApiProviders`.
- `site/docs/usage/node-api-quick-reference.md` — add `loadApiProviders` to the import block, the Test Multiple Providers task, the Provider Functions stability table, and the Batch Testing Providers pattern.
- `site/docs/usage/node-api-examples.md` — Example 6 (Batch Provider Testing) uses `loadApiProviders` again.

## Test plan
- [x] `npx vitest run test/index.test.ts` — 55/55 pass (export contract intact).
- [x] `cd site && SKIP_OG_GENERATION=true npm run build` — SUCCESS.
- [x] Pre-commit hook (Biome + Prettier) passes.