### PR TITLE
chore: address AI code quality findings

### DIFF
--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -195,7 +195,8 @@ async function expectChartsUnavailable(...reasonTexts: string[]) {
 
   await userEvent.click(showChartsButton);
 
-  expect(screen.getByRole('button', { name: 'Hide Charts' })).toBeInTheDocument();
+  const hideChartsButtonAfterOpen = screen.getByRole('button', { name: 'Hide Charts' });
+  expect(hideChartsButtonAfterOpen).toBeInTheDocument();
   expect(screen.queryByTestId('results-charts')).toBeNull();
   expect(screen.getByText('Charts are unavailable for this evaluation')).toBeInTheDocument();
   expect(
@@ -208,34 +209,28 @@ async function expectChartsUnavailable(...reasonTexts: string[]) {
     expect(screen.getByText(reasonText)).toBeInTheDocument();
   }
 
-  await userEvent.click(screen.getByRole('button', { name: 'Hide Charts' }));
+  await userEvent.click(hideChartsButtonAfterOpen);
 
-  expect(screen.getByRole('button', { name: 'Show Charts' })).toBeInTheDocument();
+  const showChartsButtonAfterClose = screen.getByRole('button', { name: 'Show Charts' });
+  expect(showChartsButtonAfterClose).toBeInTheDocument();
   expect(screen.queryByText('Charts are unavailable for this evaluation')).toBeNull();
   for (const reasonText of reasonTexts) {
     expect(screen.queryByText(reasonText)).toBeNull();
   }
+
+  return {
+    showChartsButton,
+    hideChartsButtonAfterOpen,
+    showChartsButtonAfterClose,
+  };
 }
 
 function createCopyEvalResponse(): Response {
-  return {
-    ok: true,
-    json: () => Promise.resolve({ id: 'new-eval-id', distinctTestCount: 1234 }),
+  return new Response(JSON.stringify({ id: 'new-eval-id', distinctTestCount: 1234 }), {
     status: 200,
     statusText: 'OK',
-    headers: new Headers(),
-    redirected: false,
-    type: 'basic',
-    url: 'http://example.com',
-    bodyUsed: false,
-    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-    blob: () => Promise.resolve(new Blob()),
-    formData: () => Promise.resolve(new FormData()),
-    text: () => Promise.resolve(''),
-    body: null,
-    bytes: () => Promise.resolve(new Uint8Array()),
-    clone: () => createCopyEvalResponse(),
-  };
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 beforeEach(() => {

--- a/src/app/src/pages/redteam/setup/components/Strategies.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.test.tsx
@@ -11,6 +11,8 @@ import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import Strategies from './Strategies';
 
 const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient();
+
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
@@ -27,8 +29,6 @@ vi.mock('@app/hooks/useToast');
 vi.mock('./StrategyConfigDialog', () => ({
   default: () => <div data-testid="strategy-config-dialog">Strategy Config Dialog</div>,
 }));
-
-const queryClient = new QueryClient();
 
 const mockUpdateConfig = vi.fn();
 const mockRecordEvent = vi.fn();

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -1,4 +1,4 @@
-import * as fsPromises from 'fs/promises';
+import * as fsPromises from 'node:fs/promises';
 import path from 'path';
 import type { ConnectionOptions } from 'tls';
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -48,7 +48,9 @@ vi.mock('../src/util/time', () => ({
 
 const mockFetchWithRetries = vi.mocked(fetchWithRetries);
 
-// Mock cache-manager v7
+// Mock cache-manager v7. This is a behavioral test double, not a complete
+// cache-manager implementation; it models only the storage, TTL, namespace
+// iteration, and in-flight deduplication semantics exercised by this suite.
 vi.mock('cache-manager', () => ({
   createCache: vi.fn().mockImplementation(({ stores }) => {
     const cache = new Map<string, unknown>();
@@ -1068,7 +1070,9 @@ describe('fetchWithCache', () => {
   });
 
   describe('with cache disabled', () => {
-    const BODY_READ_TOTAL_ATTEMPTS = 3; // 1 initial attempt + 2 retries
+    // Mirrors fetchAndReadBody's idempotent body-read policy: one initial read
+    // plus two transient-error retries.
+    const BODY_READ_TOTAL_ATTEMPTS = 3;
 
     beforeEach(() => {
       disableCache();

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -143,13 +143,6 @@ vi.mock('../src/envars', () => {
   };
 });
 
-vi.mock('node:fs', () => ({
-  default: {
-    readFileSync: vi.fn(),
-  },
-  readFileSync: vi.fn(),
-}));
-
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
 }));

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -105,7 +105,7 @@ function resetModulesAndMockFetch(
   fetchMocks: Partial<Record<'fetchWithTimeout' | 'fetchWithProxy', Mock>> = {},
 ) {
   vi.resetModules();
-  vi.doMock('../src/util/fetch/index.ts', () => ({
+  vi.doMock('../src/util/fetch/index', () => ({
     fetchWithTimeout: fetchMocks.fetchWithTimeout ?? vi.fn().mockResolvedValue({ ok: true }),
     fetchWithProxy: fetchMocks.fetchWithProxy ?? vi.fn().mockResolvedValue({ ok: true }),
   }));

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -15,7 +15,7 @@ import { TELEMETRY_EVENTS, Telemetry, TelemetryEventSchema } from '../src/teleme
 import { fetchWithProxy, fetchWithTimeout } from '../src/util/fetch/index';
 import { mockProcessEnv } from './util/utils';
 
-vi.mock('../src/util/fetch/index.ts', () => ({
+vi.mock('../src/util/fetch/index', () => ({
   fetchWithTimeout: vi.fn().mockResolvedValue({ ok: true }),
   fetchWithProxy: vi.fn().mockResolvedValue({ ok: true }),
 }));
@@ -381,7 +381,15 @@ describe('Telemetry', () => {
   });
 
   describe('PostHog operations', () => {
-    let mockPostHogInstance: any;
+    type PostHogMockInstance = {
+      identify: ReturnType<typeof vi.fn>;
+      capture: ReturnType<typeof vi.fn>;
+      flush: ReturnType<typeof vi.fn>;
+      on: ReturnType<typeof vi.fn>;
+      shutdown?: ReturnType<typeof vi.fn>;
+    };
+
+    let mockPostHogInstance: PostHogMockInstance;
     let mockPostHog: Mock;
 
     beforeEach(async () => {
@@ -392,7 +400,7 @@ describe('Telemetry', () => {
         on: vi.fn(), // Add the 'on' method for error handling
       };
       // Use a class-like constructor for PostHog
-      mockPostHog = vi.fn(function (this: any) {
+      mockPostHog = vi.fn(function (this: PostHogMockInstance) {
         Object.assign(this, mockPostHogInstance);
         return this;
       });


### PR DESCRIPTION
## Summary
- address the 10 currently visible GitHub Security AI findings across 5 files
- simplify test helpers and mocks for ResultsView, Strategies, cache, fetch, and telemetry tests
- align the `fs/promises` built-in import with the test mock path

## Testing
- `npm run f`
- `npm run l`
- `npm run test:app -- src/pages/eval/components/ResultsView.test.tsx src/pages/redteam/setup/components/Strategies.test.tsx --run`
- `npm test -- test/cache.test.ts test/fetch.test.ts test/telemetry.test.ts`
- `npm test -- test/telemetry.test.ts`
- `npm run tsc`
