### PR TITLE
fix(redteam): keep fresh target type state in sync

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
@@ -181,6 +181,28 @@ describe('TargetTypeSelection', () => {
     expect(mockSetProviderType).not.toHaveBeenCalled();
   });
 
+  it('should clear a stale persisted provider type for an incomplete target', () => {
+    const mockSetProviderType = vi.fn();
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        target: {
+          id: 'http',
+          label: '',
+          config: {},
+        },
+      },
+      updateConfig: mockUpdateConfig,
+      providerType: 'http',
+      setProviderType: mockSetProviderType,
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
+    expect(mockSetProviderType).toHaveBeenCalledWith(undefined);
+  });
+
   it('should update the selectedTarget and providerType when a new provider type is selected and record telemetry event', async () => {
     const user = userEvent.setup();
     const mockSetProviderType = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx
@@ -159,6 +159,28 @@ describe('TargetTypeSelection', () => {
     expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
   });
 
+  it('should not derive a selected provider type from the default incomplete target', () => {
+    const mockSetProviderType = vi.fn();
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        target: {
+          id: 'http',
+          label: '',
+          config: {},
+        },
+      },
+      updateConfig: mockUpdateConfig,
+      providerType: undefined,
+      setProviderType: mockSetProviderType,
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('Select Target Type')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Next$/i })).toBeDisabled();
+    expect(mockSetProviderType).not.toHaveBeenCalled();
+  });
+
   it('should update the selectedTarget and providerType when a new provider type is selected and record telemetry event', async () => {
     const user = userEvent.setup();
     const mockSetProviderType = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -39,8 +39,8 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
     recordEvent('webui_page_view', { page: 'redteam_config_target_type_selection' });
-    // Initialize providerType if not already set
-    if (!providerType && config.target?.id) {
+    // Restore providerType only for saved selections that remain valid in local state.
+    if (hasCompleteSavedConfig && !providerType && config.target?.id) {
       setProviderType(getProviderType(config.target.id));
     }
   }, []);
@@ -98,13 +98,7 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
       return 'Please enter a target name';
     }
     if (!isValidSelection()) {
-      if (!selectedTarget.id && !selectedTarget.label?.trim()) {
-        return 'Please select a target';
-      }
-      if (selectedTarget.id === '' && !selectedTarget.label?.trim()) {
-        return 'Please enter a label for your custom target';
-      }
-      return 'Please complete the target selection';
+      return 'Please select a target type';
     }
     return undefined;
   };

--- a/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx
@@ -39,9 +39,11 @@ export default function TargetTypeSelection({ onNext, onBack }: TargetTypeSelect
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
     recordEvent('webui_page_view', { page: 'redteam_config_target_type_selection' });
-    // Restore providerType only for saved selections that remain valid in local state.
+    // Keep persisted providerType aligned with the local selection state on mount.
     if (hasCompleteSavedConfig && !providerType && config.target?.id) {
       setProviderType(getProviderType(config.target.id));
+    } else if (!hasCompleteSavedConfig && providerType) {
+      setProviderType(undefined);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Follow up on #9141 by keeping the freshly rendered target type selector aligned with the actual local selection state.

- Restore `providerType` only for complete saved targets, so a fresh default config does not make `HTTP` appear selected while `selectedTarget` is intentionally empty.
- Add regression coverage for the real fresh default path where `target.id === 'http'` but no target name has been entered yet.
- Simplify the disabled-state tooltip after the selector became always-visible.

## Why

#9141 correctly removed the extra reveal step for target type selection, but it exposed a pre-existing split between UI state and selection state on a fresh setup. The default config includes an HTTP target id, while incomplete setup intentionally resets the local selected target to an empty object. Initializing `providerType` from the default config in that state can make the UI look selected even though validation still treats the target as unselected.

## Validation

- `npm run test:app -- src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx --run`
- `./node_modules/.bin/biome check src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx`
- `git diff --check -- src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.tsx src/app/src/pages/redteam/setup/components/Targets/TargetTypeSelection.test.tsx`
