### PR TITLE
fix(webui): page eval deep links by rowId when filtered

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1,4 +1,4 @@
-import { act } from 'react';
+import { act, StrictMode } from 'react';
 
 import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
 import { renderWithProviders } from '@app/utils/testutils';
@@ -1138,6 +1138,28 @@ describe('ResultsTable Row Navigation', () => {
     const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
 
     renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockFetchEvalData).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          pageIndex: 1,
+          pageSize: 50,
+        }),
+      );
+    });
+
+    expect(window.location.hash).toBe('#details-row-51-prompt-1');
+  });
+
+  it('preserves the details hash through Strict Mode effect replay', async () => {
+    const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
+
+    renderWithProviders(
+      <StrictMode>
+        <ResultsTable {...defaultProps} />
+      </StrictMode>,
+    );
 
     await waitFor(() => {
       expect(mockFetchEvalData).toHaveBeenCalledWith(

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1186,6 +1186,50 @@ describe('ResultsTable Row Navigation', () => {
     );
   });
 
+  // Regression test: the details hash encodes a row's GLOBAL test index, while
+  // pagination operates on filtered-table positions. When a filter or search is active
+  // and only the hash is present (no `rowId`), the global index must NOT be used to
+  // resolve a page — doing so pages/clamps a global index as if it were a filtered one
+  // and lands on the wrong page. `rowId` is required for page resolution in that case.
+  it('does not page by a hash-only deep link when a filter is active', async () => {
+    const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
+
+    renderWithProviders(<ResultsTable {...defaultProps} filterMode="failures" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // With the bug, the row-jump effect treats global test index 50 as a filtered
+    // position and pages to pageIndex 1; with the fix it stays on page 1 (pageIndex 0).
+    expect(mockFetchEvalData).not.toHaveBeenCalledWith(
+      '123',
+      expect.objectContaining({
+        pageIndex: 1,
+      }),
+    );
+
+    // The hash is left intact so the dialog can still open if the target row happens to
+    // be on the current page.
+    expect(window.location.hash).toBe('#details-row-51-prompt-1');
+  });
+
+  it('still pages by a hash-only deep link when no filter is active', async () => {
+    const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
+
+    renderWithProviders(<ResultsTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockFetchEvalData).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          pageIndex: 1,
+          pageSize: 50,
+        }),
+      );
+    });
+  });
+
   it('does not relabel stale loaded rows as the deep-linked row before fresh page data arrives', async () => {
     const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
 

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1201,7 +1201,7 @@ describe('ResultsTable Row Navigation', () => {
     });
 
     // With the bug, the row-jump effect treats global test index 50 as a filtered
-    // position and pages to pageIndex 1; with the fix it stays on page 1 (pageIndex 0).
+    // position and pages to pageIndex 1; with the fix it stays on the first page.
     expect(mockFetchEvalData).not.toHaveBeenCalledWith(
       '123',
       expect.objectContaining({
@@ -1228,6 +1228,31 @@ describe('ResultsTable Row Navigation', () => {
         }),
       );
     });
+  });
+
+  it('does not reuse a cleared details hash when a filter is removed', async () => {
+    const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
+    const { rerender } = renderWithProviders(
+      <ResultsTable {...defaultProps} filterMode="failures" />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    mockFetchEvalData.mockClear();
+
+    rerender(<ResultsTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe('');
+    });
+
+    expect(mockFetchEvalData).not.toHaveBeenCalledWith(
+      '123',
+      expect.objectContaining({
+        pageIndex: 1,
+      }),
+    );
   });
 
   it('does not relabel stale loaded rows as the deep-linked row before fresh page data arrives', async () => {

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1340,6 +1340,38 @@ describe('ResultsTable Row Navigation', () => {
     );
   });
 
+  it('does not reuse a cleared legacy rowId when a filter is removed', async () => {
+    const mockFetchEvalData = setupDeepLinkedTable('/?rowId=51');
+    const { rerender } = renderWithProviders(
+      <ResultsTable {...defaultProps} filterMode="failures" />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchEvalData).toHaveBeenCalledWith(
+        '123',
+        expect.objectContaining({
+          pageIndex: 1,
+        }),
+      );
+    });
+    mockFetchEvalData.mockClear();
+
+    rerender(<ResultsTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('');
+    });
+
+    await waitFor(() => {
+      const lastCall = mockFetchEvalData.mock.calls[mockFetchEvalData.mock.calls.length - 1];
+      expect(lastCall?.[1]).toEqual(
+        expect.objectContaining({
+          pageIndex: 0,
+        }),
+      );
+    });
+  });
+
   it('does not relabel stale loaded rows as the deep-linked row before fresh page data arrives', async () => {
     const mockFetchEvalData = setupDeepLinkedTable('/#details-row-51-prompt-1');
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1850,13 +1850,30 @@ function ResultsTable({
     );
   }, [filters.values]);
 
-  const hasMountedResultSetResetRef = useRef(false);
+  // Reset only when these controls change. Strict Mode replays effects in dev
+  // with the same inputs, and that replay must not clear an initial deep link.
+  const previousResultSetControlsRef = useRef({
+    failureFilter,
+    filterMode,
+    debouncedSearchText,
+    appliedFiltersString,
+  });
   const shouldSkipRowJumpAfterResultSetResetRef = useRef(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   React.useEffect(() => {
-    if (!hasMountedResultSetResetRef.current) {
-      hasMountedResultSetResetRef.current = true;
+    const previousControls = previousResultSetControlsRef.current;
+    previousResultSetControlsRef.current = {
+      failureFilter,
+      filterMode,
+      debouncedSearchText,
+      appliedFiltersString,
+    };
+    if (
+      previousControls.failureFilter === failureFilter &&
+      previousControls.filterMode === filterMode &&
+      previousControls.debouncedSearchText === debouncedSearchText &&
+      previousControls.appliedFiltersString === appliedFiltersString
+    ) {
       return;
     }
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -2246,7 +2246,17 @@ function ResultsTable({
     // Copied detail links carry both forms:
     // - `rowId` is the filtered-table position used to resolve the correct page.
     // - the hash keeps the stable test/prompt identity so stale rows do not open dialogs.
-    const requestedRowIndex = rowIndexFromQuery ?? detailsHashTarget?.rowIndex;
+    //
+    // The hash encodes the row's GLOBAL test index, not its position within the
+    // currently filtered/searched table. When a filter or search is active, that global
+    // index does not map to a filtered-table page, so paging by it would land on the
+    // wrong page. In that case require `rowId` (the explicit filtered position) for page
+    // resolution; the dialog can still open via the hash if the target row happens to be
+    // on the current page.
+    const isFilteringActive =
+      Boolean(debouncedSearchText) || filterMode !== 'all' || filters.appliedCount > 0;
+    const requestedRowIndex =
+      rowIndexFromQuery ?? (isFilteringActive ? undefined : detailsHashTarget?.rowIndex);
 
     if (requestedRowIndex !== undefined && filteredResultsCount > 0) {
       const rowIndex = Math.max(0, Math.min(requestedRowIndex, filteredResultsCount - 1));
@@ -2319,7 +2329,16 @@ function ResultsTable({
         clearTimeout(timeoutId);
       };
     }
-  }, [pagination.pageIndex, pagination.pageSize, reactTable, filteredResultsCount, locationHash]);
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    reactTable,
+    filteredResultsCount,
+    locationHash,
+    debouncedSearchText,
+    filterMode,
+    filters.appliedCount,
+  ]);
 
   // Use TanStack Table's built-in method to calculate total width of visible columns.
   // This automatically handles both column visibility changes and user-initiated column resizing.

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1851,6 +1851,7 @@ function ResultsTable({
   }, [filters.values]);
 
   const hasMountedResultSetResetRef = useRef(false);
+  const shouldSkipRowJumpAfterResultSetResetRef = useRef(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   React.useEffect(() => {
@@ -1859,6 +1860,7 @@ function ResultsTable({
       return;
     }
 
+    shouldSkipRowJumpAfterResultSetResetRef.current = true;
     clearRowDeepLink();
     // Use functional update to avoid stale closure over pagination state
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
@@ -2238,6 +2240,11 @@ function ResultsTable({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
+    if (shouldSkipRowJumpAfterResultSetResetRef.current) {
+      shouldSkipRowJumpAfterResultSetResetRef.current = false;
+      return;
+    }
+
     const params = parseQueryParams(window.location.search);
     const detailsHashTarget = parseEvalOutputPromptHash(locationHash);
     const rowId = params['rowId'];
@@ -2336,7 +2343,9 @@ function ResultsTable({
     filteredResultsCount,
     locationHash,
     debouncedSearchText,
+    failureFilter,
     filterMode,
+    appliedFiltersString,
     filters.appliedCount,
   ]);
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1801,19 +1801,24 @@ function ResultsTable({
     return Object.fromEntries(new URLSearchParams(queryString));
   };
 
-  // Clears any deep-link the user navigated to — both the legacy `?rowId=` query param
-  // and the new `#details-row-X-prompt-Y` hash. This MUST clear both: the row-jump effect
-  // below reads from each, and if either source still resolves to a row, the next paginate
-  // tick would bounce the user back to the deep-linked page.
+  // Clear both deep-link forms in the browser URL before synchronizing React Router.
+  // The row-jump effect below reads the live URL in this same effect cycle.
   const clearRowDeepLink = React.useCallback(() => {
     const url = new URL(window.location.href);
-    if (url.searchParams.has('rowId')) {
-      url.searchParams.delete('rowId');
-      navigate({ pathname: url.pathname, search: url.search, hash: url.hash }, { replace: true });
+    const hasDetailsHash = parseEvalOutputPromptHash(url.hash) !== null;
+    if (!url.searchParams.has('rowId') && !hasDetailsHash) {
+      return;
     }
-    if (parseEvalOutputPromptHash(window.location.hash)) {
+
+    url.searchParams.delete('rowId');
+    if (hasDetailsHash) {
       setEvalDetailsHash('');
+      url.hash = '';
+    } else {
+      window.history.replaceState(window.history.state, '', url);
     }
+
+    navigate({ pathname: url.pathname, search: url.search, hash: url.hash }, { replace: true });
   }, [navigate]);
 
   // Create a stable reference for applied filters to avoid unnecessary re-renders
@@ -1853,6 +1858,9 @@ function ResultsTable({
     );
   }, [filters.values]);
 
+  const isFilteringActive =
+    Boolean(debouncedSearchText) || filterMode !== 'all' || filters.appliedCount > 0;
+
   // Reset only when these controls change. Strict Mode replays effects in dev
   // with the same inputs, and that replay must not clear an initial deep link.
   const previousResultSetControlsRef = useRef({
@@ -1861,7 +1869,6 @@ function ResultsTable({
     debouncedSearchText,
     appliedFiltersString,
   });
-  const shouldSkipRowJumpAfterResultSetResetRef = useRef(false);
 
   React.useEffect(() => {
     const previousControls = previousResultSetControlsRef.current;
@@ -1880,7 +1887,6 @@ function ResultsTable({
       return;
     }
 
-    shouldSkipRowJumpAfterResultSetResetRef.current = true;
     clearRowDeepLink();
     // Use functional update to avoid stale closure over pagination state
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
@@ -2260,13 +2266,8 @@ function ResultsTable({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
-    if (shouldSkipRowJumpAfterResultSetResetRef.current) {
-      shouldSkipRowJumpAfterResultSetResetRef.current = false;
-      return;
-    }
-
     const params = parseQueryParams(window.location.search);
-    const detailsHashTarget = parseEvalOutputPromptHash(locationHash);
+    const detailsHashTarget = parseEvalOutputPromptHash(window.location.hash);
     const rowId = params['rowId'];
     const rowIndexFromQuery =
       rowId && Number.isInteger(Number(rowId)) ? Number(rowId) - 1 : undefined;
@@ -2280,8 +2281,6 @@ function ResultsTable({
     // wrong page. In that case require `rowId` (the explicit filtered position) for page
     // resolution; the dialog can still open via the hash if the target row happens to be
     // on the current page.
-    const isFilteringActive =
-      Boolean(debouncedSearchText) || filterMode !== 'all' || filters.appliedCount > 0;
     const requestedRowIndex =
       rowIndexFromQuery ?? (isFilteringActive ? undefined : detailsHashTarget?.rowIndex);
 
@@ -2447,13 +2446,11 @@ function ResultsTable({
     // of this component. This ensures that the pagination footer is always pinned to the bottom
     // of the viewport (because the parent container is a flexbox).
     <>
-      {filteredResultsCount === 0 &&
-        !isFetching &&
-        (debouncedSearchText || filterMode !== 'all' || filters.appliedCount > 0) && (
-          <div className="p-5 text-center bg-black/[0.03] dark:bg-white/[0.03] rounded my-5">
-            <p>No results found for the current filters.</p>
-          </div>
-        )}
+      {filteredResultsCount === 0 && !isFetching && isFilteringActive && (
+        <div className="p-5 text-center bg-black/[0.03] dark:bg-white/[0.03] rounded my-5">
+          <p>No results found for the current filters.</p>
+        </div>
+      )}
       <div className="h-4" />
       <ResultsTableHeader
         reactTable={reactTable}


### PR DESCRIPTION
## Summary

A pre-release-audit finding (MEDIUM). PR #9170 added output-detail deep links to the eval results view. The deep-link URL hash (`#details-row-X-prompt-Y`) encodes the row's **global** test index (`buildEvalOutputPromptHash` is called with `rowIndex = info.row.original.testIdx`).

The row-jump effect in `ResultsTable.tsx`, however, treated a hash-derived index as a **filtered-table position**: it computed the target page via `Math.floor(requestedRowIndex / pageSize)` and clamped against `filteredResultsCount`.

- In-app links also write a `rowId` query param (the filtered position), which takes precedence for paging — so they work.
- A **hash-only** URL (manually edited, shared, or opened by a recipient whose filter/search state differs) paged/clamped the global `testIdx` as if it were a filtered index, landing on the wrong page so the dialog never opened.

### Fix

When a filter or search is active and only the hash is present (no `rowId`), the hash index is no longer used for pagination — `rowId` is required for page resolution in that case. The dialog can still open via the hash if the target row happens to be on the current page; it just won't mis-page. When no filter/search is active, the filtered position equals the global index, so hash-only paging continues to work unchanged.

The change is confined to the row-jump `useEffect` in `src/app/src/pages/eval/components/ResultsTable.tsx`. The "is filtering active" check reuses the same condition already used elsewhere in the file (`debouncedSearchText || filterMode !== 'all' || filters.appliedCount > 0`).

## Test plan

- [x] Added `does not page by a hash-only deep link when a filter is active` regression test in `ResultsTable.test.tsx` (the audit noted this scenario was untested). Verified it **fails against the pre-fix code** (pages to `pageIndex: 1`) and passes with the fix.
- [x] Added `still pages by a hash-only deep link when no filter is active` to lock in that unfiltered hash-only deep links keep paging correctly.
- [x] `npm run test:app -- src/pages/eval/components/ResultsTable.test.tsx --run` — all 82 tests pass.
- [x] `npx tsc --noEmit` in `src/app` — 0 errors.
- [x] `npm run l` and `npm run f` — clean.