### PR TITLE
fix(fetch): decompress pooled undici responses

### DIFF
--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import type { ConnectionOptions } from 'tls';
 
 import { getProxyForUrl } from 'proxy-from-env';
-import { Agent, ProxyAgent } from 'undici';
+import { Agent, type Dispatcher, interceptors, ProxyAgent } from 'undici';
 import cliState from '../../cliState';
 import { DEFAULT_MAX_CONCURRENCY, VERSION } from '../../constants';
 import { getEnvBool, getEnvInt, getEnvString } from '../../envars';
@@ -33,8 +33,8 @@ import type { FetchOptions } from './types';
 // Note: TLS options (rejectUnauthorized, CA cert) are captured at agent
 // creation time. This is acceptable because these env vars don't change
 // mid-process. If that assumption changes, add cache-invalidation logic.
-const cachedAgents: Map<number, Agent> = new Map();
-const cachedProxyAgents: Map<string, ProxyAgent> = new Map();
+const cachedAgents: Map<number, Dispatcher> = new Map();
+const cachedProxyAgents: Map<string, Dispatcher> = new Map();
 
 /**
  * Get the connection pool size for HTTP agents.
@@ -72,7 +72,7 @@ export function clearAgentCache(): void {
   cachedProxyAgents.clear();
 }
 
-function getOrCreateAgent(tlsOptions: ConnectionOptions): Agent {
+function getOrCreateAgent(tlsOptions: ConnectionOptions): Dispatcher {
   const concurrency = getConnectionPoolSize();
   const existing = cachedAgents.get(concurrency);
   if (existing) {
@@ -84,7 +84,7 @@ function getOrCreateAgent(tlsOptions: ConnectionOptions): Agent {
     keepAliveMaxTimeout: 60_000,
     connections: concurrency,
     connect: tlsOptions,
-  });
+  }).compose(interceptors.decompress());
   cachedAgents.set(concurrency, agent);
   return agent;
 }
@@ -93,7 +93,7 @@ function getProxyAgentCacheKey(proxyUrl: string, concurrency: number): string {
   return `${proxyUrl}::${concurrency}`;
 }
 
-function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions): ProxyAgent {
+function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions): Dispatcher {
   const concurrency = getConnectionPoolSize();
   const cacheKey = getProxyAgentCacheKey(proxyUrl, concurrency);
   const existing = cachedProxyAgents.get(cacheKey);
@@ -108,7 +108,7 @@ function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions):
     keepAliveTimeout: 30_000,
     keepAliveMaxTimeout: 60_000,
     connections: concurrency,
-  });
+  }).compose(interceptors.decompress());
   cachedProxyAgents.set(cacheKey, agent);
   return agent;
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,7 +1,7 @@
 import * as fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
-import { Agent, ProxyAgent } from 'undici';
+import { Agent, interceptors, ProxyAgent } from 'undici';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../src/cliState';
 import { DEFAULT_MAX_CONCURRENCY, VERSION } from '../src/constants';
@@ -63,26 +63,33 @@ vi.mock('../src/globalConfig/cloud', () => ({
 }));
 
 vi.mock('undici', () => {
-  // Use regular functions instead of arrow functions for constructors
-  const ProxyAgent = vi.fn(function (this: any, options: any) {
-    return {
+  const createMockDispatcher = (options: any) => {
+    const dispatcher = {
       options,
       addRequest: vi.fn(),
+      close: vi.fn(),
       destroy: vi.fn(),
+      compose: vi.fn(),
     };
+    dispatcher.compose.mockReturnValue(dispatcher);
+    return dispatcher;
+  };
+
+  // Use regular functions instead of arrow functions for constructors
+  const ProxyAgent = vi.fn(function (this: any, options: any) {
+    return createMockDispatcher(options);
   });
 
   const Agent = vi.fn(function (this: any, options: any) {
-    return {
-      options,
-      addRequest: vi.fn(),
-      destroy: vi.fn(),
-    };
+    return createMockDispatcher(options);
   });
 
   return {
     ProxyAgent,
     Agent,
+    interceptors: {
+      decompress: vi.fn(() => ({ name: 'decompress' })),
+    },
   };
 });
 
@@ -863,6 +870,14 @@ describe('fetchWithProxy', () => {
     expect(dispatchers[1]).not.toBe(dispatchers[0]);
   });
 
+  it('should compose default Agent dispatchers with response decompression', async () => {
+    await fetchWithProxy('https://example.com/api');
+
+    const agent = vi.mocked(Agent).mock.results[0]?.value as { compose: ReturnType<typeof vi.fn> };
+    expect(interceptors.decompress).toHaveBeenCalledTimes(1);
+    expect(agent.compose).toHaveBeenCalledWith({ name: 'decompress' });
+  });
+
   it('should create a dedicated ProxyAgent dispatcher per proxy URL and maxConcurrency value', async () => {
     const mockProxyUrl = 'http://proxy.example.com';
     mockProcessEnv({ HTTPS_PROXY: mockProxyUrl });
@@ -891,6 +906,18 @@ describe('fetchWithProxy', () => {
         connections: 5,
       }),
     );
+  });
+
+  it('should compose ProxyAgent dispatchers with response decompression', async () => {
+    mockProcessEnv({ HTTPS_PROXY: 'http://proxy.example.com' });
+
+    await fetchWithProxy('https://example.com/api');
+
+    const proxyAgent = vi.mocked(ProxyAgent).mock.results[0]?.value as {
+      compose: ReturnType<typeof vi.fn>;
+    };
+    expect(interceptors.decompress).toHaveBeenCalledTimes(1);
+    expect(proxyAgent.compose).toHaveBeenCalledWith({ name: 'decompress' });
   });
 
   it('should preserve a caller-provided dispatcher instead of overwriting it', async () => {


### PR DESCRIPTION
## Summary

- compose promptfoo's pooled Undici Agent with `interceptors.decompress()`
- apply the same decompression interceptor to ProxyAgent-backed dispatchers
- keep caller-provided dispatchers untouched
- add fetch tests that lock the decompression interceptor onto both cached dispatcher types

Fixes #9214.

## Tests

- `npx vitest run test/fetch.test.ts --testNamePattern "decompression|dedicated Agent dispatcher|dedicated ProxyAgent dispatcher|preserve a caller-provided dispatcher"`
- `npm run tsc`
- `npx @biomejs/biome check src/util/fetch/index.ts test/fetch.test.ts`
- `git diff --check`
