### PR TITLE
test(code-scan): cover SARIF action newline

### DIFF
--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -482,6 +482,7 @@ describe('code-scan-action main', () => {
 
       expect(mocks.fs.mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
       const [, sarifJson] = mocks.fs.writeFileSync.mock.calls[0];
+      expect(sarifJson).toEqual(expect.stringMatching(/\n$/));
       expect(JSON.parse(sarifJson as string)).toMatchObject({
         $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
         version: '2.1.0',


### PR DESCRIPTION
## Summary

- Add focused code-scan action coverage for the SARIF file serialization contract.
- Assert the mocked SARIF write ends with a trailing newline before parsing the JSON payload.

## Why

The recent SARIF ergonomics change made action output POSIX text-file friendly by appending a newline. Existing tests parsed the generated JSON but did not catch losing the trailing newline.

## Validation

- `./node_modules/.bin/vitest run test/code-scan-action/main.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`
- `git diff --check`
