### PR TITLE
fix(openclaw): support protocol negotiation for versions 3 and 4

### DIFF
--- a/src/providers/openclaw/agent.ts
+++ b/src/providers/openclaw/agent.ts
@@ -17,7 +17,8 @@ import type { ApiProvider, ProviderOptions, ProviderResponse } from '../../types
 import type { OpenClawDeviceIdentity } from './device-auth';
 import type { OpenClawConfig } from './types';
 
-const OPENCLAW_PROTOCOL_VERSION = 3;
+const MIN_OPENCLAW_PROTOCOL_VERSION = 3;
+const MAX_OPENCLAW_PROTOCOL_VERSION = 4;
 const CLIENT_ID = 'gateway-client';
 const CLIENT_MODE = 'cli';
 const CLIENT_ROLE = 'operator';
@@ -534,8 +535,8 @@ export class OpenClawAgentProvider implements ApiProvider {
   private buildConnectParams(frame: OpenClawWsFrame, authState: ConnectAuthState) {
     const nonce = this.extractChallengeNonce(frame);
     const params: Record<string, unknown> = {
-      minProtocol: OPENCLAW_PROTOCOL_VERSION,
-      maxProtocol: OPENCLAW_PROTOCOL_VERSION,
+      minProtocol: MIN_OPENCLAW_PROTOCOL_VERSION,
+      maxProtocol: MAX_OPENCLAW_PROTOCOL_VERSION,
       client: {
         id: CLIENT_ID,
         displayName: 'promptfoo',

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -1656,6 +1656,8 @@ describe('OpenClaw Provider', () => {
       // Verify connect request
       expect(connectReq.type).toBe('req');
       expect(connectReq.method).toBe('connect');
+      expect(connectReq.params.minProtocol).toBe(3);
+      expect(connectReq.params.maxProtocol).toBe(4);
       expect(connectReq.params.auth.token).toBe('test-token');
       expect(connectReq.params.device).toEqual({
         id: 'device-1',


### PR DESCRIPTION
## Summary

The OpenClaw provider previously hard-coded protocol version 3 by sending:

```javascript
const OPENCLAW_PROTOCOL_VERSION = 3;
...
minProtocol = OPENCLAW_PROTOCOL_VERSION
maxProtocol = OPENCLAW_PROTOCOL_VERSION
```

Recent OpenClaw versions require protocol 4, which caused the provider to fail
with a protocol mismatch during the WebSocket handshake.

This change introduces separate min and max protocol constants and advertises
support for protocol versions 3 through 4, allowing the gateway to negotiate
the highest mutually supported version.

## Testing

- Confirmed that protocol 3 only reproduces the protocol mismatch.
- Confirmed that advertising support for versions 3–4 successfully connects,
  pairs the device, and passes Promptfoo evaluations against an OpenClaw
  gateway requiring protocol 4.