### PR TITLE
fix(ui): improve table filter accessibility

### DIFF
--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -438,6 +438,8 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
   );
   const multiSelectSummary = formatMultiSelectSummary(multiSelectValues, filterOptions);
   const [isMultiSelectOpen, setIsMultiSelectOpen] = React.useState<boolean>(false);
+  const multiSelectDropdownId = React.useId();
+  const multiSelectTriggerRef = React.useRef<HTMLButtonElement>(null);
   const columnHeader =
     typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id;
 
@@ -551,6 +553,15 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
       <PopoverContent
         className="w-fit min-w-[320px] max-w-[min(90vw,560px)] overflow-visible p-3"
         align="start"
+        onEscapeKeyDown={(event) => {
+          // When the multi-select dropdown is open, Escape should close it
+          // and leave the parent popover open.
+          if (isMultiSelectOpen) {
+            event.preventDefault();
+            setIsMultiSelectOpen(false);
+            multiSelectTriggerRef.current?.focus();
+          }
+        }}
         onInteractOutside={(e) => {
           // Prevent popover from closing when interacting with portaled Select content.
           // Radix Select renders its dropdown in a separate portal, which can be interpreted
@@ -594,14 +605,17 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                 {operator === 'isAny' ? (
                   <div className="relative min-w-0 w-full">
                     <Button
+                      ref={multiSelectTriggerRef}
                       variant="outline"
                       aria-label={`Value for ${columnHeader} filter: ${multiSelectSummary}`}
+                      aria-haspopup="dialog"
+                      aria-controls={multiSelectDropdownId}
                       aria-expanded={isMultiSelectOpen}
                       className="h-8 w-full min-w-0 overflow-hidden justify-start font-normal"
                       onMouseDown={(event) => event.stopPropagation()}
                       onClick={(event) => {
                         event.stopPropagation();
-                        setIsMultiSelectOpen(true);
+                        setIsMultiSelectOpen((prev) => !prev);
                       }}
                     >
                       {multiSelectValues.length > 0 ? (
@@ -611,7 +625,12 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                       )}
                     </Button>
                     {isMultiSelectOpen && (
-                      <div className="absolute left-0 right-0 top-full mt-1 w-full rounded-md border border-border bg-white dark:bg-zinc-900 shadow-md p-2 z-(--z-dropdown)">
+                      <div
+                        id={multiSelectDropdownId}
+                        role="dialog"
+                        aria-label={`Select values for ${columnHeader} filter`}
+                        className="absolute left-0 right-0 top-full mt-1 w-full rounded-md border border-border bg-white dark:bg-zinc-900 shadow-md p-2 z-(--z-dropdown)"
+                      >
                         <div className="space-y-1">
                           {filterOptions.map((option) => {
                             const isSelected = multiSelectValues.includes(option.value);

--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -246,6 +246,8 @@ interface SelectFilterProps {
   operator: SelectOperator;
   value: string | string[];
   options: FilterOption[];
+  operatorLabel: string;
+  valueLabel: string;
   onOperatorChange: (operator: SelectOperator) => void;
   onChange: (value: string | string[]) => void;
   disabled?: boolean;
@@ -255,12 +257,28 @@ function SelectFilterInput({
   operator,
   value,
   options,
+  operatorLabel,
+  valueLabel,
   onOperatorChange,
   onChange,
   disabled = false,
 }: SelectFilterProps) {
   const isMultiSelect = operator === 'isAny';
   const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
+  const selectedValueSummary =
+    selectedValues.length > 0
+      ? `${selectedValues.length} selected${
+          selectedValues.length <= 2
+            ? `: ${selectedValues
+                .map(
+                  (selectedValue) =>
+                    options.find((option) => option.value === selectedValue)?.label ||
+                    selectedValue,
+                )
+                .join(', ')}`
+            : ''
+        }`
+      : 'No values selected';
 
   const handleSingleSelect = (newValue: string) => {
     onChange(newValue);
@@ -277,7 +295,7 @@ function SelectFilterInput({
   return (
     <>
       <Select value={operator} onValueChange={onOperatorChange} disabled={disabled}>
-        <SelectTrigger className="h-8 w-[110px] shrink-0">
+        <SelectTrigger aria-label={operatorLabel} className="h-8 w-[110px] shrink-0">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -295,6 +313,7 @@ function SelectFilterInput({
             <Button
               variant="outline"
               disabled={disabled}
+              aria-label={`${valueLabel}: ${selectedValueSummary}`}
               className="h-8 min-w-[150px] flex-1 justify-start font-normal"
             >
               {selectedValues.length > 0 ? (
@@ -313,21 +332,27 @@ function SelectFilterInput({
               {options.map((option) => {
                 const isSelected = selectedValues.includes(option.value);
                 return (
-                  <div
+                  <label
                     key={option.value}
-                    className="flex items-center space-x-2 px-2 py-1.5 rounded-sm hover:bg-accent cursor-pointer"
-                    onClick={() => handleMultiSelectToggle(option.value)}
+                    className="flex w-full cursor-pointer items-center space-x-2 rounded-sm px-2 py-1.5 hover:bg-accent focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
                   >
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => handleMultiSelectToggle(option.value)}
+                      className="sr-only"
+                    />
                     <div
                       className={cn(
                         'size-4 border border-input rounded flex items-center justify-center',
                         isSelected && 'bg-primary border-primary text-primary-foreground',
                       )}
+                      aria-hidden="true"
                     >
                       {isSelected && <span className="text-xs">✓</span>}
                     </div>
                     <span className="text-sm">{option.label}</span>
-                  </div>
+                  </label>
                 );
               })}
             </div>
@@ -339,7 +364,7 @@ function SelectFilterInput({
           onValueChange={handleSingleSelect}
           disabled={disabled}
         >
-          <SelectTrigger className="h-8 min-w-[150px] flex-1">
+          <SelectTrigger aria-label={valueLabel} className="h-8 min-w-[150px] flex-1">
             <SelectValue placeholder="Select value..." />
           </SelectTrigger>
           <SelectContent>
@@ -359,6 +384,8 @@ function SelectFilterInput({
 interface ComparisonFilterProps {
   operator: FilterOperator;
   value: string;
+  operatorLabel: string;
+  valueLabel: string;
   onOperatorChange: (operator: FilterOperator) => void;
   onValueChange: (value: string) => void;
   disabled?: boolean;
@@ -367,6 +394,8 @@ interface ComparisonFilterProps {
 function ComparisonFilterInput({
   operator,
   value,
+  operatorLabel,
+  valueLabel,
   onOperatorChange,
   onValueChange,
   disabled = false,
@@ -374,7 +403,7 @@ function ComparisonFilterInput({
   return (
     <>
       <Select value={operator} onValueChange={onOperatorChange} disabled={disabled}>
-        <SelectTrigger className="h-8 w-[110px] shrink-0">
+        <SelectTrigger aria-label={operatorLabel} className="h-8 w-[110px] shrink-0">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -386,6 +415,7 @@ function ComparisonFilterInput({
         </SelectContent>
       </Select>
       <Input
+        aria-label={valueLabel}
         placeholder="Value..."
         value={value}
         onChange={(e) => onValueChange(e.target.value)}
@@ -409,6 +439,18 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
   const [multiSelectValues, setMultiSelectValues] = React.useState<string[]>(
     Array.isArray(value) ? value : typeof value === 'string' && value ? [value] : [],
   );
+  const multiSelectSummary =
+    multiSelectValues.length > 0
+      ? `${multiSelectValues.length} selected${
+          multiSelectValues.length <= 2
+            ? `: ${multiSelectValues
+                .map(
+                  (entry) => filterOptions.find((option) => option.value === entry)?.label || entry,
+                )
+                .join(', ')}`
+            : ''
+        }`
+      : 'No values selected';
   const [isMultiSelectOpen, setIsMultiSelectOpen] = React.useState<boolean>(false);
   const columnHeader =
     typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id;
@@ -548,7 +590,10 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                     handleOperatorChange(selectedOperator as FilterOperator)
                   }
                 >
-                  <SelectTrigger className="h-8 w-full">
+                  <SelectTrigger
+                    aria-label={`Operator for ${columnHeader} filter`}
+                    className="h-8 w-full"
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -564,6 +609,8 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                   <div className="relative min-w-0 w-full">
                     <Button
                       variant="outline"
+                      aria-label={`Value for ${columnHeader} filter: ${multiSelectSummary}`}
+                      aria-expanded={isMultiSelectOpen}
                       className="h-8 w-full min-w-0 overflow-hidden justify-start font-normal"
                       onMouseDown={(event) => event.stopPropagation()}
                       onClick={(event) => {
@@ -594,27 +641,32 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                             const isSelected = multiSelectValues.includes(option.value);
 
                             return (
-                              <div
+                              <label
                                 key={option.value}
-                                role="menuitem"
-                                className="flex items-center space-x-2 px-2 py-1.5 rounded-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer"
+                                className="flex w-full cursor-pointer items-center space-x-2 rounded-sm px-2 py-1.5 hover:bg-zinc-100 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 dark:hover:bg-zinc-800"
                                 onMouseDown={(event) => event.stopPropagation()}
                                 onClick={(event) => {
                                   event.stopPropagation();
-                                  handleMultiSelectChange(option.value);
                                 }}
                               >
+                                <input
+                                  type="checkbox"
+                                  checked={isSelected}
+                                  onChange={() => handleMultiSelectChange(option.value)}
+                                  className="sr-only"
+                                />
                                 <div
                                   className={`size-4 border rounded flex items-center justify-center ${
                                     isSelected
                                       ? 'bg-zinc-900 border-zinc-900 text-white dark:bg-zinc-100 dark:border-zinc-100 dark:text-zinc-900'
                                       : 'border-zinc-300 dark:border-zinc-600'
                                   }`}
+                                  aria-hidden="true"
                                 >
                                   {isSelected && <span className="text-xs">✓</span>}
                                 </div>
                                 <span className="text-sm">{option.label}</span>
-                              </div>
+                              </label>
                             );
                           })}
                         </div>
@@ -629,7 +681,10 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                       setFilterValue(operator, nextValue);
                     }}
                   >
-                    <SelectTrigger className="h-8 w-full min-w-0">
+                    <SelectTrigger
+                      aria-label={`Value for ${columnHeader} filter`}
+                      className="h-8 w-full min-w-0"
+                    >
                       <SelectValue placeholder="Select value..." />
                     </SelectTrigger>
                     <SelectContent>
@@ -650,7 +705,10 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                     handleOperatorChange(selectedOperator as FilterOperator)
                   }
                 >
-                  <SelectTrigger className="h-8 w-full">
+                  <SelectTrigger
+                    aria-label={`Operator for ${columnHeader} filter`}
+                    className="h-8 w-full"
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -662,6 +720,7 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                   </SelectContent>
                 </Select>
                 <Input
+                  aria-label={`Value for ${columnHeader} filter`}
                   placeholder="Value..."
                   value={textValue}
                   onChange={(event) => {
@@ -968,8 +1027,12 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
           </div>
 
           <div className="space-y-2">
-            {activeFilters.map((filter) => {
-              const { isSelectFilter, filterOptions } = getColumnMetadata(filter.columnId);
+            {activeFilters.map((filter, filterIndex) => {
+              const { column, isSelectFilter, filterOptions } = getColumnMetadata(filter.columnId);
+              const columnHeader =
+                typeof column?.columnDef.header === 'string'
+                  ? column.columnDef.header
+                  : filter.columnId;
 
               return (
                 <div
@@ -993,7 +1056,10 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                       updateFilter(filter.id, { columnId: value, value: '' });
                     }}
                   >
-                    <SelectTrigger className="h-8 w-[110px] shrink-0">
+                    <SelectTrigger
+                      aria-label={`Column for filter ${filterIndex + 1}`}
+                      className="h-8 w-[110px] shrink-0"
+                    >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -1013,6 +1079,8 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                       operator={filter.operator as SelectOperator}
                       value={filter.value}
                       options={filterOptions}
+                      operatorLabel={`Operator for ${columnHeader} filter`}
+                      valueLabel={`Value for ${columnHeader} filter`}
                       onOperatorChange={(operator) => {
                         // When switching to/from isAny, reset value appropriately
                         const newValue =
@@ -1033,6 +1101,8 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                     <ComparisonFilterInput
                       operator={filter.operator as ComparisonOperator}
                       value={typeof filter.value === 'string' ? filter.value : ''}
+                      operatorLabel={`Operator for ${columnHeader} filter`}
+                      valueLabel={`Value for ${columnHeader} filter`}
                       onOperatorChange={(operator) => {
                         updateFilter(filter.id, { operator });
                       }}
@@ -1046,6 +1116,7 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label={`Remove filter for ${columnHeader}`}
                     onClick={() => removeFilter(filter.id)}
                     className="size-8 p-0 shrink-0"
                   >
@@ -1097,6 +1168,7 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label={`Remove filter for ${filter.columnHeader}`}
                     onClick={() => table.getColumn(filter.columnId)?.setFilterValue(undefined)}
                     className="size-8 p-0 shrink-0"
                   >

--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -241,6 +241,19 @@ interface ColumnFilterDisplay {
   filterOptions: FilterOption[];
 }
 
+const formatMultiSelectSummary = (selectedValues: string[], options: FilterOption[]): string => {
+  if (selectedValues.length === 0) {
+    return 'No values selected';
+  }
+  if (selectedValues.length > 2) {
+    return `${selectedValues.length} selected`;
+  }
+  const labels = selectedValues.map(
+    (entry) => options.find((option) => option.value === entry)?.label || entry,
+  );
+  return `${selectedValues.length} selected: ${labels.join(', ')}`;
+};
+
 // Select filter component for discrete values
 interface SelectFilterProps {
   operator: SelectOperator;
@@ -265,30 +278,18 @@ function SelectFilterInput({
 }: SelectFilterProps) {
   const isMultiSelect = operator === 'isAny';
   const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
-  const selectedValueSummary =
-    selectedValues.length > 0
-      ? `${selectedValues.length} selected${
-          selectedValues.length <= 2
-            ? `: ${selectedValues
-                .map(
-                  (selectedValue) =>
-                    options.find((option) => option.value === selectedValue)?.label ||
-                    selectedValue,
-                )
-                .join(', ')}`
-            : ''
-        }`
-      : 'No values selected';
+  const selectedSummary = formatMultiSelectSummary(selectedValues, options);
 
   const handleSingleSelect = (newValue: string) => {
     onChange(newValue);
   };
 
   const handleMultiSelectToggle = (optionValue: string) => {
-    const currentValues = Array.isArray(value) ? value : [];
-    const newValues = currentValues.includes(optionValue)
-      ? currentValues.filter((v) => v !== optionValue)
-      : [...currentValues, optionValue];
+    // Use the normalized selectedValues so a string-shaped value isn't silently
+    // dropped on the first toggle when the UI was already showing it as selected.
+    const newValues = selectedValues.includes(optionValue)
+      ? selectedValues.filter((v) => v !== optionValue)
+      : [...selectedValues, optionValue];
     onChange(newValues);
   };
 
@@ -313,15 +314,11 @@ function SelectFilterInput({
             <Button
               variant="outline"
               disabled={disabled}
-              aria-label={`${valueLabel}: ${selectedValueSummary}`}
+              aria-label={`${valueLabel}: ${selectedSummary}`}
               className="h-8 min-w-[150px] flex-1 justify-start font-normal"
             >
               {selectedValues.length > 0 ? (
-                <span className="truncate">
-                  {selectedValues.length} selected
-                  {selectedValues.length <= 2 &&
-                    `: ${selectedValues.map((v) => options.find((o) => o.value === v)?.label || v).join(', ')}`}
-                </span>
+                <span className="truncate">{selectedSummary}</span>
               ) : (
                 <span className="text-gray-500 dark:text-gray-400">Select values...</span>
               )}
@@ -439,18 +436,7 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
   const [multiSelectValues, setMultiSelectValues] = React.useState<string[]>(
     Array.isArray(value) ? value : typeof value === 'string' && value ? [value] : [],
   );
-  const multiSelectSummary =
-    multiSelectValues.length > 0
-      ? `${multiSelectValues.length} selected${
-          multiSelectValues.length <= 2
-            ? `: ${multiSelectValues
-                .map(
-                  (entry) => filterOptions.find((option) => option.value === entry)?.label || entry,
-                )
-                .join(', ')}`
-            : ''
-        }`
-      : 'No values selected';
+  const multiSelectSummary = formatMultiSelectSummary(multiSelectValues, filterOptions);
   const [isMultiSelectOpen, setIsMultiSelectOpen] = React.useState<boolean>(false);
   const columnHeader =
     typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id;
@@ -619,17 +605,7 @@ export function DataTableHeaderFilter<TData>({ column }: { column: Column<TData,
                       }}
                     >
                       {multiSelectValues.length > 0 ? (
-                        <span className="truncate">
-                          {multiSelectValues.length} selected
-                          {multiSelectValues.length <= 2 &&
-                            `: ${multiSelectValues
-                              .map(
-                                (entry) =>
-                                  filterOptions.find((option) => option.value === entry)?.label ||
-                                  entry,
-                              )
-                              .join(', ')}`}
-                        </span>
+                        <span className="truncate">{multiSelectSummary}</span>
                       ) : (
                         <span className="text-zinc-500 dark:text-zinc-400">Select values...</span>
                       )}

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -752,11 +752,12 @@ describe('DataTable', () => {
       await user.click(operatorSelect);
       await user.click(await screen.findByRole('option', { name: 'is any of' }));
 
-      await user.click(
+      // Switching to 'is any of' auto-opens the dropdown.
+      expect(
         within(popover).getByRole('button', {
           name: 'Value for Status filter: No values selected',
         }),
-      );
+      ).toHaveAttribute('aria-expanded', 'true');
       const alphaOption = within(popover).getByRole('checkbox', { name: 'Alpha' });
       expect(alphaOption).not.toBeChecked();
       alphaOption.focus();
@@ -774,6 +775,49 @@ describe('DataTable', () => {
       expect(screen.getByText('Row One')).toBeInTheDocument();
       expect(screen.getByText('Row Two')).toBeInTheDocument();
       expect(screen.getByText('Row Four')).toBeInTheDocument();
+    });
+
+    it('toggles and dismisses the multi-select dropdown via the trigger and Escape key', async () => {
+      const user = userEvent.setup();
+
+      render(<DataTable columns={headerFilterColumns} data={headerFilterRows} />);
+
+      const popover = await openHeaderFilterPopover('Status');
+
+      const operatorSelect = within(popover).getByRole('combobox', {
+        name: 'Operator for Status filter',
+      });
+      await user.click(operatorSelect);
+      await user.click(await screen.findByRole('option', { name: 'is any of' }));
+
+      const trigger = within(popover).getByRole('button', {
+        name: 'Value for Status filter: No values selected',
+      });
+      const dropdownLabel = 'Select values for Status filter';
+      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(within(popover).getByRole('dialog', { name: dropdownLabel })).toBeVisible();
+
+      // Click on the open trigger toggles the dropdown closed.
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(
+        within(popover).queryByRole('dialog', { name: dropdownLabel }),
+      ).not.toBeInTheDocument();
+
+      // Click reopens.
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      // Escape closes the dropdown and leaves the parent header filter popover open.
+      const dropdown = within(popover).getByRole('dialog', { name: dropdownLabel });
+      const alpha = within(dropdown).getByRole('checkbox', { name: 'Alpha' });
+      alpha.focus();
+      await user.keyboard('[Escape]');
+      expect(
+        within(popover).queryByRole('dialog', { name: dropdownLabel }),
+      ).not.toBeInTheDocument();
+      expect(popover).toBeInTheDocument();
     });
 
     it('should open header filter popovers with an active interactive row by default', async () => {

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -126,6 +126,12 @@ describe('DataTable', () => {
 
     expect(filterRow).toHaveClass('flex-wrap');
     expect(valueInput).toHaveClass('min-w-[150px]');
+    expect(within(filterRow).getByRole('combobox', { name: 'Column for filter 1' })).toBeVisible();
+    expect(
+      within(filterRow).getByRole('combobox', { name: 'Operator for ID filter' }),
+    ).toBeVisible();
+    expect(within(filterRow).getByRole('textbox', { name: 'Value for ID filter' })).toBeVisible();
+    expect(within(filterRow).getByRole('button', { name: 'Remove filter for ID' })).toBeVisible();
   });
 
   it('keeps toolbar controls easier to tap on narrow screens', () => {
@@ -135,6 +141,40 @@ describe('DataTable', () => {
 
     expect(screen.getByText('Columns').closest('button')).toHaveClass('h-11', 'sm:h-8');
     expect(screen.getByText('Filters').closest('button')).toHaveClass('h-11', 'sm:h-8');
+  });
+
+  it('exposes toolbar multi-select filters as labeled checkbox controls', async () => {
+    const user = userEvent.setup();
+
+    render(<DataTable columns={headerFilterColumns} data={headerFilterRows} showToolbar />);
+
+    await user.click(screen.getByText('Filters'));
+    const filterRow = screen.getByTestId('data-table-filter-row');
+
+    await user.click(within(filterRow).getByRole('combobox', { name: 'Column for filter 1' }));
+    await user.click(await screen.findByRole('option', { name: 'Status' }));
+
+    await user.click(
+      within(filterRow).getByRole('combobox', { name: 'Operator for Status filter' }),
+    );
+    await user.click(await screen.findByRole('option', { name: 'is any of' }));
+
+    await user.click(
+      within(filterRow).getByRole('button', {
+        name: 'Value for Status filter: No values selected',
+      }),
+    );
+    const alphaOption = screen.getByRole('checkbox', { name: 'Alpha' });
+    expect(alphaOption).not.toBeChecked();
+
+    alphaOption.focus();
+    await user.keyboard('[Space]');
+    expect(alphaOption).toBeChecked();
+    expect(
+      within(filterRow).getByRole('button', {
+        name: 'Value for Status filter: 1 selected: Alpha',
+      }),
+    ).toBeVisible();
   });
 
   it('should render table with data when data is provided', () => {
@@ -667,7 +707,13 @@ describe('DataTable', () => {
       render(<DataTable columns={headerFilterColumns} data={data} />);
 
       const popover = await openHeaderFilterPopover('Name', user);
-      await user.type(within(popover).getByPlaceholderText('Value...'), 'Alpha');
+      expect(
+        within(popover).getByRole('combobox', { name: 'Operator for Name filter' }),
+      ).toBeVisible();
+      await user.type(
+        within(popover).getByRole('textbox', { name: 'Value for Name filter' }),
+        'Alpha',
+      );
 
       await waitFor(() => expect(screen.queryByText('Row Two')).not.toBeInTheDocument());
       expect(screen.getByText('Alpha Row')).toBeInTheDocument();
@@ -680,8 +726,9 @@ describe('DataTable', () => {
       render(<DataTable columns={headerFilterColumns} data={headerFilterRows} />);
 
       const popover = await openHeaderFilterPopover('Status');
-      const comboboxes = within(popover).getAllByRole('combobox');
-      const valueSelect = comboboxes[1];
+      const valueSelect = within(popover).getByRole('combobox', {
+        name: 'Value for Status filter',
+      });
 
       await user.click(valueSelect);
       await user.click(await screen.findByRole('option', { name: 'Beta' }));
@@ -699,13 +746,29 @@ describe('DataTable', () => {
 
       const popover = await openHeaderFilterPopover('Status');
 
-      const operatorSelect = within(popover).getAllByRole('combobox')[0];
+      const operatorSelect = within(popover).getByRole('combobox', {
+        name: 'Operator for Status filter',
+      });
       await user.click(operatorSelect);
       await user.click(await screen.findByRole('option', { name: 'is any of' }));
 
-      await user.click(within(popover).getByRole('button', { name: 'Select values...' }));
-      await user.click(within(popover).getByText('Alpha'));
-      await user.click(within(popover).getByText('Beta'));
+      await user.click(
+        within(popover).getByRole('button', {
+          name: 'Value for Status filter: No values selected',
+        }),
+      );
+      const alphaOption = within(popover).getByRole('checkbox', { name: 'Alpha' });
+      expect(alphaOption).not.toBeChecked();
+      alphaOption.focus();
+      await user.keyboard('[Space]');
+      expect(alphaOption).toBeChecked();
+      expect(within(popover).getByRole('checkbox', { name: 'Alpha' })).toBeInTheDocument();
+      expect(
+        within(popover).getByRole('button', {
+          name: 'Value for Status filter: 1 selected: Alpha',
+        }),
+      ).toBeVisible();
+      await user.click(within(popover).getByRole('checkbox', { name: 'Beta' }));
 
       await waitFor(() => expect(screen.queryByText('Row Three')).not.toBeInTheDocument());
       expect(screen.getByText('Row One')).toBeInTheDocument();
@@ -718,8 +781,12 @@ describe('DataTable', () => {
       render(<DataTable columns={headerFilterColumns} data={headerFilterRows} />);
 
       const popover = await openHeaderFilterPopover('Name', user);
-      const operatorSelect = within(popover).getByRole('combobox');
-      const valueInput = within(popover).getByPlaceholderText('Value...');
+      const operatorSelect = within(popover).getByRole('combobox', {
+        name: 'Operator for Name filter',
+      });
+      const valueInput = within(popover).getByRole('textbox', {
+        name: 'Value for Name filter',
+      });
 
       expect(operatorSelect).toBeInTheDocument();
       expect(valueInput).toBeInTheDocument();
@@ -753,6 +820,9 @@ describe('DataTable', () => {
       expect(toolbarDialog).toHaveClass('w-[min(520px,calc(100vw-1rem))]');
       expect(await within(toolbarDialog).findByText('Status')).toBeInTheDocument();
       expect(await within(toolbarDialog).findByText(/beta/i)).toBeInTheDocument();
+      expect(
+        within(toolbarDialog).getByRole('button', { name: 'Remove filter for Status' }),
+      ).toBeVisible();
     });
 
     it('keeps externally-added static filter rows usable on narrow popovers', async () => {


### PR DESCRIPTION
## Summary
- label shared table filter controls so repeated operator/value inputs are distinguishable
- replace mouse-only multi-select rows with native checkbox semantics and visible keyboard focus
- name remove-filter actions and cover both toolbar and header filter flows with accessibility regressions

## Validation
- `npm run test:app -- src/components/data-table/data-table.test.tsx --run`
- `npm run test:app -- --run`
- `npm run tsc`
- `npm run l`
- `npm run lint:src` *(passes with existing repository warnings only)*

## Notes
- This is the upstream Promptfoo slice of the broader on-prem table accessibility remediation; the coordinated cloud slice is tracked separately in `openai/promptfoo-cloud`.
- `npm run build:app` is currently blocked in this checkout by a pre-existing missing declaration for `diff` in `EvalOutputCell.tsx`, unrelated to this patch.
