### PR TITLE
fix(eval): keep package APIs in library mode

### DIFF
--- a/site/docs/configuration/reference.md
+++ b/site/docs/configuration/reference.md
@@ -1118,7 +1118,6 @@ EvaluateOptions is an object that includes options for how the evaluation should
 interface EvaluateOptions {
   cache?: boolean;
   delay?: number;
-  eventSource?: string;
   generateSuggestions?: boolean;
   suggestionsCount?: number;
   /** Deprecated: use maxConcurrency: 1 or -j 1 instead. */

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -3090,10 +3090,6 @@
         "delay": {
           "type": "number"
         },
-        "eventSource": {
-          "type": "string",
-          "enum": ["cli", "library", "web", "mcp", "default"]
-        },
         "generateSuggestions": {
           "type": "boolean"
         },

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -61,7 +61,7 @@ import { notCloudEnabledShareInstructions } from './share';
 import type { Command } from 'commander';
 
 import type { CommandLineOptions, Scenario, TestSuite, UnifiedConfig } from '../types/index';
-import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
+import type { InternalEvaluateOptions } from '../types/internal';
 import type { FilterOptions } from './eval/filterTests';
 
 const EvalCommandSchema = CommandLineOptionsSchema.extend({
@@ -130,8 +130,8 @@ function handleRecoverableWatchError(error: unknown): boolean {
 function resolveSuggestionOptions(
   cmdObj: Partial<CommandLineOptions & Command>,
   commandLineOptions: Record<string, any> | undefined,
-  evaluateOptions: EvaluateOptions,
-): Pick<EvaluateOptions, 'generateSuggestions' | 'suggestionsCount'> {
+  evaluateOptions: InternalEvaluateOptions,
+): Pick<InternalEvaluateOptions, 'generateSuggestions' | 'suggestionsCount'> {
   const { suggestPrompts } = cmdObj as EvalCommandOptions;
 
   // --suggest-prompts is itself an enable signal — passing a count opts in even
@@ -180,7 +180,7 @@ export async function doEval(
   cmdObj: Partial<CommandLineOptions & Command>,
   defaultConfig: Partial<UnifiedConfig>,
   defaultConfigPath: string | undefined,
-  evaluateOptions: EvaluateOptions,
+  evaluateOptions: InternalEvaluateOptions,
 ): Promise<Eval> {
   // Phase 1: Load environment from CLI args (preserves existing behavior)
   setupEnv(cmdObj.envPath);
@@ -436,7 +436,7 @@ export async function doEval(
     if (resumeRaw) {
       const persisted = (resumeEval?.runtimeOptions ||
         config.evaluateOptions ||
-        {}) as EvaluateOptions;
+        {}) as InternalEvaluateOptions;
       repeat =
         Number.isSafeInteger(persisted.repeat || 0) && (persisted.repeat as number) > 0
           ? (persisted.repeat as number)
@@ -469,7 +469,7 @@ export async function doEval(
     // For resume mode, include persisted value as "explicit", with fallback to config when
     // runtimeOptions are missing (e.g., older evals that didn't persist runtimeOptions)
     const explicitMaxConcurrency = resumeRaw
-      ? ((resumeEval?.runtimeOptions as EvaluateOptions | undefined)?.maxConcurrency ??
+      ? ((resumeEval?.runtimeOptions as InternalEvaluateOptions | undefined)?.maxConcurrency ??
         cmdObj.maxConcurrency ??
         commandLineOptions?.maxConcurrency ??
         evaluateOptions.maxConcurrency)
@@ -490,7 +490,7 @@ export async function doEval(
 
     const hasScenarios = Boolean(testSuite.scenarios?.length);
     const explicitTestCountBeforeFiltering = testSuite.tests?.length;
-    const resumeRuntimeOptions = resumeEval?.runtimeOptions as EvaluateOptions | undefined;
+    const resumeRuntimeOptions = resumeEval?.runtimeOptions as InternalEvaluateOptions | undefined;
     const persistedFilterRange =
       typeof resumeRuntimeOptions?.filterRange === 'string'
         ? resumeRuntimeOptions.filterRange
@@ -581,7 +581,7 @@ export async function doEval(
 
     await checkCloudPermissions(config as UnifiedConfig);
 
-    const options: EvaluateOptions = {
+    const options: InternalEvaluateOptions = {
       ...evaluateOptions,
       showProgressBar:
         getLogLevel() === 'debug'
@@ -1082,7 +1082,7 @@ export function evalCommand(
   defaultConfig: Partial<UnifiedConfig>,
   defaultConfigPath: string | undefined,
 ) {
-  const evaluateOptions: EvaluateOptions = {};
+  const evaluateOptions: InternalEvaluateOptions = {};
   if (defaultConfig.evaluateOptions) {
     evaluateOptions.generateSuggestions = defaultConfig.evaluateOptions.generateSuggestions;
     evaluateOptions.suggestionsCount = defaultConfig.evaluateOptions.suggestionsCount;

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -116,11 +116,7 @@ function handleRecoverableWatchError(error: unknown): boolean {
     // Account helpers already render these user-facing failures.
     return true;
   }
-  if (error instanceof EvalRunError) {
-    logger.error(error.message);
-    return true;
-  }
-  if (error instanceof PromptSuggestionsRejectedError) {
+  if (error instanceof EvalRunError || error instanceof PromptSuggestionsRejectedError) {
     logger.error(error.message);
     return true;
   }

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -60,13 +60,8 @@ import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from 
 import { notCloudEnabledShareInstructions } from './share';
 import type { Command } from 'commander';
 
-import type {
-  CommandLineOptions,
-  EvaluateOptions,
-  Scenario,
-  TestSuite,
-  UnifiedConfig,
-} from '../types/index';
+import type { CommandLineOptions, Scenario, TestSuite, UnifiedConfig } from '../types/index';
+import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
 import type { FilterOptions } from './eval/filterTests';
 
 const EvalCommandSchema = CommandLineOptionsSchema.extend({

--- a/src/commands/mcp/tools/runEvaluation.ts
+++ b/src/commands/mcp/tools/runEvaluation.ts
@@ -11,7 +11,8 @@ import { createToolResponse } from '../lib/utils';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Command } from 'commander';
 
-import type { CommandLineOptions, EvaluateOptions } from '../../../types/index';
+import type { CommandLineOptions } from '../../../types/index';
+import type { InternalEvaluateOptions as EvaluateOptions } from '../../../types/internal';
 
 /**
  * Run an eval from a promptfoo config with optional test case filtering

--- a/src/commands/mcp/tools/runEvaluation.ts
+++ b/src/commands/mcp/tools/runEvaluation.ts
@@ -12,7 +12,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Command } from 'commander';
 
 import type { CommandLineOptions } from '../../../types/index';
-import type { InternalEvaluateOptions as EvaluateOptions } from '../../../types/internal';
+import type { InternalEvaluateOptions } from '../../../types/internal';
 
 /**
  * Run an eval from a promptfoo config with optional test case filtering
@@ -410,7 +410,7 @@ export function registerRunEvaluationTool(server: McpServer) {
           };
 
           // Prepare evaluate options
-          const evaluateOptions: EvaluateOptions = {
+          const evaluateOptions: InternalEvaluateOptions = {
             maxConcurrency,
             eventSource: 'mcp',
             showProgressBar: false, // Disable for MCP usage

--- a/src/commands/retry.ts
+++ b/src/commands/retry.ts
@@ -24,7 +24,8 @@ import {
 } from '../util/tokenUsageUtils';
 import type { Command } from 'commander';
 
-import type { EvaluateOptions, TokenUsage } from '../types/index';
+import type { TokenUsage } from '../types/index';
+import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
 
 interface RetryCommandOptions {
   config?: string;

--- a/src/commands/retry.ts
+++ b/src/commands/retry.ts
@@ -25,7 +25,7 @@ import {
 import type { Command } from 'commander';
 
 import type { TokenUsage } from '../types/index';
-import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
+import type { InternalEvaluateOptions } from '../types/internal';
 
 interface RetryCommandOptions {
   config?: string;
@@ -316,7 +316,7 @@ export async function retryCommand(evalId: string, cmdObj: RetryCommandOptions) 
   }
 
   // Set up evaluation options
-  const evaluateOptions: EvaluateOptions = {
+  const evaluateOptions: InternalEvaluateOptions = {
     maxConcurrency: effectiveDelay && effectiveDelay > 0 ? 1 : effectiveMaxConcurrency,
     delay: effectiveDelay,
     eventSource: 'cli',

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -312,6 +312,10 @@ async function writeConfiguredOutputs(
   outputPath: EvaluateTestSuite['outputPath'],
   evalRecord: Eval,
 ): Promise<void> {
+  if (!outputPath) {
+    return;
+  }
+
   if (typeof outputPath === 'string') {
     await writeOutput(outputPath, evalRecord, null);
   } else if (Array.isArray(outputPath)) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -193,45 +193,48 @@ function createSerializableUnifiedConfig(
   return config;
 }
 
-export async function evaluateWithSource(
-  testSuite: EvaluateTestSuite,
-  options: InternalEvaluateOptions = {},
-) {
-  const { author: suiteAuthor, ...testSuiteConfig } = testSuite;
-
-  if (testSuiteConfig.writeLatestResults) {
-    await runDbMigrations();
-  }
-
-  const loadedProviders = await loadApiProviders(testSuiteConfig.providers, {
-    env: testSuiteConfig.env,
-  });
+function buildProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
   const providerMap: Record<string, ApiProvider> = {};
-  for (const p of loadedProviders) {
-    providerMap[p.id()] = p;
-    if (p.label) {
-      providerMap[p.label] = p;
+  for (const provider of providers) {
+    providerMap[provider.id()] = provider;
+    if (provider.label) {
+      providerMap[provider.label] = provider;
     }
   }
+  return providerMap;
+}
 
-  let resolvedDefaultTest = testSuiteConfig.defaultTest;
-  if (
-    typeof testSuiteConfig.defaultTest === 'string' &&
-    testSuiteConfig.defaultTest.startsWith('file://')
-  ) {
-    resolvedDefaultTest = await maybeLoadFromExternalFile(testSuiteConfig.defaultTest);
+async function resolveDefaultTestRef(
+  defaultTest: EvaluateTestSuite['defaultTest'],
+): Promise<EvaluateTestSuite['defaultTest']> {
+  if (typeof defaultTest === 'string' && defaultTest.startsWith('file://')) {
+    return maybeLoadFromExternalFile(defaultTest);
   }
+  return defaultTest;
+}
 
-  const constructedTestSuite: TestSuite = {
+async function createRuntimeTestSuite(
+  testSuiteConfig: Omit<EvaluateTestSuite, 'author'>,
+  loadedProviders: ApiProvider[],
+): Promise<TestSuite> {
+  return {
     ...testSuiteConfig,
-    defaultTest: resolvedDefaultTest as TestSuite['defaultTest'],
+    defaultTest: (await resolveDefaultTestRef(
+      testSuiteConfig.defaultTest,
+    )) as TestSuite['defaultTest'],
     scenarios: testSuiteConfig.scenarios as Scenario[],
     providers: loadedProviders,
     tests: await readTests(testSuiteConfig.tests),
     nunjucksFilters: await readFilters(testSuiteConfig.nunjucksFilters || {}),
     prompts: await processPrompts(testSuiteConfig.prompts),
   };
+}
 
+async function resolveNestedProviders(
+  testSuiteConfig: Omit<EvaluateTestSuite, 'author'>,
+  constructedTestSuite: TestSuite,
+  providerMap: Record<string, ApiProvider>,
+): Promise<void> {
   if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
     constructedTestSuite.defaultTest = cloneTestForResolve(constructedTestSuite.defaultTest);
 
@@ -278,6 +281,60 @@ export async function evaluateWithSource(
       }
     }
   }
+}
+
+async function maybeShareEval(
+  testSuiteConfig: Omit<EvaluateTestSuite, 'author'>,
+  evalResult: Awaited<ReturnType<typeof doEvaluate>>,
+): Promise<void> {
+  if (!testSuiteConfig.writeLatestResults || !testSuiteConfig.sharing) {
+    return;
+  }
+
+  if (!isSharingEnabled(evalResult)) {
+    logger.debug('Sharing requested but not enabled (check cloud config or sharing settings)');
+    return;
+  }
+
+  try {
+    const shareableUrl = await createShareableUrl(evalResult, { silent: true });
+    if (shareableUrl) {
+      evalResult.shareableUrl = shareableUrl;
+      evalResult.shared = true;
+      logger.debug(`Eval shared successfully: ${shareableUrl}`);
+    }
+  } catch (error) {
+    logger.warn(`Failed to create shareable URL: ${error}`);
+  }
+}
+
+async function writeConfiguredOutputs(
+  outputPath: EvaluateTestSuite['outputPath'],
+  evalRecord: Eval,
+): Promise<void> {
+  if (typeof outputPath === 'string') {
+    await writeOutput(outputPath, evalRecord, null);
+  } else if (Array.isArray(outputPath)) {
+    await writeMultipleOutputs(outputPath, evalRecord, null);
+  }
+}
+
+export async function evaluateWithSource(
+  testSuite: EvaluateTestSuite,
+  options: InternalEvaluateOptions = {},
+) {
+  const { author: suiteAuthor, ...testSuiteConfig } = testSuite;
+
+  if (testSuiteConfig.writeLatestResults) {
+    await runDbMigrations();
+  }
+
+  const loadedProviders = await loadApiProviders(testSuiteConfig.providers, {
+    env: testSuiteConfig.env,
+  });
+  const providerMap = buildProviderMap(loadedProviders);
+  const constructedTestSuite = await createRuntimeTestSuite(testSuiteConfig, loadedProviders);
+  await resolveNestedProviders(testSuiteConfig, constructedTestSuite, providerMap);
 
   const parsedProviderPromptMap = readProviderPromptMap(
     testSuiteConfig,
@@ -306,30 +363,8 @@ export async function evaluateWithSource(
     ),
   );
 
-  if (testSuiteConfig.writeLatestResults && testSuiteConfig.sharing) {
-    if (isSharingEnabled(ret)) {
-      try {
-        const shareableUrl = await createShareableUrl(ret, { silent: true });
-        if (shareableUrl) {
-          ret.shareableUrl = shareableUrl;
-          ret.shared = true;
-          logger.debug(`Eval shared successfully: ${shareableUrl}`);
-        }
-      } catch (error) {
-        logger.warn(`Failed to create shareable URL: ${error}`);
-      }
-    } else {
-      logger.debug('Sharing requested but not enabled (check cloud config or sharing settings)');
-    }
-  }
-
-  if (testSuiteConfig.outputPath) {
-    if (typeof testSuiteConfig.outputPath === 'string') {
-      await writeOutput(testSuiteConfig.outputPath, evalRecord, null);
-    } else if (Array.isArray(testSuiteConfig.outputPath)) {
-      await writeMultipleOutputs(testSuiteConfig.outputPath, evalRecord, null);
-    }
-  }
+  await maybeShareEval(testSuiteConfig, ret);
+  await writeConfiguredOutputs(testSuiteConfig.outputPath, evalRecord);
 
   return ret;
 }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,0 +1,335 @@
+import * as cache from './cache';
+import cliState from './cliState';
+import { evaluate as doEvaluate } from './evaluator';
+import { getAuthor } from './globalConfig/accounts';
+import logger from './logger';
+import { runDbMigrations } from './migrate';
+import Eval from './models/eval';
+import { sanitizeProvider } from './models/evalResult';
+import { processPrompts, readProviderPromptMap } from './prompts/index';
+import { loadApiProviders, resolveProvider } from './providers/index';
+import { createShareableUrl, isSharingEnabled } from './share';
+import { isApiProvider } from './types/providers';
+import { isTransformFunction } from './types/transform';
+import { maybeLoadFromExternalFile } from './util/file';
+import { readFilters, writeMultipleOutputs, writeOutput } from './util/index';
+import { readTests } from './util/testCaseReader';
+import { INLINE_FUNCTION_LABEL, TRANSFORM_KEYS } from './util/transform';
+
+import type {
+  EvaluateTestSuite,
+  Scenario,
+  TestCase,
+  TestSuite,
+  UnifiedConfig,
+} from './types/index';
+import type { InternalEvaluateOptions } from './types/internal';
+import type { ApiProvider } from './types/providers';
+
+/**
+ * Shallow-clone a test case so the caller can swap in resolved ApiProvider
+ * instances on `options.provider` / `assert[].provider` without leaking those
+ * mutations back to the input. The input may alias the unified config written
+ * to the Eval record, and a live SDK client (e.g. Bedrock's BedrockRuntime,
+ * Anthropic's client) holds circular references that break drizzle's JSON
+ * serialization on `evalRecord.save()`. Fixes #8687.
+ *
+ * Detaches only `options` and `assert[]`. Other reference fields (`provider`,
+ * `vars`, `metadata`, `providerOutput`) remain aliased — callers must reassign
+ * those by reference rather than mutating in place. `assert-set` children are
+ * not deep-cloned because the resolve loop skips `assert-set`; if that ever
+ * changes, extend this helper.
+ */
+function cloneTestForResolve<T extends Pick<TestCase, 'options' | 'assert'>>(test: T): T {
+  const cloned: T = { ...test };
+  if (test.options) {
+    cloned.options = { ...test.options };
+  }
+  if (test.assert) {
+    cloned.assert = test.assert.map((assertion) => ({ ...assertion }));
+  }
+  return cloned;
+}
+
+function toSerializableProviderRef(provider: unknown): unknown {
+  if (isApiProvider(provider)) {
+    return sanitizeProvider(provider);
+  }
+  if (Array.isArray(provider)) {
+    return provider.map(toSerializableProviderRef);
+  }
+  return provider;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function withSerializableProvider<T extends Record<string, unknown>>(record: T): T {
+  if (!isApiProvider(record.provider)) {
+    return record;
+  }
+  return {
+    ...record,
+    provider: sanitizeProvider(record.provider),
+  };
+}
+
+/**
+ * Function-valued transforms are first-class at runtime but are silently dropped
+ * by `JSON.stringify`. Persisted eval configs (drizzle-stored) must never retain
+ * a function reference, so replace every `transform`-like field with a
+ * `[inline function]: name` marker. Non-function values pass through unchanged.
+ *
+ * `droppedRef.value` is flipped to `true` the first time a function is replaced
+ * so the caller can emit a single warning instead of logging per field.
+ */
+function replaceFunctionTransforms<T extends Record<string, unknown>>(
+  record: T,
+  droppedRef: { value: boolean },
+): T {
+  let result: T | undefined;
+  for (const key of TRANSFORM_KEYS) {
+    const value = record[key];
+    if (!isTransformFunction(value)) {
+      continue;
+    }
+    if (!result) {
+      result = { ...record };
+    }
+    (result as Record<string, unknown>)[key] = value.name
+      ? `${INLINE_FUNCTION_LABEL}: ${value.name}`
+      : INLINE_FUNCTION_LABEL;
+    droppedRef.value = true;
+  }
+  return result ?? record;
+}
+
+function toSerializableAssertion(assertion: unknown, droppedRef: { value: boolean }): unknown {
+  if (!isRecord(assertion)) {
+    return assertion;
+  }
+
+  let sanitizedAssertion = withSerializableProvider(assertion);
+  sanitizedAssertion = replaceFunctionTransforms(sanitizedAssertion, droppedRef);
+
+  if (Array.isArray(assertion.assert)) {
+    sanitizedAssertion = {
+      ...sanitizedAssertion,
+      assert: assertion.assert.map((a) => toSerializableAssertion(a, droppedRef)),
+    };
+  }
+
+  return sanitizedAssertion;
+}
+
+function toSerializableTestCase(test: unknown, droppedRef: { value: boolean }): unknown {
+  if (!isRecord(test)) {
+    return test;
+  }
+
+  let sanitizedTest = withSerializableProvider(test);
+
+  if (isRecord(test.options)) {
+    let options = withSerializableProvider(test.options);
+    options = replaceFunctionTransforms(options, droppedRef);
+    if (options !== test.options) {
+      sanitizedTest = {
+        ...sanitizedTest,
+        options,
+      };
+    }
+  }
+
+  if (Array.isArray(test.assert)) {
+    sanitizedTest = {
+      ...sanitizedTest,
+      assert: test.assert.map((a) => toSerializableAssertion(a, droppedRef)),
+    };
+  }
+
+  return sanitizedTest;
+}
+
+function toSerializableScenario(scenario: unknown, droppedRef: { value: boolean }): unknown {
+  if (!isRecord(scenario)) {
+    return scenario;
+  }
+
+  if (!Array.isArray(scenario.tests)) {
+    return scenario;
+  }
+
+  return {
+    ...scenario,
+    tests: scenario.tests.map((t) => toSerializableTestCase(t, droppedRef)),
+  };
+}
+
+function createSerializableUnifiedConfig(
+  testSuite: EvaluateTestSuite,
+  prompts: TestSuite['prompts'],
+): Partial<UnifiedConfig> {
+  const droppedRef = { value: false };
+  const config = {
+    ...testSuite,
+    providers: toSerializableProviderRef(testSuite.providers),
+    defaultTest: toSerializableTestCase(testSuite.defaultTest, droppedRef),
+    tests: Array.isArray(testSuite.tests)
+      ? testSuite.tests.map((t) => toSerializableTestCase(t, droppedRef))
+      : testSuite.tests,
+    scenarios: Array.isArray(testSuite.scenarios)
+      ? testSuite.scenarios.map((s) => toSerializableScenario(s, droppedRef))
+      : testSuite.scenarios,
+    prompts,
+  } as Partial<UnifiedConfig>;
+
+  if (droppedRef.value && testSuite.writeLatestResults) {
+    logger.warn(
+      'Function-valued transform(s) in testSuite were replaced with "[inline function]" markers in the persisted config. Re-running the saved eval will not invoke them; use string expressions or file:// references if you need the config to round-trip.',
+    );
+  }
+
+  return config;
+}
+
+export async function evaluateWithSource(
+  testSuite: EvaluateTestSuite,
+  options: InternalEvaluateOptions = {},
+) {
+  const { author: suiteAuthor, ...testSuiteConfig } = testSuite;
+
+  if (testSuiteConfig.writeLatestResults) {
+    await runDbMigrations();
+  }
+
+  const loadedProviders = await loadApiProviders(testSuiteConfig.providers, {
+    env: testSuiteConfig.env,
+  });
+  const providerMap: Record<string, ApiProvider> = {};
+  for (const p of loadedProviders) {
+    providerMap[p.id()] = p;
+    if (p.label) {
+      providerMap[p.label] = p;
+    }
+  }
+
+  let resolvedDefaultTest = testSuiteConfig.defaultTest;
+  if (
+    typeof testSuiteConfig.defaultTest === 'string' &&
+    testSuiteConfig.defaultTest.startsWith('file://')
+  ) {
+    resolvedDefaultTest = await maybeLoadFromExternalFile(testSuiteConfig.defaultTest);
+  }
+
+  const constructedTestSuite: TestSuite = {
+    ...testSuiteConfig,
+    defaultTest: resolvedDefaultTest as TestSuite['defaultTest'],
+    scenarios: testSuiteConfig.scenarios as Scenario[],
+    providers: loadedProviders,
+    tests: await readTests(testSuiteConfig.tests),
+    nunjucksFilters: await readFilters(testSuiteConfig.nunjucksFilters || {}),
+    prompts: await processPrompts(testSuiteConfig.prompts),
+  };
+
+  if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
+    constructedTestSuite.defaultTest = cloneTestForResolve(constructedTestSuite.defaultTest);
+
+    if (
+      constructedTestSuite.defaultTest.provider &&
+      !isApiProvider(constructedTestSuite.defaultTest.provider)
+    ) {
+      constructedTestSuite.defaultTest.provider = await resolveProvider(
+        constructedTestSuite.defaultTest.provider,
+        providerMap,
+        { env: testSuiteConfig.env, basePath: cliState.basePath },
+      );
+    }
+    if (
+      constructedTestSuite.defaultTest.options?.provider &&
+      !isApiProvider(constructedTestSuite.defaultTest.options.provider)
+    ) {
+      constructedTestSuite.defaultTest.options.provider = await resolveProvider(
+        constructedTestSuite.defaultTest.options.provider,
+        providerMap,
+        { env: testSuiteConfig.env, basePath: cliState.basePath },
+      );
+    }
+  }
+
+  constructedTestSuite.tests = (constructedTestSuite.tests || []).map(cloneTestForResolve);
+
+  for (const test of constructedTestSuite.tests) {
+    if (test.options?.provider && !isApiProvider(test.options.provider)) {
+      test.options.provider = await resolveProvider(test.options.provider, providerMap, {
+        env: testSuiteConfig.env,
+        basePath: cliState.basePath,
+      });
+    }
+    for (const assertion of test.assert || []) {
+      if (assertion.type === 'assert-set' || typeof assertion.provider === 'function') {
+        continue;
+      }
+      if (assertion.provider && !isApiProvider(assertion.provider)) {
+        assertion.provider = await resolveProvider(assertion.provider, providerMap, {
+          env: testSuiteConfig.env,
+          basePath: cliState.basePath,
+        });
+      }
+    }
+  }
+
+  const parsedProviderPromptMap = readProviderPromptMap(
+    testSuiteConfig,
+    constructedTestSuite.prompts,
+  );
+  const unifiedConfig = createSerializableUnifiedConfig(
+    testSuiteConfig,
+    constructedTestSuite.prompts,
+  );
+  const author = getAuthor(suiteAuthor);
+  const evalRecord = testSuiteConfig.writeLatestResults
+    ? await Eval.create(unifiedConfig, constructedTestSuite.prompts, { author })
+    : new Eval(unifiedConfig, { author });
+
+  const ret = await cache.withCacheEnabled(options.cache === false ? false : undefined, () =>
+    doEvaluate(
+      {
+        ...constructedTestSuite,
+        providerPromptMap: parsedProviderPromptMap,
+      },
+      evalRecord,
+      {
+        isRedteam: Boolean(testSuiteConfig.redteam),
+        ...options,
+      },
+    ),
+  );
+
+  if (testSuiteConfig.writeLatestResults && testSuiteConfig.sharing) {
+    if (isSharingEnabled(ret)) {
+      try {
+        const shareableUrl = await createShareableUrl(ret, { silent: true });
+        if (shareableUrl) {
+          ret.shareableUrl = shareableUrl;
+          ret.shared = true;
+          logger.debug(`Eval shared successfully: ${shareableUrl}`);
+        }
+      } catch (error) {
+        logger.warn(`Failed to create shareable URL: ${error}`);
+      }
+    } else {
+      logger.debug('Sharing requested but not enabled (check cloud config or sharing settings)');
+    }
+  }
+
+  if (testSuiteConfig.outputPath) {
+    if (typeof testSuiteConfig.outputPath === 'string') {
+      await writeOutput(testSuiteConfig.outputPath, evalRecord, null);
+    } else if (Array.isArray(testSuiteConfig.outputPath)) {
+      await writeMultipleOutputs(testSuiteConfig.outputPath, evalRecord, null);
+    }
+  }
+
+  return ret;
+}

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -204,24 +204,19 @@ function buildProviderMap(providers: ApiProvider[]): Record<string, ApiProvider>
   return providerMap;
 }
 
-async function resolveDefaultTestRef(
-  defaultTest: EvaluateTestSuite['defaultTest'],
-): Promise<EvaluateTestSuite['defaultTest']> {
-  if (typeof defaultTest === 'string' && defaultTest.startsWith('file://')) {
-    return maybeLoadFromExternalFile(defaultTest);
-  }
-  return defaultTest;
-}
-
 async function createRuntimeTestSuite(
   testSuiteConfig: Omit<EvaluateTestSuite, 'author'>,
   loadedProviders: ApiProvider[],
 ): Promise<TestSuite> {
+  const defaultTest =
+    typeof testSuiteConfig.defaultTest === 'string' &&
+    testSuiteConfig.defaultTest.startsWith('file://')
+      ? await maybeLoadFromExternalFile(testSuiteConfig.defaultTest)
+      : testSuiteConfig.defaultTest;
+
   return {
     ...testSuiteConfig,
-    defaultTest: (await resolveDefaultTestRef(
-      testSuiteConfig.defaultTest,
-    )) as TestSuite['defaultTest'],
+    defaultTest: defaultTest as TestSuite['defaultTest'],
     scenarios: testSuiteConfig.scenarios as Scenario[],
     providers: loadedProviders,
     tests: await readTests(testSuiteConfig.tests),
@@ -308,21 +303,6 @@ async function maybeShareEval(
   }
 }
 
-async function writeConfiguredOutputs(
-  outputPath: EvaluateTestSuite['outputPath'],
-  evalRecord: Eval,
-): Promise<void> {
-  if (!outputPath) {
-    return;
-  }
-
-  if (typeof outputPath === 'string') {
-    await writeOutput(outputPath, evalRecord, null);
-  } else if (Array.isArray(outputPath)) {
-    await writeMultipleOutputs(outputPath, evalRecord, null);
-  }
-}
-
 export async function evaluateWithSource(
   testSuite: EvaluateTestSuite,
   options: InternalEvaluateOptions = {},
@@ -368,7 +348,13 @@ export async function evaluateWithSource(
   );
 
   await maybeShareEval(testSuiteConfig, ret);
-  await writeConfiguredOutputs(testSuiteConfig.outputPath, evalRecord);
+  if (testSuiteConfig.outputPath) {
+    if (typeof testSuiteConfig.outputPath === 'string') {
+      await writeOutput(testSuiteConfig.outputPath, evalRecord, null);
+    } else if (Array.isArray(testSuiteConfig.outputPath)) {
+      await writeMultipleOutputs(testSuiteConfig.outputPath, evalRecord, null);
+    }
+  }
 
   return ret;
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -107,7 +107,7 @@ import type {
   Vars,
   VarValue,
 } from './types/index';
-import type { InternalEvaluateOptions as EvaluateOptions } from './types/internal';
+import type { InternalEvaluateOptions } from './types/internal';
 import type { CallApiContextParams } from './types/providers';
 
 export class PromptSuggestionsRejectedError extends Error {
@@ -409,7 +409,7 @@ function hasNestedRedteamAssertion(assertion: NestedAssertion): boolean {
 
 function getRepeatCacheNamespace(
   repeatIndex: number,
-  evaluateOptions?: EvaluateOptions,
+  evaluateOptions?: InternalEvaluateOptions,
 ): string | undefined {
   if (repeatIndex > 0 || (evaluateOptions?.repeat ?? 1) > 1) {
     return `repeat:${repeatIndex}`;
@@ -1794,7 +1794,7 @@ function ensureDefaultTestForExtensions(testSuite: TestSuite) {
   }
 }
 
-async function maybeAddGeneratedPrompts(testSuite: TestSuite, options: EvaluateOptions) {
+async function maybeAddGeneratedPrompts(testSuite: TestSuite, options: InternalEvaluateOptions) {
   if (!options.generateSuggestions) {
     return true;
   }
@@ -2052,7 +2052,7 @@ async function buildRunEvalOptions({
   concurrency: number;
   conversations: EvalConversations;
   evalId: string;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   promptIndexMap: Map<string, number>;
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
@@ -2176,7 +2176,7 @@ function appendRunEvalOptionsForTestCase({
   conversations: EvalConversations;
   evalId: string;
   nextTestIdx: number;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
   promptIndexMap: Map<string, number>;
   providerAbortSignal?: AbortSignal;
@@ -2243,7 +2243,7 @@ function appendRunEvalOptionsForVars({
   concurrency: number;
   conversations: EvalConversations;
   evalId: string;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
   promptIndexMap: Map<string, number>;
   promptPrefix: string;
@@ -2308,7 +2308,7 @@ function appendRunEvalOptionsForProvider({
   concurrency: number;
   conversations: EvalConversations;
   evalId: string;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
   promptIndexMap: Map<string, number>;
   promptPrefix: string;
@@ -2396,7 +2396,7 @@ function createRunEvalOption({
   concurrency: number;
   conversations: EvalConversations;
   evalId: string;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   prompt: Prompt;
   promptIdx: number;
   promptPrefix: string;
@@ -2581,7 +2581,7 @@ interface EvalProcessingContext {
   assertionTypes: Set<string>;
   concurrency: number;
   numComplete: number;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   promptEvalCounts: number[];
   prompts: CompletedPrompt[];
   rowsWithMaxScoreAssertion: Set<number>;
@@ -2880,14 +2880,14 @@ function usesExampleProvider(testSuite: TestSuite) {
 class Evaluator {
   evalRecord: Eval;
   testSuite: TestSuite;
-  options: EvaluateOptions;
+  options: InternalEvaluateOptions;
   stats: EvaluateStats;
   conversations: EvalConversations;
   registers: EvalRegisters;
   fileWriters: JsonlFileWriter[];
   rateLimitRegistry: RateLimitRegistry | undefined;
 
-  constructor(testSuite: TestSuite, evalRecord: Eval, options: EvaluateOptions) {
+  constructor(testSuite: TestSuite, evalRecord: Eval, options: InternalEvaluateOptions) {
     this.testSuite = testSuite;
     this.evalRecord = evalRecord;
     this.options = options;
@@ -4022,7 +4022,7 @@ class Evaluator {
     evalTimedOut: boolean;
     globalTimeout?: NodeJS.Timeout;
     maxEvalTimeMs: number;
-    options: EvaluateOptions;
+    options: InternalEvaluateOptions;
     processedIndices: Set<number>;
     progressBarManager: ProgressBarManager | null;
     prompts: CompletedPrompt[];
@@ -4135,7 +4135,7 @@ class Evaluator {
     assertionTypes: Set<string>;
     concurrency: number;
     evalTimedOut: boolean;
-    options: EvaluateOptions;
+    options: InternalEvaluateOptions;
     prompts: CompletedPrompt[];
     startTime: number;
     testSuite: TestSuite;
@@ -4531,7 +4531,7 @@ class Evaluator {
 export function evaluate(
   testSuite: TestSuite,
   evalRecord: Eval,
-  options: EvaluateOptions,
+  options: InternalEvaluateOptions,
 ): Promise<Eval> {
   const ev = new Evaluator(testSuite, evalRecord, options);
   return ev.evaluate();

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -53,7 +53,6 @@ import {
   type AssertionType,
   type AtomicTestCase,
   type CompletedPrompt,
-  type EvaluateOptions,
   type EvaluateResult,
   type EvaluateStats,
   type GradingResult,
@@ -108,6 +107,7 @@ import type {
   Vars,
   VarValue,
 } from './types/index';
+import type { InternalEvaluateOptions as EvaluateOptions } from './types/internal';
 import type { CallApiContextParams } from './types/providers';
 
 export class PromptSuggestionsRejectedError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,8 @@
 import assertions from './assertions/index';
 import * as cache from './cache';
-import cliState from './cliState';
-import { evaluate as doEvaluate } from './evaluator';
-import { getAuthor } from './globalConfig/accounts';
+import { evaluateWithSource } from './evaluate';
 import guardrails from './guardrails';
-import logger from './logger';
-import { runDbMigrations } from './migrate';
-import Eval from './models/eval';
-import { sanitizeProvider } from './models/evalResult';
-import { processPrompts, readProviderPromptMap } from './prompts/index';
-import { loadApiProvider, loadApiProviders, resolveProvider } from './providers/index';
+import { loadApiProvider, loadApiProviders } from './providers/index';
 import { doGenerateRedteam } from './redteam/commands/generate';
 import { extractEntities } from './redteam/extraction/entities';
 import { extractMcpToolsInfo } from './redteam/extraction/mcpTools';
@@ -19,23 +12,9 @@ import { RedteamGraderBase, RedteamPluginBase } from './redteam/plugins/base';
 import { Plugins } from './redteam/plugins/index';
 import { doRedteamRun } from './redteam/shared';
 import { Strategies } from './redteam/strategies/index';
-import { createShareableUrl, isSharingEnabled } from './share';
-import { isApiProvider } from './types/providers';
-import { isTransformFunction } from './types/transform';
-import { maybeLoadFromExternalFile } from './util/file';
-import { readFilters, writeMultipleOutputs, writeOutput } from './util/index';
-import { readTests } from './util/testCaseReader';
-import { INLINE_FUNCTION_LABEL, TRANSFORM_KEYS } from './util/transform';
 
-import type {
-  EvaluateOptions,
-  EvaluateTestSuite,
-  Scenario,
-  TestCase,
-  TestSuite,
-  UnifiedConfig,
-} from './types/index';
-import type { ApiProvider } from './types/providers';
+import type { RedteamRunOptions } from './redteam/types';
+import type { EvaluateOptions, EvaluateTestSuite } from './types/index';
 
 export { EvalRunError } from './commands/eval';
 export { PromptSuggestionsRejectedError } from './evaluator';
@@ -58,173 +37,6 @@ export type {
   ExtensionHookContextMap,
 } from './evaluatorHelpers';
 export type { TransformContext, TransformFunction, TransformPrompt } from './types/transform';
-
-/**
- * Shallow-clone a test case so the caller can swap in resolved ApiProvider
- * instances on `options.provider` / `assert[].provider` without leaking those
- * mutations back to the input. The input may alias the unified config written
- * to the Eval record, and a live SDK client (e.g. Bedrock's BedrockRuntime,
- * Anthropic's client) holds circular references that break drizzle's JSON
- * serialization on `evalRecord.save()`. Fixes #8687.
- *
- * Detaches only `options` and `assert[]`. Other reference fields (`provider`,
- * `vars`, `metadata`, `providerOutput`) remain aliased — callers must reassign
- * those by reference rather than mutating in place. `assert-set` children are
- * not deep-cloned because the resolve loop skips `assert-set`; if that ever
- * changes, extend this helper.
- */
-function cloneTestForResolve<T extends Pick<TestCase, 'options' | 'assert'>>(test: T): T {
-  const cloned: T = { ...test };
-  if (test.options) {
-    cloned.options = { ...test.options };
-  }
-  if (test.assert) {
-    cloned.assert = test.assert.map((assertion) => ({ ...assertion }));
-  }
-  return cloned;
-}
-
-function toSerializableProviderRef(provider: unknown): unknown {
-  if (isApiProvider(provider)) {
-    return sanitizeProvider(provider);
-  }
-  if (Array.isArray(provider)) {
-    return provider.map(toSerializableProviderRef);
-  }
-  return provider;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-}
-
-function withSerializableProvider<T extends Record<string, unknown>>(record: T): T {
-  if (!isApiProvider(record.provider)) {
-    return record;
-  }
-  return {
-    ...record,
-    provider: sanitizeProvider(record.provider),
-  };
-}
-
-/**
- * Function-valued transforms are first-class at runtime but are silently dropped
- * by `JSON.stringify`. Persisted eval configs (drizzle-stored) must never retain
- * a function reference, so replace every `transform`-like field with a
- * `[inline function]: name` marker. Non-function values pass through unchanged.
- *
- * `droppedRef.value` is flipped to `true` the first time a function is replaced
- * so the caller can emit a single warning instead of logging per field.
- */
-function replaceFunctionTransforms<T extends Record<string, unknown>>(
-  record: T,
-  droppedRef: { value: boolean },
-): T {
-  let result: T | undefined;
-  for (const key of TRANSFORM_KEYS) {
-    const value = record[key];
-    if (!isTransformFunction(value)) {
-      continue;
-    }
-    if (!result) {
-      result = { ...record };
-    }
-    (result as Record<string, unknown>)[key] = value.name
-      ? `${INLINE_FUNCTION_LABEL}: ${value.name}`
-      : INLINE_FUNCTION_LABEL;
-    droppedRef.value = true;
-  }
-  return result ?? record;
-}
-
-function toSerializableAssertion(assertion: unknown, droppedRef: { value: boolean }): unknown {
-  if (!isRecord(assertion)) {
-    return assertion;
-  }
-
-  let sanitizedAssertion = withSerializableProvider(assertion);
-  sanitizedAssertion = replaceFunctionTransforms(sanitizedAssertion, droppedRef);
-
-  if (Array.isArray(assertion.assert)) {
-    sanitizedAssertion = {
-      ...sanitizedAssertion,
-      assert: assertion.assert.map((a) => toSerializableAssertion(a, droppedRef)),
-    };
-  }
-
-  return sanitizedAssertion;
-}
-
-function toSerializableTestCase(test: unknown, droppedRef: { value: boolean }): unknown {
-  if (!isRecord(test)) {
-    return test;
-  }
-
-  let sanitizedTest = withSerializableProvider(test);
-
-  if (isRecord(test.options)) {
-    let options = withSerializableProvider(test.options);
-    options = replaceFunctionTransforms(options, droppedRef);
-    if (options !== test.options) {
-      sanitizedTest = {
-        ...sanitizedTest,
-        options,
-      };
-    }
-  }
-
-  if (Array.isArray(test.assert)) {
-    sanitizedTest = {
-      ...sanitizedTest,
-      assert: test.assert.map((a) => toSerializableAssertion(a, droppedRef)),
-    };
-  }
-
-  return sanitizedTest;
-}
-
-function toSerializableScenario(scenario: unknown, droppedRef: { value: boolean }): unknown {
-  if (!isRecord(scenario)) {
-    return scenario;
-  }
-
-  if (!Array.isArray(scenario.tests)) {
-    return scenario;
-  }
-
-  return {
-    ...scenario,
-    tests: scenario.tests.map((t) => toSerializableTestCase(t, droppedRef)),
-  };
-}
-
-function createSerializableUnifiedConfig(
-  testSuite: EvaluateTestSuite,
-  prompts: TestSuite['prompts'],
-): Partial<UnifiedConfig> {
-  const droppedRef = { value: false };
-  const config = {
-    ...testSuite,
-    providers: toSerializableProviderRef(testSuite.providers),
-    defaultTest: toSerializableTestCase(testSuite.defaultTest, droppedRef),
-    tests: Array.isArray(testSuite.tests)
-      ? testSuite.tests.map((t) => toSerializableTestCase(t, droppedRef))
-      : testSuite.tests,
-    scenarios: Array.isArray(testSuite.scenarios)
-      ? testSuite.scenarios.map((s) => toSerializableScenario(s, droppedRef))
-      : testSuite.scenarios,
-    prompts,
-  } as Partial<UnifiedConfig>;
-
-  if (droppedRef.value && testSuite.writeLatestResults) {
-    logger.warn(
-      'Function-valued transform(s) in testSuite were replaced with "[inline function]" markers in the persisted config. Re-running the saved eval will not invoke them; use string expressions or file:// references if you need the config to round-trip.',
-    );
-  }
-
-  return config;
-}
 
 /**
  * Run an evaluation test suite.
@@ -287,156 +99,13 @@ function createSerializableUnifiedConfig(
  * @see runAssertion for testing specific outputs
  */
 async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions = {}) {
-  const { author: suiteAuthor, ...testSuiteConfig } = testSuite;
+  return evaluateWithSource(testSuite, { ...options, eventSource: 'library' });
+}
 
-  if (testSuiteConfig.writeLatestResults) {
-    await runDbMigrations();
-  }
+type LibraryRedteamRunOptions = Omit<RedteamRunOptions, 'eventSource'>;
 
-  const loadedProviders = await loadApiProviders(testSuiteConfig.providers, {
-    env: testSuiteConfig.env,
-  });
-  const providerMap: Record<string, ApiProvider> = {};
-  for (const p of loadedProviders) {
-    providerMap[p.id()] = p;
-    if (p.label) {
-      providerMap[p.label] = p;
-    }
-  }
-
-  // Resolve defaultTest from file reference if needed
-  let resolvedDefaultTest = testSuiteConfig.defaultTest;
-  if (
-    typeof testSuiteConfig.defaultTest === 'string' &&
-    testSuiteConfig.defaultTest.startsWith('file://')
-  ) {
-    resolvedDefaultTest = await maybeLoadFromExternalFile(testSuiteConfig.defaultTest);
-  }
-
-  const constructedTestSuite: TestSuite = {
-    ...testSuiteConfig,
-    defaultTest: resolvedDefaultTest as TestSuite['defaultTest'],
-    scenarios: testSuiteConfig.scenarios as Scenario[],
-    providers: loadedProviders,
-    tests: await readTests(testSuiteConfig.tests),
-
-    nunjucksFilters: await readFilters(testSuiteConfig.nunjucksFilters || {}),
-
-    // Full prompts expected (not filepaths)
-    prompts: await processPrompts(testSuiteConfig.prompts),
-  };
-
-  // Resolve nested providers. `constructedTestSuite` shallow-shares `defaultTest`
-  // and `readTests()` shallow-copies inline test cases, so detach via
-  // `cloneTestForResolve()` before mutating — see helper docstring for the why.
-  if (typeof constructedTestSuite.defaultTest === 'object' && constructedTestSuite.defaultTest) {
-    constructedTestSuite.defaultTest = cloneTestForResolve(constructedTestSuite.defaultTest);
-
-    if (
-      constructedTestSuite.defaultTest.provider &&
-      !isApiProvider(constructedTestSuite.defaultTest.provider)
-    ) {
-      constructedTestSuite.defaultTest.provider = await resolveProvider(
-        constructedTestSuite.defaultTest.provider,
-        providerMap,
-        { env: testSuiteConfig.env, basePath: cliState.basePath },
-      );
-    }
-    if (
-      constructedTestSuite.defaultTest.options?.provider &&
-      !isApiProvider(constructedTestSuite.defaultTest.options.provider)
-    ) {
-      constructedTestSuite.defaultTest.options.provider = await resolveProvider(
-        constructedTestSuite.defaultTest.options.provider,
-        providerMap,
-        { env: testSuiteConfig.env, basePath: cliState.basePath },
-      );
-    }
-  }
-
-  constructedTestSuite.tests = (constructedTestSuite.tests || []).map(cloneTestForResolve);
-
-  for (const test of constructedTestSuite.tests) {
-    if (test.options?.provider && !isApiProvider(test.options.provider)) {
-      test.options.provider = await resolveProvider(test.options.provider, providerMap, {
-        env: testSuiteConfig.env,
-        basePath: cliState.basePath,
-      });
-    }
-    for (const assertion of test.assert || []) {
-      if (assertion.type === 'assert-set' || typeof assertion.provider === 'function') {
-        continue;
-      }
-      if (assertion.provider && !isApiProvider(assertion.provider)) {
-        assertion.provider = await resolveProvider(assertion.provider, providerMap, {
-          env: testSuiteConfig.env,
-          basePath: cliState.basePath,
-        });
-      }
-    }
-  }
-
-  const parsedProviderPromptMap = readProviderPromptMap(
-    testSuiteConfig,
-    constructedTestSuite.prompts,
-  );
-  // INVARIANT: the unified config persisted to the Eval record must not alias any
-  // object mutated above with a resolved ApiProvider (see `cloneTestForResolve()`).
-  // Live SDK clients hold circular refs and break drizzle JSON serialization on
-  // `evalRecord.save()`. Fixes #8687.
-  const unifiedConfig = createSerializableUnifiedConfig(
-    testSuiteConfig,
-    constructedTestSuite.prompts,
-  );
-  const author = getAuthor(suiteAuthor);
-  const evalRecord = testSuiteConfig.writeLatestResults
-    ? await Eval.create(unifiedConfig, constructedTestSuite.prompts, { author })
-    : new Eval(unifiedConfig, { author });
-
-  // Run the eval!
-  const ret = await cache.withCacheEnabled(options.cache === false ? false : undefined, () =>
-    doEvaluate(
-      {
-        ...constructedTestSuite,
-        providerPromptMap: parsedProviderPromptMap,
-      },
-      evalRecord,
-      {
-        eventSource: 'library',
-        isRedteam: Boolean(testSuiteConfig.redteam),
-        ...options,
-      },
-    ),
-  );
-
-  // Handle sharing if enabled
-  if (testSuiteConfig.writeLatestResults && testSuiteConfig.sharing) {
-    if (isSharingEnabled(ret)) {
-      try {
-        const shareableUrl = await createShareableUrl(ret, { silent: true });
-        if (shareableUrl) {
-          ret.shareableUrl = shareableUrl;
-          ret.shared = true;
-          logger.debug(`Eval shared successfully: ${shareableUrl}`);
-        }
-      } catch (error) {
-        // Don't fail the evaluation if sharing fails
-        logger.warn(`Failed to create shareable URL: ${error}`);
-      }
-    } else {
-      logger.debug('Sharing requested but not enabled (check cloud config or sharing settings)');
-    }
-  }
-
-  if (testSuiteConfig.outputPath) {
-    if (typeof testSuiteConfig.outputPath === 'string') {
-      await writeOutput(testSuiteConfig.outputPath, evalRecord, null);
-    } else if (Array.isArray(testSuiteConfig.outputPath)) {
-      await writeMultipleOutputs(testSuiteConfig.outputPath, evalRecord, null);
-    }
-  }
-
-  return ret;
+async function runRedteam(options: LibraryRedteamRunOptions = {}) {
+  return doRedteamRun({ ...options, eventSource: 'library' });
 }
 
 const redteam = {
@@ -453,7 +122,7 @@ const redteam = {
     Grader: RedteamGraderBase,
   },
   generate: doGenerateRedteam,
-  run: doRedteamRun,
+  run: runRedteam,
 };
 
 export { assertions, cache, evaluate, guardrails, loadApiProvider, loadApiProviders, redteam };

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -156,10 +156,11 @@ evalRouter.post('/job', (req: Request, res: Response): void => {
   });
 
   evaluateWithSource(
-    Object.assign({}, testSuite as EvaluateTestSuite, {
+    {
+      ...(testSuite as EvaluateTestSuite),
       writeLatestResults: true,
       sharing: testSuite.sharing ?? shouldShareResults({}),
-    }),
+    },
     {
       ...evaluateOptions,
       eventSource: 'web',

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { HUMAN_ASSERTION_TYPE } from '../../constants';
+import { evaluateWithSource } from '../../evaluate';
 import { getUserEmail, setUserEmail } from '../../globalConfig/accounts';
-import promptfoo from '../../index';
 import logger from '../../logger';
 import Eval, { EvalQueries } from '../../models/eval';
 import EvalResult from '../../models/evalResult';
@@ -155,23 +155,23 @@ evalRouter.post('/job', (req: Request, res: Response): void => {
     logs: [],
   });
 
-  promptfoo
-    .evaluate(
-      Object.assign({}, testSuite as EvaluateTestSuite, {
-        writeLatestResults: true,
-        sharing: testSuite.sharing ?? shouldShareResults({}),
-      }),
-      Object.assign({}, evaluateOptions, {
-        eventSource: 'web',
-        progressCallback: (progress: number, total: number) => {
-          const job = evalJobs.get(id);
-          invariant(job, 'Job not found');
-          job.progress = progress;
-          job.total = total;
-          console.log(`[${id}] ${progress}/${total}`);
-        },
-      }),
-    )
+  evaluateWithSource(
+    Object.assign({}, testSuite as EvaluateTestSuite, {
+      writeLatestResults: true,
+      sharing: testSuite.sharing ?? shouldShareResults({}),
+    }),
+    {
+      ...evaluateOptions,
+      eventSource: 'web',
+      progressCallback: (progress: number, total: number) => {
+        const job = evalJobs.get(id);
+        invariant(job, 'Job not found');
+        job.progress = progress;
+        job.total = total;
+        console.log(`[${id}] ${progress}/${total}`);
+      },
+    },
+  )
     .then(async (evalResult) => {
       const job = evalJobs.get(id);
       invariant(job, 'Job not found');
@@ -632,7 +632,7 @@ evalRouter.post('/replay', async (req: Request, res: Response): Promise<void> =>
     }
 
     // Run the prompt through the provider
-    const result = await promptfoo.evaluate(
+    const result = await evaluateWithSource(
       {
         prompts: [
           {

--- a/src/tracing/evaluatorTracing.ts
+++ b/src/tracing/evaluatorTracing.ts
@@ -4,7 +4,8 @@ import { getEnvBool } from '../envars';
 import logger from '../logger';
 import telemetry from '../telemetry';
 
-import type { EvaluateOptions, TestCase, TestSuite } from '../types/index';
+import type { TestCase, TestSuite } from '../types/index';
+import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
 
 // Track whether OTLP receiver has been started
 let otlpReceiverStarted = false;

--- a/src/tracing/evaluatorTracing.ts
+++ b/src/tracing/evaluatorTracing.ts
@@ -5,7 +5,7 @@ import logger from '../logger';
 import telemetry from '../telemetry';
 
 import type { TestCase, TestSuite } from '../types/index';
-import type { InternalEvaluateOptions as EvaluateOptions } from '../types/internal';
+import type { InternalEvaluateOptions } from '../types/internal';
 
 // Track whether OTLP receiver has been started
 let otlpReceiverStarted = false;
@@ -155,7 +155,7 @@ export function isTracingEnabled(test: TestCase, testSuite?: TestSuite): boolean
  */
 export async function generateTraceContextIfNeeded(
   test: TestCase,
-  evaluateOptions: EvaluateOptions | undefined,
+  evaluateOptions: InternalEvaluateOptions | undefined,
   testIdx: number,
   promptIdx: number,
   testSuite?: TestSuite,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,6 @@ export { ProvidersSchema };
 
 import { RedteamConfigSchema } from '../validators/redteam';
 import { NunjucksFilterMapSchema, StringOrFunctionSchema } from '../validators/shared';
-import { EventSourceSchema } from './eventSource';
 
 export {
   EVENT_SOURCES,
@@ -263,7 +262,6 @@ export interface RunEvalOptions {
 export const EvaluateOptionsSchema = z.object({
   cache: z.boolean().optional(),
   delay: z.number().optional(),
-  eventSource: EventSourceSchema.optional(),
   generateSuggestions: z.boolean().optional(),
   suggestionsCount: z.coerce.number().int().positive().max(MAX_SUGGESTIONS_COUNT).optional(),
   /**

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,0 +1,11 @@
+import type { EventSource } from './eventSource';
+import type { EvaluateOptions } from './index';
+
+/**
+ * Internal orchestration metadata that should not be accepted from reusable
+ * package callers. Process-lifecycle behavior keys off `eventSource`, so keep it
+ * separate from the public `EvaluateOptions` surface.
+ */
+export type InternalEvaluateOptions = EvaluateOptions & {
+  eventSource?: EventSource;
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,7 @@ import logger from '../src/logger';
 import Eval from '../src/models/eval';
 import { readProviderPromptMap } from '../src/prompts/index';
 import * as providers from '../src/providers/index';
+import { doRedteamRun } from '../src/redteam/shared';
 import * as fileUtils from '../src/util/file';
 import { writeMultipleOutputs, writeOutput } from '../src/util/index';
 import { createMockProvider } from './factories/provider';
@@ -67,6 +68,14 @@ vi.mock('../src/prompts', async () => {
   return {
     ...originalModule,
     readProviderPromptMap: vi.fn().mockReturnValue({}),
+  };
+});
+vi.mock('../src/redteam/shared', async () => {
+  const originalModule =
+    await vi.importActual<typeof import('../src/redteam/shared')>('../src/redteam/shared');
+  return {
+    ...originalModule,
+    doRedteamRun: vi.fn(),
   };
 });
 vi.mock('../src/providers', async () => {
@@ -273,6 +282,25 @@ describe('evaluate function', () => {
         ],
         providerPromptMap: {},
       }),
+      expect.anything(),
+      expect.objectContaining({
+        eventSource: 'library',
+      }),
+    );
+  });
+
+  it('should pin package callers to library semantics', async () => {
+    await evaluate(
+      {
+        prompts: ['test prompt'],
+        providers: [],
+        tests: [],
+      },
+      { eventSource: 'cli' } as never,
+    );
+
+    expect(doEvaluate).toHaveBeenCalledWith(
+      expect.anything(),
       expect.anything(),
       expect.objectContaining({
         eventSource: 'library',
@@ -924,6 +952,23 @@ describe('evaluate function', () => {
         );
       });
     });
+  });
+});
+
+describe('redteam package wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(doRedteamRun).mockResolvedValue(undefined);
+  });
+
+  it('should pin package callers to library semantics', async () => {
+    await index.redteam.run({ eventSource: 'cli' } as never);
+
+    expect(doRedteamRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventSource: 'library',
+      }),
+    );
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -961,6 +961,10 @@ describe('redteam package wrapper', () => {
     vi.mocked(doRedteamRun).mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.mocked(doRedteamRun).mockReset();
+  });
+
   it('should pin package callers to library semantics', async () => {
     await index.redteam.run({ eventSource: 'cli' } as never);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -560,6 +560,17 @@ describe('evaluate function', () => {
     expect(writeOutput).toHaveBeenCalledWith('test.json', expect.any(Eval), null);
   });
 
+  it('should skip writing output when outputPath is empty', async () => {
+    const testSuite = {
+      prompts: ['test'],
+      providers: [],
+      outputPath: '',
+    };
+    await evaluate(testSuite);
+    expect(writeOutput).not.toHaveBeenCalled();
+    expect(writeMultipleOutputs).not.toHaveBeenCalled();
+  });
+
   it('should write multiple outputs when outputPath is an array', async () => {
     const testSuite = {
       prompts: ['test'],

--- a/test/server/routes/eval.sharing.test.ts
+++ b/test/server/routes/eval.sharing.test.ts
@@ -4,12 +4,10 @@ import request from 'supertest';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies BEFORE imports
-vi.mock('../../../src/index', () => ({
-  default: {
-    evaluate: vi.fn().mockResolvedValue({
-      toEvaluateSummary: vi.fn().mockResolvedValue({ results: [] }),
-    }),
-  },
+vi.mock('../../../src/evaluate', () => ({
+  evaluateWithSource: vi.fn().mockResolvedValue({
+    toEvaluateSummary: vi.fn().mockResolvedValue({ results: [] }),
+  }),
 }));
 
 vi.mock('../../../src/util/sharing', () => ({
@@ -23,7 +21,7 @@ vi.mock('../../../src/models/eval', () => ({
 }));
 vi.mock('../../../src/globalConfig/accounts');
 
-import promptfoo from '../../../src/index';
+import { evaluateWithSource } from '../../../src/evaluate';
 import logger from '../../../src/logger';
 import Eval from '../../../src/models/eval';
 import { createApp } from '../../../src/server/server';
@@ -31,7 +29,7 @@ import { shouldShareResults } from '../../../src/util/sharing';
 
 const errorSpy = vi.spyOn(logger, 'error');
 const mockedEvalCreate = vi.mocked(Eval.create);
-const mockedEvaluate = vi.mocked(promptfoo.evaluate);
+const mockedEvaluateWithSource = vi.mocked(evaluateWithSource);
 const mockedShouldShareResults = vi.mocked(shouldShareResults);
 
 describe('Eval Routes - Sharing behavior', () => {
@@ -60,7 +58,7 @@ describe('Eval Routes - Sharing behavior', () => {
     vi.resetAllMocks();
     errorSpy.mockClear();
 
-    mockedEvaluate.mockResolvedValue({
+    mockedEvaluateWithSource.mockResolvedValue({
       toEvaluateSummary: vi.fn().mockResolvedValue({ results: [] }),
     } as any);
 
@@ -84,10 +82,10 @@ describe('Eval Routes - Sharing behavior', () => {
 
     // Wait for async evaluate call
     await vi.waitFor(() => {
-      expect(mockedEvaluate).toHaveBeenCalled();
+      expect(mockedEvaluateWithSource).toHaveBeenCalled();
     });
 
-    const evaluateArg = mockedEvaluate.mock.calls[0][0] as any;
+    const evaluateArg = mockedEvaluateWithSource.mock.calls[0][0] as any;
     expect(evaluateArg.sharing).toBe(true);
   });
 
@@ -97,10 +95,10 @@ describe('Eval Routes - Sharing behavior', () => {
     await postJob({ ...minimalTestSuite, sharing: false });
 
     await vi.waitFor(() => {
-      expect(mockedEvaluate).toHaveBeenCalled();
+      expect(mockedEvaluateWithSource).toHaveBeenCalled();
     });
 
-    const evaluateArg = mockedEvaluate.mock.calls[0][0] as any;
+    const evaluateArg = mockedEvaluateWithSource.mock.calls[0][0] as any;
     expect(evaluateArg.sharing).toBe(false);
   });
 
@@ -110,16 +108,16 @@ describe('Eval Routes - Sharing behavior', () => {
     await postJob(minimalTestSuite);
 
     await vi.waitFor(() => {
-      expect(mockedEvaluate).toHaveBeenCalled();
+      expect(mockedEvaluateWithSource).toHaveBeenCalled();
     });
 
-    const evaluateArg = mockedEvaluate.mock.calls[0][0] as any;
+    const evaluateArg = mockedEvaluateWithSource.mock.calls[0][0] as any;
     expect(evaluateArg.sharing).toBe(true);
     expect(mockedShouldShareResults).toHaveBeenCalledWith({});
   });
 
   it('should not log the raw job body on evaluation failure', async () => {
-    mockedEvaluate.mockRejectedValueOnce(new Error('boom'));
+    mockedEvaluateWithSource.mockRejectedValueOnce(new Error('boom'));
 
     const sensitiveBody = {
       prompts: ['test prompt'],
@@ -186,10 +184,10 @@ describe('Eval Routes - Sharing behavior', () => {
     await postJob(minimalTestSuite);
 
     await vi.waitFor(() => {
-      expect(mockedEvaluate).toHaveBeenCalled();
+      expect(mockedEvaluateWithSource).toHaveBeenCalled();
     });
 
-    const evaluateArg = mockedEvaluate.mock.calls[0][0] as any;
+    const evaluateArg = mockedEvaluateWithSource.mock.calls[0][0] as any;
     expect(evaluateArg.sharing).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- pin the public package `evaluate()` and `redteam.run()` wrappers to library semantics even if callers pass an internal `eventSource`
- move event-source-aware evaluation behind an internal `evaluateWithSource()` helper so CLI/web/MCP callers can still retain their attribution
- remove `eventSource` from the public `EvaluateOptions` surface and add regression coverage for package callers trying to force CLI mode

## Why
PR #9042 fixed the default reusable watch-loop path, but package consumers could still opt back into CLI behavior by passing `eventSource: 'cli'`. That left two package-facing footguns:
- `redteam.run()` could still reach CLI SIGINT handling and call `process.exit(130)`
- `evaluate()` could still mutate host `process.exitCode`

The package entrypoints should stay host-safe regardless of caller-supplied options; only internal command/server paths should be able to select non-library event sources.

## Validation
- `source ~/.nvm/nvm.sh && nvm use >/dev/null && npm run tsc`
- `npm test -- --run test/index.test.ts test/evaluator/generatedPrompts.test.ts test/redteam/shared.test.ts test/commands/eval.test.ts test/server/routes/eval.sharing.test.ts test/config-schema.test.ts test/types/index.test.ts`
- `npm run build`
- `node --input-type=module -e "import('./dist/src/index.js').then(({ evaluate, redteam }) => console.log(JSON.stringify({ evaluate: typeof evaluate, redteamRun: typeof redteam.run })))"`
- `npm run local -- eval -c test/smoke/fixtures/configs/provider-label.yaml --no-cache -o /tmp/promptfoo-event-source-smoke.json`
- `npm run l`
- `npm run f`

The combined focused Vitest run passed 549 tests. The CLI smoke eval passed 1/1 and exported a clean result JSON.