### PR TITLE
fix: resolve code quality findings

### DIFF
--- a/examples/integration-google-adk/provider.py
+++ b/examples/integration-google-adk/provider.py
@@ -8,6 +8,7 @@ import logging
 import os
 import sys
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -34,8 +35,15 @@ DEFAULT_USER_ID = "promptfoo-user"
 DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
 
 _logger = logging.getLogger(__name__)
-_configured_tracer_provider: TracerProvider | None = None
-_configured_otlp_endpoint: str | None = None
+
+
+@dataclass
+class _TracerProviderState:
+    provider: TracerProvider | None = None
+    otlp_endpoint: str | None = None
+
+
+_tracer_provider_state = _TracerProviderState()
 
 
 def _build_steps(prompt: str, vars_dict: dict[str, Any]) -> list[str]:
@@ -85,16 +93,14 @@ def _ensure_tracer_provider(otlp_endpoint: str) -> TracerProvider:
     to be exported twice).
     """
 
-    global _configured_tracer_provider, _configured_otlp_endpoint
-
-    if _configured_tracer_provider is not None:
-        if _configured_otlp_endpoint != otlp_endpoint:
+    if _tracer_provider_state.provider is not None:
+        if _tracer_provider_state.otlp_endpoint != otlp_endpoint:
             _logger.warning(
                 "TracerProvider already configured for %s; ignoring request to switch to %s",
-                _configured_otlp_endpoint,
+                _tracer_provider_state.otlp_endpoint,
                 otlp_endpoint,
             )
-        return _configured_tracer_provider
+        return _tracer_provider_state.provider
 
     exporter = OTLPSpanExporter(endpoint=f"{otlp_endpoint.rstrip('/')}/v1/traces")
     provider = TracerProvider(
@@ -103,8 +109,8 @@ def _ensure_tracer_provider(otlp_endpoint: str) -> TracerProvider:
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
 
-    _configured_tracer_provider = provider
-    _configured_otlp_endpoint = otlp_endpoint
+    _tracer_provider_state.provider = provider
+    _tracer_provider_state.otlp_endpoint = otlp_endpoint
     return provider
 
 

--- a/site/docs/integrations/python.md
+++ b/site/docs/integrations/python.md
@@ -76,6 +76,7 @@ defaultTest:
 client = OpenAI()
 
 def call_api(prompt, options, context):
+    # The Responses API exposes combined text through output_text.
     response = client.responses.create(
         model="gpt-5.1-mini",
         input=prompt,

--- a/src/providers/mcp/util.ts
+++ b/src/providers/mcp/util.ts
@@ -63,6 +63,15 @@ function getOAuthCacheKey(auth: MCPOAuthClientCredentialsAuth | MCPOAuthPassword
 // Cache for discovered token endpoints
 const tokenEndpointCache = new Map<string, string>();
 
+function isValidTokenEndpoint(tokenEndpoint: string): boolean {
+  try {
+    const parsedUrl = new URL(tokenEndpoint);
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Discover the OAuth token endpoint from the server's well-known metadata.
  * Follows RFC 8414 OAuth 2.0 Authorization Server Metadata.
@@ -105,13 +114,13 @@ export async function discoverTokenEndpoint(serverUrl: string): Promise<string> 
       }
 
       const metadata = (await response.json()) as { token_endpoint?: string };
-      if (metadata.token_endpoint) {
+      if (metadata.token_endpoint && isValidTokenEndpoint(metadata.token_endpoint)) {
         logger.debug(`[MCP Auth] Discovered token endpoint: ${metadata.token_endpoint}`);
         tokenEndpointCache.set(serverUrl, metadata.token_endpoint);
         return metadata.token_endpoint;
       }
 
-      logger.debug(`[MCP Auth] No token_endpoint in metadata from ${discoveryUrl}`);
+      logger.debug(`[MCP Auth] No valid token_endpoint in metadata from ${discoveryUrl}`);
     } catch (error) {
       logger.debug(`[MCP Auth] Error fetching ${discoveryUrl}: ${error}`);
     }

--- a/src/redteam/mcpTargetProvider.ts
+++ b/src/redteam/mcpTargetProvider.ts
@@ -104,7 +104,7 @@ class RedteamMcpTargetProvider implements ApiProvider {
           }
         : undefined;
 
-      return this.target.callApi(materializedPrompt, materializedContext, options);
+      return await this.target.callApi(materializedPrompt, materializedContext, options);
     } catch (error) {
       return {
         error: `Failed to materialize MCP target prompt: ${

--- a/test/providers/mcp/util.test.ts
+++ b/test/providers/mcp/util.test.ts
@@ -268,6 +268,36 @@ describe('discoverTokenEndpoint', () => {
     );
   });
 
+  it('should ignore empty token endpoints during discovery', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: '' }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: 'https://auth.example.com/token' }),
+    });
+
+    await expect(discoverTokenEndpoint('https://example.com/path')).resolves.toBe(
+      'https://auth.example.com/token',
+    );
+  });
+
+  it('should ignore malformed token endpoints during discovery', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: 'not a url' }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: 'https://auth.example.com/token' }),
+    });
+
+    await expect(discoverTokenEndpoint('https://example.com/path')).resolves.toBe(
+      'https://auth.example.com/token',
+    );
+  });
+
   it('should handle network errors gracefully', async () => {
     mockFetch.mockRejectedValue(new Error('Network error'));
 

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -615,7 +615,7 @@ describe('calculateOpenAICost', () => {
   it('should use custom audioCost from config when provided', () => {
     const audioCost = 0.05; // per 1M tokens
 
-    const promiseTokens = 1000;
+    const promptTokens = 1000;
     const completionTokens = 500;
     const audioPromptTokens = 200;
     const audioCompletionTokens = 100;
@@ -632,7 +632,7 @@ describe('calculateOpenAICost', () => {
       return;
     }
 
-    const baseInputCost = model.cost.input * promiseTokens;
+    const baseInputCost = model.cost.input * promptTokens;
     const baseOutputCost = model.cost.output * completionTokens;
 
     const audioInputCostCustom = audioCost * audioPromptTokens;
@@ -644,7 +644,7 @@ describe('calculateOpenAICost', () => {
     const cost = calculateOpenAICost(
       'gpt-4o-audio-preview',
       { audioCost },
-      promiseTokens,
+      promptTokens,
       completionTokens,
       audioPromptTokens,
       audioCompletionTokens,

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -3290,6 +3290,58 @@ describe('redteam generate command with target option', () => {
     ]);
   });
 
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('should handle backwards compatibility with %s targets', async (_label, targets) => {
+    const mockConfig = {
+      prompts: ['Test prompt'],
+      vars: {},
+      providers: [{ id: 'test-provider' }],
+      targets,
+      redteam: {
+        plugins: ['harmful:hate'] as any,
+        strategies: [],
+      },
+    };
+    vi.mocked(getConfigFromCloud).mockResolvedValue(mockConfig as any);
+
+    vi.mocked(fs.existsSync).mockImplementation(function () {
+      return false;
+    });
+    vi.mocked(fs.writeFileSync).mockImplementation(function () {});
+
+    vi.mocked(synthesize).mockResolvedValue({
+      testCases: [],
+      purpose: 'Test purpose',
+      entities: [],
+      injectVar: 'input',
+      failedPlugins: [],
+    });
+
+    const configUUID = '12345678-1234-1234-1234-123456789012';
+    const targetUUID = '87654321-4321-4321-4321-210987654321';
+    const generateCommand = program.commands.find((cmd) => cmd.name() === 'generate');
+
+    await generateCommand!.parseAsync([
+      'node',
+      'test',
+      '--config',
+      configUUID,
+      '--target',
+      targetUUID,
+      '--output',
+      'test-output.yaml',
+    ]);
+
+    expect(mockConfig.targets).toEqual([
+      {
+        id: `promptfoo://provider/${targetUUID}`,
+        config: {},
+      },
+    ]);
+  });
+
   it('should throw error when target is not a UUID but config is', async () => {
     const configUUID = '12345678-1234-1234-1234-123456789012';
     const invalidTarget = 'not-a-uuid';

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -209,6 +209,43 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     expect(target.calls).toHaveLength(0);
   });
 
+  it('returns a materialization error when the wrapped provider call fails', async () => {
+    providerManagerMocks.getProvider.mockResolvedValueOnce({
+      id: () => 'openai:test',
+      callApi: async () => ({
+        output:
+          '{"tool":"search_companies","args":{"query":"Find clean energy companies.","limit":10}}',
+      }),
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    vi.spyOn(target, 'callApi').mockRejectedValueOnce(new Error('Target provider failed'));
+    const wrapped = maybeWrapMcpProviderForRedteam(target, {
+      metadata: {
+        pluginId: 'harmful:hate',
+        purpose: 'Search companies',
+      },
+    });
+
+    await expect(
+      wrapped.callApi('Find clean energy companies.', {
+        prompt: {
+          raw: '{{prompt}}',
+          label: 'prompt',
+        },
+        vars: { prompt: 'Find clean energy companies.' },
+        test: {
+          metadata: {
+            pluginId: 'harmful:hate',
+            purpose: 'Search companies',
+          },
+        },
+      } as unknown as CallApiContextParams),
+    ).resolves.toEqual({
+      error: expect.stringContaining('Target provider failed'),
+    });
+  });
+
   it('does not wrap non-redteam MCP calls', () => {
     const target = new FakeMcpProvider([searchCompaniesTool]);
 

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -209,6 +209,42 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     expect(target.calls).toHaveLength(0);
   });
 
+  it('returns a materialization error when inference provider calls fail', async () => {
+    providerManagerMocks.getProvider.mockResolvedValueOnce({
+      id: () => 'openai:test',
+      callApi: async () => {
+        throw new Error('Repair provider failed');
+      },
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    const wrapped = maybeWrapMcpProviderForRedteam(target, {
+      metadata: {
+        pluginId: 'harmful:hate',
+        purpose: 'Search companies',
+      },
+    });
+
+    await expect(
+      wrapped.callApi('Find clean energy companies.', {
+        prompt: {
+          raw: '{{prompt}}',
+          label: 'prompt',
+        },
+        vars: { prompt: 'Find clean energy companies.' },
+        test: {
+          metadata: {
+            pluginId: 'harmful:hate',
+            purpose: 'Search companies',
+          },
+        },
+      } as unknown as CallApiContextParams),
+    ).resolves.toEqual({
+      error: expect.stringContaining('Failed to materialize MCP target prompt'),
+    });
+    expect(target.calls).toHaveLength(0);
+  });
+
   it('returns a materialization error when the wrapped provider call fails', async () => {
     providerManagerMocks.getProvider.mockResolvedValueOnce({
       id: () => 'openai:test',


### PR DESCRIPTION
## Summary
- validate discovered MCP OAuth token endpoints before caching them
- cover missing redteam and MCP materialization edge cases
- replace Google ADK example globals with explicit tracer state
- clarify the Python integration example's Responses API usage
- clean up the OpenAI cost test typo surfaced by AI findings

## Why
The active quality dashboards surfaced a mix of real gaps, one real async bug in the MCP redteam wrapper, and two false-positive AI suggestions against a correct Responses API example. This keeps the dashboard cleanup tied to behavior that is actually safer or clearer.

## Validation
- `npx vitest run test/providers/mcp/util.test.ts test/providers/openai/util.test.ts test/redteam/commands/generate.test.ts test/redteam/mcpTargetProvider.test.ts`
- `npx vitest run test/redteam/mcpTargetProvider.test.ts`
- `npm run l`
- `npm run f`
- `python3 -m py_compile examples/integration-google-adk/provider.py`