### PR TITLE
chore(app): move zoom into table settings

### DIFF
--- a/site/docs/usage/web-ui.md
+++ b/site/docs/usage/web-ui.md
@@ -28,7 +28,6 @@ See [`promptfoo view`](/docs/usage/command-line#promptfoo-view) for CLI options.
 ## Toolbar
 
 - **Eval selector** - Switch between evals
-- **Zoom** - Scale columns (50%-200%)
 - **Display mode** - Filter: All, Failures, Passes, Errors, Different, Highlights
 - **Search** - Text or regex
 - **Filters** - By metrics, metadata, pass/fail. Operators: `=`, `contains`, `>`, `<`
@@ -40,6 +39,7 @@ See [`promptfoo view`](/docs/usage/command-line#promptfoo-view) for CLI options.
 ![Table Settings dialog](/img/docs/web-ui-table-settings.png)
 
 - **Columns** - Toggle variable and prompt visibility
+- **Zoom** - Scale columns (50%-200%)
 - **Truncation** - Max text length, word wrap
 - **Rendering** - Markdown, JSON prettification
 - **Inference details** - Tokens, latency, cost, tokens/sec

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -12,7 +12,6 @@ import {
 } from '@app/components/ui/dialog';
 import { DropdownMenuItem } from '@app/components/ui/dropdown-menu';
 import { SearchInput } from '@app/components/ui/search-input';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@app/components/ui/select';
 import { Separator } from '@app/components/ui/separator';
 import { Spinner } from '@app/components/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tooltip';
@@ -840,28 +839,6 @@ export default function ResultsView({
                     />
                     <FiltersForm />
                     <div className="flex-1" />
-                    <Select
-                      value={String(resultsTableZoom)}
-                      onValueChange={(val) => setResultsTableZoom(Number(val))}
-                    >
-                      <SelectTrigger aria-label="Results zoom" className="w-[115px] h-8 text-xs">
-                        <span>
-                          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                            ZOOM
-                          </span>{' '}
-                          {Math.round(resultsTableZoom * 100)}%
-                        </span>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="0.5">50%</SelectItem>
-                        <SelectItem value="0.75">75%</SelectItem>
-                        <SelectItem value="0.9">90%</SelectItem>
-                        <SelectItem value="1">100%</SelectItem>
-                        <SelectItem value="1.25">125%</SelectItem>
-                        <SelectItem value="1.5">150%</SelectItem>
-                        <SelectItem value="2">200%</SelectItem>
-                      </SelectContent>
-                    </Select>
                     <ColumnSelector
                       columnData={columnData}
                       selectedColumns={currentColumnState.selectedColumns}
@@ -1011,7 +988,12 @@ export default function ResultsView({
         filterByDatasetId
       />
       <DownloadDialog open={downloadDialogOpen} onClose={() => setDownloadDialogOpen(false)} />
-      <SettingsModal open={viewSettingsModalOpen} onClose={() => setViewSettingsModalOpen(false)} />
+      <SettingsModal
+        open={viewSettingsModalOpen}
+        onClose={() => setViewSettingsModalOpen(false)}
+        resultsTableZoom={resultsTableZoom}
+        onResultsTableZoomChange={setResultsTableZoom}
+      />
       <ConfirmEvalNameDialog
         open={editNameDialogOpen}
         onClose={() => setEditNameDialogOpen(false)}

--- a/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.test.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.test.tsx
@@ -17,6 +17,13 @@ vi.mock('./components/SettingsPanel', () => ({
 describe('TableSettingsModal', () => {
   const mockOnClose = vi.fn();
   const mockResetToDefaults = vi.fn();
+  const mockOnResultsTableZoomChange = vi.fn();
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    resultsTableZoom: 1,
+    onResultsTableZoomChange: mockOnResultsTableZoomChange,
+  };
 
   const mockSettingsState = (hasChanges: boolean) => {
     vi.mocked(useSettingsState).mockReturnValue({
@@ -37,14 +44,14 @@ describe('TableSettingsModal', () => {
   });
 
   it("should not render the settings dialog when 'open' is false", () => {
-    render(<TableSettingsModal open={false} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} open={false} />);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(screen.queryByText('Table Settings')).not.toBeInTheDocument();
   });
 
   it("should render the settings dialog when 'open' is true", () => {
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Table Settings')).toBeInTheDocument();
@@ -52,7 +59,7 @@ describe('TableSettingsModal', () => {
 
   it('should call the onClose callback when the close button is clicked', async () => {
     const user = userEvent.setup();
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
     const closeButton = screen.getByRole('button', { name: 'Close' });
     await user.click(closeButton);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
@@ -60,34 +67,35 @@ describe('TableSettingsModal', () => {
 
   it('should call resetToDefaults when the "Reset to Defaults" button is clicked', async () => {
     const user = userEvent.setup();
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
 
     const resetButton = screen.getByRole('button', { name: 'Reset settings to defaults' });
     await user.click(resetButton);
 
     expect(mockResetToDefaults).toHaveBeenCalled();
+    expect(mockOnResultsTableZoomChange).toHaveBeenCalledWith(1);
   });
 
   it('should display "Done" button', () => {
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
     expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
   });
 
   it('should call useSettingsState with the correct initial open state', () => {
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
     expect(useSettingsState).toHaveBeenCalledWith(true);
   });
 
   it('should call onClose when the Done button is clicked', async () => {
     const user = userEvent.setup();
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
     const mainActionButton = screen.getByRole('button', { name: 'Done' });
     await user.click(mainActionButton);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('should render the dialog with proper sizing', () => {
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
 
     const dialog = screen.getByRole('dialog');
 
@@ -96,7 +104,7 @@ describe('TableSettingsModal', () => {
   });
 
   it('keeps the settings body scrollable while the footer stays visible', () => {
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
 
     const settingsPanel = screen.getByTestId('mock-settings-panel');
     expect(settingsPanel.parentElement).toHaveClass('min-h-0', 'overflow-y-auto');
@@ -107,7 +115,7 @@ describe('TableSettingsModal', () => {
     const user = userEvent.setup();
     mockSettingsState(true);
 
-    render(<TableSettingsModal open={true} onClose={mockOnClose} />);
+    render(<TableSettingsModal {...defaultProps} />);
 
     const closeButton = screen.getByRole('button', { name: 'Close' });
     await user.click(closeButton);
@@ -123,7 +131,7 @@ describe('TableSettingsModal', () => {
         setIsOpen(false);
       }, 50);
 
-      return <TableSettingsModal open={isOpen} onClose={mockOnClose} />;
+      return <TableSettingsModal {...defaultProps} open={isOpen} />;
     };
 
     render(<TestComponent />);

--- a/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/TableSettingsModal.tsx
@@ -16,13 +16,25 @@ import { useSettingsState } from './hooks/useSettingsState';
 interface SettingsModalProps {
   open: boolean;
   onClose: () => void;
+  resultsTableZoom: number;
+  onResultsTableZoomChange: (zoom: number) => void;
 }
 
-const TableSettingsModal = ({ open, onClose }: SettingsModalProps) => {
+const TableSettingsModal = ({
+  open,
+  onClose,
+  resultsTableZoom,
+  onResultsTableZoomChange,
+}: SettingsModalProps) => {
   const { resetToDefaults } = useSettingsState(open);
 
   const handleClose = () => {
     onClose();
+  };
+
+  const handleResetToDefaults = () => {
+    resetToDefaults();
+    onResultsTableZoomChange(1);
   };
 
   return (
@@ -36,14 +48,17 @@ const TableSettingsModal = ({ open, onClose }: SettingsModalProps) => {
         </DialogHeader>
 
         <div className="min-h-0 overflow-y-auto p-0">
-          <SettingsPanel />
+          <SettingsPanel
+            resultsTableZoom={resultsTableZoom}
+            onResultsTableZoomChange={onResultsTableZoomChange}
+          />
         </div>
 
         <Separator className="opacity-60" />
 
         <DialogFooter className="shrink-0 justify-between px-5 py-3">
           <Button
-            onClick={resetToDefaults}
+            onClick={handleResetToDefaults}
             variant="ghost"
             size="sm"
             aria-label="Reset settings to defaults"

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.test.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../store', () => ({
 const mockedUseResultsViewSettingsStore = vi.mocked(useResultsViewSettingsStore);
 
 describe('SettingsPanel', () => {
+  const mockOnResultsTableZoomChange = vi.fn();
   const mockStore = {
     stickyHeader: true,
     setStickyHeader: vi.fn(),
@@ -36,6 +37,10 @@ describe('SettingsPanel', () => {
     wordBreak: 'break-word',
     setWordBreak: vi.fn(),
   } as const;
+  const defaultProps = {
+    resultsTableZoom: 1,
+    onResultsTableZoomChange: mockOnResultsTableZoomChange,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -90,7 +95,7 @@ describe('SettingsPanel', () => {
     expectedNewValue,
   }) => {
     const user = userEvent.setup();
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const toggle = screen.getByRole('checkbox', { name });
     expect(toggle).toBeInTheDocument();
@@ -109,7 +114,7 @@ describe('SettingsPanel', () => {
 
   it('should call setMaxTextLength when slider value is committed via keyboard', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const slider = screen.getByRole('slider', { name: /max text length/i });
     expect(slider).toBeInTheDocument();
@@ -129,7 +134,7 @@ describe('SettingsPanel', () => {
       maxTextLength: Number.POSITIVE_INFINITY,
     });
 
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const slider = screen.getByRole('slider', {
       name: /max text length/i,
@@ -140,7 +145,7 @@ describe('SettingsPanel', () => {
   });
 
   it('should have slider for max text length', () => {
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const slider = screen.getByRole('slider', {
       name: /max text length/i,
@@ -150,7 +155,7 @@ describe('SettingsPanel', () => {
   });
 
   it('stacks the settings sections before the small breakpoint', () => {
-    const { container } = renderWithProviders(<SettingsPanel />);
+    const { container } = renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     expect(container.firstElementChild).toHaveClass('grid-cols-1', 'sm:grid-cols-[1fr_1px_1fr]');
     expect(container.querySelector('.bg-border\\/10')).toHaveClass('hidden', 'sm:block');
@@ -162,16 +167,26 @@ describe('SettingsPanel', () => {
       showPassFail: false,
     });
 
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const passReasonsToggle = screen.getByRole('checkbox', { name: 'Pass reasons' });
     expect(passReasonsToggle).toBeDisabled();
   });
 
   it('should enable Pass reasons when Pass/fail indicators is on', () => {
-    renderWithProviders(<SettingsPanel />);
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
 
     const passReasonsToggle = screen.getByRole('checkbox', { name: 'Pass reasons' });
     expect(passReasonsToggle).not.toBeDisabled();
+  });
+
+  it('should update results zoom when a new zoom option is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsPanel {...defaultProps} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Results zoom' }));
+    await user.click(screen.getByRole('option', { name: '150%' }));
+
+    expect(mockOnResultsTableZoomChange).toHaveBeenCalledWith(1.5);
   });
 });

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -1,8 +1,24 @@
 import React, { useCallback, useState } from 'react';
 
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@app/components/ui/select';
 import { useResultsViewSettingsStore } from '../../store';
 import CompactSlider from './CompactSlider';
 import CompactToggle from './CompactToggle';
+
+interface SettingsPanelProps {
+  resultsTableZoom: number;
+  onResultsTableZoomChange: (zoom: number) => void;
+}
+
+const RESULTS_TABLE_ZOOM_OPTIONS = [
+  { value: '0.5', label: '50%' },
+  { value: '0.75', label: '75%' },
+  { value: '0.9', label: '90%' },
+  { value: '1', label: '100%' },
+  { value: '1.25', label: '125%' },
+  { value: '1.5', label: '150%' },
+  { value: '2', label: '200%' },
+] as const;
 
 const SectionHeader = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -12,7 +28,10 @@ const SectionHeader = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-const SettingsPanel = () => {
+const SettingsPanel = ({
+  resultsTableZoom,
+  onResultsTableZoomChange,
+}: SettingsPanelProps) => {
   const {
     stickyHeader,
     setStickyHeader,
@@ -66,6 +85,13 @@ const SettingsPanel = () => {
       setWordBreak(checked ? 'break-all' : 'break-word');
     },
     [setWordBreak],
+  );
+
+  const handleResultsTableZoomChange = useCallback(
+    (value: string) => {
+      onResultsTableZoomChange(Number(value));
+    },
+    [onResultsTableZoomChange],
   );
 
   return (
@@ -140,6 +166,25 @@ const SettingsPanel = () => {
         />
 
         <div className="mt-3">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <span className="text-[0.8125rem] leading-normal">Zoom</span>
+            <Select
+              value={String(resultsTableZoom)}
+              onValueChange={handleResultsTableZoomChange}
+            >
+              <SelectTrigger aria-label="Results zoom" className="h-8 w-[110px] text-xs">
+                {Math.round(resultsTableZoom * 100)}%
+              </SelectTrigger>
+              <SelectContent>
+                {RESULTS_TABLE_ZOOM_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           <CompactSlider
             label="Max text length"
             value={localMaxTextLength}

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -28,10 +28,7 @@ const SectionHeader = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-const SettingsPanel = ({
-  resultsTableZoom,
-  onResultsTableZoomChange,
-}: SettingsPanelProps) => {
+const SettingsPanel = ({ resultsTableZoom, onResultsTableZoomChange }: SettingsPanelProps) => {
   const {
     stickyHeader,
     setStickyHeader,
@@ -168,10 +165,7 @@ const SettingsPanel = ({
         <div className="mt-3">
           <div className="mb-3 flex items-center justify-between gap-3">
             <span className="text-[0.8125rem] leading-normal">Zoom</span>
-            <Select
-              value={String(resultsTableZoom)}
-              onValueChange={handleResultsTableZoomChange}
-            >
+            <Select value={String(resultsTableZoom)} onValueChange={handleResultsTableZoomChange}>
               <SelectTrigger aria-label="Results zoom" className="h-8 w-[110px] text-xs">
                 {Math.round(resultsTableZoom * 100)}%
               </SelectTrigger>


### PR DESCRIPTION
Move the eval table zoom control into Table Settings so the toolbar stays focused on primary table actions.

![Table Settings zoom control](https://iili.io/Bp11r42.png)
