### PR TITLE
ci(release): recover publishes after release-please failures

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: refs/tags/${{ inputs.tag_name }}
 
       - name: Verify package version matches tag
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,61 @@
+name: Publish npm package
+run-name: publish npm ${{ inputs.tag_name }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Existing release tag to publish (e.g., 0.121.10)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-npm-${{ inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TAG_NAME: ${{ inputs.tag_name }}
+    steps:
+      - name: Validate release tag
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::TAG_NAME '$TAG_NAME' is empty or invalid"
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Verify package version matches tag
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          if [[ "$package_version" != "$TAG_NAME" ]]; then
+            echo "::error::package.json version '$package_version' does not match tag '$TAG_NAME'"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      - run: npm install -g npm@11.11.0
+      - run: npm ci
+      - name: Publish package
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ''
+          PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,18 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
   build:
-    if: needs.release-please.outputs.release_created == 'true' || needs.release-please.outputs.code_scan_action_release_created == 'true'
+    # release-please can create a release, then still fail while opening the
+    # next release PR. Preserve artifact publication when the release outputs
+    # prove a release was already created.
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        (
+          needs.release-please.outputs.release_created == 'true' ||
+          needs.release-please.outputs.code_scan_action_release_created == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: release-please
@@ -66,7 +77,13 @@ jobs:
       - run: npm test
 
   publish-npm:
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.release-please.outputs.release_created == 'true' &&
+        needs.build.result == 'success'
+      }}
     needs: [build, release-please]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -93,8 +110,8 @@ jobs:
   docker:
     if: >-
       ${{
+        always() &&
         !cancelled() &&
-        needs.release-please.result == 'success' &&
         needs.publish-npm.result == 'success' &&
         needs.release-please.outputs.release_created == 'true'
       }}
@@ -109,7 +126,13 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   publish-code-scan-action:
-    if: needs.release-please.outputs.code_scan_action_release_created == 'true'
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.release-please.outputs.code_scan_action_release_created == 'true' &&
+        needs.build.result == 'success'
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Gate on `build` so root test failures block the mirror — code-scan-action


### PR DESCRIPTION
## Summary
- keep release artifact jobs eligible when release-please already created a release before a later transient failure
- add a manual tag-based npm publish workflow for stranded release recovery

## Validation
- yq eval on edited workflows
- prettier on edited workflows
- actionlint on edited workflows
- live incident verification: GitHub release 0.121.10 exists, npm has no 0.121.10 version, GHCR has no 0.121.10 manifest