### PR TITLE
chore(webui): tighten shared responsive chrome

### DIFF
--- a/src/app/src/components/ApiSettingsModal.test.tsx
+++ b/src/app/src/components/ApiSettingsModal.test.tsx
@@ -47,6 +47,11 @@ describe('ApiSettingsModal', () => {
     expect(screen.getByText('API and Sharing Settings')).toBeInTheDocument();
   });
 
+  it('keeps space for the close control beside the title', () => {
+    renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
+    expect(screen.getByText('API and Sharing Settings')).toHaveClass('pr-8');
+  });
+
   it('shows current API URL in text field', () => {
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
     const input = screen.getByLabelText('API Base URL') as HTMLInputElement;

--- a/src/app/src/components/ApiSettingsModal.tsx
+++ b/src/app/src/components/ApiSettingsModal.tsx
@@ -94,7 +94,7 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>API and Sharing Settings</DialogTitle>
+          <DialogTitle className="pr-8">API and Sharing Settings</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -113,7 +113,7 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
                   {isChecking ? <Spinner size="sm" /> : <RefreshCw className="size-4" />}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Check connection</TooltipContent>
+              <TooltipContent side="bottom">Check connection</TooltipContent>
             </Tooltip>
           </div>
 

--- a/src/app/src/components/Logo.tsx
+++ b/src/app/src/components/Logo.tsx
@@ -5,13 +5,16 @@ import './Logo.css';
 
 export default function Logo() {
   return (
-    <Link to="/" className="inline-flex items-center px-2 py-1 no-underline perspective-[2000px]">
+    <Link
+      to="/"
+      className="hidden shrink-0 items-center px-2 py-1 no-underline perspective-[2000px] min-[360px]:inline-flex"
+    >
       <img
         src={logoPanda}
         alt="Promptfoo Logo"
         className="logo-icon w-[25px] h-auto transition-all duration-1000 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)]"
       />
-      <span className="logo-text font-['Inter',sans-serif] font-semibold text-base text-foreground tracking-[0.02em] ml-2 transition-all duration-300">
+      <span className="logo-text ml-2 hidden font-['Inter',sans-serif] text-base font-semibold tracking-[0.02em] text-foreground transition-all duration-300 sm:inline">
         promptfoo
       </span>
     </Link>

--- a/src/app/src/components/Navigation.test.tsx
+++ b/src/app/src/components/Navigation.test.tsx
@@ -93,6 +93,22 @@ describe('Navigation', () => {
     expect(screen.getByText('History')).toBeInTheDocument();
   });
 
+  it('keeps a compact results label available for very narrow screens', () => {
+    renderNavigation();
+
+    expect(screen.getByRole('button', { name: 'View Results' })).toBeInTheDocument();
+    expect(screen.getByText('Results')).toHaveClass('min-[390px]:hidden');
+  });
+
+  it('hides the logo below the extra-narrow breakpoint', () => {
+    renderNavigation();
+
+    expect(screen.getByRole('link', { name: /Promptfoo Logo/ })).toHaveClass(
+      'hidden',
+      'min-[360px]:inline-flex',
+    );
+  });
+
   it('should have the correct z-index class', () => {
     renderNavigation();
     const header = screen.getByRole('banner');
@@ -165,7 +181,7 @@ describe('Navigation', () => {
     const navBar = screen.getByRole('banner');
     const modelAuditLink = within(navBar).getByRole('link', { name: 'Model Audit' });
     expect(modelAuditLink).toHaveClass('bg-primary/10');
-    expect(modelAuditLink).toHaveClass('text-primary');
+    expect(modelAuditLink).toHaveClass('text-foreground');
   });
 
   it('activates the Model Audit NavLink on /model-audit/:id path', () => {
@@ -173,7 +189,7 @@ describe('Navigation', () => {
     const navBar = screen.getByRole('banner');
     const modelAuditLink = within(navBar).getByRole('link', { name: 'Model Audit' });
     expect(modelAuditLink).toHaveClass('bg-primary/10');
-    expect(modelAuditLink).toHaveClass('text-primary');
+    expect(modelAuditLink).toHaveClass('text-foreground');
   });
 
   it('does not activate Model Audit NavLink on /model-audit/setup path', () => {
@@ -308,7 +324,7 @@ describe('Navigation', () => {
       );
       expect(topLevelModelAuditLink).toBeDefined();
       expect(topLevelModelAuditLink).toHaveClass('bg-primary/10');
-      expect(topLevelModelAuditLink).toHaveClass('text-primary');
+      expect(topLevelModelAuditLink).toHaveClass('text-foreground');
     });
 
     it('activates Model Audit NavLink on /model-audit/:id path', () => {
@@ -320,7 +336,7 @@ describe('Navigation', () => {
       );
       expect(topLevelModelAuditLink).toBeDefined();
       expect(topLevelModelAuditLink).toHaveClass('bg-primary/10');
-      expect(topLevelModelAuditLink).toHaveClass('text-primary');
+      expect(topLevelModelAuditLink).toHaveClass('text-foreground');
     });
 
     it('does not activate Model Audit NavLink on /model-audit/setup path', () => {

--- a/src/app/src/components/Navigation.tsx
+++ b/src/app/src/components/Navigation.tsx
@@ -48,7 +48,7 @@ function NavLink({ href, label }: NavLinkProps) {
         'inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         isActive
-          ? 'bg-primary/10 text-primary hover:bg-primary/15 focus-visible:bg-primary/15'
+          ? 'bg-primary/10 text-foreground hover:bg-primary/15 focus-visible:bg-primary/15'
           : 'text-foreground hover:bg-accent focus-visible:bg-accent',
       )}
     >
@@ -65,27 +65,36 @@ interface MenuItem {
 
 interface NavDropdownProps {
   label: string;
+  compactLabel?: string;
   items: MenuItem[];
   isActiveCheck: (pathname: string) => boolean;
 }
 
-function NavDropdown({ label, items, isActiveCheck }: NavDropdownProps) {
+function NavDropdown({ label, compactLabel, items, isActiveCheck }: NavDropdownProps) {
   const location = useLocation();
   const isActive = isActiveCheck(location.pathname);
 
   return (
     <NavigationMenuItem>
       <NavigationMenuTrigger
+        aria-label={label}
         className={cn(
           'h-8 bg-transparent px-3 text-sm font-medium',
           'data-[state=open]:bg-accent',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
           isActive
-            ? 'bg-primary/10 text-primary hover:bg-primary/15 focus-visible:bg-primary/15'
+            ? 'bg-primary/10 text-foreground hover:bg-primary/15 focus-visible:bg-primary/15'
             : 'text-foreground hover:bg-accent focus-visible:bg-accent',
         )}
       >
-        {label}
+        {compactLabel ? (
+          <>
+            <span className="hidden min-[390px]:inline">{label}</span>
+            <span className="min-[390px]:hidden">{compactLabel}</span>
+          </>
+        ) : (
+          label
+        )}
       </NavigationMenuTrigger>
       <NavigationMenuContent>
         <ul className="w-[300px] p-1.5">
@@ -166,9 +175,9 @@ export default function Navigation() {
   return (
     <>
       <header className="sticky top-0 z-(--z-appbar) w-full border-b border-border bg-card shadow-sm">
-        <div className="flex h-14 items-center justify-between px-4">
+        <div className="flex h-14 min-w-0 items-center justify-between gap-2 px-3 sm:px-4">
           {/* Left section: Logo and Navigation */}
-          <div className="flex items-center gap-6">
+          <div className="flex min-w-0 items-center gap-2 sm:gap-6">
             <Logo />
             <NavigationMenu>
               <NavigationMenuList className="gap-1">
@@ -183,6 +192,7 @@ export default function Navigation() {
                 />
                 <NavDropdown
                   label="View Results"
+                  compactLabel="Results"
                   items={resultsMenuItems}
                   isActiveCheck={(pathname) =>
                     [EVAL_ROUTES.ROOT, EVAL_ROUTES.LIST, REDTEAM_ROUTES.REPORTS, ROUTES.MEDIA].some(
@@ -192,7 +202,7 @@ export default function Navigation() {
                 />
               </NavigationMenuList>
             </NavigationMenu>
-            <nav className="hidden items-center gap-1 md:flex">
+            <nav className="hidden items-center gap-1 lg:flex">
               <NavLink href={MODEL_AUDIT_ROUTES.ROOT} label="Model Audit" />
               <NavLink href={ROUTES.PROMPTS} label="Prompts" />
               <NavLink href={ROUTES.DATASETS} label="Datasets" />
@@ -201,7 +211,7 @@ export default function Navigation() {
           </div>
 
           {/* Right section: Actions */}
-          <div className="flex items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button

--- a/src/app/src/components/UpdateBanner.tsx
+++ b/src/app/src/components/UpdateBanner.tsx
@@ -100,15 +100,15 @@ export default function UpdateBanner() {
       ref={bannerRef}
       variant="info"
       className={cn(
-        'rounded-none py-2 px-4 relative z-(--z-banner)',
-        'flex items-center justify-between gap-4',
+        'relative z-(--z-banner) rounded-none px-4 py-2',
+        'flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4',
         // Use solid background to prevent content showing through the banner
         'dark:bg-blue-950',
       )}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3 sm:items-center">
         <RefreshCw className="size-4 shrink-0" />
-        <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="text-sm font-medium">
             Update available: v{versionInfo.latestVersion}
           </span>
@@ -117,7 +117,7 @@ export default function UpdateBanner() {
           </span>
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
         <Button variant="ghost" size="sm" asChild className="gap-1.5 text-xs">
           <a
             href="https://github.com/promptfoo/promptfoo/releases/latest"

--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -295,7 +295,7 @@ function SelectFilterInput({
             <Button
               variant="outline"
               disabled={disabled}
-              className="h-8 flex-1 justify-start font-normal"
+              className="h-8 min-w-[150px] flex-1 justify-start font-normal"
             >
               {selectedValues.length > 0 ? (
                 <span className="truncate">
@@ -339,7 +339,7 @@ function SelectFilterInput({
           onValueChange={handleSingleSelect}
           disabled={disabled}
         >
-          <SelectTrigger className="h-8 flex-1">
+          <SelectTrigger className="h-8 min-w-[150px] flex-1">
             <SelectValue placeholder="Select value..." />
           </SelectTrigger>
           <SelectContent>
@@ -390,7 +390,7 @@ function ComparisonFilterInput({
         value={value}
         onChange={(e) => onValueChange(e.target.value)}
         disabled={disabled}
-        className="h-8 flex-1"
+        className="h-8 min-w-[150px] flex-1"
       />
     </>
   );
@@ -936,7 +936,7 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[520px] p-3"
+        className="w-[min(520px,calc(100vw-1rem))] p-3"
         align="start"
         onInteractOutside={(e) => {
           // Prevent popover from closing when interacting with portaled Select/Popover content.
@@ -972,7 +972,11 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
               const { isSelectFilter, filterOptions } = getColumnMetadata(filter.columnId);
 
               return (
-                <div key={filter.id} className="flex items-center gap-1.5">
+                <div
+                  key={filter.id}
+                  data-testid="data-table-filter-row"
+                  className="flex flex-wrap items-center gap-1.5"
+                >
                   {/* Column selector */}
                   <Select
                     value={filter.columnId}

--- a/src/app/src/components/data-table/data-table-toolbar.tsx
+++ b/src/app/src/components/data-table/data-table-toolbar.tsx
@@ -28,8 +28,8 @@ export function DataTableToolbar<TData>({
   toolbarActions,
 }: DataTableToolbarProps<TData>) {
   return (
-    <div className="flex items-center justify-between gap-2 p-2 border-b border-border">
-      <div className="flex items-center gap-2">
+    <div className="flex flex-col gap-2 border-b border-border p-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-wrap items-center gap-2">
         {showColumnToggle && (
           <DataTableColumnToggle
             table={table}
@@ -61,13 +61,13 @@ export function DataTableToolbar<TData>({
       </div>
 
       {showGlobalFilter && (
-        <div className="relative max-w-sm">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-gray-500 dark:text-gray-400" />
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
             placeholder="Search..."
             value={globalFilter ?? ''}
             onChange={(e) => setGlobalFilter(e.target.value)}
-            className="pl-8 rounded-lg bg-white dark:bg-gray-900"
+            className="pl-8 rounded-lg"
           />
         </div>
       )}

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -113,6 +113,21 @@ describe('DataTable', () => {
     expect(screen.getByText('Test Item 2')).toBeInTheDocument();
   });
 
+  it('keeps filter value controls usable on narrow filter popovers', async () => {
+    const user = userEvent.setup();
+    const data: TestRow[] = [{ id: '1', name: 'Test Item 1' }];
+
+    render(<DataTable columns={columns} data={data} showToolbar />);
+
+    await user.click(screen.getByText('Filters'));
+
+    const filterRow = screen.getByTestId('data-table-filter-row');
+    const valueInput = screen.getByPlaceholderText('Value...');
+
+    expect(filterRow).toHaveClass('flex-wrap');
+    expect(valueInput).toHaveClass('min-w-[150px]');
+  });
+
   it('should render table with data when data is provided', () => {
     const data: TestRow[] = [
       { id: '1', name: 'Test Item 1' },
@@ -726,6 +741,7 @@ describe('DataTable', () => {
         return dialog as HTMLElement;
       });
       expect(toolbarDialog).toBeDefined();
+      expect(toolbarDialog).toHaveClass('w-[min(520px,calc(100vw-1rem))]');
       expect(await within(toolbarDialog).findByText('Status')).toBeInTheDocument();
       expect(await within(toolbarDialog).findByText(/beta/i)).toBeInTheDocument();
     });
@@ -991,7 +1007,18 @@ describe('DataTable', () => {
       const actionGroup = headerContent?.querySelector('button')?.closest('span');
       expect(actionGroup).toBeInTheDocument();
       expect(actionGroup).toHaveClass('flex', 'shrink-0', 'items-center');
+      expect(actionGroup).toHaveClass(
+        'opacity-100',
+        'pointer-events-auto',
+        'sm:opacity-0',
+        'sm:pointer-events-none',
+        'sm:group-hover:opacity-100',
+        'sm:group-hover:pointer-events-auto',
+      );
       expect(actionGroup).not.toHaveClass('absolute', 'left-0', 'right-0');
+
+      const sortButton = headerContent?.querySelector('button');
+      expect(sortButton).toHaveAttribute('aria-label', `Sort ${headerText} ascending`);
     };
 
     assertHeaderLayout('Identifier');

--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -45,18 +45,30 @@ type DataTableHeaderActionsProps<TData, TValue> = {
 };
 
 type DataTableHeaderSortButtonProps = {
+  columnLabel: string;
   onToggleSorting?: (event: unknown) => void;
   sortDirection: false | 'asc' | 'desc';
 };
 
 function renderDataTableHeaderSortButton({
+  columnLabel,
   onToggleSorting,
   sortDirection,
 }: DataTableHeaderSortButtonProps) {
+  const nextSortDirection =
+    sortDirection === 'asc'
+      ? 'descending'
+      : sortDirection === 'desc'
+        ? 'clear sorting'
+        : 'ascending';
+  const sortLabel = `Sort ${columnLabel} ${nextSortDirection}`;
+
   return (
     <Button
       variant="ghost"
       size="sm"
+      aria-label={sortLabel}
+      title={sortLabel}
       className={cn(
         'h-6 w-6 p-0',
         sortDirection ? 'text-blue-700 dark:text-blue-100' : 'text-zinc-400 dark:text-zinc-500',
@@ -92,12 +104,16 @@ function renderDataTableHeaderActions<TData, TValue>({
     <span
       className={cn(
         'flex shrink-0 items-center gap-0.5',
-        'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity',
+        'opacity-100 pointer-events-auto transition-opacity sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto',
         (sortDirection || isFiltered) && 'opacity-100 pointer-events-auto',
       )}
     >
       {canSort &&
         renderDataTableHeaderSortButton({
+          columnLabel:
+            typeof header.column.columnDef.header === 'string'
+              ? header.column.columnDef.header
+              : header.column.id,
           onToggleSorting: header.column.getToggleSortingHandler(),
           sortDirection,
         })}

--- a/src/app/src/components/traces/TraceTimeline.test.tsx
+++ b/src/app/src/components/traces/TraceTimeline.test.tsx
@@ -1,5 +1,6 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import TraceTimeline from './TraceTimeline';
 import type { TraceData } from '@promptfoo/types';
@@ -154,6 +155,7 @@ describe('TraceTimeline', () => {
   });
 
   it('should display span with attributes', async () => {
+    const user = userEvent.setup();
     const mockTrace: TraceData = {
       traceId: 'trace-with-attributes',
       evaluationId: 'test-evaluation-id',
@@ -178,6 +180,15 @@ describe('TraceTimeline', () => {
     // Verify the span renders correctly
     expect(screen.getByText('Span with Attributes')).toBeInTheDocument();
     expect(screen.getByText('Total Duration: 100ms')).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(screen.getByText('Span Details').parentElement).toHaveClass('sm:ml-10');
+    expect(screen.getByText('Span ID').parentElement?.parentElement).toHaveClass(
+      'grid-cols-1',
+      'sm:grid-cols-2',
+    );
+    expect(screen.getByText('http.method').parentElement).toHaveClass('flex-col', 'sm:flex-row');
   });
 
   it('should apply error color styling to spans with error status code', () => {

--- a/src/app/src/components/traces/TraceTimeline.tsx
+++ b/src/app/src/components/traces/TraceTimeline.tsx
@@ -249,10 +249,10 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
 
               {/* Expandable attributes panel */}
               <CollapsibleContent>
-                <div className="ml-10 mt-2 mb-4 p-4 bg-muted/50 rounded border-l-[3px] border-primary">
+                <div className="mb-4 mt-2 rounded border-l-[3px] border-primary bg-muted/50 p-4 sm:ml-10">
                   <h4 className="text-sm font-semibold mb-2">Span Details</h4>
 
-                  <div className="grid grid-cols-2 gap-2 mb-4">
+                  <div className="mb-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     <div>
                       <p className="text-xs text-muted-foreground">Span ID</p>
                       <p className="text-sm font-mono text-[11px]">{span.spanId}</p>
@@ -291,11 +291,11 @@ export default function TraceTimeline({ trace }: TraceTimelineProps) {
                           <div
                             key={key}
                             className={cn(
-                              'flex gap-2 py-1',
+                              'flex flex-col gap-1 py-1 sm:flex-row sm:gap-2',
                               attrIndex < arr.length - 1 && 'border-b border-border',
                             )}
                           >
-                            <span className="font-mono text-[11px] text-primary min-w-[200px] break-all">
+                            <span className="min-w-0 break-all font-mono text-[11px] text-primary sm:min-w-[200px]">
                               {key}
                             </span>
                             <span className="font-mono text-[11px] break-all whitespace-pre-wrap">

--- a/src/app/src/pages/evals/components/EvalsTable.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.tsx
@@ -174,7 +174,11 @@ export default function EvalsTable({
         cell: ({ getValue }) => {
           const evalId = getValue<string>();
           if (evalId === focusedEvalId) {
-            return <span className="font-mono text-sm">{evalId}</span>;
+            return (
+              <span title={evalId} className="block truncate font-mono text-sm">
+                {evalId}
+              </span>
+            );
           }
           return (
             <Link
@@ -183,7 +187,8 @@ export default function EvalsTable({
                 e.preventDefault();
                 onEvalSelected(evalId);
               }}
-              className="text-primary hover:underline font-mono text-sm"
+              title={evalId}
+              className="block truncate font-mono text-sm text-primary hover:underline"
             >
               {evalId}
             </Link>

--- a/src/app/src/pages/evals/page.tsx
+++ b/src/app/src/pages/evals/page.tsx
@@ -12,10 +12,10 @@ export default function EvalsIndexPage() {
   usePageMeta({ title: 'Evals', description: 'Browse evaluation runs' });
 
   return (
-    <PageContainer className="fixed top-14 left-0 right-0 bottom-0 flex flex-col overflow-hidden min-h-0">
+    <PageContainer className="fixed top-[calc(var(--nav-height)+var(--update-banner-height,0px))] left-0 right-0 bottom-0 flex flex-col overflow-hidden min-h-0">
       <PageHeader>
         <div className="container max-w-7xl mx-auto p-6">
-          <h1 className="text-2xl font-semibold">Evaluations</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Evaluations</h1>
           <p className="text-sm text-muted-foreground mt-1">View and manage your evaluation runs</p>
         </div>
       </PageHeader>

--- a/src/app/src/pages/history/History.test.tsx
+++ b/src/app/src/pages/history/History.test.tsx
@@ -84,6 +84,8 @@ describe('History', () => {
     const row1Cells = within(row1);
     const evalLink1 = row1Cells.getByRole('link', { name: 'eval-2024-01-01' });
     expect(evalLink1).toHaveAttribute('href', '/eval/eval-2024-01-01');
+    expect(evalLink1).toHaveAttribute('title', 'eval-2024-01-01');
+    expect(evalLink1).toHaveClass('truncate');
     const datasetLink1 = row1Cells.getByRole('link', { name: 'alpha-' });
     expect(datasetLink1).toHaveAttribute('href', '/datasets?id=alpha-dataset');
     expect(row1Cells.getByText('TestProviderA')).toBeInTheDocument();

--- a/src/app/src/pages/history/History.tsx
+++ b/src/app/src/pages/history/History.tsx
@@ -125,7 +125,8 @@ export default function History({
         cell: ({ getValue }) => (
           <Link
             to={EVAL_ROUTES.DETAIL(getValue<string>() || '')}
-            className="text-primary hover:underline font-mono text-sm"
+            title={getValue<string>()}
+            className="block truncate font-mono text-sm text-primary hover:underline"
           >
             {getValue<string>()}
           </Link>
@@ -252,10 +253,10 @@ export default function History({
   );
 
   return (
-    <PageContainer className="fixed top-14 left-0 right-0 bottom-0 flex flex-col overflow-hidden min-h-0">
+    <PageContainer className="fixed top-[calc(var(--nav-height)+var(--update-banner-height,0px))] left-0 right-0 bottom-0 flex flex-col overflow-hidden min-h-0">
       <PageHeader>
         <div className="container max-w-7xl mx-auto p-6">
-          <h1 className="text-2xl font-semibold">Evaluation History</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Evaluation History</h1>
           <p className="text-sm text-muted-foreground mt-1">View and compare all evaluation runs</p>
         </div>
       </PageHeader>

--- a/src/app/src/pages/login.tsx
+++ b/src/app/src/pages/login.tsx
@@ -148,7 +148,7 @@ export default function LoginPage() {
                     href="https://promptfoo.app/welcome"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-primary hover:underline"
+                    className="text-primary underline underline-offset-2 hover:no-underline"
                   >
                     Generate your token here
                   </a>


### PR DESCRIPTION
## Summary
- make the shared app chrome more resilient on narrow screens
- improve compact navigation, shared table controls, and icon labeling
- align fixed list-page shells and long-ID truncation across common views

## Validation
- `npm run test:app -- src/components/ApiSettingsModal.test.tsx src/components/Navigation.test.tsx src/components/data-table/data-table.test.tsx src/components/traces/TraceTimeline.test.tsx src/pages/history/History.test.tsx --run`
