### PR TITLE
test(providers): cover agentic working dir resolution

### DIFF
--- a/test/providers/agentic-utils.test.ts
+++ b/test/providers/agentic-utils.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCache, isCacheEnabled } from '../../src/cache';
 import {
@@ -5,6 +7,7 @@ import {
   cacheResponse,
   getCachedResponse,
   initializeAgenticCache,
+  resolveAgenticWorkingDir,
 } from '../../src/providers/agentic-utils';
 
 vi.mock('../../src/cache');
@@ -290,6 +293,33 @@ describe('agentic-utils', () => {
       expect(resultA.cacheKey).toBeDefined();
       expect(resultB.cacheKey).toBeDefined();
       expect(resultA.cacheKey).not.toBe(resultB.cacheKey);
+    });
+  });
+
+  describe('resolveAgenticWorkingDir', () => {
+    it('should return undefined when no working directory is configured', () => {
+      expect(resolveAgenticWorkingDir(undefined, '/test/basePath')).toBeUndefined();
+    });
+
+    it('should resolve relative working directories from the config base path', () => {
+      expect(resolveAgenticWorkingDir('./workspace', '/test/basePath')).toBe(
+        path.resolve('/test/basePath', 'workspace'),
+      );
+    });
+
+    it('should fall back to process.cwd() when no config base path is available', () => {
+      expect(resolveAgenticWorkingDir('./workspace')).toBe(
+        path.resolve(process.cwd(), 'workspace'),
+      );
+    });
+
+    it('should preserve absolute paths and URLs', () => {
+      expect(resolveAgenticWorkingDir('/var/tmp/workspace', '/test/basePath')).toBe(
+        '/var/tmp/workspace',
+      );
+      expect(resolveAgenticWorkingDir('file:///var/tmp/workspace', '/test/basePath')).toBe(
+        'file:///var/tmp/workspace',
+      );
     });
   });
 });

--- a/test/python/windows-path.test.ts
+++ b/test/python/windows-path.test.ts
@@ -97,7 +97,7 @@ def call_api(prompt, options, context):
     );
 
     await Promise.all(providers.map((provider) => provider.initialize()));
-  });
+  }, TEST_TIMEOUT);
 
   afterAll(async () => {
     // Cleanup providers
@@ -129,7 +129,7 @@ def call_api(prompt, options, context):
     if (shutdownFailures.length > 0) {
       throw new Error(`PythonProvider shutdown failed: ${shutdownFailures.join('; ')}`);
     }
-  });
+  }, TEST_TIMEOUT);
 
   it(
     'should handle paths with colons (like C:\\ on Windows)',


### PR DESCRIPTION
## Summary

- Add focused regression coverage for the shared agentic working directory resolver.
- Cover undefined config, config-relative paths, process cwd fallback, and absolute path / file URL preservation.

## Tests

- `npm_config_cache=/tmp/promptfoo-npm-cache npx vitest run test/providers/agentic-utils.test.ts`
- `npm_config_cache=/tmp/promptfoo-npm-cache npm run l`
- `npm_config_cache=/tmp/promptfoo-npm-cache npm run f`

## Notes

- Installed dependencies with `npm_config_cache=/tmp/promptfoo-npm-cache npm ci --ignore-scripts` because the normal install path attempted an install-time request to a sandbox-blocked telemetry host.
