### PR TITLE
fix(webui): clear stale rowId and details hash on filter clear

### DIFF
--- a/src/app/src/pages/eval/components/Eval.test.tsx
+++ b/src/app/src/pages/eval/components/Eval.test.tsx
@@ -425,6 +425,61 @@ describe('Eval', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('clears a stale rowId param when filters are cleared without a filter param', async () => {
+    let subscriptionCallback: ((filters: any) => void) | null = null;
+
+    // Mock subscribe to capture the callback and trigger it
+    (useTableStore as any).subscribe = vi.fn((selector, callback) => {
+      if (selector.toString().includes('filters')) {
+        subscriptionCallback = callback;
+      }
+      return vi.fn(); // unsubscribe function
+    });
+
+    const mockFilters = {
+      values: {},
+      appliedCount: 0, // Filters cleared
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      ...baseMockTableStore,
+      filters: mockFilters,
+    });
+
+    // No `filter` param, but a stale `rowId` and details hash are present.
+    const initialUrl = '/eval/test-eval?rowId=51#details-row-51-prompt-1';
+    window.history.replaceState({}, '', initialUrl);
+
+    render(
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Eval fetchId="test-eval" />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // Trigger the subscription callback manually
+    if (subscriptionCallback) {
+      await act(async () => {
+        subscriptionCallback!(mockFilters);
+      });
+    }
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/eval/test-eval',
+        hash: '',
+      }),
+      { replace: true },
+    );
+
+    const [nextLocation] = mockNavigate.mock.calls[0];
+    expect(new URLSearchParams(nextLocation.search).has('rowId')).toBe(false);
+    expect(new URLSearchParams(nextLocation.search).has('filter')).toBe(false);
+  });
+
   it('preserves a details hash while rehydrating filters from the URL', async () => {
     let subscriptionCallback: ((filters: any) => void) | null = null;
 

--- a/src/app/src/pages/eval/components/Eval.test.tsx
+++ b/src/app/src/pages/eval/components/Eval.test.tsx
@@ -536,6 +536,60 @@ describe('Eval', () => {
     expect(new URLSearchParams(nextLocation.search).has('filter')).toBe(false);
   });
 
+  it('does not discard an unrelated hash when filters clear without URL filter state', async () => {
+    let subscriptionCallback: ((filters: any, previousFilters: any) => void) | null = null;
+
+    (useTableStore as any).subscribe = vi.fn((selector, callback) => {
+      if (selector.toString().includes('filters')) {
+        subscriptionCallback = callback;
+      }
+      return vi.fn();
+    });
+
+    const mockFilters = {
+      values: {},
+      appliedCount: 0,
+    };
+    const previousFilters = {
+      values: {
+        filter1: {
+          id: 'filter1',
+          type: 'text',
+          operator: 'contains',
+          value: 'weather',
+        },
+      },
+      appliedCount: 1,
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      ...baseMockTableStore,
+      filters: mockFilters,
+    });
+
+    const initialUrl = '/eval/test-eval#section';
+    window.history.replaceState({}, '', initialUrl);
+
+    render(
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Eval fetchId="test-eval" />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    if (subscriptionCallback) {
+      await act(async () => {
+        subscriptionCallback!(mockFilters, previousFilters);
+      });
+    }
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe('#section');
+  });
+
   it('preserves a details hash while rehydrating filters from the URL', async () => {
     let subscriptionCallback: ((filters: any) => void) | null = null;
 

--- a/src/app/src/pages/eval/components/Eval.test.tsx
+++ b/src/app/src/pages/eval/components/Eval.test.tsx
@@ -384,8 +384,8 @@ describe('Eval', () => {
     expect(resultsView?.getAttribute('data-default-eval-id')).toBe('eval-2');
   });
 
-  it('does not rewrite the URL when clearing filters that are not present', async () => {
-    let subscriptionCallback: ((filters: any) => void) | null = null;
+  it('does not rewrite a details hash on a zero-filter store update', async () => {
+    let subscriptionCallback: ((filters: any, previousFilters: any) => void) | null = null;
 
     // Mock subscribe to capture the callback and trigger it
     (useTableStore as any).subscribe = vi.fn((selector, callback) => {
@@ -405,8 +405,11 @@ describe('Eval', () => {
       filters: mockFilters,
     });
 
+    const initialUrl = '/eval/test-eval#details-row-51-prompt-1';
+    window.history.replaceState({}, '', initialUrl);
+
     render(
-      <MemoryRouter initialEntries={['/eval/test-eval#details-row-51-prompt-1']}>
+      <MemoryRouter initialEntries={[initialUrl]}>
         <Eval fetchId="test-eval" />
       </MemoryRouter>,
     );
@@ -418,7 +421,49 @@ describe('Eval', () => {
     // Trigger the subscription callback manually
     if (subscriptionCallback) {
       await act(async () => {
-        subscriptionCallback!(mockFilters);
+        subscriptionCallback!(mockFilters, mockFilters);
+      });
+    }
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('preserves an initial rowId details deep link on a zero-filter store update', async () => {
+    let subscriptionCallback: ((filters: any, previousFilters: any) => void) | null = null;
+
+    (useTableStore as any).subscribe = vi.fn((selector, callback) => {
+      if (selector.toString().includes('filters')) {
+        subscriptionCallback = callback;
+      }
+      return vi.fn();
+    });
+
+    const mockFilters = {
+      values: {},
+      appliedCount: 0,
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      ...baseMockTableStore,
+      filters: mockFilters,
+    });
+
+    const initialUrl = '/eval/test-eval?rowId=51#details-row-51-prompt-1';
+    window.history.replaceState({}, '', initialUrl);
+
+    render(
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Eval fetchId="test-eval" />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    if (subscriptionCallback) {
+      await act(async () => {
+        subscriptionCallback!(mockFilters, mockFilters);
       });
     }
 
@@ -426,7 +471,7 @@ describe('Eval', () => {
   });
 
   it('clears a stale rowId param when filters are cleared without a filter param', async () => {
-    let subscriptionCallback: ((filters: any) => void) | null = null;
+    let subscriptionCallback: ((filters: any, previousFilters: any) => void) | null = null;
 
     // Mock subscribe to capture the callback and trigger it
     (useTableStore as any).subscribe = vi.fn((selector, callback) => {
@@ -439,6 +484,17 @@ describe('Eval', () => {
     const mockFilters = {
       values: {},
       appliedCount: 0, // Filters cleared
+    };
+    const previousFilters = {
+      values: {
+        filter1: {
+          id: 'filter1',
+          type: 'text',
+          operator: 'contains',
+          value: 'weather',
+        },
+      },
+      appliedCount: 1,
     };
 
     vi.mocked(useTableStore).mockReturnValue({
@@ -463,7 +519,7 @@ describe('Eval', () => {
     // Trigger the subscription callback manually
     if (subscriptionCallback) {
       await act(async () => {
-        subscriptionCallback!(mockFilters);
+        subscriptionCallback!(mockFilters, previousFilters);
       });
     }
 

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -19,7 +19,11 @@ import './Eval.css';
 import { useToast } from '@app/hooks/useToast';
 import logger from '../../../../../logger';
 import { useFilterMode } from './FilterModeProvider';
-import { buildEvalUrlWithSearchParams, setEvalDetailsHash } from './utils';
+import {
+  buildEvalUrlWithSearchParams,
+  parseEvalOutputPromptHash,
+  setEvalDetailsHash,
+} from './utils';
 
 interface EvalOptions {
   /**
@@ -189,7 +193,7 @@ export default function Eval({ fetchId }: EvalOptions) {
             didClearAppliedFilters &&
             (_searchParams.has('filter') ||
               _searchParams.has('rowId') ||
-              Boolean(window.location.hash))
+              parseEvalOutputPromptHash(window.location.hash) !== null)
           ) {
             replaceSearchParams((params) => {
               params.delete('filter');

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -181,7 +181,13 @@ export default function Eval({ fetchId }: EvalOptions) {
 
         // Do search params need to be removed?
         if (_filters.appliedCount === 0) {
-          if (_searchParams.has('filter')) {
+          // `replaceSearchParams` also drops `rowId` and the details hash, so it must
+          // still run when those are present even if there is no `filter` param.
+          if (
+            _searchParams.has('filter') ||
+            _searchParams.has('rowId') ||
+            Boolean(window.location.hash)
+          ) {
             replaceSearchParams((params) => {
               params.delete('filter');
             });

--- a/src/app/src/pages/eval/components/Eval.tsx
+++ b/src/app/src/pages/eval/components/Eval.tsx
@@ -171,7 +171,7 @@ export default function Eval({ fetchId }: EvalOptions) {
   useEffect(() => {
     const unsubscribe = useTableStore.subscribe(
       (state) => state.filters,
-      (_filters) => {
+      (_filters, previousFilters) => {
         if (isHydratingFiltersRef.current) {
           return;
         }
@@ -181,12 +181,15 @@ export default function Eval({ fetchId }: EvalOptions) {
 
         // Do search params need to be removed?
         if (_filters.appliedCount === 0) {
+          const didClearAppliedFilters = previousFilters.appliedCount > 0;
           // `replaceSearchParams` also drops `rowId` and the details hash, so it must
-          // still run when those are present even if there is no `filter` param.
+          // still run when those are present after a filter clear even if there is no
+          // `filter` param.
           if (
-            _searchParams.has('filter') ||
-            _searchParams.has('rowId') ||
-            Boolean(window.location.hash)
+            didClearAppliedFilters &&
+            (_searchParams.has('filter') ||
+              _searchParams.has('rowId') ||
+              Boolean(window.location.hash))
           ) {
             replaceSearchParams((params) => {
               params.delete('filter');


### PR DESCRIPTION
## Summary

- Clearing applied eval filters can leave a copied output-detail URL behind when the live URL has a stale `rowId` and details hash but no `filter` query param.
- Keep the URL cleanup on the real applied-filter-clear transition (`appliedCount` moving from greater than zero to zero). That still removes stale `rowId` and details hash state after a clear, while load-time `filters.options` refreshes with zero applied filters no longer erase initial deep links before the table can consume them.
- Add regressions for both sides of that boundary: initial hash/`rowId` detail links survive zero-filter store updates, and an actual filter clear with no `filter` query removes stale row detail state.

## Test plan

- [x] `npm run test:app -- src/pages/eval/components/Eval.test.tsx --run`
- [x] `npm run test:app -- src/pages/eval/components/Eval.test.tsx src/pages/eval/components/ResultsTable.test.tsx --run`
- [x] `cd src/app && npx tsc --noEmit`
- [x] `npm run l`
- [x] `npm run build`
- [x] `npm run f` ran Biome on the two TypeScript files, then hit the repo's empty Prettier-input path (`No parser and no file path given`) because this diff has no Prettier-target files
- [x] Live browser proof against isolated `PROMPTFOO_CONFIG_DIR` state: a 60-row echo eval applied a metadata filter, removed the `filter` query from a stale `?rowId=51#details-row-51-prompt-1` URL, then `Clear all` returned the app to a clean eval URL with no page errors
