### PR TITLE
fix(webui): anchor nav menus to their triggers

### DIFF
--- a/src/app/src/components/ui/navigation-menu.test.tsx
+++ b/src/app/src/components/ui/navigation-menu.test.tsx
@@ -76,6 +76,54 @@ describe('NavigationMenu', () => {
     expect(await screen.findByRole('link', { name: 'Product 1' })).toBeInTheDocument();
   });
 
+  it('expands menu content on trigger hover', async () => {
+    const user = userEvent.setup();
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/product1">Product 1</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    await user.hover(screen.getByText('Products'));
+
+    expect(await screen.findByRole('link', { name: 'Product 1' })).toBeInTheDocument();
+  });
+
+  it('anchors dropdown content to the owning item instead of a shared viewport', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/product1">Product 1</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    await user.click(screen.getByText('Products'));
+
+    expect(screen.getByText('Products').closest('li')).toHaveClass('relative');
+    expect(screen.getByRole('link', { name: 'Product 1' }).parentElement).toHaveClass(
+      'absolute',
+      'left-0',
+      'top-full',
+    );
+    expect(
+      container.querySelector('[data-radix-navigation-menu-viewport]'),
+    ).not.toBeInTheDocument();
+  });
+
   it('applies custom className to menu', () => {
     render(
       <NavigationMenu className="custom-nav">

--- a/src/app/src/components/ui/navigation-menu.tsx
+++ b/src/app/src/components/ui/navigation-menu.tsx
@@ -93,25 +93,6 @@ function NavigationMenuContent({
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
-function NavigationMenuViewport({
-  className,
-  ref,
-  ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
-  return (
-    <div className={cn('absolute left-0 top-full flex justify-center')}>
-      <NavigationMenuPrimitive.Viewport
-        className={cn(
-          'origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg ring-1 ring-black/5 dark:ring-white/10 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 md:w-[var(--radix-navigation-menu-viewport-width)]',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    </div>
-  );
-}
-
 function NavigationMenuIndicator({
   className,
   ref,
@@ -139,6 +120,5 @@ export {
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  NavigationMenuViewport,
   navigationMenuTriggerStyle,
 };

--- a/src/app/src/components/ui/navigation-menu.tsx
+++ b/src/app/src/components/ui/navigation-menu.tsx
@@ -21,7 +21,6 @@ function NavigationMenu({
       {...props}
     >
       {children}
-      <NavigationMenuViewport />
     </NavigationMenuPrimitive.Root>
   );
 }
@@ -40,7 +39,15 @@ function NavigationMenuList({
   );
 }
 
-const NavigationMenuItem = NavigationMenuPrimitive.Item;
+function NavigationMenuItem({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+  return (
+    <NavigationMenuPrimitive.Item ref={ref} className={cn('relative', className)} {...props} />
+  );
+}
 
 const navigationMenuTriggerStyle = cva(
   'group inline-flex h-9 w-max items-center justify-center rounded-md bg-transparent px-4 py-2 text-sm font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:opacity-50 cursor-pointer',
@@ -76,7 +83,7 @@ function NavigationMenuContent({
     <NavigationMenuPrimitive.Content
       ref={ref}
       className={cn(
-        'left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto',
+        'absolute left-0 top-full mt-1.5 w-auto overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg ring-1 ring-black/5 dark:ring-white/10 data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- render navigation-menu content from each owning item instead of a shared viewport
- keep Radix hover behavior while restoring exact per-trigger dropdown alignment
- add regression coverage for hover-open behavior and item-local anchoring

## Why
The shared `NavigationMenuViewport` anchored all dropdown content to the menu root. That changed the header behavior from the old per-button MUI `Popper` model and caused panels to open from the wrong horizontal origin when the nav root spans wider than the trigger cluster.

## Validation
- `npm run l`
- `npm run f`
- `npm run test:app -- src/components/ui/navigation-menu.test.tsx src/components/Navigation.test.tsx --run`
- verified locally in the running web UI that `New` and `View Results` open on hover beneath their own triggers