### PR TITLE
fix(server): cap eval table page size

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
 import { renderWithProviders } from '@app/utils/testutils';
 import { FILE_METADATA_KEY } from '@promptfoo/providers/constants';
+import { EVAL_TABLE_MAX_PAGE_SIZE } from '@promptfoo/types/api/eval';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -2274,6 +2275,50 @@ describe('ResultsTable Pagination', () => {
     renderWithProviders(<ResultsTable {...defaultProps} />);
     const paginationElement = screen.getByText(/results per page/i);
     expect(paginationElement).toBeInTheDocument();
+  });
+
+  it('should never offer a page size that exceeds the server cap', async () => {
+    vi.mocked(useTableStore).mockImplementation(() => ({
+      config: {},
+      evalId: '123',
+      setTable: vi.fn(),
+      table: {
+        body: [],
+        head: {
+          prompts: [],
+          vars: [],
+        },
+      },
+      version: 4,
+      fetchEvalData: vi.fn(),
+      // Large enough to enable every option in the selector.
+      filteredResultsCount: EVAL_TABLE_MAX_PAGE_SIZE + 1,
+      totalResultsCount: EVAL_TABLE_MAX_PAGE_SIZE + 1,
+      filters: {
+        values: {},
+        appliedCount: 0,
+        options: {
+          metric: [],
+        },
+      },
+    }));
+
+    renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    const trigger = screen.getByLabelText(/results per page/i);
+    await act(async () => {
+      await userEvent.click(trigger);
+    });
+
+    const options = await screen.findAllByRole('option');
+    const offered = options.map((node) =>
+      Number(node.getAttribute('data-value') ?? node.textContent ?? '0'),
+    );
+
+    expect(offered.length).toBeGreaterThan(0);
+    for (const size of offered) {
+      expect(size).toBeLessThanOrEqual(EVAL_TABLE_MAX_PAGE_SIZE);
+    }
   });
 
   it('should keep the pagination footer pinned for short tables', () => {

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -2291,7 +2291,6 @@ describe('ResultsTable Pagination', () => {
       },
       version: 4,
       fetchEvalData: vi.fn(),
-      // Large enough to enable every option in the selector.
       filteredResultsCount: EVAL_TABLE_MAX_PAGE_SIZE + 1,
       totalResultsCount: EVAL_TABLE_MAX_PAGE_SIZE + 1,
       filters: {
@@ -2311,13 +2310,9 @@ describe('ResultsTable Pagination', () => {
     });
 
     const options = await screen.findAllByRole('option');
-    const offered = options.map((node) =>
-      Number(node.getAttribute('data-value') ?? node.textContent ?? '0'),
-    );
-
-    expect(offered.length).toBeGreaterThan(0);
-    for (const size of offered) {
-      expect(size).toBeLessThanOrEqual(EVAL_TABLE_MAX_PAGE_SIZE);
+    expect(options.length).toBeGreaterThan(0);
+    for (const option of options) {
+      expect(Number(option.textContent)).toBeLessThanOrEqual(EVAL_TABLE_MAX_PAGE_SIZE);
     }
   });
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -29,6 +29,7 @@ import {
   type ProviderOptions,
   type Vars,
 } from '@promptfoo/types';
+import { EVAL_TABLE_MAX_PAGE_SIZE } from '@promptfoo/types/api/eval';
 import invariant from '@promptfoo/util/invariant';
 import {
   createColumnHelper,
@@ -65,6 +66,13 @@ import { isBlobRef, isStorageRef, resolveAudioUrl } from '@app/utils/mediaStorag
 import { isEncodingStrategy } from '@promptfoo/redteam/constants/strategies';
 import { useMetricsGetter, usePassingTestCounts, usePassRates, useTestCounts } from './hooks';
 import { getNamedMetricTotals } from './utils';
+
+// Options shown in the "Results per page" selector. Filtered against
+// EVAL_TABLE_MAX_PAGE_SIZE so the dropdown never offers a value the server
+// would reject for non-export requests.
+const PAGE_SIZE_OPTIONS = [10, 50, 100, 500, 1000].filter(
+  (size) => size <= EVAL_TABLE_MAX_PAGE_SIZE,
+);
 
 /**
  * Renders an audio player for evaluation outputs that may be stored in different representations.
@@ -2470,19 +2478,20 @@ function ResultsTable({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="10">10</SelectItem>
-                <SelectItem value="50" disabled={filteredResultsCount <= 10}>
-                  50
-                </SelectItem>
-                <SelectItem value="100" disabled={filteredResultsCount <= 50}>
-                  100
-                </SelectItem>
-                <SelectItem value="500" disabled={filteredResultsCount <= 100}>
-                  500
-                </SelectItem>
-                <SelectItem value="1000" disabled={filteredResultsCount <= 500}>
-                  1000
-                </SelectItem>
+                {PAGE_SIZE_OPTIONS.map((size, idx) => {
+                  // Disable an option until the previous tier is exceeded, so the
+                  // dropdown only offers sizes that meaningfully change the view.
+                  const previousSize = idx === 0 ? 0 : PAGE_SIZE_OPTIONS[idx - 1];
+                  return (
+                    <SelectItem
+                      key={size}
+                      value={String(size)}
+                      disabled={filteredResultsCount <= previousSize}
+                    >
+                      {size}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
           </div>

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -67,9 +67,6 @@ import { isEncodingStrategy } from '@promptfoo/redteam/constants/strategies';
 import { useMetricsGetter, usePassingTestCounts, usePassRates, useTestCounts } from './hooks';
 import { getNamedMetricTotals } from './utils';
 
-// Options shown in the "Results per page" selector. Filtered against
-// EVAL_TABLE_MAX_PAGE_SIZE so the dropdown never offers a value the server
-// would reject for non-export requests.
 const PAGE_SIZE_OPTIONS = [10, 50, 100, 500, 1000].filter(
   (size) => size <= EVAL_TABLE_MAX_PAGE_SIZE,
 );
@@ -2478,20 +2475,15 @@ function ResultsTable({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {PAGE_SIZE_OPTIONS.map((size, idx) => {
-                  // Disable an option until the previous tier is exceeded, so the
-                  // dropdown only offers sizes that meaningfully change the view.
-                  const previousSize = idx === 0 ? 0 : PAGE_SIZE_OPTIONS[idx - 1];
-                  return (
-                    <SelectItem
-                      key={size}
-                      value={String(size)}
-                      disabled={filteredResultsCount <= previousSize}
-                    >
-                      {size}
-                    </SelectItem>
-                  );
-                })}
+                {PAGE_SIZE_OPTIONS.map((size, idx) => (
+                  <SelectItem
+                    key={size}
+                    value={String(size)}
+                    disabled={filteredResultsCount <= (PAGE_SIZE_OPTIONS[idx - 1] ?? 0)}
+                  >
+                    {size}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/types/api/eval.ts
+++ b/src/types/api/eval.ts
@@ -82,7 +82,14 @@ export type CopyEvalResponse = z.infer<typeof CopyEvalResponseSchema>;
 
 // GET /api/evals/:id/table
 
-export const EVAL_TABLE_MAX_PAGE_SIZE = 500;
+/**
+ * Upper bound on `limit` for non-export page requests. Matches the largest
+ * page-size option offered by the web UI's results-per-page selector so the
+ * UI cannot accidentally request a size the server would reject. Exports
+ * (`format=csv` / `format=json`) bypass this cap because the route always
+ * fetches the full table for those.
+ */
+export const EVAL_TABLE_MAX_PAGE_SIZE = 1000;
 
 /** Query parameters for eval table endpoint. */
 export const EvalTableQuerySchema = z

--- a/src/types/api/eval.ts
+++ b/src/types/api/eval.ts
@@ -82,13 +82,7 @@ export type CopyEvalResponse = z.infer<typeof CopyEvalResponseSchema>;
 
 // GET /api/evals/:id/table
 
-/**
- * Upper bound on `limit` for non-export page requests. Matches the largest
- * page-size option offered by the web UI's results-per-page selector so the
- * UI cannot accidentally request a size the server would reject. Exports
- * (`format=csv` / `format=json`) bypass this cap because the route always
- * fetches the full table for those.
- */
+/** Upper bound on `limit` for non-export page requests; must stay >= the UI's largest page-size option. */
 export const EVAL_TABLE_MAX_PAGE_SIZE = 1000;
 
 /** Query parameters for eval table endpoint. */

--- a/src/types/api/eval.ts
+++ b/src/types/api/eval.ts
@@ -82,22 +82,29 @@ export type CopyEvalResponse = z.infer<typeof CopyEvalResponseSchema>;
 
 // GET /api/evals/:id/table
 
+export const EVAL_TABLE_MAX_PAGE_SIZE = 500;
+
 /** Query parameters for eval table endpoint. */
-export const EvalTableQuerySchema = z.object({
-  format: z.enum(['csv', 'json']).optional(),
-  limit: z.coerce.number().int().positive().prefault(50),
-  offset: z.coerce.number().int().nonnegative().prefault(0),
-  filterMode: EvalResultsFilterMode.prefault('all'),
-  search: z.string().prefault(''),
-  filter: z
-    .union([z.string(), z.array(z.string())])
-    .transform((v) => (Array.isArray(v) ? v : v ? [v] : []))
-    .prefault([]),
-  comparisonEvalIds: z
-    .union([z.string(), z.array(z.string())])
-    .transform((v) => (Array.isArray(v) ? v : v ? [v] : []))
-    .prefault([]),
-});
+export const EvalTableQuerySchema = z
+  .object({
+    format: z.enum(['csv', 'json']).optional(),
+    limit: z.coerce.number().int().positive().prefault(50),
+    offset: z.coerce.number().int().nonnegative().prefault(0),
+    filterMode: EvalResultsFilterMode.prefault('all'),
+    search: z.string().prefault(''),
+    filter: z
+      .union([z.string(), z.array(z.string())])
+      .transform((v) => (Array.isArray(v) ? v : v ? [v] : []))
+      .prefault([]),
+    comparisonEvalIds: z
+      .union([z.string(), z.array(z.string())])
+      .transform((v) => (Array.isArray(v) ? v : v ? [v] : []))
+      .prefault([]),
+  })
+  .refine((query) => query.format || query.limit <= EVAL_TABLE_MAX_PAGE_SIZE, {
+    message: `limit must be less than or equal to ${EVAL_TABLE_MAX_PAGE_SIZE}`,
+    path: ['limit'],
+  });
 
 export type EvalTableQuery = z.infer<typeof EvalTableQuerySchema>;
 

--- a/test/server/routes/eval.export.test.ts
+++ b/test/server/routes/eval.export.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../../src/server/utils/downloadHelpers', async (importOriginal) => {
 import Eval from '../../../src/models/eval';
 import { setDownloadHeaders } from '../../../src/server/utils/downloadHelpers';
 import { evalTableToCsv, evalTableToJson } from '../../../src/server/utils/evalTableUtils';
+import { EVAL_TABLE_MAX_PAGE_SIZE, EvalSchemas } from '../../../src/types/api/eval';
 
 // Setup mocked functions
 const mockedEvalFindById = vi.fn() as MockedFunction<typeof Eval.findById>;
@@ -352,18 +353,23 @@ describe('evalRouter - GET /:id/table with export formats', () => {
     });
   });
 
-  it('should handle pagination parameters correctly for exports', async () => {
-    mockReq.query = { format: 'csv', limit: '100', offset: '50' };
+  it('should ignore pagination parameters for exports if limit exceeds the table page size', async () => {
+    mockReq.query = {
+      format: 'csv',
+      limit: String(EVAL_TABLE_MAX_PAGE_SIZE + 1),
+      offset: '50',
+    };
+    const query = EvalSchemas.Table.Query.parse(mockReq.query);
 
     const eval_ = await Eval.findById(mockReq.params!.id as string);
 
     // When format is specified, should ignore pagination and get all data
     await eval_!.getTablePage({
-      offset: 0, // Should be 0 for export
-      limit: Number.MAX_SAFE_INTEGER, // Should be MAX for export
-      filterMode: 'all',
-      searchQuery: '',
-      filters: [],
+      offset: query.format ? 0 : query.offset,
+      limit: query.format ? Number.MAX_SAFE_INTEGER : query.limit,
+      filterMode: query.filterMode,
+      searchQuery: query.search,
+      filters: query.filter,
     });
 
     expect(eval_!.getTablePage).toHaveBeenCalledWith(

--- a/test/server/routes/eval.validation.test.ts
+++ b/test/server/routes/eval.validation.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../../src/globalConfig/accounts');
 import Eval, { EvalQueries } from '../../../src/models/eval';
 // Import after mocking
 import { createApp } from '../../../src/server/server';
+import { EVAL_TABLE_MAX_PAGE_SIZE } from '../../../src/types/api/eval';
 
 const mockedEval = vi.mocked(Eval);
 const mockedEvalQueries = vi.mocked(EvalQueries);
@@ -152,8 +153,9 @@ describe('Eval Routes - Zod Validation', () => {
     it.each([
       ['format', { format: 'xml' }],
       ['limit', { limit: '1.5' }],
+      ['limit', { limit: String(EVAL_TABLE_MAX_PAGE_SIZE + 1) }],
       ['offset', { offset: '1.5' }],
-    ])('should return 400 when %s query param is invalid', async (field, query) => {
+    ])('should return 400 if %s query param is invalid', async (field, query) => {
       const response = await api.get('/api/eval/test-id/table').query(query);
 
       expect(response.status).toBe(400);

--- a/test/types/apiSchemas.redteam.test.ts
+++ b/test/types/apiSchemas.redteam.test.ts
@@ -7,7 +7,7 @@ import {
   SuccessResponseSchema,
 } from '../../src/types/api/common';
 import { ConfigSchemas } from '../../src/types/api/configs';
-import { EvalSchemas } from '../../src/types/api/eval';
+import { EVAL_TABLE_MAX_PAGE_SIZE, EvalSchemas } from '../../src/types/api/eval';
 import { MediaSchemas } from '../../src/types/api/media';
 import { ModelAuditSchemas } from '../../src/types/api/modelAudit';
 import { ProviderSchemas } from '../../src/types/api/providers';
@@ -585,6 +585,18 @@ describe('API schema red-team coverage', () => {
       expect(EvalSchemas.Table.Query.safeParse({ limit: '1.5' }).success).toBe(false);
       expect(EvalSchemas.Table.Query.safeParse({ offset: '1.5' }).success).toBe(false);
       expect(EvalSchemas.Table.Query.safeParse({ format: 'xml' }).success).toBe(false);
+    });
+
+    it('should reject excessive table page sizes if the request is not an export', () => {
+      expect(
+        EvalSchemas.Table.Query.safeParse({ limit: String(EVAL_TABLE_MAX_PAGE_SIZE + 1) }).success,
+      ).toBe(false);
+      expect(
+        EvalSchemas.Table.Query.safeParse({
+          format: 'csv',
+          limit: String(EVAL_TABLE_MAX_PAGE_SIZE + 1),
+        }).success,
+      ).toBe(true);
     });
 
     it('accepts single comparison eval IDs for metadata keys and rejects empty metadata probes', () => {


### PR DESCRIPTION
## Summary
- cap non-export `GET /api/eval/:id/table` `limit` at `EVAL_TABLE_MAX_PAGE_SIZE` (1000) — matches the largest option the web UI's "Results per page" selector exposes
- keep `format=csv` / `format=json` exports uncapped (route still uses `Number.MAX_SAFE_INTEGER`)
- derive the UI page-size selector from the same shared constant so the dropdown can never offer a value the server would reject
- add schema, route validation, and UI regression coverage for the cap

Fixes #9312

## Why 1000
The eval table UI already lets users with large evals pick 1000 rows per page. Capping below that would silently 400 the request and leave the table blank (the store swallows non-OK responses), so the cap is set to the existing UI ceiling rather than below it.

## Validation
- `npx vitest run test/types/apiSchemas.redteam.test.ts test/server/routes/eval.validation.test.ts test/server/routes/eval.export.test.ts`
- `npm run test:app -- src/pages/eval/components/ResultsTable.test.tsx --run`
- `npm run l && npm run f && npm run tsc`
- Live: `GET /api/eval/<id>/table?limit=1000` → 200, `?limit=1001` → 400 with `"limit must be less than or equal to 1000"`, `?format=csv&limit=99999` → 200