### PR TITLE
fix(cache): include status in JSON parse errors

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -552,7 +552,7 @@ async function prepareFetchResponse(
     throw new Error(
       `Error parsing response from ${url}: ${
         (err as Error).message
-      }. Received text: ${responseText}`,
+      }. HTTP ${response.status} ${response.statusText}. Received text: ${responseText}`,
     );
   }
 }
@@ -634,8 +634,12 @@ export async function fetchWithCache<T = unknown>(
           // No-op when cache is disabled
         },
       };
-    } catch {
-      throw new Error(`Error parsing response as JSON: ${respText}`);
+    } catch (err) {
+      throw new Error(
+        `Error parsing response from ${url}: ${
+          (err as Error).message
+        }. HTTP ${resp.status} ${resp.statusText}. Received text: ${respText}`,
+      );
     }
   }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1107,6 +1107,23 @@ describe('fetchWithCache', () => {
       expect(secondResult.deleteFromCache).toBeInstanceOf(Function);
     });
 
+    it('should include response context when JSON parsing fails', async () => {
+      mockFetchWithRetries.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: () => Promise.resolve('error code: 1006'),
+        headers: new Headers({ 'content-type': 'text/plain' }),
+      } as Response);
+
+      const error = await fetchWithCache(url, {}, 1000, 'json').catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(`Error parsing response from ${url}:`);
+      expect((error as Error).message).toContain('HTTP 403 Forbidden');
+      expect((error as Error).message).toContain('Received text: error code: 1006');
+    });
+
     it('should retry on transient body-read error then succeed', async () => {
       const responseText = JSON.stringify(response);
       const textMockFail = vi


### PR DESCRIPTION
## Summary

- include the request URL and HTTP status when `fetchWithCache` cannot parse an expected JSON response
- align the no-cache JSON parse error with the cached response preparation path
- cover the plain-text `403` edge-response shape that motivated the change

## Context

While investigating Cloudflare-blocked CI requests, one failure surfaced as:

```text
Error parsing response as JSON: error code: 1006
```

That body text was useful, but it omitted the request URL and the HTTP status that identify whether the failure came from the target endpoint, an upstream edge layer, or a different non-JSON response path. The cached response preparation path already included the URL and response text; the no-cache path reduced the error to the raw body.

## Changes

`fetchWithCache` now reports JSON parse failures with:

- the request URL
- the JSON parse failure message
- the HTTP status and status text
- the received response text

The cached and no-cache paths now keep the same diagnostic context for this error class. A regression test exercises a plain-text `403 Forbidden` response with a Cloudflare-style `error code: 1006` body.

## Validation

- `npm run l`
- `npm run f`
- `npx vitest run test/cache.test.ts --sequence.shuffle=false`
- `npx biome check src/cache.ts test/cache.test.ts`
- `git diff --check`
