### PR TITLE
chore(build): add Node 26 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,8 @@ jobs:
   test:
     needs: ci-config
     name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}${{ matrix.shard && format(' (shard {0}/3)', matrix.shard) || '' }}
-    timeout-minutes: 15
+    # Cold-cache installs for newer Node/native-addon combinations can consume most of the old 15m budget.
+    timeout-minutes: 25
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -141,8 +142,8 @@ jobs:
     name: Build on Node ${{ matrix.node }}
     env:
       PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
-    # Keep enough headroom for slow PR merge-ref checkout and npm install on GitHub-hosted runners.
-    timeout-minutes: 10
+    # Keep enough headroom for slow PR merge-ref checkout plus cold-cache installs on GitHub-hosted runners.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.ci-config.outputs.build-matrix) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,10 +117,12 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        # Node 26 ships with newer npm; npm@11.11.0 repeatedly stalled in CI on the Node 26 lanes.
+        # Node 26 hosted installs stall when lifecycle scripts run during npm ci.
+        # Install the tree without scripts, then rebuild the native addon tests need.
         run: |
           if [ "${{ matrix.node }}" = "26.x" ]; then
-            npm ci
+            npm ci --ignore-scripts
+            npm rebuild better-sqlite3
           else
             npx -y npm@11.11.0 ci
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,10 +166,11 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        # Node 26 ships with newer npm; npm@11.11.0 repeatedly stalled in CI on the Node 26 lane.
+        # The build does not need native dependency lifecycle scripts. Skipping them
+        # keeps the Node 26 build lane out of the install stall seen on hosted runners.
         run: |
           if [ "${{ matrix.node }}" = "26.x" ]; then
-            npm ci
+            npm ci --ignore-scripts
           else
             npx -y npm@11.11.0 ci
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,13 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npx -y npm@11.11.0 ci
+        # Node 26 ships with newer npm; npm@11.11.0 repeatedly stalled in CI on the Node 26 lanes.
+        run: |
+          if [ "${{ matrix.node }}" = "26.x" ]; then
+            npm ci
+          else
+            npx -y npm@11.11.0 ci
+          fi
 
       - name: Test
         run: npm run test${{ matrix.shard && format(' -- --shard={0}/3', matrix.shard) || '' }}${{ matrix.os == 'ubuntu-latest' && matrix.node == '20.20' && !matrix.shard && ' -- --coverage' || '' }}
@@ -160,7 +166,13 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npx -y npm@11.11.0 ci
+        # Node 26 ships with newer npm; npm@11.11.0 repeatedly stalled in CI on the Node 26 lane.
+        run: |
+          if [ "${{ matrix.node }}" = "26.x" ]; then
+            npm ci
+          else
+            npx -y npm@11.11.0 ci
+          fi
 
       - name: Build
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,8 @@ jobs:
   test:
     needs: ci-config
     name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}${{ matrix.shard && format(' (shard {0}/3)', matrix.shard) || '' }}
-    # Cold-cache installs for newer Node/native-addon combinations can consume most of the old 15m budget.
-    timeout-minutes: 25
+    # Cold-cache Node 26 installs can approach 20m before the test phase starts, so leave room for the test body.
+    timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -142,8 +142,8 @@ jobs:
     name: Build on Node ${{ matrix.node }}
     env:
       PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
-    # Keep enough headroom for slow PR merge-ref checkout plus cold-cache installs on GitHub-hosted runners.
-    timeout-minutes: 20
+    # Cold-cache Node 26 installs can approach 20m before the build phase starts on GitHub-hosted runners.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.ci-config.outputs.build-matrix) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
             {"node":"20.20","os":"ubuntu-latest","shard":""},
             {"node":"22.22","os":"ubuntu-latest","shard":""},
             {"node":"24.x","os":"ubuntu-latest","shard":""},
+            {"node":"26.x","os":"ubuntu-latest","shard":""},
             {"node":"22.22","os":"windows-latest","shard":1},
             {"node":"22.22","os":"windows-latest","shard":2},
             {"node":"22.22","os":"windows-latest","shard":3}
@@ -43,7 +44,7 @@ jobs:
             extra_entries='
               ,{"node":"22.22","os":"macOS-latest","shard":""}
             '
-            build_matrix='{"node":["20.20","24.x"]}'
+            build_matrix='{"node":["20.20","24.x","26.x"]}'
           else
             # Main/dispatch: add all macOS versions + remaining Windows shards
             extra_entries='
@@ -54,9 +55,12 @@ jobs:
               {"node":"20.20","os":"windows-latest","shard":3},
               {"node":"24.x","os":"windows-latest","shard":1},
               {"node":"24.x","os":"windows-latest","shard":2},
-              {"node":"24.x","os":"windows-latest","shard":3}
+              {"node":"24.x","os":"windows-latest","shard":3},
+              {"node":"26.x","os":"windows-latest","shard":1},
+              {"node":"26.x","os":"windows-latest","shard":2},
+              {"node":"26.x","os":"windows-latest","shard":3}
             '
