### PR TITLE
fix(google): drop late live messages after resolution

### DIFF
--- a/src/providers/google/live.ts
+++ b/src/providers/google/live.ts
@@ -442,6 +442,12 @@ export class GoogleLiveProvider implements ApiProvider {
       };
 
       ws.onmessage = async (event) => {
+        // Once the request has been resolved (e.g. by an early onclose or
+        // timeout), drop any in-flight messages so they don't trigger side
+        // effects like stateful-API fetches after the caller has moved on.
+        if (isResolved) {
+          return;
+        }
         // Handle different data types from WebSocket
         logger.debug('WebSocket message received');
         let responseData: string;

--- a/src/providers/google/live.ts
+++ b/src/providers/google/live.ts
@@ -326,8 +326,11 @@ export class GoogleLiveProvider implements ApiProvider {
         }
         clearTimeout(timeout);
 
-        // Retrieve final state from stateful API before shutting down
-        if (!toolsDisabled && config.functionToolStatefulApi) {
+        // Retrieve final state from stateful API before shutting down. Skip
+        // if the request has already been resolved (e.g. by an early
+        // onclose/timeout) — the caller has moved on and won't read the
+        // result.
+        if (!isResolved && !toolsDisabled && config.functionToolStatefulApi) {
           try {
             const url = new URL('get_state', config.functionToolStatefulApi.url).href;
             statefulApiState = await fetchJson(url);
@@ -478,6 +481,11 @@ export class GoogleLiveProvider implements ApiProvider {
 
         try {
           const responseText = await new Response(responseData).text();
+          // Re-check after the await: the request may have been resolved by an
+          // onclose/timeout while we were parsing.
+          if (isResolved) {
+            return;
+          }
           const response = JSON.parse(responseText);
 
           if (response.error) {
@@ -605,6 +613,11 @@ export class GoogleLiveProvider implements ApiProvider {
             }
             return;
           } else if (response.toolCall?.functionCalls) {
+            // Skip tool execution and tool_response sends if the request is
+            // already resolved (e.g. via timeout/onclose).
+            if (isResolved) {
+              return;
+            }
             if (toolsDisabled) {
               // Reply with an error tool_response so the model can complete its turn
               // instead of waiting for a response that will never come (which would
@@ -666,6 +679,11 @@ export class GoogleLiveProvider implements ApiProvider {
                     logger.error(
                       `Error executing function ${functionName}: ${JSON.stringify(err)}`,
                     );
+                  }
+                  // The callback above may have awaited; bail before sending
+                  // a tool_response if the request has since been resolved.
+                  if (isResolved) {
+                    return;
                   }
                   const toolMessage = {
                     tool_response: {


### PR DESCRIPTION
## Summary

`test/providers/google/live.test.ts > should skip tool side effects when tools are disabled` flakes under random test ordering. Reproducible with `--sequence.seed=60`:

```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
  1st vi.fn() call: ["http://127.0.0.1:8765/get_state", undefined]
```

## Root cause

The `Python executable integration > should properly clean up Python process on WebSocket close` test (and similar tests using `127.0.0.1:8765`) simulates messages via `setImmediate` and then fires `mockWs.onclose` synchronously. `onclose` resolves `provider.callApi` first, but the queued `turnComplete` message still fires `ws.onmessage` afterward → `finalizeResponse` → `fetchJson('http://127.0.0.1:8765/get_state')`. That deferred `fetchWithProxy` call lands in the *next* test's mock history.

In production this is also a real (if minor) defect: any message that races past an early `onclose`/timeout would still trigger stateful-API side effects after the caller has already moved on.

## Fix

Guard `ws.onmessage` to bail out when `isResolved` is already true, so post-resolution messages can't trigger `finalizeResponse` or its `get_state` fetch.

## Test plan

- [x] `npx vitest run test/providers/google/live.test.ts --sequence.seed=60` — fails on `main`, passes with this change
- [x] `npx vitest run test/providers/google/live.test.ts` across seeds 1–80, 100, 200, 300, 400, 500, 600, 700, 800, 1000, 1234, 5678 — all pass
- [x] `npx vitest run test/providers/google/` — 584 tests pass