### PR TITLE
fix(dev): use tsx watch for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "openapi:check": "tsx scripts/generateOpenApi.ts --check",
     "dev:app": "npm run dev --prefix src/app",
     "storybook": "npm run storybook --prefix src/app",
-    "dev:server": "tsx --watch src/server/index.ts",
+    "dev:server": "tsx watch src/server/index.ts",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:app\"",
     "f": "git diff --name-only --diff-filter=ACMRTUXB origin/main | grep -E '\\.(js|jsx|mjs|cjs|ts|tsx|json)$' | xargs npx @biomejs/biome check --write && git diff --name-only --diff-filter=ACMRTUXB origin/main | grep -E '\\.(css|scss|html|md|mdc|mdx|yaml|yml)$' | xargs prettier --write",
     "format:check": "npx @biomejs/biome check && prettier --check '**/*.{css,scss,html,md,mdc,mdx,yaml,yml}'",


### PR DESCRIPTION
## Summary
- switch the dev server script from Node's `--watch` flag to `tsx watch`
- avoids the local `EMFILE: too many open files, watch` crash while preserving server watch mode

## Verification
- `API_PORT=15501 npm run dev`
