### PR TITLE
fix(webui): clear stale eval detail row hint

### DIFF
--- a/src/app/src/pages/eval/components/utils.test.ts
+++ b/src/app/src/pages/eval/components/utils.test.ts
@@ -148,6 +148,17 @@ describe('eval-details hash store', () => {
     expect(window.location.hash).toBe('#details-row-51-prompt-2');
   });
 
+  it('clears the stale row hint when removing the details hash', () => {
+    window.history.replaceState({}, '', '/eval/x?rowId=51#details-row-51-prompt-2');
+
+    act(() => {
+      setEvalDetailsHash('');
+    });
+
+    expect(window.location.search).toBe('');
+    expect(window.location.hash).toBe('');
+  });
+
   it('coordinates updates across multiple subscribers', () => {
     const { result: a } = renderHook(() => useEvalDetailsHash());
     const { result: b } = renderHook(() => useEvalDetailsHash());

--- a/src/app/src/pages/eval/components/utils.ts
+++ b/src/app/src/pages/eval/components/utils.ts
@@ -122,6 +122,8 @@ export function setEvalDetailsHash(hash: string, rowPositionIndex?: number): voi
   const url = new URL(window.location.href);
   if (rowPositionIndex !== undefined) {
     url.searchParams.set('rowId', String(rowPositionIndex + 1));
+  } else if (!next) {
+    url.searchParams.delete('rowId');
   }
   url.hash = next;
   if (url.href === window.location.href) {


### PR DESCRIPTION
## Summary
This fixes a regression in the new eval output deep-link flow.

Closing an eval output details dialog cleared the `#details-row-...` hash, but it left the `?rowId=` query parameter behind. That meant the URL still looked like a deep link to a specific filtered row even after the dialog was closed.

## Root cause
This regression was introduced by commit [`1f5845b9f508a01de0b821c6671eae438fb7109c`](https://github.com/promptfoo/promptfoo/commit/1f5845b9f508a01de0b821c6671eae438fb7109c) in PR [#9170](https://github.com/promptfoo/promptfoo/pull/9170) (`feat(eval): add output detail deep links`).

The shared `setEvalDetailsHash()` helper was updated to add `rowId` when opening a deep-linked result, but the clear path only removed the hash fragment. The stale query param remained in the URL until some other navigation path explicitly removed it.

## Changes
- remove `rowId` when `setEvalDetailsHash('')` clears the deep-link state
- add a regression test that proves both the hash and `rowId` are removed together

## Impact
Users who open and close eval result details no longer keep a stale deep-link row hint in the URL.

## Validation
- Added regression coverage in `src/app/src/pages/eval/components/utils.test.ts`
- Local Vitest execution is currently blocked in this worktree because dependency resolution fails against the registry mirror for `@anthropic-ai/sdk@^0.97.1`
