### PR TITLE
fix(ci): scope code-scan-action mirror sync to release artifacts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -283,22 +283,26 @@ jobs:
           cd "$mirror_dir"
 
           git switch -C "$branch" origin/main
-          rsync -a --delete \
-            --exclude='.git' \
-            --exclude='.github' \
-            --exclude='AGENTS.md' \
-            --exclude='CLAUDE.md' \
-            --exclude='LICENSE*' \
-            "$export_dir"/ "$mirror_dir"/
 
-          if git diff --quiet; then
+          # Replace only the generated release-artifact paths. The mirror repo
+          # owns every other path (.github/, renovate.json, AGENTS.md, ...);
+          # syncing the whole tree with `rsync --delete` silently deleted those
+          # and broke the mirror's validate-release-pr check.
+          rm -rf dist
+          cp -R "$export_dir/dist" dist
+          cp "$export_dir/action.yml" action.yml
+          cp "$export_dir/README.md" README.md
+          cp "$export_dir/CHANGELOG.md" CHANGELOG.md
+          cp "$export_dir/.release-source.json" .release-source.json
+
+          git add action.yml README.md CHANGELOG.md dist .release-source.json
+          if git diff --cached --quiet; then
             echo "No mirror changes to publish for code-scan-action v${CODE_SCAN_ACTION_VERSION}"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
           git -c core.hooksPath=/dev/null \
             commit -m "Release code-scan-action v${CODE_SCAN_ACTION_VERSION}"
           git -c "$auth_header" -c core.hooksPath=/dev/null \


### PR DESCRIPTION
## Summary

`publish-code-scan-action` in `release-please.yml` syncs the `promptfoo/code-scan-action` mirror repo with `rsync -a --delete` over the **whole tree** — exporting only `{action.yml, README.md, CHANGELOG.md, dist/, .release-source.json}` and excluding `{.git, .github, AGENTS.md, CLAUDE.md, LICENSE*}`. Any mirror-owned path in neither set gets **deleted** by the sync: `renovate.json` (added to the mirror in April) and the stale `cli-bundle/` directory.

The mirror's `validate-release-pr` workflow only permits release PRs to touch the artifact set, so those stray deletions fail validation — which is why **no code-scan-action mirror release has validated cleanly since v0.1.4** (the v0.1.5 and v0.1.6 mirror PRs are both stuck on a red `validate-release-pr`).

This replaces only the five generated artifact paths instead of `rsync --delete`-ing the whole tree, so mirror-owned files survive the sync untouched. It also drops the `rsync` dependency.

The stale `cli-bundle/` directory is being purged from the mirror repo separately.

## Test plan
- [ ] CI green (GitHub Actions Lint, etc.)
- [ ] Next code-scan-action release produces a mirror PR whose diff is limited to `action.yml`, `README.md`, `CHANGELOG.md`, `dist/**`, `.release-source.json` and passes `validate-release-pr`