### PR TITLE
docs(site): improve mobile nav and blog responsiveness

### DIFF
--- a/site/src/components/GitHubStars/styles.module.css
+++ b/site/src/components/GitHubStars/styles.module.css
@@ -27,8 +27,14 @@
   font-variant-numeric: tabular-nums;
 }
 
-@media screen and (max-width: 1280px) {
+@media screen and (max-width: 768px) {
   .githubStars {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 1280px) {
+  :global(.docs-wrapper) .githubStars {
     display: none;
   }
 }

--- a/site/src/components/GitHubStars/styles.module.css
+++ b/site/src/components/GitHubStars/styles.module.css
@@ -27,7 +27,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1280px) {
   .githubStars {
     display: none;
   }

--- a/site/src/components/NavMenuCard/index.tsx
+++ b/site/src/components/NavMenuCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
@@ -26,6 +26,7 @@ export default function NavMenuCard({
 }: NavMenuCardProps): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const dropdownId = useId();
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -80,17 +81,11 @@ export default function NavMenuCard({
 
   return (
     <div className={styles.navMenuCard} ref={menuRef}>
-      <div
-        className={`${styles.navMenuCardButton} navbar__link`}
+      <button
+        type="button"
+        className={`${styles.navMenuCardButton} ${isOpen ? styles.navMenuCardButtonOpen : ''} navbar__link`}
         onClick={handleToggle}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleToggle();
-          }
-        }}
-        role="button"
-        tabIndex={0}
+        aria-controls={dropdownId}
         aria-expanded={isOpen}
         aria-haspopup="true"
       >
@@ -109,9 +104,10 @@ export default function NavMenuCard({
         >
           <path d="m6 9 6 6 6-6" />
         </svg>
-      </div>
+      </button>
 
       <div
+        id={dropdownId}
         className={`${styles.navMenuCardDropdown} ${isOpen ? styles.navMenuCardDropdownOpen : ''}`}
       >
         <div className={styles.navMenuCardContainer}>

--- a/site/src/components/NavMenuCard/index.tsx
+++ b/site/src/components/NavMenuCard/index.tsx
@@ -36,15 +36,30 @@ export default function NavMenuCard({
       }
     }
 
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleEscape);
       return () => {
         document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('keydown', handleEscape);
       };
     }
   }, [isOpen]);
 
+  const canHover = () => window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
   const handleToggle = () => {
+    if (canHover()) {
+      setIsOpen(true);
+      return;
+    }
+
     setIsOpen(!isOpen);
   };
   // Group items by section
@@ -80,7 +95,25 @@ export default function NavMenuCard({
         ];
 
   return (
-    <div className={styles.navMenuCard} ref={menuRef}>
+    <div
+      className={styles.navMenuCard}
+      ref={menuRef}
+      onMouseEnter={() => {
+        if (canHover()) {
+          setIsOpen(true);
+        }
+      }}
+      onMouseLeave={() => {
+        if (canHover()) {
+          setIsOpen(false);
+        }
+      }}
+      onBlurCapture={(event) => {
+        if (!menuRef.current?.contains(event.relatedTarget as Node)) {
+          setIsOpen(false);
+        }
+      }}
+    >
       <button
         type="button"
         className={`${styles.navMenuCardButton} ${isOpen ? styles.navMenuCardButtonOpen : ''} navbar__link`}

--- a/site/src/components/NavMenuCard/styles.module.css
+++ b/site/src/components/NavMenuCard/styles.module.css
@@ -24,7 +24,6 @@
   transition: transform 0.2s ease;
 }
 
-.navMenuCard:hover .navMenuCardIcon,
 .navMenuCardButtonOpen .navMenuCardIcon {
   transform: rotate(180deg);
 }
@@ -42,13 +41,6 @@
     visibility 0.2s ease;
   padding-top: 8px;
   z-index: 1000;
-}
-
-/* Show dropdown on hover */
-.navMenuCard:hover .navMenuCardDropdown {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: all;
 }
 
 /* Inner dropdown with background and border */
