### PR TITLE
chore: resolve AI code quality findings

### DIFF
--- a/site/docs/usage/node-api-quick-reference.md
+++ b/site/docs/usage/node-api-quick-reference.md
@@ -340,7 +340,7 @@ for (const p of providers) {
 # Caching
 PROMPTFOO_CACHE_ENABLED=true
 PROMPTFOO_CACHE_PATH=~/.promptfoo/cache
-PROMPTFOO_CACHE_TTL=604800          # Seconds (default: 14 days)
+PROMPTFOO_CACHE_TTL=1209600         # Seconds (default: 14 days)
 PROMPTFOO_CACHE_TYPE=disk           # or 'memory'
 
 # Logging

--- a/site/docs/usage/node-api-reference.md
+++ b/site/docs/usage/node-api-reference.md
@@ -535,8 +535,8 @@ Set cache location and TTL via environment variables:
 # Cache directory (default: ~/.promptfoo/cache)
 export PROMPTFOO_CACHE_PATH=/path/to/cache
 
-# Cache TTL in seconds (default: 604800 = 7 days)
-export PROMPTFOO_CACHE_TTL=604800
+# Cache TTL in seconds (default: 1209600 = 14 days)
+export PROMPTFOO_CACHE_TTL=1209600
 
 # Disable cache via env
 export PROMPTFOO_CACHE_ENABLED=false

--- a/test/providers/alibaba.test.ts
+++ b/test/providers/alibaba.test.ts
@@ -96,6 +96,9 @@ describe('Alibaba Cloud Provider', () => {
       // Unknown models now only warn, they don't throw errors
       const provider = new AlibabaChatCompletionProvider('unknown-model', {});
       expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown Alibaba Cloud model: unknown-model.'),
+      );
     });
 
     it('should pass through environment variables', () => {
@@ -160,6 +163,9 @@ describe('Alibaba Cloud Provider', () => {
       // Unknown models now only warn, they don't throw errors
       const provider = new AlibabaEmbeddingProvider('unknown-model', {});
       expect(provider).toBeInstanceOf(OpenAiEmbeddingProvider);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown Alibaba Cloud model: unknown-model.'),
+      );
     });
 
     it('should pass through environment variables', () => {

--- a/test/providers/deepseek.test.ts
+++ b/test/providers/deepseek.test.ts
@@ -60,7 +60,7 @@ describe('calculateDeepSeekCost', () => {
     expect(cost).toBeCloseTo(4.0);
   });
 
-  it('should handle unknown model names', () => {
+  it('should return undefined when an unknown model has no pricing', () => {
     const cost = calculateDeepSeekCost('unknown-model', {}, 1000000, 1000000);
     expect(cost).toBeUndefined();
   });

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -78,9 +78,9 @@ describe('Mistral', () => {
     });
 
     it('should support current Mistral model families', () => {
-      const magistralSmallProvider = new MistralChatCompletionProvider('magistral-small-2509');
-      expect(magistralSmallProvider.modelName).toBe('magistral-small-2509');
-      expect(magistralSmallProvider.config).toEqual({});
+      const smallProvider = new MistralChatCompletionProvider('magistral-small-2509');
+      expect(smallProvider.modelName).toBe('magistral-small-2509');
+      expect(smallProvider.config).toEqual({});
 
       const magistralMediumProvider = new MistralChatCompletionProvider('magistral-medium-latest', {
         config: { temperature: 0.7, max_tokens: 40960 },
@@ -349,7 +349,7 @@ describe('Mistral', () => {
 
       const result = await latestProvider.callApi('Test latest alias pricing');
 
-      // mistral-large-latest currently tracks Mistral Large 3 pricing: $0.5/M in, $1.5/M out
+      // mistral-large-latest currently tracks mistral-large-2512 pricing: $0.5/M in, $1.5/M out
       expect(result.cost).toBeCloseTo(0.0011, 6);
     });
 

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -60,7 +60,7 @@ describe('writeOutput', () => {
       mockFileHandle as unknown as fsPromises.FileHandle,
     );
     consoleLogSpy = mockConsole('log');
-    // @ts-ignore
+    // @ts-expect-error getDb is mocked with a partial test double.
     vi.mocked(getDb).mockReturnValue({
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -81,7 +81,7 @@ describe('writeOutput', () => {
   });
 
   it('writeOutput with CSV output', async () => {
-    // @ts-ignore
+    // @ts-expect-error getDb is mocked with a partial test double.
     vi.mocked(getDb).mockReturnValue({
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -393,7 +393,7 @@ describe('writeOutput', () => {
 
   it('does not sanitize config for CSV output', async () => {
     const outputPath = 'output.csv';
-    // @ts-ignore
+    // @ts-expect-error getDb is mocked with a partial test double.
     vi.mocked(getDb).mockReturnValue({
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -421,7 +421,7 @@ describe('writeOutput', () => {
 
   it('does not sanitize config for JSONL output', async () => {
     const outputPath = 'output.jsonl';
-    // @ts-ignore
+    // @ts-expect-error getDb is mocked with a partial test double.
     vi.mocked(getDb).mockReturnValue({
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Summary
- Resolve the 10 visible GitHub Security AI findings across docs and provider/output tests
- Align Node API cache TTL examples with the 14-day source default
- Tighten test assertions and comments for Alibaba, DeepSeek, Mistral, and output mocks

## Test plan
- `npx vitest test/providers/alibaba.test.ts test/providers/deepseek.test.ts test/providers/mistral.test.ts test/util/output.test.ts --run`
- `npm run l`
- `npm run f`
- `npm run tsc`
