### PR TITLE
test(providers): cover MCP response parser fallback

### DIFF
--- a/test/providers/mcp/provider.test.ts
+++ b/test/providers/mcp/provider.test.ts
@@ -87,6 +87,62 @@ describe('MCPProvider', () => {
     });
   });
 
+  it('should use deprecated responseParser when transformResponse is not configured', async () => {
+    const rawResult = {
+      structuredContent: { answer: 'legacy response' },
+    };
+    mcpClientMock.callTool.mockResolvedValue({
+      content: 'normalized response',
+      raw: rawResult,
+    });
+
+    const provider = new MCPProvider({
+      config: {
+        enabled: true,
+        responseParser:
+          '({ output: result.structuredContent.answer, metadata: { parser: "legacy" } })',
+      },
+    });
+
+    await expect(provider.callTool('lookup_user', { id: '123' })).resolves.toEqual({
+      output: 'legacy response',
+      raw: rawResult,
+      metadata: {
+        parser: 'legacy',
+        toolName: 'lookup_user',
+        toolArgs: { id: '123' },
+      },
+    });
+  });
+
+  it('should prefer transformResponse over deprecated responseParser when both are configured', async () => {
+    const rawResult = {
+      structuredContent: { answer: 'structured response' },
+    };
+    mcpClientMock.callTool.mockResolvedValue({
+      content: 'normalized response',
+      raw: rawResult,
+    });
+
+    const provider = new MCPProvider({
+      config: {
+        enabled: true,
+        responseParser: '({ output: "legacy response", metadata: { parser: "legacy" } })',
+        transformResponse: '({ output: "new response", metadata: { parser: "transform" } })',
+      },
+    });
+
+    await expect(provider.callTool('lookup_user', { id: '123' })).resolves.toEqual({
+      output: 'new response',
+      raw: rawResult,
+      metadata: {
+        parser: 'transform',
+        toolName: 'lookup_user',
+        toolArgs: { id: '123' },
+      },
+    });
+  });
+
   it('should keep provider metadata authoritative when transforms return conflicting keys', async () => {
     const rawResult = {
       structuredContent: { answer: 'structured response' },


### PR DESCRIPTION
## Summary
- add MCP provider coverage for deprecated responseParser fallback
- assert transformResponse takes precedence when both parser keys are configured

## Test plan
- npx vitest run test/providers/mcp/provider.test.ts
- /Users/mdangelo/code/promptfoo/node_modules/.bin/prettier --check test/providers/mcp/provider.test.ts
- git diff --check

Note: npm run l and npm run f were attempted, but Biome emitted its known worker stack-overflow message in this temp checkout.