### PR TITLE
fix(providers): honor max_tool_calls: 0 for Anthropic MCP

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -117,7 +117,9 @@ function getMaxMcpToolCalls(config: AnthropicMessageOptions): number {
     return DEFAULT_MAX_MCP_TOOL_CALLS;
   }
 
-  if (!Number.isFinite(config.max_tool_calls) || config.max_tool_calls < 1) {
+  // Negative or non-finite values are invalid and fall back to the default;
+  // 0 is honored as an explicit "disable automatic MCP tool execution" setting.
+  if (!Number.isFinite(config.max_tool_calls) || config.max_tool_calls < 0) {
     return DEFAULT_MAX_MCP_TOOL_CALLS;
   }
 
@@ -295,10 +297,17 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       return { response: initialResponse };
     }
 
+    const maxToolCalls = getMaxMcpToolCalls(config);
+    if (maxToolCalls === 0) {
+      // max_tool_calls: 0 explicitly disables automatic MCP tool execution.
+      // Return the model's initial response (which may contain tool_use
+      // blocks) unchanged rather than treating unexecuted tools as an error.
+      return { response: initialResponse };
+    }
+
     let response = initialResponse;
     const responses = [initialResponse];
     let messages = params.messages;
-    const maxToolCalls = getMaxMcpToolCalls(config);
     let executedMcpToolCalls = 0;
 
     for (let iteration = 0; iteration < maxToolCalls; iteration++) {

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1766,6 +1766,46 @@ describe('AnthropicMessagesProvider', () => {
       expect(result.cost).toBeGreaterThan(0);
     });
 
+    it('disables MCP tool execution when max_tool_calls is 0', async () => {
+      // Regression: max_tool_calls: 0 is an explicit "do not auto-execute MCP
+      // tools" guard, but 0 was treated as invalid and silently widened to the
+      // default of 8, so tools ran anyway.
+      provider = createProvider('claude-3-5-sonnet-latest', {
+        config: {
+          max_tool_calls: 0,
+          mcp: {
+            enabled: true,
+            server: {
+              command: 'npm',
+              args: ['start'],
+            },
+          },
+        },
+      });
+
+      const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_search',
+            name: 'search_companies',
+            input: { query: 'clean energy' },
+          },
+        ],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5, server_tool_use: null },
+      } as Anthropic.Messages.Message);
+
+      const result = await provider.callApi('Find clean energy companies');
+
+      // No tool was executed and no continuation request was made.
+      expect(mcpMocks.callTool).not.toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      // The initial response is returned on the normal output path, not as an error.
+      expect(result.error).toBeUndefined();
+      expect(result.tokenUsage).toMatchObject({ prompt: 10, completion: 5 });
+    });
+
     it('blocks parallel MCP tool execution when it would exceed max_tool_calls', async () => {
       provider = createProvider('claude-3-5-sonnet-latest', {
         config: {


### PR DESCRIPTION
## Summary

Found during a pre-release audit of changes since `0.121.11` (introduced by #9286, which added Anthropic MCP tool execution).

`getMaxMcpToolCalls` treated `max_tool_calls < 1` as invalid and silently returned the default of `8`. A user who set `max_tool_calls: 0` as a hard "do not automatically execute MCP tools" guard instead got **up to 8 real tool invocations** — the associated spend, latency, and side effects — turning an explicit safety cap into the opposite behavior.

The fix has two parts:
- `getMaxMcpToolCalls` now rejects only negative / non-finite values; `0` is returned as-is.
- `resolveMcpToolUse` short-circuits to the model's initial response when the cap is `0`, so the model's `tool_use` blocks flow through the normal output path instead of being reported as a `max_tool_calls`-exceeded error.

## Test plan

- [x] New regression test — `disables MCP tool execution when max_tool_calls is 0` — asserts no tool is executed, no continuation request is made, and the initial response is returned without an error
- [x] `npx vitest run test/providers/anthropic/messages.test.ts` — 102 passed (existing `max_tool_calls: 1` cap tests unaffected)