### PR TITLE
fix(providers): preserve interleaved command output deltas

### DIFF
--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -2291,13 +2291,18 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     if (
       completedItem?.type === 'commandExecution' &&
       typeof completedItem.id === 'string' &&
-      typeof completedItem.aggregatedOutput === 'string' &&
-      !state.commandExecutionOutputDeltasByItemId.has(completedItem.id)
+      typeof completedItem.aggregatedOutput === 'string'
     ) {
-      state.commandExecutionOutputDeltasByItemId.set(
-        completedItem.id,
-        completedItem.aggregatedOutput,
-      );
+      const existingOutput = state.commandExecutionOutputDeltasByItemId.get(completedItem.id);
+      if (
+        typeof existingOutput !== 'string' ||
+        completedItem.aggregatedOutput.startsWith(existingOutput)
+      ) {
+        state.commandExecutionOutputDeltasByItemId.set(
+          completedItem.id,
+          completedItem.aggregatedOutput,
+        );
+      }
     }
     state.items.push(completedItem);
     const itemId = completedItem.id ? String(completedItem.id) : crypto.randomUUID();
@@ -2349,7 +2354,14 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     }
 
     const aggregatedOutput = state.commandExecutionOutputDeltasByItemId.get(item.id);
-    if (typeof item.aggregatedOutput === 'string' || typeof aggregatedOutput !== 'string') {
+    if (typeof aggregatedOutput !== 'string') {
+      return item;
+    }
+
+    if (
+      typeof item.aggregatedOutput === 'string' &&
+      !aggregatedOutput.startsWith(item.aggregatedOutput)
+    ) {
       return item;
     }
 

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3748,6 +3748,103 @@ describe('OpenAICodexAppServerProvider', () => {
     );
   });
 
+  it('continues from a completed command aggregate when earlier deltas already exist', async () => {
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    const provider = new OpenAICodexAppServerProvider({
+      config: {
+        thread_cleanup: 'none',
+      },
+    });
+
+    const resultPromise = provider.callApi('Run a command with interleaved output');
+
+    const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+    server.send({ id: initialize.id, result: {} });
+    const threadStart = await waitForMessage(
+      server,
+      (message) => message.method === 'thread/start',
+    );
+    server.send({ id: threadStart.id, result: { thread: { id: 'thr_interleaved_output' } } });
+    const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+    server.send({
+      id: turnStart.id,
+      result: { turn: { id: 'turn_interleaved_output', status: 'inProgress' } },
+    });
+
+    server.send({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thr_interleaved_output',
+        turnId: 'turn_interleaved_output',
+        itemId: 'cmd_interleaved_output',
+        delta: 'line one\n',
+      },
+    });
+    server.send({
+      method: 'item/completed',
+      params: {
+        threadId: 'thr_interleaved_output',
+        turnId: 'turn_interleaved_output',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd_interleaved_output',
+          command: 'printf "line one\\nline two\\nline three"',
+          cwd: process.cwd(),
+          status: 'completed',
+          aggregatedOutput: 'line one\nline two\n',
+          exitCode: 0,
+          durationMs: 1,
+        },
+      },
+    });
+    server.send({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thr_interleaved_output',
+        turnId: 'turn_interleaved_output',
+        itemId: 'cmd_interleaved_output',
+        delta: 'line three',
+      },
+    });
+    server.send({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thr_interleaved_output',
+        turnId: 'turn_interleaved_output',
+        itemId: 'msg_interleaved_output',
+        delta: 'Done',
+      },
+    });
+    server.send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thr_interleaved_output',
+        turn: { id: 'turn_interleaved_output', status: 'completed', items: [], error: null },
+      },
+    });
+
+    const result = await resultPromise;
+    const raw = JSON.parse(result.raw as string);
+    expect(raw.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'command_execution',
+          aggregated_output: 'line one\nline two\nline three',
+        }),
+      ]),
+    );
+    expect(result.metadata?.codexAppServer.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'commandExecution',
+          aggregatedOutput: 'line one\nline two\nline three',
+        }),
+      ]),
+    );
+  });
+
   it('emits SDK-compatible raw items for coding-agent verifiers', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);


### PR DESCRIPTION
## Summary

- Preserve a completed command aggregate as the base when earlier output deltas already exist.
- Keep longer locally aggregated output when the completed item carries a stale shorter aggregate.
- Add a regression for interleaved command output notifications around `item/completed`.

## Tests

- `node_modules/.bin/vitest run test/providers/openai-codex-app-server.test.ts -t "continues from a completed command aggregate" --sequence.shuffle=false` (failed before the fix, passed after)
- `node_modules/.bin/vitest run test/providers/openai-codex-app-server.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`
- `npm run tsc`
