### PR TITLE
fix: isolate loadFunction cache entries

### DIFF
--- a/src/util/functions/loadFunction.ts
+++ b/src/util/functions/loadFunction.ts
@@ -28,13 +28,14 @@ export async function loadFunction<T extends Function>({
   basePath = cliState.basePath,
   useCache = true,
 }: LoadFunctionOptions): Promise<T> {
-  const cacheKey = `${filePath}${functionName ? `:${functionName}` : ''}`;
+  const resolvedPath = basePath ? path.resolve(basePath, filePath) : filePath;
+  const cacheKey = `${resolvedPath}:${
+    functionName ? `named:${functionName}` : `default:${defaultFunctionName}`
+  }`;
 
   if (useCache && functionCache[cacheKey]) {
     return functionCache[cacheKey] as T;
   }
-
-  const resolvedPath = basePath ? path.resolve(basePath, filePath) : filePath;
 
   if (!isJavascriptFile(resolvedPath) && !resolvedPath.endsWith('.py')) {
     throw new Error(

--- a/test/util/functions/loadFunction.test.ts
+++ b/test/util/functions/loadFunction.test.ts
@@ -233,6 +233,27 @@ describe('loadFunction', () => {
       await result('test input');
       expect(runPython).toHaveBeenCalledWith(TEST_PY_PATH, 'func', ['test input']);
     });
+
+    it('should keep cached Python functions isolated by default function name', async () => {
+      const result1 = await loadFunction({
+        filePath: 'function.py',
+        defaultFunctionName: 'first',
+        useCache: true,
+      });
+      const result2 = await loadFunction({
+        filePath: 'function.py',
+        defaultFunctionName: 'second',
+        useCache: true,
+      });
+
+      expect(result1).not.toBe(result2);
+
+      await result1('first input');
+      await result2('second input');
+
+      expect(runPython).toHaveBeenNthCalledWith(1, TEST_PY_PATH, 'first', ['first input']);
+      expect(runPython).toHaveBeenNthCalledWith(2, TEST_PY_PATH, 'second', ['second input']);
+    });
   });
 
   describe('Error handling', () => {

--- a/test/util/functions/loadFunction.test.ts
+++ b/test/util/functions/loadFunction.test.ts
@@ -139,6 +139,51 @@ describe('loadFunction', () => {
       expect(result1).toBe(mockFn);
     });
 
+    it('should keep cached functions isolated by resolved path', async () => {
+      const mockFn1 = vi.fn();
+      const mockFn2 = vi.fn();
+      mockResolve.mockImplementation((basePath, filePath) => `${basePath}/${filePath}`);
+      vi.mocked(importModule).mockResolvedValueOnce(mockFn1).mockResolvedValueOnce(mockFn2);
+
+      const result1 = await loadFunction({
+        filePath: 'function.js',
+        basePath: '/base/one',
+        useCache: true,
+      });
+      const result2 = await loadFunction({
+        filePath: 'function.js',
+        basePath: '/base/two',
+        useCache: true,
+      });
+
+      expect(importModule).toHaveBeenCalledTimes(2);
+      expect(importModule).toHaveBeenNthCalledWith(1, '/base/one/function.js', undefined);
+      expect(importModule).toHaveBeenNthCalledWith(2, '/base/two/function.js', undefined);
+      expect(result1).toBe(mockFn1);
+      expect(result2).toBe(mockFn2);
+    });
+
+    it('should keep cached functions isolated by default function name', async () => {
+      const mockFn1 = vi.fn();
+      const mockFn2 = vi.fn();
+      vi.mocked(importModule).mockResolvedValue({ first: mockFn1, second: mockFn2 });
+
+      const result1 = await loadFunction({
+        filePath: 'function.js',
+        defaultFunctionName: 'first',
+        useCache: true,
+      });
+      const result2 = await loadFunction({
+        filePath: 'function.js',
+        defaultFunctionName: 'second',
+        useCache: true,
+      });
+
+      expect(importModule).toHaveBeenCalledTimes(2);
+      expect(result1).toBe(mockFn1);
+      expect(result2).toBe(mockFn2);
+    });
+
     it('should not use cache when disabled', async () => {
       const mockFn1 = vi.fn();
       const mockFn2 = vi.fn();


### PR DESCRIPTION
## Summary
- cache loaded functions by resolved file path instead of the raw relative file path
- include the selected export mode/default function name in the cache key
- add regression coverage for basePath and defaultFunctionName collisions

## Root cause
loadFunction previously keyed cached functions by the unresolved filePath and optional explicit functionName. Reusing the same relative filename from different basePath values, or loading the same module with different defaultFunctionName values, could return a stale function from the first call.

## Validation
- npx vitest run test/util/functions/loadFunction.test.ts
- npx @biomejs/biome check src/util/functions/loadFunction.ts test/util/functions/loadFunction.test.ts
- npm run tsc