### PR TITLE
fix(cache): stabilize Anthropic cache hashes across runs

### DIFF
--- a/src/providers/anthropic/generic.ts
+++ b/src/providers/anthropic/generic.ts
@@ -40,17 +40,28 @@ interface AnthropicBaseOptions {
 
 const ANTHROPIC_CACHE_HASH_CONTEXT = 'promptfoo:anthropic:cache-key:v1';
 
-// Canonicalize before hashing so semantically identical objects with different
-// property insertion orders produce the same cache key. See
-// `src/providers/AGENTS.md` "Cache Key Hygiene".
+// Canonicalize before hashing so semantically identical plain objects with
+// different property insertion orders produce the same cache key. See
+// `src/providers/AGENTS.md` "Cache Key Hygiene". Class instances such as
+// `Date` or `Buffer` are passed through so their `toJSON` / default
+// serialization is preserved — rebuilding them via `Object.keys` would
+// collapse distinct values to the same shape and cause cache collisions.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(canonicalize);
   }
-  if (value && typeof value === 'object') {
-    const entries = Object.keys(value as Record<string, unknown>)
+  if (isPlainObject(value)) {
+    const entries = Object.keys(value)
       .sort()
-      .map((k) => [k, canonicalize((value as Record<string, unknown>)[k])] as const);
+      .map((k) => [k, canonicalize(value[k])] as const);
     return Object.fromEntries(entries);
   }
   return value;

--- a/src/providers/anthropic/generic.ts
+++ b/src/providers/anthropic/generic.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes } from 'crypto';
+import { createHmac } from 'crypto';
 
 import Anthropic from '@anthropic-ai/sdk';
 import { getEnvString } from '../../envars';
@@ -39,37 +39,14 @@ interface AnthropicBaseOptions {
 }
 
 const ANTHROPIC_CACHE_HASH_CONTEXT = 'promptfoo:anthropic:cache-key:v1';
