### PR TITLE
fix(redteam): refine report table layout

### DIFF
--- a/src/app/src/components/data-table/data-table-toolbar.tsx
+++ b/src/app/src/components/data-table/data-table-toolbar.tsx
@@ -28,8 +28,8 @@ export function DataTableToolbar<TData>({
   toolbarActions,
 }: DataTableToolbarProps<TData>) {
   return (
-    <div className="flex items-center justify-between gap-2 p-2 border-b border-border">
-      <div className="flex items-center gap-2">
+    <div className="flex flex-col gap-2 border-b border-border p-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-wrap items-center gap-2">
         {showColumnToggle && (
           <DataTableColumnToggle
             table={table}
@@ -61,7 +61,7 @@ export function DataTableToolbar<TData>({
       </div>
 
       {showGlobalFilter && (
-        <div className="relative max-w-sm">
+        <div className="relative w-full sm:w-64">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-gray-500 dark:text-gray-400" />
           <Input
             placeholder="Search..."

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -953,7 +953,7 @@ describe('DataTable', () => {
     expect(headerCells[3].className).toContain('overflow-hidden');
   });
 
-  it('should reserve inline space for sortable header actions without absolute positioning', () => {
+  it('should overlay sortable header actions without consuming label width', () => {
     const layoutColumns: ColumnDef<TestRow>[] = [
       {
         accessorKey: 'id',
@@ -977,7 +977,8 @@ describe('DataTable', () => {
       const headerLabel = screen.getByText(headerText);
       const headerContent = headerLabel.closest('div');
       expect(headerContent).not.toBeNull();
-      expect(headerContent).toHaveClass('flex', 'min-w-0', 'items-center', 'gap-1');
+      expect(headerContent).toHaveClass('flex', 'min-w-0', 'items-center');
+      expect(headerContent).not.toHaveClass('gap-1');
       expect(headerContent).toHaveClass('overflow-hidden');
 
       if (shouldBeRightAligned) {
@@ -990,8 +991,8 @@ describe('DataTable', () => {
 
       const actionGroup = headerContent?.querySelector('button')?.closest('span');
       expect(actionGroup).toBeInTheDocument();
-      expect(actionGroup).toHaveClass('flex', 'shrink-0', 'items-center');
-      expect(actionGroup).not.toHaveClass('absolute', 'left-0', 'right-0');
+      expect(actionGroup).toHaveClass('absolute', 'right-1', 'items-center');
+      expect(actionGroup).not.toHaveClass('shrink-0', 'left-0');
     };
 
     assertHeaderLayout('Identifier');
@@ -1346,6 +1347,50 @@ describe('DataTable', () => {
 
       const expandedRow = screen.getByTestId('expanded-1').closest('tr');
       expect(expandedRow).toHaveClass('bg-transparent');
+    });
+  });
+
+  describe('sticky columns', () => {
+    it('should pin configured edge columns during horizontal scrolling', () => {
+      const stickyColumns: ColumnDef<TestRow>[] = [
+        {
+          accessorKey: 'id',
+          header: 'Identifier',
+          size: 96,
+          meta: { sticky: 'left' },
+        },
+        {
+          accessorKey: 'name',
+          header: 'Name',
+          size: 160,
+        },
+        {
+          id: 'actions',
+          header: 'Actions',
+          size: 80,
+          meta: { sticky: 'right' },
+          cell: () => 'Open',
+        },
+      ];
+      const data: TestRow[] = [{ id: '1', name: 'Pinned row' }];
+
+      render(<DataTable columns={stickyColumns} data={data} />);
+
+      const leftHeader = screen.getByText('Identifier').closest('th');
+      const rightHeader = screen.getByText('Actions').closest('th');
+      const leftCell = screen.getByText('1').closest('td');
+      const rightCell = screen.getByText('Open').closest('td');
+
+      expect(leftHeader).toHaveClass('sticky');
+      expect(leftHeader).toHaveStyle({ left: '0px' });
+      expect(leftHeader).toHaveClass('border-r');
+      expect(rightHeader).toHaveClass('sticky');
+      expect(rightHeader).toHaveStyle({ right: '0px' });
+      expect(rightHeader).toHaveClass('border-l');
+      expect(leftCell).toHaveClass('sticky');
+      expect(leftCell).toHaveStyle({ left: '0px' });
+      expect(rightCell).toHaveClass('sticky');
+      expect(rightCell).toHaveStyle({ right: '0px' });
     });
   });
 });

--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -35,6 +35,12 @@ import type { DataTableProps } from './types';
 const UTILITY_COLUMN_IDS = new Set(['select', 'expand']);
 
 type RowDisplayMode = 'client-virtualized' | 'server-virtualized';
+type StickyColumnSide = 'left' | 'right';
+type StickyColumnPosition = {
+  side: StickyColumnSide;
+  offset: number;
+  isBoundary: boolean;
+};
 
 type DataTableHeaderActionsProps<TData, TValue> = {
   canFilter: boolean;
@@ -91,7 +97,7 @@ function renderDataTableHeaderActions<TData, TValue>({
   return (
     <span
       className={cn(
-        'flex shrink-0 items-center gap-0.5',
+        'absolute right-1 top-1/2 z-[2] flex -translate-y-1/2 items-center gap-0.5 rounded-sm bg-white/95 pl-1 dark:bg-zinc-900/95',
         'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity',
         (sortDirection || isFiltered) && 'opacity-100 pointer-events-auto',
       )}
@@ -131,6 +137,7 @@ function renderDataTableHeaderResizeHandle<TData, TValue>(header: Header<TData, 
 
 function renderDataTableHeaderCell<TData, TValue = unknown>(
   header: Header<TData, TValue>,
+  stickyColumnPosition?: StickyColumnPosition,
   showFilter = true,
 ) {
   const canSort = header.column.getCanSort();
@@ -149,18 +156,26 @@ function renderDataTableHeaderCell<TData, TValue = unknown>(
         isRightAligned ? 'text-right' : 'text-left',
         isUtilityColumn ? 'px-3' : 'px-4 overflow-hidden',
         canSort && 'cursor-pointer select-none',
+        stickyColumnPosition && 'sticky z-20 print:static print:z-auto',
+        stickyColumnPosition?.isBoundary &&
+          (stickyColumnPosition.side === 'left'
+            ? 'border-r border-zinc-200 dark:border-zinc-800'
+            : 'border-l border-zinc-200 dark:border-zinc-800'),
       )}
       style={{
         width: headerSize,
         minWidth: headerSize,
         maxWidth: headerSize,
+        ...(stickyColumnPosition
+          ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
+          : {}),
       }}
       onClick={header.column.getToggleSortingHandler()}
     >
       {header.isPlaceholder ? null : (
         <div
           className={cn(
-            'flex min-w-0 items-center gap-1 overflow-hidden',
+            'flex min-w-0 items-center overflow-hidden',
             isRightAligned && 'flex-row-reverse',
           )}
         >
@@ -456,7 +471,39 @@ export function DataTable<TData, TValue = unknown>({
     ...(renderSubComponent ? { getExpandedRowModel: getExpandedRowModel() } : {}),
   });
 
-  const visibleColumnCount = table.getVisibleLeafColumns().length;
+  const visibleLeafColumns = table.getVisibleLeafColumns();
+  const visibleColumnCount = visibleLeafColumns.length;
+  const stickyColumnPositions = (() => {
+    const positions = new Map<string, StickyColumnPosition>();
+    const leftStickyColumns = visibleLeafColumns.filter(
+      (column) => column.columnDef.meta?.sticky === 'left',
+    );
+    const rightStickyColumns = visibleLeafColumns.filter(
+      (column) => column.columnDef.meta?.sticky === 'right',
+    );
+
+    let leftOffset = 0;
+    leftStickyColumns.forEach((column, index) => {
+      positions.set(column.id, {
+        side: 'left',
+        offset: leftOffset,
+        isBoundary: index === leftStickyColumns.length - 1,
+      });
+      leftOffset += column.getSize();
+    });
+
+    let rightOffset = 0;
+    [...rightStickyColumns].reverse().forEach((column, index) => {
+      positions.set(column.id, {
+        side: 'right',
+        offset: rightOffset,
+        isBoundary: index === rightStickyColumns.length - 1,
+      });
+      rightOffset += column.getSize();
+    });
+
+    return positions;
+  })();
   const tableMinWidth = table.getTotalSize() ? `${table.getTotalSize()}px` : undefined;
   const clientRows = table.getRowModel().rows;
   const serverRowCount = serverVirtualization?.rowCount ?? 0;
@@ -724,7 +771,7 @@ export function DataTable<TData, TValue = unknown>({
           }
         }}
         className={cn(
-          'border-b border-zinc-200 dark:border-zinc-800 last:border-b-0 transition-colors print:border-gray-300',
+          'group border-b border-zinc-200 dark:border-zinc-800 last:border-b-0 transition-colors print:border-gray-300',
           (onRowClick || (renderSubComponent && row.getCanExpand())) &&
             'cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50',
         )}
@@ -733,6 +780,7 @@ export function DataTable<TData, TValue = unknown>({
           const cellAlign = cell.column.columnDef.meta?.align ?? 'left';
           const cellSize = `${cell.column.getSize()}px`;
           const isUtilityColumn = UTILITY_COLUMN_IDS.has(cell.column.id);
+          const stickyColumnPosition = stickyColumnPositions.get(cell.column.id);
 
           return (
             <td
@@ -743,11 +791,20 @@ export function DataTable<TData, TValue = unknown>({
                   ? cn('px-3', cell.column.id === 'select' && 'cursor-pointer')
                   : 'px-4 overflow-hidden text-ellipsis',
                 cellAlign === 'right' && 'text-right',
+                stickyColumnPosition &&
+                  'sticky z-[1] bg-white group-hover:bg-zinc-50 dark:bg-zinc-900 dark:group-hover:bg-zinc-800/50 print:static print:z-auto print:bg-white',
+                stickyColumnPosition?.isBoundary &&
+                  (stickyColumnPosition.side === 'left'
+                    ? 'border-r border-zinc-200 dark:border-zinc-800'
+                    : 'border-l border-zinc-200 dark:border-zinc-800'),
               )}
               style={{
                 width: cellSize,
                 minWidth: cellSize,
                 maxWidth: cellSize,
+                ...(stickyColumnPosition
+                  ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
+                  : {}),
               }}
               onClick={
                 cell.column.id === 'select'
@@ -803,14 +860,31 @@ export function DataTable<TData, TValue = unknown>({
       aria-busy={serverIsRowLoading?.(virtualIndex) ?? true}
       className="border-b border-zinc-200 dark:border-zinc-800"
     >
-      {table.getVisibleLeafColumns().map((column) => {
+      {visibleLeafColumns.map((column) => {
         const columnSize = `${column.getSize()}px`;
         const isUtilityColumn = UTILITY_COLUMN_IDS.has(column.id);
+        const stickyColumnPosition = stickyColumnPositions.get(column.id);
         return (
           <td
             key={column.id}
-            className={cn('py-3 text-sm', isUtilityColumn ? 'px-3' : 'px-4')}
-            style={{ width: columnSize, minWidth: columnSize, maxWidth: columnSize }}
+            className={cn(
+              'py-3 text-sm',
+              isUtilityColumn ? 'px-3' : 'px-4',
+              stickyColumnPosition &&
+                'sticky z-[1] bg-white dark:bg-zinc-900 print:static print:z-auto print:bg-white',
+              stickyColumnPosition?.isBoundary &&
+                (stickyColumnPosition.side === 'left'
+                  ? 'border-r border-zinc-200 dark:border-zinc-800'
+                  : 'border-l border-zinc-200 dark:border-zinc-800'),
+            )}
+            style={{
+              width: columnSize,
+              minWidth: columnSize,
+              maxWidth: columnSize,
+              ...(stickyColumnPosition
+                ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
+                : {}),
+            }}
           >
             {!isUtilityColumn && <Skeleton className="h-4 w-full" />}
           </td>
@@ -869,7 +943,7 @@ export function DataTable<TData, TValue = unknown>({
     <div className={cn('flex flex-col gap-3 flex-1 min-h-0', className)}>
       <div
         className={cn(
-          'rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 flex-1 min-h-0 flex flex-col',
+          'rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 flex-1 min-h-0 flex flex-col overflow-hidden',
           'print:bg-white print:border-gray-300',
         )}
       >
@@ -895,7 +969,7 @@ export function DataTable<TData, TValue = unknown>({
 
         <div
           ref={scrollContainerRef}
-          className="overflow-auto flex-1 min-h-0 print:overflow-visible print:max-h-none print:flex-none"
+          className="overflow-auto overflow-x-auto overflow-y-auto overscroll-x-contain flex-1 min-h-0 print:overflow-visible print:max-h-none print:flex-none"
           style={maxHeight ? { maxHeight } : undefined}
         >
           <table
@@ -912,7 +986,11 @@ export function DataTable<TData, TValue = unknown>({
                   className="border-b border-zinc-200 dark:border-zinc-800 print:border-gray-300"
                 >
                   {headerGroup.headers.map((header) =>
-                    renderDataTableHeaderCell(header, showColumnFilterControls),
+                    renderDataTableHeaderCell(
+                      header,
+                      stickyColumnPositions.get(header.column.id),
+                      showColumnFilterControls,
+                    ),
                   )}
                 </tr>
               ))}

--- a/src/app/src/components/data-table/types.ts
+++ b/src/app/src/components/data-table/types.ts
@@ -16,6 +16,8 @@ declare module '@tanstack/react-table' {
     filterOptions?: Array<{ label: string; value: string }>;
     /** Column alignment - affects both header and cell content. When 'right', sort icon appears on the left of the header label. */
     align?: 'left' | 'right';
+    /** Pin important columns to an edge while the table scrolls horizontally. */
+    sticky?: 'left' | 'right';
   }
 }
 

--- a/src/app/src/pages/redteam/report/components/TestSuites.tsx
+++ b/src/app/src/pages/redteam/report/components/TestSuites.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { DataTable } from '@app/components/data-table/data-table';
 import { Button } from '@app/components/ui/button';
-import { Card } from '@app/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tooltip';
 import { EVAL_ROUTES } from '@app/constants/routes';
 import { useCustomPoliciesMap } from '@app/hooks/useCustomPoliciesMap';
@@ -27,7 +26,7 @@ import {
   prepareTestResultsFromStats,
 } from '@promptfoo/redteam/riskScoring';
 import { getRiskCategorySeverityMap } from '@promptfoo/redteam/sharedFrontend';
-import { Download } from 'lucide-react';
+import { Download, ScrollText } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getSeverityColor } from '../utils/color';
 import { type TestResultStats } from './FrameworkComplianceUtils';
@@ -300,7 +299,8 @@ const TestSuites = ({
       {
         accessorKey: 'type',
         header: 'Type',
-        size: 180,
+        size: 200,
+        meta: { sticky: 'left' },
         accessorFn: (row) =>
           displayNameOverrides[row.pluginName as keyof typeof displayNameOverrides] || row.type,
         cell: ({ getValue }) => <span style={{ fontWeight: 500 }}>{getValue<string>()}</span>,
@@ -308,7 +308,7 @@ const TestSuites = ({
       {
         accessorKey: 'description',
         header: 'Description',
-        size: 220,
+        size: 230,
         cell: ({ getValue }) => (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -320,14 +320,22 @@ const TestSuites = ({
       },
       {
         accessorKey: 'riskScore',
-        header: 'Risk Score',
-        size: 160,
+        header: () => (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-help">Risk</span>
+            </TooltipTrigger>
+            <TooltipContent>Risk Score</TooltipContent>
+          </Tooltip>
+        ),
+        size: 110,
+        meta: { align: 'right' },
         cell: ({ row }) => {
           const value = row.original.riskScore;
           return (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="flex cursor-help items-center gap-2">
+                <span className="flex cursor-help items-center justify-end gap-2 tabular-nums">
                   <span
                     className="size-3 rounded-full"
                     style={{ backgroundColor: getRiskScoreColor(value) }}
@@ -359,13 +367,14 @@ const TestSuites = ({
       {
         accessorKey: 'complexityScore',
         header: 'Complexity',
-        size: 170,
+        size: 100,
+        meta: { align: 'right' },
         cell: ({ row }) => {
           const value = row.original.complexityScore;
           return (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="cursor-help">{value.toFixed(0)}</span>
+                <span className="cursor-help tabular-nums">{value.toFixed(0)}</span>
               </TooltipTrigger>
               <TooltipContent className="max-w-xs">
                 <div className="space-y-1">
@@ -392,8 +401,17 @@ const TestSuites = ({
       },
       {
         accessorKey: 'successfulAttacks',
-        header: 'Successful Attacks',
-        size: 220,
+        header: () => (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-help">Succeeded</span>
+            </TooltipTrigger>
+            <TooltipContent>Successful Attacks</TooltipContent>
+          </Tooltip>
+        ),
+        size: 120,
+        meta: { align: 'right' },
+        cell: ({ getValue }) => <span className="tabular-nums">{getValue<number>()}</span>,
       },
       {
         accessorKey: 'attackSuccessRate',
@@ -405,13 +423,14 @@ const TestSuites = ({
             <TooltipContent>Attack Success Rate</TooltipContent>
           </Tooltip>
         ),
-        size: 120,
+        size: 88,
+        meta: { align: 'right' },
         cell: ({ row }) => {
           const value = row.original.attackSuccessRate;
           const passRateWithFilter = row.original.passRateWithFilter;
           const passRate = row.original.passRate;
           return (
-            <div>
+            <div className="tabular-nums">
               <strong>{formatASRForDisplay(value)}%</strong>
               {passRateWithFilter !== passRate && (
                 <>
@@ -425,7 +444,7 @@ const TestSuites = ({
       {
         accessorKey: 'severity',
         header: 'Severity',
-        size: 150,
+        size: 100,
         cell: ({ getValue }) => {
           const value = getValue<Severity>();
           return severityDisplayNames[value] || 'Unknown';
@@ -456,34 +475,42 @@ const TestSuites = ({
       {
         id: 'actions',
         header: 'Actions',
-        size: 100,
+        size: 72,
+        meta: { sticky: 'right' },
         enableSorting: false,
         cell: ({ row }) => (
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={() => {
-                const pluginId = row.original.pluginName;
-                const plugin = pluginsById[pluginId];
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                aria-label="View logs"
+                onClick={() => {
+                  const pluginId = row.original.pluginName;
+                  const plugin = pluginsById[pluginId];
 
-                const filterParam = encodeURIComponent(
-                  JSON.stringify([
-                    {
-                      type: plugin?.id === 'policy' ? 'policy' : 'plugin',
-                      operator: 'equals',
-                      value: pluginId,
-                    },
-                  ]),
-                );
+                  const filterParam = encodeURIComponent(
+                    JSON.stringify([
+                      {
+                        type: plugin?.id === 'policy' ? 'policy' : 'plugin',
+                        operator: 'equals',
+                        value: pluginId,
+                      },
+                    ]),
+                  );
 
-                // If ASR is 0, show passes
-                const mode = row.original.attackSuccessRate === 0 ? 'passes' : 'failures';
-                navigate(`${EVAL_ROUTES.DETAIL(evalId)}?filter=${filterParam}&mode=${mode}`);
-              }}
-            >
-              View logs
-            </Button>
-          </div>
+                  // If ASR is 0, show passes
+                  const mode = row.original.attackSuccessRate === 0 ? 'passes' : 'failures';
+                  navigate(`${EVAL_ROUTES.DETAIL(evalId)}?filter=${filterParam}&mode=${mode}`);
+                }}
+              >
+                <ScrollText className="size-4" />
+                <span className="sr-only">View logs</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>View logs</TooltipContent>
+          </Tooltip>
         ),
       },
     ],
@@ -491,7 +518,7 @@ const TestSuites = ({
   );
 
   return (
-    <div ref={vulnerabilitiesDataGridRef}>
+    <div ref={vulnerabilitiesDataGridRef} className="min-w-0">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-semibold">Vulnerabilities and Mitigations</h2>
         <Button onClick={exportToCSV} className="print:hidden">
@@ -499,19 +526,18 @@ const TestSuites = ({
           Export vulnerabilities to CSV
         </Button>
       </div>
-      <Card className="pb-4">
-        <DataTable
-          columns={columns}
-          data={rows}
-          initialSorting={sortModel}
-          onExportCSV={exportToCSV}
-          showToolbar={true}
-          showColumnToggle={true}
-          showFilter={true}
-          showExport={false}
-          getRowId={(row) => row.id}
-        />
-      </Card>
+      <DataTable
+        className="[&_td]:py-2.5 [&_th]:py-2.5"
+        columns={columns}
+        data={rows}
+        initialSorting={sortModel}
+        onExportCSV={exportToCSV}
+        showToolbar={true}
+        showColumnToggle={true}
+        showFilter={true}
+        showExport={false}
+        getRowId={(row) => row.id}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make the vulnerabilities table fit the report width at normal desktop sizes
- tighten shared table chrome with responsive toolbar wrapping and overlayed header actions
- keep edge columns usable when horizontal scrolling is unavoidable on narrower screens

## Test plan
- npm run test:app -- src/components/data-table/data-table.test.tsx src/pages/redteam/report/components/TestSuites.test.tsx --run
- inspected the Nina-style Dutch utility red team report locally at http://localhost:3001/reports?evalId=eval-Z9m-2026-05-06T13:58:21
