### PR TITLE
chore(tooling): ignore codex worktrees in biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -17,6 +17,7 @@
       "**/*.grit",
       "**/*.mjs",
       "**/*.cjs",
+      "!!.codex",
       "!!drizzle",
       "!!src/app/src/polyfills",
       "!!**/node_modules",


### PR DESCRIPTION
## Summary
- exclude local `.codex` worktree directories from Biome file discovery

## Why
Local Codex worktrees can contain their own `biome.jsonc` files under `.codex/worktrees`. Biome treats those as nested root configurations when it walks the main checkout, which can block changed-file lint and formatting commands in the parent Promptfoo workspace.

## Validation
- `/Users/mdangelo/code/promptfoo/node_modules/.bin/biome check biome.jsonc`
- reproduced the nested-root failure locally before the split by running a changed-file Biome check from a Promptfoo checkout with `.codex/worktrees/*/biome.jsonc` present
