### PR TITLE
fix(cli): clearer errors for malformed eval imports

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -26,17 +26,29 @@ function extractEvalId(evalData: any): string | undefined {
   return evalData.evalId || evalData.id;
 }
 
+function parseImportedDate(value: unknown, field: string): Date | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const parsed = new Date(value as string | number);
+  if (Number.isNaN(parsed.getTime())) {
+    logger.warn(
+      `Imported eval has an unparseable ${field} (${JSON.stringify(value)}); falling back.`,
+    );
+    return undefined;
+  }
+  return parsed;
+}
+
 function extractCreatedAt(evalData: any): Date {
-  if (evalData.metadata?.evaluationCreatedAt) {
-    return new Date(evalData.metadata.evaluationCreatedAt);
-  }
-  if (evalData.results?.timestamp) {
-    return new Date(evalData.results.timestamp);
-  }
-  if (evalData.createdAt) {
-    return new Date(evalData.createdAt);
-  }
-  return new Date();
+  // A present-but-corrupt timestamp must not reach createEvalId().toISOString(),
+  // which would throw an opaque "Invalid time value" mid-import.
+  return (
+    parseImportedDate(evalData.metadata?.evaluationCreatedAt, 'metadata.evaluationCreatedAt') ??
+    parseImportedDate(evalData.results?.timestamp, 'results.timestamp') ??
+    parseImportedDate(evalData.createdAt, 'createdAt') ??
+    new Date()
+  );
 }
 
 function extractAuthor(evalData: any): string | undefined {
@@ -411,7 +423,12 @@ export function importCommand(program: Command) {
           importV3 && Array.isArray(evalData.blobAssets) && evalData.blobAssets.length > 0
             ? prepareBlobAssets(
                 evalData.blobAssets,
-                collectBlobHashes({ results: evalData.results, traces }),
+                // Bound the scan: imported files are untrusted, and deeply
+                // nested JSON would otherwise overflow the stack here.
+                collectBlobHashes(
+                  { results: evalData.results, traces },
+                  { maxDepth: 64, maxStringLength: 100_000 },
+                ),
               )
             : [];
 

--- a/src/importers/parse.ts
+++ b/src/importers/parse.ts
@@ -52,11 +52,21 @@ export function parseImportFile(fileContent: string): ParsedImportFile {
     parsedJson = JSON.parse(fileContent);
   } catch (jsonError) {
     const parsedRows = parseJsonlLines(fileContent);
-    if (parsedRows && parsedRows.every(isOpenAIEvalsJsonlRow)) {
-      return {
-        source: IMPORT_SOURCE_OPENAI_EVALS,
-        evalData: convertOpenAIEvalsJsonl(parsedRows),
-      };
+    if (parsedRows) {
+      if (parsedRows.every(isOpenAIEvalsJsonlRow)) {
+        return {
+          source: IMPORT_SOURCE_OPENAI_EVALS,
+          evalData: convertOpenAIEvalsJsonl(parsedRows),
+        };
+      }
+      // The file parsed cleanly as JSONL but is not a valid OpenAI Evals
+      // export. Re-throwing the whole-file JSON error here would point at a
+      // bogus position; report the schema mismatch and the offending row.
+      const invalidRowIndex = parsedRows.findIndex((row) => !isOpenAIEvalsJsonlRow(row));
+      throw new Error(
+        `File parsed as JSONL but line ${invalidRowIndex + 1} is not a valid OpenAI Evals row. ` +
+          `Expected a promptfoo eval JSON export or an OpenAI Evals JSONL export.`,
+      );
     }
     throw jsonError;
   }

--- a/src/importers/parse.ts
+++ b/src/importers/parse.ts
@@ -53,7 +53,8 @@ export function parseImportFile(fileContent: string): ParsedImportFile {
   } catch (jsonError) {
     const parsedRows = parseJsonlLines(fileContent);
     if (parsedRows) {
-      if (parsedRows.every(isOpenAIEvalsJsonlRow)) {
+      const invalidRowIndex = parsedRows.findIndex((row) => !isOpenAIEvalsJsonlRow(row));
+      if (invalidRowIndex === -1) {
         return {
           source: IMPORT_SOURCE_OPENAI_EVALS,
           evalData: convertOpenAIEvalsJsonl(parsedRows),
@@ -62,7 +63,6 @@ export function parseImportFile(fileContent: string): ParsedImportFile {
       // The file parsed cleanly as JSONL but is not a valid OpenAI Evals
       // export. Re-throwing the whole-file JSON error here would point at a
       // bogus position; report the schema mismatch and the offending row.
-      const invalidRowIndex = parsedRows.findIndex((row) => !isOpenAIEvalsJsonlRow(row));
       throw new Error(
         `File parsed as JSONL but line ${invalidRowIndex + 1} is not a valid OpenAI Evals row. ` +
           `Expected a promptfoo eval JSON export or an OpenAI Evals JSONL export.`,

--- a/src/importers/parse.ts
+++ b/src/importers/parse.ts
@@ -53,8 +53,7 @@ export function parseImportFile(fileContent: string): ParsedImportFile {
   } catch (jsonError) {
     const parsedRows = parseJsonlLines(fileContent);
     if (parsedRows) {
-      const invalidRowIndex = parsedRows.findIndex((row) => !isOpenAIEvalsJsonlRow(row));
-      if (invalidRowIndex === -1) {
+      if (parsedRows.every(isOpenAIEvalsJsonlRow)) {
         return {
           source: IMPORT_SOURCE_OPENAI_EVALS,
           evalData: convertOpenAIEvalsJsonl(parsedRows),
@@ -63,6 +62,7 @@ export function parseImportFile(fileContent: string): ParsedImportFile {
       // The file parsed cleanly as JSONL but is not a valid OpenAI Evals
       // export. Re-throwing the whole-file JSON error here would point at a
       // bogus position; report the schema mismatch and the offending row.
+      const invalidRowIndex = parsedRows.findIndex((row) => !isOpenAIEvalsJsonlRow(row));
       throw new Error(
         `File parsed as JSONL but line ${invalidRowIndex + 1} is not a valid OpenAI Evals row. ` +
           `Expected a promptfoo eval JSON export or an OpenAI Evals JSONL export.`,

--- a/test/blobs/blobRefs.test.ts
+++ b/test/blobs/blobRefs.test.ts
@@ -79,6 +79,15 @@ describe('collectBlobHashes', () => {
     expect([...collectBlobHashes(value, { maxDepth: 2 })]).toEqual([HASH_A]);
   });
 
+  it('does not overflow the stack on deeply nested input', () => {
+    let node: unknown = uri(HASH_A);
+    for (let depth = 0; depth < 50_000; depth += 1) {
+      node = { child: node };
+    }
+    // maxDepth bounds recursion long before the call stack is exhausted.
+    expect(() => collectBlobHashes(node, { maxDepth: 64 })).not.toThrow();
+  });
+
   it('honors maxStringLength while still scanning blob-scheme-prefixed strings', () => {
     const buried = { output: `${'x'.repeat(200)} ${uri(HASH_A)}` };
     const prefixed = { output: `${uri(HASH_B)}${'y'.repeat(200)}` };

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -131,6 +131,45 @@ describe('importCommand', () => {
       expect(await Eval.findById(evalId)).toBeUndefined();
       expect(process.exitCode).toBe(1);
     });
+
+    it('reports a schema mismatch for valid JSONL that is not an OpenAI Evals export', async () => {
+      // Every line is valid JSON, so the whole-file JSON.parse fails but the
+      // JSONL path succeeds. The error must describe the schema mismatch
+      // rather than re-throw the misleading whole-file JSON parse error.
+      const filePath = path.join(__dirname, `temp-bad-jsonl-${Date.now()}.json`);
+      fs.writeFileSync(filePath, ['{"foo":1}', '{"bar":2}'].join('\n'));
+      tempFilePath = filePath;
+
+      importCommand(program);
+      await program.parseAsync(['node', 'test', 'import', filePath]);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringMatching(/parsed as JSONL but line 1 is not a valid OpenAI Evals row/),
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('imports successfully when evaluationCreatedAt is corrupt', async () => {
+      // Regression: a present-but-unparseable timestamp reached
+      // createEvalId().toISOString() and crashed mid-import with an opaque
+      // "Invalid time value".
+      const sampleFilePath = path.join(__dirname, '../__fixtures__/sample-export.json');
+      const sampleData = JSON.parse(fs.readFileSync(sampleFilePath, 'utf-8'));
+      sampleData.metadata.evaluationCreatedAt = 'this-is-not-a-date';
+      const filePath = path.join(__dirname, `temp-bad-date-${Date.now()}.json`);
+      fs.writeFileSync(filePath, JSON.stringify(sampleData));
+      tempFilePath = filePath;
+
+      importCommand(program);
+      await program.parseAsync(['node', 'test', 'import', filePath]);
+
+      expect(logger.error).not.toHaveBeenCalledWith(expect.stringMatching(/Invalid time value/));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/unparseable metadata\.evaluationCreatedAt/),
+      );
+      expect(process.exitCode).not.toBe(1);
+      expect(await Eval.findById(sampleData.evalId)).toBeDefined();
+    });
   });
 
   describe('with real sample file', () => {


### PR DESCRIPTION
## Summary

Found during a pre-release audit of changes since `0.121.11`. Three robustness fixes in the `import` path — each already failed *safely* (no data corruption, before the `--force` delete), but with a misleading or opaque message.

1. **`parseImportFile` (`src/importers/parse.ts`)** — when a file's lines are each valid JSON but at least one is not a valid OpenAI Evals row, the whole-file `JSON.parse` fails and the code fell through to re-throw that stale error (e.g. `Unexpected non-whitespace character after JSON at position 94`), pointing at a bogus position. It now reports the schema mismatch and which line failed.

2. **`extractCreatedAt` (`src/commands/import.ts`)** — a present-but-unparseable `metadata.evaluationCreatedAt` produced an `Invalid Date` that reached `createEvalId().toISOString()` and crashed mid-import with an opaque `RangeError: Invalid time value`. (Its sibling `extractDurations` already validates with `Number.isFinite`.) Corrupt timestamps are now warned about and fall through to the next candidate, then `new Date()`.

3. **`collectBlobHashes` call (`src/commands/import.ts`)** — the import passed no `maxDepth`, so recursion depth equalled JSON nesting depth; a deeply nested (untrusted) import file overflowed the stack with `Maximum call stack size exceeded`. The scan is now depth/string-length bounded. A generous `maxDepth: 64` is used rather than `inlineBlobsForShare`'s `8`, since import only needs overflow protection and a shallower bound risked silently skipping legitimately-nested blob refs.

## Test plan

- [x] `test/commands/import.test.ts` — new tests: schema-invalid JSONL reports the row; a corrupt `evaluationCreatedAt` imports successfully (warns, no crash)
- [x] `test/blobs/blobRefs.test.ts` — new test: `collectBlobHashes` does not overflow the stack on 50k-deep input when `maxDepth` is set
- [x] `npx vitest run test/commands/import.test.ts test/blobs/blobRefs.test.ts` — 54 passed
- [x] Biome lint/format clean; `tsc --noEmit` clean