### PR TITLE
feat(google): add Gemini 3.5 Flash and refresh Google/Vertex models

### DIFF
--- a/examples/google-aistudio-gemini/README.md
+++ b/examples/google-aistudio-gemini/README.md
@@ -20,13 +20,14 @@ The example tests across multiple Gemini and Gemma models:
 
 - **Gemma 4 31B IT** - Open model with strong reasoning, coding, and agentic capabilities
 - **Gemma 4 26B A4B IT** - Smaller open Gemma 4 model for lower-latency reasoning and coding evals
-- **Gemini 2.5 Pro** - Latest stable model with enhanced reasoning, coding, and multimodal understanding
-- **Gemini 2.5 Flash** - Latest stable Flash model with enhanced reasoning and thinking capabilities
-- **Gemini 2.5 Flash-Lite** - Most cost-efficient and fastest 2.5 model, optimized for high-volume, latency-sensitive tasks
-- Gemini 2.0 Flash
-- Gemini 2.0 Flash Thinking
-- Gemini 1.5 Flash
-- Gemini 1.5 Pro - Standard model for complex reasoning, used with both structured JSON output and function calling capabilities
+- **Gemini 3.5 Flash** - Newest, fastest frontier Flash model with high-effort thinking
+- **Gemini 3.1 Pro** - Frontier model with improved reasoning and multimodal understanding
+- **Gemini 3 Flash** - Frontier Flash model with strong reasoning at lower latency
+- **Gemini 3.1 Flash-Lite** - Low-latency, cost-efficient model for high-volume tasks
+- **Gemini 2.5 Pro** - Stable model with strong reasoning, coding, and multimodal understanding; also used with structured JSON output and function calling
+- **Gemini 2.5 Flash** - Stable Flash model with enhanced reasoning and thinking capabilities
+- **Gemini 2.5 Flash-Lite** - Cost-efficient and fast 2.5 model, optimized for high-volume, latency-sensitive tasks
+- **gemini-embedding-001** - Embedding model used for similarity-based assertions
 
 ## System Instructions from File
 

--- a/examples/google-aistudio-gemini/promptfooconfig.yaml
+++ b/examples/google-aistudio-gemini/promptfooconfig.yaml
@@ -25,6 +25,14 @@ providers:
         thinkingConfig:
           thinkingLevel: HIGH # Improved reasoning and performance
 
+  - id: google:gemini-3.5-flash
+    config:
+      generationConfig:
+        temperature: 0.7
+        maxOutputTokens: 2048
+        thinkingConfig:
+          thinkingLevel: HIGH # Newest, fastest frontier Flash model
+
   - id: google:gemini-3-flash-preview
     config:
       generationConfig:
@@ -33,12 +41,12 @@ providers:
         thinkingConfig:
           thinkingLevel: HIGH # Frontier Flash reasoning with preview features
 
-  - id: google:gemini-3.1-flash-lite-preview
+  - id: google:gemini-3.1-flash-lite
     config:
       generationConfig:
         temperature: 0.7
         maxOutputTokens: 2048
-        # Current low-latency preview model
+        # Low-latency Flash-Lite model
 
   - id: google:gemini-2.5-pro
     config:

--- a/examples/google-aistudio-gemini/promptfooconfig.yaml
+++ b/examples/google-aistudio-gemini/promptfooconfig.yaml
@@ -75,7 +75,7 @@ providers:
   - id: google:gemini-2.5-pro
     config:
       temperature: 0.7
-      maxOutputTokens: 1024
+      maxOutputTokens: 8192
       topP: 0.9
       topK: 40
 
@@ -84,7 +84,7 @@ providers:
     label: gemini-with-system-instruction-file
     config:
       temperature: 0.3
-      maxOutputTokens: 1024
+      maxOutputTokens: 8192
       systemInstruction: file://system-instruction.txt
 
   # Structured output example
@@ -92,7 +92,7 @@ providers:
     config:
       generationConfig:
         temperature: 0
-        maxOutputTokens: 1024
+        maxOutputTokens: 8192
         response_mime_type: 'application/json'
         response_schema:
           type: 'object'

--- a/examples/google-aistudio-tools/README.md
+++ b/examples/google-aistudio-tools/README.md
@@ -42,7 +42,7 @@ The search grounding configuration (`promptfooconfig.search.yaml`) demonstrates:
 
 - Using Gemini 2.5 Flash with Google Search as a tool
 - Using Gemini 2.5 Pro with thinking capabilities and Search grounding
-- Using Gemini 2.5 Flash-Lite with dynamic retrieval configuration
+- Using Gemini 2.5 Flash-Lite with Google Search grounding
 - Testing queries that benefit from real-time web information
 - Verifying responses include relevant information
 
@@ -115,13 +115,10 @@ This example demonstrates three approaches to search:
      - googleSearch: {}
    ```
 
-3. **Dynamic retrieval** (Gemini 2.5): Controls when to use search with threshold settings
+3. **Search on Flash-Lite** (Gemini 2.5): Uses the lower-cost Flash-Lite model with the same search tool
    ```yaml
    tools:
-     - googleSearchRetrieval:
-         dynamicRetrievalConfig:
-           mode: 'MODE_DYNAMIC'
-           dynamicThreshold: 0 # 0 = always use search, 1 = never use search
+     - googleSearch: {}
    ```
 
 ## Further Resources

--- a/examples/google-aistudio-tools/README.md
+++ b/examples/google-aistudio-tools/README.md
@@ -42,7 +42,7 @@ The search grounding configuration (`promptfooconfig.search.yaml`) demonstrates:
 
 - Using Gemini 2.5 Flash with Google Search as a tool
 - Using Gemini 2.5 Pro with thinking capabilities and Search grounding
-- Using Gemini 1.5 Flash with dynamic retrieval configuration
+- Using Gemini 2.5 Flash-Lite with dynamic retrieval configuration
 - Testing queries that benefit from real-time web information
 - Verifying responses include relevant information
 
@@ -115,7 +115,7 @@ This example demonstrates three approaches to search:
      - googleSearch: {}
    ```
 
