### PR TITLE
fix(deps): remove stray smithy lockfile root dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@opentelemetry/sdk-trace-base": "^2.6.0",
         "@opentelemetry/sdk-trace-node": "^2.6.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@smithy/node-http-handler": "^4.7.0",
         "@types/ws": "^8.18.1",
         "ai": "^6.0.168",
         "ajv": "^8.18.0",


### PR DESCRIPTION
## Summary
- remove the undeclared root `@smithy/node-http-handler` entry that landed in `package-lock.json` with #9266
- keep the lockfile aligned with `package.json`, where that package remains optional-only

## Validation
- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts`
- targeted Bedrock/SageMaker Vitest coverage
- `npm run build`
- `npm run tsc`
- `npm run lint`
- `npm run format:check`
- `npx check-dependency-version-consistency`
- smoke eval: `npm run local -- eval -c test/smoke/fixtures/configs/transform-json-path.yaml -o /tmp/promptfoo-dep-check-9266.json --no-cache`

## Notes
- local full-suite reruns hit transient localhost listener failures in OTLP/model-audit route tests after the rest of the suite passed; exact-head GitHub CI is the merge gate for this follow-up
