### PR TITLE
chore(deps): raise npm release age to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 engine-strict=true
-# Global floor for manual npm installs; Renovate still applies stricter per-package delays.
-min-release-age=2
+# Global floor for manual npm installs; Renovate rules should not undercut it.
+min-release-age=7

--- a/renovate.json
+++ b/renovate.json
@@ -238,7 +238,7 @@
       "schedule": ["before 6am on Monday"]
     },
     {
-      "description": "LLM provider packages: frequent updates with a short stabilization window",
+      "description": "LLM provider packages: frequent updates with a one-week stabilization window",
       "matchPackagePatterns": [
         "^@anthropic-ai/",
         "^@aws-sdk/client-bedrock",
@@ -256,56 +256,56 @@
       ],
       "schedule": ["every weekday"],
       "rangeStrategy": "bump",
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Runtime npm deps: wait 5 days before updates",
+      "description": "Runtime npm deps: wait 7 days before updates",
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "minimumReleaseAge": "5 days"
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Dev npm deps: wait 2 days before updates",
+      "description": "Dev npm deps: wait 7 days before updates",
       "matchDatasources": ["npm"],
       "matchDepTypes": ["devDependencies"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Optional npm deps: wait 2 days before updates (same as devDependencies)",
+      "description": "Optional npm deps: wait 7 days before updates (same as devDependencies)",
       "matchDatasources": ["npm"],
       "matchDepTypes": ["optionalDependencies"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "npm overrides/resolutions: wait 2 days to match .npmrc min-release-age floor",
+      "description": "npm overrides/resolutions: wait 7 days to match .npmrc min-release-age floor",
       "matchDatasources": ["npm"],
       "matchDepTypes": ["overrides", "pnpm.overrides", "resolutions"],
-      "minimumReleaseAge": "2 days"
+      "minimumReleaseAge": "7 days"
     },
 
     {
       "description": "@opencode-ai/sdk: weekly updates to reduce noise from daily releases",
       "matchPackageNames": ["@opencode-ai/sdk"],
       "schedule": ["before 6am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "AWS SDK packages: weekly updates to reduce noise",
       "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
       "schedule": ["before 6am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Biome: weekly updates",
       "matchPackageNames": ["@biomejs/biome"],
       "schedule": ["before 6am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Dev tooling: weekly updates (low urgency)",
       "matchPackageNames": ["hono", "knip"],
       "schedule": ["before 6am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "framer-motion: monthly updates (animation library, low urgency)",


### PR DESCRIPTION
## Summary
- raise the repo npm `min-release-age` floor from 2 to 7 days
- align Renovate npm age gates so dependency PRs do not undercut the stricter install policy
- refresh the related wording so the config documents the new one-week stabilization window clearly

## Validation
- `jq . renovate.json > /dev/null`
- `env -u NPM_CONFIG_BEFORE -u npm_config_before NPM_CONFIG_USERCONFIG=/dev/null npm_config_cache=/private/tmp/promptfoo-npm-cache npx --yes --package renovate renovate-config-validator renovate.json`
- `env -u NPM_CONFIG_BEFORE -u npm_config_before NPM_CONFIG_USERCONFIG=/dev/null npm_config_cache=/private/tmp/promptfoo-npm-cache npm run l`
- `env -u NPM_CONFIG_BEFORE -u npm_config_before NPM_CONFIG_USERCONFIG=/dev/null npm_config_cache=/private/tmp/promptfoo-npm-cache npm run f`
- `git diff --check`