### PR TITLE
test: stabilize flaky provider tests

### DIFF
--- a/test/examples/integrationInspectOsworldProvider.test.ts
+++ b/test/examples/integrationInspectOsworldProvider.test.ts
@@ -9,6 +9,7 @@ import { mockProcessEnv } from '../util/utils';
 describe('integration-inspect-osworld example provider', () => {
   const tempDirs: string[] = [];
   let restoreEnv: (() => void) | undefined;
+  let cachedPythonExecutable: string | undefined;
 
   afterEach(() => {
     restoreEnv?.();
@@ -28,12 +29,38 @@ describe('integration-inspect-osworld example provider', () => {
   }
 
   function pythonExecutable(): string {
-    return (
-      process.env.PROMPTFOO_PYTHON ||
-      process.env.PYTHON ||
-      process.env.PYTHON3 ||
-      (process.platform === 'win32' ? 'python' : 'python3')
-    );
+    if (cachedPythonExecutable) {
+      return cachedPythonExecutable;
+    }
+
+    const pythonProbe = 'import sys; print(sys.executable)';
+    const candidates = [
+      ...(process.env.PROMPTFOO_PYTHON
+        ? [{ command: process.env.PROMPTFOO_PYTHON, args: ['-c', pythonProbe] }]
+        : []),
+      ...(process.env.PYTHON ? [{ command: process.env.PYTHON, args: ['-c', pythonProbe] }] : []),
+      ...(process.env.PYTHON3 ? [{ command: process.env.PYTHON3, args: ['-c', pythonProbe] }] : []),
+      ...(process.platform === 'win32'
+        ? [
+            { command: 'py', args: ['-3', '-c', pythonProbe] },
+            { command: 'python', args: ['-c', pythonProbe] },
+          ]
+        : [
+            { command: 'python3', args: ['-c', pythonProbe] },
+            { command: 'python', args: ['-c', pythonProbe] },
+          ]),
+    ];
+
+    for (const candidate of candidates) {
+      const result = spawnSync(candidate.command, candidate.args, { encoding: 'utf8' });
+      const executable = result.status === 0 ? result.stdout.trim() : '';
+      if (executable) {
+        cachedPythonExecutable = executable;
+        return executable;
+      }
+    }
+
+    return process.platform === 'win32' ? 'python' : 'python3';
   }
 
   it('generates the Inspect osworld_small sample suite', () => {

--- a/test/providers/opencode-sdk.test.ts
+++ b/test/providers/opencode-sdk.test.ts
@@ -9,6 +9,7 @@ import {
   FS_READONLY_TOOLS,
   OpenCodeSDKProvider,
 } from '../../src/providers/opencode-sdk';
+import { createDeferred } from '../util/utils';
 import type { MockInstance } from 'vitest';
 
 import type { CallApiContextParams } from '../../src/types/index';
@@ -1601,12 +1602,14 @@ describe('OpenCodeSDKProvider', () => {
   describe('abortSignal mid-flight cancellation', () => {
     it('calls session.abort when the caller aborts during the prompt', async () => {
       const controller = new AbortController();
+      const promptStarted = createDeferred<void>();
       // The prompt mock waits for the abort signal itself, then returns a
       // canned response — that mirrors how a real server completes after an
       // abort request rather than hanging forever.
       mockSessionPrompt.mockImplementationOnce(
         () =>
           new Promise((resolve) => {
+            promptStarted.resolve();
             controller.signal.addEventListener(
               'abort',
               () =>
@@ -1629,10 +1632,7 @@ describe('OpenCodeSDKProvider', () => {
         abortSignal: controller.signal,
       });
 
-      // Yield enough microtasks for callApi to walk through ensureClient,
-      // getOrCreateSession, and reach `addEventListener('abort', ...)` before
-      // we trigger the signal.
-      await new Promise((resolve) => setImmediate(resolve));
+      await promptStarted.promise;
       controller.abort();
 
       const result = await callPromise;


### PR DESCRIPTION
## Summary
- resolve the OSWorld example provider test's Python executable before passing it as explicit config
- make the OpenCode abort test wait for the mocked prompt to start before aborting

## Why
Two CI lanes on `main` exposed separate flaky assumptions:
- Windows can have Python available without an invokable `python` command, but the OSWorld test forced `python` as an explicit executable
- the OpenCode abort test could fire the signal before the mocked prompt had attached its listener, leaving the promise unresolved until timeout

## Validation
- `npx vitest run test/examples/integrationInspectOsworldProvider.test.ts --sequence.shuffle=false`
- `npx vitest run test/providers/opencode-sdk.test.ts --sequence.shuffle=false`
- repeated the OpenCode abort test 20 times locally
- `npm run l`
- `npm run f`
