### PR TITLE
test: cover junit xml output format routing

### DIFF
--- a/test/util/outputFormats.test.ts
+++ b/test/util/outputFormats.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getOutputFileFormat, SUPPORTED_OUTPUT_FILE_FORMATS } from '../../src/util/outputFormats';
+
+describe('outputFormats', () => {
+  it('detects JUnit XML outputs by the full suffix', () => {
+    expect(getOutputFileFormat('results.junit.xml')).toBe('junit.xml');
+    expect(getOutputFileFormat('reports/ci.RESULTS.JUNIT.XML')).toBe('junit.xml');
+  });
+
+  it('keeps Promptfoo XML separate from JUnit XML routing', () => {
+    expect(getOutputFileFormat('results.xml')).toBe('xml');
+    expect(getOutputFileFormat('results.junit')).toBeUndefined();
+  });
+
+  it('advertises junit.xml as a supported output format', () => {
+    expect(SUPPORTED_OUTPUT_FILE_FORMATS).toContain('junit.xml');
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the JUnit XML output routing added for CI integrations:

- verifies `results.junit.xml` is routed as `junit.xml`
- verifies the suffix match is case-insensitive
- verifies plain `results.xml` still routes to Promptfoo XML
- verifies `junit.xml` is advertised in supported output formats

## Scope

Promptfoo `main` already has the core JUnit XML writer, output path routing, and docs. This PR intentionally avoids re-implementing that work and only pins the filename-format boundary that makes the CI projection reachable through `--output results.junit.xml`.

This does not add a new `--output-type` flag or change export semantics.

## Verification

- `npx vitest run test/util/outputFormats.test.ts`
- `npx @biomejs/biome check test/util/outputFormats.test.ts`
- `npm run tsc`
