### PR TITLE
test(providers): cover responses reasoning suppression

### DIFF
--- a/test/providers/responses/processor.test.ts
+++ b/test/providers/responses/processor.test.ts
@@ -115,6 +115,31 @@ describe('ResponsesProcessor', () => {
       expect(result.output).toContain('Step 2: Find the solution');
     });
 
+    it('should suppress reasoning output when requested', async () => {
+      const mockData = {
+        output: [
+          {
+            type: 'reasoning',
+            summary: [{ text: 'Internal reasoning summary' }],
+          },
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Final answer' }],
+          },
+        ],
+        usage: { input_tokens: 15, output_tokens: 20 },
+      };
+
+      const result = await processor.processResponseOutput(mockData, {}, false, {
+        suppressReasoningOutput: true,
+      });
+
+      expect(result.output).toBe('Final answer');
+      expect(result.output).not.toContain('Reasoning:');
+      expect(result.output).not.toContain('Internal reasoning summary');
+    });
+
     it('should process web search calls', async () => {
       const mockData = {
         output: [


### PR DESCRIPTION
## Summary

- Add direct `ResponsesProcessor` coverage for the `suppressReasoningOutput` option added for streamed Responses API handling
- Verify reasoning summaries are omitted while assistant message output is preserved

## Testing

- `./node_modules/.bin/vitest run test/providers/responses/processor.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`
