### PR TITLE
feat(eval): load test sets from azure blob storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,7 @@
         "@azure/identity": "^4.13.0",
         "@azure/msal-node": "^5.2.0",
         "@azure/openai-assistants": "^1.0.0-beta.6",
+        "@azure/storage-blob": "^12.31.0",
         "@fal-ai/client": "~1.10.1",
         "@huggingface/transformers": "^4.0.0",
         "@ibm-cloud/watsonx-ai": "^1.7.11",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "@azure/identity": "^4.13.0",
     "@azure/msal-node": "^5.2.0",
     "@azure/openai-assistants": "^1.0.0-beta.6",
+    "@azure/storage-blob": "^12.31.0",
     "@fal-ai/client": "~1.10.1",
     "@huggingface/transformers": "^4.0.0",
     "@ibm-cloud/watsonx-ai": "^1.7.11",

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -166,7 +166,7 @@ tests:
 ```
 
 :::tip
-Test files can be defined in YAML/JSON, JSONL, [CSV](/docs/configuration/test-cases#csv-format), and TypeScript/JavaScript. We also support [Google Sheets](/docs/integrations/google-sheets) CSV datasets.
+Test files can be defined in YAML/JSON, JSONL, [CSV](/docs/configuration/test-cases#csv-format), and TypeScript/JavaScript. Promptfoo also supports external datasets from [Google Sheets](/docs/integrations/google-sheets) and [Azure Blob Storage](/docs/configuration/test-cases#azure-blob-storage).
 :::
 
 ## Import vars from separate files
@@ -899,3 +899,12 @@ tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsK
 Here's a [full example](https://github.com/promptfoo/promptfoo/tree/main/examples/integration-google-sheets).
 
 See [Google Sheets integration](/docs/integrations/google-sheets) for details on how to set up promptfoo to access a private spreadsheet.
+
+Promptfoo can also load test sets from Azure Blob Storage:
+
+```yaml
+// highlight-next-line
+tests: az://myaccount/evals/tests.json
+```
+
+See [Azure Blob Storage test sets](/docs/configuration/test-cases#azure-blob-storage) for supported file types and authentication options.

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -113,6 +113,12 @@ tests: file://test_cases.csv
 tests: huggingface://datasets/rajpurkar/squad
 ```
 
+**Azure Blob Storage**
+
+```yaml
+tests: az://myaccount/evals/tests.json
+```
+
 **Dynamic generation**
 
 ```yaml

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -736,6 +736,10 @@ Authentication uses the first available option:
 
 When using `AZURE_STORAGE_CONNECTION_STRING`, the storage account comes from the connection string. Keep the `az://` account segment aligned with that account so the URI remains self-describing; Promptfoo rejects clearly mismatched `AccountName` values. Query strings are interpreted as SAS tokens and must include `sig`.
 
+SAS query strings and `DefaultAzureCredential` use the standard public Azure Blob endpoint for the named account. For Azure Government, Azure operated by 21Vianet, or custom blob endpoints, use `AZURE_STORAGE_CONNECTION_STRING` with the appropriate `EndpointSuffix` or explicit `BlobEndpoint`.
+
+Blob-hosted YAML, JSON, and JSONL files are treated as remote test-case data. Promptfoo does not expand local file references or provider references found inside those blob contents.
+
 ### HuggingFace Datasets
 
 See [HuggingFace Datasets](/docs/configuration/huggingface-datasets) for instructions on importing test cases from existing datasets.

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -734,6 +734,8 @@ Authentication uses the first available option:
 2. `AZURE_STORAGE_CONNECTION_STRING`
 3. Azure identity credentials through `DefaultAzureCredential`, such as Azure CLI login, managed identity, or service principal environment variables
 
+When using `AZURE_STORAGE_CONNECTION_STRING`, the storage account comes from the connection string. Keep the `az://` account segment aligned with that account so the URI remains self-describing.
+
 ### HuggingFace Datasets
 
 See [HuggingFace Datasets](/docs/configuration/huggingface-datasets) for instructions on importing test cases from existing datasets.

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -718,6 +718,22 @@ See [Google Sheets integration](/docs/integrations/google-sheets) for details on
 
 See [SharePoint integration](/docs/integrations/sharepoint) for details on loading test data from Microsoft SharePoint document libraries.
 
+### Azure Blob Storage
+
+Promptfoo can read test sets directly from Azure Blob Storage:
+
+```yaml
+tests: az://myaccount/evals/tests.json
+```
+
+Use `az://<account>/<container>/<blob>`. Promptfoo supports CSV, JSON, JSONL, YAML, and YML test-set blobs. Blob names may keep the original extension and append a suffix, such as `tests.json.<sha256>`.
+
+Authentication uses the first available option:
+
+1. A SAS query string on the URI, such as `az://myaccount/evals/tests.json?<sas-token>`
+2. `AZURE_STORAGE_CONNECTION_STRING`
+3. Azure identity credentials through `DefaultAzureCredential`, such as Azure CLI login, managed identity, or service principal environment variables
+
 ### HuggingFace Datasets
 
 See [HuggingFace Datasets](/docs/configuration/huggingface-datasets) for instructions on importing test cases from existing datasets.

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -734,7 +734,7 @@ Authentication uses the first available option:
 2. `AZURE_STORAGE_CONNECTION_STRING`
 3. Azure identity credentials through `DefaultAzureCredential`, such as Azure CLI login, managed identity, or service principal environment variables
 
-When using `AZURE_STORAGE_CONNECTION_STRING`, the storage account comes from the connection string. Keep the `az://` account segment aligned with that account so the URI remains self-describing.
+When using `AZURE_STORAGE_CONNECTION_STRING`, the storage account comes from the connection string. Keep the `az://` account segment aligned with that account so the URI remains self-describing; Promptfoo rejects clearly mismatched `AccountName` values. Query strings are interpreted as SAS tokens and must include `sig`.
 
 ### HuggingFace Datasets
 

--- a/src/util/azureBlob.ts
+++ b/src/util/azureBlob.ts
@@ -15,20 +15,35 @@ export type AzureBlobUriParts = {
   sasToken: string;
 };
 
