### PR TITLE
fix(providers): aggregate command output deltas

### DIFF
--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -2288,6 +2288,17 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     }
 
     const completedItem = this.withCommandExecutionOutput(state, item);
+    if (
+      completedItem?.type === 'commandExecution' &&
+      typeof completedItem.id === 'string' &&
+      typeof completedItem.aggregatedOutput === 'string' &&
+      !state.commandExecutionOutputDeltasByItemId.has(completedItem.id)
+    ) {
+      state.commandExecutionOutputDeltasByItemId.set(
+        completedItem.id,
+        completedItem.aggregatedOutput,
+      );
+    }
     state.items.push(completedItem);
     const itemId = completedItem.id ? String(completedItem.id) : crypto.randomUUID();
     const span =

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -2323,7 +2323,11 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     const completedItem = state.items.find(
       (item) => item?.type === 'commandExecution' && String(item.id) === params.itemId,
     );
-    if (completedItem && typeof completedItem.aggregatedOutput !== 'string') {
+    if (
+      completedItem &&
+      (typeof completedItem.aggregatedOutput !== 'string' ||
+        completedItem.aggregatedOutput === existing)
+    ) {
       completedItem.aggregatedOutput = aggregatedOutput;
     }
   }

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3660,6 +3660,94 @@ describe('OpenAICodexAppServerProvider', () => {
     );
   });
 
+  it('continues completed command output when later deltas extend an existing aggregate', async () => {
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    const provider = new OpenAICodexAppServerProvider({
+      config: {
+        thread_cleanup: 'none',
+      },
+    });
+
+    const resultPromise = provider.callApi('Run a command with late trailing output');
+
+    const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+    server.send({ id: initialize.id, result: {} });
+    const threadStart = await waitForMessage(
+      server,
+      (message) => message.method === 'thread/start',
+    );
+    server.send({ id: threadStart.id, result: { thread: { id: 'thr_trailing_output' } } });
+    const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+    server.send({
+      id: turnStart.id,
+      result: { turn: { id: 'turn_trailing_output', status: 'inProgress' } },
+    });
+
+    server.send({
+      method: 'item/completed',
+      params: {
+        threadId: 'thr_trailing_output',
+        turnId: 'turn_trailing_output',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd_trailing_output',
+          command: 'printf "line one\\nline two"',
+          cwd: process.cwd(),
+          status: 'completed',
+          aggregatedOutput: 'line one\n',
+          exitCode: 0,
+          durationMs: 1,
+        },
+      },
+    });
+    server.send({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thr_trailing_output',
+        turnId: 'turn_trailing_output',
+        itemId: 'cmd_trailing_output',
+        delta: 'line two',
+      },
+    });
+    server.send({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thr_trailing_output',
+        turnId: 'turn_trailing_output',
+        itemId: 'msg_trailing_output',
+        delta: 'Done',
+      },
+    });
+    server.send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thr_trailing_output',
+        turn: { id: 'turn_trailing_output', status: 'completed', items: [], error: null },
+      },
+    });
+
+    const result = await resultPromise;
+    const raw = JSON.parse(result.raw as string);
+    expect(raw.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'command_execution',
+          aggregated_output: 'line one\nline two',
+        }),
+      ]),
+    );
+    expect(result.metadata?.codexAppServer.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'commandExecution',
+          aggregatedOutput: 'line one\nline two',
+        }),
+      ]),
+    );
+  });
+
   it('emits SDK-compatible raw items for coding-agent verifiers', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3563,6 +3563,103 @@ describe('OpenAICodexAppServerProvider', () => {
     expect(result.output).toBe('Done');
   });
 
+  it('keeps aggregating command output deltas after command completion', async () => {
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    const provider = new OpenAICodexAppServerProvider({
+      config: {
+        thread_cleanup: 'none',
+      },
+    });
+
+    const resultPromise = provider.callApi('Run a command with delayed output');
+
+    const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+    server.send({ id: initialize.id, result: {} });
+    const threadStart = await waitForMessage(
+      server,
+      (message) => message.method === 'thread/start',
+    );
+    server.send({ id: threadStart.id, result: { thread: { id: 'thr_delayed_output' } } });
+    const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+    server.send({
+      id: turnStart.id,
+      result: { turn: { id: 'turn_delayed_output', status: 'inProgress' } },
+    });
+
+    server.send({
+      method: 'item/completed',
+      params: {
+        threadId: 'thr_delayed_output',
+        turnId: 'turn_delayed_output',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd_delayed_output',
+          command: 'printf "line one\\nline two"',
+          cwd: process.cwd(),
+          status: 'completed',
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 1,
+        },
+      },
+    });
+    server.send({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thr_delayed_output',
+        turnId: 'turn_delayed_output',
+        itemId: 'cmd_delayed_output',
+        delta: 'line one\n',
+      },
+    });
+    server.send({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thr_delayed_output',
+        turnId: 'turn_delayed_output',
+        itemId: 'cmd_delayed_output',
+        delta: 'line two',
+      },
+    });
+    server.send({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thr_delayed_output',
+        turnId: 'turn_delayed_output',
+        itemId: 'msg_delayed_output',
+        delta: 'Done',
+      },
+    });
+    server.send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thr_delayed_output',
+        turn: { id: 'turn_delayed_output', status: 'completed', items: [], error: null },
+      },
+    });
+
+    const result = await resultPromise;
+    const raw = JSON.parse(result.raw as string);
+    expect(raw.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'command_execution',
+          aggregated_output: 'line one\nline two',
+        }),
+      ]),
+    );
+    expect(result.metadata?.codexAppServer.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'commandExecution',
+          aggregatedOutput: 'line one\nline two',
+        }),
+      ]),
+    );
+  });
+
   it('emits SDK-compatible raw items for coding-agent verifiers', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);


### PR DESCRIPTION
## Summary
- keep command execution output aggregation live when output deltas arrive after item completion
- add a regression covering raw and metadata command output evidence

## Tests
- ./node_modules/.bin/vitest run test/providers/openai-codex-app-server.test.ts -t "keeps aggregating command output deltas after command completion" --sequence.shuffle=false
- ./node_modules/.bin/vitest run test/providers/openai-codex-app-server.test.ts --sequence.shuffle=false
- npm run l
- npm run f
- npm run tsc