### PR TITLE
fix(providers): map Python worker stderr log levels

### DIFF
--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { StringDecoder } from 'string_decoder';
 
 import { PythonShell } from 'python-shell';
 import { getWrapperDir } from '../esm';
@@ -15,6 +16,9 @@ export class PythonWorker {
   private busy: boolean = false;
   private shuttingDown: boolean = false;
   private crashCount: number = 0;
+  private stderrBuffer: string = '';
+  private stderrDecoder = new StringDecoder('utf8');
+  private stderrTracebackLevel: 'error' | null = null;
   private readonly maxCrashes: number = 3;
   private pendingRequest: {
     resolve: (result: unknown) => void;
@@ -84,6 +88,7 @@ export class PythonWorker {
       });
 
       this.process!.on('close', () => {
+        this.flushStderr();
         if (!this.shuttingDown) {
           this.handleCrash();
         }
@@ -96,26 +101,81 @@ export class PythonWorker {
   }
 
   private handleStderr(data: Buffer | string): void {
-    const lines = data
-      .toString()
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
+    const text = typeof data === 'string' ? data : this.stderrDecoder.write(data);
+    this.stderrBuffer += text;
+
+    const lines = this.stderrBuffer.split('\n');
+    this.stderrBuffer = lines.pop() ?? '';
 
     for (const line of lines) {
-      const message = `Python worker stderr: ${line}`;
-      if (/\b(ERROR|CRITICAL|FATAL)\b|^ERROR[: ]|Traceback \(most recent call last\)/i.test(line)) {
-        logger.error(message);
-      } else if (/\b(WARN|WARNING)\b/i.test(line)) {
-        logger.warn(message);
-      } else if (/\bINFO\b/i.test(line)) {
-        logger.info(message);
-      } else if (/\bDEBUG\b/i.test(line)) {
-        logger.debug(message);
-      } else {
-        logger.warn(message);
+      this.logStderrLine(line.replace(/\r$/, ''));
+    }
+  }
+
+  private flushStderr(): void {
+    const remaining = this.stderrBuffer + this.stderrDecoder.end();
+    this.stderrBuffer = '';
+    this.stderrTracebackLevel = null;
+
+    if (remaining) {
+      for (const line of remaining.split(/\r?\n/)) {
+        this.logStderrLine(line);
       }
     }
+  }
+
+  private logStderrLine(line: string): void {
+    if (!line.trim()) {
+      return;
+    }
+
+    const trimmedStart = line.trimStart();
+    const prefixMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)\b[: ]?/i.exec(
+      trimmedStart,
+    );
+
+    if (prefixMatch) {
+      const level = this.normalizeStderrLevel(prefixMatch[1]);
+      this.stderrTracebackLevel = level === 'error' ? 'error' : null;
+      this.writeStderrLog(level, line);
+      return;
+    }
+
+    if (/^Traceback \(most recent call last\):/i.test(trimmedStart)) {
+      this.stderrTracebackLevel = 'error';
+      this.writeStderrLog('error', line);
+      return;
+    }
+
+    if (this.stderrTracebackLevel) {
+      this.writeStderrLog(this.stderrTracebackLevel, line);
+      return;
+    }
+
+    this.writeStderrLog('warn', line);
+  }
+
+  private normalizeStderrLevel(level: string): 'debug' | 'info' | 'warn' | 'error' {
+    switch (level.toUpperCase()) {
+      case 'DEBUG':
+        return 'debug';
+      case 'INFO':
+        return 'info';
+      case 'WARN':
+      case 'WARNING':
+        return 'warn';
+      case 'ERROR':
+      case 'CRITICAL':
+      case 'FATAL':
+        return 'error';
+      default:
+        return 'warn';
+    }
+  }
+
+  private writeStderrLog(level: 'debug' | 'info' | 'warn' | 'error', line: string): void {
+    const message = `Python worker stderr: ${line}`;
+    logger[level](message);
   }
 
   async call(functionName: string, args: unknown[]): Promise<unknown> {

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -20,7 +20,7 @@ export class PythonWorker {
   private crashCount: number = 0;
   private stderrBuffer: string = '';
   private stderrDecoder = new StringDecoder('utf8');
-  private stderrTracebackLevel: 'error' | null = null;
+  private inTraceback: boolean = false;
   private readonly maxCrashes: number = 3;
   private pendingRequest: {
     resolve: (result: unknown) => void;
@@ -104,15 +104,26 @@ export class PythonWorker {
 
   private handleStderr(data: Buffer | string): void {
     const text = typeof data === 'string' ? data : this.stderrDecoder.write(data);
-    this.stderrBuffer += text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    this.stderrBuffer += text;
 
-    const lines = this.stderrBuffer.split('\n');
-    this.stderrBuffer = lines.pop() ?? '';
+    // A trailing bare `\r` may be the first half of a `\r\n` pair split across
+    // chunks, so hold it back until the next chunk (or flush) disambiguates it.
+    const carry = this.stderrBuffer.endsWith('\r') ? '\r' : '';
+    const normalized = (carry ? this.stderrBuffer.slice(0, -1) : this.stderrBuffer).replace(
+      /\r\n?/g,
+      '\n',
+    );
+
+    const lines = normalized.split('\n');
+    this.stderrBuffer = (lines.pop() ?? '') + carry;
 
     for (const line of lines) {
       this.logStderrLine(line);
     }
 
+    // Bound an unterminated line so a misbehaving provider cannot grow the
+    // buffer without limit. The flushed fragment is best-effort: it may be the
+    // middle of a longer line and is classified on its own.
     if (this.stderrBuffer.length >= MAX_STDERR_BUFFER_LENGTH) {
       this.logStderrLine(this.stderrBuffer);
       this.stderrBuffer = '';
@@ -122,44 +133,74 @@ export class PythonWorker {
   private flushStderr(): void {
     const remaining = this.stderrBuffer + this.stderrDecoder.end();
     this.stderrBuffer = '';
-    this.stderrTracebackLevel = null;
 
     if (remaining) {
-      for (const line of remaining.split(/\r?\n/)) {
+      for (const line of remaining.split(/\r\n|[\r\n]/)) {
         this.logStderrLine(line);
       }
     }
+
+    // Reset traceback state only after the buffered lines are logged, so a
+    // buffered final traceback line is still classified as an error. Refresh
+    // the decoder in case the worker restarts and reuses this instance.
+    this.inTraceback = false;
+    this.stderrDecoder = new StringDecoder('utf8');
   }
 
   private logStderrLine(line: string): void {
+    // Blank lines terminate any in-progress traceback.
     if (!line.trim()) {
-      this.stderrTracebackLevel = null;
+      this.inTraceback = false;
       return;
     }
 
-    const trimmedStart = line.trimStart();
-    const prefixMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)\b[: ]?/i.exec(
-      trimmedStart,
-    );
-
-    if (prefixMatch) {
-      const level = this.normalizeStderrLevel(prefixMatch[1]);
-      this.stderrTracebackLevel = null;
-      this.writeStderrLog(level, line);
-      return;
-    }
-
-    if (/^Traceback \(most recent call last\):/i.test(trimmedStart)) {
-      this.stderrTracebackLevel = 'error';
+    // Inside a traceback, indented lines are always continuation frames.
+    // Classify them before prefix detection so a source line such as
+    // `    info = get_info()` is not mistaken for an INFO log record.
+    if (this.inTraceback && /^\s/.test(line)) {
       this.writeStderrLog('error', line);
       return;
     }
 
-    if (this.stderrTracebackLevel) {
-      this.writeStderrLog(this.stderrTracebackLevel, line);
+    const trimmedStart = line.trimStart();
+
+    // The traceback header opens a new traceback block.
+    if (/^Traceback \(most recent call last\):/i.test(trimmedStart)) {
+      this.inTraceback = true;
+      this.writeStderrLog('error', line);
       return;
     }
 
+    // An explicit Python log-level prefix wins over everything else.
+    const prefixMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)\b[: ]?/i.exec(
+      trimmedStart,
+    );
+    if (prefixMatch) {
+      this.inTraceback = false;
+      this.writeStderrLog(this.normalizeStderrLevel(prefixMatch[1]), line);
+      return;
+    }
+
+    // A non-indented line while inside a traceback is the exception summary
+    // (e.g. `ValueError: boom`) that ends the traceback.
+    if (this.inTraceback) {
+      this.inTraceback = false;
+      this.writeStderrLog('error', line);
+      return;
+    }
+
+    // Connector lines bridge chained exceptions; keep them at error level so a
+    // multi-exception report reads coherently in the logs.
+    if (
+      /^(During handling of the above exception|The above exception was the direct cause)/i.test(
+        trimmedStart,
+      )
+    ) {
+      this.writeStderrLog('error', line);
+      return;
+    }
+
+    // Unclassified stderr stays visible without being treated as a failure.
     this.writeStderrLog('warn', line);
   }
 

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -10,6 +10,8 @@ import { getRequestTimeoutMs } from '../providers/shared';
 import { safeJsonStringify } from '../util/json';
 import { validatePythonPath } from './pythonUtils';
 
+const MAX_STDERR_BUFFER_LENGTH = 16_384;
+
 export class PythonWorker {
   private process: PythonShell | null = null;
   private ready: boolean = false;
@@ -102,13 +104,18 @@ export class PythonWorker {
 
   private handleStderr(data: Buffer | string): void {
     const text = typeof data === 'string' ? data : this.stderrDecoder.write(data);
-    this.stderrBuffer += text;
+    this.stderrBuffer += text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
     const lines = this.stderrBuffer.split('\n');
     this.stderrBuffer = lines.pop() ?? '';
 
     for (const line of lines) {
-      this.logStderrLine(line.replace(/\r$/, ''));
+      this.logStderrLine(line);
+    }
+
+    if (this.stderrBuffer.length >= MAX_STDERR_BUFFER_LENGTH) {
+      this.logStderrLine(this.stderrBuffer);
+      this.stderrBuffer = '';
     }
   }
 
@@ -126,6 +133,7 @@ export class PythonWorker {
 
   private logStderrLine(line: string): void {
     if (!line.trim()) {
+      this.stderrTracebackLevel = null;
       return;
     }
 
@@ -136,7 +144,7 @@ export class PythonWorker {
 
     if (prefixMatch) {
       const level = this.normalizeStderrLevel(prefixMatch[1]);
-      this.stderrTracebackLevel = level === 'error' ? 'error' : null;
+      this.stderrTracebackLevel = null;
       this.writeStderrLog(level, line);
       return;
     }

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -90,9 +90,32 @@ export class PythonWorker {
       });
 
       this.process!.stderr?.on('data', (data) => {
-        logger.error(`Python worker stderr: ${data.toString()}`);
+        this.handleStderr(data);
       });
     });
+  }
+
+  private handleStderr(data: Buffer | string): void {
+    const lines = data
+      .toString()
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    for (const line of lines) {
+      const message = `Python worker stderr: ${line}`;
+      if (/\b(ERROR|CRITICAL|FATAL)\b|^ERROR[: ]|Traceback \(most recent call last\)/i.test(line)) {
+        logger.error(message);
+      } else if (/\b(WARN|WARNING)\b/i.test(line)) {
+        logger.warn(message);
+      } else if (/\bINFO\b/i.test(line)) {
+        logger.info(message);
+      } else if (/\bDEBUG\b/i.test(line)) {
+        logger.debug(message);
+      } else {
+        logger.warn(message);
+      }
+    }
   }
 
   async call(functionName: string, args: unknown[]): Promise<unknown> {

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -76,6 +76,39 @@ describe('PythonWorker stderr parsing', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it('clears traceback state after a blank traceback separator', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr(
+      [
+        'Traceback (most recent call last):',
+        '  File "/tmp/provider.py", line 1, in <module>',
+        'ValueError: boom',
+        '',
+        'plain stderr after handled error',
+        '',
+      ].join('\n'),
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr: Traceback (most recent call last):',
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Python worker stderr: plain stderr after handled error',
+    );
+  });
+
+  it('does not treat a one-line ERROR log as traceback continuation state', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('ERROR:provider reported a recoverable issue\nplain stderr later\n');
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr: ERROR:provider reported a recoverable issue',
+    );
+    expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: plain stderr later');
+  });
+
   it('buffers split stderr chunks before classifying complete lines', () => {
     const worker = createTestableWorker();
 
@@ -101,6 +134,24 @@ describe('PythonWorker stderr parsing', () => {
     worker.flushStderr();
 
     expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: WARNING:partial stderr line');
+  });
+
+  it('flushes carriage-return-delimited stderr updates', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('INFO:step 1\rINFO:step 2\r');
+
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:step 1');
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:step 2');
+  });
+
+  it('bounds an unterminated stderr buffer', () => {
+    const worker = createTestableWorker();
+    const longLine = 'x'.repeat(16_384);
+
+    worker.handleStderr(longLine);
+
+    expect(logger.warn).toHaveBeenCalledWith(`Python worker stderr: ${longLine}`);
   });
 });
 

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import logger from '../../src/logger';
 import { PythonWorker } from '../../src/python/worker';
 
 vi.mock('../../src/logger', () => ({
@@ -32,6 +33,7 @@ describeOrSkip('PythonWorker', () => {
   let nonexistentFunctionWorker: PythonWorker;
   let wrongNameWorker: PythonWorker;
   let embeddingsOnlyWorker: PythonWorker;
+  let loggingWorker: PythonWorker;
   const fixturesDir = path.join(__dirname, 'fixtures');
   const testScriptPath = path.join(__dirname, 'fixtures', 'simple_provider.py');
   const multiApiPath = path.join(__dirname, 'fixtures', 'multi_api_provider.py');
@@ -39,6 +41,7 @@ describeOrSkip('PythonWorker', () => {
   const nonexistentPath = path.join(__dirname, 'fixtures', 'test_nonexistent_function.py');
   const wrongNamePath = path.join(__dirname, 'fixtures', 'test_wrong_function_name.py');
   const embeddingsOnlyPath = path.join(__dirname, 'fixtures', 'test_embeddings_only.py');
+  const loggingPath = path.join(__dirname, 'fixtures', 'logging_provider.py');
 
   beforeAll(async () => {
     // Create test fixture
@@ -78,12 +81,27 @@ def call_api(prompt, options, context):
 `,
     );
 
+    fs.writeFileSync(
+      loggingPath,
+      `
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+
+def call_api(prompt, options, context):
+    logging.info("provider startup details")
+    logging.warning("provider warning")
+    return {"output": f"Logged: {prompt}"}
+`,
+    );
+
     sharedWorker = new PythonWorker(testScriptPath, 'call_api');
     multiApiWorker = new PythonWorker(multiApiPath, 'call_api');
     errorWorker = new PythonWorker(errorPath, 'call_api');
     nonexistentFunctionWorker = new PythonWorker(nonexistentPath, 'call_api');
     wrongNameWorker = new PythonWorker(wrongNamePath, 'call_api');
     embeddingsOnlyWorker = new PythonWorker(embeddingsOnlyPath, 'call_api');
+    loggingWorker = new PythonWorker(loggingPath, 'call_api');
 
     await Promise.all([
       sharedWorker.initialize(),
@@ -92,6 +110,7 @@ def call_api(prompt, options, context):
       nonexistentFunctionWorker.initialize(),
       wrongNameWorker.initialize(),
       embeddingsOnlyWorker.initialize(),
+      loggingWorker.initialize(),
     ]);
   });
 
@@ -104,12 +123,13 @@ def call_api(prompt, options, context):
         nonexistentFunctionWorker,
         wrongNameWorker,
         embeddingsOnlyWorker,
+        loggingWorker,
       ]
         .filter((worker): worker is PythonWorker => Boolean(worker))
         .map((worker) => worker.shutdown()),
     );
 
-    for (const fixturePath of [testScriptPath, multiApiPath, errorPath]) {
+    for (const fixturePath of [testScriptPath, multiApiPath, errorPath, loggingPath]) {
       if (fs.existsSync(fixturePath)) {
         fs.unlinkSync(fixturePath);
       }
@@ -169,6 +189,25 @@ def call_api(prompt, options, context):
 
       expect((classResult as Record<string, unknown>).type).toBe('classification');
       expect((classResult as Record<string, unknown>).output).toBe('positive');
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'should not surface routine Python stderr logging as worker errors',
+    async () => {
+      const result = (await loggingWorker.call('call_api', ['hello', {}, {}])) as {
+        output: string;
+      };
+
+      expect(result.output).toBe('Logged: hello');
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Python worker stderr: WARNING:provider warning'),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Python worker stderr: INFO:provider startup details'),
+      );
     },
     TEST_TIMEOUT,
   );

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -26,6 +26,84 @@ const TEST_TIMEOUT = process.platform === 'win32' ? 90000 : 15000;
 // Works fine on local Windows and all other platforms
 const describeOrSkip = process.platform === 'win32' && process.env.CI ? describe.skip : describe;
 
+type TestablePythonWorker = {
+  flushStderr(): void;
+  handleStderr(data: Buffer | string): void;
+};
+
+function createTestableWorker() {
+  return new PythonWorker('/tmp/provider.py', 'call_api') as unknown as TestablePythonWorker;
+}
+
+describe('PythonWorker stderr parsing', () => {
+  it('honors explicit INFO and DEBUG prefixes before scanning message text', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('INFO:loaded error budget config\nDEBUG:error retry state\n');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Python worker stderr: INFO:loaded error budget config',
+    );
+    expect(logger.debug).toHaveBeenCalledWith('Python worker stderr: DEBUG:error retry state');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps traceback continuation lines at error level and preserves indentation', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr(
+      [
+        'ERROR: Failed to load module: boom',
+        'Traceback (most recent call last):',
+        '  File "/tmp/provider.py", line 1, in <module>',
+        '    raise ValueError("boom")',
+        'ValueError: boom',
+        '',
+      ].join('\n'),
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr: ERROR: Failed to load module: boom',
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr: Traceback (most recent call last):',
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr:   File "/tmp/provider.py", line 1, in <module>',
+    );
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr:     raise ValueError("boom")');
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: ValueError: boom');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('buffers split stderr chunks before classifying complete lines', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('IN');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+
+    worker.handleStderr('FO:loaded error budget config\n');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Python worker stderr: INFO:loaded error budget config',
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('flushes an unterminated buffered stderr line', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('WARNING:partial stderr line');
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    worker.flushStderr();
+
+    expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: WARNING:partial stderr line');
+  });
+});
+
 describeOrSkip('PythonWorker', () => {
   let sharedWorker: PythonWorker;
   let multiApiWorker: PythonWorker;

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -76,26 +76,139 @@ describe('PythonWorker stderr parsing', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('clears traceback state after a blank traceback separator', () => {
+  it('classifies the standard Python logging format (LEVEL:name:message)', () => {
     const worker = createTestableWorker();
 
+    worker.handleStderr(
+      ['DEBUG:root:retry state', 'INFO:root:loaded config', 'WARNING:urllib3:pool full', ''].join(
+        '\n',
+      ),
+    );
+
+    expect(logger.debug).toHaveBeenCalledWith('Python worker stderr: DEBUG:root:retry state');
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:root:loaded config');
+    expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: WARNING:urllib3:pool full');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('ends a traceback at its exception summary without a trailing blank line', () => {
+    const worker = createTestableWorker();
+
+    // A real traceback.print_exc() emits no trailing blank line. The summary
+    // line itself must terminate the traceback so later stderr is not poisoned.
     worker.handleStderr(
       [
         'Traceback (most recent call last):',
         '  File "/tmp/provider.py", line 1, in <module>',
         'ValueError: boom',
         '',
-        'plain stderr after handled error',
+      ].join('\n'),
+    );
+
+    worker.handleStderr('routine progress from the next call\n');
+
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: ValueError: boom');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Python worker stderr: routine progress from the next call',
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      'Python worker stderr: routine progress from the next call',
+    );
+  });
+
+  it('does not leak traceback state across calls in a long-lived worker', () => {
+    const worker = createTestableWorker();
+
+    // Call 1 prints a handled traceback (no trailing blank line).
+    worker.handleStderr(
+      'Traceback (most recent call last):\n  File "x", line 1\nValueError: boom\n',
+    );
+    // Call 2 emits a plain, unprefixed stderr line.
+    worker.handleStderr('plain progress line\n');
+
+    expect(logger.error).not.toHaveBeenCalledWith('Python worker stderr: plain progress line');
+    expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: plain progress line');
+  });
+
+  it('keeps chained exception reports coherent at error level', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr(
+      [
+        'Traceback (most recent call last):',
+        '  File "x", line 1',
+        'ValueError: inner',
+        '',
+        'During handling of the above exception, another exception occurred:',
+        '',
+        'Traceback (most recent call last):',
+        '  File "x", line 2',
+        'RuntimeError: outer',
         '',
       ].join('\n'),
     );
 
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: ValueError: inner');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Python worker stderr: During handling of the above exception, another exception occurred:',
+    );
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: RuntimeError: outer');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not mistake an indented traceback source line for a log prefix', () => {
+    const worker = createTestableWorker();
+
+    // The displayed source frame happens to start with the word INFO.
+    worker.handleStderr(
+      [
+        'Traceback (most recent call last):',
+        '  File "/tmp/provider.py", line 2, in call_api',
+        '    INFO = build_info()',
+        'ValueError: boom',
+        '',
+      ].join('\n'),
+    );
+
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr:     INFO = build_info()');
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('keeps a buffered final traceback line at error level on flush', () => {
+    const worker = createTestableWorker();
+
+    // Worker dies mid-write: the exception summary has no trailing newline.
+    worker.handleStderr('Traceback (most recent call last):\n  File "x", line 1\nValueError: boom');
+    worker.flushStderr();
+
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: ValueError: boom');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps traceback continuation at error level when a CRLF pair is split across chunks', () => {
+    const worker = createTestableWorker();
+
+    worker.handleStderr('Traceback (most recent call last):\r');
+    worker.handleStderr('\n  File "x", line 1\r\nValueError: boom\r\n');
+
     expect(logger.error).toHaveBeenCalledWith(
       'Python worker stderr: Traceback (most recent call last):',
     );
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Python worker stderr: plain stderr after handled error',
-    );
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr:   File "x", line 1');
+    expect(logger.error).toHaveBeenCalledWith('Python worker stderr: ValueError: boom');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('decodes multi-byte stderr characters split across buffer chunks', () => {
+    const worker = createTestableWorker();
+    const full = Buffer.from('INFO:café\n', 'utf8');
+
+    // Split inside the two-byte UTF-8 sequence for é.
+    worker.handleStderr(full.subarray(0, full.length - 2));
+    expect(logger.info).not.toHaveBeenCalled();
+
+    worker.handleStderr(full.subarray(full.length - 2));
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:café');
   });
 
   it('does not treat a one-line ERROR log as traceback continuation state', () => {
@@ -136,13 +249,26 @@ describe('PythonWorker stderr parsing', () => {
     expect(logger.warn).toHaveBeenCalledWith('Python worker stderr: WARNING:partial stderr line');
   });
 
-  it('flushes carriage-return-delimited stderr updates', () => {
+  it('treats bare carriage returns as line delimiters', () => {
     const worker = createTestableWorker();
 
-    worker.handleStderr('INFO:step 1\rINFO:step 2\r');
+    // Each \r that is followed by more data is a complete line ending.
+    worker.handleStderr('INFO:step 1\rINFO:step 2\rINFO:step 3\n');
 
     expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:step 1');
     expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:step 2');
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:step 3');
+  });
+
+  it('holds a trailing carriage return until the next chunk disambiguates it', () => {
+    const worker = createTestableWorker();
+
+    // A trailing \r might be the first half of a split \r\n, so it waits.
+    worker.handleStderr('INFO:buffered step\r');
+    expect(logger.info).not.toHaveBeenCalled();
+
+    worker.flushStderr();
+    expect(logger.info).toHaveBeenCalledWith('Python worker stderr: INFO:buffered step');
   });
 
   it('bounds an unterminated stderr buffer', () => {
@@ -210,12 +336,14 @@ def call_api(prompt, options, context):
 `,
     );
 
+    // Uses Python's default logging format (LEVEL:name:message) so the test
+    // exercises what real providers emit when they don't customize logging.
     fs.writeFileSync(
       loggingPath,
       `
 import logging
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+logging.basicConfig(level=logging.INFO)
 
 def call_api(prompt, options, context):
     logging.info("provider startup details")
@@ -331,11 +459,12 @@ def call_api(prompt, options, context):
 
       expect(result.output).toBe('Logged: hello');
       expect(logger.error).not.toHaveBeenCalled();
+      // Default Python logging format is LEVEL:name:message (e.g. WARNING:root:...).
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Python worker stderr: WARNING:provider warning'),
+        expect.stringContaining('Python worker stderr: WARNING:root:provider warning'),
       );
       expect(logger.info).toHaveBeenCalledWith(
-        expect.stringContaining('Python worker stderr: INFO:provider startup details'),
+        expect.stringContaining('Python worker stderr: INFO:root:provider startup details'),
       );
     },
     TEST_TIMEOUT,


### PR DESCRIPTION
## Summary
- classify Python worker stderr lines by recognizable Python log levels instead of always logging them as errors
- preserve real failures as errors, map warnings/info/debug to matching Promptfoo log levels, and keep unclassified stderr visible as warnings
- add a regression test for Python providers using the standard `logging` module

## Testing
- `npx vitest run test/python/worker.test.ts`
- `npm run l`
- `npm run f`
- `git diff --check`