### PR TITLE
fix(providers): price unknown Grok Imagine slugs at the quality tier

### DIFF
--- a/src/providers/xai/image.ts
+++ b/src/providers/xai/image.ts
@@ -113,8 +113,14 @@ export class XAIImageProvider extends OpenAiImageProvider {
     resolution: XaiImageOptions['resolution'] = '1k',
     sourceImageCount: number = 0,
   ): number {
-    // xAI redirects this retired slug to the quality model after May 15, 2026.
-    const pricingModel = model === 'grok-imagine-image-pro' ? 'grok-imagine-image-quality' : model;
+    // grok-imagine-image-pro is redirected to the quality model after
+    // 2026-05-15; any other unrecognized grok-imagine-* slug (e.g. a future
+    // alias promptfoo has not indexed) is priced at the quality tier too,
+    // rather than falling through to legacy grok-2-image pricing.
+    const pricingModel =
+      model.startsWith('grok-imagine-') && model !== 'grok-imagine-image'
+        ? 'grok-imagine-image-quality'
+        : model;
 
     if (pricingModel === 'grok-imagine-image') {
       return 0.02 * n + 0.002 * sourceImageCount;

--- a/test/providers/xai/image.test.ts
+++ b/test/providers/xai/image.test.ts
@@ -233,6 +233,18 @@ describe('XAI Image Provider', () => {
       );
     });
 
+    it('prices unknown Grok Imagine slugs at the quality tier, not grok-2-image', async () => {
+      const provider = new XAIImageProvider('grok-imagine-image-future-preview', {
+        config: { apiKey: mockApiKey },
+      });
+
+      const result = await provider.callApi('Generate a cat');
+
+      // Unknown grok-imagine-* slugs are priced like grok-imagine-image-quality
+      // ($0.05 at 1k), not the legacy grok-2-image rate ($0.07).
+      expect(result.cost).toBe(0.05);
+    });
+
     it('supports the quality image model with resolution-sensitive fallback pricing', async () => {
       const provider = new XAIImageProvider('grok-imagine-image-quality', {
         config: { apiKey: mockApiKey, resolution: '2k' },


### PR DESCRIPTION
## Summary

Found during a pre-release audit of changes since `0.121.11` (#9237).

`getApiModelName` preserves unrecognized `grok-imagine-*` slugs as-is, so a new xAI alias promptfoo has not yet indexed is **not** silently downgraded to `grok-2-image` for request routing — good. But `calculateImageCost` only had explicit branches for `grok-imagine-image` and `grok-imagine-image-quality` (with `grok-imagine-image-pro` special-cased to the latter). Any other `grok-imagine-*` slug fell through to the final `return 0.07 * n` — the **legacy `grok-2-image` rate** — an arbitrary and likely-wrong price for a Grok Imagine model, and one that also ignores `sourceImageCount`.

Unrecognized `grok-imagine-*` slugs are now priced at the `grok-imagine-image-quality` tier, consistent with how `grok-imagine-image-pro` is already handled. Only the fallback path (when the API omits `cost_in_usd_ticks`) is affected; known slugs and `grok-2-image` are unchanged.

## Test plan

- [x] New regression test — an unknown `grok-imagine-*` slug is priced at the quality tier (`$0.05` at 1k), not the `grok-2-image` rate (`$0.07`)
- [x] `npx vitest run test/providers/xai/image.test.ts` — 48 passed (existing `grok-imagine-image`, `-quality`, `-pro`, and `grok-2-image` pricing tests unaffected)
- [x] Biome lint/format clean; `tsc --noEmit` clean