### PR TITLE
fix(redteam): keep results toolbar visible

### DIFF
--- a/src/app/src/pages/eval/components/ResultsChartsSection.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsChartsSection.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ResultsChartsSection } from './ResultsView';
+
+describe('ResultsChartsSection', () => {
+  it('keeps children visible while hiding chart controls for redteam evals', () => {
+    render(
+      <ResultsChartsSection
+        canRenderResultsCharts
+        isRedteamEval
+        resultsChartsScores={[0.2, 0.8]}
+        resultsChartsUnavailableReasons={[]}
+      >
+        {(chartsToggleButton) => (
+          <>
+            <div>Results toolbar</div>
+            {chartsToggleButton}
+          </>
+        )}
+      </ResultsChartsSection>,
+    );
+
+    expect(screen.getByText('Results toolbar')).toBeInTheDocument();
+    expect(screen.queryByText('Show Charts')).toBeNull();
+    expect(screen.queryByText('Hide Charts')).toBeNull();
+  });
+});

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -65,7 +65,7 @@ interface ResultsChartsSectionProps {
   isRedteamEval: boolean;
   resultsChartsScores: number[];
   resultsChartsUnavailableReasons: string[];
-  children: (toggleButton: React.ReactNode) => React.ReactNode;
+  children: (toggleButton: React.ReactNode | null) => React.ReactNode;
 }
 
 interface AppliedFilterBadgesProps {
@@ -166,7 +166,7 @@ function AppliedFilterBadges({
   });
 }
 
-function ResultsChartsSection({
+export function ResultsChartsSection({
   canRenderResultsCharts,
   isRedteamEval,
   resultsChartsScores,
@@ -178,7 +178,7 @@ function ResultsChartsSection({
   );
 
   if (isRedteamEval) {
-    return null;
+    return <>{children(null)}</>;
   }
 
   const toggleButton = (


### PR DESCRIPTION
## Summary
- keep the shared eval-results toolbar visible for red-team evals
- continue hiding chart controls and chart content for red-team evals
- add focused regression coverage for the red-team chart-wrapper path

## Why
Red-team evals intentionally suppress charts, but the shared toolbar was nested inside the same wrapper. Returning `null` for red-team evals therefore hid the search controls, display selector, and red-team filter chips along with the charts.

## Validation
- `npm run test:app -- src/pages/eval/components/ResultsChartsSection.test.tsx src/pages/eval/components/ResultsView.test.tsx src/pages/eval/components/FilterChips.test.tsx --run`
- `npm run l`
- `npm run f`
