### PR TITLE
fix(ci): pin code-scan Node to 24.15.0 to stop install timeout

### DIFF
--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -15,10 +15,7 @@ permissions:
 jobs:
   security-scan:
     runs-on: ubuntu-latest
-    # The pinned scanner action installs the promptfoo CLI at runtime before the
-    # remote scan starts. The global install can exceed 15 minutes as the CLI's
-    # dependency graph grows, so keep enough headroom for install plus scan.
-    timeout-minutes: 45
+    timeout-minutes: 15
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PROMPTFOO_DISABLE_UPDATE: true
@@ -33,10 +30,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin to 24.15.0 (not .nvmrc): Node 24.16.0 adds ~10s to every HTTPS
+      # request on Linux runners, dragging the scanner's uncached
+      # `npm install -g promptfoo` (~860 packages) into a 14-minute crawl that
+      # trips the job timeout. Revisit when a newer Node resolves it.
       - name: Use Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
+          node-version: '24.15.0'
 
       - name: Run Promptfoo Code Scan
         uses: promptfoo/code-scan-action@c4839dcb8623ca031ee6d271c7850dc71d994dd3 # v0


### PR DESCRIPTION
## Summary

The **Promptfoo Code Scan** (`security-scan`) check has been getting cancelled on PRs — the job runs ~14 minutes, then hits its timeout.

**Root cause:** the scanner action runs `npm install -g promptfoo` (~860 packages, uncached) on every run. **Node 24.16.0 adds ~10s to every HTTPS request on Linux runners**, so that install — normally ~1 minute — crawls for 14+ minutes and trips the timeout. It regressed when `.nvmrc` was bumped 24.15.0 → 24.16.0 in #9342.

**Diagnosis** — clean-room Docker repro, same host/network, only the Node version varied:

| Node | `npm install -g promptfoo` |
|------|----------------------------|
| `node:24.15.0` | `added 859 packages in 44s` ✅ |
| `node:24.16.0` | timed out at 330s — every `npm http fetch` took 10–14s ❌ |

macOS is unaffected, which is why this only surfaced on CI runners.

## Change

- Pin `setup-node` to `24.15.0` (last known-good) instead of `.nvmrc`. The scan job only needs Node to run the action and install the CLI — it doesn't need to track the repo-wide version.
- Revert `timeout-minutes` 45 → 15. The bump in #9344 treated the hang as slowness; a longer timeout can't fix a per-request slowdown — it just delays the cancellation.

## Follow-ups (not in this PR)

- The underlying Node 24.16.0 Linux networking regression is worth reporting upstream and re-checking before the repo-wide `.nvmrc` adoption settles.
- The scanner action could cache the global `promptfoo` install instead of reinstalling ~860 packages every run.

## Test plan

- [ ] CI green
- [ ] A subsequent PR's `security-scan` check completes (install ~1 min) instead of timing out