### PR TITLE
fix(providers): execute Anthropic MCP tool results

### DIFF
--- a/examples/anthropic/mcp/README.md
+++ b/examples/anthropic/mcp/README.md
@@ -1,0 +1,48 @@
+# anthropic/mcp (Anthropic Messages + MCP tools)
+
+This example wires Claude up to a [Model Context Protocol](https://modelcontextprotocol.io) server through the Anthropic Messages provider. Promptfoo exposes the MCP server's tools to Claude, executes any `tool_use` blocks the model emits, and feeds the `tool_result` back into the conversation until Claude produces a final reply.
+
+```bash
+npx promptfoo@latest init --example anthropic/mcp
+cd anthropic/mcp
+```
+
+## Setup
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+npx promptfoo@latest eval
+```
+
+The bundled config uses the public [deepwiki MCP server](https://mcp.deepwiki.com/) so the example works out of the box without installing anything. To swap in your own server, replace the `mcp` block:
+
+```yaml
+mcp:
+  enabled: true
+  # Local stdio server
+  server:
+    command: npx
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/workspace']
+  # …or remote SSE / streamable HTTP
+  # servers:
+  #   - name: my-server
+  #     url: https://example.com/mcp
+```
+
+## What it demonstrates
+
+- **Tool discovery**: Tools exposed by the MCP server are forwarded to Claude alongside any inline `tools` you define.
+- **Multi-round execution**: When Claude returns a `tool_use` block matching an MCP tool, promptfoo invokes the tool with the model's arguments and appends a `tool_result` on the next user turn. The loop continues until Claude returns text — bounded by `max_tool_calls` (default `8`).
+- **Error pass-through**: Tool errors come back as `tool_result` blocks with `is_error: true` so Claude can recover or report the failure.
+- **Mixed tool handling**: Non-MCP tools (regular function-calling tools, or built-ins like `web_search`) fall through to the existing tool-use output without being auto-executed.
+
+## Caching
+
+Promptfoo's disk response cache is **skipped automatically** when `mcp.enabled` is `true`, because tool results can vary between runs. Use `max_tool_calls` to bound the per-request cost.
+
+## See also
+
+- [Anthropic provider docs](https://promptfoo.dev/docs/providers/anthropic/#model-context-protocol-mcp)
+- [MCP integration guide](https://promptfoo.dev/docs/integrations/mcp/) — full server configuration (auth, timeouts, multi-server)
+- [examples/openai-mcp](../../openai-mcp/) — the same pattern via the OpenAI Responses API
+- [examples/simple-mcp](../../simple-mcp/) — testing an MCP server directly without an LLM provider

--- a/examples/anthropic/mcp/promptfooconfig.yaml
+++ b/examples/anthropic/mcp/promptfooconfig.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Anthropic Messages provider with MCP tool execution'
+
+prompts:
+  - 'Answer the question using the available MCP tools, then summarize what you found in 2-3 sentences. Question: {{question}}'
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    label: 'Claude Sonnet 4.6 + deepwiki MCP'
+    config:
+      max_tokens: 1500
+      temperature: 0
+      # Cap how many MCP rounds promptfoo will run per request. Default is 8.
+      max_tool_calls: 5
+      mcp:
+        enabled: true
+        servers:
+          # Hosted MCP server with two tools: ask_question, read_wiki_structure.
+          # Streams over HTTP — no local install required to try this example.
+          - name: deepwiki
+            url: https://mcp.deepwiki.com/mcp
+
+tests:
+  - vars:
+      question: 'Which transport protocols are described in the modelcontextprotocol/modelcontextprotocol repository?'
+    assert:
+      - type: contains-any
+        value: ['stdio', 'sse', 'streamable']
+      - type: llm-rubric
+        value: 'The response identifies at least one MCP transport (stdio, SSE, or streamable HTTP) and explains its purpose.'
+
+  - vars:
+      question: 'What is the high-level architecture of the promptfoo/promptfoo repository according to its docs?'
+    assert:
+      - type: contains
+        value: 'promptfoo'
+      - type: llm-rubric
+        value: 'The response describes promptfoo as an evaluation framework for LLMs (or similar wording) and mentions at least one concrete feature such as evals, redteam, providers, or assertions.'
+
+  # Demonstrate the loop terminating gracefully when the model decides it has
+  # enough information without further tool calls.
+  - vars:
+      question: 'In one sentence, what does MCP stand for?'
+    assert:
+      - type: contains
+        value: 'Model Context Protocol'

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -154,6 +154,8 @@ The Anthropic provider supports several options to customize the behavior of the
 - `stop_sequences`: An array of strings that stop generation when encountered.
 - `metadata`: Request metadata (e.g., `user_id`) passed to the API.
 - `extra_body`: Additional parameters to pass directly to the Anthropic API request body.
+- `mcp`: Connect to one or more [Model Context Protocol](#model-context-protocol-mcp) servers. Tools exposed by the server become callable by Claude.
+- `max_tool_calls`: Maximum number of MCP tool executions promptfoo will perform per request before aborting the loop. Defaults to `8` and is only relevant when `mcp.enabled` is `true`.
 
 Example configuration with options and prompts:
 
@@ -860,7 +862,7 @@ We provide several example implementations demonstrating Claude's capabilities:
 #### Core Features
 
 - [Tool Use Example](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-tool-use) - Shows how to use Claude's tool calling capabilities
-- [MCP Example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/mcp) - Run Claude against a local Model Context Protocol server
+- [MCP Example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/mcp) - Connect Claude to a Model Context Protocol server and let it execute the discovered tools
 - [Structured Outputs Example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/structured-outputs) - Demonstrates JSON outputs and strict tool use for guaranteed schema compliance
 - [Vision Example](https://github.com/promptfoo/promptfoo/tree/main/examples/claude-vision) - Demonstrates using Claude's vision capabilities
 

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -10,7 +10,7 @@ This provider supports the [Anthropic Claude](https://www.anthropic.com/claude) 
 > **Note:** Anthropic models can also be accessed through [Azure AI Foundry](/docs/providers/azure/#using-claude-models), [AWS Bedrock](/docs/providers/aws-bedrock/), and [Google Vertex](/docs/providers/vertex/).
 
 :::tip Agentic Evals
-For agentic evaluations with file access, tool use, and MCP servers, see the [Claude Agent SDK provider](/docs/providers/claude-agent-sdk/).
+For agentic evaluations that need built-in file access and skill plugins on top of the Messages API, see the [Claude Agent SDK provider](/docs/providers/claude-agent-sdk/). The Messages provider documented here speaks directly to MCP servers via the [`mcp` config](#model-context-protocol-mcp) so you can plug in your own tools without changing providers.
 :::
 
 ## Setup
@@ -363,6 +363,42 @@ providers:
   - Use `allowed_domains` to whitelist trusted domains (recommended)
   - Use `blocked_domains` to blacklist specific domains
   - **Note:** Only one of `allowed_domains` or `blocked_domains` can be specified, not both
+
+#### Model Context Protocol (MCP)
+
+The Anthropic Messages provider can connect to any [MCP server](https://modelcontextprotocol.io) — stdio, SSE, or streamable HTTP — and execute the model's `tool_use` blocks against that server, feeding the `tool_result` back into the conversation until Claude produces a final reply.
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      mcp:
+        enabled: true
+        # Inline command-based stdio server, or `path` to a local script
+        server:
+          command: npx
+          args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/workspace']
+        # Or use a remote SSE / streamable HTTP server
+        # servers:
+        #   - name: deepwiki
+        #     url: https://mcp.deepwiki.com/mcp
+      # Optional cap on MCP rounds per request (default 8). Enforced locally;
+      # not sent to Anthropic.
+      max_tool_calls: 5
+```
+
+How it works:
+
+- Tools discovered on the MCP server are passed to Claude alongside any inline `tools`.
+- When Claude returns a `tool_use` block whose name matches an MCP tool, promptfoo calls the tool with the model's arguments and appends a matching `tool_result` block on the user turn.
+- The loop repeats until Claude returns text (no more `tool_use`) or `max_tool_calls` is hit. Tool errors are forwarded as `tool_result` blocks with `is_error: true` so the model can recover.
+- Non-MCP `tool_use` blocks (regular function tools, or built-ins like `web_search`) are passed through to the existing output and not auto-executed.
+
+:::note Response caching with MCP
+The disk response cache is skipped while `mcp.enabled` is `true`, because tool results can be non-deterministic between runs. Use `max_tool_calls` to bound spend.
+:::
+
+See the [MCP integration guide](/docs/integrations/mcp/) for full server configuration options (auth, timeouts, multiple servers, etc.) and the [Anthropic MCP example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/mcp).
 
 See the [Anthropic Tool Use Guide](https://docs.anthropic.com/en/docs/tool-use) for more information on how to define tools and the tool use example [here](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-tool-use).
 
@@ -824,6 +860,7 @@ We provide several example implementations demonstrating Claude's capabilities:
 #### Core Features
 
 - [Tool Use Example](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-tool-use) - Shows how to use Claude's tool calling capabilities
+- [MCP Example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/mcp) - Run Claude against a local Model Context Protocol server
 - [Structured Outputs Example](https://github.com/promptfoo/promptfoo/tree/main/examples/anthropic/structured-outputs) - Demonstrates JSON outputs and strict tool use for guaranteed schema compliance
 - [Vision Example](https://github.com/promptfoo/promptfoo/tree/main/examples/claude-vision) - Demonstrates using Claude's vision capabilities
 

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -38,6 +38,8 @@ import type { EnvOverrides } from '../../types/env';
 import type { CallApiContextParams, ProviderResponse } from '../../types/index';
 import type { AnthropicMessageOptions } from './types';
 
+const DEFAULT_MAX_MCP_TOOL_CALLS = 8;
+
 function parseEnvFloat(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -109,6 +111,99 @@ function getMessagesResponseMetadata(response: Anthropic.Messages.Message) {
   };
 }
 
+function getMaxMcpToolCalls(config: AnthropicMessageOptions): number {
+  if (config.max_tool_calls == null) {
+    return DEFAULT_MAX_MCP_TOOL_CALLS;
+  }
+
+  if (!Number.isFinite(config.max_tool_calls) || config.max_tool_calls < 1) {
+    return DEFAULT_MAX_MCP_TOOL_CALLS;
+  }
+
+  return Math.floor(config.max_tool_calls);
+}
+
+function normalizeMcpToolContent(content: unknown): string {
+  if (content == null) {
+    return '';
+  }
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (part && typeof part === 'object') {
+          if ('text' in part && (part as { text?: unknown }).text != null) {
+            return String((part as { text: unknown }).text);
+          }
+          if ('json' in part) {
+            return JSON.stringify((part as { json: unknown }).json);
+          }
+          if ('data' in part) {
+            return JSON.stringify((part as { data: unknown }).data);
+          }
+          return JSON.stringify(part);
+        }
+        return String(part);
+      })
+      .join('\n');
+  }
+  return JSON.stringify(content);
+}
+
+function coerceMcpToolInput(input: unknown): Record<string, unknown> {
+  if (input == null || input === '') {
+    return {};
+  }
+  if (typeof input === 'string') {
+    const parsed = JSON.parse(input);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : {};
+  }
+  return typeof input === 'object' && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : {};
+}
+
+function mergeAnthropicUsage(
+  messages: Anthropic.Messages.Message[],
+): Anthropic.Messages.Message['usage'] | undefined {
+  const usageEntries = messages.map((message) => message.usage).filter((usage) => usage != null);
+
+  if (usageEntries.length === 0) {
+    return undefined;
+  }
+
+  return usageEntries.reduce<NonNullable<Anthropic.Messages.Message['usage']>>(
+    (acc, usage) => ({
+      ...usage,
+      input_tokens: acc.input_tokens + (usage.input_tokens ?? 0),
+      output_tokens: acc.output_tokens + (usage.output_tokens ?? 0),
+      cache_creation_input_tokens:
+        (acc.cache_creation_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
+      cache_read_input_tokens:
+        (acc.cache_read_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0),
+    }),
+    {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  );
+}
+
+function withMergedAnthropicUsage(
+  response: Anthropic.Messages.Message,
+  responses: Anthropic.Messages.Message[],
+): Anthropic.Messages.Message {
+  const usage = mergeAnthropicUsage(responses);
+  return usage ? { ...response, usage } : response;
+}
+
 export class AnthropicMessagesProvider extends AnthropicGenericProvider {
   declare config: AnthropicMessageOptions;
   private mcpClient: MCPClient | null = null;
@@ -150,6 +245,130 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       await this.initializationPromise;
       await this.mcpClient.cleanup();
       this.mcpClient = null;
+    }
+  }
+
+  private async resolveMcpToolUse({
+    config,
+    headers,
+    initialResponse,
+    params,
+    shouldStream,
+  }: {
+    config: AnthropicMessageOptions;
+    headers: Record<string, string>;
+    initialResponse: Anthropic.Messages.Message;
+    params: Anthropic.Messages.MessageCreateParams;
+    shouldStream: boolean;
+  }): Promise<{ error?: string; response: Anthropic.Messages.Message }> {
+    if (!this.mcpClient) {
+      return { response: initialResponse };
+    }
+
+    const mcpToolNames = new Set(this.mcpClient.getAllTools().map((tool) => tool.name));
+    if (mcpToolNames.size === 0) {
+      return { response: initialResponse };
+    }
+
+    let response = initialResponse;
+    const responses = [initialResponse];
+    let messages = params.messages;
+    const maxToolCalls = getMaxMcpToolCalls(config);
+
+    for (let iteration = 0; iteration < maxToolCalls; iteration++) {
+      const toolUses = response.content.filter(
+        (block): block is Anthropic.Messages.ToolUseBlock =>
+          block.type === 'tool_use' && mcpToolNames.has(block.name),
+      );
+
+      if (toolUses.length === 0) {
+        return { response: withMergedAnthropicUsage(response, responses) };
+      }
+
+      const toolResultBlocks = await Promise.all(
+        toolUses.map((toolUse) => this.callMcpToolForAnthropic(toolUse)),
+      );
+
+      messages = [
+        ...messages,
+        {
+          role: 'assistant',
+          content: response.content as Anthropic.Messages.ContentBlockParam[],
+        },
+        {
+          role: 'user',
+          content: toolResultBlocks,
+        },
+      ];
+
+      const nextParams = {
+        ...params,
+        messages,
+      };
+
+      if (shouldStream) {
+        const stream = await this.anthropic.messages.stream(nextParams, {
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
+        });
+        response = await stream.finalMessage();
+      } else {
+        response = (await this.anthropic.messages.create(nextParams, {
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
+        })) as Anthropic.Messages.Message;
+      }
+
+      logger.debug('Anthropic Messages API MCP follow-up response', {
+        response: getMessagesResponseMetadata(response),
+      });
+      responses.push(response);
+    }
+
+    const unresolvedToolUses = response.content.filter(
+      (block) => block.type === 'tool_use' && mcpToolNames.has(block.name),
+    );
+
+    return {
+      response: withMergedAnthropicUsage(response, responses),
+      ...(unresolvedToolUses.length > 0
+        ? {
+            error: `Anthropic MCP tool-use loop exceeded max_tool_calls=${maxToolCalls}. Increase provider config.max_tool_calls if this evaluation legitimately needs more tool calls.`,
+          }
+        : {}),
+    };
+  }
+
+  private async callMcpToolForAnthropic(
+    toolUse: Anthropic.Messages.ToolUseBlock,
+  ): Promise<Anthropic.Messages.ToolResultBlockParam> {
+    try {
+      const result = await this.mcpClient!.callTool(
+        toolUse.name,
+        coerceMcpToolInput(toolUse.input),
+      );
+
+      if (result.error) {
+        return {
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: `MCP Tool Error (${toolUse.name}): ${result.error}`,
+          is_error: true,
+        };
+      }
+
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: normalizeMcpToolContent(result.content),
+      };
+    } catch (error) {
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: `MCP Tool Error (${toolUse.name}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        is_error: true,
+      };
     }
   }
 
@@ -543,16 +762,30 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           finalMessage: getMessagesResponseMetadata(finalMessage),
         });
 
+        const { error, response: resolvedMessage } = await this.resolveMcpToolUse({
+          config,
+          headers,
+          initialResponse: finalMessage,
+          params,
+          shouldStream,
+        });
+        if (error) {
+          return {
+            error,
+            tokenUsage: getTokenUsage(resolvedMessage, false),
+          };
+        }
+
         if (isCacheEnabled()) {
           try {
-            await cache.set(cacheKey, JSON.stringify(finalMessage));
+            await cache.set(cacheKey, JSON.stringify(resolvedMessage));
           } catch (err) {
             logger.error(`Failed to cache response: ${String(err)}`);
           }
         }
 
-        const finishReason = normalizeFinishReason(finalMessage.stop_reason);
-        let output = outputFromMessage(finalMessage, config.showThinking ?? true);
+        const finishReason = normalizeFinishReason(resolvedMessage.stop_reason);
+        let output = outputFromMessage(resolvedMessage, config.showThinking ?? true);
 
         // Handle structured JSON output parsing
         if (processedOutputFormat?.type === 'json_schema' && typeof output === 'string') {
@@ -563,23 +796,23 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           }
         }
 
-        const refusalDetails = getRefusalDetails(finalMessage);
+        const refusalDetails = getRefusalDetails(resolvedMessage);
         if (refusalDetails) {
           logger.warn(refusalDetails);
         }
 
         return {
           output,
-          tokenUsage: getTokenUsage(finalMessage, false),
+          tokenUsage: getTokenUsage(resolvedMessage, false),
           ...(finishReason && { finishReason }),
           ...(refusalDetails && { guardrails: { flagged: true, reason: refusalDetails } }),
           cost: calculateAnthropicCost(
             this.modelName,
             config,
-            finalMessage.usage?.input_tokens,
-            finalMessage.usage?.output_tokens,
-            finalMessage.usage?.cache_read_input_tokens ?? undefined,
-            finalMessage.usage?.cache_creation_input_tokens ?? undefined,
+            resolvedMessage.usage?.input_tokens,
+            resolvedMessage.usage?.output_tokens,
+            resolvedMessage.usage?.cache_read_input_tokens ?? undefined,
+            resolvedMessage.usage?.cache_creation_input_tokens ?? undefined,
           ),
         };
       } else {
@@ -591,16 +824,30 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           response: getMessagesResponseMetadata(response),
         });
 
+        const { error, response: resolvedMessage } = await this.resolveMcpToolUse({
+          config,
+          headers,
+          initialResponse: response,
+          params,
+          shouldStream,
+        });
+        if (error) {
+          return {
+            error,
+            tokenUsage: getTokenUsage(resolvedMessage, false),
+          };
+        }
+
         if (isCacheEnabled()) {
           try {
-            await cache.set(cacheKey, JSON.stringify(response));
+            await cache.set(cacheKey, JSON.stringify(resolvedMessage));
           } catch (err) {
             logger.error(`Failed to cache response: ${String(err)}`);
           }
         }
 
-        const finishReason = normalizeFinishReason(response.stop_reason);
-        let output = outputFromMessage(response, config.showThinking ?? true);
+        const finishReason = normalizeFinishReason(resolvedMessage.stop_reason);
+        let output = outputFromMessage(resolvedMessage, config.showThinking ?? true);
 
         // Handle structured JSON output parsing
         if (processedOutputFormat?.type === 'json_schema' && typeof output === 'string') {
@@ -611,23 +858,23 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           }
         }
 
-        const refusalDetails = getRefusalDetails(response);
+        const refusalDetails = getRefusalDetails(resolvedMessage);
         if (refusalDetails) {
           logger.warn(refusalDetails);
         }
 
         return {
           output,
-          tokenUsage: getTokenUsage(response, false),
+          tokenUsage: getTokenUsage(resolvedMessage, false),
           ...(finishReason && { finishReason }),
           ...(refusalDetails && { guardrails: { flagged: true, reason: refusalDetails } }),
           cost: calculateAnthropicCost(
             this.modelName,
             config,
-            response.usage?.input_tokens,
-            response.usage?.output_tokens,
-            response.usage?.cache_read_input_tokens ?? undefined,
-            response.usage?.cache_creation_input_tokens ?? undefined,
+            resolvedMessage.usage?.input_tokens,
+            resolvedMessage.usage?.output_tokens,
+            resolvedMessage.usage?.cache_read_input_tokens ?? undefined,
+            resolvedMessage.usage?.cache_creation_input_tokens ?? undefined,
           ),
         };
       }

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -177,7 +177,9 @@ function mergeAnthropicUsage(
     return undefined;
   }
 
-  return usageEntries.reduce<NonNullable<Anthropic.Messages.Message['usage']>>(
+  const [firstUsage, ...remainingUsageEntries] = usageEntries;
+
+  return remainingUsageEntries.reduce<NonNullable<Anthropic.Messages.Message['usage']>>(
     (acc, usage) => ({
       ...usage,
       input_tokens: acc.input_tokens + (usage.input_tokens ?? 0),
@@ -187,12 +189,7 @@ function mergeAnthropicUsage(
       cache_read_input_tokens:
         (acc.cache_read_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0),
     }),
-    {
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_creation_input_tokens: 0,
-      cache_read_input_tokens: 0,
-    },
+    firstUsage,
   );
 }
 

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -283,6 +283,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     const responses = [initialResponse];
     let messages = params.messages;
     const maxToolCalls = getMaxMcpToolCalls(config);
+    let executedMcpToolCalls = 0;
 
     for (let iteration = 0; iteration < maxToolCalls; iteration++) {
       const responseToolUses = response.content.filter(
@@ -302,6 +303,14 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
         return { response: withMergedAnthropicUsage(response, responses) };
       }
 
+      if (executedMcpToolCalls + toolUses.length > maxToolCalls) {
+        return {
+          response: withMergedAnthropicUsage(response, responses),
+          error: `Anthropic MCP tool execution exceeded max_tool_calls=${maxToolCalls}. Increase provider config.max_tool_calls if this evaluation legitimately needs more tool calls.`,
+        };
+      }
+
+      executedMcpToolCalls += toolUses.length;
       const toolResultBlocks = await Promise.all(
         toolUses.map((toolUse) => this.callMcpToolForAnthropic(toolUse)),
       );
@@ -345,7 +354,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       response: withMergedAnthropicUsage(response, responses),
       ...(unresolvedToolUses.length > 0
         ? {
-            error: `Anthropic MCP tool-use loop exceeded max_tool_calls=${maxToolCalls}. Increase provider config.max_tool_calls if this evaluation legitimately needs more tool calls.`,
+            error: `Anthropic MCP tool execution exceeded max_tool_calls=${maxToolCalls}. Increase provider config.max_tool_calls if this evaluation legitimately needs more tool calls.`,
           }
         : {}),
     };

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -213,6 +213,21 @@ function withMergedAnthropicUsage(
   return usage ? { ...response, usage } : response;
 }
 
+function getAnthropicCostFromMessage(
+  modelName: string,
+  config: AnthropicMessageOptions,
+  message: Anthropic.Messages.Message,
+): number | undefined {
+  return calculateAnthropicCost(
+    modelName,
+    config,
+    message.usage?.input_tokens,
+    message.usage?.output_tokens,
+    message.usage?.cache_read_input_tokens ?? undefined,
+    message.usage?.cache_creation_input_tokens ?? undefined,
+  );
+}
+
 export class AnthropicMessagesProvider extends AnthropicGenericProvider {
   declare config: AnthropicMessageOptions;
   private mcpClient: MCPClient | null = null;
@@ -753,14 +768,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
             ...(cachedRefusalDetails && {
               guardrails: { flagged: true, reason: cachedRefusalDetails },
             }),
-            cost: calculateAnthropicCost(
-              this.modelName,
-              config,
-              parsedCachedResponse.usage?.input_tokens,
-              parsedCachedResponse.usage?.output_tokens,
-              parsedCachedResponse.usage?.cache_read_input_tokens ?? undefined,
-              parsedCachedResponse.usage?.cache_creation_input_tokens ?? undefined,
-            ),
+            cost: getAnthropicCostFromMessage(this.modelName, config, parsedCachedResponse),
             cached: true,
           };
         } catch {
@@ -773,135 +781,78 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       }
     }
 
+    const requestOptions =
+      Object.keys(headers).length > 0 ? ({ headers } as { headers: Record<string, string> }) : {};
+
     try {
+      let initialMessage: Anthropic.Messages.Message;
       if (shouldStream) {
-        // Handle streaming request
-        const stream = await this.anthropic.messages.stream(params, {
-          ...(typeof headers === 'object' && Object.keys(headers).length > 0 ? { headers } : {}),
-        });
-
-        // Wait for the stream to complete and get the final message
-        const finalMessage = await stream.finalMessage();
+        const stream = await this.anthropic.messages.stream(params, requestOptions);
+        initialMessage = await stream.finalMessage();
         logger.debug(`Anthropic Messages API streaming complete`, {
-          finalMessage: getMessagesResponseMetadata(finalMessage),
+          finalMessage: getMessagesResponseMetadata(initialMessage),
         });
-
-        const { error, response: resolvedMessage } = await this.resolveMcpToolUse({
-          config,
-          headers,
-          initialResponse: finalMessage,
-          params,
-          shouldStream,
-        });
-        if (error) {
-          return {
-            error,
-            tokenUsage: getTokenUsage(resolvedMessage, false),
-          };
-        }
-
-        if (shouldUseResponseCache) {
-          try {
-            await cache.set(cacheKey, JSON.stringify(resolvedMessage));
-          } catch (err) {
-            logger.error(`Failed to cache response: ${String(err)}`);
-          }
-        }
-
-        const finishReason = normalizeFinishReason(resolvedMessage.stop_reason);
-        let output = outputFromMessage(resolvedMessage, config.showThinking ?? true);
-
-        // Handle structured JSON output parsing
-        if (processedOutputFormat?.type === 'json_schema' && typeof output === 'string') {
-          try {
-            output = JSON.parse(output);
-          } catch (error) {
-            logger.error(`Failed to parse JSON output from structured outputs: ${error}`);
-          }
-        }
-
-        const refusalDetails = getRefusalDetails(resolvedMessage);
-        if (refusalDetails) {
-          logger.warn(refusalDetails);
-        }
-
-        return {
-          output,
-          tokenUsage: getTokenUsage(resolvedMessage, false),
-          ...(finishReason && { finishReason }),
-          ...(refusalDetails && { guardrails: { flagged: true, reason: refusalDetails } }),
-          cost: calculateAnthropicCost(
-            this.modelName,
-            config,
-            resolvedMessage.usage?.input_tokens,
-            resolvedMessage.usage?.output_tokens,
-            resolvedMessage.usage?.cache_read_input_tokens ?? undefined,
-            resolvedMessage.usage?.cache_creation_input_tokens ?? undefined,
-          ),
-        };
       } else {
-        // Handle non-streaming request
-        const response = (await this.anthropic.messages.create(params, {
-          ...(typeof headers === 'object' && Object.keys(headers).length > 0 ? { headers } : {}),
-        })) as Anthropic.Messages.Message;
-        logger.debug(`Anthropic Messages API response`, {
-          response: getMessagesResponseMetadata(response),
-        });
-
-        const { error, response: resolvedMessage } = await this.resolveMcpToolUse({
-          config,
-          headers,
-          initialResponse: response,
+        initialMessage = (await this.anthropic.messages.create(
           params,
-          shouldStream,
+          requestOptions,
+        )) as Anthropic.Messages.Message;
+        logger.debug(`Anthropic Messages API response`, {
+          response: getMessagesResponseMetadata(initialMessage),
         });
-        if (error) {
-          return {
-            error,
-            tokenUsage: getTokenUsage(resolvedMessage, false),
-          };
-        }
+      }
 
-        if (shouldUseResponseCache) {
-          try {
-            await cache.set(cacheKey, JSON.stringify(resolvedMessage));
-          } catch (err) {
-            logger.error(`Failed to cache response: ${String(err)}`);
-          }
-        }
+      const { error, response: resolvedMessage } = await this.resolveMcpToolUse({
+        config,
+        headers,
+        initialResponse: initialMessage,
+        params,
+        shouldStream,
+      });
 
-        const finishReason = normalizeFinishReason(resolvedMessage.stop_reason);
-        let output = outputFromMessage(resolvedMessage, config.showThinking ?? true);
-
-        // Handle structured JSON output parsing
-        if (processedOutputFormat?.type === 'json_schema' && typeof output === 'string') {
-          try {
-            output = JSON.parse(output);
-          } catch (error) {
-            logger.error(`Failed to parse JSON output from structured outputs: ${error}`);
-          }
-        }
-
-        const refusalDetails = getRefusalDetails(resolvedMessage);
-        if (refusalDetails) {
-          logger.warn(refusalDetails);
-        }
-
+      if (error) {
+        // max_tool_calls was exceeded — tokens were still spent across the loop,
+        // so surface the cost alongside the error so it doesn't disappear from
+        // eval cost tracking.
         return {
-          output,
+          error,
           tokenUsage: getTokenUsage(resolvedMessage, false),
-          ...(finishReason && { finishReason }),
-          ...(refusalDetails && { guardrails: { flagged: true, reason: refusalDetails } }),
-          cost: calculateAnthropicCost(
-            this.modelName,
-            config,
-            resolvedMessage.usage?.input_tokens,
-            resolvedMessage.usage?.output_tokens,
-            resolvedMessage.usage?.cache_read_input_tokens ?? undefined,
-            resolvedMessage.usage?.cache_creation_input_tokens ?? undefined,
-          ),
+          cost: getAnthropicCostFromMessage(this.modelName, config, resolvedMessage),
         };
       }
+
+      if (shouldUseResponseCache) {
+        try {
+          await cache.set(cacheKey, JSON.stringify(resolvedMessage));
+        } catch (err) {
+          logger.error(`Failed to cache response: ${String(err)}`);
+        }
+      }
+
+      const finishReason = normalizeFinishReason(resolvedMessage.stop_reason);
+      let output = outputFromMessage(resolvedMessage, config.showThinking ?? true);
+
+      // Handle structured JSON output parsing
+      if (processedOutputFormat?.type === 'json_schema' && typeof output === 'string') {
+        try {
+          output = JSON.parse(output);
+        } catch (error) {
+          logger.error(`Failed to parse JSON output from structured outputs: ${error}`);
+        }
+      }
+
+      const refusalDetails = getRefusalDetails(resolvedMessage);
+      if (refusalDetails) {
+        logger.warn(refusalDetails);
+      }
+
+      return {
+        output,
+        tokenUsage: getTokenUsage(resolvedMessage, false),
+        ...(finishReason && { finishReason }),
+        ...(refusalDetails && { guardrails: { flagged: true, reason: refusalDetails } }),
+        cost: getAnthropicCostFromMessage(this.modelName, config, resolvedMessage),
+      };
     } catch (err) {
       logger.error(
         `Anthropic Messages API call error: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -123,6 +123,18 @@ function getMaxMcpToolCalls(config: AnthropicMessageOptions): number {
   return Math.floor(config.max_tool_calls);
 }
 
+function getMcpContinuationParams(
+  params: Anthropic.Messages.MessageCreateParams,
+  messages: Anthropic.Messages.MessageCreateParams['messages'],
+): Anthropic.Messages.MessageCreateParams {
+  if (params.tool_choice?.type === 'any' || params.tool_choice?.type === 'tool') {
+    const { tool_choice: _toolChoice, ...continuationParams } = params;
+    return { ...continuationParams, messages };
+  }
+
+  return { ...params, messages };
+}
+
 function normalizeMcpToolContent(content: unknown): string {
   if (content == null) {
     return '';
@@ -273,12 +285,20 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     const maxToolCalls = getMaxMcpToolCalls(config);
 
     for (let iteration = 0; iteration < maxToolCalls; iteration++) {
-      const toolUses = response.content.filter(
+      const responseToolUses = response.content.filter(
         (block): block is Anthropic.Messages.ToolUseBlock =>
-          block.type === 'tool_use' && mcpToolNames.has(block.name),
+          block.type === 'tool_use',
       );
+      const toolUses = responseToolUses.filter((block) => mcpToolNames.has(block.name));
 
       if (toolUses.length === 0) {
+        return { response: withMergedAnthropicUsage(response, responses) };
+      }
+
+      if (toolUses.length !== responseToolUses.length) {
+        logger.warn(
+          'Skipping Anthropic MCP continuation because the response mixes MCP and non-MCP tool_use blocks.',
+        );
         return { response: withMergedAnthropicUsage(response, responses) };
       }
 
@@ -298,10 +318,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
         },
       ];
 
-      const nextParams = {
-        ...params,
-        messages,
-      };
+      const nextParams = getMcpContinuationParams(params, messages);
 
       if (shouldStream) {
         const stream = await this.anthropic.messages.stream(nextParams, {
@@ -697,8 +714,9 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
         ...(cacheKeyHeaders ? { headers: cacheKeyHeaders } : {}),
       },
     )}`;
+    const shouldUseResponseCache = isCacheEnabled() && config.mcp?.enabled !== true;
 
-    if (isCacheEnabled()) {
+    if (shouldUseResponseCache) {
       // Try to get the cached response
       const cachedResponse = await cache.get<string | undefined>(cacheKey);
       if (cachedResponse) {
@@ -773,7 +791,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           };
         }
 
-        if (isCacheEnabled()) {
+        if (shouldUseResponseCache) {
           try {
             await cache.set(cacheKey, JSON.stringify(resolvedMessage));
           } catch (err) {
@@ -835,7 +853,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           };
         }
 
-        if (isCacheEnabled()) {
+        if (shouldUseResponseCache) {
           try {
             await cache.set(cacheKey, JSON.stringify(resolvedMessage));
           } catch (err) {

--- a/src/providers/anthropic/types.ts
+++ b/src/providers/anthropic/types.ts
@@ -112,9 +112,9 @@ export interface AnthropicMessageOptions {
   showThinking?: boolean;
   mcp?: MCPConfig;
   /**
-   * Maximum number of MCP tool-use continuation rounds for Anthropic Messages.
-   * Defaults to 8. This is enforced locally by promptfoo and is not sent to
-   * Anthropic.
+   * Maximum number of MCP tool executions across Anthropic Messages
+   * continuations. Defaults to 8. This is enforced locally by promptfoo and is
+   * not sent to Anthropic.
    */
   max_tool_calls?: number;
   output_format?: OutputFormat; // Structured outputs - JSON schema for response format

--- a/src/providers/anthropic/types.ts
+++ b/src/providers/anthropic/types.ts
@@ -111,6 +111,12 @@ export interface AnthropicMessageOptions {
   beta?: string[]; // For features like 'output-128k-2025-02-19', 'web-fetch-2025-09-10', 'structured-outputs-2025-11-13'
   showThinking?: boolean;
   mcp?: MCPConfig;
+  /**
+   * Maximum number of MCP tool-use continuation rounds for Anthropic Messages.
+   * Defaults to 8. This is enforced locally by promptfoo and is not sent to
+   * Anthropic.
+   */
+  max_tool_calls?: number;
   output_format?: OutputFormat; // Structured outputs - JSON schema for response format
 }
 

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1444,6 +1444,164 @@ describe('AnthropicMessagesProvider', () => {
       ]);
     });
 
+    it('does not cache MCP continuation results by default', async () => {
+      enableCache();
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValue({
+        content: 'Fresh tool output.',
+      });
+
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_first_cache',
+              name: 'search_companies',
+              input: { query: 'clean energy' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'First fresh answer.' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 7, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_second_cache',
+              name: 'search_companies',
+              input: { query: 'clean energy' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 11, output_tokens: 6, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'Second fresh answer.' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 8, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message);
+      const cache = await getCache();
+      const getSpy = vi.spyOn(cache, 'get');
+      const setSpy = vi.spyOn(cache, 'set');
+
+      const firstResult = await provider.callApi('Find clean energy companies');
+      const secondResult = await provider.callApi('Find clean energy companies');
+
+      expect(firstResult.output).toBe('First fresh answer.');
+      expect(secondResult.output).toBe('Second fresh answer.');
+      expect(createSpy).toHaveBeenCalledTimes(4);
+      expect(mcpMocks.callTool).toHaveBeenCalledTimes(2);
+      expect(getSpy).not.toHaveBeenCalled();
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves mixed MCP and non-MCP tool_use blocks on the existing output path', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_search',
+            name: 'search_companies',
+            input: { query: 'clean energy' },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_weather',
+            name: 'get_weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+      } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find companies and weather');
+
+      expect(mcpMocks.callTool).not.toHaveBeenCalled();
+      expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
+      expect(result.finishReason).toBe('tool_calls');
+      expect(result.output).toContain('"name":"search_companies"');
+      expect(result.output).toContain('"name":"get_weather"');
+    });
+
+    it('drops forced tool_choice on MCP continuation requests', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          tool_choice: 'required' as any,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValueOnce({
+        content: 'Found Acme Solar.',
+      });
+
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_required',
+              name: 'search_companies',
+              input: { query: 'solar' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'Acme Solar is a match.' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 7, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find solar companies');
+
+      expect(result.output).toBe('Acme Solar is a match.');
+      expect(createSpy).toHaveBeenCalledTimes(2);
+      expect(createSpy.mock.calls[0][0]).toMatchObject({
+        tool_choice: { type: 'any' },
+      });
+      expect(createSpy.mock.calls[1][0]).not.toHaveProperty('tool_choice');
+    });
+
     it('leaves non-MCP Anthropic tool_use blocks on the existing output path', async () => {
       provider = createProvider('claude-3-5-sonnet-latest', {
         config: {

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1744,6 +1744,9 @@ describe('AnthropicMessagesProvider', () => {
         completion: 9,
         total: 27,
       });
+      // Cost should still be tracked even when the loop cap aborts the eval —
+      // tokens were spent across both rounds.
+      expect(result.cost).toBeGreaterThan(0);
     });
 
     it('blocks parallel MCP tool execution when it would exceed max_tool_calls', async () => {
@@ -1783,6 +1786,7 @@ describe('AnthropicMessagesProvider', () => {
 
       expect(result.error).toContain('Anthropic MCP tool execution exceeded max_tool_calls=1');
       expect(mcpMocks.callTool).not.toHaveBeenCalled();
+      expect(result.cost).toBeGreaterThan(0);
     });
 
     it('continues MCP tool execution through the streaming path', async () => {
@@ -1904,6 +1908,7 @@ describe('AnthropicMessagesProvider', () => {
         completion: 9,
         total: 27,
       });
+      expect(result.cost).toBeGreaterThan(0);
     });
   });
 

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -18,19 +18,21 @@ const mcpMocks = vi.hoisted(() => {
   const initialize = vi.fn();
   const cleanup = vi.fn();
   const getAllTools = vi.fn().mockReturnValue([]);
+  const callTool = vi.fn();
   const instances: any[] = [];
 
   class MockMCPClient {
     initialize = initialize;
     cleanup = cleanup;
     getAllTools = getAllTools;
+    callTool = callTool;
 
     constructor() {
       instances.push(this);
     }
   }
 
-  return { cleanup, getAllTools, initialize, instances, MockMCPClient };
+  return { callTool, cleanup, getAllTools, initialize, instances, MockMCPClient };
 });
 
 const claudeCodeAuthMocks = vi.hoisted(() => ({
@@ -109,6 +111,7 @@ describe('AnthropicMessagesProvider', () => {
     mcpMocks.instances.length = 0;
     mcpMocks.initialize.mockReset();
     mcpMocks.cleanup.mockReset();
+    mcpMocks.callTool.mockReset();
     mcpMocks.getAllTools.mockReset();
     mcpMocks.getAllTools.mockReturnValue([]);
     claudeCodeAuthMocks.loadClaudeCodeCredential.mockReset();
@@ -1338,6 +1341,194 @@ describe('AnthropicMessagesProvider', () => {
 
         const result = await provider.callApi('Test prompt');
         expect(result.finishReason).toBe('unknown_reason');
+      });
+    });
+  });
+
+  describe('MCP tool execution', () => {
+    const mcpTool = {
+      name: 'search_companies',
+      description: 'Search sample company records.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+      },
+    };
+
+    beforeEach(() => {
+      disableCache();
+      mcpMocks.getAllTools.mockReturnValue([mcpTool]);
+    });
+
+    afterEach(() => {
+      enableCache();
+    });
+
+    it('executes MCP tool_use blocks and continues the Anthropic conversation with tool_result', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValueOnce({
+        content: 'Found Acme Solar and Gridwise.',
+      });
+
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_search',
+              name: 'search_companies',
+              input: { query: 'clean energy' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'Acme Solar and Gridwise match your query.' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 7, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find clean energy companies');
+
+      expect(result.output).toBe('Acme Solar and Gridwise match your query.');
+      expect(result.finishReason).toBe('stop');
+      expect(result.tokenUsage).toMatchObject({
+        prompt: 17,
+        completion: 9,
+        total: 26,
+      });
+      expect(mcpMocks.callTool).toHaveBeenCalledWith('search_companies', {
+        query: 'clean energy',
+      });
+      expect(createSpy).toHaveBeenCalledTimes(2);
+
+      const secondRequest = createSpy.mock.calls[1][0] as Anthropic.Messages.MessageCreateParams;
+      expect(secondRequest.messages.slice(-2)).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_search',
+              name: 'search_companies',
+              input: { query: 'clean energy' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_search',
+              content: 'Found Acme Solar and Gridwise.',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('leaves non-MCP Anthropic tool_use blocks on the existing output path', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_weather',
+            name: 'get_weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+      } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('What is the weather?');
+
+      expect(mcpMocks.callTool).not.toHaveBeenCalled();
+      expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(1);
+      expect(result.finishReason).toBe('tool_calls');
+      expect(result.output).toContain('"name":"get_weather"');
+    });
+
+    it('returns an error when MCP tool_use continuation exceeds max_tool_calls', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          max_tool_calls: 1,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValue({
+        content: 'Still needs another lookup.',
+      });
+
+      vi.spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_first',
+              name: 'search_companies',
+              input: { query: 'clean energy' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_second',
+              name: 'search_companies',
+              input: { query: 'solar' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 8, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find clean energy companies');
+
+      expect(result.error).toContain('Anthropic MCP tool-use loop exceeded max_tool_calls=1');
+      expect(result.tokenUsage).toMatchObject({
+        prompt: 18,
+        completion: 9,
+        total: 27,
       });
     });
   });

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1602,6 +1602,62 @@ describe('AnthropicMessagesProvider', () => {
       expect(createSpy.mock.calls[1][0]).not.toHaveProperty('tool_choice');
     });
 
+    it('marks MCP tool_result blocks as errors before continuing the Anthropic conversation', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValueOnce({
+        error: 'lookup failed',
+      });
+
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_error',
+              name: 'search_companies',
+              input: { query: 'grid storage' },
+            },
+          ],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+        } as Anthropic.Messages.Message)
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'I could not complete that lookup.' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 7, output_tokens: 4, server_tool_use: null },
+        } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find grid storage companies');
+
+      expect(result.output).toBe('I could not complete that lookup.');
+      const secondRequest = createSpy.mock.calls[1][0] as Anthropic.Messages.MessageCreateParams;
+      expect(secondRequest.messages.slice(-1)).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_error',
+              content: 'MCP Tool Error (search_companies): lookup failed',
+              is_error: true,
+            },
+          ],
+        },
+      ]);
+    });
+
     it('leaves non-MCP Anthropic tool_use blocks on the existing output path', async () => {
       provider = createProvider('claude-3-5-sonnet-latest', {
         config: {
@@ -1636,7 +1692,7 @@ describe('AnthropicMessagesProvider', () => {
       expect(result.output).toContain('"name":"get_weather"');
     });
 
-    it('returns an error when MCP tool_use continuation exceeds max_tool_calls', async () => {
+    it('returns an error when MCP tool execution exceeds max_tool_calls', async () => {
       provider = createProvider('claude-3-5-sonnet-latest', {
         config: {
           max_tool_calls: 1,
@@ -1682,7 +1738,167 @@ describe('AnthropicMessagesProvider', () => {
 
       const result = await provider.callApi('Find clean energy companies');
 
-      expect(result.error).toContain('Anthropic MCP tool-use loop exceeded max_tool_calls=1');
+      expect(result.error).toContain('Anthropic MCP tool execution exceeded max_tool_calls=1');
+      expect(result.tokenUsage).toMatchObject({
+        prompt: 18,
+        completion: 9,
+        total: 27,
+      });
+    });
+
+    it('blocks parallel MCP tool execution when it would exceed max_tool_calls', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          max_tool_calls: 1,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_first',
+            name: 'search_companies',
+            input: { query: 'solar' },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_second',
+            name: 'search_companies',
+            input: { query: 'wind' },
+          },
+        ],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+      } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find clean energy companies');
+
+      expect(result.error).toContain('Anthropic MCP tool execution exceeded max_tool_calls=1');
+      expect(mcpMocks.callTool).not.toHaveBeenCalled();
+    });
+
+    it('continues MCP tool execution through the streaming path', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          stream: true,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValueOnce({
+        content: 'Found Acme Solar.',
+      });
+
+      const streamSpy = vi
+        .spyOn(provider.anthropic.messages, 'stream')
+        .mockResolvedValueOnce({
+          finalMessage: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_stream',
+                name: 'search_companies',
+                input: { query: 'solar' },
+              },
+            ],
+            stop_reason: 'tool_use',
+            usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+          } as Anthropic.Messages.Message),
+        } as any)
+        .mockResolvedValueOnce({
+          finalMessage: vi.fn().mockResolvedValue({
+            content: [{ type: 'text', text: 'Acme Solar is a match.' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 7, output_tokens: 4, server_tool_use: null },
+          } as Anthropic.Messages.Message),
+        } as any);
+
+      const result = await provider.callApi('Find solar companies');
+
+      expect(result.output).toBe('Acme Solar is a match.');
+      expect(streamSpy).toHaveBeenCalledTimes(2);
+      const secondRequest = streamSpy.mock.calls[1][0] as Anthropic.Messages.MessageCreateParams;
+      expect(secondRequest.messages.slice(-1)).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_stream',
+              content: 'Found Acme Solar.',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('returns a streaming error once further MCP execution exceeds max_tool_calls', async () => {
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          max_tool_calls: 1,
+          stream: true,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      mcpMocks.callTool.mockResolvedValue({
+        content: 'Still needs another lookup.',
+      });
+
+      vi.spyOn(provider.anthropic.messages, 'stream')
+        .mockResolvedValueOnce({
+          finalMessage: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_stream_first',
+                name: 'search_companies',
+                input: { query: 'solar' },
+              },
+            ],
+            stop_reason: 'tool_use',
+            usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+          } as Anthropic.Messages.Message),
+        } as any)
+        .mockResolvedValueOnce({
+          finalMessage: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_stream_second',
+                name: 'search_companies',
+                input: { query: 'wind' },
+              },
+            ],
+            stop_reason: 'tool_use',
+            usage: { input_tokens: 8, output_tokens: 4, server_tool_use: null },
+          } as Anthropic.Messages.Message),
+        } as any);
+
+      const result = await provider.callApi('Find clean energy companies');
+
+      expect(result.error).toContain('Anthropic MCP tool execution exceeded max_tool_calls=1');
+      expect(mcpMocks.callTool).toHaveBeenCalledTimes(1);
       expect(result.tokenUsage).toMatchObject({
         prompt: 18,
         completion: 9,


### PR DESCRIPTION
## Summary
- Execute Anthropic MCP-backed `tool_use` blocks with `MCPClient.callTool`
- Continue the Anthropic Messages conversation with `tool_result` blocks until a final response or `max_tool_calls` cap
- Preserve existing non-MCP tool behavior and add regression coverage for success, pass-through, and loop-cap cases

## Testing
- `npx vitest run test/providers/anthropic/messages.test.ts --sequence.shuffle=false` passed before refreshing dependencies
- `npm run l` passed with existing `callApiInternal` complexity warning
- `npm run f` passed with existing `callApiInternal` complexity warning
- `git diff --check` passed

## Notes
- After fast-forwarding from latest `main`, `npm run tsc` initially failed because `@inquirer/search` was missing from stale local `node_modules`.
- Running `npm ci` to refresh dependencies was blocked by the OpenAI Socket policy for newly published `ws@8.20.1`, which then left local `node_modules` incomplete. Subsequent Vitest/TypeScript runs could not start in this workspace.