-const ANTHROPIC_CACHE_HASH_KEY_SYMBOL = Symbol.for('promptfoo.anthropic.cacheHashKey');
-
-function getAnthropicCacheHashKey(): Buffer {
-  const globalCache = globalThis as typeof globalThis & Record<symbol, Buffer | undefined>;
-  const existingKey = globalCache[ANTHROPIC_CACHE_HASH_KEY_SYMBOL];
-  if (existingKey) {
-    return existingKey;
-  }
-
-  const newKey = randomBytes(32);
-  globalCache[ANTHROPIC_CACHE_HASH_KEY_SYMBOL] = newKey;
-  return newKey;
-}
-
-const ANTHROPIC_CACHE_HASH_KEY = getAnthropicCacheHashKey();
 
 export function hashAnthropicCacheValue(value: unknown): string {
   const serialized = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
-  return createHmac('sha256', ANTHROPIC_CACHE_HASH_KEY)
-    .update(ANTHROPIC_CACHE_HASH_CONTEXT)
-    .update('\0')
-    .update(serialized)
-    .digest('hex');
+  return createHmac('sha256', ANTHROPIC_CACHE_HASH_CONTEXT).update(serialized).digest('hex');
 }
 
 export function getAnthropicAuthCacheNamespace(apiKey: string): string {
-  return createHmac('sha256', ANTHROPIC_CACHE_HASH_KEY)
-    .update(ANTHROPIC_CACHE_HASH_CONTEXT)
-    .update('\0')
-    .update(apiKey)
-    .digest('hex');
+  return createHmac('sha256', apiKey).update(`${ANTHROPIC_CACHE_HASH_CONTEXT}:auth`).digest('hex');
 }
 
 /**

--- a/src/providers/anthropic/generic.ts
+++ b/src/providers/anthropic/generic.ts
@@ -40,8 +40,26 @@ interface AnthropicBaseOptions {
 
 const ANTHROPIC_CACHE_HASH_CONTEXT = 'promptfoo:anthropic:cache-key:v1';
 
+// Canonicalize before hashing so semantically identical objects with different
+// property insertion orders produce the same cache key. See
+// `src/providers/AGENTS.md` "Cache Key Hygiene".
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((k) => [k, canonicalize((value as Record<string, unknown>)[k])] as const);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
 export function hashAnthropicCacheValue(value: unknown): string {
-  const serialized = typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
+  const canonical = canonicalize(value);
+  const serialized =
+    typeof canonical === 'string' ? canonical : (JSON.stringify(canonical) ?? String(canonical));
   return createHmac('sha256', ANTHROPIC_CACHE_HASH_CONTEXT).update(serialized).digest('hex');
 }
 

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -173,15 +173,24 @@ describe('AnthropicCompletionProvider', () => {
         }));
       `;
 
-      const firstRun = spawnSync(process.execPath, ['--import', 'tsx', '-e', importProbe], {
+      const spawnOptions = {
         cwd: process.cwd(),
-        encoding: 'utf8',
-      });
-      const secondRun = spawnSync(process.execPath, ['--import', 'tsx', '-e', importProbe], {
-        cwd: process.cwd(),
-        encoding: 'utf8',
-      });
+        encoding: 'utf8' as const,
+        timeout: 30_000,
+      };
+      const firstRun = spawnSync(
+        process.execPath,
+        ['--import', 'tsx', '-e', importProbe],
+        spawnOptions,
+      );
+      const secondRun = spawnSync(
+        process.execPath,
+        ['--import', 'tsx', '-e', importProbe],
+        spawnOptions,
+      );
 
+      expect(firstRun.error, firstRun.error?.message).toBeUndefined();
+      expect(secondRun.error, secondRun.error?.message).toBeUndefined();
       expect(firstRun.status, firstRun.stderr || firstRun.stdout).toBe(0);
       expect(secondRun.status, secondRun.stderr || secondRun.stdout).toBe(0);
       expect(firstRun.stdout).toBe(secondRun.stdout);
@@ -190,6 +199,25 @@ describe('AnthropicCompletionProvider', () => {
         requestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
       });
       expect(firstRun.stdout).not.toContain('sk-ant-restart-secret');
+    });
+
+    it('should produce known hex digests for fixed inputs', async () => {
+      const { getAnthropicAuthCacheNamespace, hashAnthropicCacheValue } = await import(
+        '../../../src/providers/anthropic/generic'
+      );
+
+      expect(getAnthropicAuthCacheNamespace('sk-ant-restart-secret')).toBe(
+        '7c26fdc69a372e71532057f3039c789205d499e73d7b7356842127c3f9280701',
+      );
+      expect(hashAnthropicCacheValue({ prompt: 'same prompt' })).toBe(
+        'e1436b0a7084971817a4a1cfea0202abca38ec5fcf652c536c5a1686010603cc',
+      );
+      expect(hashAnthropicCacheValue(undefined)).toBe(
+        '1a7e490079dddef29372602f205771e36d0d1e43d9da356f22194ea8f685e397',
+      );
+      expect(getAnthropicAuthCacheNamespace('')).toBe(
+        '7b632cd5180136645b21af8e6f3708e0782bdc3a9d81f094a9385cade8ce0987',
+      );
     });
 
     it('should avoid logging prompts and generated outputs in debug metadata', async () => {

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -221,9 +221,7 @@ describe('AnthropicCompletionProvider', () => {
     });
 
     it('should hash semantically identical objects to the same value regardless of key order', async () => {
-      const { hashAnthropicCacheValue } = await import(
-        '../../../src/providers/anthropic/generic'
-      );
+      const { hashAnthropicCacheValue } = await import('../../../src/providers/anthropic/generic');
 
       expect(hashAnthropicCacheValue({ a: 1, b: 2, c: 3 })).toBe(
         hashAnthropicCacheValue({ c: 3, a: 1, b: 2 }),
@@ -235,6 +233,23 @@ describe('AnthropicCompletionProvider', () => {
       );
       // Arrays preserve order — element ordering is semantically meaningful.
       expect(hashAnthropicCacheValue([1, 2, 3])).not.toBe(hashAnthropicCacheValue([3, 2, 1]));
+    });
+
+    it('should preserve non-plain-object semantics so distinct values do not collide', async () => {
+      const { hashAnthropicCacheValue } = await import('../../../src/providers/anthropic/generic');
+
+      // Date and Buffer expose state via toJSON / default serialization rather
+      // than enumerable own keys. Naïve canonicalization would rebuild them as
+      // empty/index-only objects and collapse distinct values to the same hash.
+      expect(hashAnthropicCacheValue(new Date('2026-01-01T00:00:00.000Z'))).not.toBe(
+        hashAnthropicCacheValue(new Date('2027-06-15T12:00:00.000Z')),
+      );
+      expect(hashAnthropicCacheValue({ ts: new Date('2026-01-01T00:00:00.000Z') })).not.toBe(
+        hashAnthropicCacheValue({ ts: new Date('2027-06-15T12:00:00.000Z') }),
+      );
+      expect(hashAnthropicCacheValue(Buffer.from('alpha'))).not.toBe(
+        hashAnthropicCacheValue(Buffer.from('beta')),
+      );
     });
 
     it('should avoid logging prompts and generated outputs in debug metadata', async () => {

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -220,6 +220,23 @@ describe('AnthropicCompletionProvider', () => {
       );
     });
 
+    it('should hash semantically identical objects to the same value regardless of key order', async () => {
+      const { hashAnthropicCacheValue } = await import(
+        '../../../src/providers/anthropic/generic'
+      );
+
+      expect(hashAnthropicCacheValue({ a: 1, b: 2, c: 3 })).toBe(
+        hashAnthropicCacheValue({ c: 3, a: 1, b: 2 }),
+      );
+      expect(
+        hashAnthropicCacheValue({ messages: [{ role: 'user', content: 'hi' }], model: 'claude' }),
+      ).toBe(
+        hashAnthropicCacheValue({ model: 'claude', messages: [{ content: 'hi', role: 'user' }] }),
+      );
+      // Arrays preserve order — element ordering is semantically meaningful.
+      expect(hashAnthropicCacheValue([1, 2, 3])).not.toBe(hashAnthropicCacheValue([3, 2, 1]));
+    });
+
     it('should avoid logging prompts and generated outputs in debug metadata', async () => {
       const provider = new AnthropicCompletionProvider('claude-1');
       const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache, disableCache, enableCache, getCache } from '../../../src/cache';
 import logger from '../../../src/logger';
@@ -159,6 +161,35 @@ describe('AnthropicCompletionProvider', () => {
       expect(firstNamespace).toBe(secondNamespace);
       expect(firstNamespace).toMatch(/^[a-f0-9]{64}$/);
       expect(firstNamespace).not.toContain('sk-ant-reload-secret');
+    });
+
+    it('should keep cache key hashes stable across fresh processes', () => {
+      const importProbe = `
+        const { getAnthropicAuthCacheNamespace, hashAnthropicCacheValue } =
+          await import('./src/providers/anthropic/generic.ts');
+        process.stdout.write(JSON.stringify({
+          authNamespace: getAnthropicAuthCacheNamespace('sk-ant-restart-secret'),
+          requestHash: hashAnthropicCacheValue({ prompt: 'same prompt' }),
+        }));
+      `;
+
+      const firstRun = spawnSync(process.execPath, ['--import', 'tsx', '-e', importProbe], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      });
+      const secondRun = spawnSync(process.execPath, ['--import', 'tsx', '-e', importProbe], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      });
+
+      expect(firstRun.status, firstRun.stderr || firstRun.stdout).toBe(0);
+      expect(secondRun.status, secondRun.stderr || secondRun.stdout).toBe(0);
+      expect(firstRun.stdout).toBe(secondRun.stdout);
+      expect(JSON.parse(firstRun.stdout)).toMatchObject({
+        authNamespace: expect.stringMatching(/^[a-f0-9]{64}$/),
+        requestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+      expect(firstRun.stdout).not.toContain('sk-ant-restart-secret');
     });
 
     it('should avoid logging prompts and generated outputs in debug metadata', async () => {


### PR DESCRIPTION
## Summary
- keep Anthropic cache-key hashing stable across fresh processes
- fingerprint Anthropic credentials without embedding raw API keys in cache entries
- add a regression test that compares hashes produced by two separate Node processes

## Why
`d1f1e5b48` introduced per-process random HMAC material for Anthropic cache keys. That kept secrets out of the key string, but it also meant the same request generated a different disk-cache key after each fresh process start, so later CLI runs could not reuse prior Anthropic cache entries.

## Validation
- `npm_config_cache=/tmp/promptfoo-npm-cache npx vitest run test/providers/anthropic/completion.test.ts test/providers/anthropic/messages.test.ts --sequence.shuffle=false`
- `npm_config_cache=/tmp/promptfoo-npm-cache npm run l`
- `npm_config_cache=/tmp/promptfoo-npm-cache npm run f`