### PR TITLE
fix(webui): improve data table keyboard access

### DIFF
--- a/src/app/src/components/data-table/data-table-toolbar.tsx
+++ b/src/app/src/components/data-table/data-table-toolbar.tsx
@@ -23,6 +23,7 @@ export function DataTableToolbar<TData>({
   showFilter = true,
   showGlobalFilter = true,
   showExport = true,
+  globalFilterLabel,
   onExportCSV,
   onExportJSON,
   toolbarActions,
@@ -64,6 +65,8 @@ export function DataTableToolbar<TData>({
         <div className="relative w-full sm:max-w-sm">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
+            type="search"
+            aria-label={globalFilterLabel}
             placeholder="Search..."
             value={globalFilter ?? ''}
             onChange={(e) => setGlobalFilter(e.target.value)}

--- a/src/app/src/components/data-table/data-table.test.tsx
+++ b/src/app/src/components/data-table/data-table.test.tsx
@@ -273,6 +273,33 @@ describe('DataTable', () => {
     expect(screen.getByText('No results match your search')).toBeInTheDocument();
   });
 
+  it('should expose an accessible search label', () => {
+    const data: TestRow[] = [{ id: '1', name: 'Apple' }];
+
+    render(<DataTable columns={columns} data={data} globalFilterLabel="Search apples" />);
+
+    expect(screen.getByRole('searchbox', { name: 'Search apples' })).toBeInTheDocument();
+  });
+
+  it('should expose sort direction on sortable headers', async () => {
+    const user = userEvent.setup();
+    const data: TestRow[] = [
+      { id: '1', name: 'Apple' },
+      { id: '2', name: 'Banana' },
+    ];
+
+    render(<DataTable columns={columns} data={data} />);
+
+    const idHeader = screen.getByRole('columnheader', { name: /ID/i });
+    expect(idHeader).toHaveAttribute('aria-sort', 'none');
+
+    await user.click(idHeader);
+    expect(idHeader).toHaveAttribute('aria-sort', 'ascending');
+
+    await user.click(idHeader);
+    expect(idHeader).toHaveAttribute('aria-sort', 'descending');
+  });
+
   it('should show no-results state instead of empty state when manual column filters are active with no data', () => {
     const activeColumnFilters = [{ id: 'name', value: 'Apple' }];
 
@@ -1484,6 +1511,26 @@ describe('DataTable', () => {
       expect(screen.getByTestId('expanded-1')).toBeInTheDocument();
     });
 
+    it('should keep row expansion on the explicit disclosure control', async () => {
+      const user = userEvent.setup();
+
+      render(<DataTable columns={columns} data={data} renderSubComponent={renderSubComponent} />);
+
+      const firstRow = screen.getByText('Item 1').closest('tr');
+      const firstExpandButton = screen.getAllByRole('button', { name: /expand row/i })[0];
+
+      expect(firstRow).not.toHaveAttribute('tabindex');
+      expect(firstRow).not.toHaveAttribute('aria-expanded');
+      expect(firstExpandButton).toHaveAttribute('aria-expanded', 'false');
+
+      firstExpandButton.focus();
+      await user.keyboard('{Enter}');
+
+      expect(screen.getByTestId('expanded-1')).toBeInTheDocument();
+      expect(firstExpandButton).toHaveAttribute('aria-expanded', 'true');
+      expect(firstExpandButton).toHaveAccessibleName('Collapse row');
+    });
+
     it('should NOT toggle expansion on row click when onRowClick IS provided', async () => {
       const user = userEvent.setup();
       const onRowClick = vi.fn();
@@ -1503,6 +1550,33 @@ describe('DataTable', () => {
 
       expect(onRowClick).toHaveBeenCalledOnce();
       expect(screen.queryByTestId('expanded-1')).not.toBeInTheDocument();
+    });
+
+    it('should call onRowClick from the keyboard without hijacking nested controls', async () => {
+      const user = userEvent.setup();
+      const onRowClick = vi.fn();
+
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          renderSubComponent={renderSubComponent}
+          onRowClick={onRowClick}
+        />,
+      );
+
+      const firstRow = screen.getByText('Item 1').closest('tr');
+      const firstExpandButton = screen.getAllByRole('button', { name: /expand row/i })[0];
+
+      expect(firstRow).toHaveAttribute('tabindex', '0');
+      firstRow?.focus();
+      await user.keyboard('{Enter}');
+      expect(onRowClick).toHaveBeenCalledOnce();
+
+      firstExpandButton.focus();
+      await user.keyboard('{Enter}');
+      expect(onRowClick).toHaveBeenCalledOnce();
+      expect(screen.getByTestId('expanded-1')).toBeInTheDocument();
     });
 
     it('should render expanded content spanning all columns', async () => {

--- a/src/app/src/components/data-table/data-table.tsx
+++ b/src/app/src/components/data-table/data-table.tsx
@@ -165,6 +165,8 @@ function renderDataTableHeaderCell<TData, TValue = unknown>(
   const isFiltered = header.column.getIsFiltered();
   const isRightAligned = header.column.columnDef.meta?.align === 'right';
   const sortDirection = header.column.getIsSorted();
+  const ariaSort =
+    sortDirection === 'asc' ? 'ascending' : sortDirection === 'desc' ? 'descending' : 'none';
   const headerSize = `${header.getSize()}px`;
   const isUtilityColumn = UTILITY_COLUMN_IDS.has(header.column.id);
 
@@ -190,6 +192,7 @@ function renderDataTableHeaderCell<TData, TValue = unknown>(
           ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
           : {}),
       }}
+      aria-sort={canSort ? ariaSort : undefined}
       onClick={header.column.getToggleSortingHandler()}
     >
       {header.isPlaceholder ? null : (
@@ -256,6 +259,7 @@ export function DataTable<TData, TValue = unknown>({
   showColumnToggle = true,
   showFilter = true,
   showExport = true,
+  globalFilterLabel = 'Search table',
   rowDisplayMode,
   virtualRowEstimate = 48,
   virtualOverscan = 10,
@@ -420,7 +424,8 @@ export function DataTable<TData, TValue = unknown>({
               e.stopPropagation();
               row.toggleExpanded();
             }}
-            aria-label="Expand row"
+            aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+            aria-expanded={row.getIsExpanded()}
             className="flex items-center justify-center size-6 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800"
           >
             <ChevronRight
@@ -709,6 +714,7 @@ export function DataTable<TData, TValue = unknown>({
             showColumnToggle={false}
             showFilter={false}
             showExport={false}
+            globalFilterLabel={globalFilterLabel}
             toolbarActions={toolbarActions}
           />
         )}
@@ -734,6 +740,7 @@ export function DataTable<TData, TValue = unknown>({
             showColumnToggle={false}
             showFilter={false}
             showExport={false}
+            globalFilterLabel={globalFilterLabel}
             toolbarActions={toolbarActions}
           />
         )}
@@ -763,6 +770,7 @@ export function DataTable<TData, TValue = unknown>({
             showColumnToggle={false}
             showFilter={false}
             showExport={false}
+            globalFilterLabel={globalFilterLabel}
             toolbarActions={toolbarActions}
           />
         )}
@@ -777,87 +785,106 @@ export function DataTable<TData, TValue = unknown>({
     );
   }
 
-  const renderTableRow = (row: Row<TData>, virtualIndex?: number) => (
-    <React.Fragment key={virtualIndex === undefined ? row.id : `${row.id}-${virtualIndex}`}>
-      <tr
-        data-index={virtualIndex}
-        data-rowindex={virtualIndex ?? row.index}
-        ref={virtualIndex === undefined || isPrinting ? undefined : rowVirtualizer.measureElement}
-        onClick={() => {
-          if (onRowClick) {
-            onRowClick(row.original);
-          } else if (renderSubComponent && row.getCanExpand()) {
-            row.toggleExpanded();
-          }
-        }}
-        className={cn(
-          'group border-b border-zinc-200 dark:border-zinc-800 last:border-b-0 transition-colors print:border-gray-300',
-          (onRowClick || (renderSubComponent && row.getCanExpand())) &&
-            'cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50',
-        )}
-      >
-        {row.getVisibleCells().map((cell) => {
-          const cellAlign = cell.column.columnDef.meta?.align ?? 'left';
-          const cellSize = `${cell.column.getSize()}px`;
-          const isUtilityColumn = UTILITY_COLUMN_IDS.has(cell.column.id);
-          const stickyColumnPosition = stickyColumnPositions.get(cell.column.id);
+  const renderTableRow = (row: Row<TData>, virtualIndex?: number) => {
+    const canToggleExpansionFromRow =
+      !onRowClick && Boolean(renderSubComponent && row.getCanExpand());
+    const canActivateRow = Boolean(onRowClick);
+    const activateRow = () => {
+      if (onRowClick) {
+        onRowClick(row.original);
+      } else if (canToggleExpansionFromRow) {
+        row.toggleExpanded();
+      }
+    };
 
-          return (
-            <td
-              key={cell.id}
-              className={cn(
-                'py-3 text-sm',
-                isUtilityColumn
-                  ? cn('px-3', cell.column.id === 'select' && 'cursor-pointer')
-                  : 'px-4 overflow-hidden text-ellipsis',
-                cellAlign === 'right' && 'text-right',
-                stickyColumnPosition &&
-                  'sticky z-[1] bg-white group-hover:bg-zinc-50 dark:bg-zinc-900 dark:group-hover:bg-zinc-800/50 print:static print:z-auto print:bg-white',
-                stickyColumnPosition?.isBoundary &&
-                  (stickyColumnPosition.side === 'left'
-                    ? 'border-r border-zinc-200 dark:border-zinc-800'
-                    : 'border-l border-zinc-200 dark:border-zinc-800'),
-              )}
-              style={{
-                width: cellSize,
-                minWidth: cellSize,
-                maxWidth: cellSize,
-                ...(stickyColumnPosition
-                  ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
-                  : {}),
-              }}
-              onClick={
-                cell.column.id === 'select'
-                  ? (e) => {
-                      e.stopPropagation();
-                      row.toggleSelected();
-                    }
-                  : undefined
-              }
-            >
-              {isUtilityColumn ? (
-                flexRender(cell.column.columnDef.cell, cell.getContext())
-              ) : (
-                <div className="overflow-hidden min-w-0">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </div>
-              )}
-            </td>
-          );
-        })}
-      </tr>
-      {renderSubComponent && row.getIsExpanded() && (
-        <tr className={cn('bg-neutral-100/30 dark:bg-neutral-800/30', expandedRowClassName)}>
-          <td
-            colSpan={visibleColumnCount}
-            className="border-b border-zinc-200 p-4 dark:border-zinc-800"
-          >
-            {renderSubComponent(row)}
-          </td>
+    return (
+      <React.Fragment key={virtualIndex === undefined ? row.id : `${row.id}-${virtualIndex}`}>
+        <tr
+          data-index={virtualIndex}
+          data-rowindex={virtualIndex ?? row.index}
+          ref={virtualIndex === undefined || isPrinting ? undefined : rowVirtualizer.measureElement}
+          onClick={activateRow}
+          onKeyDown={(event) => {
+            if (
+              event.target !== event.currentTarget ||
+              (event.key !== 'Enter' && event.key !== ' ')
+            ) {
+              return;
+            }
+
+            event.preventDefault();
+            activateRow();
+          }}
+          tabIndex={canActivateRow ? 0 : undefined}
+          className={cn(
+            'group border-b border-zinc-200 dark:border-zinc-800 last:border-b-0 transition-colors print:border-gray-300',
+            (onRowClick || (renderSubComponent && row.getCanExpand())) &&
+              'cursor-pointer hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring dark:hover:bg-zinc-800/50',
+          )}
+        >
+          {row.getVisibleCells().map((cell) => {
+            const cellAlign = cell.column.columnDef.meta?.align ?? 'left';
+            const cellSize = `${cell.column.getSize()}px`;
+            const isUtilityColumn = UTILITY_COLUMN_IDS.has(cell.column.id);
+            const stickyColumnPosition = stickyColumnPositions.get(cell.column.id);
+
+            return (
+              <td
+                key={cell.id}
+                className={cn(
+                  'py-3 text-sm',
+                  isUtilityColumn
+                    ? cn('px-3', cell.column.id === 'select' && 'cursor-pointer')
+                    : 'px-4 overflow-hidden text-ellipsis',
+                  cellAlign === 'right' && 'text-right',
+                  stickyColumnPosition &&
+                    'sticky z-[1] bg-white group-hover:bg-zinc-50 dark:bg-zinc-900 dark:group-hover:bg-zinc-800/50 print:static print:z-auto print:bg-white',
+                  stickyColumnPosition?.isBoundary &&
+                    (stickyColumnPosition.side === 'left'
+                      ? 'border-r border-zinc-200 dark:border-zinc-800'
+                      : 'border-l border-zinc-200 dark:border-zinc-800'),
+                )}
+                style={{
+                  width: cellSize,
+                  minWidth: cellSize,
+                  maxWidth: cellSize,
+                  ...(stickyColumnPosition
+                    ? { [stickyColumnPosition.side]: `${stickyColumnPosition.offset}px` }
+                    : {}),
+                }}
+                onClick={
+                  cell.column.id === 'select'
+                    ? (e) => {
+                        e.stopPropagation();
+                        row.toggleSelected();
+                      }
+                    : undefined
+                }
+              >
+                {isUtilityColumn ? (
+                  flexRender(cell.column.columnDef.cell, cell.getContext())
+                ) : (
+                  <div className="overflow-hidden min-w-0">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </div>
+                )}
+              </td>
+            );
+          })}
         </tr>
-      )}
-    </React.Fragment>
-  );
+        {renderSubComponent && row.getIsExpanded() && (
+          <tr className={cn('bg-neutral-100/30 dark:bg-neutral-800/30', expandedRowClassName)}>
+            <td
+              colSpan={visibleColumnCount}
+              className="border-b border-zinc-200 p-4 dark:border-zinc-800"
+            >
+              {renderSubComponent(row)}
+            </td>
+          </tr>
+        )}
+      </React.Fragment>
+    );
+  };
 
   const renderVirtualSpacerRow = (height: number, key: string) => {
     if (height <= 0) {
@@ -980,6 +1007,7 @@ export function DataTable<TData, TValue = unknown>({
               showFilter={showColumnFilterControls}
               showGlobalFilter={showGlobalFilterControl}
               showExport={showExport}
+              globalFilterLabel={globalFilterLabel}
               onExportCSV={onExportCSV}
               onExportJSON={onExportJSON}
               toolbarActions={toolbarActions}

--- a/src/app/src/components/data-table/types.ts
+++ b/src/app/src/components/data-table/types.ts
@@ -37,6 +37,7 @@ interface DataTablePropsBase<TData, TValue = unknown> {
   showColumnToggle?: boolean;
   showFilter?: boolean;
   showExport?: boolean;
+  globalFilterLabel?: string;
   /**
    * @deprecated The shared DataTable is virtualized instead of paginated. This is accepted
    * temporarily so downstream consumers can upgrade before deleting old call-site props.
@@ -141,6 +142,7 @@ export interface DataTableToolbarProps<TData> {
   showFilter?: boolean;
   showGlobalFilter?: boolean;
   showExport?: boolean;
+  globalFilterLabel: string;
   onExportCSV?: () => void;
   onExportJSON?: () => void;
   toolbarActions?: React.ReactNode;

--- a/src/app/src/pages/datasets/Datasets.tsx
+++ b/src/app/src/pages/datasets/Datasets.tsx
@@ -173,6 +173,7 @@ export default function Datasets({ data, isLoading, error }: DatasetsProps) {
               onRowClick={handleRowClick}
               emptyMessage="Create a dataset to start evaluating your AI responses"
               initialSorting={[{ id: 'recentEvalDate', desc: true }]}
+              globalFilterLabel="Search datasets"
             />
           </Card>
         </div>

--- a/src/app/src/pages/evals/components/EvalsTable.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.tsx
@@ -326,6 +326,7 @@ export default function EvalsTable({
         onRowSelectionChange={setRowSelection}
         getRowId={(row) => row.evalId}
         initialSorting={[{ id: 'createdAt', desc: true }]}
+        globalFilterLabel="Search evaluations"
         showToolbar={showUtilityButtons}
         showColumnToggle={showUtilityButtons}
         toolbarActions={deleteButton}

--- a/src/app/src/pages/model-audit-history/ModelAuditHistory.tsx
+++ b/src/app/src/pages/model-audit-history/ModelAuditHistory.tsx
@@ -320,6 +320,7 @@ export default function ModelAuditHistory() {
               getRowId={(row) => row.id}
               rowDisplayMode="server-virtualized"
               maxHeight="70vh"
+              globalFilterLabel="Search scans"
               manualSorting
               sorting={tableSorting}
               onSortingChange={handleSortingChange}

--- a/src/app/src/pages/prompts/Prompts.tsx
+++ b/src/app/src/pages/prompts/Prompts.tsx
@@ -144,6 +144,7 @@ export default function Prompts({
               onRowClick={handleRowClick}
               emptyMessage="Create a prompt to start evaluating your AI responses"
               initialSorting={[{ id: 'recentEvalDate', desc: true }]}
+              globalFilterLabel="Search prompts"
             />
           </Card>
         </div>

--- a/src/app/src/pages/redteam/report/components/ReportsTable.tsx
+++ b/src/app/src/pages/redteam/report/components/ReportsTable.tsx
@@ -200,6 +200,7 @@ export default function ReportsTable({ onReportSelected }: ReportsTableProps) {
       emptyMessage="No red team reports found. Run a red team evaluation to get started."
       onRowClick={(row) => onReportSelected(row.evalId)}
       initialSorting={[{ id: 'createdAt', desc: true }]}
+      globalFilterLabel="Search reports"
       showToolbar
       showColumnToggle
       showExport


### PR DESCRIPTION
## Summary
- add explicit search labels and `aria-sort` semantics to the shared data table
- make navigable rows keyboard reachable with visible focus treatment
- keep expandable rows on a single disclosure control with stateful labels

## Validation
- `npm run test:app -- src/components/data-table/data-table.test.tsx --run`
- `npm run l`
- `npm run f`
- `npm run tsc`
- live QA at laptop width on `/evals`, `/reports`, `/datasets`, and `/prompts`
