### PR TITLE
fix(webui): align custom intent count gating

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
@@ -381,6 +381,29 @@ describe('Plugins', () => {
     });
   });
 
+  it('enables next button when a custom intent is configured as a bare string', async () => {
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        plugins: [
+          {
+            id: 'intent',
+            config: {
+              intent: 'How can I build a secure system?',
+            },
+          },
+        ],
+      },
+      updatePlugins: mockUpdatePlugins,
+    });
+
+    renderWithProviders(<Plugins onNext={mockOnNext} onBack={mockOnBack} />);
+
+    const nextButton = screen.getByRole('button', { name: /Next/i });
+    await waitFor(() => {
+      expect(nextButton).toBeEnabled();
+    });
+  });
+
   it('does not enable next button for empty custom policies', async () => {
     mockUseRedTeamConfig.mockReturnValue({
       config: {
@@ -412,6 +435,29 @@ describe('Plugins', () => {
             id: 'intent',
             config: {
               intent: [], // Empty array
+            },
+          },
+        ],
+      },
+      updatePlugins: mockUpdatePlugins,
+    });
+
+    renderWithProviders(<Plugins onNext={mockOnNext} onBack={mockOnBack} />);
+
+    const nextButton = screen.getByRole('button', { name: /Next/i });
+    await waitFor(() => {
+      expect(nextButton).toBeDisabled();
+    });
+  });
+
+  it('does not enable next button for whitespace-only custom intents', async () => {
+    mockUseRedTeamConfig.mockReturnValue({
+      config: {
+        plugins: [
+          {
+            id: 'intent',
+            config: {
+              intent: ['', '   ', [' ', '\t']],
             },
           },
         ],

--- a/src/app/src/pages/redteam/setup/components/Plugins.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.tsx
@@ -286,15 +286,7 @@ export default function Plugins({ onNext, onBack }: PluginsProps) {
       return typeof policy.text === 'string' && policy.text.trim().length > 0;
     });
 
-    // Check custom intents with actual content
-    const hasIntents = config.plugins.some(
-      (p) =>
-        typeof p === 'object' &&
-        p.id === 'intent' &&
-        p.config?.intent &&
-        Array.isArray(p.config.intent) &&
-        p.config.intent.length > 0,
-    );
+    const hasIntents = countSelectedCustomIntents({ plugins: config.plugins }) > 0;
 
     return hasPolicies || hasIntents;
   }, [selectedPlugins, config.plugins]);

--- a/src/app/src/pages/redteam/setup/utils/plugins.test.ts
+++ b/src/app/src/pages/redteam/setup/utils/plugins.test.ts
@@ -61,6 +61,31 @@ describe('countSelectedCustomIntents', () => {
       ),
     ).toBe(3);
   });
+
+  it('ignores empty entries and whitespace-only multi-step intents', () => {
+    expect(
+      countSelectedCustomIntents(
+        makeConfig([
+          {
+            id: 'intent',
+            config: { intent: ['', '   ', [' ', '\t'], ['valid step', '']] } as any,
+          },
+        ]),
+      ),
+    ).toBe(1);
+  });
+
+  it('aggregates custom intents across multiple intent plugins', () => {
+    expect(
+      countSelectedCustomIntents(
+        makeConfig([
+          { id: 'intent', config: { intent: 'first plugin intent' } as any },
+          { id: 'sql-injection' },
+          { id: 'intent', config: { intent: ['second a', ['second b1', 'second b2']] } as any },
+        ]),
+      ),
+    ).toBe(3);
+  });
 });
 
 describe('countSelectedCustomPolicies', () => {

--- a/src/app/src/pages/redteam/setup/utils/plugins.ts
+++ b/src/app/src/pages/redteam/setup/utils/plugins.ts
@@ -4,11 +4,26 @@ import type { PluginConfig } from '@promptfoo/redteam/types';
 /**
  * Counts the number of custom policies defined in the config.
  */
-export function countSelectedCustomPolicies(config: Config): number {
+export function countSelectedCustomPolicies(config: Pick<Config, 'plugins'>): number {
   return (
     config.plugins.filter((p) => typeof p === 'object' && 'id' in p && p.id === 'policy').length ||
     0
   );
+}
+
+function hasIntentContent(intent: unknown): boolean {
+  if (typeof intent === 'string') {
+    return intent.trim().length > 0;
+  }
+  if (Array.isArray(intent)) {
+    return intent.some((step) => typeof step === 'string' && step.trim().length > 0);
+  }
+  return false;
+}
+
+function countIntentEntries(intent: unknown): number {
+  const entries = Array.isArray(intent) ? intent : [intent];
+  return entries.filter(hasIntentContent).length;
 }
 
 /**
@@ -22,14 +37,18 @@ export function countSelectedCustomPolicies(config: Config): number {
  * shown in the UI for file-backed intent lists are therefore a lower bound;
  * the CLI/server resolves them and produces the actual count.
  */
-export function countSelectedCustomIntents(config: Config): number {
-  const intent = config.plugins.find(
-    (p): p is { id: string; config: PluginConfig } =>
-      typeof p === 'object' && 'id' in p && p.id === 'intent' && 'config' in p,
-  )?.config?.intent;
+export function countSelectedCustomIntents(config: Pick<Config, 'plugins'>): number {
+  return config.plugins.reduce((count, plugin) => {
+    if (
+      typeof plugin !== 'object' ||
+      plugin === null ||
+      !('id' in plugin) ||
+      plugin.id !== 'intent' ||
+      !('config' in plugin)
+    ) {
+      return count;
+    }
 
-  if (!intent) {
-    return 0;
-  }
-  return Array.isArray(intent) ? intent.length : 1;
+    return count + countIntentEntries((plugin as { config: PluginConfig }).config?.intent);
+  }, 0);
 }


### PR DESCRIPTION
## Summary
- count configured custom intents across all intent plugin blocks
- ignore empty and whitespace-only custom intent entries in the shared count helper
- use the shared count helper for the Plugins page Next-button gate so bare-string intents can proceed

## Tests
- npm run test:app -- src/pages/redteam/setup/utils/plugins.test.ts src/pages/redteam/setup/components/Plugins.test.tsx --run
- npm run l
- npm run f
- git diff --check