### PR TITLE
fix(app): align table settings info buttons

### DIFF
--- a/src/app/src/pages/eval/components/TableSettings/components/CompactToggle.test.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/CompactToggle.test.tsx
@@ -1,0 +1,40 @@
+import { renderWithProviders } from '@app/utils/testutils';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import CompactToggle from './CompactToggle';
+
+describe('CompactToggle', () => {
+  it('keeps the info button adjacent to the label instead of pushing it to the row edge', () => {
+    renderWithProviders(
+      <CompactToggle
+        label="Sticky header"
+        checked={false}
+        onChange={vi.fn()}
+        tooltipText="Keep the header fixed when scrolling"
+      />,
+    );
+
+    const label = screen.getByText('Sticky header');
+
+    expect(label).not.toHaveClass('flex-1');
+  });
+
+  it('does not toggle the setting when the info button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithProviders(
+      <CompactToggle
+        label="Sticky header"
+        checked={false}
+        onChange={onChange}
+        tooltipText="Keep the header fixed when scrolling"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Information about Sticky header' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/src/pages/eval/components/TableSettings/components/CompactToggle.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/CompactToggle.tsx
@@ -61,7 +61,7 @@ const CompactToggle = ({
       <span
         id={labelId}
         className={cn(
-          'flex-1 text-[0.8125rem] leading-normal select-none whitespace-nowrap',
+          'text-[0.8125rem] leading-normal select-none whitespace-nowrap',
           disabled ? 'text-muted-foreground' : '',
         )}
       >
@@ -75,6 +75,7 @@ const CompactToggle = ({
               tabIndex={-1}
               className="p-0.5 ml-1 text-muted-foreground/40 hover:text-muted-foreground"
               aria-label={`Information about ${label}`}
+              onClick={handleStopPropagation}
             >
               <Info className="size-3.5" />
             </button>


### PR DESCRIPTION
Keeps the Table Settings info buttons beside their labels, and prevents help-button clicks from toggling the parent setting.

![Updated Table Settings dialog](https://iili.io/BpENa1e.jpg)

Checked with:
- `../../node_modules/.bin/vitest src/pages/eval/components/TableSettings/components/CompactToggle.test.tsx src/pages/eval/components/TableSettings/components/SettingsPanel.test.tsx --run`
