### PR TITLE
fix(mcp): surface tool error results

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -302,8 +302,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
 
     for (let iteration = 0; iteration < maxToolCalls; iteration++) {
       const responseToolUses = response.content.filter(
-        (block): block is Anthropic.Messages.ToolUseBlock =>
-          block.type === 'tool_use',
+        (block): block is Anthropic.Messages.ToolUseBlock => block.type === 'tool_use',
       );
       const toolUses = responseToolUses.filter((block) => mcpToolNames.has(block.name));
 
@@ -384,11 +383,12 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
         coerceMcpToolInput(toolUse.input),
       );
 
-      if (result.error) {
+      if (result.error || result.isError) {
+        const errorContent = result.error || result.content || 'Tool returned an error result';
         return {
           type: 'tool_result',
           tool_use_id: toolUse.id,
-          content: `MCP Tool Error (${toolUse.name}): ${result.error}`,
+          content: `MCP Tool Error (${toolUse.name}): ${errorContent}`,
           is_error: true,
         };
       }

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -13,6 +13,7 @@ import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToAnthropic } from '../mcp/transform';
+import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
 import { transformToolChoice, transformTools } from '../shared';
 import {
   CLAUDE_CODE_IDENTITY_PROMPT,
@@ -383,12 +384,11 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
         coerceMcpToolInput(toolUse.input),
       );
 
