### PR TITLE
fix(eval): allow header horizontal scrolling

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -4149,3 +4149,103 @@ describe('ResultsTable minimal scroll room detection', () => {
     expect(stickyContainer.className).toContain('relative');
   });
 });
+
+describe('ResultsTable header horizontal scrolling', () => {
+  const mockTable = {
+    body: [
+      {
+        outputs: [{ pass: true, score: 1, text: 'test output' }],
+        test: {},
+        vars: [],
+      },
+    ],
+    head: {
+      prompts: [{ provider: 'test-provider' }],
+      vars: [],
+    },
+  };
+
+  const defaultProps = {
+    columnVisibility: {},
+    failureFilter: {},
+    filterMode: 'all' as const,
+    maxTextLength: 100,
+    onFailureFilterToggle: vi.fn(),
+    onSearchTextChange: vi.fn(),
+    searchText: '',
+    showStats: true,
+    wordBreak: 'break-word' as const,
+    setFilterMode: vi.fn(),
+    zoom: 1,
+    onResultsContainerScroll: vi.fn(),
+    atInitialVerticalScrollPosition: true,
+  };
+
+  beforeEach(() => {
+    vi.mocked(useResultsViewSettingsStore).mockImplementation(() => ({
+      inComparisonMode: false,
+      renderMarkdown: true,
+    }));
+
+    vi.mocked(useTableStore).mockImplementation(() => ({
+      config: {},
+      evalId: '123',
+      setTable: vi.fn(),
+      table: mockTable,
+      version: 4,
+      fetchEvalData: vi.fn(),
+      isFetching: false,
+      filteredResultsCount: 1,
+      filters: {
+        values: {},
+        appliedCount: 0,
+        options: {
+          metric: [],
+        },
+      },
+    }));
+  });
+
+  it('exposes a horizontally scrollable header container', () => {
+    renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    expect(screen.getByTestId('results-table-header-scroll-container')).toHaveClass(
+      'overflow-x-auto',
+      'overflow-y-hidden',
+    );
+  });
+
+  it('syncs header scrolling into the table body', () => {
+    renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    const headerScrollContainer = screen.getByTestId('results-table-header-scroll-container');
+    const tableContainer = document.getElementById('results-table-container');
+
+    expect(tableContainer).not.toBeNull();
+
+    act(() => {
+      headerScrollContainer.scrollLeft = 120;
+      headerScrollContainer.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(tableContainer?.scrollLeft).toBe(120);
+  });
+
+  it('keeps body scrolling mirrored in the header', () => {
+    renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    const headerScrollContainer = screen.getByTestId('results-table-header-scroll-container');
+    const tableContainer = document.getElementById('results-table-container');
+
+    expect(tableContainer).not.toBeNull();
+
+    act(() => {
+      if (tableContainer) {
+        tableContainer.scrollLeft = 180;
+        tableContainer.dispatchEvent(new Event('scroll'));
+      }
+    });
+
+    expect(headerScrollContainer.scrollLeft).toBe(180);
+  });
+});

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1371,6 +1371,7 @@ function ResultsTableHeader({
   tableWidth,
   maxTextLength,
   wordBreak,
+  headerScrollRef,
   theadRef,
   stickyHeader,
   setStickyHeader,
@@ -1381,6 +1382,7 @@ function ResultsTableHeader({
   tableWidth: number;
   maxTextLength: number;
   wordBreak: 'break-word' | 'break-all';
+  headerScrollRef: React.RefObject<HTMLDivElement | null>;
   theadRef: React.RefObject<HTMLTableSectionElement | null>;
   stickyHeader: boolean;
   setStickyHeader: (sticky: boolean) => void;
@@ -1406,46 +1408,52 @@ function ResultsTableHeader({
           <X className="size-4" />
         </button>
       </div>
-      <table
-        className={`results-table firefox-fix ${maxTextLength <= 25 ? 'compact' : ''}`}
-        style={{
-          wordBreak,
-          width: `${tableWidth}px`,
-          zoom,
-        }}
+      <div
+        ref={headerScrollRef}
+        data-testid="results-table-header-scroll-container"
+        className="overflow-x-auto overflow-y-hidden overscroll-x-contain"
       >
-        <thead ref={theadRef}>
-          {reactTable.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className="header">
-              {headerGroup.headers.map((header) => {
-                const isFinalRow = headerGroup.depth === 1;
+        <table
+          className={`results-table firefox-fix ${maxTextLength <= 25 ? 'compact' : ''}`}
+          style={{
+            wordBreak,
+            width: `${tableWidth}px`,
+            zoom,
+          }}
+        >
+          <thead ref={theadRef}>
+            {reactTable.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id} className="header">
+                {headerGroup.headers.map((header) => {
+                  const isFinalRow = headerGroup.depth === 1;
 
-                return (
-                  <th
-                    key={header.id}
-                    tabIndex={0}
-                    colSpan={header.colSpan}
-                    style={{
-                      width: header.getSize(),
-                      borderBottom: 'none',
-                      height: isFinalRow ? 'fit-content' : 'auto',
-                    }}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                    <div
-                      onMouseDown={header.getResizeHandler()}
-                      onTouchStart={header.getResizeHandler()}
-                      className={`resizer ${header.column.getIsResizing() ? 'isResizing' : ''}`}
-                    />
-                  </th>
-                );
-              })}
-            </tr>
-          ))}
-        </thead>
-      </table>
+                  return (
+                    <th
+                      key={header.id}
+                      tabIndex={0}
+                      colSpan={header.colSpan}
+                      style={{
+                        width: header.getSize(),
+                        borderBottom: 'none',
+                        height: isFinalRow ? 'fit-content' : 'auto',
+                      }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                      <div
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        className={`resizer ${header.column.getIsResizing() ? 'isResizing' : ''}`}
+                      />
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+        </table>
+      </div>
     </div>
   );
 }
@@ -2115,8 +2123,9 @@ function ResultsTable({
   // This automatically handles both column visibility changes and user-initiated column resizing.
   const tableWidth = reactTable.getTotalSize();
 
-  // Listen for scroll events on the table container and sync the header horizontally
+  // Keep the standalone header and the scrollable table body aligned in both directions.
   const tableRef = useRef<HTMLDivElement>(null);
+  const headerScrollRef = useRef<HTMLDivElement>(null);
   const theadRef = useRef<HTMLTableSectionElement>(null);
 
   // Detect if there's minimal scroll room - in this case, disable height collapse
@@ -2147,38 +2156,39 @@ function ResultsTable({
   }, [filteredResultsCount, checkScrollRoom]);
 
   useEffect(() => {
-    if (!tableRef.current || !theadRef.current) {
+    if (!tableRef.current || !headerScrollRef.current) {
       return;
     }
 
-    const container = tableRef.current;
-    let rafId: number | null = null;
+    const tableContainer = tableRef.current;
+    const headerContainer = headerScrollRef.current;
 
-    const handleScroll = () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
+    const syncScrollLeft = (source: HTMLDivElement, target: HTMLDivElement) => {
+      if (target.scrollLeft !== source.scrollLeft) {
+        target.scrollLeft = source.scrollLeft;
       }
-      rafId = requestAnimationFrame(() => {
-        if (theadRef.current) {
-          const xScroll = container.scrollLeft;
-          theadRef.current.style.transform = `translateX(-${xScroll}px)`;
-        }
-      });
     };
 
-    container.addEventListener('scroll', handleScroll, { passive: true });
+    const handleTableScroll = () => {
+      syncScrollLeft(tableContainer, headerContainer);
+    };
+
+    const handleHeaderScroll = () => {
+      syncScrollLeft(headerContainer, tableContainer);
+    };
+
+    tableContainer.addEventListener('scroll', handleTableScroll, { passive: true });
+    headerContainer.addEventListener('scroll', handleHeaderScroll, { passive: true });
 
     // Initial sync
-    handleScroll();
+    handleTableScroll();
     // Keep in sync on resize
-    window.addEventListener('resize', handleScroll);
+    window.addEventListener('resize', handleTableScroll);
 
     return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      container.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('resize', handleScroll);
+      tableContainer.removeEventListener('scroll', handleTableScroll);
+      headerContainer.removeEventListener('scroll', handleHeaderScroll);
+      window.removeEventListener('resize', handleTableScroll);
     };
   }, []);
 
@@ -2202,6 +2212,7 @@ function ResultsTable({
         tableWidth={tableWidth}
         maxTextLength={maxTextLength}
         wordBreak={wordBreak}
+        headerScrollRef={headerScrollRef}
         theadRef={theadRef}
         stickyHeader={stickyHeader}
         setStickyHeader={setStickyHeader}


### PR DESCRIPTION
Make the eval results header horizontally scrollable while keeping it synchronized with the table body.