### PR TITLE
chore: resolve AI quality findings

### DIFF
--- a/site/blog/rag-architecture.md
+++ b/site/blog/rag-architecture.md
@@ -183,7 +183,7 @@ An attacker who can flood retrieval with irrelevant text can crowd out more impo
 
 ## Mitigating Controls for RAG
 
-Start by testing the complete retrieval path, not just the base model. A [Promptfoo red team eval](https://www.promptfoo.dev/docs/guides/evaluate-rag/) configured for your RAG environment can help expose the highest-risk failure modes.
+Start by testing the complete retrieval path, not just the base model. A [promptfoo red team eval](https://www.promptfoo.dev/docs/guides/evaluate-rag/) configured for your RAG environment can help expose the highest-risk failure modes.
 
 The most important controls are concrete:
 

--- a/src/app/src/components/ui/navigation-menu.tsx
+++ b/src/app/src/components/ui/navigation-menu.tsx
@@ -10,7 +10,7 @@ function NavigationMenu({
   children,
   ref,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root>) {
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Root>) {
   return (
     <NavigationMenuPrimitive.Root
       ref={ref}
@@ -29,7 +29,7 @@ function NavigationMenuList({
   className,
   ref,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.List>) {
   return (
     <NavigationMenuPrimitive.List
       ref={ref}
@@ -43,7 +43,7 @@ function NavigationMenuItem({
   className,
   ref,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Item>) {
   return (
     <NavigationMenuPrimitive.Item ref={ref} className={cn('relative', className)} {...props} />
   );
@@ -58,7 +58,7 @@ function NavigationMenuTrigger({
   children,
   ref,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+}: React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Trigger>) {
   return (
     <NavigationMenuPrimitive.Trigger
       ref={ref}
@@ -83,7 +83,7 @@ const navigationMenuContentAlignClasses: Record<NavigationMenuContentAlign, stri
 };
 
 interface NavigationMenuContentProps
-  extends React.ComponentProps<typeof NavigationMenuPrimitive.Content> {
+  extends React.ComponentPropsWithRef<typeof NavigationMenuPrimitive.Content> {
   align?: NavigationMenuContentAlign;
 }
 

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -5,6 +5,7 @@
  */
 
 import * as path from 'node:path';
+import type { Stats } from 'node:fs';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileChangeStatus } from '../../src/types/codeScan';
@@ -620,7 +621,7 @@ describe('code-scan-action main', () => {
     });
 
     it('refuses to overwrite an existing symlink at the target path', async () => {
-      mocks.fs.lstatSync.mockReturnValue({ isSymbolicLink: () => true });
+      mocks.fs.lstatSync.mockReturnValue({ isSymbolicLink: () => true } as Stats);
 
       await triggerSarifAction('promptfoo-code-scan.sarif');
 

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -51,6 +51,22 @@ type SynthesizeMockResult = {
   failedPlugins: FailedPluginInfo[];
 };
 
+const TEST_PROBE_LIMIT = vi.hoisted(() => 100_000);
+
+function resetCommonMocks() {
+  vi.mocked(extractMcpToolsInfo).mockReset().mockResolvedValue('');
+  vi.mocked(checkEmailStatusAndMaybeExit).mockReset().mockResolvedValue('ok');
+  vi.mocked(promptForEmailUnverified).mockReset().mockResolvedValue({
+    emailNeedsValidation: false,
+  });
+}
+
+function mockReadFileSync(content: unknown) {
+  vi.mocked(fs.readFileSync).mockImplementation(() =>
+    typeof content === 'string' ? content : JSON.stringify(content),
+  );
+}
+
 const fsMocks = vi.hoisted(() => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
@@ -216,8 +232,8 @@ vi.mock('../../../src/util/redteamProbeLimit', async (importOriginal) => {
     checkRedteamProbeLimit: vi.fn().mockReturnValue({
       withinLimit: true,
       used: 0,
-      limit: 100_000,
-      remaining: 100_000,
+      limit: TEST_PROBE_LIMIT,
+      remaining: TEST_PROBE_LIMIT,
     }),
   };
 });
@@ -277,11 +293,7 @@ describe('doGenerateRedteam', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset mock implementations that persist across tests (clearAllMocks only clears call history)
-    vi.mocked(extractMcpToolsInfo).mockReset().mockResolvedValue('');
-    vi.mocked(checkEmailStatusAndMaybeExit).mockReset().mockResolvedValue('ok');
-    vi.mocked(promptForEmailUnverified)
-      .mockReset()
-      .mockResolvedValue({ emailNeedsValidation: false });
+    resetCommonMocks();
     mockProvider = createMockProvider({
       response: { output: 'test output' },
       cleanup: true,
@@ -317,12 +329,10 @@ describe('doGenerateRedteam', () => {
       write: true,
     };
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -382,9 +392,7 @@ describe('doGenerateRedteam', () => {
       write: true,
     };
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({});
-    });
+    mockReadFileSync({});
     vi.mocked(synthesize).mockResolvedValue({
       testCases: [
         {
@@ -436,12 +444,10 @@ describe('doGenerateRedteam', () => {
       description: 'My custom scan description',
     };
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -479,9 +485,7 @@ describe('doGenerateRedteam', () => {
       description: 'My custom scan description',
     };
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({});
-    });
+    mockReadFileSync({});
     vi.mocked(synthesize).mockResolvedValue({
       testCases: [
         {
@@ -584,12 +588,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -653,12 +655,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -723,12 +723,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -781,12 +779,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -843,12 +839,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Test prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Test prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(synthesize).mockResolvedValue({
@@ -1286,12 +1280,10 @@ describe('doGenerateRedteam', () => {
       },
     });
 
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return JSON.stringify({
-        prompts: [{ raw: 'Prompt' }],
-        providers: [],
-        tests: [],
-      });
+    mockReadFileSync({
+      prompts: [{ raw: 'Prompt' }],
+      providers: [],
+      tests: [],
     });
 
     vi.mocked(doTargetPurposeDiscovery).mockResolvedValue({
@@ -1522,9 +1514,7 @@ describe('doGenerateRedteam', () => {
       vi.mocked(getUserEmail).mockImplementation(function () {
         return 'test@example.com';
       });
-      vi.mocked(fs.readFileSync).mockImplementation(function () {
-        return JSON.stringify({});
-      });
+      mockReadFileSync({});
 
       vi.mocked(synthesize).mockResolvedValue({
         testCases: [
@@ -1780,7 +1770,7 @@ describe('doGenerateRedteam', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      vi.mocked(extractMcpToolsInfo).mockReset().mockResolvedValue('');
+      resetCommonMocks();
       vi.mocked(getCustomPolicies).mockReset();
       vi.mocked(resolveTeamId).mockReset();
       vi.mocked(resolveTeamId).mockResolvedValue({ id: 'resolved-team-id', name: 'Resolved Team' });
@@ -3099,9 +3089,7 @@ describe('doGenerateRedteam with external defaultTest', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return false;
     });
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return '';
-    });
+    mockReadFileSync('');
   });
 
   it('should handle string defaultTest when updating config', async () => {
@@ -3123,9 +3111,7 @@ describe('doGenerateRedteam with external defaultTest', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return true;
     });
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return yaml.dump(existingConfig);
-    });
+    mockReadFileSync(yaml.dump(existingConfig));
     vi.mocked(readConfig).mockResolvedValue(existingConfig);
 
     // Mock synthesize to return test cases
@@ -3182,9 +3168,7 @@ describe('doGenerateRedteam with external defaultTest', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return true;
     });
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return yaml.dump(existingConfig);
-    });
+    mockReadFileSync(yaml.dump(existingConfig));
     vi.mocked(readConfig).mockResolvedValue(existingConfig);
 
     // Mock synthesize to return test cases
@@ -3239,9 +3223,7 @@ describe('doGenerateRedteam with external defaultTest', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return true;
     });
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return yaml.dump(existingConfig);
-    });
+    mockReadFileSync(yaml.dump(existingConfig));
     vi.mocked(readConfig).mockResolvedValue(existingConfig);
 
     // Mock synthesize to return test cases
@@ -3509,13 +3491,13 @@ describe('redteam generate command with target option', () => {
     vi.mocked(fs.existsSync).mockImplementation(function () {
       return true;
     });
-    vi.mocked(fs.readFileSync).mockImplementation(function () {
-      return yaml.dump({
+    mockReadFileSync(
+      yaml.dump({
         prompts: ['Test prompt'],
         providers: [],
         tests: [],
-      });
-    });
+      }),
+    );
 
     // Find the generate command
     const generateCommand = program.commands.find((cmd) => cmd.name() === 'generate');
@@ -3886,8 +3868,8 @@ describe('target ID extraction for retry strategy', () => {
     it('should block generation when probe limit is exceeded', async () => {
       vi.mocked(checkRedteamProbeLimit).mockReturnValue({
         withinLimit: false,
-        used: 100_001,
-        limit: 100_000,
+        used: TEST_PROBE_LIMIT + 1,
+        limit: TEST_PROBE_LIMIT,
         remaining: 0,
       });
 
@@ -3909,8 +3891,8 @@ describe('target ID extraction for retry strategy', () => {
       vi.mocked(checkRedteamProbeLimit).mockReturnValue({
         withinLimit: true,
         used: 0,
-        limit: 100_000,
-        remaining: 100_000,
+        limit: TEST_PROBE_LIMIT,
+        remaining: TEST_PROBE_LIMIT,
       });
     });
 
@@ -3931,8 +3913,8 @@ describe('target ID extraction for retry strategy', () => {
       vi.mocked(checkRedteamProbeLimit).mockReturnValue({
         withinLimit: true,
         used: 0,
-        limit: 100_000,
-        remaining: 100_000,
+        limit: TEST_PROBE_LIMIT,
+        remaining: TEST_PROBE_LIMIT,
       });
       vi.mocked(neverGenerateRemote).mockReturnValue(true);
 
@@ -3960,8 +3942,8 @@ describe('target ID extraction for retry strategy', () => {
       vi.mocked(checkRedteamProbeLimit).mockReturnValue({
         withinLimit: true,
         used: 500,
-        limit: 100_000,
-        remaining: 99_500,
+        limit: TEST_PROBE_LIMIT,
+        remaining: TEST_PROBE_LIMIT - 500,
       });
 
       // Skip email validation by pretending we never generate remotely

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -3,7 +3,7 @@ import { MCPProvider } from '../../src/providers/mcp';
 import { maybeWrapMcpProviderForRedteam } from '../../src/redteam/mcpTargetProvider';
 
 import type { MCPTool } from '../../src/providers/mcp/types';
-import type { CallApiContextParams, ProviderResponse } from '../../src/types';
+import type { CallApiContextParams, CallApiOptionsParams, ProviderResponse } from '../../src/types';
 
 const providerManagerMocks = vi.hoisted(() => ({
   getProvider: vi.fn(),
@@ -16,7 +16,7 @@ vi.mock('../../src/redteam/providers/shared', () => ({
 }));
 
 class FakeMcpProvider extends MCPProvider {
-  calls: { context?: CallApiContextParams; prompt: string }[] = [];
+  calls: { context?: CallApiContextParams; options?: CallApiOptionsParams; prompt: string }[] = [];
   cleanupCalls = 0;
 
   constructor(private readonly tools: MCPTool[]) {
@@ -27,8 +27,12 @@ class FakeMcpProvider extends MCPProvider {
     return this.tools;
   }
 
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
-    this.calls.push({ prompt, context });
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    this.calls.push({ prompt, context, options });
     return { output: 'ok' };
   }
 
@@ -146,11 +150,13 @@ describe('maybeWrapMcpProviderForRedteam', () => {
       },
     });
 
-    const response = await wrapped.callApi('Plain prompt', undefined, { includeLogProbs: true });
+    const options = { includeLogProbs: true };
+
+    const response = await wrapped.callApi('Plain prompt', undefined, options);
 
     expect(response).toEqual({ output: 'ok' });
     expect(providerManagerMocks.getProvider).not.toHaveBeenCalled();
-    expect(target.calls).toEqual([{ prompt: 'Plain prompt', context: undefined }]);
+    expect(target.calls).toEqual([{ prompt: 'Plain prompt', context: undefined, options }]);
   });
 
   it('preserves provider identity helpers and cleanup behavior', async () => {


### PR DESCRIPTION
## Summary
- Resolve all 12 visible GitHub Security AI findings across 5 files.
- Tighten navigation ref prop typing, stats/options test mocks, redteam test helpers, and promptfoo docs capitalization.

## Testing
- npm_config_cache=/private/tmp/promptfoo-npm-cache-20260511 npx vitest run test/code-scan-action/main.test.ts test/redteam/commands/generate.test.ts test/redteam/mcpTargetProvider.test.ts --sequence.shuffle=false
- npm_config_cache=/private/tmp/promptfoo-npm-cache-20260511 npm run l
- npm_config_cache=/private/tmp/promptfoo-npm-cache-20260511 npm run f
- npm_config_cache=/private/tmp/promptfoo-npm-cache-20260511 npm run tsc
- npm_config_cache=/private/tmp/promptfoo-npm-cache-20260511 npm --prefix src/app run tsc