-            build_matrix='{"node":["20.20","22.22","24.x"]}'
+            build_matrix='{"node":["20.20","22.22","24.x","26.x"]}'
           fi
 
           # Build the matrix JSON (shard:"" is falsy in GHA expressions, used to skip shard flags)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Quick Start
 
-Requires [Node.js](https://nodejs.org/en/download) 20.20+ or 22.22+ for npm and npx usage.
+Requires [Node.js](https://nodejs.org/en/download) `^20.20.0` or `>=22.22.0` for npm and npx usage.
 
 ```sh
 npm install -g promptfoo

--- a/examples/openai-codex-sdk/README.md
+++ b/examples/openai-codex-sdk/README.md
@@ -17,7 +17,7 @@ Install the OpenAI Codex SDK:
 npm install @openai/codex-sdk
 ```
 
-**Requirements**: Node.js 20.20+ or 22.22+
+**Requirements**: Node.js `^20.20.0` or `>=22.22.0`
 
 Authenticate with Codex using one of these options:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "async": "^3.2.6",
-        "better-sqlite3": "^12.8.0",
+        "better-sqlite3": "^12.10.0",
         "binary-extensions": "^3.1.0",
         "cache-manager": "^7.2.8",
         "chalk": "^5.6.2",
@@ -20745,9 +20745,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20755,7 +20755,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "async": "^3.2.6",
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.10.0",
     "binary-extensions": "^3.1.0",
     "cache-manager": "^7.2.8",
     "chalk": "^5.6.2",

--- a/site/docs/guides/chatbase-redteam.md
+++ b/site/docs/guides/chatbase-redteam.md
@@ -25,7 +25,7 @@ In Promptfoo, this state is managed through a `conversationId` that links messag
 
 ### Prerequisites
 
-- Node.js 20.20+ or 22.22+
+- Node.js `^20.20.0` or `>=22.22.0`
 - promptfoo CLI (`npm install -g promptfoo`)
 - Chatbase API credentials:
   - API Bearer Token (from your Chatbase dashboard)

--- a/site/docs/guides/deepseek-benchmark.md
+++ b/site/docs/guides/deepseek-benchmark.md
@@ -13,7 +13,7 @@ In this guide, we'll create a practical comparison that results in a detailed si
 
 ## Requirements
 
-- Node.js 20.20+ or 22.22+
+- Node.js `^20.20.0` or `>=22.22.0`
 - OpenRouter API access for DeepSeek and Llama (set `OPENROUTER_API_KEY`)
 - OpenAI API access for GPT-5 and o3-mini (set `OPENAI_API_KEY`)
 

--- a/site/docs/guides/evaluate-crewai.md
+++ b/site/docs/guides/evaluate-crewai.md
@@ -43,7 +43,7 @@ promptfoo eval
 Before starting, make sure you have:
 
 - Python 3.10+
-- Node.js 20.20+ or 22.22+
+- Node.js `^20.20.0` or `>=22.22.0`
 - OpenAI API access (for GPT-5, GPT-5-mini, or other models)
 - An OpenAI API key
 
@@ -77,7 +77,7 @@ And check npm (Node package manager):
 npm -v
 ```
 
-In our example, you can see `v22.22.0` for Node and `10.9.0` for npm — that’s solid. Promptfoo requires Node.js 20.20+ or 22.22+.
+In our example, you can see `v22.22.0` for Node and `10.9.0` for npm — that’s solid. Promptfoo requires Node.js `^20.20.0` or `>=22.22.0`.
 
 **Why do we need these?**
 

--- a/site/docs/guides/llm-redteaming.md
+++ b/site/docs/guides/llm-redteaming.md
@@ -54,7 +54,7 @@ You can also dig into specific red team failure cases:
 
 ## Prerequisites
 
-First, install [Node.js](https://nodejs.org/en/download/package-manager/) 20.20+ or 22.22+.
+First, install [Node.js](https://nodejs.org/en/download/package-manager/) `^20.20.0` or `>=22.22.0`.
 
 Then create a new project for your red teaming needs:
 

--- a/site/docs/guides/qwen-benchmark.md
+++ b/site/docs/guides/qwen-benchmark.md
@@ -19,7 +19,7 @@ The chatbot should provide accurate information, respond quickly, and handle com
 
 ## Requirements
 
-- Node.js 20.20+ or 22.22+
+- Node.js `^20.20.0` or `>=22.22.0`
 - Access to OpenRouter for Qwen and Llama (set environment variable `OPENROUTER_API_KEY`)
 - Access to OpenAI for GPT-5 (set environment variable `OPENAI_API_KEY`)
 

--- a/site/docs/installation.md
+++ b/site/docs/installation.md
@@ -32,7 +32,7 @@ Install promptfoo using [npm](https://nodejs.org/en/download), [npx](https://nod
 </Tabs>
 
 :::note
-npm and npx require [Node.js](https://nodejs.org/en/download) 20.20+ or 22.22+.
+npm and npx require [Node.js](https://nodejs.org/en/download) `^20.20.0` or `>=22.22.0`.
 :::
 
 To use promptfoo as a library in your project, run `npm install promptfoo --save`.

--- a/site/docs/integrations/azure-pipelines.md
+++ b/site/docs/integrations/azure-pipelines.md
@@ -183,6 +183,6 @@ If you encounter issues with your Azure Pipelines integration:
 - **Check logs**: Review detailed logs in Azure DevOps to identify errors
 - **Verify API keys**: Ensure your API keys are correctly set as pipeline variables
 - **Permissions**: Make sure the pipeline has access to read your configuration files
-- **Node.js version**: Promptfoo requires Node.js 20.20+ or 22.22+
+- **Node.js version**: Promptfoo requires Node.js `^20.20.0` or `>=22.22.0`
 
 If you're getting timeouts during evaluations, you may need to adjust the pipeline timeout settings or consider using a [self-hosted agent](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/agents) for better stability with long-running evaluations.

--- a/site/docs/integrations/ci-cd.md
+++ b/site/docs/integrations/ci-cd.md
@@ -41,7 +41,7 @@ npx promptfoo@latest redteam run
 
 ## Prerequisites
 
-- Node.js 20.20+ or 22.22+ installed in your CI environment
+- Node.js `^20.20.0` or `>=22.22.0` installed in your CI environment
 - LLM provider API keys (stored as secure environment variables)
 - A promptfoo configuration file (`promptfooconfig.yaml`)
 - (Optional) Docker for containerized environments

--- a/site/docs/red-team/quickstart.md
+++ b/site/docs/red-team/quickstart.md
@@ -28,7 +28,7 @@ Promptfoo is an [open-source](https://github.com/promptfoo/promptfoo) tool for r
 
 ## Prerequisites
 
-- Install [Node.js](https://nodejs.org/en/download/package-manager/) 20.20+ or 22.22+
+- Install [Node.js](https://nodejs.org/en/download/package-manager/) `^20.20.0` or `>=22.22.0`
 - Optional: Set your `OPENAI_API_KEY` environment variable
 
 ## Initialize the project

--- a/site/docs/usage/self-hosting.md
+++ b/site/docs/usage/self-hosting.md
@@ -583,7 +583,7 @@ The `VITE_PUBLIC_BASENAME` build argument configures the frontend to use the cor
 - **GPU**: Not required
 - **RAM**: 4 GB+
 - **Storage**: 10 GB+
-- **Dependencies**: Node.js 20.20+ or 22.22+, npm
+- **Dependencies**: Node.js `^20.20.0` or `>=22.22.0`, npm
 
 ### Server Requirements (Hosting the Web UI/API)
 

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -270,7 +270,7 @@ async function loadClaudeCodeSDK(): Promise<typeof import('@anthropic-ai/claude-
       dedent`Failed to load @anthropic-ai/claude-agent-sdk.
 
       The package was found but could not be loaded. This may be due to:
-      - Incompatible Node.js version (requires Node.js 20.20+ or 22.22+)
+      - Incompatible Node.js version (requires Node.js ^20.20.0 or >=22.22.0)
       - Corrupted installation
 
       Try reinstalling:

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -409,7 +409,7 @@ async function loadCodexSDK(): Promise<any> {
       To use the OpenAI Codex SDK provider, install it with:
         npm install @openai/codex-sdk
 
-      Requires Node.js 20.20+ or 22.22+.
+      Requires Node.js ^20.20.0 or >=22.22.0.
 
       For more information, see: https://www.promptfoo.dev/docs/providers/openai-codex-sdk/`,
     );
@@ -426,7 +426,7 @@ async function loadCodexSDK(): Promise<any> {
       dedent`Failed to load @openai/codex-sdk.
 
       The package was found but could not be loaded. This may be due to:
-      - Incompatible Node.js version (requires Node.js 20.20+ or 22.22+)
+      - Incompatible Node.js version (requires Node.js ^20.20.0 or >=22.22.0)
       - Corrupted installation
 
       Try reinstalling:


### PR DESCRIPTION
## Summary

- add Node 26 to the CI build/test matrix
- bump `better-sqlite3` to `12.10.0`, which advertises Node 26 support
- refresh docs and provider guidance to state the precise supported Node semver range: `^20.20.0` or `>=22.22.0`

## Why

Promptfoo's root engine range already admits Node 26, but CI did not exercise it and `better-sqlite3@12.9.0` still stopped at Node 25. That left Node 26 installs partially declared but not actually proven.

## Validation

- `npm ci` on Node `26.1.0` with strict engines enabled
- `node -e 'require("better-sqlite3")'` on Node `26.1.0`
- `vitest test/entrypoint.test.ts test/database.test.ts test/nativeAddonErrors.test.ts --run` on Node `26.1.0`
- `tsc --noEmit` on Node `26.1.0`
- `npm run build` on Node `26.1.0`
- `npm rebuild better-sqlite3` + `test/database.test.ts` smoke on Node `20.20.2`, `22.22.2`, and `24.15.0`
- `npm run f`
- `npm run l`
- `SKIP_OG_GENERATION=true npm run build` in `site/`

## Notes

- The docs build completed successfully after the stats prefetch fell back because those external fetches were unavailable locally.
- The changed-file Biome pass reported the pre-existing cognitive-complexity warnings already present in `src/providers/claude-agent-sdk.ts`; no new lint findings were introduced.