@@ -134,6 +126,18 @@
 [data-theme='dark'] .navMenuCardItem:hover {
   background-color: rgba(255, 255, 255, 0.06);
   border-color: rgba(255, 255, 255, 0.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navMenuCardIcon,
+  .navMenuCardDropdown,
+  .navMenuCardItem {
+    transition: none;
+  }
+
+  .navMenuCardItem:hover {
+    transform: none;
+  }
 }
 
 /* Open state for mobile (when clicked) */

--- a/site/src/components/NavMenuCard/styles.module.css
+++ b/site/src/components/NavMenuCard/styles.module.css
@@ -11,6 +11,10 @@
   gap: 4px;
   cursor: pointer;
   padding: var(--ifm-navbar-item-padding-vertical) var(--ifm-navbar-item-padding-horizontal);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
 }
 
 /* Dropdown icon */
@@ -20,7 +24,8 @@
   transition: transform 0.2s ease;
 }
 
-.navMenuCard:hover .navMenuCardIcon {
+.navMenuCard:hover .navMenuCardIcon,
+.navMenuCardButtonOpen .navMenuCardIcon {
   transform: rotate(180deg);
 }
 
@@ -138,10 +143,6 @@
   pointer-events: all;
 }
 
-.navMenuCardDropdownOpen .navMenuCardIcon {
-  transform: rotate(180deg);
-}
-
 /* Responsive */
 @media (max-width: 1100px) {
   /* Hide dropdown menus in the top navbar but keep them for the hamburger menu */
@@ -167,6 +168,7 @@
     width: 100%;
     justify-content: space-between;
     font-weight: 600;
+    min-height: 44px;
   }
 
   .navMenuCardDropdown {
@@ -203,7 +205,10 @@
   }
 
   .navMenuCardItem {
-    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 10px 16px;
     font-size: 14px;
   }
 
