### PR TITLE
fix(eval): prevent optimize from polluting jsonl output

### DIFF
--- a/src/optimizer/promptOptimizer.ts
+++ b/src/optimizer/promptOptimizer.ts
@@ -628,16 +628,21 @@ export async function optimizePromptTestSuite(
   const { searchTestSuite, validationTestSuite, searchTestCount, validationTestCount } =
     createValidationPartition(selectedTestSuite, options.validationSplit);
 
+  // Internal optimizer evals are intermediate runs and must not write to the user's
+  // configured output. Strip outputPath so the Evaluator does not append baseline or
+  // candidate result rows to a .jsonl file the user expects only `eval` to populate.
+  const optimizationConfig: Partial<UnifiedConfig> = { ...config, outputPath: undefined };
+
   logger.info('Running baseline evaluation for prompt optimization...');
   const baselineEval = await evaluate(
     cloneOptimizationTestSuite(searchTestSuite),
-    new Eval(config, { persisted: false }),
+    new Eval(optimizationConfig, { persisted: false }),
     createEvaluationOptions(config),
   );
   const baselineValidationEval = validationTestSuite
     ? await evaluate(
         cloneOptimizationTestSuite(validationTestSuite),
-        new Eval(config, { persisted: false }),
+        new Eval(optimizationConfig, { persisted: false }),
         createEvaluationOptions(config),
       )
     : undefined;
@@ -700,7 +705,7 @@ export async function optimizePromptTestSuite(
     );
     const candidateEval = await evaluate(
       cloneOptimizationTestSuite(candidateSearchSuite),
-      new Eval(config, { persisted: false }),
+      new Eval(optimizationConfig, { persisted: false }),
       createEvaluationOptions(config),
     );
     const candidateValidationEval = validationTestSuite
@@ -713,7 +718,7 @@ export async function optimizePromptTestSuite(
               candidates,
             ),
           ),
-          new Eval(config, { persisted: false }),
+          new Eval(optimizationConfig, { persisted: false }),
           createEvaluationOptions(config),
         )
       : undefined;

--- a/test/optimizer/promptOptimizer.test.ts
+++ b/test/optimizer/promptOptimizer.test.ts
@@ -361,6 +361,55 @@ describe('prompt optimizer', () => {
     );
   });
 
+  it('strips outputPath from internal optimizer evals so they do not pollute the user output file', async () => {
+    const provider = createMockProvider({
+      id: 'optimizer-provider',
+      response: optimizerResponse('Optimized Seed'),
+    });
+    vi.mocked(provider.callApi)
+      .mockResolvedValueOnce(optimizerResponse('Optimized Seed'))
+      .mockResolvedValueOnce(optimizerResponse('Optimized Seed 2'))
+      .mockResolvedValueOnce(optimizerResponse('Optimized Seed 3'));
+    vi.mocked(getDefaultProviders).mockResolvedValue({
+      embeddingProvider: provider,
+      gradingJsonProvider: provider,
+      gradingProvider: provider,
+      moderationProvider: provider,
+      suggestionsProvider: provider,
+      synthesizeProvider: provider,
+    } as any);
+
+    const baselineEval = evalWith([completedPrompt('Seed', 'Seed', 0.5)], []);
+    const candidateEval = evalWith(
+      [
+        completedPrompt('Seed', 'Seed', 0.5),
+        completedPrompt('Optimized Seed', 'Seed [optimized 1]', 0.8),
+      ],
+      [],
+    );
+
+    vi.mocked(evaluate)
+      .mockResolvedValueOnce(baselineEval)
+      .mockResolvedValueOnce(candidateEval)
+      .mockResolvedValueOnce(candidateEval)
+      .mockResolvedValueOnce(candidateEval);
+
+    const testSuite: TestSuite = {
+      providers: [createMockProvider({ id: 'target-provider' })],
+      prompts: [{ raw: 'Seed', label: 'Seed' }],
+      tests: [{}],
+    };
+
+    await optimizePromptTestSuite({ outputPath: 'results.jsonl' }, testSuite);
+
+    const evalCalls = vi.mocked(evaluate).mock.calls;
+    expect(evalCalls.length).toBeGreaterThan(0);
+    for (const call of evalCalls) {
+      expect(call[1]).toBeInstanceOf(Eval);
+      expect(call[1].config.outputPath).toBeUndefined();
+    }
+  });
+
   it('keeps optimized candidates eligible when provider prompt routing uses prompt ids', async () => {
     const provider = createMockProvider({
       id: 'optimizer-provider',

--- a/test/optimizer/promptOptimizer.test.ts
+++ b/test/optimizer/promptOptimizer.test.ts
@@ -390,6 +390,10 @@ describe('prompt optimizer', () => {
 
     vi.mocked(evaluate)
       .mockResolvedValueOnce(baselineEval)
+      .mockResolvedValueOnce(baselineEval)
+      .mockResolvedValueOnce(candidateEval)
+      .mockResolvedValueOnce(candidateEval)
+      .mockResolvedValueOnce(candidateEval)
       .mockResolvedValueOnce(candidateEval)
       .mockResolvedValueOnce(candidateEval)
       .mockResolvedValueOnce(candidateEval);
@@ -397,13 +401,15 @@ describe('prompt optimizer', () => {
     const testSuite: TestSuite = {
       providers: [createMockProvider({ id: 'target-provider' })],
       prompts: [{ raw: 'Seed', label: 'Seed' }],
-      tests: [{}],
+      tests: [{}, {}],
     };
 
-    await optimizePromptTestSuite({ outputPath: 'results.jsonl' }, testSuite);
+    await optimizePromptTestSuite({ outputPath: 'results.jsonl' }, testSuite, {
+      validationSplit: 0.5,
+    });
 
     const evalCalls = vi.mocked(evaluate).mock.calls;
-    expect(evalCalls.length).toBeGreaterThan(0);
+    expect(evalCalls).toHaveLength(8);
     for (const call of evalCalls) {
       expect(call[1]).toBeInstanceOf(Eval);
       expect(call[1].config.outputPath).toBeUndefined();


### PR DESCRIPTION
## Summary

- The `promptfoo optimize` command runs internal baseline and candidate evaluations via `optimizePromptTestSuite` in `src/optimizer/promptOptimizer.ts`, constructing each intermediate run as `new Eval(config, { persisted: false })` with the full user `config`.
- The `Evaluator` constructor (`src/evaluator.ts`) creates a `JsonlFileWriter` for any `.jsonl` path in `config.outputPath` and appends every result row. So when a user ran `optimize` with a config whose `outputPath` was a `.jsonl` file, every internal baseline/candidate eval appended its rows to the user's real output file — even though `optimize` is supposed to write nothing itself.
- Fix: build a single config copy with `outputPath` stripped (`optimizationConfig`) and pass it to all four internal `new Eval(...)` sites, so no `JsonlFileWriter` is created for those intermediate runs. Runtime `evaluateOptions` are still derived from the original `config`, so behavior is otherwise unchanged.

## Test plan

- [x] Added a regression test in `test/optimizer/promptOptimizer.test.ts` that runs `optimizePromptTestSuite` with `outputPath: 'results.jsonl'` and asserts every internal `Eval` is constructed with `config.outputPath === undefined`. Verified it fails before the fix (`Received: "results.jsonl"`) and passes after.
- [x] `npm run l` and `npm run f` — clean.
- [x] `npx tsc --noEmit -p tsconfig.json` — 0 errors.
- [x] `npx vitest run test/optimizer/promptOptimizer.test.ts test/commands/optimize.test.ts` — 29 passed.