### PR TITLE
fix(redteam): keep fresh target type state in sync

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
@@ -97,7 +97,7 @@ describe('TargetTypeSelection', () => {
     });
   });
 
-  it('should allow user to enter name, reveal types, select one, and proceed', async () => {
+  it('should render target types immediately, require a name and type, and proceed', async () => {
     const user = userEvent.setup();
     const mockSetProviderType = vi.fn();
     mockUseRedTeamConfig.mockReturnValue({
@@ -115,34 +115,19 @@ describe('TargetTypeSelection', () => {
 
     renderComponent();
 
-    // Initially, no footer Next button should be present
-    expect(screen.queryByRole('button', { name: /^Next$/i })).not.toBeInTheDocument();
-    expect(screen.queryByText('Select Target Type')).not.toBeInTheDocument();
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+    expect(screen.getByText('OpenAI')).toBeInTheDocument();
+    const footerNextButton = screen.getByRole('button', { name: /^Next$/i });
+    expect(footerNextButton).toBeDisabled();
 
     const nameInput = screen.getByRole('textbox', { name: /Target Name/i });
     await user.type(nameInput, 'My Test API');
 
-    // After entering name, the inline "Continue" button should appear
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
-    });
-
-    const inlineNextButton = screen.getByRole('button', { name: 'Continue' });
-    await user.click(inlineNextButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
-    });
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
     expect(onNext).not.toHaveBeenCalled();
-    expect(mockRecordEvent).toHaveBeenCalledWith('feature_used', {
-      feature: 'redteam_config_target_type_section_revealed',
-    });
-
-    // Now the footer Next button should appear but be disabled (no provider selected)
-    const footerNextButton = await screen.findByRole('button', { name: /^Next$/i });
     expect(footerNextButton).toBeDisabled();
 
-    // Provider list is expanded - select OpenAI by clicking the card
+    // Select OpenAI by clicking the card
     const openAICard = await screen.findByText('OpenAI');
     const cardElement = openAICard.closest('[role="button"]');
     await user.click(cardElement!);
@@ -167,12 +152,11 @@ describe('TargetTypeSelection', () => {
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it('should have the Next button disabled and provider type section not visible when target name is empty', () => {
+  it('should show the target type section and keep Next disabled when target name is empty', () => {
     renderComponent();
 
-    // Initially, no footer Next button should be present, and no target type section
-    expect(screen.queryByRole('button', { name: /^Next$/i })).not.toBeInTheDocument();
-    expect(screen.queryByText('Select Target Type')).not.toBeInTheDocument();
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
   });
 
   it('should update the selectedTarget and providerType when a new provider type is selected and record telemetry event', async () => {
@@ -198,16 +182,7 @@ describe('TargetTypeSelection', () => {
     await user.keyboard('{Control>}a{/Control}');
     await user.paste('My Test API');
 
-    const inlineNextButton = await screen.findByRole('button', {
-      name: 'Continue',
-    });
-    await user.click(inlineNextButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
-    });
-
-    // Provider list is expanded - select OpenAI
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
     const openAICard = await screen.findByText('OpenAI');
     await user.click(openAICard.closest('.cursor-pointer') as HTMLElement);
 
@@ -228,7 +203,7 @@ describe('TargetTypeSelection', () => {
     });
   });
 
-  it('should disable Next button after entering a target name, revealing the target type section, and then deleting the target name', async () => {
+  it('should disable Next button after entering a target name, selecting a type, and then deleting the target name', async () => {
     const user = userEvent.setup();
     renderComponent();
 
@@ -237,17 +212,15 @@ describe('TargetTypeSelection', () => {
     await user.keyboard('{Control>}a{/Control}');
     await user.paste('My Test API');
 
-    const inlineNextButton = await screen.findByRole('button', {
-      name: 'Continue',
-    });
-    await user.click(inlineNextButton);
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
-    });
+    const openAICard = await screen.findByText('OpenAI');
+    await user.click(openAICard.closest('.cursor-pointer') as HTMLElement);
 
     // Now the footer Next button should be present
-    await screen.findByRole('button', { name: /^Next$/i });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Next$/i })).toBeEnabled();
+    });
 
     await user.clear(nameInput);
 
@@ -277,10 +250,7 @@ describe('TargetTypeSelection', () => {
 
     renderComponent();
 
-    // With complete saved config, target type section should be visible
-    await waitFor(() => {
-      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
 
     // Now the footer Next button should be present and enabled
     const footerNextButton = await screen.findByRole('button', { name: /^Next$/i });
@@ -358,14 +328,12 @@ describe('TargetTypeSelection', () => {
         expect(screen.getByText('Select Target Type')).toBeInTheDocument();
       });
 
-      // The footer Next button should be present (visible when target type section is shown)
+      // The footer Next button should be present while validation controls whether it can advance.
       const footerNextButton = screen.getByRole('button', { name: /^Next$/i });
       expect(footerNextButton).toBeInTheDocument();
     });
 
-    it('should NOT show target type section when no provider is selected (empty id without providerType)', async () => {
-      // This verifies we don't accidentally show the section for truly incomplete configs
-      // When there's no complete saved config, the component resets to initial state
+    it('should show target type section when no provider is selected', () => {
       const mockSetProviderType = vi.fn();
       mockUseRedTeamConfig.mockReturnValue({
         config: {
@@ -382,11 +350,8 @@ describe('TargetTypeSelection', () => {
 
       renderComponent();
 
-      // The target type section should NOT be visible
-      expect(screen.queryByText('Select Target Type')).not.toBeInTheDocument();
-
-      // No footer Next button should be present
-      expect(screen.queryByRole('button', { name: /^Next$/i })).not.toBeInTheDocument();
+      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
     });
 
     it('should show target type section for standard providers with non-empty id', async () => {
@@ -443,16 +408,7 @@ describe('TargetTypeSelection', () => {
       const nameInput = screen.getByRole('textbox', { name: /Target Name/i });
       await user.type(nameInput, 'my-custom-target');
 
-      // Click the inline "Continue" button to reveal the section
-      const inlineNextButton = await screen.findByRole('button', {
-        name: 'Continue',
-      });
-      await user.click(inlineNextButton);
-
-      // Wait for target type section to be visible
-      await waitFor(() => {
-        expect(screen.getByText('Select Target Type')).toBeInTheDocument();
-      });
+      expect(screen.getByText('Select Target Type')).toBeInTheDocument();
 
       // The footer Next button should be present and enabled since we have providerType set and label entered
       const footerNextButton = await screen.findByRole('button', { name: /^Next$/i });

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
@@ -159,6 +159,28 @@ describe('TargetTypeSelection', () => {
     expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
   });
 
+  it('should not derive a selected provider type from the default incomplete target', () => {
+    const mockSetProviderType = vi.fn();
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        target: {
+          id: 'http',
+          label: '',
+          config: {},
+        },
+      },
+      updateConfig: mockUpdateConfig,
+      providerType: undefined,
+      setProviderType: mockSetProviderType,
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
+    expect(mockSetProviderType).not.toHaveBeenCalled();
+  });
+
   it('should update the selectedTarget and providerType when a new provider type is selected and record telemetry event', async () => {
     const user = userEvent.setup();
     const mockSetProviderType = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import { Button } from '@app/components/ui/button';
 import { Input } from '@app/components/ui/input';
 import { Label } from '@app/components/ui/label';
 import { useTelemetry } from '@app/hooks/useTelemetry';
-import { isInputComposing } from '@app/utils/keyboard';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import LoadExampleButton from '../LoadExampleButton';
 import PageWrapper from '../PageWrapper';
@@ -21,7 +19,7 @@ interface TargetTypeSelectionProps {
 export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelectionProps) {
   const { config, updateConfig, providerType, setProviderType } = useRedTeamConfig();
 
-  // Check if we have a complete saved configuration
+  // Use saved selections only when they have enough data to represent an actual target.
   // For custom providers, id is intentionally empty but providerType is set to 'custom'
   const hasCompleteSavedConfig = Boolean(
     config.target?.label?.trim() && (config.target?.id || providerType === 'custom'),
@@ -35,9 +33,6 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
     // Start with empty target - no default provider selected
     return { id: '', label: '', config: {} };
   });
-
-  // Only show target type section if we have a complete saved configuration
-  const [showTargetTypeSection, setShowTargetTypeSection] = useState(hasCompleteSavedConfig);
 
   const { recordEvent } = useTelemetry();
 
@@ -66,17 +61,7 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
   };
 
   const handleNext = () => {
-    // If target type section is not shown yet, show it first
-    if (hasTargetName && !showTargetTypeSection) {
-      setShowTargetTypeSection(true);
-      recordEvent('feature_used', {
-        feature: 'redteam_config_target_type_section_revealed',
-      });
-      return;
-    }
-
-    // If target type section is shown and selection is valid, proceed to next step
-    if (showTargetTypeSection && isValidSelection()) {
+    if (hasTargetName && isValidSelection()) {
       // Track provider type selection when moving to next step
       recordEvent('feature_used', {
         feature: 'redteam_config_provider_selected',
@@ -108,14 +93,7 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
     return !hasTargetName || !isValidSelection();
   };
 
-  const shouldShowFooterButton = () => {
-    return showTargetTypeSection;
-  };
-
   const getNextButtonTooltip = () => {
-    if (!showTargetTypeSection) {
-      return 'Please select a target type first';
-    }
     if (!hasTargetName) {
       return 'Please enter a target name';
     }
@@ -135,13 +113,11 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
     <PageWrapper
       title="Target Setup"
       description="Configure the AI system you want to test"
-      onNext={shouldShowFooterButton() ? handleNext : undefined}
+      onNext={handleNext}
       onBack={onBack}
-      nextLabel={shouldShowFooterButton() ? getNextButtonText() : undefined}
-      nextDisabled={shouldShowFooterButton() ? isNextButtonDisabled() : true}
-      warningMessage={
-        shouldShowFooterButton() && isNextButtonDisabled() ? getNextButtonTooltip() : undefined
-      }
+      nextLabel={getNextButtonText()}
+      nextDisabled={isNextButtonDisabled()}
+      warningMessage={isNextButtonDisabled() ? getNextButtonTooltip() : undefined}
     >
       <div className="flex flex-col gap-6">
         {/* Quick Start */}
@@ -167,49 +143,20 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
               setSelectedTarget(newTarget);
               updateConfig('target', newTarget);
             }}
-            onKeyDown={(e) => {
-              if (isInputComposing(e)) {
-                return;
-              }
-              if (e.key === 'Enter' && hasTargetName && !showTargetTypeSection) {
-                setShowTargetTypeSection(true);
-                recordEvent('feature_used', {
-                  feature: 'redteam_config_target_type_section_revealed',
-                });
-              }
-            }}
             autoFocus
           />
         </div>
 
-        {/* Continue button - shown before target type is revealed */}
-        {hasTargetName && !showTargetTypeSection && (
-          <div>
-            <Button
-              onClick={() => {
-                setShowTargetTypeSection(true);
-                recordEvent('feature_used', {
-                  feature: 'redteam_config_target_type_section_revealed',
-                });
-              }}
-            >
-              Continue
-            </Button>
-          </div>
-        )}
-
         {/* Target Type Selection */}
-        {showTargetTypeSection && (
-          <section className="space-y-4">
-            <Label className="text-sm font-semibold">Select Target Type</Label>
+        <section className="space-y-4">
+          <Label className="text-sm font-semibold">Select Target Type</Label>
 
-            <ProviderTypeSelector
-              provider={selectedTarget}
-              setProvider={handleProviderChange}
-              providerType={providerType}
-            />
-          </section>
-        )}
+          <ProviderTypeSelector
+            provider={selectedTarget}
+            setProvider={handleProviderChange}
+            providerType={providerType}
+          />
+        </section>
       </div>
     </PageWrapper>
   );

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -39,8 +39,8 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
     recordEvent('webui_page_view', { page: 'redteam_config_target_type_selection' });
-    // Initialize providerType if not already set
-    if (!providerType && config.target?.id) {
+    // Restore providerType only for saved selections that remain valid in local state.
+    if (hasCompleteSavedConfig && !providerType && config.target?.id) {
       setProviderType(getProviderType(config.target.id));
     }
   }, []);
@@ -98,13 +98,7 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
       return 'Please enter a target name';
     }
     if (!isValidSelection()) {
-      if (!selectedTarget.id && !selectedTarget.label?.trim()) {
-        return 'Please select a target';
-      }
-      if (selectedTarget.id === '' && !selectedTarget.label?.trim()) {
-        return 'Please enter a label for your custom target';
-      }
-      return 'Please complete the target selection';
+      return 'Please select a target type';
     }
     return undefined;
   };


### PR DESCRIPTION
## Summary

Follow up on #9141 by keeping the freshly rendered target type selector aligned with the actual local selection state.

- Restore `providerType` only for complete saved targets, so a fresh default config does not make `HTTP` appear selected while `selectedTarget` is intentionally empty.
- Add regression coverage for the real fresh default path where `target.id === 'http'` but no target name has been entered yet.
- Simplify the disabled-state tooltip after the selector became always-visible.

## Why

#9141 correctly removed the extra reveal step for target type selection, but it exposed a pre-existing split between UI state and selection state on a fresh setup. The default config includes an HTTP target id, while incomplete setup intentionally resets the local selected target to an empty object. Initializing `providerType` from the default config in that state can make the UI look selected even though validation still treats the target as unselected.

## Validation

- `npm run test:app -- src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx --run`
- `./node_modules/.bin/biome check src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx`
- `git diff --check -- src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx`
