### PR TITLE
fix(code-scan): skip unrelated default config startup

### DIFF
--- a/src/app/src/pages/media/hooks/useHoverIntent.test.ts
+++ b/src/app/src/pages/media/hooks/useHoverIntent.test.ts
@@ -1,4 +1,4 @@
-import { mockMatchMedia } from '@app/tests/browserMocks';
+import { mockBrowserProperty, mockMatchMedia, restoreBrowserMocks } from '@app/tests/browserMocks';
 import { type TestTimers, useTestTimers } from '@app/tests/timers';
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -221,5 +221,22 @@ describe('useHoverIntent', () => {
     unmount();
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it('should ignore delayed hover work after the browser window tears down', () => {
+    const { result } = renderHook(() => useHoverIntent({ delay: 300 }));
+
+    act(() => {
+      result.current.hoverProps.onMouseEnter();
+    });
+
+    mockBrowserProperty(globalThis, 'window', undefined);
+
+    expect(() => {
+      timers.advanceBy(300);
+    }).not.toThrow();
+
+    restoreBrowserMocks();
+    expect(result.current.isIntentional).toBe(false);
   });
 });

--- a/src/app/src/pages/media/hooks/useHoverIntent.ts
+++ b/src/app/src/pages/media/hooks/useHoverIntent.ts
@@ -67,6 +67,18 @@ export function useHoverIntent({
   const isEffectivelyEnabled =
     enabled && hasHoverCapability() && !(respectReducedMotion && prefersReducedMotion());
 
+  const markIntentional = useCallback(() => {
+    timeoutRef.current = undefined;
+
+    // Test environments can tear down jsdom between scheduling and execution.
+    // Avoid dispatching a React update once the browser global is already gone.
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    setIsIntentional(true);
+  }, []);
+
   // Clear timeout on unmount
   useEffect(() => {
     return () => {
@@ -82,10 +94,8 @@ export function useHoverIntent({
     }
 
     setIsHovering(true);
-    timeoutRef.current = window.setTimeout(() => {
-      setIsIntentional(true);
-    }, delay);
-  }, [isEffectivelyEnabled, delay]);
+    timeoutRef.current = window.setTimeout(markIntentional, delay);
+  }, [isEffectivelyEnabled, delay, markIntentional]);
 
   const onMouseLeave = useCallback(() => {
     setIsHovering(false);
@@ -105,10 +115,8 @@ export function useHoverIntent({
 
     setIsHovering(true);
     // For keyboard users, we can be more immediate
-    timeoutRef.current = window.setTimeout(() => {
-      setIsIntentional(true);
-    }, delay / 2);
-  }, [isEffectivelyEnabled, delay]);
+    timeoutRef.current = window.setTimeout(markIntentional, delay / 2);
+  }, [isEffectivelyEnabled, delay, markIntentional]);
 
   const onBlur = useCallback(() => {
     setIsHovering(false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
   addCommonOptionsRecursively,
   isMainModule,
   setupEnvFilesFromArgv,
+  shouldSkipDefaultConfigLoading,
   shutdownGracefully,
 } from './mainUtils';
 import { runDbMigrations } from './migrate';
@@ -48,7 +49,8 @@ import { formatNativeAddonVersionMismatchMessage } from './util/nativeAddonError
 import { VERSION } from './version';
 
 async function main() {
-  setupEnvFilesFromArgv();
+  const argv = process.argv.slice(2);
+  setupEnvFilesFromArgv(argv);
   initializeRunLogging();
 
   // Set PROMPTFOO_DISABLE_UPDATE=true in CI to prevent hanging on network requests
@@ -59,7 +61,10 @@ async function main() {
   await checkForUpdates();
   await runDbMigrations({ suppressNativeAddonLogging: true });
 
-  const { defaultConfig, defaultConfigPath } = await loadDefaultConfig();
+  const skipDefaultConfigLoading = shouldSkipDefaultConfigLoading(argv);
+  const { defaultConfig, defaultConfigPath } = skipDefaultConfigLoading
+    ? { defaultConfig: {}, defaultConfigPath: undefined }
+    : await loadDefaultConfig();
 
   const program = new Command('promptfoo');
   program
@@ -109,7 +114,9 @@ async function main() {
   redteamGenerateCommand(generateCommand, 'redteam', defaultConfig, defaultConfigPath);
 
   const { defaultConfig: redteamConfig, defaultConfigPath: redteamConfigPath } =
-    await loadDefaultConfig(undefined, 'redteam');
+    skipDefaultConfigLoading
+      ? { defaultConfig: {}, defaultConfigPath: undefined }
+      : await loadDefaultConfig(undefined, 'redteam');
 
   redteamInitCommand(redteamBaseCommand);
   evalCommand(

--- a/src/mainUtils.ts
+++ b/src/mainUtils.ts
@@ -90,6 +90,34 @@ export function setupEnvFilesFromArgv(argv: string[] = process.argv.slice(2)): v
   }
 }
 
+export function shouldSkipDefaultConfigLoading(argv: string[] = process.argv.slice(2)): boolean {
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    if (arg === '--') {
+      return false;
+    }
+
+    if (arg === '--env-file' || arg === '--env-path') {
+      index += 1;
+      continue;
+    }
+
+    if (
+      arg === '-v' ||
+      arg === '--verbose' ||
+      arg.startsWith('--env-file=') ||
+      arg.startsWith('--env-path=')
+    ) {
+      continue;
+    }
+
+    return arg === 'code-scans';
+  }
+
+  return false;
+}
+
 export function isMainModule(importMetaUrl: string, processArgv1: string | undefined): boolean {
   if (!processArgv1) {
     return false;

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -53,13 +53,19 @@ vi.mock('../src/codeScan', () => ({
 
 let addCommonOptionsRecursively: typeof import('../src/mainUtils').addCommonOptionsRecursively;
 let isMainModule: typeof import('../src/mainUtils').isMainModule;
+let shouldSkipDefaultConfigLoading: typeof import('../src/mainUtils').shouldSkipDefaultConfigLoading;
 let setupEnvFilesFromArgv: typeof import('../src/mainUtils').setupEnvFilesFromArgv;
 let shutdownGracefully: typeof import('../src/mainUtils').shutdownGracefully;
 
 async function loadMainModule() {
   vi.resetModules();
-  ({ addCommonOptionsRecursively, isMainModule, setupEnvFilesFromArgv, shutdownGracefully } =
-    await import('../src/mainUtils'));
+  ({
+    addCommonOptionsRecursively,
+    isMainModule,
+    shouldSkipDefaultConfigLoading,
+    setupEnvFilesFromArgv,
+    shutdownGracefully,
+  } = await import('../src/mainUtils'));
 }
 
 describe('setupEnvFilesFromArgv', () => {
@@ -108,6 +114,28 @@ describe('setupEnvFilesFromArgv', () => {
     setupEnvFilesFromArgv(['eval', '--env-file', '--verbose']);
 
     expect(mockSetupEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldSkipDefaultConfigLoading', () => {
+  beforeEach(async () => {
+    await loadMainModule();
+  });
+
+  it('skips unrelated default config discovery for code-scans commands', () => {
+    expect(shouldSkipDefaultConfigLoading(['code-scans', 'run'])).toBe(true);
+    expect(shouldSkipDefaultConfigLoading(['--verbose', 'code-scans', 'run', '--help'])).toBe(true);
+    expect(
+      shouldSkipDefaultConfigLoading(['--env-file', '.env.local', 'code-scans', 'run', '--help']),
+    ).toBe(true);
+    expect(shouldSkipDefaultConfigLoading(['--env-path=.env.local', 'code-scans', 'run'])).toBe(
+      true,
+    );
+  });
+
+  it('keeps default config discovery for other commands and post-separator arguments', () => {
+    expect(shouldSkipDefaultConfigLoading(['eval', '--help'])).toBe(false);
+    expect(shouldSkipDefaultConfigLoading(['--', 'code-scans', 'run'])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- skip eval/redteam default-config discovery for the `code-scans` command family
- avoid importing unrelated `promptfooconfig.ts` files before `code-scans` dispatch
- add focused startup-argv coverage for the new skip rule

## Why

Homebrew's current Promptfoo formula installs with `--omit=optional`. That removes
esbuild's platform binary package, such as `@esbuild/darwin-arm64`.

`promptfoo code-scans run` does not need eval/redteam default config discovery, but
the CLI startup path still loaded `promptfooconfig.*` before command dispatch. If the
current repo contains `promptfooconfig.ts`, startup imports `tsx`, which then asks
esbuild for the missing Homebrew-omitted platform package and crashes.

Fixes #9228.

## Validation

- `./node_modules/.bin/vitest run test/main.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check --write src/main.ts src/mainUtils.ts test/main.test.ts`
- `./node_modules/.bin/tsdown`
- `./node_modules/.bin/tsx scripts/postbuild.ts`
- `node dist/src/entrypoint.js code-scans run --help`
- reproduced the pre-fix Homebrew-shaped crash with an `--omit=optional` install and a local `promptfooconfig.ts`
- verified the fixed built CLI ignores a throwing `promptfooconfig.ts` for `code-scans run --help`, while `eval --help` still loads it
