### PR TITLE
chore: address AI code quality findings

### DIFF
--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -2720,7 +2720,6 @@
                     "description": "Name of the plugin"
                   },
                   "numTests": {
-                    "default": 5,
                     "description": "Number of tests to generate for this plugin",
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -2740,7 +2739,7 @@
                     "enum": ["critical", "high", "medium", "low", "informational"]
                   }
                 },
-                "required": ["id", "numTests"],
+                "required": ["id"],
                 "additionalProperties": false
               }
             ]

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -2720,6 +2720,7 @@
                     "description": "Name of the plugin"
                   },
                   "numTests": {
+                    "default": 5,
                     "description": "Number of tests to generate for this plugin",
                     "type": "integer",
                     "exclusiveMinimum": 0,
@@ -2747,6 +2748,7 @@
           "description": "Plugins to use for redteam generation"
         },
         "strategies": {
+          "default": ["default"],
           "type": "array",
           "items": {
             "anyOf": [

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -132,8 +132,8 @@ const VARIABLE_COLUMN_SIZE_PX = 200;
 const PROMPT_COLUMN_SIZE_PX = 400;
 const DESCRIPTION_COLUMN_SIZE_PX = 100;
 const MEDIA_MIME_PATTERNS = {
-  audio: /(?:^|[;,\s=])audio\/[a-z0-9.+-]+(?:$|[;,\s])/i,
-  image: /(?:^|[;,\s=])image\/[a-z0-9.+-]+(?:$|[;,\s])/i,
+  audio: /(?:^|[;,\s=:])audio\/[a-z0-9.+-]+(?:$|[;,\s])/i,
+  image: /(?:^|[;,\s=:])image\/[a-z0-9.+-]+(?:$|[;,\s])/i,
 } as const;
 
 function formatRowOutput(output: EvaluateTableOutput | string | null | undefined) {
@@ -524,7 +524,12 @@ function getNumberFormatter(
   options: Intl.NumberFormatOptions,
   locale?: string | string[],
 ): Intl.NumberFormat {
-  const normalizedLocale = Array.isArray(locale) ? locale.join(',') : locale || 'default';
+  let normalizedLocale = 'default';
+  if (Array.isArray(locale)) {
+    normalizedLocale = locale.join(',');
+  } else if (typeof locale === 'string') {
+    normalizedLocale = locale;
+  }
   const normalizedOptions = Object.entries(options)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}:${String(value)}`)

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -67,7 +67,18 @@ import { useMetricsGetter, usePassingTestCounts, usePassRates, useTestCounts } f
 import { getNamedMetricTotals } from './utils';
 
 /**
- * Audio player component that handles both storage refs and base64 data
+ * Renders an audio player for evaluation outputs that may be stored in different representations.
+ *
+ * This component accepts either:
+ * - A storage/blob reference, which is resolved asynchronously, or
+ * - Inline base64/data URL audio content, which is used immediately.
+ *
+ * @param data Audio payload or reference. Supported inputs:
+ *   - storage ref/blob ref string understood by `isStorageRef` / `isBlobRef`
+ *   - data URL (`data:audio/...`)
+ *   - raw base64 audio data
+ * @param format Audio MIME subtype used when constructing inline base64 sources and the `<source>` type.
+ * Defaults to `'mp3'`. Typical values include `'mp3'`, `'wav'`, `'ogg'`, and `'webm'`.
  */
 function StorageRefAudioPlayer({ data, format = 'mp3' }: { data: string; format?: string }) {
   const [audioUrl, setAudioUrl] = React.useState<string | null>(null);
@@ -120,6 +131,10 @@ function StorageRefAudioPlayer({ data, format = 'mp3' }: { data: string; format?
 const VARIABLE_COLUMN_SIZE_PX = 200;
 const PROMPT_COLUMN_SIZE_PX = 400;
 const DESCRIPTION_COLUMN_SIZE_PX = 100;
+const MEDIA_MIME_PATTERNS = {
+  audio: /(?:^|[;,\s=])audio\/[a-z0-9.+-]+(?:$|[;,\s])/i,
+  image: /(?:^|[;,\s=])image\/[a-z0-9.+-]+(?:$|[;,\s])/i,
+} as const;
 
 function formatRowOutput(output: EvaluateTableOutput | string | null | undefined) {
   if (output == null) {
@@ -270,8 +285,11 @@ function renderMediaVariableCell({
 
   const { type: mediaType, format = '' } = mediaMetadata;
   const normalizedValue = normalizeMediaText(value);
+  const isRefValue = isBlobRef(value) || isStorageRef(value);
   const audioSource =
-    mediaType === 'audio' ? resolveAudioSource({ data: value, format, blobRef: value }) : null;
+    mediaType === 'audio'
+      ? resolveAudioSource(isRefValue ? { format, blobRef: value } : { data: value, format })
+      : null;
   const imageSrc =
     mediaType === 'image' ? resolveImageSource({ data: value, format, blobRef: value }) : undefined;
 
@@ -362,12 +380,12 @@ function renderDecodedVariableCell({
     strategyId === 'audio' ||
     (typeof value === 'string' &&
       (isStorageRef(value) || isBlobRef(value)) &&
-      value.includes('audio/'));
+      MEDIA_MIME_PATTERNS.audio.test(value));
   const isImageContent =
     strategyId === 'image' ||
     (typeof value === 'string' &&
       (isStorageRef(value) || isBlobRef(value)) &&
-      value.includes('image/'));
+      MEDIA_MIME_PATTERNS.image.test(value));
 
   return (
     <div className="cell" data-capture="true">
@@ -497,7 +515,29 @@ function formatMetricValue(
   value: number,
   options: Intl.NumberFormatOptions = { maximumFractionDigits: 0 },
 ): string {
-  return Intl.NumberFormat(undefined, options).format(value);
+  return getNumberFormatter(options).format(value);
+}
+
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+
+function getNumberFormatter(
+  options: Intl.NumberFormatOptions,
+  locale?: string | string[],
+): Intl.NumberFormat {
+  const normalizedLocale = Array.isArray(locale) ? locale.join(',') : locale || 'default';
+  const normalizedOptions = Object.entries(options)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}:${String(value)}`)
+    .join('|');
+  const cacheKey = `${normalizedLocale}|${normalizedOptions}`;
+
+  let formatter = numberFormatCache.get(cacheKey);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    numberFormatCache.set(cacheKey, formatter);
+  }
+
+  return formatter;
 }
 
 function renderFilteredSuffix(value: React.ReactNode, unit = 'filtered'): React.ReactNode {
@@ -598,9 +638,9 @@ function renderTokenMetrics({
   metrics: PromptMetrics['total'];
   filteredMetrics: PromptMetrics['filtered'];
   testCount?: PromptSummaryMetric;
-}): React.ReactNode[] {
+}): React.ReactNode {
   if (!metrics?.tokenUsage?.total) {
-    return [];
+    return null;
   }
 
   const totalTokens = metrics.tokenUsage.total;
@@ -609,16 +649,18 @@ function renderTokenMetrics({
   const filteredAverage =
     filteredTokens && testCount?.filtered ? filteredTokens / testCount.filtered : undefined;
 
-  return [
-    <div key="total-tokens">
-      <strong>Total Tokens:</strong> {formatMetricValue(totalTokens)}
-      {filteredTokens ? renderFilteredSuffix(formatMetricValue(filteredTokens)) : null}
-    </div>,
-    <div key="avg-tokens">
-      <strong>Avg Tokens:</strong> {formatMetricValue(totalAverage)}
-      {filteredAverage ? renderFilteredSuffix(formatMetricValue(filteredAverage)) : null}
-    </div>,
-  ];
+  return (
+    <>
+      <div>
+        <strong>Total Tokens:</strong> {formatMetricValue(totalTokens)}
+        {filteredTokens ? renderFilteredSuffix(formatMetricValue(filteredTokens)) : null}
+      </div>
+      <div>
+        <strong>Avg Tokens:</strong> {formatMetricValue(totalAverage)}
+        {filteredAverage ? renderFilteredSuffix(formatMetricValue(filteredAverage)) : null}
+      </div>
+    </>
+  );
 }
 
 function renderLatencyMetric({

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -525,8 +525,9 @@ function getNumberFormatter(
   locale?: string | string[],
 ): Intl.NumberFormat {
   let normalizedLocale = 'default';
-  if (Array.isArray(locale)) {
-    normalizedLocale = locale.join(',');
+  const localeArray = Array.isArray(locale) ? locale : undefined;
+  if (localeArray) {
+    normalizedLocale = localeArray.join(',');
   } else if (typeof locale === 'string') {
     normalizedLocale = locale;
   }

--- a/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
+++ b/src/app/src/pages/eval/components/TableSettings/components/SettingsPanel.tsx
@@ -19,6 +19,22 @@ const RESULTS_TABLE_ZOOM_OPTIONS = [
   { value: '1.5', label: '150%' },
   { value: '2', label: '200%' },
 ] as const;
+const DEFAULT_MAX_TEXT_LENGTH = 500;
+// Slider values are finite-only, so this sentinel represents "unlimited"
+// and maps to Number.POSITIVE_INFINITY in settings state.
+const INFINITY_SLIDER_VALUE = 1001;
+
+function sanitizeMaxTextLength(value: number) {
+  if (value === Number.POSITIVE_INFINITY) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  if (Number.isFinite(value) && value >= 25) {
+    return value;
+  }
+
+  return DEFAULT_MAX_TEXT_LENGTH;
+}
 
 const SectionHeader = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -55,14 +71,11 @@ const SettingsPanel = ({ resultsTableZoom, onResultsTableZoomChange }: SettingsP
   } = useResultsViewSettingsStore();
 
   // Local state for text length slider
-  const sanitizedMaxTextLength =
-    maxTextLength === Number.POSITIVE_INFINITY
-      ? Number.POSITIVE_INFINITY
-      : Number.isFinite(maxTextLength) && maxTextLength >= 25
-        ? maxTextLength
-        : 500;
+  const sanitizedMaxTextLength = sanitizeMaxTextLength(maxTextLength);
   const [localMaxTextLength, setLocalMaxTextLength] = useState(
-    sanitizedMaxTextLength === Number.POSITIVE_INFINITY ? 1001 : sanitizedMaxTextLength,
+    sanitizedMaxTextLength === Number.POSITIVE_INFINITY
+      ? INFINITY_SLIDER_VALUE
+      : sanitizedMaxTextLength,
   );
 
   const handleTextLengthChange = useCallback((value: number) => {
@@ -71,7 +84,7 @@ const SettingsPanel = ({ resultsTableZoom, onResultsTableZoomChange }: SettingsP
 
   const handleTextLengthCommitted = useCallback(
     (value: number) => {
-      const newValue = value === 1001 ? Number.POSITIVE_INFINITY : value;
+      const newValue = value === INFINITY_SLIDER_VALUE ? Number.POSITIVE_INFINITY : value;
       setMaxTextLength(newValue);
     },
     [setMaxTextLength],
@@ -185,7 +198,7 @@ const SettingsPanel = ({ resultsTableZoom, onResultsTableZoomChange }: SettingsP
             onChange={handleTextLengthChange}
             onChangeCommitted={handleTextLengthCommitted}
             min={25}
-            max={1001}
+            max={INFINITY_SLIDER_VALUE}
             tooltipText="Characters before truncating"
             unlimited
           />

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -112,7 +112,7 @@ export const RedteamPluginObjectSchema = z.object({
   numTests: z
     .int()
     .positive()
-    .prefault(DEFAULT_NUM_TESTS_PER_PLUGIN)
+    .default(DEFAULT_NUM_TESTS_PER_PLUGIN)
     .describe('Number of tests to generate for this plugin'),
   config: z.record(z.string(), z.unknown()).optional().describe('Plugin-specific configuration'),
   severity: SeveritySchema.optional().describe('Severity level for this plugin'),
@@ -306,7 +306,7 @@ export const RedteamConfigSchema = z
         `,
       )
       .optional()
-      .prefault(['default']),
+      .default(['default']),
     maxConcurrency: z
       .int()
       .positive()

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -112,10 +112,18 @@ export const RedteamPluginObjectSchema = z.object({
   numTests: z
     .int()
     .positive()
-    .default(DEFAULT_NUM_TESTS_PER_PLUGIN)
+    .prefault(DEFAULT_NUM_TESTS_PER_PLUGIN)
     .describe('Number of tests to generate for this plugin'),
   config: z.record(z.string(), z.unknown()).optional().describe('Plugin-specific configuration'),
   severity: SeveritySchema.optional().describe('Severity level for this plugin'),
+});
+
+const RedteamConfigPluginObjectSchema = RedteamPluginObjectSchema.extend({
+  numTests: z
+    .int()
+    .positive()
+    .optional()
+    .describe('Number of tests to generate for this plugin'),
 });
 
 /**
@@ -142,7 +150,7 @@ export const RedteamPluginSchema = z.union([
       }),
     ])
     .describe('Name of the plugin or path to custom plugin'),
-  RedteamPluginObjectSchema,
+  RedteamConfigPluginObjectSchema,
 ]);
 
 export const strategyIdSchema = z.union([
@@ -453,7 +461,10 @@ export const RedteamConfigSchema = z
       const pluginObj: RedteamPluginObject =
         typeof plugin === 'string'
           ? { id: plugin, numTests: data.numTests, config: undefined, severity: undefined }
-          : { ...plugin, numTests: plugin.numTests ?? data.numTests };
+          : {
+              ...plugin,
+              numTests: plugin.numTests ?? data.numTests ?? DEFAULT_NUM_TESTS_PER_PLUGIN,
+            };
 
       if (ALIASED_PLUGIN_MAPPINGS[pluginObj.id]) {
         Object.values(ALIASED_PLUGIN_MAPPINGS[pluginObj.id]).forEach(({ plugins, strategies }) => {

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -51,7 +51,7 @@ type SynthesizeMockResult = {
   failedPlugins: FailedPluginInfo[];
 };
 
-const TEST_PROBE_LIMIT = vi.hoisted(() => 100_000);
+const { TEST_PROBE_LIMIT } = vi.hoisted(() => ({ TEST_PROBE_LIMIT: 100_000 }));
 
 function resetCommonMocks() {
   vi.mocked(extractMcpToolsInfo).mockReset().mockResolvedValue('');

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -244,7 +244,18 @@ describe('redteamConfigSchema', () => {
     { id: 'empty-purpose', purpose: '' },
     { id: 'blank-purpose', purpose: '   ' },
   ])('should accept contexts with optional or blank purposes: $id', (context) => {
-    expect(RedteamContextSchema.safeParse(context).success).toBe(true);
+    const result = RedteamContextSchema.safeParse(context);
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    if (context.purpose === undefined) {
+      expect(result.data.purpose).toBeUndefined();
+    } else {
+      expect(result.data.purpose).toBeTypeOf('string');
+      expect(result.data.purpose?.trim()).toBe('');
+    }
   });
 
   it('should accept a valid configuration with all fields', () => {

--- a/test/validators/redteam.test.ts
+++ b/test/validators/redteam.test.ts
@@ -151,6 +151,16 @@ describe('RedteamConfigSchema', () => {
     expect(result.plugins?.[0].numTests).toBe(5);
   });
 
+  it('should inherit top-level numTests for object plugins that omit numTests', () => {
+    const config = {
+      numTests: 17,
+      plugins: [{ id: 'file://test-plugin.js' }],
+    };
+
+    const result = RedteamConfigSchema.parse(config);
+    expect(result.plugins?.[0].numTests).toBe(17);
+  });
+
   it('should use default numTests when not specified', () => {
     const config = {
       plugins: [


### PR DESCRIPTION
## Summary

- Address all 11 currently visible GitHub Security AI findings across 5 files.
- Harden evaluation media rendering and metric formatting helpers.
- Simplify results table settings and redteam validation/test code quality issues.

## Verification

- `npm run f`
- `npm run l`
- `npm test -- test/redteam/commands/generate.test.ts test/redteam/validators.test.ts`
- `npm run test:app -- src/pages/eval/components/ResultsTable.test.tsx src/pages/eval/components/TableSettings/components/SettingsPanel.test.tsx --run`
- `npm run tsc`
- `npm run build:app`
- `git diff --check`