@@ -212,7 +217,7 @@
   }
 
   .navMenuCardItemDescription {
-    font-size: 12px;
+    display: none;
   }
 
   .navMenuCardSectionTitle {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -203,7 +203,7 @@ html:not(.docs-wrapper) .DocSearch {
 }
 
 @media (max-width: 1280px) {
-  .navbar__items--right .header-discord-link {
+  .docs-wrapper .navbar__items--right .header-discord-link {
     display: none;
   }
 }

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -93,6 +93,7 @@ code p {
 
 .navbar__brand {
   font-family: var(--ifm-font-family-monospace);
+  flex-shrink: 0;
 }
 
 /* Hide search bar on non-docs pages */
@@ -117,14 +118,42 @@ html:not(.docs-wrapper) .DocSearch {
 /* Mobile navbar adjustments */
 @media (max-width: 1100px) {
   /* Hide search box on mobile to prevent overlap */
-  .navbar__search,
-  .DocSearch {
+  .navbar__search {
     display: none !important;
   }
 
   /* Keep hamburger top-level items consistent */
+  .navbar-sidebar__items .menu__list > .menu__list-item > .menu__link,
+  .navbar-sidebar__items .header-book-demo-link,
+  .navbar-sidebar__items .header-discord-link {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+  }
+
   .navbar-sidebar__items .menu__list > .menu__list-item > .menu__link {
     font-weight: 600;
+  }
+
+  .navbar-sidebar__items .header-discord-link {
+    gap: 12px;
+  }
+
+  .navbar-sidebar__items .header-discord-link::after {
+    content: 'Discord';
+  }
+
+  .docs-wrapper .DocSearch-Button {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .docs-wrapper .DocSearch-Button-Placeholder,
+  .docs-wrapper .DocSearch-Button-Keys {
+    display: none;
   }
 }
 
@@ -171,6 +200,12 @@ html:not(.docs-wrapper) .DocSearch {
 .navbar__items--right > :nth-last-child(2) {
   /* Equalize the spacing to the left of the color mode toggle */
   margin-left: 4px;
+}
+
+@media (max-width: 1280px) {
+  .navbar__items--right .header-discord-link {
+    display: none;
+  }
 }
 
 .dropdown > .navbar__link:after {

--- a/site/src/theme/BlogListPage/styles.module.css
+++ b/site/src/theme/BlogListPage/styles.module.css
@@ -221,6 +221,10 @@
     transform: none;
   }
 
+  .featuredPost {
+    flex-direction: column;
+  }
+
   .featuredBadge {
     top: 8px;
     left: 8px;
@@ -229,12 +233,16 @@
   }
 
   .featuredPostImage {
-    min-width: 110px;
-    max-width: 140px;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    aspect-ratio: 16 / 9;
   }
 
   .featuredPostContent {
     padding: 1rem;
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .featuredTitle {
@@ -251,6 +259,10 @@
     font-size: 0.75rem;
     padding-top: 0.5rem;
   }
+
+  .preview {
+    display: -webkit-box;
+  }
 }
 
 /* Small mobile */
@@ -260,8 +272,8 @@
   }
 
   .featuredPostImage {
-    min-width: 90px;
-    max-width: 110px;
+    min-width: 0;
+    max-width: none;
   }
 
   .featuredPostContent {


### PR DESCRIPTION
## Summary

- make the mobile navbar easier to scan by shortening expanded product menus, restoring a compact docs search action, and keeping tap targets at least 44px tall
- align flyout behavior across pointer, keyboard, and assistive tech by using real disclosure buttons, synchronized `aria-expanded` state, `Escape` dismissal, and reduced-motion handling
- improve responsive density outside the navbar by stacking featured blog cards on phones instead of squeezing them into split layouts

## Problem

The site navigation had several mobile rough edges:

- the mobile drawer reused desktop flyout content, so a single expanded section became long and text-heavy
- product menus were only visually open on desktop hover while their accessibility state still reported closed
- docs pages removed search entirely on small screens
- the blog index kept featured cards in a side-by-side layout on phones, making the lead image and copy feel cramped

Together, those issues made the site feel less intentional on small screens and created mismatches between what users saw and what keyboard or assistive-tech users could infer.

## What Changed

### Navbar and disclosure behavior

- replaced the custom faux-button disclosure with a real `<button>`
- wired each flyout to a stable `aria-controls` target and synchronized `aria-expanded`
- made desktop hover and click behavior use the same open state, with `Escape`, blur, and outside-click dismissal
- kept mobile menu rows at 44px minimum height
- hid long submenu descriptions in the drawer so users can scan destinations quickly
- preserved visible Discord text in the mobile drawer
- restored a compact icon-only docs search button on mobile
- only hide optional social chrome early on docs pages, where the header is denser
- added reduced-motion handling for flyout animation

### Blog responsiveness

- switch featured blog cards back to a stacked layout on phones
- restore a full-width image treatment and readable preview text at mobile widths

## Why This Is Better

- mobile navigation becomes faster to parse because users see destinations first, not marketing copy inside the drawer
- the visible menu state and the accessibility state now agree, which improves keyboard and screen-reader behavior
- docs users keep search access on small screens without crowding the header
- phone layouts preserve the hierarchy of featured posts instead of compressing content into a layout that only works on tablets

## Screenshots

### Mobile product menu

| Before | After |
| --- | --- |
| ![Mobile nav before](https://iili.io/BZBGUhP.png) | ![Mobile nav after](https://iili.io/BZBMH4s.png) |

### Mobile docs header

| Before | After |
| --- | --- |
| ![Docs header before](https://iili.io/BZBMd3G.png) | ![Docs header after](https://iili.io/BZBM3v4.png) |

### Featured blog cards on phones

| Before | After |
| --- | --- |
| ![Blog mobile before](https://iili.io/BZBMFyl.png) | ![Blog mobile after](https://iili.io/BZBMfu2.png) |

## Validation

- built the docs site with `SKIP_OG_GENERATION=true npm run build`
- manually exercised the home page, docs intro page, pricing page, and blog page in the browser at mobile and desktop widths
- verified mobile menu tap behavior, docs mobile search visibility, desktop flyout `aria-expanded` state, and `Escape` close behavior
- verified the before/after screenshots against a separate `origin/main` build

## Notes

- `npm run typecheck --workspace site` still fails on the pre-existing missing declaration for `js-yaml` in `site/src/pages/validator.tsx`; this branch does not change that file
