### PR TITLE
test(providers): stabilize google live tool-isolation test

### DIFF
--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -107,8 +107,28 @@ describe('GoogleLiveProvider', () => {
   let provider: GoogleLiveProvider;
 
   beforeEach(async () => {
-    // Reset fetchWithProxy mock to prevent test pollution from async callbacks
+    // Reset mocks that hold call history or implementations across tests so
+    // shuffled-order runs see a clean slate. clearAllMocks in afterEach clears
+    // call history but preserves implementations, and async work scheduled by
+    // a prior test can still record calls before the next test runs.
     mockFetchWithProxy.mockReset();
+
+    const spawnMock = vi.mocked((await import('child_process')).spawn);
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(
+      () =>
+        ({
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setImmediate(callback);
+            }
+          }),
+          kill: vi.fn(),
+          killed: false,
+        }) as any,
+    );
 
     mockWs = {
       on: vi.fn(),
@@ -749,6 +769,12 @@ describe('GoogleLiveProvider', () => {
 
   it('should skip tool side effects when tools are disabled', async () => {
     const mockSpawn = vi.mocked((await import('child_process')).spawn);
+    // Tests run in random order; a prior test may have invoked spawn through
+    // module-mocked code paths whose deferred work is not drained by the
+    // describe-level afterEach. Clear here so this test only sees spawn calls
+    // from its own provider invocation.
+    mockSpawn.mockClear();
+    mockFetchWithProxy.mockClear();
     mockImportModule.mockReset();
 
     provider = new GoogleLiveProvider('gemini-2.0-flash-exp', {
@@ -789,6 +815,7 @@ describe('GoogleLiveProvider', () => {
 
   it('should preserve inline non-function tools in arrays containing file:// references when disabled', async () => {
     const mockSpawn = vi.mocked((await import('child_process')).spawn);
+    mockSpawn.mockClear();
     mockImportModule.mockReset();
 
     provider = new GoogleLiveProvider('gemini-2.0-flash-exp', {
@@ -1149,6 +1176,7 @@ describe('GoogleLiveProvider', () => {
 
     it('should handle errors when spawning Python process', async () => {
       const mockSpawn = vi.mocked((await import('child_process')).spawn);
+      mockSpawn.mockClear();
       const validatePythonPathMock = vi.mocked(
         (await import('../../../src/python/pythonUtils')).validatePythonPath,
       );


### PR DESCRIPTION
## Summary
- `test/providers/google/live.test.ts > should skip tool side effects when tools are disabled` flakes on CI under random ordering because the file-level `afterEach` only calls `vi.clearAllMocks()` (clears call history but preserves implementations), so an async path scheduled by a prior test (e.g. setImmediate WebSocket callbacks that drive into `spawn`) can record a call inside the next test and trip the `expect(spawn).not.toHaveBeenCalled()` assertion.
- Reset `child_process.spawn` and reinstall its mock implementation in `beforeEach`, mirror the same treatment for `mockFetchWithProxy`, and explicitly `mockClear()` `spawn` at the top of each test that asserts it was not called. 100 consecutive shuffled local runs of the file now pass.

## Why
This was the only flake in the most recent CI run for #9073, and the same pattern is the test-suite hygiene rule called out in `test/AGENTS.md` (use `mockReset()` / explicit `mockClear()` rather than relying on `clearAllMocks()` for full isolation).

## Test plan
- [x] `npx vitest run test/providers/google/live.test.ts` (100 consecutive runs, 0 failures)
- [x] `npm run l`
- [x] `npm run f`
- [ ] CI green