### PR TITLE
test(mcp): cover unsupported OAuth endpoint protocols

### DIFF
--- a/test/providers/mcp/util.test.ts
+++ b/test/providers/mcp/util.test.ts
@@ -298,6 +298,21 @@ describe('discoverTokenEndpoint', () => {
     );
   });
 
+  it('should ignore token endpoints with unsupported protocols during discovery', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: 'ftp://auth.example.com/token' }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token_endpoint: 'https://auth.example.com/token' }),
+    });
+
+    await expect(discoverTokenEndpoint('https://example.com/path')).resolves.toBe(
+      'https://auth.example.com/token',
+    );
+  });
+
   it('should handle network errors gracefully', async () => {
     mockFetch.mockRejectedValue(new Error('Network error'));
 


### PR DESCRIPTION
## Summary
- Add a focused regression for MCP OAuth discovery when metadata returns a syntactically valid token endpoint with an unsupported protocol.
- Ensure discovery skips `ftp://` token endpoints and continues to the next valid HTTPS metadata response.

## Tests
- `npx vitest run test/providers/mcp/util.test.ts`
- `npm run l`
- `npm run f`