### PR TITLE
chore: address AI quality findings

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.tsx
@@ -46,6 +46,11 @@ const buildBedrockProviderId = (apiMode: BedrockApiMode, modelId: string): strin
 const isServerConfigured = (server: MCPServerConfig): boolean =>
   Boolean(server.command || server.path || server.url);
 
+const createDefaultMCPServer = (index: number): MCPServerConfig => ({
+  name: `server-${index + 1}`,
+  args: [],
+});
+
 const FoundationModelConfiguration = ({
   selectedTarget,
   updateCustomTarget,
@@ -103,7 +108,7 @@ const FoundationModelConfiguration = ({
     const servers = selectedTarget.config?.mcp?.servers || [];
     // Don't seed `command: ''`; an empty string would be persisted and later
     // fail validation. Leave the field undefined and let the input render empty.
-    updateMCPServers([...servers, { name: `server-${servers.length + 1}`, args: [] }]);
+    updateMCPServers([...servers, createDefaultMCPServer(servers.length)]);
     setIsMcpOpen(true);
   };
 

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -511,6 +511,40 @@ describe('ProviderConfigEditor', () => {
     );
   });
 
+  it('should preserve Bedrock MCP config when provider is already using InvokeModel id format', () => {
+    const mockSetProvider = vi.fn();
+    const mcpConfig = {
+      enabled: true,
+      servers: [{ name: 'server-1', command: 'npx', args: ['mcp-server'] }],
+    };
+
+    renderWithProviders(
+      <ProviderConfigEditor
+        provider={{
+          id: 'bedrock:anthropic.claude-3-5-sonnet',
+          config: {
+            mcp: mcpConfig,
+          },
+        }}
+        setProvider={mockSetProvider}
+        providerType="bedrock"
+      />,
+    );
+
+    act(() => {
+      screen.getByTestId('switch-bedrock-invoke').click();
+    });
+
+    expect(mockSetProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'bedrock:anthropic.claude-3-5-sonnet',
+        config: {
+          mcp: mcpConfig,
+        },
+      }),
+    );
+  });
+
   describe('updateCustomTarget inputs handling', () => {
     it('should render CommonConfigurationOptions with proper props', () => {
       const mockSetProvider = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -28,6 +28,15 @@ export interface ProviderConfigEditorProps {
   mode?: 'eval' | 'redteam';
 }
 
+const shouldRemoveMcpConfig = (
+  previousTargetId: string,
+  nextTargetId: string,
+  currentProviderType?: string,
+): boolean =>
+  currentProviderType === 'bedrock' &&
+  previousTargetId.startsWith('bedrock:converse:') &&
+  !nextTargetId.startsWith('bedrock:converse:');
+
 function ProviderConfigEditor({
   provider,
   setProvider,
@@ -76,7 +85,7 @@ function ProviderConfigEditor({
 
     if (field === 'id') {
       updatedTarget.id = value as string;
-      if (providerType === 'bedrock' && !updatedTarget.id.startsWith('bedrock:converse:')) {
+      if (shouldRemoveMcpConfig(provider.id, updatedTarget.id, providerType)) {
         delete updatedTarget.config.mcp;
       }
     } else if (field === 'url') {

--- a/src/providers/google/live.ts
+++ b/src/providers/google/live.ts
@@ -35,10 +35,10 @@ const formatContentMessage = (
   contentIndex: number,
   useRealtimeTextInput = false,
 ) => {
-  if (contents[contentIndex].role != 'user') {
+  if (contents[contentIndex].role !== 'user') {
     throw new Error('Can only take user role inputs.');
   }
-  if (contents[contentIndex].parts.length != 1) {
+  if (contents[contentIndex].parts.length !== 1) {
     throw new Error('Unexpected number of parts in user input.');
   }
   const userMessage = contents[contentIndex].parts[0].text;
@@ -68,31 +68,34 @@ const formatContentMessage = (
 /**
  * Helper function to fetch JSON with error handling
  */
-export const fetchJson = async (url: string, options?: RequestInit): Promise<any> => {
+export const fetchJson = async <T = unknown>(url: string, options?: RequestInit): Promise<T> => {
   const response = await fetchWithProxy(url, options);
   if (!response.ok) {
     throw new Error(`HTTP error - status: ${response.status}`);
   }
-  return response.json();
+  return response.json() as Promise<T>;
 };
 
 /**
  * Helper function to try GET with query params, fallback to POST with JSON body
  */
-export const tryGetThenPost = async (url: string, data?: any): Promise<any> => {
+export const tryGetThenPost = async <T = unknown>(url: string, data?: unknown): Promise<T> => {
   try {
     // Try GET first with query params
     const urlWithParams = new URL(url);
     if (data) {
-      const params = typeof data === 'string' ? JSON.parse(data) : data;
+      const params = (typeof data === 'string' ? JSON.parse(data) : data) as Record<
+        string,
+        unknown
+      >;
       Object.entries(params).forEach(([key, value]) => {
         urlWithParams.searchParams.append(key, String(value));
       });
     }
-    return await fetchJson(urlWithParams.href);
+    return await fetchJson<T>(urlWithParams.href);
   } catch {
     // Fall back to POST
-    return fetchJson(url, {
+    return fetchJson<T>(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -292,7 +295,7 @@ export class GoogleLiveProvider implements ApiProvider {
       let response_audio_transcript = '';
       let hasAudioContent = false;
       const function_calls_total: FunctionCall[] = [];
-      let statefulApiState: any = undefined;
+      let statefulApiState: unknown = undefined;
       let hasFinalized = false;
 
       const isTextExpected =
@@ -641,7 +644,7 @@ export class GoogleLiveProvider implements ApiProvider {
               for (const functionCall of response.toolCall.functionCalls) {
                 function_calls_total.push(functionCall);
                 if (functionCall && functionCall.id && functionCall.name) {
-                  let callbackResponse = {};
+                  let callbackResponse: unknown = {};
                   const functionName = functionCall.name;
                   try {
                     if (config.functionToolCallbacks?.[functionName]) {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import * as genaiTracer from '../../../src/tracing/genaiTracer';
 import { mockProcessEnv } from '../../util/utils';
 import type { ContentBlock, StopReason } from '@aws-sdk/client-bedrock-runtime';
@@ -32,7 +32,7 @@ interface MockConverseCommandOutput {
   };
 }
 
-const mockSend = vi.hoisted(() => vi.fn<any>());
+const mockSend = vi.hoisted(() => vi.fn<(command: unknown) => Promise<unknown>>());
 const mcpMocks = vi.hoisted(() => {
   const mockConstructor = vi.fn();
   const mockInitialize = vi.fn().mockResolvedValue(undefined);
@@ -139,7 +139,14 @@ vi.mock('@smithy/node-http-handler', async (importOriginal) => {
   };
 });
 
-vi.mock('proxy-agent', () => vi.fn());
+// Provide the proxy-agent module shape without creating real agents in tests.
+vi.mock('proxy-agent', () => {
+  const ProxyAgentMock = vi.fn();
+  return {
+    default: ProxyAgentMock,
+    ProxyAgent: ProxyAgentMock,
+  };
+});
 
 vi.mock('../../../src/cache', async (importOriginal) => {
   return {
@@ -763,7 +770,12 @@ describe('AwsBedrockConverseProvider', () => {
         createMockConverseResponse('', {
           // String input that is not valid JSON. parseToolInput must coerce to {}
           // rather than letting JSON.parse crash the eval row.
-          toolUse: { id: 'tool-123', name: 'list_resources', input: '{not json' as any },
+          toolUse: {
+            id: 'tool-123',
+            name: 'list_resources',
+            // Intentionally invalid JSON plus type bypass for the error-handling path.
+            input: '{not json' as any,
+          },
           stopReason: 'tool_use',
         }),
       );


### PR DESCRIPTION
## Summary
- address the 12 visible GitHub AI findings across 5 files
- extract Bedrock/MCP UI helpers and add regression coverage for preserving InvokeModel MCP config
- tighten Google Live helper typing/equality and Bedrock provider test mocks/comments

## Verification
- npm run test:app -- src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx --run
- npx vitest run test/providers/google/live.test.ts test/providers/bedrock/converse.test.ts
- npm run tsc
- npm run f
- npm run l