### PR TITLE
chore: address AI code quality findings

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -55,6 +55,9 @@ import type { ResultsFilter } from './store';
 const Report = React.lazy(() => import('@app/pages/redteam/report/components/Report'));
 
 const MAX_SEARCH_BADGE_LENGTH = 5;
+const MAX_FILTER_VALUE_LENGTH = 50;
+const MAX_PROMPT_LABEL_LENGTH = 60;
+
 // Default to showing charts only on sufficiently tall viewports to avoid crowding above-the-fold content.
 const MIN_VIEWPORT_HEIGHT_FOR_CHARTS = 1100;
 
@@ -100,7 +103,10 @@ function getAppliedFilterLabel(
   }
 
   const filterValue = filter.value ?? '';
-  const truncatedValue = filterValue.length > 50 ? `${filterValue.slice(0, 50)}...` : filterValue;
+  const truncatedValue =
+    filterValue.length > MAX_FILTER_VALUE_LENGTH
+      ? `${filterValue.slice(0, MAX_FILTER_VALUE_LENGTH)}...`
+      : filterValue;
 
   if (filter.type === 'metric') {
     const operatorSymbols: Record<string, string> = {
@@ -421,12 +427,12 @@ export default function ResultsView({
   const promptOptions = head.prompts.map((prompt, idx) => {
     const label = prompt.label || prompt.display || prompt.raw;
     const provider = prompt.provider || 'unknown';
-    const displayLabel = [
-      label && `"${label.slice(0, 60)}${label.length > 60 ? '...' : ''}"`,
-      provider && `[${provider}]`,
-    ]
-      .filter(Boolean)
-      .join(' ');
+    const truncatedLabel =
+      label &&
+      `"${label.slice(0, MAX_PROMPT_LABEL_LENGTH)}${
+        label.length > MAX_PROMPT_LABEL_LENGTH ? '...' : ''
+      }"`;
+    const displayLabel = [truncatedLabel, provider && `[${provider}]`].filter(Boolean).join(' ');
 
     return {
       value: `Prompt ${idx + 1}`,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -223,8 +223,8 @@ describe('addCommonOptionsRecursively', () => {
     // Create a deeper command structure
     const subSubCommand = subCommand.command('subsubcommand');
     subSubCommand.action(() => {});
-    const subSubSubCommand = subSubCommand.command('subsubsubcommand');
-    subSubSubCommand.action(() => {});
+    const level3Command = subSubCommand.command('subsubsubcommand');
+    level3Command.action(() => {});
 
     addCommonOptionsRecursively(program);
 
@@ -250,10 +250,10 @@ describe('addCommonOptionsRecursively', () => {
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
 
-    const hasSubSubSubCommandVerboseOption = subSubSubCommand.options.some(
+    const hasSubSubSubCommandVerboseOption = level3Command.options.some(
       (option) => option.short === '-v' || option.long === '--verbose',
     );
-    const hasSubSubSubCommandEnvFileOption = subSubSubCommand.options.some(
+    const hasSubSubSubCommandEnvFileOption = level3Command.options.some(
       (option) => option.long === '--env-file' || option.long === '--env-path',
     );
 
@@ -589,16 +589,16 @@ describe('shutdownGracefully', () => {
   });
 
   it('should clear force exit timeout when cleanup completes normally', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
     const shutdownPromise = shutdownGracefully();
 
-    // Advance a little to let the cleanup complete
     await vi.runAllTimersAsync();
 
     await shutdownPromise;
 
-    // The force exit (3s) should not have been called since cleanup completed
-    // We verify this by checking process.exit was called with the natural exit timeout (100ms)
-    // not the force exit message
+    const forceExitTimeout = setTimeoutSpy.mock.results[0]?.value;
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(forceExitTimeout);
     expect(process.exit).toHaveBeenCalled();
   });
 

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -74,7 +74,6 @@ describe('synthesize', () => {
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.resetAllMocks();
 
     // Set up logger mocks
@@ -1962,7 +1961,6 @@ vi.mock('js-yaml');
 
 describe('resolvePluginConfig', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.resetAllMocks();
 
     // Set up logger mocks

--- a/test/server/routes/serverRouteSmoke.test.ts
+++ b/test/server/routes/serverRouteSmoke.test.ts
@@ -246,9 +246,12 @@ type SmokeCase = {
 class MockSocket extends Duplex {
   remoteAddress = '127.0.0.1';
 
-  _read() {}
+  _read() {
+    // This test double never emits readable data; IncomingMessage only needs the stream shape.
+  }
 
   _write(_chunk: unknown, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    // Accept and discard smoke-test transport writes.
     callback();
   }
 }

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -101,6 +101,25 @@ vi.mock('../src/constants/build', () => ({
   POSTHOG_KEY: 'test-posthog-key',
 }));
 
+function resetModulesAndMockFetch(
+  fetchMocks: Partial<Record<'fetchWithTimeout' | 'fetchWithProxy', Mock>> = {},
+) {
+  vi.resetModules();
+  vi.doMock('../src/util/fetch/index.ts', () => ({
+    fetchWithTimeout: fetchMocks.fetchWithTimeout ?? vi.fn().mockResolvedValue({ ok: true }),
+    fetchWithProxy: fetchMocks.fetchWithProxy ?? vi.fn().mockResolvedValue({ ok: true }),
+  }));
+}
+
+function setupTelemetryEnv(baseEnv: NodeJS.ProcessEnv) {
+  mockProcessEnv({ ...baseEnv }, { clear: true });
+  mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-key' });
+}
+
+function restoreTelemetryEnv(env: NodeJS.ProcessEnv) {
+  mockProcessEnv(env, { clear: true });
+}
+
 describe('Telemetry', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let fetchWithProxySpy: MockedFunction<typeof fetchWithProxy>;
@@ -108,8 +127,7 @@ describe('Telemetry', () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env };
-    mockProcessEnv({ ...originalEnv }, { clear: true });
-    mockProcessEnv({ PROMPTFOO_POSTHOG_KEY: 'test-key' });
+    setupTelemetryEnv(originalEnv);
 
     // Get the mocked fetchWithProxy function
     fetchWithProxySpy = fetchWithProxy as MockedFunction<typeof fetchWithProxy>;
@@ -122,7 +140,7 @@ describe('Telemetry', () => {
   });
 
   afterEach(() => {
-    mockProcessEnv(originalEnv, { clear: true });
+    restoreTelemetryEnv(originalEnv);
     vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -291,13 +309,7 @@ describe('Telemetry', () => {
   it('should not send user events when telemetry is disabled', async () => {
     mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
 
-    vi.resetModules();
-
-    // Re-establish fetch mocks after module reset
-    vi.doMock('../src/util/fetch/index.ts', () => ({
-      fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-      fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-    }));
+    resetModulesAndMockFetch();
 
     const telemetryModule = await import('../src/telemetry');
     const { Telemetry: TelemetryClass, default: telemetryInstance } = telemetryModule;
@@ -328,13 +340,7 @@ describe('Telemetry', () => {
         flush: vi.fn().mockResolvedValue(undefined),
       }));
 
-      vi.resetModules();
-
-      // Re-establish fetch mocks after module reset
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       vi.doMock('posthog-node', () => ({
         PostHog: mockPostHog,
@@ -361,13 +367,7 @@ describe('Telemetry', () => {
         throw new Error('PostHog initialization failed');
       });
 
-      vi.resetModules();
-
-      // Re-establish fetch mocks after module reset
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       vi.doMock('posthog-node', () => ({
         PostHog: mockPostHog,
@@ -397,15 +397,8 @@ describe('Telemetry', () => {
         return this;
       });
 
-      // Clear all modules and re-mock
-      vi.resetModules();
+      resetModulesAndMockFetch();
       vi.clearAllMocks();
-
-      // Re-establish all mocks after module reset
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
 
       vi.doMock('posthog-node', () => ({
         PostHog: mockPostHog,
@@ -725,13 +718,9 @@ describe('Telemetry', () => {
     it('should handle network errors when saving consent', async () => {
       const mockError = new Error('Network error');
 
-      // Reset modules to ensure clean state
-      vi.resetModules();
-
-      // Re-mock fetchWithTimeout
-      vi.doMock('../src/util/fetch/index.ts', () => ({
+      resetModulesAndMockFetch({
         fetchWithTimeout: vi.fn().mockRejectedValue(mockError),
-      }));
+      });
 
       // Re-mock logger to capture debug calls
       vi.doMock('../src/logger', () => ({
@@ -783,21 +772,13 @@ describe('Telemetry', () => {
     it('should register beforeExit handler only once across multiple module loads', async () => {
       const beforeExitListenersBefore = process.listenerCount('beforeExit');
 
-      vi.resetModules();
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       // First import
       await import('../src/telemetry');
       const listenersAfterFirst = process.listenerCount('beforeExit');
 
-      vi.resetModules();
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       // Second import
       await import('../src/telemetry');
@@ -809,11 +790,7 @@ describe('Telemetry', () => {
     });
 
     it('should store telemetry instance on process for beforeExit handler', async () => {
-      vi.resetModules();
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       const telemetryModule = await import('../src/telemetry');
       const telemetryInstance = telemetryModule.default;
@@ -825,20 +802,12 @@ describe('Telemetry', () => {
     });
 
     it('should update stored instance when module is reloaded', async () => {
-      vi.resetModules();
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       const firstModule = await import('../src/telemetry');
       const firstInstance = firstModule.default;
 
-      vi.resetModules();
-      vi.doMock('../src/util/fetch/index.ts', () => ({
-        fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
-        fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
-      }));
+      resetModulesAndMockFetch();
 
       const secondModule = await import('../src/telemetry');
       const secondInstance = secondModule.default;


### PR DESCRIPTION
## Summary
- Address all 9 currently visible GitHub AI code quality findings across 5 files
- Extract truncation lengths into named constants in ResultsView
- Tighten and simplify affected tests for mock resets, timers, and telemetry setup

## Testing
- PROMPTFOO_DISABLE_TELEMETRY=1 ./node_modules/.bin/vitest run test/main.test.ts test/redteam/index.test.ts test/server/routes/serverRouteSmoke.test.ts test/telemetry.test.ts --sequence.shuffle=false
- PROMPTFOO_DISABLE_TELEMETRY=1 ../../node_modules/.bin/vitest run src/pages/eval/components/ResultsView.test.tsx (from src/app)
- npm --min-release-age=0 run f
- npm --min-release-age=0 run l
- npm --min-release-age=0 run tsc

Note: local npm commands required unsetting the automation-provided npm before config and using a temporary npm cache because the default ~/.npm cache contains root-owned files.