+function sanitizeAzureBlobUriForError(uri: string): string {
+  const queryStart = uri.indexOf('?');
+  if (queryStart < 0) {
+    return uri;
+  }
+
+  const fragmentStart = uri.indexOf('#', queryStart);
+  return fragmentStart >= 0
+    ? `${uri.slice(0, queryStart)}?<redacted>${uri.slice(fragmentStart)}`
+    : `${uri.slice(0, queryStart)}?<redacted>`;
+}
+
 function createAzureBlobUriError(uri: string, detail: string): Error {
+  const sanitizedUri = sanitizeAzureBlobUriForError(uri);
   return new Error(
-    `Invalid Azure Blob Storage URI "${uri}": ${detail}. Expected az://<account>/<container>/<blob>.`,
+    `Invalid Azure Blob Storage URI "${sanitizedUri}": ${detail}. Expected az://<account>/<container>/<blob>.`,
   );
 }
 
 function formatAzureBlobReadError(uri: string, error: unknown): Error {
   const detail = error instanceof Error ? error.message : String(error);
-  return new Error(`Failed to read Azure Blob Storage URI "${uri}": ${detail}`);
+  return new Error(
+    `Failed to read Azure Blob Storage URI "${sanitizeAzureBlobUriForError(uri)}": ${detail}`,
+  );
 }
 
