### PR TITLE
fix(tracing): skip orphan otlp trace rows

### DIFF
--- a/src/tracing/otlpReceiver.ts
+++ b/src/tracing/otlpReceiver.ts
@@ -425,12 +425,17 @@ export class OTLPReceiver {
 
   private async createTraceRecords(traceInfoById: Map<string, TraceInfo>): Promise<void> {
     for (const [traceId, info] of traceInfoById) {
+      if (!info.evaluationId || !info.testCaseId) {
+        logger.debug(`[OtlpReceiver] Skipping trace record creation for unlinked trace ${traceId}`);
+        continue;
+      }
+
       try {
         logger.debug(`[OtlpReceiver] Creating trace record for ${traceId}`);
         await this.traceStore.createTrace({
           traceId,
-          evaluationId: info.evaluationId || '',
-          testCaseId: info.testCaseId || '',
+          evaluationId: info.evaluationId,
+          testCaseId: info.testCaseId,
         });
       } catch (error) {
         // Trace might already exist, which is fine
@@ -442,7 +447,10 @@ export class OTLPReceiver {
   private async storeSpans(spansByTrace: Map<string, SpanData[]>): Promise<void> {
     for (const [traceId, spans] of spansByTrace) {
       logger.debug(`[OtlpReceiver] Storing ${spans.length} spans for trace ${traceId}`);
-      await this.traceStore.addSpans(traceId, spans, { skipTraceCheck: true });
+      await this.traceStore.addSpans(traceId, spans, {
+        skipTraceCheck: false,
+        warnIfMissingTrace: false,
+      });
     }
   }
 

--- a/test/tracing/otlpReceiver.test.ts
+++ b/test/tracing/otlpReceiver.test.ts
@@ -219,7 +219,7 @@ describe('OTLPReceiver', () => {
             statusMessage: 'OK',
           }),
         ]),
-        { skipTraceCheck: true },
+        { skipTraceCheck: false, warnIfMissingTrace: false },
       );
     });
 
@@ -258,7 +258,7 @@ describe('OTLPReceiver', () => {
             name: 'json-with-charset',
           }),
         ]),
-        { skipTraceCheck: true },
+        { skipTraceCheck: false, warnIfMissingTrace: false },
       );
     });
 
@@ -314,7 +314,7 @@ describe('OTLPReceiver', () => {
             name: 'span-2',
           }),
         ]),
-        { skipTraceCheck: true },
+        { skipTraceCheck: false, warnIfMissingTrace: false },
       );
     });
 
@@ -375,7 +375,7 @@ describe('OTLPReceiver', () => {
             }),
           }),
         ]),
-        { skipTraceCheck: true },
+        { skipTraceCheck: false, warnIfMissingTrace: false },
       );
     });
 
@@ -535,7 +535,7 @@ describe('OTLPReceiver', () => {
             statusMessage: 'Success',
           }),
         ]),
-        { skipTraceCheck: true },
+        { skipTraceCheck: false, warnIfMissingTrace: false },
       );
     });
 
@@ -616,7 +616,42 @@ describe('OTLPReceiver', () => {
         .expect(200);
 
       expect(mockTraceStore.addSpans).toHaveBeenCalledWith(traceIdHex, expect.any(Array), {
-        skipTraceCheck: true,
+        skipTraceCheck: false,
+        warnIfMissingTrace: false,
+      });
+    });
+
+    it('stores unlinked OTLP spans against existing traces without creating invalid rows', async () => {
+      const traceIdHex = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const otlpRequest = {
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    traceId: Buffer.from(traceIdHex, 'hex').toString('base64'),
+                    spanId: Buffer.from('bbbbbbbbbbbbbbbb', 'hex').toString('base64'),
+                    name: 'child-span-without-linkage',
+                    startTimeUnixNano: '1000000000',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      await request(receiver.getApp())
+        .post('/v1/traces')
+        .set('Content-Type', 'application/json')
+        .send(otlpRequest)
+        .expect(200);
+
+      expect(mockTraceStore.createTrace).not.toHaveBeenCalled();
+      expect(mockTraceStore.addSpans).toHaveBeenCalledWith(traceIdHex, expect.any(Array), {
+        skipTraceCheck: false,
+        warnIfMissingTrace: false,
       });
     });
   });

--- a/test/tracing/otlpReceiver.test.ts
+++ b/test/tracing/otlpReceiver.test.ts
@@ -621,7 +621,7 @@ describe('OTLPReceiver', () => {
       });
     });
 
-    it('stores unlinked OTLP spans against existing traces without creating invalid rows', async () => {
+    it('stores unlinked OTLP spans without creating invalid trace rows', async () => {
       const traceIdHex = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       const otlpRequest = {
         resourceSpans: [


### PR DESCRIPTION
## Summary

- skip creating OTLP trace rows when incoming spans are not linked to an eval/test case
- keep span persistence checked against existing traces without noisy missing-trace warnings
- add regression coverage for orphan child-span batches

## Validation

- `npx vitest run test/tracing/otlpReceiver.test.ts --sequence.shuffle=false`