-3. **Dynamic retrieval** (Gemini 1.5): Controls when to use search with threshold settings
+3. **Dynamic retrieval** (Gemini 2.5): Controls when to use search with threshold settings
    ```yaml
    tools:
      - googleSearchRetrieval:

--- a/examples/google-aistudio-tools/promptfooconfig.search.yaml
+++ b/examples/google-aistudio-tools/promptfooconfig.search.yaml
@@ -25,16 +25,13 @@ providers:
       tools:
         - googleSearch: {}
 
-  # Dynamic retrieval configuration for Gemini 2.5 models
+  # Google Search grounding on the cost-efficient Flash-Lite model
   - id: google:gemini-2.5-flash-lite
     config:
       temperature: 0.2
       maxOutputTokens: 1024
       tools:
-        - googleSearchRetrieval:
-            dynamicRetrievalConfig:
-              mode: 'MODE_DYNAMIC'
-              dynamicThreshold: 0
+        - googleSearch: {}
 
 tests:
   # Test current events
@@ -44,7 +41,7 @@ tests:
       - type: contains
         value: stock
       - type: contains
-        value: price
+        value: '$'
 
   # Test a technical question
   - vars:

--- a/examples/google-aistudio-tools/promptfooconfig.yaml
+++ b/examples/google-aistudio-tools/promptfooconfig.yaml
@@ -8,7 +8,7 @@ prompts:
   - What is the weather in {{location}}?
 
 providers:
-  - id: 'google:gemini-2.0-flash-001'
+  - id: 'google:gemini-2.5-flash'
     config:
       tools: file://tools.json
 
@@ -17,7 +17,7 @@ defaultTest:
     # This overrides the default grading providers with Vertex AI models
     providers:
       embedding: 'google:embedding:text-embedding-005'
-      text: 'google:gemini-2.0-flash-001'
+      text: 'google:gemini-2.5-flash'
 
 tests:
   # Function calling tests

--- a/examples/google-vertex/promptfooconfig.gemini.yaml
+++ b/examples/google-vertex/promptfooconfig.gemini.yaml
@@ -49,6 +49,7 @@ providers:
 
   - id: vertex:gemini-3.5-flash
     config:
+      region: global # Gemini 3.5 Flash is served on Vertex AI's global endpoint
       generationConfig:
         temperature: 0.7
         maxOutputTokens: 2048

--- a/examples/google-vertex/promptfooconfig.gemini.yaml
+++ b/examples/google-vertex/promptfooconfig.gemini.yaml
@@ -47,7 +47,7 @@ providers:
                     enum: ['restaurant', 'hotel', 'attraction']
                 required: ['query']
 
-  - id: vertex:gemini-2.5-flash-preview-09-2025
+  - id: vertex:gemini-3.5-flash
     config:
       generationConfig:
         temperature: 0.7
@@ -80,7 +80,40 @@ providers:
                     enum: ['restaurant', 'hotel', 'attraction']
                 required: ['query']
 
-  - id: vertex:gemini-2.5-flash-lite-preview-09-2025
+  - id: vertex:gemini-2.5-flash
+    config:
+      generationConfig:
+        temperature: 0.7
+        maxOutputTokens: 2048
+      toolConfig:
+        functionCallingConfig:
+          mode: 'AUTO'
+      tools:
+        - functionDeclarations:
+            - name: 'get_weather'
+              description: 'Get weather information for a location'
+              parameters:
+                type: 'OBJECT'
+                properties:
+                  location:
+                    type: 'STRING'
+                    description: 'City name'
+                required: ['location']
+            - name: 'search_places'
+              description: 'Search for places of interest'
+              parameters:
+                type: 'OBJECT'
+                properties:
+                  query:
+                    type: 'STRING'
+                    description: 'Search query'
+                  type:
+                    type: 'STRING'
+                    description: 'Type of place'
+                    enum: ['restaurant', 'hotel', 'attraction']
+                required: ['query']
+
+  - id: vertex:gemini-2.5-flash-lite
     config:
       generationConfig:
         temperature: 0

--- a/examples/google-vertex/promptfooconfig.gemini.yaml
+++ b/examples/google-vertex/promptfooconfig.gemini.yaml
@@ -50,6 +50,7 @@ providers:
   - id: vertex:gemini-3.5-flash
     config:
       region: global # Gemini 3.5 Flash is served on Vertex AI's global endpoint
+      apiHost: aiplatform.googleapis.com
       generationConfig:
         temperature: 0.7
         maxOutputTokens: 2048

--- a/examples/google-vertex/promptfooconfig.response-schema.yaml
+++ b/examples/google-vertex/promptfooconfig.response-schema.yaml
@@ -8,15 +8,14 @@ providers:
   - id: vertex:gemini-2.5-flash
     config:
       region: us-central1
-      projectId: your-project-id # Replace with your actual project ID
       responseSchema: file://response-schema.json
 
 tests:
   - vars:
       topic: bananas
     assert:
-      - type: equals
-        value: 'Bananas are great'
+      - type: icontains
+        value: 'banana'
         transform: JSON.parse(output).tweet
 
   - vars:

--- a/examples/google-vertex/promptfooconfig.search.yaml
+++ b/examples/google-vertex/promptfooconfig.search.yaml
@@ -32,7 +32,7 @@ tests:
       - type: contains
         value: stock
       - type: contains
-        value: price
+        value: '$'
 
   # Test a technical question
   - vars:

--- a/examples/google-vertex/promptfooconfig.search.yaml
+++ b/examples/google-vertex/promptfooconfig.search.yaml
@@ -6,13 +6,15 @@ prompts:
   - '{{query}}'
 
 providers:
-  - id: vertex:gemini-2.0-flash
+  - id: vertex:gemini-2.5-flash
+    label: gemini-2.5-flash-search
     config:
       temperature: 0.2
       maxOutputTokens: 1024
       tools:
         - googleSearch: {}
   - id: vertex:gemini-2.5-flash
+    label: gemini-2.5-flash-search-thinking
     config:
       temperature: 0.2
       maxOutputTokens: 1024

--- a/examples/google-vertex/promptfooconfig.yaml
+++ b/examples/google-vertex/promptfooconfig.yaml
@@ -12,7 +12,7 @@ providers:
       systemInstruction:
         parts:
           - text: Always talk like a cow. Mooo!
-  - id: 'vertex:gemini-2.0-flash-thinking-exp'
+  - id: 'vertex:gemini-2.5-flash'
     config:
       systemInstruction:
         parts:

--- a/examples/google-vertex/promptfooconfig.yaml
+++ b/examples/google-vertex/promptfooconfig.yaml
@@ -8,11 +8,13 @@ prompts:
 
 providers:
   - id: 'vertex:gemini-2.5-flash'
+    label: gemini-2.5-flash-cow
     config:
       systemInstruction:
         parts:
           - text: Always talk like a cow. Mooo!
   - id: 'vertex:gemini-2.5-flash'
+    label: gemini-2.5-flash-sheep
     config:
       systemInstruction:
         parts:

--- a/examples/google-video/promptfooconfig-image.yaml
+++ b/examples/google-video/promptfooconfig-image.yaml
@@ -10,7 +10,7 @@ providers:
       # Provide your own image path here
       image: file://assets/start-frame.jpg
       aspectRatio: '16:9'
-      duration: 5
+      durationSeconds: 5
 
 tests:
   - vars:

--- a/examples/huggingface/dataset-factuality/promptfooconfig.yaml
+++ b/examples/huggingface/dataset-factuality/promptfooconfig.yaml
@@ -14,7 +14,7 @@ providers:
   # Uncomment to add more providers
   # - bedrock:us.meta.llama3-2-1b-instruct-v1:0
   # - openai:gpt-4.1-mini
-  # - google:gemini-2.0-flash
+  # - google:gemini-2.5-flash
 
 defaultTest:
   options:
@@ -22,7 +22,7 @@ defaultTest:
     # provider: anthropic:messages:claude-sonnet-4-6
     # provider: bedrock:us.meta.llama3-2-1b-instruct-v1:0
     # provider: openai:gpt-4.1-mini
-    # provider: google:gemini-2.0-flash
+    # provider: google:gemini-2.5-flash
 
     # Optional: Custom scoring weights for different factuality categories
     factuality:

--- a/examples/provider-model-armor/promptfooconfig.vertex.yaml
+++ b/examples/provider-model-armor/promptfooconfig.vertex.yaml
@@ -25,7 +25,7 @@ prompts:
 providers:
   # Gemini with Model Armor enabled via template
   # IMPORTANT: Update the projectId and promptTemplate with your actual values
-  - id: vertex:gemini-2.0-flash
+  - id: vertex:gemini-2.5-flash
     label: gemini-with-model-armor
     config:
       # Replace with your project ID or set VERTEX_PROJECT_ID env var
@@ -38,7 +38,7 @@ providers:
       maxOutputTokens: 1024
 
   # Baseline Gemini without Model Armor for comparison
-  - id: vertex:gemini-2.0-flash
+  - id: vertex:gemini-2.5-flash
     label: gemini-baseline
     config:
       projectId: your-project-id

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -140,7 +140,7 @@ providers:
   - google:gemma-4-31b-it
   - google:gemini-2.5-flash
   - google:gemini-2.5-pro
-  - google:gemini-2.0-flash
+  - google:gemini-3.5-flash
 
 prompts:
   - 'Explain {{concept}} in simple terms'
@@ -277,23 +277,23 @@ See the [Vertex AI provider documentation](/docs/providers/vertex) for detailed 
 
 - `google:gemma-4-31b-it` - Gemma 4 31B instruction-tuned open model with strong reasoning, coding, and agentic capabilities
 - `google:gemma-4-26b-a4b-it` - Gemma 4 26B A4B instruction-tuned open model for lower-latency reasoning and coding evals
+- `google:gemini-3.5-flash` - Gemini 3.5 Flash, the latest frontier Flash model for agentic and coding tasks ($1.50/1M input, $9/1M output)
 - `google:gemini-3.1-pro-preview` - Gemini 3.1 Pro preview with improved reasoning and performance ($2/1M input, $12/1M output; $4/$18 above 200K)
 - `google:gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro preview variant for custom tools with the same pricing as Gemini 3.1 Pro
