### PR TITLE
fix(webui): make full metric chip area clickable

### DIFF
--- a/src/app/src/pages/eval/components/CustomMetrics.css
+++ b/src/app/src/pages/eval/components/CustomMetrics.css
@@ -10,7 +10,6 @@
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
   border-radius: 8px;
   font-size: 0.8125rem;
   font-weight: 500;
@@ -28,12 +27,16 @@
   cursor: pointer;
 }
 
+/*
+ * The clickable button fills the chip and owns the padding so the entire
+ * chip surface (including its inset) is clickable, with no dead zone.
+ */
 .metric-content {
   display: flex;
   align-items: center;
   gap: 0.25rem;
   flex: 1;
-  padding: 0;
+  padding: 0.25rem 0.5rem;
   border: 0;
   color: inherit;
   background: transparent;
@@ -114,8 +117,11 @@
   }
 
   .metric-chip {
-    padding: 0.2rem 0.4rem;
     font-size: 0.75rem;
+  }
+
+  .metric-content {
+    padding: 0.2rem 0.4rem;
   }
 
   .filter-icon {

--- a/src/app/src/pages/eval/components/CustomMetrics.css
+++ b/src/app/src/pages/eval/components/CustomMetrics.css
@@ -56,7 +56,7 @@
 }
 
 .metric-content:focus-visible {
-  outline: 2px solid var(--primary-color, #2563eb);
+  outline: 2px solid var(--color-ring);
   outline-offset: -2px;
 }
 

--- a/src/app/src/pages/eval/components/CustomMetrics.css
+++ b/src/app/src/pages/eval/components/CustomMetrics.css
@@ -37,6 +37,7 @@
   gap: 0.25rem;
   flex: 1;
   padding: 0.25rem 0.5rem;
+  border-radius: inherit;
   border: 0;
   color: inherit;
   background: transparent;
@@ -57,7 +58,6 @@
 .metric-content:focus-visible {
   outline: 2px solid var(--primary-color, #2563eb);
   outline-offset: -2px;
-  border-radius: 8px;
 }
 
 .metric-name {

--- a/src/app/src/pages/eval/components/CustomMetrics.css
+++ b/src/app/src/pages/eval/components/CustomMetrics.css
@@ -46,6 +46,20 @@
   transition: all 0.15s ease-in-out;
 }
 
+/*
+ * Draw the keyboard-focus ring inset: `.metric-chip` has `overflow: hidden`,
+ * which would clip a default (outset) outline on the inner button.
+ */
+.metric-content:focus {
+  outline: none;
+}
+
+.metric-content:focus-visible {
+  outline: 2px solid var(--primary-color, #2563eb);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+
 .metric-name {
   font-weight: 600;
   color: inherit;

--- a/src/app/src/pages/eval/components/CustomMetrics.test.tsx
+++ b/src/app/src/pages/eval/components/CustomMetrics.test.tsx
@@ -198,6 +198,18 @@ describe('CustomMetrics', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Click to filter by this metric');
   });
 
+  it('keeps the clickable button as the chip child so the whole chip area filters', () => {
+    renderWithProviders(<CustomMetrics lookup={{ metric1: 10 }} />);
+
+    const chip = screen.getByTestId('metric-metric1');
+    const metricButton = screen.getByRole('button', { name: 'Filter by metric metric1' });
+
+    // The button must be a direct child of the chip so the chip has no
+    // non-clickable padding ring around the button.
+    expect(metricButton.parentElement).toBe(chip);
+    expect(metricButton).toHaveClass('metric-content');
+  });
+
   it('keeps policy details alongside the filter hint tooltip', async () => {
     const user = userEvent.setup();
     const policyMetric = 'policy:policy-1';


### PR DESCRIPTION
## Summary

PR #9252 moved the metric pill's click handler from the chip `<div>` onto an inner `<button>` (`.metric-content`) — a good accessibility improvement. But `.metric-chip` (in `CustomMetrics.css`) kept its own `padding: 0.25rem 0.5rem` *outside* that button, and `.metric-chip` itself has no `onClick`. The result: the padding ring around each metric chip became a non-clickable dead zone, so clicking the edge of a chip did nothing.

This moves the chip padding off `.metric-chip` and onto the inner `.metric-content` button. The button already has `flex: 1`, so it fills the chip and the entire chip surface (including the inset that used to be padding) is clickable again.

- Removed `padding` from `.metric-chip`; added the same `padding: 0.25rem 0.5rem` to `.metric-content`.
- Applied the same swap inside the `max-width: 768px` responsive block (`0.2rem 0.4rem`).
- The accessible `<button>` is preserved; the rendered geometry and visual appearance are unchanged (the button fills the chip and contributes the same padding).
- Added a regression test asserting the clickable button stays a direct child of the chip element, so no non-clickable wrapper can reappear.

## Test plan

- [x] `npm run l` — passes, no fixes applied
- [x] `npm run f` — passes, no changes
- [x] `cd src/app && npx tsc --noEmit` — 0 errors
- [x] `npm run test:app -- src/pages/eval/components/CustomMetrics.test.tsx --run` — 21/21 pass (includes the new regression test)
- [ ] Manual: hover/click the padded edge of a metric chip in the eval results view and confirm the filter applies