-      if (result.error || result.isError) {
-        const errorContent = result.error || result.content || 'Tool returned an error result';
+      if (isMcpErrorResult(result)) {
         return {
           type: 'tool_result',
           tool_use_id: toolUse.id,
-          content: `MCP Tool Error (${toolUse.name}): ${errorContent}`,
+          content: `MCP Tool Error (${toolUse.name}): ${getMcpErrorMessage(result)}`,
           is_error: true,
         };
       }

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -1430,8 +1430,11 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
   ): Promise<{ output: string; error?: string }> {
     try {
       const mcpResult = await this.mcpClient!.callTool(name, parseToolInput(input));
-      if (mcpResult?.error) {
-        const msg = formatMcpToolError(name, String(mcpResult.error));
+      if (mcpResult?.error || mcpResult?.isError) {
+        const msg = formatMcpToolError(
+          name,
+          mcpResult.error || mcpResult.content || 'Tool returned an error result',
+        );
         return { output: msg, error: msg };
       }
       return { output: formatMcpToolResult(name, mcpResult?.content) };

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -28,6 +28,7 @@ import { isJavascriptFile } from '../../util/fileExtensions';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { isClaudeOpus47Model } from '../anthropic/util';
 import { MCPClient } from '../mcp/client';
+import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
 import { providerRegistry } from '../providerRegistry';
 import {
   isOpenAIToolArray,
@@ -1430,11 +1431,8 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
   ): Promise<{ output: string; error?: string }> {
     try {
       const mcpResult = await this.mcpClient!.callTool(name, parseToolInput(input));
-      if (mcpResult?.error || mcpResult?.isError) {
-        const msg = formatMcpToolError(
-          name,
-          mcpResult.error || mcpResult.content || 'Tool returned an error result',
-        );
+      if (isMcpErrorResult(mcpResult)) {
+        const msg = formatMcpToolError(name, getMcpErrorMessage(mcpResult));
         return { output: msg, error: msg };
       }
       return { output: formatMcpToolResult(name, mcpResult?.content) };

--- a/src/providers/functionCallbackUtils.ts
+++ b/src/providers/functionCallbackUtils.ts
@@ -4,6 +4,7 @@ import cliState from '../cliState';
 import { importModule } from '../esm';
 import logger from '../logger';
 import { isJavascriptFile } from '../util/fileExtensions';
+import { getMcpErrorMessage, isMcpErrorResult } from './mcp/util';
 
 import type {
   FunctionCall,
@@ -246,11 +247,9 @@ export class FunctionCallbackHandler {
         args == null || args === '' ? {} : typeof args === 'string' ? JSON.parse(args) : args;
       const result = await this.mcpClient.callTool(toolName, parsedArgs);
 
-      if (result?.error || result?.isError) {
+      if (isMcpErrorResult(result)) {
         return {
-          output: `MCP Tool Error (${toolName}): ${
-            result.error || result.content || 'Tool returned an error result'
-          }`,
+          output: `MCP Tool Error (${toolName}): ${getMcpErrorMessage(result)}`,
           isError: true,
         };
       }

--- a/src/providers/functionCallbackUtils.ts
+++ b/src/providers/functionCallbackUtils.ts
@@ -246,9 +246,11 @@ export class FunctionCallbackHandler {
         args == null || args === '' ? {} : typeof args === 'string' ? JSON.parse(args) : args;
       const result = await this.mcpClient.callTool(toolName, parsedArgs);
 
-      if (result?.error) {
+      if (result?.error || result?.isError) {
         return {
-          output: `MCP Tool Error (${toolName}): ${result.error}`,
+          output: `MCP Tool Error (${toolName}): ${
+            result.error || result.content || 'Tool returned an error result'
+          }`,
           isError: true,
         };
       }

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -458,7 +458,7 @@ export class MCPClient {
 
             return {
               content,
-              ...(result.isError ? { error: content || 'MCP tool returned an error result' } : {}),
+              ...(result.isError ? { isError: true } : {}),
               raw: result,
             };
           } catch (error) {

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -458,6 +458,7 @@ export class MCPClient {
 
             return {
               content,
+              ...(result.isError ? { error: content || 'MCP tool returned an error result' } : {}),
               raw: result,
             };
           } catch (error) {

--- a/src/providers/mcp/types.ts
+++ b/src/providers/mcp/types.ts
@@ -122,5 +122,6 @@ export interface MCPTool {
 export interface MCPToolResult {
   content: string;
   error?: string;
+  isError?: boolean;
   raw?: unknown;
 }

--- a/src/providers/mcp/types.ts
+++ b/src/providers/mcp/types.ts
@@ -121,7 +121,9 @@ export interface MCPTool {
 
 export interface MCPToolResult {
   content: string;
+  /** Set when the SDK call itself threw (transport, timeout, auth failure). */
   error?: string;
-  isError?: boolean;
+  /** Set when the tool resolved with a protocol-level `isError: true` result. */
+  isError?: true;
   raw?: unknown;
 }

--- a/src/providers/mcp/util.ts
+++ b/src/providers/mcp/util.ts
@@ -9,6 +9,7 @@ import type {
   MCPOAuthClientCredentialsAuth,
   MCPOAuthPasswordAuth,
   MCPServerConfig,
+  MCPToolResult,
 } from './types';
 
 export type { OAuthTokenResult };
@@ -20,6 +21,24 @@ export function isMcpToolNameFilter(tools: unknown): tools is string | string[] 
   return (
     isPlainToolName(tools) || (Array.isArray(tools) && tools.every((tool) => isPlainToolName(tool)))
   );
+}
+
+/**
+ * Returns true when an MCP tool call surfaced a failure: either the SDK call
+ * threw (`error` is set) or the tool resolved with a protocol-level
+ * `isError: true` result.
+ */
+export function isMcpErrorResult(result: MCPToolResult): boolean {
+  return Boolean(result.error || result.isError);
+}
+
+/**
+ * Resolve a human-readable message for a failed MCP tool call. Prefers the
+ * thrown-error message, falls back to the tool's own error content, and finally
+ * to a generic message for tools that signal `isError` without any detail.
+ */
+export function getMcpErrorMessage(result: MCPToolResult): string {
+  return result.error || result.content || 'Tool returned an error result';
 }
 
 /**

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -685,8 +685,12 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
                 const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args;
                 const mcpResult = await this.mcpClient.callTool(functionName, parsedArgs);
 
-                if (mcpResult?.error) {
-                  results.push(`MCP Tool Error (${functionName}): ${mcpResult.error}`);
+                if (mcpResult?.error || mcpResult?.isError) {
+                  results.push(
+                    `MCP Tool Error (${functionName}): ${
+                      mcpResult.error || mcpResult.content || 'Tool returned an error result'
+                    }`,
+                  );
                 } else {
                   // Normalize MCP content to a readable string
                   const normalizeContent = (content: any): string => {

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -21,6 +21,7 @@ import {
 } from '../../util/index';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
+import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
 import {
   getRequestTimeoutMs,
   parseChatPrompt,
@@ -685,11 +686,9 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
                 const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args;
                 const mcpResult = await this.mcpClient.callTool(functionName, parsedArgs);
 
-                if (mcpResult?.error || mcpResult?.isError) {
+                if (isMcpErrorResult(mcpResult)) {
                   results.push(
-                    `MCP Tool Error (${functionName}): ${
-                      mcpResult.error || mcpResult.content || 'Tool returned an error result'
-                    }`,
+                    `MCP Tool Error (${functionName}): ${getMcpErrorMessage(mcpResult)}`,
                   );
                 } else {
                   // Normalize MCP content to a readable string

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1602,7 +1602,26 @@ describe('AnthropicMessagesProvider', () => {
       expect(createSpy.mock.calls[1][0]).not.toHaveProperty('tool_choice');
     });
 
-    it('marks MCP tool_result blocks as errors before continuing the Anthropic conversation', async () => {
+    it.each([
+      {
+        label: 'isError result with content',
+        mcpResult: { content: 'lookup failed', isError: true },
+        expectedContent: 'MCP Tool Error (search_companies): lookup failed',
+      },
+      {
+        label: 'thrown error surfaced via the error field',
+        mcpResult: { content: '', error: 'lookup failed' },
+        expectedContent: 'MCP Tool Error (search_companies): lookup failed',
+      },
+      {
+        label: 'error result without content',
+        mcpResult: { content: '', isError: true },
+        expectedContent: 'MCP Tool Error (search_companies): Tool returned an error result',
+      },
+    ])('marks MCP tool_result blocks as errors before continuing the Anthropic conversation ($label)', async ({
+      mcpResult,
+      expectedContent,
+    }) => {
       provider = createProvider('claude-3-5-sonnet-latest', {
         config: {
           mcp: {
@@ -1615,10 +1634,7 @@ describe('AnthropicMessagesProvider', () => {
         },
       });
 
-      mcpMocks.callTool.mockResolvedValueOnce({
-        content: 'lookup failed',
-        isError: true,
-      });
+      mcpMocks.callTool.mockResolvedValueOnce(mcpResult);
 
       const createSpy = vi
         .spyOn(provider.anthropic.messages, 'create')
@@ -1651,7 +1667,7 @@ describe('AnthropicMessagesProvider', () => {
             {
               type: 'tool_result',
               tool_use_id: 'toolu_error',
-              content: 'MCP Tool Error (search_companies): lookup failed',
+              content: expectedContent,
               is_error: true,
             },
           ],

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1616,7 +1616,8 @@ describe('AnthropicMessagesProvider', () => {
       });
 
       mcpMocks.callTool.mockResolvedValueOnce({
-        error: 'lookup failed',
+        content: 'lookup failed',
+        isError: true,
       });
 
       const createSpy = vi

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -701,8 +701,8 @@ describe('AwsBedrockConverseProvider', () => {
 
     it('should return MCP tool errors', async () => {
       mcpMocks.mockCallTool.mockResolvedValueOnce({
-        content: '',
-        error: 'MCP server failed',
+        content: 'MCP server failed',
+        isError: true,
       });
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {

--- a/test/providers/functionCallbackUtils.test.ts
+++ b/test/providers/functionCallbackUtils.test.ts
@@ -468,8 +468,8 @@ describe('FunctionCallbackHandler', () => {
         { name: 'failing_tool', description: 'A tool that fails' },
       ]);
       mockMCPClient.callTool.mockResolvedValue({
-        content: '',
-        error: 'Tool execution failed: Invalid arguments',
+        content: 'Tool execution failed: Invalid arguments',
+        isError: true,
       });
 
       const call = { name: 'failing_tool', arguments: '{"invalid": true}' };

--- a/test/providers/functionCallbackUtils.test.ts
+++ b/test/providers/functionCallbackUtils.test.ts
@@ -481,6 +481,42 @@ describe('FunctionCallbackHandler', () => {
       });
     });
 
+    it('should surface MCP results that resolve with an error field', async () => {
+      mockMCPClient.getAllTools.mockReturnValue([
+        { name: 'failing_tool', description: 'A tool that fails' },
+      ]);
+      mockMCPClient.callTool.mockResolvedValue({
+        content: '',
+        error: 'Connection refused',
+      });
+
+      const call = { name: 'failing_tool', arguments: '{}' };
+      const result = await handler.processCall(call, {});
+
+      expect(result).toEqual({
+        output: 'MCP Tool Error (failing_tool): Connection refused',
+        isError: true,
+      });
+    });
+
+    it('should fall back to a generic message when an error result has no content', async () => {
+      mockMCPClient.getAllTools.mockReturnValue([
+        { name: 'failing_tool', description: 'A tool that fails' },
+      ]);
+      mockMCPClient.callTool.mockResolvedValue({
+        content: '',
+        isError: true,
+      });
+
+      const call = { name: 'failing_tool', arguments: '{}' };
+      const result = await handler.processCall(call, {});
+
+      expect(result).toEqual({
+        output: 'MCP Tool Error (failing_tool): Tool returned an error result',
+        isError: true,
+      });
+    });
+
     it('should handle MCP client exceptions', async () => {
       mockMCPClient.getAllTools.mockReturnValue([
         { name: 'error_tool', description: 'A tool that throws' },

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -785,6 +785,39 @@ describe('MCPClient', () => {
       });
     });
 
+    it('should surface MCP tool error results', async () => {
+      // Reset mocks for this test
+      const errorContent = [{ type: 'text', text: 'Invalid arguments' }];
+      mockClient.connect.mockResolvedValueOnce(undefined);
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [{ name: 'tool1', description: 'desc1', inputSchema: {} }],
+      });
+      mockClient.callTool.mockResolvedValueOnce({
+        content: errorContent,
+        isError: true,
+      });
+
+      mcpClient = new MCPClient({
+        enabled: true,
+        server: {
+          command: 'npm',
+          args: ['start'],
+        },
+      });
+
+      await mcpClient.initialize();
+      const result = await mcpClient.callTool('tool1', {});
+
+      expect(result).toEqual({
+        content: JSON.stringify(errorContent),
+        error: JSON.stringify(errorContent),
+        raw: {
+          content: errorContent,
+          isError: true,
+        },
+      });
+    });
+
     it('should throw error for unknown tool', async () => {
       // Reset mocks for this test
       mockClient.connect.mockResolvedValueOnce(undefined);

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -810,7 +810,7 @@ describe('MCPClient', () => {
 
       expect(result).toEqual({
         content: JSON.stringify(errorContent),
-        error: JSON.stringify(errorContent),
+        isError: true,
         raw: {
           content: errorContent,
           isError: true,

--- a/test/providers/mcp/provider.test.ts
+++ b/test/providers/mcp/provider.test.ts
@@ -78,6 +78,44 @@ describe('MCPProvider', () => {
     });
   });
 
+  it('should preserve MCP tool error results as direct provider output via callApi', async () => {
+    const rawResult = {
+      content: [{ type: 'text', text: 'Path traversal not allowed' }],
+      isError: true,
+    };
+    mcpClientMock.callTool.mockResolvedValue({
+      content: 'Path traversal not allowed',
+      isError: true,
+      raw: rawResult,
+    });
+
+    const provider = new MCPProvider({ config: { enabled: true } });
+    const payload = { tool: 'read_file', args: { path: '../../../etc/passwd' } };
+
+    await expect(provider.callApi('', createContext(payload))).resolves.toEqual({
+      output: 'Path traversal not allowed',
+      raw: rawResult,
+      metadata: {
+        toolName: 'read_file',
+        toolArgs: { path: '../../../etc/passwd' },
+        originalPayload: payload,
+      },
+    });
+  });
+
+  it('should surface MCP client failures as a provider error', async () => {
+    const failure = { content: '', error: 'connection lost' };
+    mcpClientMock.callTool.mockResolvedValue(failure);
+
+    const provider = new MCPProvider({ config: { enabled: true } });
+    const payload = { tool: 'lookup_user', args: { id: '123' } };
+
+    await expect(provider.callApi('', createContext(payload))).resolves.toEqual({
+      error: 'MCP tool error: connection lost',
+      raw: failure,
+    });
+  });
+
   it('should transform raw MCP results and merge provider metadata', async () => {
     const rawResult = {
       content: [{ type: 'text', text: 'raw response' }],

--- a/test/providers/mcp/provider.test.ts
+++ b/test/providers/mcp/provider.test.ts
@@ -55,6 +55,29 @@ describe('MCPProvider', () => {
     });
   });
 
+  it('should preserve MCP tool error results as direct provider output', async () => {
+    const rawResult = {
+      content: [{ type: 'text', text: 'Path traversal not allowed' }],
+      isError: true,
+    };
+    mcpClientMock.callTool.mockResolvedValue({
+      content: 'Path traversal not allowed',
+      isError: true,
+      raw: rawResult,
+    });
+
+    const provider = new MCPProvider({ config: { enabled: true } });
+
+    await expect(provider.callTool('read_file', { path: '../../../etc/passwd' })).resolves.toEqual({
+      output: 'Path traversal not allowed',
+      raw: rawResult,
+      metadata: {
+        toolName: 'read_file',
+        toolArgs: { path: '../../../etc/passwd' },
+      },
+    });
+  });
+
   it('should transform raw MCP results and merge provider metadata', async () => {
     const rawResult = {
       content: [{ type: 'text', text: 'raw response' }],

--- a/test/providers/mcp/util.test.ts
+++ b/test/providers/mcp/util.test.ts
@@ -4,6 +4,8 @@ import {
   discoverTokenEndpoint,
   getAuthHeaders,
   getAuthQueryParams,
+  getMcpErrorMessage,
+  isMcpErrorResult,
   isMcpToolNameFilter,
 } from '../../../src/providers/mcp/util';
 
@@ -25,6 +27,40 @@ describe('isMcpToolNameFilter', () => {
     expect(isMcpToolNameFilter('file://tools.json')).toBe(false);
     expect(isMcpToolNameFilter(['file://tools.json'])).toBe(false);
     expect(isMcpToolNameFilter([{ type: 'function', function: { name: 'lookup' } }])).toBe(false);
+  });
+});
+
+describe('isMcpErrorResult', () => {
+  it('flags results with a thrown SDK error', () => {
+    expect(isMcpErrorResult({ content: '', error: 'connection lost' })).toBe(true);
+  });
+
+  it('flags results with a protocol-level isError flag', () => {
+    expect(isMcpErrorResult({ content: 'Path traversal not allowed', isError: true })).toBe(true);
+  });
+
+  it('does not flag successful results', () => {
+    expect(isMcpErrorResult({ content: 'ok' })).toBe(false);
+  });
+});
+
+describe('getMcpErrorMessage', () => {
+  it('prefers the thrown-error message', () => {
+    expect(getMcpErrorMessage({ content: 'ignored', error: 'connection lost' })).toBe(
+      'connection lost',
+    );
+  });
+
+  it('falls back to the tool error content', () => {
+    expect(getMcpErrorMessage({ content: 'Path traversal not allowed', isError: true })).toBe(
+      'Path traversal not allowed',
+    );
+  });
+
+  it('falls back to a generic message when an error result has no content', () => {
+    expect(getMcpErrorMessage({ content: '', isError: true })).toBe(
+      'Tool returned an error result',
+    );
   });
 });
 

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -766,7 +766,26 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(result.tokenUsage).toEqual({ total: 15, prompt: 10, completion: 5, numRequests: 1 });
     });
 
-    it('should surface MCP tool error results in chat tool callbacks', async () => {
+    it.each([
+      {
+        label: 'isError result',
+        callToolResult: { content: 'Path traversal not allowed', isError: true },
+        expectedOutput: 'MCP Tool Error (read_file): Path traversal not allowed',
+      },
+      {
+        label: 'thrown error surfaced via the error field',
+        callToolResult: { content: '', error: 'Connection refused' },
+        expectedOutput: 'MCP Tool Error (read_file): Connection refused',
+      },
+      {
+        label: 'error result without content',
+        callToolResult: { content: '', isError: true },
+        expectedOutput: 'MCP Tool Error (read_file): Tool returned an error result',
+      },
+    ])('should surface MCP tool error results in chat tool callbacks ($label)', async ({
+      callToolResult,
+      expectedOutput,
+    }) => {
       const mockResponse = {
         data: {
           choices: [
@@ -795,10 +814,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
       const mcpClient = {
         getAllTools: vi.fn().mockReturnValue([{ name: 'read_file' }]),
-        callTool: vi.fn().mockResolvedValue({
-          content: 'Path traversal not allowed',
-          isError: true,
-        }),
+        callTool: vi.fn().mockResolvedValue(callToolResult),
       };
       (provider as any).mcpClient = mcpClient;
 
@@ -807,7 +823,7 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(mcpClient.callTool).toHaveBeenCalledWith('read_file', {
         path: '../../../etc/passwd',
       });
-      expect(result.output).toBe('MCP Tool Error (read_file): Path traversal not allowed');
+      expect(result.output).toBe(expectedOutput);
     });
 
     it('should handle multiple function tool calls', async () => {

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -766,6 +766,50 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(result.tokenUsage).toEqual({ total: 15, prompt: 10, completion: 5, numRequests: 1 });
     });
 
+    it('should surface MCP tool error results in chat tool callbacks', async () => {
+      const mockResponse = {
+        data: {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    function: {
+                      name: 'read_file',
+                      arguments: '{"path":"../../../etc/passwd"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          usage: { total_tokens: 15, prompt_tokens: 10, completion_tokens: 5 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetchWithCache.mockResolvedValue(mockResponse);
+
+      const provider = new OpenAiChatCompletionProvider('gpt-4o-mini');
+      const mcpClient = {
+        getAllTools: vi.fn().mockReturnValue([{ name: 'read_file' }]),
+        callTool: vi.fn().mockResolvedValue({
+          content: 'Path traversal not allowed',
+          isError: true,
+        }),
+      };
+      (provider as any).mcpClient = mcpClient;
+
+      const result = await provider.callApi('Read the file');
+
+      expect(mcpClient.callTool).toHaveBeenCalledWith('read_file', {
+        path: '../../../etc/passwd',
+      });
+      expect(result.output).toBe('MCP Tool Error (read_file): Path traversal not allowed');
+    });
+
     it('should handle multiple function tool calls', async () => {
       const mockResponse = {
         data: {


### PR DESCRIPTION
## Summary
- preserve MCP protocol `isError` tool results as a distinct client signal instead of dropping them
- surface tool-level MCP failures to Anthropic, Bedrock, OpenAI chat, and shared function-callback flows
- keep direct `mcp` provider tool-error content available as output for eval assertions and response transforms

## Testing
- `./node_modules/.bin/vitest run test/providers/mcp/client.test.ts test/providers/mcp/provider.test.ts test/providers/anthropic/messages.test.ts test/providers/functionCallbackUtils.test.ts test/providers/bedrock/converse.test.ts test/providers/openai/chat.test.ts --sequence.shuffle=false`
- `./node_modules/.bin/vitest run test/providers/azure/chat-mcp-integration.test.ts --sequence.shuffle=false`
- `npm run local -- eval -c examples/simple-mcp/promptfooconfig.yaml --no-cache -o /tmp/promptfoo-mcp-error-results-simple-eval-fixed.json` with sharing disabled; exported JSON showed 14 successes, score 1, and no errors
- `npm run l`
- `npm run f`
- `npm run tsc`
- `git -c core.fsmonitor=false diff --check`