-- `google:gemini-3.1-flash-lite-preview` - Gemini 3.1 Flash-Lite preview optimized for high-volume, low-latency tasks ($0.25/1M text/image/video input, $1.50/1M output)
+- `google:gemini-3.1-flash-lite` - Gemini 3.1 Flash-Lite optimized for high-volume, low-latency tasks ($0.25/1M text/image/video input, $1.50/1M output)
 - `google:gemini-3-flash-preview` - Gemini 3.0 Flash preview with frontier intelligence, Pro-grade reasoning at Flash-level speed, thinking, and grounding ($0.50/1M input, $3/1M output)
 - `google:gemini-2.5-pro` - Gemini 2.5 Pro model with enhanced reasoning, coding, and multimodal understanding
 - `google:gemini-2.5-flash` - Gemini 2.5 Flash model with enhanced reasoning and thinking capabilities
 - `google:gemini-2.5-flash-lite` - Cost-efficient Gemini 2.5 model optimized for high-volume, latency-sensitive tasks
 - `google:gemini-flash-latest` - Google-maintained alias for the latest Gemini Flash release
 - `google:gemini-flash-lite-latest` - Google-maintained alias for the latest Gemini Flash-Lite release
-- `google:gemini-2.0-flash` - Multimodal model with next-gen features, 1M token context window
-- `google:gemini-2.0-flash-lite` - Cost-efficient version of 2.0 Flash with 1M token context
 
 ### Embedding Models
 
 Use the `google:embedding:` prefix (or the plural `google:embeddings:` alias) to call the Gemini API `embedContent` endpoint:
 
 - `google:embedding:gemini-embedding-001` - Recommended default. Multilingual plus code, up to 3,072 dimensions, 2,048 input-token limit
