### PR TITLE
chore: resolve AI code quality findings

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -54,6 +54,11 @@ import type { ResultsFilter } from './store';
 
 const Report = React.lazy(() => import('@app/pages/redteam/report/components/Report'));
 
+const MAX_SEARCH_BADGE_LENGTH = 5;
+
+// Default to showing charts only on sufficiently tall viewports to avoid crowding above-the-fold content.
+const MIN_VIEWPORT_HEIGHT_FOR_CHARTS = 1100;
+
 interface ResultsViewProps {
   recentEvals: ResultLightweightWithLabel[];
   onRecentEvalSelected: (file: string) => void;
@@ -95,8 +100,8 @@ function getAppliedFilterLabel(
     return null;
   }
 
-  const truncatedValue =
-    filter.value.length > 50 ? `${filter.value.slice(0, 50)}...` : filter.value;
+  const filterValue = filter.value ?? '';
+  const truncatedValue = filterValue.length > 50 ? `${filterValue.slice(0, 50)}...` : filterValue;
 
   if (filter.type === 'metric') {
     const operatorSymbols: Record<string, string> = {
@@ -174,7 +179,9 @@ export function ResultsChartsSection({
   children,
 }: ResultsChartsSectionProps) {
   const [renderResultsCharts, setRenderResultsCharts] = React.useState(
-    !isRedteamEval && window.innerHeight >= 1100 && canRenderResultsCharts,
+    !isRedteamEval &&
+      window.innerHeight >= MIN_VIEWPORT_HEIGHT_FOR_CHARTS &&
+      canRenderResultsCharts,
   );
 
   if (isRedteamEval) {
@@ -753,7 +760,10 @@ export default function ResultsView({
       </DropdownMenuItem>
       <DropdownMenuItem
         onClick={() => {
-          updateConfig(config!);
+          if (!config) {
+            return;
+          }
+          updateConfig(config);
           navigate(ROUTES.SETUP);
         }}
       >
@@ -882,8 +892,8 @@ export default function ResultsView({
                     {debouncedSearchText && (
                       <Badge variant="secondary" className="text-xs h-5 gap-1">
                         Search:{' '}
-                        {debouncedSearchText.length > 5
-                          ? debouncedSearchText.substring(0, 5) + '...'
+                        {debouncedSearchText.length > MAX_SEARCH_BADGE_LENGTH
+                          ? debouncedSearchText.substring(0, MAX_SEARCH_BADGE_LENGTH) + '...'
                           : debouncedSearchText}
                         <button
                           type="button"

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -52,11 +52,14 @@ vi.mock('cache-manager', () => ({
   createCache: vi.fn().mockImplementation(({ stores }) => {
     const cache = new Map<string, unknown>();
     const expiresAt = new Map<string, number>();
-    const inflight = new Map();
+    const inflight = new Map<string, Promise<unknown>>();
     const memoryStore = {
-      iterator: vi.fn().mockImplementation(async function* (_namespace?: string) {
+      iterator: vi.fn().mockImplementation(async function* (namespace?: string) {
+        const prefix = namespace ? `${namespace}:` : undefined;
         for (const [key, value] of cache.entries()) {
-          yield [key, value];
+          if (!prefix || key.startsWith(prefix)) {
+            yield [key, value];
+          }
         }
       }),
       delete: vi.fn().mockImplementation((key: string) => {
@@ -226,14 +229,16 @@ describe('cache configuration', () => {
     const cache = cacheModule.getCache();
     // In test environment, promptfoo falls back to an in-memory store instead of disk.
     expect(cache.stores.length).toBeGreaterThan(0);
+    expect(cache.stores[0]?.constructor?.name).not.toBe('KeyvFile');
   });
 
   it('should use disk cache in non-test environment', async () => {
     mockProcessEnv({ NODE_ENV: 'production' });
     const cacheModule = await import('../src/cache');
-    const cache = cacheModule.getCache();
-    // In production, stores array should have at least one store (disk cache)
-    expect(cache.stores.length).toBeGreaterThan(0);
+    cacheModule.getCache();
+    // In production, disk cache initialization should check/create cache directory.
+    expect(fs.existsSync).toHaveBeenCalled();
+    expect(fs.mkdirSync).toHaveBeenCalled();
   });
 
   it('should respect custom cache path', async () => {
@@ -1222,11 +1227,11 @@ describe('fetchWithCache', () => {
       const mockResponse = mockFetchWithRetriesResponse(true, response);
       mockFetchWithRetries.mockResolvedValueOnce(mockResponse);
 
-      // First call with repeatIndex: 0
+      // First call with repeatIndex: 0 using the new CacheOptions object API.
       const result1 = await fetchWithCache(url, {}, 1000, 'json', { repeatIndex: 0 });
       expect(result1.cached).toBe(false);
 
-      // Second call with no repeatIndex should hit the same cache
+      // Second call uses legacy API (`false`) with no repeatIndex and should hit the same cache.
       const result2 = await fetchWithCache(url, {}, 1000, 'json', false);
       expect(result2.cached).toBe(true);
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -41,10 +41,6 @@ vi.mock('../../src/util/templates', async () => {
   };
 });
 
-vi.spyOn(process, 'exit').mockImplementation(function () {
-  return undefined as never;
-});
-
 vi.mock('../../src/redteam/strategies', async () => ({
   ...(await vi.importActual('../../src/redteam/strategies')),
 
@@ -197,11 +193,10 @@ describe('synthesize', () => {
         'Prompt 2',
         'Prompt 3',
       ]);
-      expect(extractEntities).toHaveBeenCalledWith(expect.any(Object), [
-        'Prompt 1',
-        'Prompt 2',
-        'Prompt 3',
-      ]);
+      expect(extractEntities).toHaveBeenCalledWith(
+        expect.objectContaining({ id: expect.any(Function) }),
+        ['Prompt 1', 'Prompt 2', 'Prompt 3'],
+      );
     });
   });
 
@@ -2159,8 +2154,9 @@ describe('calculateTotalTests', () => {
   });
 
   it('should resolve file:// intents from a JSON array for pre-generation totals', () => {
-    // fs is mocked at the module level (see vi.mock('fs') below). Stub readFileSync
-    // so maybeLoadFromExternalFile sees a JSON array of intents.
+    // fs is mocked at the module level (see vi.mock('fs') below). Stub existsSync/readFileSync
+    // so maybeLoadFromExternalFile sees an existing file with a JSON array of intents.
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     const readFileSyncSpy = vi
       .spyOn(fs, 'readFileSync')
       .mockReturnValue(JSON.stringify(['do thing 1', 'do thing 2', 'do thing 3', 'do thing 4']));
@@ -2184,6 +2180,7 @@ describe('calculateTotalTests', () => {
       });
     } finally {
       readFileSyncSpy.mockRestore();
+      existsSyncSpy.mockRestore();
     }
   });
 
@@ -3486,7 +3483,7 @@ describe('Language configuration', () => {
         message: 'Cloud API is healthy',
       });
       vi.mocked(getRemoteHealthUrl).mockReturnValue('http://health.test');
-      vi.mocked(shouldGenerateRemote).mockResolvedValue(true);
+      vi.mocked(shouldGenerateRemote).mockReturnValue(true);
     });
 
     it('should show truncated policy text in plugin list for policy plugins', async () => {
@@ -3872,21 +3869,16 @@ describe('Language configuration', () => {
         // Mock the provider loading to return a mock provider for test generation
         // This avoids the loadApiProviders error while still testing strategy config
         const mockProvider = { id: () => 'mock-provider', callApi: vi.fn() };
-        const providerSpy = vi
-          .spyOn(
-            await import('../../src/redteam/providers/shared'),
-            'redteamProviderManager',
-            'get',
-          )
-          .mockReturnValue({
-            getProvider: vi.fn().mockResolvedValue(mockProvider),
-            getGradingProvider: vi.fn().mockResolvedValue(mockProvider),
-            getMultilingualProvider: vi.fn().mockResolvedValue(undefined),
-            setProvider: vi.fn(),
-            setGradingProvider: vi.fn(),
-            setMultilingualProvider: vi.fn(),
-            clearProvider: vi.fn(),
-          } as any);
+        const providersShared = await import('../../src/redteam/providers/shared');
+        const getProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getProvider')
+          .mockResolvedValue(mockProvider as any);
+        const getGradingProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getGradingProvider')
+          .mockResolvedValue(mockProvider as any);
+        const getMultilingualProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getMultilingualProvider')
+          .mockResolvedValue(undefined);
 
         try {
           await synthesize({
@@ -3902,7 +3894,9 @@ describe('Language configuration', () => {
           expect(capturedConfig).toBeDefined();
           expect(capturedConfig?.redteamProvider).toBe('vertex:gemini-2.5-flash');
         } finally {
-          providerSpy.mockRestore();
+          getProviderSpy.mockRestore();
+          getGradingProviderSpy.mockRestore();
+          getMultilingualProviderSpy.mockRestore();
         }
       } finally {
         // Restore original cliState
@@ -3995,21 +3989,16 @@ describe('Language configuration', () => {
 
         // Mock the provider loading
         const mockProvider = { id: () => 'mock-provider', callApi: vi.fn() };
-        const providerSpy = vi
-          .spyOn(
-            await import('../../src/redteam/providers/shared'),
-            'redteamProviderManager',
-            'get',
-          )
-          .mockReturnValue({
-            getProvider: vi.fn().mockResolvedValue(mockProvider),
-            getGradingProvider: vi.fn().mockResolvedValue(mockProvider),
-            getMultilingualProvider: vi.fn().mockResolvedValue(undefined),
-            setProvider: vi.fn(),
-            setGradingProvider: vi.fn(),
-            setMultilingualProvider: vi.fn(),
-            clearProvider: vi.fn(),
-          } as any);
+        const providersShared = await import('../../src/redteam/providers/shared');
+        const getProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getProvider')
+          .mockResolvedValue(mockProvider as any);
+        const getGradingProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getGradingProvider')
+          .mockResolvedValue(mockProvider as any);
+        const getMultilingualProviderSpy = vi
+          .spyOn(providersShared.redteamProviderManager, 'getMultilingualProvider')
+          .mockResolvedValue(undefined);
 
         try {
           await synthesize({
@@ -4025,7 +4014,9 @@ describe('Language configuration', () => {
           // Should pass the full provider options object
           expect(capturedConfig?.redteamProvider).toEqual(providerOptions);
         } finally {
-          providerSpy.mockRestore();
+          getProviderSpy.mockRestore();
+          getGradingProviderSpy.mockRestore();
+          getMultilingualProviderSpy.mockRestore();
         }
       } finally {
         cliState.config = originalConfig;

--- a/test/server/routes/serverRouteSmoke.test.ts
+++ b/test/server/routes/serverRouteSmoke.test.ts
@@ -9,6 +9,8 @@ import {
 import { createApp } from '../../../src/server/server';
 import type { Express } from 'express';
 
+const REQUEST_TIMEOUT_MS = 2000;
+
 const mocks = vi.hoisted(() => ({
   checkEmailStatus: vi.fn(),
   checkModelAuditInstalled: vi.fn(),
@@ -227,7 +229,7 @@ vi.mock('../../../src/server/config/serverConfig', () => ({
   getAvailableProviders: mocks.getAvailableProviders,
 }));
 
-const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'] as const;
 
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
@@ -792,7 +794,7 @@ async function sendRequest(app: Express, testCase: SmokeCase) {
   }>((resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error(`${routeKey(testCase)} did not finish`));
-    }, 2000);
+    }, REQUEST_TIMEOUT_MS);
 
     res.once('finish', () => {
       clearTimeout(timeout);
@@ -856,13 +858,10 @@ describe('server route end-to-end smoke coverage', { concurrent: false }, () => 
 
     const response = await sendRequest(app, testCase);
 
-    if (response.status !== testCase.expectedStatus) {
-      throw new Error(
-        `${routeKey(testCase)} expected ${testCase.expectedStatus}, got ${response.status}: ${
-          response.text
-        }`,
-      );
-    }
+    expect(
+      response.status,
+      `${routeKey(testCase)} expected ${testCase.expectedStatus}, got ${response.status}: ${response.text}`,
+    ).toBe(testCase.expectedStatus);
 
     if (response.status !== 204) {
       expect(response.headers['content-type']).toContain('application/json');

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -138,8 +138,8 @@ describe('Telemetry', () => {
 
   it('should not track events with PostHog when telemetry is disabled', () => {
     mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
-    const _telemetry = new Telemetry();
-    _telemetry.record('eval_ran', { foo: 'bar' });
+    const telemetry = new Telemetry();
+    telemetry.record('eval_ran', { foo: 'bar' });
     expect(sendEventSpy).not.toHaveBeenCalledWith('eval_ran', expect.anything());
   });
 
@@ -160,8 +160,8 @@ describe('Telemetry', () => {
 
   it('should include version in telemetry events', () => {
     mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
-    const _telemetry = new Telemetry();
-    _telemetry.record('eval_ran', { foo: 'bar' });
+    const telemetry = new Telemetry();
+    telemetry.record('eval_ran', { foo: 'bar' });
 
     expect(sendEventSpy).toHaveBeenCalledWith('eval_ran', { foo: 'bar' });
     expect(fetchWithProxySpy).toHaveBeenCalledWith(
@@ -200,8 +200,8 @@ describe('Telemetry', () => {
     isCIMock.mockReturnValue(true);
     fetchWithProxySpy.mockClear();
 
-    const _telemetry = new Telemetry();
-    _telemetry.record('feature_used', { test: 'value' });
+    const telemetry = new Telemetry();
+    telemetry.record('feature_used', { test: 'value' });
 
     await vi.waitFor(() => {
       expect(fetchWithProxySpy.mock.calls.length).toBeGreaterThan(0);
@@ -252,9 +252,9 @@ describe('Telemetry', () => {
 
   it('should save consent successfully', async () => {
     vi.mocked(fetchWithTimeout).mockResolvedValue({ ok: true } as any);
-    const _telemetry = new Telemetry();
+    const telemetry = new Telemetry();
 
-    await _telemetry.saveConsent('test@example.com', { source: 'test' });
+    await telemetry.saveConsent('test@example.com', { source: 'test' });
 
     expect(fetchWithTimeout).toHaveBeenCalledWith(
       'https://api.promptfoo.dev/consent',
@@ -271,9 +271,9 @@ describe('Telemetry', () => {
 
   it('should handle failed consent save', async () => {
     vi.mocked(fetchWithTimeout).mockResolvedValue({ ok: false, statusText: 'Not Found' } as any);
-    const _telemetry = new Telemetry();
+    const telemetry = new Telemetry();
 
-    await _telemetry.saveConsent('test@example.com', { source: 'test' });
+    await telemetry.saveConsent('test@example.com', { source: 'test' });
 
     expect(fetchWithTimeout).toHaveBeenCalledWith(
       'https://api.promptfoo.dev/consent',
@@ -341,9 +341,9 @@ describe('Telemetry', () => {
       }));
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await _telemetry.identify();
+      await telemetry.identify();
 
       expect(mockPostHog).toHaveBeenCalledWith('test-posthog-key', {
         host: 'https://a.promptfoo.app',
@@ -374,9 +374,9 @@ describe('Telemetry', () => {
       }));
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await expect(_telemetry.identify()).resolves.not.toThrow();
+      await expect(telemetry.identify()).resolves.not.toThrow();
     });
   });
 
@@ -486,15 +486,17 @@ describe('Telemetry', () => {
       }));
     });
 
-    it('should call PostHog identify when telemetry is enabled', async () => {
+    it('should call PostHog identify via constructor when telemetry is enabled', async () => {
       mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
       mockProcessEnv({ IS_TESTING: undefined });
       mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await _telemetry.identify();
+      expect(telemetry).toBeDefined();
+      await Promise.resolve();
+      await Promise.resolve();
 
       expect(mockPostHogInstance.identify).toHaveBeenCalledWith({
         distinctId: 'test-user-id',
@@ -520,9 +522,9 @@ describe('Telemetry', () => {
       const { default: logger } = await import('../src/logger');
       const loggerSpy = vi.spyOn(logger, 'debug');
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await expect(_telemetry.identify()).resolves.not.toThrow();
+      await expect(telemetry.identify()).resolves.not.toThrow();
       expect(loggerSpy).toHaveBeenCalledWith('PostHog identify error: Error: Identify failed');
     });
 
@@ -532,9 +534,9 @@ describe('Telemetry', () => {
       mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-posthog-key' });
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      _telemetry.record('eval_ran', { test: 'value' });
+      telemetry.record('eval_ran', { test: 'value' });
 
       expect(mockPostHogInstance.capture).toHaveBeenCalledWith({
         distinctId: 'test-user-id',
@@ -572,16 +574,32 @@ describe('Telemetry', () => {
       });
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
+
+      await vi.waitFor(() => {
+        expect(mockPostHogInstance.identify).toHaveBeenCalledWith({
+          distinctId: 'test-user-id',
+          properties: {
+            email: 'old@example.com',
+            isLoggedIntoCloud: false,
+            authMethod: 'email',
+            isRunningInCi: false,
+          },
+        });
+      });
 
       getUserAuthInfoMock.mockClear();
+      mockPostHogInstance.identify.mockClear();
+      mockPostHogInstance.capture.mockClear();
+      mockPostHogInstance.flush.mockClear();
+
       getUserAuthInfoMock.mockReturnValue({
         email: 'new@example.com',
         isLoggedIntoCloud: true,
         authMethod: 'api-key',
       });
 
-      _telemetry.record('eval_ran', { test: 'value' });
+      telemetry.record('eval_ran', { test: 'value' });
 
       expect(getUserAuthInfoMock).toHaveBeenCalledTimes(1);
       expect(mockPostHogInstance.capture).toHaveBeenCalledWith({
@@ -627,9 +645,9 @@ describe('Telemetry', () => {
       const { default: logger } = await import('../src/logger');
       const loggerSpy = vi.spyOn(logger, 'debug');
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      expect(() => _telemetry.record('eval_ran', { test: 'value' })).not.toThrow();
+      expect(() => telemetry.record('eval_ran', { test: 'value' })).not.toThrow();
       expect(loggerSpy).toHaveBeenCalledWith('PostHog capture error: Error: Capture failed');
     });
 
@@ -641,9 +659,9 @@ describe('Telemetry', () => {
       mockPostHogInstance.flush.mockRejectedValue(new Error('Flush failed'));
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await expect(_telemetry.identify()).resolves.not.toThrow();
+      await expect(telemetry.identify()).resolves.not.toThrow();
     });
 
     it('should call PostHog shutdown when telemetry shutdown is called', async () => {
@@ -654,9 +672,9 @@ describe('Telemetry', () => {
       mockPostHogInstance.shutdown = vi.fn().mockResolvedValue(undefined);
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await _telemetry.shutdown();
+      await telemetry.shutdown();
 
       expect(mockPostHogInstance.shutdown).toHaveBeenCalled();
     });
@@ -671,9 +689,9 @@ describe('Telemetry', () => {
       const { default: logger } = await import('../src/logger');
       const loggerSpy = vi.spyOn(logger, 'debug');
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await expect(_telemetry.shutdown()).resolves.not.toThrow();
+      await expect(telemetry.shutdown()).resolves.not.toThrow();
       expect(loggerSpy).toHaveBeenCalledWith('PostHog shutdown error: Error: Shutdown failed');
     });
 
@@ -681,23 +699,23 @@ describe('Telemetry', () => {
       mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
 
       const telemetryModule = await import('../src/telemetry');
-      const _telemetry = new telemetryModule.Telemetry();
+      const telemetry = new telemetryModule.Telemetry();
 
-      await expect(_telemetry.shutdown()).resolves.not.toThrow();
+      await expect(telemetry.shutdown()).resolves.not.toThrow();
     });
   });
 
   describe('telemetry disabled recording', () => {
     it('should record telemetry disabled event only once', () => {
       mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
-      const _telemetry = new Telemetry();
+      const telemetry = new Telemetry();
 
-      _telemetry.record('eval_ran', { foo: 'bar' });
+      telemetry.record('eval_ran', { foo: 'bar' });
       expect(sendEventSpy).toHaveBeenCalledWith('feature_used', { feature: 'telemetry disabled' });
       expect(sendEventSpy).toHaveBeenCalledTimes(1);
 
       sendEventSpy.mockClear();
-      _telemetry.record('command_used', { name: 'test' });
+      telemetry.record('command_used', { name: 'test' });
       expect(sendEventSpy).not.toHaveBeenCalled();
     });
   });
@@ -710,7 +728,7 @@ describe('Telemetry', () => {
       vi.resetModules();
 
       // Re-mock fetchWithTimeout
-      vi.doMock('../src/util/fetch', () => ({
+      vi.doMock('../src/util/fetch/index.ts', () => ({
         fetchWithTimeout: vi.fn().mockRejectedValue(mockError),
       }));
 
@@ -725,17 +743,17 @@ describe('Telemetry', () => {
       const { default: logger } = await import('../src/logger');
       const { Telemetry: TelemetryClass } = await import('../src/telemetry');
 
-      const _telemetry = new TelemetryClass();
-      await _telemetry.saveConsent('test@example.com');
+      const telemetry = new TelemetryClass();
+      await telemetry.saveConsent('test@example.com');
 
       expect(logger.debug).toHaveBeenCalledWith('Failed to save consent: Network error');
     });
 
     it('should save consent without metadata', async () => {
       vi.mocked(fetchWithTimeout).mockResolvedValue({ ok: true } as any);
-      const _telemetry = new Telemetry();
+      const telemetry = new Telemetry();
 
-      await _telemetry.saveConsent('test@example.com');
+      await telemetry.saveConsent('test@example.com');
 
       expect(fetchWithTimeout).toHaveBeenCalledWith(
         'https://api.promptfoo.dev/consent',


### PR DESCRIPTION
## Summary
- Resolve all 21 currently visible GitHub Security AI findings across 5 files
- Guard ResultsView config/nullability paths and name magic constants
- Tighten cache, redteam, server smoke, and telemetry tests to match runtime behavior

## Verification
- npm run f
- npm test -- test/cache.test.ts test/redteam/index.test.ts test/server/routes/serverRouteSmoke.test.ts test/telemetry.test.ts
- npm run l
- npm run tsc
- npm run build:app