### PR TITLE
fix(ui): wrap static table filters

### DIFF
--- a/src/app/src/components/data-table/data-table-filter.tsx
+++ b/src/app/src/components/data-table/data-table-filter.tsx
@@ -1065,11 +1065,15 @@ export function DataTableFilter<TData>({ table, columnFilters }: DataTableFilter
                   ),
               )
               .map((filter) => (
-                <div key={`column-${filter.id}`} className="flex items-center gap-1.5">
+                <div
+                  key={`column-${filter.id}`}
+                  data-testid="data-table-static-filter-row"
+                  className="flex flex-wrap items-center gap-1.5"
+                >
                   <div className="h-8 w-[110px] px-3 py-1.5 text-xs rounded-md border border-input bg-background shrink-0">
                     <span className="truncate">{filter.columnHeader}</span>
                   </div>
-                  <div className="flex min-h-8 h-8 flex-1 items-center border rounded-md bg-gray-100/50 dark:bg-gray-800/50 px-3 text-sm">
+                  <div className="flex min-h-8 h-8 min-w-[150px] flex-1 items-center border rounded-md bg-gray-100/50 dark:bg-gray-800/50 px-3 text-sm">
                     {filter.isSelectFilter ? (
                       <span className="truncate">
                         {`${filter.operator} ${

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -754,6 +754,53 @@ describe('DataTable', () => {
       expect(await within(toolbarDialog).findByText('Status')).toBeInTheDocument();
       expect(await within(toolbarDialog).findByText(/beta/i)).toBeInTheDocument();
     });
+
+    it('keeps externally-added static filter rows usable on narrow popovers', async () => {
+      const user = userEvent.setup();
+      const onColumnFiltersChange = vi.fn();
+      const { rerender } = render(
+        <DataTable
+          columns={headerFilterColumns}
+          data={headerFilterRows}
+          manualFiltering
+          columnFilters={[]}
+          onColumnFiltersChange={onColumnFiltersChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /Filters/ }));
+
+      rerender(
+        <DataTable
+          columns={headerFilterColumns}
+          data={headerFilterRows}
+          manualFiltering
+          columnFilters={[
+            { id: 'status', value: { operator: 'equals', value: 'beta' } },
+            { id: 'status', value: { operator: 'is any of', value: ['alpha', 'beta', 'gamma'] } },
+            { id: 'name', value: { operator: 'contains', value: 'Row' } },
+          ]}
+          onColumnFiltersChange={onColumnFiltersChange}
+        />,
+      );
+
+      const staticFilterRows = await screen.findAllByTestId('data-table-static-filter-row');
+      expect(staticFilterRows).toHaveLength(3);
+
+      for (const staticFilterRow of staticFilterRows) {
+        expect(staticFilterRow).toHaveClass('flex-wrap');
+      }
+
+      expect(within(staticFilterRows[0]).getByText(/beta/i).parentElement).toHaveClass(
+        'min-w-[150px]',
+      );
+      expect(within(staticFilterRows[1]).getByText(/3 selected/i).parentElement).toHaveClass(
+        'min-w-[150px]',
+      );
+      expect(within(staticFilterRows[2]).getByText(/contains Row/i).parentElement).toHaveClass(
+        'min-w-[150px]',
+      );
+    });
   });
 
   describe('row selection', () => {


### PR DESCRIPTION
## Summary
- let externally-added static filter rows wrap inside narrow table filter popovers
- preserve a usable minimum value width across scalar select, multi-select, and text filters
- add regression coverage for the static-row render path

## Verification
- npm run test:app -- src/components/data-table/data-table.test.tsx --run
- npm run test:app -- --run
- npm run tsc
- npm run l
- npm run f
- npm run build:app