### PR TITLE
fix(providers): honor passthrough for OpenAI embeddings

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -24,7 +24,7 @@ The OpenAI provider supports the following model formats:
 - `openai:chat:ft:gpt-5-mini:company-name:ID` - example of a fine-tuned chat completion model
 - `openai:completion` - defaults to `gpt-3.5-turbo-instruct`
 - `openai:completion:<model name>` - uses any model name against the `/v1/completions` endpoint
-- `openai:embeddings:<model name>` - uses any model name against the `/v1/embeddings` endpoint
+- `openai:embedding:<model name>` / `openai:embeddings:<model name>` - uses any model name against the `/v1/embeddings` endpoint
 - `openai:moderation:<model name>` - uses moderation models (default: `omni-moderation-latest`)
 - `openai:image:<model name>` - uses image generation models
 - `openai:transcription:<model name>` - uses audio transcription models
@@ -199,6 +199,18 @@ providers:
 ```
 
 When `n > 1`, the primary `output` contains the first choice's content, and all generated choices are available in the response metadata under `metadata.choices`. Each choice includes the full response object with `message`, `finish_reason`, and `index`.
+
+### Reducing Embedding Dimensions
+
+Use `passthrough` to send raw [Embeddings API](https://platform.openai.com/docs/api-reference/embeddings) fields such as `dimensions`. OpenAI supports `dimensions` on `text-embedding-3` and later models when you want a smaller vector size:
+
+```yaml
+providers:
+  - id: openai:embedding:text-embedding-3-large
+    config:
+      passthrough:
+        dimensions: 1024
+```
 
 ## Models
 

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -14,14 +14,13 @@ type OpenAiEmbeddingOptions = OpenAiSharedOptions & {
 };
 
 export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
-  config: OpenAiEmbeddingOptions;
+  declare config: OpenAiEmbeddingOptions;
 
   constructor(
     modelName: string,
     options: { config?: OpenAiEmbeddingOptions; id?: string; env?: EnvOverrides } = {},
   ) {
     super(modelName, options);
-    this.config = options.config || {};
   }
 
   protected getBillingModelName(): string {

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -5,9 +5,25 @@ import { OpenAiGenericProvider } from '.';
 import { calculateOpenAIUsageCost } from './billing';
 import { getTokenUsage } from './util';
 
+import type { EnvOverrides } from '../../types/env';
 import type { ProviderEmbeddingResponse } from '../../types/index';
+import type { OpenAiSharedOptions } from './types';
+
+type OpenAiEmbeddingOptions = OpenAiSharedOptions & {
+  passthrough?: object;
+};
 
 export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
+  config: OpenAiEmbeddingOptions;
+
+  constructor(
+    modelName: string,
+    options: { config?: OpenAiEmbeddingOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    super(modelName, options);
+    this.config = options.config || {};
+  }
+
   protected getBillingModelName(): string {
     return this.modelName;
   }

--- a/src/providers/openai/embedding.ts
+++ b/src/providers/openai/embedding.ts
@@ -30,6 +30,7 @@ export class OpenAiEmbeddingProvider extends OpenAiGenericProvider {
     const body = {
       input: text,
       model: this.modelName,
+      ...(this.config.passthrough || {}),
     };
 
     let data: any;

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -48,6 +48,8 @@ export interface OpenAiSharedOptions {
   headers?: { [key: string]: string };
   /** defaults to 4; set to 0 to disable retries; negative values are clamped to 0. */
   maxRetries?: number;
+  /** Additional raw request fields supported by the target OpenAI endpoint. */
+  passthrough?: object;
 }
 
 export type ReasoningEffort = 'none' | 'low' | 'medium' | 'high' | null;
@@ -158,7 +160,6 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
       };
   stop?: string[];
   seed?: number;
-  passthrough?: object;
   prompt_cache_key?: string;
   prompt_cache_retention?: OpenAiPromptCacheRetention;
   reasoning_effort?: GPT5ReasoningEffort;

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -48,8 +48,6 @@ export interface OpenAiSharedOptions {
   headers?: { [key: string]: string };
   /** defaults to 4; set to 0 to disable retries; negative values are clamped to 0. */
   maxRetries?: number;
-  /** Additional raw request fields supported by the target OpenAI endpoint. */
-  passthrough?: object;
 }
 
 export type ReasoningEffort = 'none' | 'low' | 'medium' | 'high' | null;
@@ -160,6 +158,7 @@ export type OpenAiCompletionOptions = OpenAiSharedOptions & {
       };
   stop?: string[];
   seed?: number;
+  passthrough?: object;
   prompt_cache_key?: string;
   prompt_cache_retention?: OpenAiPromptCacheRetention;
   reasoning_effort?: GPT5ReasoningEffort;

--- a/test/providers/openai/embedding.test.ts
+++ b/test/providers/openai/embedding.test.ts
@@ -55,6 +55,50 @@ describe('OpenAI Provider', () => {
       expect(result.cost).toBeCloseTo((10 * 0.13) / 1e6, 12);
     });
 
+    it('should pass through embedding request fields', async () => {
+      const passthroughProvider = new OpenAiEmbeddingProvider('text-embedding-3-small', {
+        config: {
+          apiKey: 'test-key',
+          passthrough: {
+            dimensions: 8,
+            encoding_format: 'float',
+          },
+        },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: {
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+          usage: {
+            total_tokens: 10,
+            prompt_tokens: 10,
+            completion_tokens: 0,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await passthroughProvider.callEmbeddingApi('test text');
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        expect.stringContaining('/embeddings'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            input: 'test text',
+            model: 'text-embedding-3-small',
+            dimensions: 8,
+            encoding_format: 'float',
+          }),
+        }),
+        expect.any(Number),
+        'json',
+        false,
+        undefined,
+      );
+    });
+
     it('should handle API errors', async () => {
       vi.mocked(fetchWithCache).mockRejectedValue(new Error('API error'));
 


### PR DESCRIPTION
## Summary

- honor `config.passthrough` in the OpenAI embeddings provider so Embeddings API fields such as `dimensions` reach `/v1/embeddings`
- keep `passthrough` typed on the embeddings provider without widening unrelated OpenAI provider config
- document both `openai:embedding:*` and `openai:embeddings:*`, including how to send the Embeddings API `dimensions` field

## Issue

Fixes [#9098](https://github.com/promptfoo/promptfoo/issues/9098), where the OpenAI embeddings provider ignored `passthrough` and gave users no way to send `dimensions` for embedding comparisons.

## Root cause

The embeddings provider built its request body from only `input` and `model`, so raw OpenAI fields configured under `passthrough` were silently dropped even though the OpenAI provider docs describe `passthrough` as being merged into the final request body.

## Validation

- `npx vitest run test/providers/openai/embedding.test.ts`
- `npm run tsc`
- `npm run build`
- `cd site && SKIP_OG_GENERATION=true npm run build`
- `npm run local -- eval -c /tmp/promptfoo-9098-eval.yaml --env-file /Users/mdangelo/code/promptfoo/.env --no-cache -o /tmp/promptfoo-9098-output.json`
  - live eval passed against OpenAI
  - captured outbound embeddings request included `\"dimensions\": 8`

Closes [#9098](https://github.com/promptfoo/promptfoo/issues/9098)