### PR TITLE
feat(telemetry): capture node runtime metadata

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -41,6 +41,15 @@ function getPostHogClient(): PostHog | null {
 
 const TELEMETRY_TIMEOUT_MS = 1000;
 
+function getRuntimeMetadata() {
+  return {
+    nodeVersion: process.version,
+    nodeMajor: Number.parseInt(process.versions.node, 10),
+    platform: process.platform,
+    arch: process.arch,
+  };
+}
+
 export class Telemetry {
   private telemetryDisabledRecorded = false;
   private id: string;
@@ -106,6 +115,7 @@ export class Telemetry {
       ...properties,
       packageVersion: VERSION,
       isRunningInCi: ciFlag,
+      ...getRuntimeMetadata(),
     };
 
     const client = getPostHogClient();

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -222,7 +222,11 @@ describe('Telemetry', () => {
             if (
               data.meta.test === 'value' &&
               data.meta.packageVersion === '1.0.0' &&
-              typeof data.meta.isRunningInCi === 'boolean'
+              typeof data.meta.isRunningInCi === 'boolean' &&
+              data.meta.nodeVersion === process.version &&
+              data.meta.nodeMajor === Number.parseInt(process.versions.node, 10) &&
+              data.meta.platform === process.platform &&
+              data.meta.arch === process.arch
             ) {
               foundExpectedProperties = true;
               break;
@@ -539,6 +543,10 @@ describe('Telemetry', () => {
           test: 'value',
           packageVersion: '1.0.0',
           isRunningInCi: false,
+          nodeVersion: process.version,
+          nodeMajor: Number.parseInt(process.versions.node, 10),
+          platform: process.platform,
+          arch: process.arch,
           $set: {
             email: 'test@example.com',
             isLoggedIntoCloud: false,
@@ -583,6 +591,10 @@ describe('Telemetry', () => {
           test: 'value',
           packageVersion: '1.0.0',
           isRunningInCi: false,
+          nodeVersion: process.version,
+          nodeMajor: Number.parseInt(process.versions.node, 10),
+          platform: process.platform,
+          arch: process.arch,
           $set: {
             email: 'new@example.com',
             isLoggedIntoCloud: true,


### PR DESCRIPTION
## Summary

- add `nodeVersion`, `nodeMajor`, `platform`, and `arch` to the shared telemetry metadata envelope
- carry those runtime fields through both PostHog event capture and the reporting endpoint payload
- extend telemetry regression coverage so both outbound paths stay pinned to the new contract

## Why

Promptfoo currently records package and CI context in analytics, but not the Node runtime context needed to understand usage by Node version or platform. This adds that instrumentation centrally in the telemetry layer so dashboards can segment real product usage without event-by-event drift.

## Validation

- `npx vitest run test/telemetry.test.ts --sequence.shuffle=false`
- `npm run tsc -- --pretty false`
- `git diff --check`
