### PR TITLE
fix(webui): avoid NaN in named metric charts

### DIFF
--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -636,6 +636,69 @@ describe('ResultsCharts', () => {
       );
       expect(values).toEqual([0, 0, 0, 0]);
     });
+
+    it('should normalize each named metric independently when one metric is all zero', () => {
+      // `accuracy` is all zero (exercises the zero-max guard), while `precision` and
+      // `coverage` have different maxima. Per-key normalization divides each metric by
+      // its own max; a regression to a single global max would yield different ratios.
+      const mockTable = {
+        head: {
+          prompts: [
+            {
+              provider: 'test-provider-1',
+              metrics: {
+                namedScores: { accuracy: 0, precision: 0.4, coverage: 0.1 },
+              },
+            },
+            {
+              provider: 'test-provider-2',
+              metrics: {
+                namedScores: { accuracy: 0, precision: 0.8, coverage: 0.2 },
+              },
+            },
+          ],
+          vars: [],
+        },
+        body: [
+          {
+            outputs: [
+              { score: 0.7, pass: true, text: 'test 1' },
+              { score: 0.8, pass: true, text: 'test 2' },
+            ],
+            vars: [],
+          },
+        ],
+      };
+
+      const scores = calculateScores(mockTable);
+
+      vi.mocked(useTableStore).mockReturnValue({
+        table: mockTable,
+        evalId: 'test-eval',
+        config: { description: 'test config' },
+        setTable: vi.fn(),
+        fetchEvalData: vi.fn(),
+      });
+
+      render(<ResultsCharts {...defaultProps} scores={scores} />);
+
+      const chartCalls = vi.mocked(Chart).mock.calls;
+      const metricChartConfig = chartCalls
+        .map(([, config]) => config)
+        .find((config) => {
+          const labels = config.data?.labels;
+          return Array.isArray(labels) && labels.includes('accuracy');
+        });
+
+      expect(metricChartConfig).toBeDefined();
+      const values = metricChartConfig!.data!.datasets.flatMap((dataset) => dataset.data ?? []);
+      expect(values.every((value) => typeof value === 'number' && Number.isFinite(value))).toBe(
+        true,
+      );
+      // datasets are [provider-1, provider-2]; keys are [accuracy, precision, coverage].
+      // accuracy -> 0 (zero max), precision -> value / 0.8, coverage -> value / 0.2.
+      expect(values).toEqual([0, 0.5, 0.5, 0, 1, 1]);
+    });
   });
 
   it('handles empty columnVisibility and includes all prompts', () => {

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { Chart } from 'chart.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ResultsCharts from './ResultsCharts';
 import { useTableStore } from './store';
@@ -569,6 +570,71 @@ describe('ResultsCharts', () => {
       // Should render charts (the specific chart type logic is tested indirectly)
       const canvasElements = container.querySelectorAll('canvas');
       expect(canvasElements.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should render finite metric chart values if named scores are all zero', () => {
+      const mockTableWithZeroNamedScores = {
+        head: {
+          prompts: [
+            {
+              provider: 'test-provider-1',
+              metrics: {
+                namedScores: {
+                  accuracy: 0,
+                  precision: 0,
+                },
+              },
+            },
+            {
+              provider: 'test-provider-2',
+              metrics: {
+                namedScores: {
+                  accuracy: 0,
+                  precision: 0,
+                },
+              },
+            },
+          ],
+          vars: [],
+        },
+        body: [
+          {
+            outputs: [
+              { score: 0.7, pass: true, text: 'test 1' },
+              { score: 0.8, pass: true, text: 'test 2' },
+            ],
+            vars: [],
+          },
+        ],
+      };
+
+      const scores = calculateScores(mockTableWithZeroNamedScores);
+
+      vi.mocked(useTableStore).mockReturnValue({
+        table: mockTableWithZeroNamedScores,
+        evalId: 'test-eval',
+        config: { description: 'test config' },
+        setTable: vi.fn(),
+        fetchEvalData: vi.fn(),
+      });
+
+      render(<ResultsCharts {...defaultProps} scores={scores} />);
+
+      const chartCalls = vi.mocked(Chart).mock.calls;
+      const metricChartConfig = chartCalls
+        .map(([, config]) => config)
+        .find((config) => {
+          const labels = config.data?.labels;
+          return Array.isArray(labels) && labels.includes('accuracy');
+        });
+
+      expect(metricChartConfig).toBeDefined();
+      const values = metricChartConfig!.data!.datasets.flatMap((dataset) => dataset.data ?? []);
+      expect(values).toHaveLength(4);
+      expect(values.every((value) => typeof value === 'number' && Number.isFinite(value))).toBe(
+        true,
+      );
+      expect(values).toEqual([0, 0, 0, 0]);
     });
   });
 

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -422,7 +422,7 @@ function MetricChart({ table }: ChartProps) {
         const maxValue = Math.max(
           ...table.head.prompts.map((p) => p.metrics?.namedScores[key] || 0),
         );
-        return value / maxValue;
+        return maxValue > 0 ? value / maxValue : 0;
       });
       return {
         label: `${table.head.prompts[promptIdx].provider}`,

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -416,12 +416,17 @@ function MetricChart({ table }: ChartProps) {
 
     const namedScoreKeys = Object.keys(table.head.prompts[0].metrics?.namedScores || {});
     const labels = namedScoreKeys;
+    // Compute each metric's max once; it depends only on the key, not the prompt.
+    const maxValueByKey = new Map(
+      namedScoreKeys.map((key) => [
+        key,
+        Math.max(...table.head.prompts.map((p) => p.metrics?.namedScores[key] || 0)),
+      ]),
+    );
     const datasets = table.head.prompts.map((prompt, promptIdx) => {
       const data = namedScoreKeys.map((key) => {
         const value = prompt.metrics?.namedScores[key] || 0;
-        const maxValue = Math.max(
-          ...table.head.prompts.map((p) => p.metrics?.namedScores[key] || 0),
-        );
+        const maxValue = maxValueByKey.get(key) ?? 0;
         return maxValue > 0 ? value / maxValue : 0;
       });
       return {


### PR DESCRIPTION
## Summary
- guard named metric normalization when every prompt has a zero value
- render all-zero named metrics as zero-height bars instead of non-finite chart data
- add regression coverage for all-zero named metric chart datasets

Fixes #9350

## Validation
- `ASDF_NODEJS_VERSION=24.15.0 asdf exec npm --prefix src/app run test -- src/pages/eval/components/ResultsCharts.test.tsx --run`
- `ASDF_NODEJS_VERSION=24.15.0 asdf exec npm --prefix src/app run tsc`
- `ASDF_NODEJS_VERSION=24.15.0 asdf exec npm run l`
- `ASDF_NODEJS_VERSION=24.15.0 asdf exec npm run tsc`
- `git diff --check`