### PR TITLE
fix(deps): bump brace-expansion and webpack-dev-server [security]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21090,9 +21090,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -42744,9 +42744,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
       "@anthropic-ai/sdk": "^0.95.2"
     },
     "@isaacs/brace-expansion": ">=5.0.1",
+    "brace-expansion@5": "^5.0.6",
     "fast-xml-parser": "$fast-xml-parser",
     "minimatch@<=3.1.3": "3.1.5",
     "vite": "^8.0.5",


### PR DESCRIPTION
## Summary

Resolves both moderate `npm audit` advisories currently flagged on `main`:

- **brace-expansion 5.0.5 → 5.0.6** ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)) — ReDoS where a large numeric range defeats the documented `max` protection. The vulnerable copy is an in-range transitive dependency of `minimatch@10` that `npm audit fix` declines to bump, so it is pinned via a scoped `brace-expansion@5` override (same pattern as the existing `minimatch@<=3.1.3` override). The legacy `brace-expansion` 1.x/2.x copies are unaffected.
- **webpack-dev-server 5.2.3 → 5.2.4** ([GHSA-79cf-xcqc-c78w](https://github.com/advisories/GHSA-79cf-xcqc-c78w)) — cross-origin source-code exposure on non-HTTPS origins (docs-site dev tooling). 5.2.4 has identical dependencies to 5.2.3, so this is a targeted `package-lock.json` bump. Going through `npm audit fix` would instead drag in unrelated nested-`chokidar` churn caused by the existing global `chokidar` override.

`npm audit` now reports **0 vulnerabilities**. The diff is scoped to just these two fixes — no `npm audit fix` drift rides along.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm install` clean — no warnings, integrity validated
- [x] `npm run build` passes
- [ ] CI green