+- `google:embedding:gemini-embedding-2` - Latest Gemini embedding model with multimodal input (text, image, video, audio, and PDF)
 
 Optional config keys (forwarded as documented in Google's [embedContent reference](https://ai.google.dev/api/embeddings#EmbedContentRequest)):
 
@@ -694,6 +694,20 @@ For more details on capabilities and configuration options, see the [Gemini API 
 
 ## Model Examples
 
+### Gemini 3.5 Flash
+
+The latest frontier Flash model, tuned for agentic and coding workloads:
+
+```yaml
+providers:
+  - id: google:gemini-3.5-flash
+    config:
+      maxOutputTokens: 4096
+      generationConfig:
+        thinkingConfig:
+          thinkingLevel: MEDIUM # MINIMAL, LOW, MEDIUM (default), or HIGH
+```
+
 ### Gemini 3 Flash Preview
 
 Gemini 3.0 Flash with frontier intelligence, Pro-grade reasoning, and thinking capabilities:
@@ -779,20 +793,6 @@ providers:
           thinkingBudget: 512 # Optimized for speed and cost efficiency
 ```
 
-### Gemini 2.0 Flash
-
-Best for fast, efficient responses and general tasks:
-
-```yaml
-providers:
-  - id: google:gemini-2.0-flash
-    config:
-      temperature: 0.7
-      maxOutputTokens: 2048
-      topP: 0.9
-      topK: 40
-```
-
 ## Advanced Features
 
 ### Overriding Providers
@@ -809,7 +809,7 @@ defaultTest:
     provider:
       # Override text generation provider
       text:
-        id: google:gemini-2.0-flash
+        id: google:gemini-2.5-flash
         config:
           temperature: 0.7
       # Override embedding provider for similarity comparisons
@@ -837,7 +837,7 @@ tests:
     options:
       provider:
         text:
-          id: google:gemini-2.0-flash
+          id: google:gemini-2.5-flash
         embedding:
           id: google:embedding:gemini-embedding-001
     assert:
@@ -948,9 +948,9 @@ providers:
 :::info
 Search grounding works with most recent Gemini models including:
 
-- Gemini 2.5 Flash and Pro models
-- Gemini 2.0 Flash and Pro models
-- Gemini 1.5 Flash and Pro models
+- Gemini 3.5 Flash
+- Gemini 3.1 Pro and Gemini 3 Flash
+- Gemini 2.5 Flash, Flash-Lite, and Pro models
   :::
 
 #### Use Cases

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -293,7 +293,7 @@ See the [Vertex AI provider documentation](/docs/providers/vertex) for detailed 
 Use the `google:embedding:` prefix (or the plural `google:embeddings:` alias) to call the Gemini API `embedContent` endpoint:
 
 - `google:embedding:gemini-embedding-001` - Recommended default. Multilingual plus code, up to 3,072 dimensions, 2,048 input-token limit
-- `google:embedding:gemini-embedding-2` - Latest Gemini embedding model with multimodal input (text, image, video, audio, and PDF)
+- `google:embedding:gemini-embedding-2` - Latest Gemini embedding model for text input through promptfoo
 
 Optional config keys (forwarded as documented in Google's [embedContent reference](https://ai.google.dev/api/embeddings#EmbedContentRequest)):
 

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -280,7 +280,7 @@ See the [Vertex AI provider documentation](/docs/providers/vertex) for detailed 
 - `google:gemini-3.5-flash` - Gemini 3.5 Flash, the latest frontier Flash model for agentic and coding tasks ($1.50/1M input, $9/1M output)
 - `google:gemini-3.1-pro-preview` - Gemini 3.1 Pro preview with improved reasoning and performance ($2/1M input, $12/1M output; $4/$18 above 200K)
 - `google:gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro preview variant for custom tools with the same pricing as Gemini 3.1 Pro
-- `google:gemini-3.1-flash-lite` - Gemini 3.1 Flash-Lite optimized for high-volume, low-latency tasks ($0.25/1M text/image/video input, $1.50/1M output)
+- `google:gemini-3.1-flash-lite` - Gemini 3.1 Flash-Lite GA model optimized for high-volume, low-latency tasks ($0.25/1M text/image/video input, $1.50/1M output)
 - `google:gemini-3-flash-preview` - Gemini 3.0 Flash preview with frontier intelligence, Pro-grade reasoning at Flash-level speed, thinking, and grounding ($0.50/1M input, $3/1M output)
 - `google:gemini-2.5-pro` - Gemini 2.5 Pro model with enhanced reasoning, coding, and multimodal understanding
 - `google:gemini-2.5-flash` - Gemini 2.5 Flash model with enhanced reasoning and thinking capabilities

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -20,11 +20,11 @@ Use `vertex:` for all Vertex AI models (Gemini, Claude, Llama, etc.). Use `googl
 
 - `vertex:gemini-3.5-flash` - Latest frontier Flash model for agentic and coding tasks ($1.50/1M input, $9/1M output)
 
-**Gemini 3.1 (Preview):**
+**Gemini 3.1:**
 
 - `vertex:gemini-3.1-pro-preview` - Improved reasoning and performance ($2/1M input, $12/1M output; $4/$18 above 200K)
 - `vertex:gemini-3.1-pro-preview-customtools` - Custom-tools variant with the same pricing as Gemini 3.1 Pro
-- `vertex:gemini-3.1-flash-lite` - Cost-efficient model optimized for high-volume agentic tasks ($0.25/1M text/image/video input, $1.50/1M output)
+- `vertex:gemini-3.1-flash-lite` - GA cost-efficient model optimized for high-volume agentic tasks ($0.25/1M text/image/video input, $1.50/1M output)
 
 **Gemini 3.0 (Preview):**
 

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -16,11 +16,15 @@ Use `vertex:` for all Vertex AI models (Gemini, Claude, Llama, etc.). Use `googl
 
 ### Gemini Models
 
+**Gemini 3.5:**
+
+- `vertex:gemini-3.5-flash` - Latest frontier Flash model for agentic and coding tasks ($1.50/1M input, $9/1M output)
+
 **Gemini 3.1 (Preview):**
 
 - `vertex:gemini-3.1-pro-preview` - Improved reasoning and performance ($2/1M input, $12/1M output; $4/$18 above 200K)
 - `vertex:gemini-3.1-pro-preview-customtools` - Custom-tools variant with the same pricing as Gemini 3.1 Pro
-- `vertex:gemini-3.1-flash-lite-preview` - Cost-efficient model optimized for high-volume agentic tasks ($0.25/1M text/image/video input, $1.50/1M output)
+- `vertex:gemini-3.1-flash-lite` - Cost-efficient model optimized for high-volume agentic tasks ($0.25/1M text/image/video input, $1.50/1M output)
 
 **Gemini 3.0 (Preview):**
 
@@ -28,20 +32,9 @@ Use `vertex:` for all Vertex AI models (Gemini, Claude, Llama, etc.). Use `googl
 
 **Gemini 2.5:**
 
-- `vertex:gemini-2.5-pro` - Enhanced reasoning, coding, and multimodal understanding with 2M context
+- `vertex:gemini-2.5-pro` - Enhanced reasoning, coding, and multimodal understanding with 1M context
 - `vertex:gemini-2.5-flash` - Fast model with enhanced reasoning and thinking capabilities
 - `vertex:gemini-2.5-flash-lite` - Cost-efficient model optimized for high-volume, latency-sensitive tasks
-- `vertex:gemini-2.5-flash-preview-09-2025` - Preview: Enhanced quality improvements
-- `vertex:gemini-2.5-flash-lite-preview-09-2025` - Preview: Cost and latency optimizations
-
-**Gemini 2.0:**
-
-- `vertex:gemini-2.0-pro` - Experimental: Strong model quality for code and world knowledge with 2M context
-- `vertex:gemini-2.0-flash-001` - Multimodal model for daily tasks with strong performance and real-time streaming
-- `vertex:gemini-2.0-flash-exp` - Experimental: Enhanced capabilities
-- `vertex:gemini-2.0-flash-thinking-exp` - Experimental: Reasoning with thinking process in responses
-- `vertex:gemini-2.0-flash-lite` - Cost-effective for high throughput
-- `vertex:gemini-2.0-flash-lite-001` - GA version for existing customers; discontinuation scheduled for June 1, 2026
 
 ### Claude Models
 
@@ -189,20 +182,20 @@ providers:
 
 ## Model Capabilities
 
-### Gemini 2.0 Pro Specifications
+### Gemini Model Specifications
 
-- Max input tokens: 2,097,152
-- Max output tokens: 8,192
-- Training data: Up to June 2024
-- Supports: Text, code, images, audio, video, PDF inputs
-- Features: System instructions, JSON support, grounding with Google Search
+Current Gemini models on Vertex AI (2.5 and 3.x):
+
+- Input context: up to 1M tokens
+- Supports: Text, code, images, audio, video, and PDF inputs
+- Features: System instructions, structured JSON output, function calling, thinking, and grounding with Google Search
 
 ### Language Support
 
 Gemini models support a wide range of languages including:
 
 - Core languages: Arabic, Bengali, Chinese (simplified/traditional), English, French, German, Hindi, Indonesian, Italian, Japanese, Korean, Portuguese, Russian, Spanish, Thai, Turkish, Vietnamese
-- Gemini 1.5 adds support for 50+ additional languages including regional and less common languages
+- Plus dozens of additional regional and less common languages
 
 If you're using Google AI Studio directly, see the [`google` provider](/docs/providers/google) documentation instead.
 
@@ -583,7 +576,7 @@ providers:
 Control AI safety filters:
 
 ```yaml
-- id: vertex:gemini-pro
+- id: vertex:gemini-2.5-pro
   config:
     safetySettings:
       - category: HARM_CATEGORY_HARASSMENT
@@ -1041,6 +1034,30 @@ When using Search grounding, the API response includes additional metadata:
 - Search will only be performed when the model determines it's necessary
 
 For more details, see the [Google documentation on Grounding with Google Search](https://ai.google.dev/docs/gemini_api/grounding).
+
+### Code Execution
+
+Code execution lets Gemini models write and run Python to solve computational problems, perform calculations, and analyze data.
+
+```yaml
+providers:
+  - id: vertex:gemini-2.5-flash
+    config:
+      tools:
+        - codeExecution: {}
+```
+
+### URL Context
+
+URL context lets Gemini models fetch and analyze content from specific web URLs.
+
+```yaml
+providers:
+  - id: vertex:gemini-2.5-flash
+    config:
+      tools:
+        - urlContext: {}
+```
 
 ### Model Armor Integration
 

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -1055,6 +1055,7 @@ URL context lets Gemini models fetch and analyze content from specific web URLs.
 providers:
   - id: vertex:gemini-2.5-flash
     config:
+      apiVersion: v1beta1
       tools:
         - urlContext: {}
 ```

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -575,7 +575,7 @@ export class AIStudioEmbeddingProvider
   }
 }
 
-const DEFAULT_AI_STUDIO_MODEL = 'gemini-3.1-pro-preview';
+const DEFAULT_AI_STUDIO_MODEL = 'gemini-2.5-pro';
 
 export function getGoogleAiStudioProviders(env?: EnvOverrides) {
   const gradingProvider = new AIStudioChatProvider(DEFAULT_AI_STUDIO_MODEL, { env });

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -75,19 +75,20 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
   /**
    * Get the API version.
    *
-   * Uses config.apiVersion if set, otherwise auto-detects based on model
-   * (v1alpha for thinking/gemini-3 models, v1beta for others).
+   * Uses config.apiVersion if set, otherwise defaults to v1beta — Google's
+   * primary endpoint for current Gemini models, including the Gemini 3.x
+   * family. The legacy gemini-2.0-flash-thinking-exp model only responds on
+   * v1alpha. Set config.apiVersion to 'v1alpha' to opt into preview-only
+   * features such as media_resolution.
    */
   private getApiVersion(): string {
     // Allow explicit override
     if (this.config.apiVersion) {
       return this.config.apiVersion;
     }
-    // Auto-detect based on model
-    return this.modelName === 'gemini-2.0-flash-thinking-exp' ||
-      this.modelName.startsWith('gemini-3-')
-      ? 'v1alpha'
-      : 'v1beta';
+    // gemini-2.0-flash-thinking-exp only responds on v1alpha; everything else
+    // (including Gemini 3.x) uses the stable v1beta endpoint.
+    return this.modelName === 'gemini-2.0-flash-thinking-exp' ? 'v1alpha' : 'v1beta';
   }
 
   /**
@@ -574,7 +575,7 @@ export class AIStudioEmbeddingProvider
   }
 }
 
-const DEFAULT_AI_STUDIO_MODEL = 'gemini-2.5-pro';
+const DEFAULT_AI_STUDIO_MODEL = 'gemini-3.1-pro-preview';
 
 export function getGoogleAiStudioProviders(env?: EnvOverrides) {
   const gradingProvider = new AIStudioChatProvider(DEFAULT_AI_STUDIO_MODEL, { env });

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -102,8 +102,9 @@ export class GoogleProvider extends GoogleGenericProvider {
    * Get the API version.
    *
    * For Vertex AI: Uses config.apiVersion, env vars, or defaults to 'v1'.
-   * For AI Studio: Uses config.apiVersion if set, otherwise auto-detects
-   * based on model (v1alpha for thinking/gemini-3 models, v1beta for others).
+   * For AI Studio: Uses config.apiVersion if set, otherwise defaults to
+   * v1beta (including the Gemini 3.x family). The legacy
+   * gemini-2.0-flash-thinking-exp model only responds on v1alpha.
    */
   private getApiVersion(): string {
     if (this.isVertexMode) {
@@ -118,11 +119,9 @@ export class GoogleProvider extends GoogleGenericProvider {
       if (this.config.apiVersion) {
         return this.config.apiVersion;
       }
-      // Auto-detect: v1alpha for thinking models and gemini-3, v1beta for others
-      return this.modelName === 'gemini-2.0-flash-thinking-exp' ||
-        this.modelName.startsWith('gemini-3-')
-        ? 'v1alpha'
-        : 'v1beta';
+      // gemini-2.0-flash-thinking-exp only responds on v1alpha; everything
+      // else (including Gemini 3.x) uses the stable v1beta endpoint.
+      return this.modelName === 'gemini-2.0-flash-thinking-exp' ? 'v1alpha' : 'v1beta';
     }
   }
 

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -39,16 +39,23 @@ const GEMINI_2_5_PRO_TIERED_COST = {
  * Note: Vertex AI may have different pricing for some models.
  */
 export const GOOGLE_MODELS: GoogleModel[] = [
-  // Gemini 3.1 models (Preview)
+  // Gemini 3.5 models
+  {
+    id: 'gemini-3.5-flash',
+    cost: { input: 1.5 / 1e6, output: 9.0 / 1e6 },
+  },
+
+  // Gemini 3.1 models
   ...['gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools'].map((id) => ({
     id,
     cost: GEMINI_3_PRO_COST,
     tieredCost: GEMINI_3_PRO_TIERED_COST,
   })),
-  {
-    id: 'gemini-3.1-flash-lite-preview',
+  // gemini-3.1-flash-lite (GA) and its preview alias share Flash-Lite pricing.
+  ...['gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview'].map((id) => ({
+    id,
     cost: { input: 0.25 / 1e6, output: 1.5 / 1e6 },
-  },
+  })),
 
   // Gemini 3.0 models (Preview)
   {
@@ -165,6 +172,10 @@ export const GOOGLE_MODELS: GoogleModel[] = [
   },
 
   // Gemini Embedding
+  {
+    id: 'gemini-embedding-2',
+    cost: { input: 0.2 / 1e6, output: 0 },
+  },
   {
     id: 'gemini-embedding-001',
     cost: { input: 0.15 / 1e6, output: 0 },

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -1236,7 +1236,7 @@ export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
   }
 }
 
-const DEFAULT_VERTEX_MODEL = 'gemini-2.5-pro';
+const DEFAULT_VERTEX_MODEL = 'gemini-3.1-pro-preview';
 const DEFAULT_VERTEX_EMBEDDING_MODEL = 'gemini-embedding-001';
 
 export function getGoogleVertexEmbeddingProvider(env?: EnvOverrides) {

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -1238,6 +1238,7 @@ export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
 
 const DEFAULT_VERTEX_MODEL = 'gemini-3.1-pro-preview';
 const DEFAULT_VERTEX_REGION = 'global';
+const DEFAULT_VERTEX_API_HOST = 'aiplatform.googleapis.com';
 const DEFAULT_VERTEX_EMBEDDING_MODEL = 'gemini-embedding-001';
 
 export function getGoogleVertexEmbeddingProvider(env?: EnvOverrides) {
@@ -1247,7 +1248,7 @@ export function getGoogleVertexEmbeddingProvider(env?: EnvOverrides) {
 export function getGoogleVertexProviders(env?: EnvOverrides) {
   const gradingProvider = new VertexChatProvider(DEFAULT_VERTEX_MODEL, {
     env,
-    config: { region: DEFAULT_VERTEX_REGION },
+    config: { region: DEFAULT_VERTEX_REGION, apiHost: DEFAULT_VERTEX_API_HOST },
   });
   return {
     embeddingProvider: getGoogleVertexEmbeddingProvider(env),

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -1237,6 +1237,7 @@ export class VertexEmbeddingProvider implements ApiEmbeddingProvider {
 }
 
 const DEFAULT_VERTEX_MODEL = 'gemini-3.1-pro-preview';
+const DEFAULT_VERTEX_REGION = 'global';
 const DEFAULT_VERTEX_EMBEDDING_MODEL = 'gemini-embedding-001';
 
 export function getGoogleVertexEmbeddingProvider(env?: EnvOverrides) {
@@ -1244,7 +1245,10 @@ export function getGoogleVertexEmbeddingProvider(env?: EnvOverrides) {
 }
 
 export function getGoogleVertexProviders(env?: EnvOverrides) {
-  const gradingProvider = new VertexChatProvider(DEFAULT_VERTEX_MODEL, { env });
+  const gradingProvider = new VertexChatProvider(DEFAULT_VERTEX_MODEL, {
+    env,
+    config: { region: DEFAULT_VERTEX_REGION },
+  });
   return {
     embeddingProvider: getGoogleVertexEmbeddingProvider(env),
     gradingJsonProvider: gradingProvider,

--- a/test/providers/google/ai.studio.defaults.test.ts
+++ b/test/providers/google/ai.studio.defaults.test.ts
@@ -7,11 +7,11 @@ import {
 describe('Google AI Studio Default Providers', () => {
   it('should create providers with correct model names', () => {
     const providers = getGoogleAiStudioProviders();
-    expect(providers.gradingProvider.id()).toBe('google:gemini-2.5-pro');
-    expect(providers.gradingJsonProvider.id()).toBe('google:gemini-2.5-pro');
-    expect(providers.llmRubricProvider.id()).toBe('google:gemini-2.5-pro');
-    expect(providers.suggestionsProvider.id()).toBe('google:gemini-2.5-pro');
-    expect(providers.synthesizeProvider.id()).toBe('google:gemini-2.5-pro');
+    expect(providers.gradingProvider.id()).toBe('google:gemini-3.1-pro-preview');
+    expect(providers.gradingJsonProvider.id()).toBe('google:gemini-3.1-pro-preview');
+    expect(providers.llmRubricProvider.id()).toBe('google:gemini-3.1-pro-preview');
+    expect(providers.suggestionsProvider.id()).toBe('google:gemini-3.1-pro-preview');
+    expect(providers.synthesizeProvider.id()).toBe('google:gemini-3.1-pro-preview');
   });
 
   it('should create AIStudioChatProvider instances', () => {

--- a/test/providers/google/ai.studio.defaults.test.ts
+++ b/test/providers/google/ai.studio.defaults.test.ts
@@ -7,11 +7,11 @@ import {
 describe('Google AI Studio Default Providers', () => {
   it('should create providers with correct model names', () => {
     const providers = getGoogleAiStudioProviders();
-    expect(providers.gradingProvider.id()).toBe('google:gemini-3.1-pro-preview');
-    expect(providers.gradingJsonProvider.id()).toBe('google:gemini-3.1-pro-preview');
-    expect(providers.llmRubricProvider.id()).toBe('google:gemini-3.1-pro-preview');
-    expect(providers.suggestionsProvider.id()).toBe('google:gemini-3.1-pro-preview');
-    expect(providers.synthesizeProvider.id()).toBe('google:gemini-3.1-pro-preview');
+    expect(providers.gradingProvider.id()).toBe('google:gemini-2.5-pro');
+    expect(providers.gradingJsonProvider.id()).toBe('google:gemini-2.5-pro');
+    expect(providers.llmRubricProvider.id()).toBe('google:gemini-2.5-pro');
+    expect(providers.suggestionsProvider.id()).toBe('google:gemini-2.5-pro');
+    expect(providers.synthesizeProvider.id()).toBe('google:gemini-2.5-pro');
   });
 
   it('should create AIStudioChatProvider instances', () => {

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -677,6 +677,39 @@ describe('AIStudioChatProvider', () => {
       );
     });
 
+    it('should use v1beta API for Gemini 3 models', async () => {
+      // Regression: all Gemini 3.x models use v1beta, including dash-named
+      // gemini-3-* preview IDs that were previously forced onto v1alpha.
+      provider = new AIStudioChatProvider('gemini-3-flash-preview', {
+        config: { apiKey: 'test-key' },
+      });
+      const mockResponse = {
+        data: {
+          candidates: [{ content: { parts: [{ text: 'gemini 3 response' }] } }],
+        },
+        cached: false,
+      };
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValue(mockResponse as any);
+      vi.mocked(util.maybeCoerceToGeminiFormat).mockImplementation(function () {
+        return {
+          contents: [{ role: 'user', parts: [{ text: 'test prompt' }] }],
+          coerced: false,
+          systemInstruction: undefined,
+        };
+      });
+
+      await provider.callGemini('test prompt');
+
+      expect(cache.fetchWithCache).toHaveBeenCalledWith(
+        expect.stringContaining('v1beta/models/gemini-3-flash-preview:generateContent'),
+        expect.any(Object),
+        expect.any(Number),
+        'json',
+        false,
+      );
+    });
+
     it('should handle API call errors', async () => {
       const provider = new AIStudioChatProvider('gemini-pro', {
         config: {

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -199,13 +199,15 @@ describe('GoogleProvider', () => {
       expect(endpoint).toContain('/v1alpha/');
     });
 
-    it('should use v1alpha for gemini-3 models', () => {
+    it('should use v1beta for gemini-3 models', () => {
+      // Regression: dash-named gemini-3-* models resolve to v1beta, the same
+      // as dotted gemini-3.x IDs. v1beta is Google's primary Gemini 3 endpoint.
       const gemini3Provider = new GoogleProvider('gemini-3-pro', {
         config: { apiKey: 'test-key' },
       });
 
       const endpoint = gemini3Provider.getApiEndpoint('generateContent');
-      expect(endpoint).toContain('/v1alpha/');
+      expect(endpoint).toContain('/v1beta/');
     });
 
     it('should use v1beta for gemini-3.1 models', () => {

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -2647,6 +2647,34 @@ describe('util', () => {
       expect(cost).toBeCloseTo(0.001, 10);
     });
 
+    it('should calculate cost for gemini-3.1-flash-lite (GA)', () => {
+      // gemini-3.1-flash-lite: input=0.25/1M, output=1.5/1M
+      const cost = calculateGoogleCost('gemini-3.1-flash-lite', {}, 1000, 500);
+      expect(cost).toBeCloseTo(0.001, 10);
+    });
+
+    it('should calculate cost for gemini-3.5-flash', () => {
+      // gemini-3.5-flash: input=1.5/1M, output=9.0/1M
+      const cost = calculateGoogleCost('gemini-3.5-flash', {}, 1000, 500);
+      // Expected: (1000 * 1.5 + 500 * 9.0) / 1M = (1500 + 4500) / 1M = 0.006
+      expect(cost).toBeCloseTo(0.006, 10);
+    });
+
+    it('should not apply long-context tiered pricing to gemini-3.5-flash', () => {
+      // gemini-3.5-flash is flat-rate: prompts above 200k tokens bill at the
+      // standard rate (unlike the tiered gemini-3.1-pro-preview).
+      const cost = calculateGoogleCost('gemini-3.5-flash', {}, 250000, 50000);
+      // Expected: (250000 * 1.5 + 50000 * 9.0) / 1M = (375000 + 450000) / 1M = 0.825
+      expect(cost).toBeCloseTo(0.825, 10);
+    });
+
+    it('should calculate cost for gemini-embedding-2', () => {
+      // gemini-embedding-2: input=0.2/1M, output=0
+      const cost = calculateGoogleCost('gemini-embedding-2', {}, 10000, 0);
+      // Expected: (10000 * 0.2) / 1M = 0.002
+      expect(cost).toBeCloseTo(0.002, 10);
+    });
+
     it('should apply tiered pricing for gemini-2.5-pro when above threshold', () => {
       // gemini-2.5-pro: base input=1.25/1M, output=10.0/1M
       // tiered (>200k): input=2.5/1M, output=15.0/1M

--- a/test/providers/google/vertex.defaults.test.ts
+++ b/test/providers/google/vertex.defaults.test.ts
@@ -11,8 +11,8 @@ describe('Google Vertex default providers', () => {
     const providers = getGoogleVertexProviders();
     expect(providers.embeddingProvider.modelName).toBe('gemini-embedding-001');
     expect(providers.embeddingProvider.id()).toBe('vertex:gemini-embedding-001');
-    expect(providers.gradingProvider.modelName).toBe('gemini-2.5-pro');
-    expect(providers.gradingProvider.id()).toBe('vertex:gemini-2.5-pro');
+    expect(providers.gradingProvider.modelName).toBe('gemini-3.1-pro-preview');
+    expect(providers.gradingProvider.id()).toBe('vertex:gemini-3.1-pro-preview');
   });
 
   it('should create correct provider instances', () => {

--- a/test/providers/google/vertex.defaults.test.ts
+++ b/test/providers/google/vertex.defaults.test.ts
@@ -21,6 +21,12 @@ describe('Google Vertex default providers', () => {
     expect(providers.gradingProvider).toBeInstanceOf(VertexChatProvider);
   });
 
+  it('should keep the default Gemini 3.1 provider on the global endpoint', () => {
+    const providers = getGoogleVertexProviders({ VERTEX_REGION: 'us-central1' });
+    expect(providers.gradingProvider.getRegion()).toBe('global');
+    expect(providers.gradingProvider.getApiHost()).toBe('aiplatform.googleapis.com');
+  });
+
   it('should share a single chat provider instance across grading roles', () => {
     const providers = getGoogleVertexProviders();
     expect(providers.gradingJsonProvider).toBe(providers.gradingProvider);

--- a/test/providers/google/vertex.defaults.test.ts
+++ b/test/providers/google/vertex.defaults.test.ts
@@ -22,7 +22,10 @@ describe('Google Vertex default providers', () => {
   });
 
   it('should keep the default Gemini 3.1 provider on the global endpoint', () => {
-    const providers = getGoogleVertexProviders({ VERTEX_REGION: 'us-central1' });
+    const providers = getGoogleVertexProviders({
+      VERTEX_REGION: 'us-central1',
+      VERTEX_API_HOST: 'us-central1-aiplatform.googleapis.com',
+    });
     expect(providers.gradingProvider.getRegion()).toBe('global');
     expect(providers.gradingProvider.getApiHost()).toBe('aiplatform.googleapis.com');
   });


### PR DESCRIPTION
## Summary

Google released Gemini 3.5 Flash (GA, May 19) and Gemini 3.1 Flash-Lite (GA, May 7); meanwhile `gemini-2.0-flash` retires June 1. This adds the new models, fixes a latent API-version bug, and refreshes the Google/Vertex docs and examples off the retiring models.

## Provider code

- Add pricing for `gemini-3.5-flash` ($1.50 in / $9.00 out per 1M), `gemini-3.1-flash-lite` (GA), and `gemini-embedding-2` to `GOOGLE_MODELS`.
- Default Vertex model -> `gemini-3.1-pro-preview` (was `gemini-2.5-pro`); keep the AI Studio default on free-tier-capable `gemini-2.5-pro`.
- `getApiVersion()`: all Gemini 3.x models now resolve to `v1beta`, Google's primary endpoint. The previous `gemini-3-` prefix check forced `gemini-3-flash-preview` onto `v1alpha` while dotted `3.1`/`3.5` IDs already used `v1beta` - an inconsistency that surfaced as soon as dotted names shipped.

## Docs & examples

- `google.md` / `vertex.md`: add the new models, drop retiring `gemini-2.0`/`1.5`/bare `gemini-pro` references, fix the search-grounding model list, add Code Execution + URL Context parity to `vertex.md`.
- Refresh example configs off `gemini-2.0-flash*` and the dying `gemini-3.1-flash-lite-preview` alias.
- Fix example bugs surfaced by running them end-to-end: `maxOutputTokens` too low for a reasoning model, the legacy `googleSearchRetrieval` tool (unsupported on Gemini 2.5), a missing global Vertex host/region pairing for `gemini-3.5-flash`, duplicate Vertex example labels, and a placeholder `projectId`.

## Validation

Ran live evals against the Gemini API and Vertex AI (ADC). Cost reporting matches Google's published pricing to the cent.

- `gemini-3.5-flash` - AI Studio + Vertex; `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-embedding-2` - AI Studio.
- Example suites: `google-aistudio-gemini` 13/13, `google-vertex` gemini 16/16, `google-vertex` 72/74, plus search / code-execution / url-context / response-schema green.
- 591 Google provider unit tests pass; `tsc` and build clean.
- Follow-up sweep checks: focused Google provider tests, isolated config validation for the edited Vertex examples, changed-file lint/format, `tsc`, and fresh PR CI.

## Deferred to a follow-up PR

- `vertex.md`'s non-Google model lists are stale: `claude-3-7-sonnet` is retired, Llama 3.1/3.2 retired Jan 2026, the Llama 4 IDs are wrong, and Gemma is two generations behind. `claude-3-5-sonnet-v2@20241022` appears in examples but is retired.
- `google-vertex-tools` is broken independently of model versions (invalid `gemini-2.5-flash-002`, plus a `functionToolCallbacks` flow that returns the raw function call).
- `gemini-embedding-2` is AI-Studio-only (404 on Vertex), so the Vertex embedding default stays `gemini-embedding-001`.