### PR TITLE
chore: remove leftover PostHog repository wiring

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -155,17 +155,6 @@
       "groupName": "langfuse"
     },
     {
-      "description": "Group PostHog packages together across all dependency types",
-      "matchPackagePatterns": ["^posthog-"],
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies"
-      ],
-      "groupName": "PostHog packages"
-    },
-    {
       "description": "Group OpenTelemetry packages together",
       "matchPackagePatterns": ["^@opentelemetry/"],
       "groupName": "OpenTelemetry"
@@ -330,13 +319,6 @@
     {
       "description": "Storybook: monthly updates to reduce noise from frequent patch releases",
       "matchPackagePatterns": ["^@storybook/", "^storybook$", "^@chromatic-com/storybook"],
-      "schedule": ["before 6am on the first day of the month"],
-      "rangeStrategy": "bump",
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "PostHog packages: monthly updates to reduce noise from frequent patch releases",
-      "matchPackagePatterns": ["^posthog-"],
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "bump",
       "minimumReleaseAge": "7 days"

--- a/site/docs/red-team/troubleshooting/data-handling.md
+++ b/site/docs/red-team/troubleshooting/data-handling.md
@@ -124,7 +124,6 @@ When using remote generation, Promptfoo requires access to:
 | ------------------- | ------------------------------------ |
 | `api.promptfoo.app` | Test generation and grading          |
 | `api.promptfoo.dev` | Consent tracking for harmful plugins |
-| `a.promptfoo.app`   | Telemetry (PostHog)                  |
 
 If blocked by your firewall, see [Remote Generation Troubleshooting](/docs/red-team/troubleshooting/remote-generation/).
 

--- a/site/static/js/scripts.js
+++ b/site/static/js/scripts.js
@@ -71,53 +71,6 @@ gtag('config', 'AW-17347444171', { anonymize_ip: true });
 })(window, document);
 vector.load('18d08a7d-45cf-4805-b8b1-978305be5dd4');
 
-!(function (t, e) {
-  var o, n, p, r;
-  e.__SV ||
-    ((window.posthog = e),
-    (e._i = []),
-    (e.init = function (i, s, a) {
-      function g(t, e) {
-        var o = e.split('.');
-        2 == o.length && ((t = t[o[0]]), (e = o[1])),
-          (t[e] = function () {
-            t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-          });
-      }
-      ((p = t.createElement('script')).type = 'text/javascript'),
-        (p.async = !0),
-        (p.src =
-          s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-        (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
-      var u = e;
-      for (
-        void 0 === a ? (a = 'posthog') : (u = e[a] = []),
-          u.people = u.people || [],
-          u.toString = function (t) {
-            var e = 'posthog';
-            return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
-          },
-          u.people.toString = function () {
-            return u.toString(1) + '.people (stub)';
-          },
-          o =
-            'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonProperties'.split(
-              ' ',
-            ),
-          n = 0;
-        n < o.length;
-        n++
-      )
-        g(u, o[n]);
-      e._i.push([i, s, a]);
-    }),
-    (e.__SV = 1));
-})(document, window.posthog || []);
-posthog.init('phc_gOS5ctlYqd64vmJtYVpAU0W5iew7OopcETkyYNpkyYP', {
-  api_host: 'https://us.i.posthog.com',
-  person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
-});
-
 /* Reo */
 !(function () {
   var e, t, n;


### PR DESCRIPTION
## Summary
- remove the remaining repo-level PostHog wiring after the backend/frontend cuts
- delete the docs-site bootstrap script, stale network-requirements row, and obsolete Renovate rules
- leave only historical changelog mentions after the stacked removal lands

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('renovate.json', 'utf8'))"`
- `rg -n "posthog|PostHog" . --glob "!node_modules/**" --glob "!dist/**" --glob "!coverage/**"` (only historical `CHANGELOG.md` matches remain)