### PR TITLE
fix(deps): avoid incompatible npm release-age config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 engine-strict=true
-# Global floor for manual npm installs; Renovate rules should not undercut it.
-min-release-age=7


### PR DESCRIPTION
Remove the project-level npm release-age setting because npm rejects it when another supported install cutoff is already configured, which can prevent routine npm commands from starting.