-function decodeAzureBlobPathSegment(segment: string, uri: string): string {
+function decodeAzureBlobPathComponent(component: string, uri: string): string {
   try {
-    return decodeURIComponent(segment);
+    return decodeURIComponent(component);
   } catch {
     throw createAzureBlobUriError(uri, 'path contains invalid percent-encoding');
   }
@@ -51,24 +66,27 @@ export function parseAzureBlobUri(uri: string): AzureBlobUriParts {
     throw createAzureBlobUriError(uri, 'storage account is missing');
   }
 
-  const pathSegments = parsed.pathname
-    .replace(/^\/+/, '')
-    .split('/')
-    .filter(Boolean)
-    .map((segment) => decodeAzureBlobPathSegment(segment, uri));
+  const pathWithoutLeadingSlash = parsed.pathname.startsWith('/')
+    ? parsed.pathname.slice(1)
+    : parsed.pathname;
+  const containerSeparatorIndex = pathWithoutLeadingSlash.indexOf('/');
+  if (containerSeparatorIndex < 0) {
+    throw createAzureBlobUriError(uri, 'blob path is missing');
+  }
 
-  const [containerName, ...blobPathSegments] = pathSegments;
-  if (!containerName) {
+  const rawContainerName = pathWithoutLeadingSlash.slice(0, containerSeparatorIndex);
+  const rawBlobName = pathWithoutLeadingSlash.slice(containerSeparatorIndex + 1);
+  if (!rawContainerName) {
     throw createAzureBlobUriError(uri, 'container name is missing');
   }
-  if (blobPathSegments.length === 0) {
+  if (!rawBlobName) {
     throw createAzureBlobUriError(uri, 'blob path is missing');
   }
 
   return {
     accountName,
-    containerName,
-    blobName: blobPathSegments.join('/'),
+    containerName: decodeAzureBlobPathComponent(rawContainerName, uri),
+    blobName: decodeAzureBlobPathComponent(rawBlobName, uri),
     sasToken: parsed.search,
   };
 }

--- a/src/util/azureBlob.ts
+++ b/src/util/azureBlob.ts
@@ -1,0 +1,143 @@
+import { getEnvString } from '../envars';
+
+type AzureBlobServiceClient = {
+  getContainerClient(containerName: string): {
+    getBlobClient(blobName: string): {
+      downloadToBuffer(): Promise<Buffer>;
+    };
+  };
+};
+
+export type AzureBlobUriParts = {
+  accountName: string;
+  containerName: string;
+  blobName: string;
+  sasToken: string;
+};
+
+function createAzureBlobUriError(uri: string, detail: string): Error {
+  return new Error(
+    `Invalid Azure Blob Storage URI "${uri}": ${detail}. Expected az://<account>/<container>/<blob>.`,
+  );
+}
+
+function formatAzureBlobReadError(uri: string, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Failed to read Azure Blob Storage URI "${uri}": ${detail}`);
+}
+
+function decodeAzureBlobPathSegment(segment: string, uri: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    throw createAzureBlobUriError(uri, 'path contains invalid percent-encoding');
+  }
+}
+
+export function parseAzureBlobUri(uri: string): AzureBlobUriParts {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw createAzureBlobUriError(uri, 'URI could not be parsed');
+  }
+
+  if (parsed.protocol !== 'az:') {
+    throw createAzureBlobUriError(uri, 'URI must use the az:// scheme');
+  }
+
+  const accountName = parsed.hostname.trim();
+  if (!accountName) {
+    throw createAzureBlobUriError(uri, 'storage account is missing');
+  }
+
+  const pathSegments = parsed.pathname
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => decodeAzureBlobPathSegment(segment, uri));
+
+  const [containerName, ...blobPathSegments] = pathSegments;
+  if (!containerName) {
+    throw createAzureBlobUriError(uri, 'container name is missing');
+  }
+  if (blobPathSegments.length === 0) {
+    throw createAzureBlobUriError(uri, 'blob path is missing');
+  }
+
+  return {
+    accountName,
+    containerName,
+    blobName: blobPathSegments.join('/'),
+    sasToken: parsed.search,
+  };
+}
+
+async function loadAzureStorageBlobPackage(uri: string) {
+  try {
+    return await import('@azure/storage-blob');
+  } catch (error) {
+    throw formatAzureBlobReadError(
+      uri,
+      new Error(
+        `@azure/storage-blob is required for az:// test references. Install optional dependencies or add @azure/storage-blob to your project. ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    );
+  }
+}
+
+async function createAzureBlobServiceClient(
+  uri: string,
+  parts: AzureBlobUriParts,
+): Promise<AzureBlobServiceClient> {
+  const { BlobServiceClient } = await loadAzureStorageBlobPackage(uri);
+  const accountUrl = `https://${parts.accountName}.blob.core.windows.net${parts.sasToken}`;
+
+  if (parts.sasToken) {
+    return new BlobServiceClient(accountUrl);
+  }
+
+  const connectionString = getEnvString('AZURE_STORAGE_CONNECTION_STRING');
+  if (connectionString) {
+    return BlobServiceClient.fromConnectionString(connectionString);
+  }
+
+  try {
+    const { DefaultAzureCredential } = await import('@azure/identity');
+    return new BlobServiceClient(accountUrl, new DefaultAzureCredential());
+  } catch (error) {
+    throw formatAzureBlobReadError(
+      uri,
+      new Error(
+        `Default Azure credentials are unavailable. Set AZURE_STORAGE_CONNECTION_STRING, append a SAS query string to the az:// URI, or configure @azure/identity credentials. ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    );
+  }
+}
+
+/**
+ * Reads a UTF-8 Azure Blob Storage object for test-set parsing.
+ *
+ * Accepted URI form: az://<account>/<container>/<blob>
+ */
+export async function readAzureBlobText(uri: string): Promise<string> {
+  const parts = parseAzureBlobUri(uri);
+
+  try {
+    const blobServiceClient = await createAzureBlobServiceClient(uri, parts);
+    const blobClient = blobServiceClient
+      .getContainerClient(parts.containerName)
+      .getBlobClient(parts.blobName);
+    const content = await blobClient.downloadToBuffer();
+    return content.toString('utf8');
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Failed to read Azure Blob Storage')) {
+      throw error;
+    }
+    throw formatAzureBlobReadError(uri, error);
+  }
+}

--- a/src/util/azureBlob.ts
+++ b/src/util/azureBlob.ts
@@ -91,6 +91,47 @@ export function parseAzureBlobUri(uri: string): AzureBlobUriParts {
   };
 }
 
+function isAzureBlobSasToken(queryString: string): boolean {
+  const searchParams = new URLSearchParams(queryString.startsWith('?') ? queryString.slice(1) : queryString);
+  return searchParams.has('sig');
+}
+
+function getConnectionStringAccountName(connectionString: string): string | undefined {
+  for (const segment of connectionString.split(';')) {
+    const separatorIndex = segment.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const key = segment.slice(0, separatorIndex).trim().toLowerCase();
+    if (key === 'accountname') {
+      const accountName = segment.slice(separatorIndex + 1).trim();
+      return accountName || undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function assertConnectionStringMatchesUriAccount(
+  uri: string,
+  parts: AzureBlobUriParts,
+  connectionString: string,
+): void {
+  const connectionStringAccountName = getConnectionStringAccountName(connectionString);
+  if (
+    connectionStringAccountName &&
+    connectionStringAccountName.toLowerCase() !== parts.accountName.toLowerCase()
+  ) {
+    throw formatAzureBlobReadError(
+      uri,
+      new Error(
+        `AZURE_STORAGE_CONNECTION_STRING targets storage account "${connectionStringAccountName}", but the az:// URI targets "${parts.accountName}".`,
+      ),
+    );
+  }
+}
+
 async function loadAzureStorageBlobPackage(uri: string) {
   try {
     return await import('@azure/storage-blob');
@@ -114,11 +155,18 @@ async function createAzureBlobServiceClient(
   const accountUrl = `https://${parts.accountName}.blob.core.windows.net${parts.sasToken}`;
 
   if (parts.sasToken) {
+    if (!isAzureBlobSasToken(parts.sasToken)) {
+      throw createAzureBlobUriError(
+        uri,
+        'query string must be a SAS token containing a sig parameter',
+      );
+    }
     return new BlobServiceClient(accountUrl);
   }
 
   const connectionString = getEnvString('AZURE_STORAGE_CONNECTION_STRING');
   if (connectionString) {
+    assertConnectionStringMatchesUriAccount(uri, parts, connectionString);
     return BlobServiceClient.fromConnectionString(connectionString);
   }
 

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -103,7 +103,7 @@ export async function readStandaloneTestsFile(
   }
 
   if (varsPath.startsWith('az://')) {
-    return await readAzureBlobStandaloneTestsFile(varsPath);
+    return await readAzureBlobStandaloneTestsFile(varsPath, basePath);
   }
 
   let rows: CsvRow[];
@@ -124,7 +124,10 @@ export async function readStandaloneTestsFile(
   return csvRowsToTestCases(rows);
 }
 
-async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestCase[]> {
+async function readAzureBlobStandaloneTestsFile(
+  varsPath: string,
+  basePath: string,
+): Promise<TestCase[]> {
   const fileExtension = getAzureBlobTestFileExtension(varsPath);
   if (!fileExtension) {
     throw new Error(
@@ -155,7 +158,7 @@ async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestC
   telemetry.record('feature_used', {
     feature: 'yaml tests file - azure blob',
   });
-  return parseYamlTestCases(fileContent);
+  return parseYamlTestCases(fileContent, basePath);
 }
 
 function getAzureBlobTestFileExtension(varsPath: string): AzureBlobTestFileExtension | undefined {
@@ -369,14 +372,21 @@ function parseJsonlTestCases(fileContent: string): TestCase[] {
     });
 }
 
-function parseYamlTestCases(fileContent: string): TestCase[] {
+async function parseYamlTestCases(fileContent: string, basePath: string): Promise<TestCase[]> {
   const rawContent = yaml.load(fileContent);
   const loadedContent = maybeLoadConfigFromExternalFile(rawContent) as TestCase[] | TestCase;
   const testCases = Array.isArray(loadedContent) ? loadedContent : [loadedContent];
-  return testCases.map((item, idx) => ({
-    ...item,
-    description: item.description || `Row #${idx + 1}`,
-  }));
+  const dereferenced = (await $RefParser.dereference(testCases)) as TestCase[];
+
+  return Promise.all(
+    dereferenced.map(async (item, idx) => {
+      const testCase = await readTest(item as TestCaseWithVarsFile, basePath);
+      return {
+        ...testCase,
+        description: testCase.description || `Row #${idx + 1}`,
+      };
+    }),
+  );
 }
 
 async function loadTestWithVars(

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -17,6 +17,7 @@ import { fetchCsvFromSharepoint } from '../microsoftSharepoint';
 import { loadApiProvider } from '../providers/index';
 import { runPython } from '../python/pythonUtils';
 import telemetry from '../telemetry';
+import { readAzureBlobText } from './azureBlob';
 import { maybeLoadConfigFromExternalFile } from './file';
 import { isJavascriptFile } from './fileExtensions';
 import { parseXlsxFile } from './xlsx';
@@ -36,6 +37,10 @@ type StandaloneTestsFileMetadata = {
   fileExtension: string;
   extensionWithoutSheet: string;
 };
+
+type AzureBlobTestFileExtension = 'csv' | 'json' | 'jsonl' | 'yaml' | 'yml';
+
+const SHA256_BLOB_SUFFIX = /\.[a-f0-9]{64}$/i;
 
 export async function readTestFiles(
   pathOrGlobs: string | string[],
@@ -67,6 +72,7 @@ export async function readTestFiles(
  *
  * Supports multiple input sources:
  * - Hugging Face datasets (huggingface://datasets/...)
+ * - Azure Blob Storage test sets (az://...)
  * - JavaScript/TypeScript files (.js, .ts, .mjs)
  * - Python files (.py) with optional function name
  * - Google Sheets (https://docs.google.com/spreadsheets/...)
@@ -96,6 +102,10 @@ export async function readStandaloneTestsFile(
     return await fetchHuggingFaceDataset(varsPath);
   }
 
+  if (varsPath.startsWith('az://')) {
+    return await readAzureBlobStandaloneTestsFile(varsPath);
+  }
+
   let rows: CsvRow[];
   if (varsPath.startsWith('https://docs.google.com/spreadsheets/')) {
     telemetry.record('feature_used', {
@@ -112,6 +122,57 @@ export async function readStandaloneTestsFile(
   }
 
   return csvRowsToTestCases(rows);
+}
+
+async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestCase[]> {
+  const fileExtension = getAzureBlobTestFileExtension(varsPath);
+  if (!fileExtension) {
+    throw new Error(
+      `Unsupported Azure Blob Storage test file type for URI: ${varsPath}. Supported formats: CSV, JSON, JSONL, YAML, and YML.`,
+    );
+  }
+
+  const fileContent = await readAzureBlobText(varsPath);
+  if (fileExtension === 'csv') {
+    telemetry.record('feature_used', {
+      feature: 'csv tests file - azure blob',
+    });
+    return csvRowsToTestCases(parseCsvRows(fileContent));
+  }
+  if (fileExtension === 'json') {
+    telemetry.record('feature_used', {
+      feature: 'json tests file - azure blob',
+    });
+    return parseJsonTestCases(fileContent);
+  }
+  if (fileExtension === 'jsonl') {
+    telemetry.record('feature_used', {
+      feature: 'jsonl tests file - azure blob',
+    });
+    return parseJsonlTestCases(fileContent);
+  }
+
+  telemetry.record('feature_used', {
+    feature: 'yaml tests file - azure blob',
+  });
+  const rawContent = yaml.load(fileContent);
+  const rows = maybeLoadConfigFromExternalFile(rawContent) as unknown as CsvRow[];
+  return csvRowsToTestCases(rows);
+}
+
+function getAzureBlobTestFileExtension(varsPath: string): AzureBlobTestFileExtension | undefined {
+  const pathWithoutBlobHash = varsPath.replace(SHA256_BLOB_SUFFIX, '');
+  const extension = parsePath(pathWithoutBlobHash).ext.slice(1).toLowerCase();
+  if (
+    extension === 'csv' ||
+    extension === 'json' ||
+    extension === 'jsonl' ||
+    extension === 'yaml' ||
+    extension === 'yml'
+  ) {
+    return extension;
+  }
+  return undefined;
 }
 
 async function readLocalStandaloneTestsFile(
@@ -250,8 +311,12 @@ function parseLocalCsv(fileContent: string, delimiter: string, relaxQuotes: bool
 }
 
 async function readLocalCsvRows(resolvedVarsPath: string): Promise<CsvRow[]> {
-  const delimiter = getEnvString('PROMPTFOO_CSV_DELIMITER', ',');
   const fileContent = await fsPromises.readFile(resolvedVarsPath, 'utf-8');
+  return parseCsvRows(fileContent);
+}
+
+function parseCsvRows(fileContent: string): CsvRow[] {
+  const delimiter = getEnvString('PROMPTFOO_CSV_DELIMITER', ',');
   const enforceStrict = getEnvBool('PROMPTFOO_CSV_STRICT', false);
 
   try {
@@ -275,6 +340,10 @@ async function readLocalCsvRows(resolvedVarsPath: string): Promise<CsvRow[]> {
 
 async function readJsonTestCases(resolvedVarsPath: string): Promise<TestCase[]> {
   const fileContent = await fsPromises.readFile(resolvedVarsPath, 'utf-8');
+  return parseJsonTestCases(fileContent);
+}
+
+function parseJsonTestCases(fileContent: string): TestCase[] {
   const jsonData = yaml.load(fileContent) as any;
   const testCases: TestCase[] = Array.isArray(jsonData) ? jsonData : [jsonData];
   return testCases.map((item, idx) => ({
@@ -285,7 +354,10 @@ async function readJsonTestCases(resolvedVarsPath: string): Promise<TestCase[]> 
 
 async function readJsonlTestCases(resolvedVarsPath: string): Promise<TestCase[]> {
   const fileContent = await fsPromises.readFile(resolvedVarsPath, 'utf-8');
+  return parseJsonlTestCases(fileContent);
+}
 
+function parseJsonlTestCases(fileContent: string): TestCase[] {
   return fileContent
     .split('\n')
     .filter((line) => line.trim())

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -17,7 +17,7 @@ import { fetchCsvFromSharepoint } from '../microsoftSharepoint';
 import { loadApiProvider } from '../providers/index';
 import { runPython } from '../python/pythonUtils';
 import telemetry from '../telemetry';
-import { readAzureBlobText } from './azureBlob';
+import { parseAzureBlobUri, readAzureBlobText } from './azureBlob';
 import { maybeLoadConfigFromExternalFile } from './file';
 import { isJavascriptFile } from './fileExtensions';
 import { parseXlsxFile } from './xlsx';
@@ -128,7 +128,7 @@ async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestC
   const fileExtension = getAzureBlobTestFileExtension(varsPath);
   if (!fileExtension) {
     throw new Error(
-      `Unsupported Azure Blob Storage test file type for URI: ${varsPath}. Supported formats: CSV, JSON, JSONL, YAML, and YML.`,
+      'Unsupported Azure Blob Storage test file type. Supported formats: CSV, JSON, JSONL, YAML, and YML.',
     );
   }
 
@@ -155,13 +155,12 @@ async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestC
   telemetry.record('feature_used', {
     feature: 'yaml tests file - azure blob',
   });
-  const rawContent = yaml.load(fileContent);
-  const rows = maybeLoadConfigFromExternalFile(rawContent) as unknown as CsvRow[];
-  return csvRowsToTestCases(rows);
+  return parseYamlTestCases(fileContent);
 }
 
 function getAzureBlobTestFileExtension(varsPath: string): AzureBlobTestFileExtension | undefined {
-  const pathWithoutBlobHash = varsPath.replace(SHA256_BLOB_SUFFIX, '');
+  const { blobName } = parseAzureBlobUri(varsPath);
+  const pathWithoutBlobHash = blobName.replace(SHA256_BLOB_SUFFIX, '');
   const extension = parsePath(pathWithoutBlobHash).ext.slice(1).toLowerCase();
   if (
     extension === 'csv' ||
@@ -370,6 +369,16 @@ function parseJsonlTestCases(fileContent: string): TestCase[] {
     });
 }
 
+function parseYamlTestCases(fileContent: string): TestCase[] {
+  const rawContent = yaml.load(fileContent);
+  const loadedContent = maybeLoadConfigFromExternalFile(rawContent) as TestCase[] | TestCase;
+  const testCases = Array.isArray(loadedContent) ? loadedContent : [loadedContent];
+  return testCases.map((item, idx) => ({
+    ...item,
+    description: item.description || `Row #${idx + 1}`,
+  }));
+}
+
 async function loadTestWithVars(
   testCase: TestCaseWithVarsFile,
   testBasePath: string,
@@ -546,6 +555,9 @@ export async function readTests(
   const ret: TestCase[] = [];
 
   if (typeof tests === 'string') {
+    if (tests.startsWith('az://')) {
+      return readStandaloneTestsFile(tests, basePath);
+    }
     // Points to a tests file with multiple test cases
     if (tests.endsWith('yaml') || tests.endsWith('yml')) {
       return loadTestsFromGlob(tests, basePath);

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -103,7 +103,7 @@ export async function readStandaloneTestsFile(
   }
 
   if (varsPath.startsWith('az://')) {
-    return await readAzureBlobStandaloneTestsFile(varsPath, basePath);
+    return await readAzureBlobStandaloneTestsFile(varsPath);
   }
 
   let rows: CsvRow[];
@@ -124,10 +124,7 @@ export async function readStandaloneTestsFile(
   return csvRowsToTestCases(rows);
 }
 
-async function readAzureBlobStandaloneTestsFile(
-  varsPath: string,
-  basePath: string,
-): Promise<TestCase[]> {
+async function readAzureBlobStandaloneTestsFile(varsPath: string): Promise<TestCase[]> {
   const fileExtension = getAzureBlobTestFileExtension(varsPath);
   if (!fileExtension) {
     throw new Error(
@@ -158,7 +155,7 @@ async function readAzureBlobStandaloneTestsFile(
   telemetry.record('feature_used', {
     feature: 'yaml tests file - azure blob',
   });
-  return parseYamlTestCases(fileContent, basePath);
+  return parseYamlTestCases(fileContent);
 }
 
 function getAzureBlobTestFileExtension(varsPath: string): AzureBlobTestFileExtension | undefined {
@@ -372,21 +369,15 @@ function parseJsonlTestCases(fileContent: string): TestCase[] {
     });
 }
 
-async function parseYamlTestCases(fileContent: string, basePath: string): Promise<TestCase[]> {
+function parseYamlTestCases(fileContent: string): TestCase[] {
   const rawContent = yaml.load(fileContent);
-  const loadedContent = maybeLoadConfigFromExternalFile(rawContent) as TestCase[] | TestCase;
-  const testCases = Array.isArray(loadedContent) ? loadedContent : [loadedContent];
-  const dereferenced = (await $RefParser.dereference(testCases)) as TestCase[];
-
-  return Promise.all(
-    dereferenced.map(async (item, idx) => {
-      const testCase = await readTest(item as TestCaseWithVarsFile, basePath);
-      return {
-        ...testCase,
-        description: testCase.description || `Row #${idx + 1}`,
-      };
-    }),
-  );
+  const testCases: TestCase[] = Array.isArray(rawContent)
+    ? (rawContent as TestCase[])
+    : [rawContent as TestCase];
+  return testCases.map((item, idx) => ({
+    ...item,
+    description: item.description || `Row #${idx + 1}`,
+  }));
 }
 
 async function loadTestWithVars(

--- a/test/util/azureBlob.test.ts
+++ b/test/util/azureBlob.test.ts
@@ -41,9 +41,23 @@ vi.mock('../../src/envars', async () => ({
 
 describe('Azure Blob test-set loading', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(getEnvString).mockReturnValue('');
-    mocks.downloadToBuffer.mockResolvedValue(Buffer.from('blob text', 'utf8'));
+    vi.mocked(getEnvString).mockReset().mockReturnValue('');
+    mocks.downloadToBuffer.mockReset().mockResolvedValue(Buffer.from('blob text', 'utf8'));
+    mocks.getBlobClient.mockReset().mockReturnValue({
+      downloadToBuffer: mocks.downloadToBuffer,
+    });
+    mocks.getContainerClient.mockReset().mockReturnValue({
+      getBlobClient: mocks.getBlobClient,
+    });
+    mocks.fromConnectionString.mockReset().mockReturnValue(mocks.serviceClient);
+    mocks.blobServiceClient.mockReset().mockImplementation(function BlobServiceClientMock() {
+      return mocks.serviceClient;
+    });
+    mocks.defaultAzureCredential
+      .mockReset()
+      .mockImplementation(function DefaultAzureCredentialMock() {
+        return { credential: 'default' };
+      });
   });
 
   afterEach(() => {
@@ -58,6 +72,15 @@ describe('Azure Blob test-set loading', () => {
       containerName: 'data',
       blobName: 'ianw/cyber-evals/tests.json',
       sasToken: '?sp=r&sig=abc',
+    });
+  });
+
+  it('preserves leading and repeated slashes in Azure blob names', () => {
+    expect(parseAzureBlobUri('az://account/container//folder//tests.json')).toEqual({
+      accountName: 'account',
+      containerName: 'container',
+      blobName: '/folder//tests.json',
+      sasToken: '',
     });
   });
 
@@ -97,5 +120,15 @@ describe('Azure Blob test-set loading', () => {
     expect(mocks.blobServiceClient).toHaveBeenCalledWith('https://account.blob.core.windows.net', {
       credential: 'default',
     });
+  });
+
+  it('redacts SAS query strings from read errors', async () => {
+    mocks.downloadToBuffer.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      readAzureBlobText('az://account/container/path/tests.json?sp=r&sig=secret'),
+    ).rejects.toThrow(
+      'Failed to read Azure Blob Storage URI "az://account/container/path/tests.json?<redacted>": boom',
+    );
   });
 });

--- a/test/util/azureBlob.test.ts
+++ b/test/util/azureBlob.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getEnvString } from '../../src/envars';
+import { parseAzureBlobUri, readAzureBlobText } from '../../src/util/azureBlob';
+
+const mocks = vi.hoisted(() => {
+  const downloadToBuffer = vi.fn();
+  const getBlobClient = vi.fn(() => ({ downloadToBuffer }));
+  const getContainerClient = vi.fn(() => ({ getBlobClient }));
+  const serviceClient = { getContainerClient };
+  const fromConnectionString = vi.fn(() => serviceClient);
+  const blobServiceClient = vi.fn(function BlobServiceClientMock() {
+    return serviceClient;
+  });
+  Object.assign(blobServiceClient, { fromConnectionString });
+
+  return {
+    blobServiceClient,
+    downloadToBuffer,
+    fromConnectionString,
+    getBlobClient,
+    getContainerClient,
+    serviceClient,
+    defaultAzureCredential: vi.fn(function DefaultAzureCredentialMock() {
+      return { credential: 'default' };
+    }),
+  };
+});
+
+vi.mock('@azure/storage-blob', () => ({
+  BlobServiceClient: mocks.blobServiceClient,
+}));
+
+vi.mock('@azure/identity', () => ({
+  DefaultAzureCredential: mocks.defaultAzureCredential,
+}));
+
+vi.mock('../../src/envars', async () => ({
+  ...(await vi.importActual('../../src/envars')),
+  getEnvString: vi.fn(),
+}));
+
+describe('Azure Blob test-set loading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnvString).mockReturnValue('');
+    mocks.downloadToBuffer.mockResolvedValue(Buffer.from('blob text', 'utf8'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('parses az:// account, container, blob, and SAS query string', () => {
+    expect(
+      parseAzureBlobUri('az://appliedciblobdata/data/ianw/cyber-evals/tests.json?sp=r&sig=abc'),
+    ).toEqual({
+      accountName: 'appliedciblobdata',
+      containerName: 'data',
+      blobName: 'ianw/cyber-evals/tests.json',
+      sasToken: '?sp=r&sig=abc',
+    });
+  });
+
+  it('rejects URIs without a blob path', () => {
+    expect(() => parseAzureBlobUri('az://account/container')).toThrow('blob path is missing');
+  });
+
+  it('uses URI SAS authentication when a query string is present', async () => {
+    const result = await readAzureBlobText('az://account/container/path/tests.json?sp=r&sig=abc');
+
+    expect(result).toBe('blob text');
+    expect(mocks.blobServiceClient).toHaveBeenCalledWith(
+      'https://account.blob.core.windows.net?sp=r&sig=abc',
+    );
+    expect(mocks.fromConnectionString).not.toHaveBeenCalled();
+    expect(mocks.defaultAzureCredential).not.toHaveBeenCalled();
+    expect(mocks.getContainerClient).toHaveBeenCalledWith('container');
+    expect(mocks.getBlobClient).toHaveBeenCalledWith('path/tests.json');
+  });
+
+  it('uses AZURE_STORAGE_CONNECTION_STRING when no SAS query string is present', async () => {
+    vi.mocked(getEnvString).mockReturnValue('UseDevelopmentStorage=true');
+
+    const result = await readAzureBlobText('az://account/container/path/tests.json');
+
+    expect(result).toBe('blob text');
+    expect(getEnvString).toHaveBeenCalledWith('AZURE_STORAGE_CONNECTION_STRING');
+    expect(mocks.fromConnectionString).toHaveBeenCalledWith('UseDevelopmentStorage=true');
+    expect(mocks.defaultAzureCredential).not.toHaveBeenCalled();
+  });
+
+  it('falls back to DefaultAzureCredential when no SAS or connection string is present', async () => {
+    const result = await readAzureBlobText('az://account/container/path/tests.json');
+
+    expect(result).toBe('blob text');
+    expect(mocks.defaultAzureCredential).toHaveBeenCalledTimes(1);
+    expect(mocks.blobServiceClient).toHaveBeenCalledWith('https://account.blob.core.windows.net', {
+      credential: 'default',
+    });
+  });
+});

--- a/test/util/azureBlob.test.ts
+++ b/test/util/azureBlob.test.ts
@@ -112,6 +112,19 @@ describe('Azure Blob test-set loading', () => {
     expect(mocks.defaultAzureCredential).not.toHaveBeenCalled();
   });
 
+  it('rejects connection strings that target a different storage account', async () => {
+    vi.mocked(getEnvString).mockReturnValue(
+      'DefaultEndpointsProtocol=https;AccountName=otheraccount;AccountKey=secret',
+    );
+
+    await expect(
+      readAzureBlobText('az://account/container/path/tests.json'),
+    ).rejects.toThrow(
+      'AZURE_STORAGE_CONNECTION_STRING targets storage account "otheraccount", but the az:// URI targets "account".',
+    );
+    expect(mocks.fromConnectionString).not.toHaveBeenCalled();
+  });
+
   it('falls back to DefaultAzureCredential when no SAS or connection string is present', async () => {
     const result = await readAzureBlobText('az://account/container/path/tests.json');
 
@@ -120,6 +133,18 @@ describe('Azure Blob test-set loading', () => {
     expect(mocks.blobServiceClient).toHaveBeenCalledWith('https://account.blob.core.windows.net', {
       credential: 'default',
     });
+  });
+
+  it('rejects non-SAS query strings instead of dropping configured credentials', async () => {
+    vi.mocked(getEnvString).mockReturnValue(
+      'DefaultEndpointsProtocol=https;AccountName=account;AccountKey=secret',
+    );
+
+    await expect(
+      readAzureBlobText('az://account/container/path/tests.json?snapshot=2026-05-19'),
+    ).rejects.toThrow('query string must be a SAS token containing a sig parameter');
+    expect(mocks.fromConnectionString).not.toHaveBeenCalled();
+    expect(mocks.defaultAzureCredential).not.toHaveBeenCalled();
   });
 
   it('redacts SAS query strings from read errors', async () => {

--- a/test/util/azureBlob.test.ts
+++ b/test/util/azureBlob.test.ts
@@ -88,6 +88,12 @@ describe('Azure Blob test-set loading', () => {
     expect(() => parseAzureBlobUri('az://account/container')).toThrow('blob path is missing');
   });
 
+  it('redacts SAS query strings while preserving URI fragments in parse errors', () => {
+    expect(() => parseAzureBlobUri('az://account/container?sp=r&sig=secret#preview')).toThrow(
+      'Invalid Azure Blob Storage URI "az://account/container?<redacted>#preview": blob path is missing.',
+    );
+  });
+
   it('uses URI SAS authentication when a query string is present', async () => {
     const result = await readAzureBlobText('az://account/container/path/tests.json?sp=r&sig=abc');
 

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -108,7 +108,10 @@ vi.mock('../../src/integrations/huggingfaceDatasets', () => ({
   fetchHuggingFaceDataset: vi.fn(),
 }));
 
-vi.mock('../../src/util/azureBlob', () => ({
+vi.mock('../../src/util/azureBlob', async () => ({
+  ...(await vi.importActual<typeof import('../../src/util/azureBlob')>(
+    '../../src/util/azureBlob',
+  )),
   readAzureBlobText: vi.fn(),
 }));
 
@@ -401,6 +404,66 @@ describe('readStandaloneTestsFile', () => {
       {
         description: 'Row #1',
         vars: { review_id: 'review-002' },
+      },
+    ]);
+  });
+
+  it('should read CSV test sets from Azure Blob Storage URIs', async () => {
+    const blobUri = 'az://account/container/tests.csv';
+    vi.mocked(readAzureBlobText).mockResolvedValue(
+      'review_id,__expected\nreview-004,ready',
+    );
+
+    const result = await readStandaloneTestsFile(blobUri);
+
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'ready' }],
+        description: 'Row #1',
+        options: {},
+        vars: { review_id: 'review-004' },
+      },
+    ]);
+  });
+
+  it('should read JSONL test sets from Azure Blob Storage URIs', async () => {
+    const blobUri = 'az://account/container/tests.jsonl';
+    vi.mocked(readAzureBlobText).mockResolvedValue(
+      '{"vars":{"review_id":"review-005"}}\n{"vars":{"review_id":"review-006"}}',
+    );
+
+    const result = await readStandaloneTestsFile(blobUri);
+
+    expect(result).toEqual([
+      {
+        description: 'Row #1',
+        vars: { review_id: 'review-005' },
+      },
+      {
+        description: 'Row #2',
+        vars: { review_id: 'review-006' },
+      },
+    ]);
+  });
+
+  it('should read YML test sets from Azure Blob Storage URIs', async () => {
+    const blobUri = 'az://account/container/tests.yml';
+    vi.mocked(readAzureBlobText).mockResolvedValue(dedent`
+      - description: Azure YML case
+        vars:
+          review_id: review-007
+        assert:
+          - type: equals
+            value: ready
+    `);
+
+    const result = await readStandaloneTestsFile(blobUri);
+
+    expect(result).toEqual([
+      {
+        assert: [{ type: 'equals', value: 'ready' }],
+        description: 'Azure YML case',
+        vars: { review_id: 'review-007' },
       },
     ]);
   });
@@ -1126,6 +1189,33 @@ describe('readTests', () => {
         assert: [{ type: 'equals', value: 'ready' }],
         description: 'Azure YAML case',
         vars: { review_id: 'review-003' },
+      },
+    ]);
+  });
+
+  it('readTests with Azure YAML vars files follows the local YAML normalization path', async () => {
+    const blobUri = 'az://account/container/tests.yaml';
+    vi.mocked(readAzureBlobText).mockResolvedValue(dedent`
+      - description: Azure YAML vars case
+        vars: vars1.yaml
+        assert:
+          - type: equals
+            value: ready
+    `);
+    vi.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob].flat());
+    vi.mocked(fs.readFileSync).mockReturnValueOnce(
+      yaml.dump({
+        review_id: 'review-008',
+      }),
+    );
+
+    const result = await readTests(blobUri);
+
+    expect(result).toEqual([
+      {
+        assert: [{ type: 'equals', value: 'ready' }],
+        description: 'Azure YAML vars case',
+        vars: { review_id: 'review-008' },
       },
     ]);
   });

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -1193,31 +1193,29 @@ describe('readTests', () => {
     ]);
   });
 
-  it('readTests with Azure YAML vars files follows the local YAML normalization path', async () => {
+  it('readTests with Azure YAML keeps blob content as remote test data', async () => {
     const blobUri = 'az://account/container/tests.yaml';
     vi.mocked(readAzureBlobText).mockResolvedValue(dedent`
-      - description: Azure YAML vars case
+      - description: Azure YAML remote data case
         vars: vars1.yaml
+        provider: file://providers/local.js
         assert:
           - type: equals
             value: ready
     `);
-    vi.mocked(globSync).mockImplementation((pathOrGlob) => [pathOrGlob].flat());
-    vi.mocked(fs.readFileSync).mockReturnValueOnce(
-      yaml.dump({
-        review_id: 'review-008',
-      }),
-    );
 
     const result = await readTests(blobUri);
 
     expect(result).toEqual([
       {
         assert: [{ type: 'equals', value: 'ready' }],
-        description: 'Azure YAML vars case',
-        vars: { review_id: 'review-008' },
+        description: 'Azure YAML remote data case',
+        provider: 'file://providers/local.js',
+        vars: 'vars1.yaml',
       },
     ]);
+    expect(globSync).not.toHaveBeenCalled();
+    expect(loadApiProvider).not.toHaveBeenCalled();
   });
 
   it('readTests with multiple __expected in CSV', async () => {

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -13,6 +13,7 @@ import logger from '../../src/logger';
 import { fetchCsvFromSharepoint } from '../../src/microsoftSharepoint';
 import { loadApiProvider } from '../../src/providers/index';
 import { runPython } from '../../src/python/pythonUtils';
+import { readAzureBlobText } from '../../src/util/azureBlob';
 import { maybeLoadConfigFromExternalFile } from '../../src/util/file';
 import {
   loadTestsFromGlob,
@@ -107,6 +108,10 @@ vi.mock('../../src/integrations/huggingfaceDatasets', () => ({
   fetchHuggingFaceDataset: vi.fn(),
 }));
 
+vi.mock('../../src/util/azureBlob', () => ({
+  readAzureBlobText: vi.fn(),
+}));
+
 vi.mock('../../src/telemetry', () => {
   const mockTelemetry = {
     record: vi.fn().mockResolvedValue(undefined),
@@ -174,6 +179,7 @@ const clearAllMocks = () => {
   vi.mocked(loadApiProvider).mockReset();
   vi.mocked(runPython).mockReset();
   vi.mocked(fetchHuggingFaceDataset).mockReset();
+  vi.mocked(readAzureBlobText).mockReset();
   vi.mocked(maybeLoadConfigFromExternalFile).mockReset();
   vi.mocked(importModule).mockReset();
 };
@@ -360,6 +366,24 @@ describe('readStandaloneTestsFile', () => {
         description: 'Row #2',
         options: {},
         vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
+  });
+
+  it('should read JSON test sets from hashed Azure Blob Storage URIs', async () => {
+    const blobUri =
+      'az://appliedciblobdata/data/ianw/cyber-evals/tests/cases.json.45856cafeef1d6df70c14f5b3c0cc353ecf3c22fa8653aa35ef0107b138f63fb';
+    vi.mocked(readAzureBlobText).mockResolvedValue(
+      JSON.stringify([{ vars: { review_id: 'review-001' } }]),
+    );
+
+    const result = await readStandaloneTestsFile(blobUri);
+
+    expect(readAzureBlobText).toHaveBeenCalledWith(blobUri);
+    expect(result).toEqual([
+      {
+        description: 'Row #1',
+        vars: { review_id: 'review-001' },
       },
     ]);
   });
@@ -1044,6 +1068,24 @@ describe('readTests', () => {
         vars: { var1: 'value3', var2: 'value4' },
         assert: [{ type: 'javascript', value: 'value5' }],
         options: {},
+      },
+    ]);
+  });
+
+  it('readTests with a hashed Azure Blob Storage JSON test set', async () => {
+    const blobUri =
+      'az://appliedciblobdata/data/ianw/cyber-evals/tests/cases.json.45856cafeef1d6df70c14f5b3c0cc353ecf3c22fa8653aa35ef0107b138f63fb';
+    vi.mocked(readAzureBlobText).mockResolvedValue(
+      JSON.stringify([{ vars: { review_id: 'review-001' } }]),
+    );
+
+    const result = await readTests(blobUri);
+
+    expect(readAzureBlobText).toHaveBeenCalledWith(blobUri);
+    expect(result).toEqual([
+      {
+        description: 'Row #1',
+        vars: { review_id: 'review-001' },
       },
     ]);
   });

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -388,6 +388,23 @@ describe('readStandaloneTestsFile', () => {
     ]);
   });
 
+  it('should read JSON test sets from SAS-authenticated Azure Blob Storage URIs', async () => {
+    const blobUri = 'az://account/container/tests.json?sp=r&sig=abc';
+    vi.mocked(readAzureBlobText).mockResolvedValue(
+      JSON.stringify([{ vars: { review_id: 'review-002' } }]),
+    );
+
+    const result = await readStandaloneTestsFile(blobUri);
+
+    expect(readAzureBlobText).toHaveBeenCalledWith(blobUri);
+    expect(result).toEqual([
+      {
+        description: 'Row #1',
+        vars: { review_id: 'review-002' },
+      },
+    ]);
+  });
+
   it('should prefer SharePoint URL handling over local JSON parsing when URL ends with .json', async () => {
     const sharepointUrls = [
       'https://example.sharepoint.com/sites/team/tests.json',
@@ -1086,6 +1103,29 @@ describe('readTests', () => {
       {
         description: 'Row #1',
         vars: { review_id: 'review-001' },
+      },
+    ]);
+  });
+
+  it('readTests with a scalar Azure Blob Storage YAML test set', async () => {
+    const blobUri = 'az://account/container/tests.yaml';
+    vi.mocked(readAzureBlobText).mockResolvedValue(dedent`
+      - description: Azure YAML case
+        vars:
+          review_id: review-003
+        assert:
+          - type: equals
+            value: ready
+    `);
+
+    const result = await readTests(blobUri);
+
+    expect(readAzureBlobText).toHaveBeenCalledWith(blobUri);
+    expect(result).toEqual([
+      {
+        assert: [{ type: 'equals', value: 'ready' }],
+        description: 'Azure YAML case',
+        vars: { review_id: 'review-003' },
       },
     ]);
   });


### PR DESCRIPTION
Adds first-class az:// test-set loading backed by Azure Blob Storage authentication, plus docs for the URI format, supported files, and credential options.