### PR TITLE
fix(webui): restore nav dropdown animations and clean up after #9154

### DIFF
--- a/src/app/src/components/ui/navigation-menu.stories.tsx
+++ b/src/app/src/components/ui/navigation-menu.stories.tsx
@@ -303,3 +303,34 @@ export const AppHeader: Story = {
     </div>
   ),
 };
+
+// Right-aligned dropdown for triggers near the right edge of the header
+export const EndAligned: Story = {
+  render: () => (
+    <div className="flex items-center justify-between p-4 border-b">
+      <div className="flex items-center gap-6">
+        <span className="font-semibold text-lg">Promptfoo</span>
+      </div>
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Account</NavigationMenuTrigger>
+            <NavigationMenuContent align="end">
+              <ul className="grid w-[260px] gap-3 p-4">
+                <ListItem href="#" title="Profile">
+                  Manage your profile and preferences.
+                </ListItem>
+                <ListItem href="#" title="Billing">
+                  Plans, invoices, and usage.
+                </ListItem>
+                <ListItem href="#" title="Sign out">
+                  End your current session.
+                </ListItem>
+              </ul>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
+    </div>
+  ),
+};

--- a/src/app/src/components/ui/navigation-menu.test.tsx
+++ b/src/app/src/components/ui/navigation-menu.test.tsx
@@ -124,6 +124,82 @@ describe('NavigationMenu', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('animates open/close via data-state since no shared viewport is present', async () => {
+    const user = userEvent.setup();
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/product1">Product 1</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    await user.click(screen.getByText('Products'));
+
+    const content = (await screen.findByRole('link', { name: 'Product 1' })).parentElement;
+    expect(content).toHaveAttribute('data-state', 'open');
+    // First open has no data-motion (Radix only sets it when transitioning between siblings),
+    // so the open/close zoom+fade must come from data-state classes.
+    expect(content).toHaveClass(
+      'data-[state=open]:animate-in',
+      'data-[state=closed]:animate-out',
+      'data-[state=open]:fade-in-0',
+      'data-[state=closed]:fade-out-0',
+      'data-[state=open]:zoom-in-95',
+      'data-[state=closed]:zoom-out-95',
+    );
+  });
+
+  it('supports end alignment to right-anchor the dropdown', async () => {
+    const user = userEvent.setup();
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Account</NavigationMenuTrigger>
+            <NavigationMenuContent align="end">
+              <NavigationMenuLink href="/profile">Profile</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    await user.click(screen.getByText('Account'));
+
+    const content = (await screen.findByRole('link', { name: 'Profile' })).parentElement;
+    expect(content).toHaveClass('right-0');
+    expect(content).not.toHaveClass('left-0');
+  });
+
+  it('supports center alignment to center the dropdown over the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Help</NavigationMenuTrigger>
+            <NavigationMenuContent align="center">
+              <NavigationMenuLink href="/docs">Docs</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    await user.click(screen.getByText('Help'));
+
+    const content = (await screen.findByRole('link', { name: 'Docs' })).parentElement;
+    expect(content).toHaveClass('left-1/2', '-translate-x-1/2');
+    expect(content).not.toHaveClass('left-0');
+    expect(content).not.toHaveClass('right-0');
+  });
+
   it('applies custom className to menu', () => {
     render(
       <NavigationMenu className="custom-nav">

--- a/src/app/src/components/ui/navigation-menu.tsx
+++ b/src/app/src/components/ui/navigation-menu.tsx
@@ -74,16 +74,31 @@ function NavigationMenuTrigger({
   );
 }
 
+type NavigationMenuContentAlign = 'start' | 'center' | 'end';
+
+const navigationMenuContentAlignClasses: Record<NavigationMenuContentAlign, string> = {
+  start: 'left-0',
+  center: 'left-1/2 -translate-x-1/2',
+  end: 'right-0',
+};
+
+interface NavigationMenuContentProps
+  extends React.ComponentProps<typeof NavigationMenuPrimitive.Content> {
+  align?: NavigationMenuContentAlign;
+}
+
 function NavigationMenuContent({
   className,
+  align = 'start',
   ref,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+}: NavigationMenuContentProps) {
   return (
     <NavigationMenuPrimitive.Content
       ref={ref}
       className={cn(
-        'absolute left-0 top-full mt-1.5 w-auto overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg ring-1 ring-black/5 dark:ring-white/10 data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52',
+        'absolute top-full mt-1.5 w-auto overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg ring-1 ring-black/5 dark:ring-white/10 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52',
+        navigationMenuContentAlignClasses[align],
         className,
       )}
       {...props}
@@ -93,29 +108,10 @@ function NavigationMenuContent({
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
-function NavigationMenuIndicator({
-  className,
-  ref,
-  ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
-  return (
-    <NavigationMenuPrimitive.Indicator
-      ref={ref}
-      className={cn(
-        'top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in',
-        className,
-      )}
-      {...props}
-    >
-      <div className="relative top-[60%] size-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
-    </NavigationMenuPrimitive.Indicator>
-  );
-}
-
+export type { NavigationMenuContentAlign, NavigationMenuContentProps };
 export {
   NavigationMenu,
   NavigationMenuContent,
-  NavigationMenuIndicator,
   NavigationMenuItem,
   NavigationMenuLink,
   NavigationMenuList,


### PR DESCRIPTION
## Summary

Follow-up to #9154 (anchor nav menus to their triggers). That PR removed the shared `NavigationMenuViewport` to fix horizontal alignment, but the cleanup left a few loose ends:

- **Open/close animation regression.** The viewport's `data-[state=open|closed]` zoom+fade classes were dropped. The only animation classes left on `NavigationMenuContent` keyed off `data-motion`, which Radix only sets when transitioning between two open siblings — so it is `null` on the first open of any dropdown. Net effect: dropdowns snapped in/out without any animation. Verified in `node_modules/@radix-ui/react-navigation-menu/dist/index.js:537-540` that Radix still sets `data-state` on per-item content when no viewport is mounted, so re-adding `data-[state=open|closed]` classes is sufficient.
- **`NavigationMenuIndicator` was orphaned.** It had no consumers anywhere in the app and was designed to point at the active trigger from above the (now-removed) viewport. Removed the function and its export.
- **Anchoring was hard-pinned to `left-0`.** Added an `align` prop (`'start' | 'center' | 'end'`) so right-side header dropdowns can opt into `right-0` without overriding internal classes.
- **Storybook coverage.** Added an `EndAligned` story to demo `align="end"`.

## Changes

| File | Change |
| ---- | ------ |
| `src/app/src/components/ui/navigation-menu.tsx` | Re-add `data-[state=open\|closed]` zoom+fade classes; add `align` prop with `start`/`center`/`end` mapping; remove `NavigationMenuIndicator` function + export. |
| `src/app/src/components/ui/navigation-menu.test.tsx` | Add tests for the restored `data-state` animation classes, `align="end"`, and `align="center"`. |
| `src/app/src/components/ui/navigation-menu.stories.tsx` | Add `EndAligned` story. |

## Test plan

- [x] `npm run test:app -- src/components/ui/navigation-menu.test.tsx src/components/Navigation.test.tsx --run` — 44/44 pass (3 new tests).
- [x] `npm run l` — clean.
- [x] `npm run f` — clean.
- [x] `npm --prefix src/app run tsc` — clean.
- [x] Live QA in browser at `http://localhost:3000/`:
  - No `[data-radix-navigation-menu-viewport]` element in the DOM.
  - "New" dropdown opens with `data-state="open"` and the full open/close animation classes present; left edge of content panel matches left edge of trigger (`x: 45`).
  - Hovering "View Results" sets `data-motion="from-end"` (sibling transition slide animation fires).
  - Both dropdowns visually anchor to their own trigger, not to the menu root.