### PR TITLE
fix: guard against empty choices and message=None in swe_runner example

### DIFF
--- a/examples/integration-e2b/swe_runner.py
+++ b/examples/integration-e2b/swe_runner.py
@@ -47,6 +47,8 @@ def model_call_patch(fail_log: str, relevant_files: dict) -> str:
                 {"role": "user", "content": user_msg},
             ],
         )
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         patch = resp.choices[0].message.content.strip()
         return patch
 


### PR DESCRIPTION
## Problem

In `examples/integration-e2b/swe_runner.py`, the OpenAI response is accessed without checking:

```python
patch = resp.choices[0].message.content.strip()
```

This raises `IndexError` (empty choices) or `AttributeError` (message=None on filtered content).

## Fix

```python
if not resp.choices or resp.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
patch = resp.choices[0].message.content.strip()
```

**2 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.