### PR TITLE
ci: fix windows node 26 dependency install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,17 +115,17 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install Dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      - name: Install Dependencies (Node 26)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && matrix.node == '26.x'
         # Node 26 hosted installs stall when lifecycle scripts run during npm ci.
         # Install the tree without scripts, then rebuild the native addon tests need.
         run: |
-          if [ "${{ matrix.node }}" = "26.x" ]; then
-            npm ci --ignore-scripts
-            npm rebuild better-sqlite3
-          else
-            npx -y npm@11.11.0 ci
-          fi
+          npm ci --ignore-scripts
+          npm rebuild better-sqlite3
+
+      - name: Install Dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true' && matrix.node != '26.x'
+        run: npx -y npm@11.11.0 ci
 
       - name: Test
         run: npm run test${{ matrix.shard && format(' -- --shard={0}/3', matrix.shard) || '' }}${{ matrix.os == 'ubuntu-latest' && matrix.node == '20.20' && !matrix.shard && ' -- --coverage' || '' }}


### PR DESCRIPTION
## Summary
- split the Node 26 dependency install path into its own Actions step
- avoid Bash-only conditionals under Windows PowerShell

## Testing
- git diff --check
- ruby -e "require \'yaml\'; YAML.load_file(\'.github/workflows/main.yml\'); puts \'yaml-ok\'"
