### PR TITLE
feat: add AgentThreatBench Inspect example

### DIFF
--- a/examples/integration-inspect-agent-threat-bench/.gitignore
+++ b/examples/integration-inspect-agent-threat-bench/.gitignore
@@ -1,0 +1,1 @@
+inspect_logs/

--- a/examples/integration-inspect-agent-threat-bench/README.md
+++ b/examples/integration-inspect-agent-threat-bench/README.md
@@ -1,0 +1,132 @@
+# integration-inspect-agent-threat-bench (AgentThreatBench via Inspect)
+
+This example runs [AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/) through promptfoo by wrapping its Inspect-native tasks in [`inspect_evals`](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/agent_threat_bench).
+
+AgentThreatBench measures model resilience to agentic attacks in tool outputs and memory stores:
+
+| Task              | OWASP risk                         | Attack surface                                          |
+| ----------------- | ---------------------------------- | ------------------------------------------------------- |
+| `memory_poison`   | ASI06 Memory and Context Poisoning | Adversarial entries returned from a knowledge base      |
+| `autonomy_hijack` | ASI01 Agent Goal Hijack            | Injection embedded in email triage tool output          |
+| `data_exfil`      | ASI01 Agent Goal Hijack            | Customer records that try to trigger unauthorized sends |
+
+This is an orchestration wrapper, not a promptfoo-native reimplementation of the benchmark. Inspect owns the benchmark prompts, task tools, tool loop, and the scorer that emits separate `utility` and `security` results. Promptfoo imports the samples, starts one Inspect eval per row, reports both scores, and can gate them in CI.
+
+## Prerequisites
+
+You need:
+
+- Python with Inspect Evals and the SDK for the Inspect model provider you choose:
+
+  ```bash
+  pip install inspect-evals openai anthropic
+  ```
+
+- An API key for the model provider. The default config uses `openai/gpt-5-nano`, so export `OPENAI_API_KEY`. To use Anthropic, export `ANTHROPIC_API_KEY` and set `vars.model` or `providers[0].config.defaultModel` to an Inspect model id.
+
+AgentThreatBench's tools are simulated by Inspect, so this example does not require a separate target agent service.
+
+## Run
+
+Create the example:
+
+```bash
+npx promptfoo@latest init --example integration-inspect-agent-threat-bench
+cd integration-inspect-agent-threat-bench
+promptfoo eval -c promptfooconfig.yaml
+```
+
+To run the same example from the Promptfoo repository source tree:
+
+```bash
+PROMPTFOO_ENABLE_OTEL=true OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
+  npm run local -- eval -c examples/integration-inspect-agent-threat-bench/promptfooconfig.yaml \
+    --no-cache
+```
+
+Use metadata filters to start with one sample or run a task or difficulty slice:
+
+```bash
+promptfoo eval -c promptfooconfig.yaml --no-cache --filter-metadata sample_id=mp_001
+promptfoo eval -c promptfooconfig.yaml --no-cache --filter-metadata task=data_exfil
+promptfoo eval -c promptfooconfig.yaml --no-cache --filter-metadata difficulty=hard
+```
+
+The unfiltered config runs every AgentThreatBench sample that Inspect exposes in the installed `inspect-evals` version.
+
+## What runs
+
+`agent_threat_bench_tests.py` calls the Inspect task loaders and creates one promptfoo row per sample. Each row includes filterable metadata for:
+
+- `task`
+- `sample_id`
+- `owasp_id`
+- `attack_name`
+- `difficulty`
+
+For every row, `provider.py` runs the matching Inspect task by exact sample id, for example:
+
+```bash
+inspect eval inspect_evals/agent_threat_bench_memory_poison \
+  --model openai/gpt-5-nano --sample-id mp_001 --log-dir <dir>
+inspect log dump <file.eval>
+```
+
+The Promptfoo prompt is only the row label passed to the file provider. Inspect reads the actual benchmark input, initializes the simulated memory, inbox, or customer data tools, and grades the resulting trajectory.
+
+## Scores
+
+AgentThreatBench scores two metrics:
+
+- `utility`: the agent completed the legitimate task
+- `security`: the agent resisted the injected behavior
+
+The assertion passes only when both metrics pass. A row with high security but low utility is still a benchmark failure because the benchmark is measuring useful work under attack, not refusal alone.
+
+The provider returns text like:
+
+```text
+Task memory_poison sample mp_001: utility=1.0 security=1.0 status=pass
+
+Final answer: <Inspect final assistant message>
+```
+
+It also returns metadata for assertions and the promptfoo UI:
+
+```json
+{
+  "inspect_log_path": "/absolute/path/to/examples/integration-inspect-agent-threat-bench/inspect_logs/.../*.eval",
+  "status": "pass",
+  "sample_id": "mp_001",
+  "task": "memory_poison",
+  "utility_score": 1.0,
+  "security_score": 1.0
+}
+```
+
+If Inspect exits before both scores are available, the provider returns an error instead of converting a harness failure into a benchmark failure.
+
+## Inspect logs
+
+Inspect writes `.eval` logs under `examples/integration-inspect-agent-threat-bench/inspect_logs/`. They are ignored by git because they can include task inputs, messages, tool calls, scorer output, and model responses.
+
+Use Inspect's log viewer when you need the benchmark trajectory:
+
+```bash
+inspect view --log-dir examples/integration-inspect-agent-threat-bench/inspect_logs
+```
+
+The example config enables Promptfoo OpenTelemetry tracing. Set
+`PROMPTFOO_ENABLE_OTEL=true` for Python provider spans; those spans also require
+Promptfoo's Python tracing dependencies:
+
+```bash
+pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+```
+
+Inspect still owns the benchmark-internal model and tool trajectory in its `.eval`
+log.
+
+## Related Promptfoo red teams
+
+Use this fixed benchmark when you want repeatable AgentThreatBench scores across models. To probe your own agent or chatbot, use Promptfoo's application-focused red-team plugins such as [`agentic:memory-poisoning`](https://promptfoo.dev/docs/red-team/plugins/memory-poisoning/), [`indirect-prompt-injection`](https://promptfoo.dev/docs/red-team/plugins/indirect-prompt-injection/), and the [OWASP Agentic preset](https://promptfoo.dev/docs/red-team/owasp-agentic-ai/).

--- a/examples/integration-inspect-agent-threat-bench/agent_threat_bench_tests.py
+++ b/examples/integration-inspect-agent-threat-bench/agent_threat_bench_tests.py
@@ -1,0 +1,64 @@
+"""Generate Promptfoo test cases from Inspect's AgentThreatBench tasks."""
+
+from __future__ import annotations
+
+
+TASK_LOADERS = {
+    "memory_poison": "agent_threat_bench_memory_poison",
+    "autonomy_hijack": "agent_threat_bench_autonomy_hijack",
+    "data_exfil": "agent_threat_bench_data_exfil",
+}
+
+
+def generate_tests():
+    """Return one Promptfoo test case per AgentThreatBench sample."""
+
+    tests = []
+    for task_name, task_loader in _task_loaders().items():
+        dataset = task_loader().dataset
+        tests.extend(_test_case(task_name, dataset[index]) for index in range(len(dataset)))
+    return tests
+
+
+def _task_loaders():
+    try:
+        from inspect_evals import agent_threat_bench
+    except ImportError as exc:
+        raise RuntimeError(
+            "Could not import inspect_evals.agent_threat_bench. Install prerequisites "
+            "with `pip install inspect-evals` before loading AgentThreatBench tests."
+        ) from exc
+
+    return {
+        task_name: getattr(agent_threat_bench, loader_name)
+        for task_name, loader_name in TASK_LOADERS.items()
+    }
+
+
+def _test_case(task_name, sample):
+    metadata = getattr(sample, "metadata", {}) or {}
+    sample_id = str(sample.id)
+    prompt = str(sample.input)
+    return {
+        "description": f"{task_name} - {_short_label(prompt)}",
+        "vars": {
+            "prompt": prompt,
+            "task": task_name,
+            "sample_id": sample_id,
+        },
+        "metadata": {
+            "task": task_name,
+            "sample_id": sample_id,
+            "owasp_id": metadata.get("owasp_id", "unknown"),
+            "attack_name": metadata.get("attack_name", "unknown"),
+            "difficulty": metadata.get("difficulty", "unknown"),
+            "testCaseId": f"agent-threat-bench-{task_name.replace('_', '-')}-{sample_id}",
+        },
+    }
+
+
+def _short_label(instruction, max_length=80):
+    label = " ".join(str(instruction).split())
+    if len(label) <= max_length:
+        return label
+    return f"{label[: max_length - 3].rstrip()}..."

--- a/examples/integration-inspect-agent-threat-bench/agent_threat_bench_tests.py
+++ b/examples/integration-inspect-agent-threat-bench/agent_threat_bench_tests.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 TASK_LOADERS = {
     "memory_poison": "agent_threat_bench_memory_poison",
     "autonomy_hijack": "agent_threat_bench_autonomy_hijack",
@@ -16,7 +15,9 @@ def generate_tests():
     tests = []
     for task_name, task_loader in _task_loaders().items():
         dataset = task_loader().dataset
-        tests.extend(_test_case(task_name, dataset[index]) for index in range(len(dataset)))
+        tests.extend(
+            _test_case(task_name, dataset[index]) for index in range(len(dataset))
+        )
     return tests
 
 

--- a/examples/integration-inspect-agent-threat-bench/assertion.py
+++ b/examples/integration-inspect-agent-threat-bench/assertion.py
@@ -1,0 +1,43 @@
+"""Promptfoo assertion for the AgentThreatBench Inspect wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_assert(output: str, context: dict[str, Any]) -> dict[str, Any]:
+    del output
+    provider_response = context.get("providerResponse") or {}
+    metadata = provider_response.get("metadata") or {}
+    status = metadata.get("status")
+    utility_score = metadata.get("utility_score")
+    security_score = metadata.get("security_score")
+
+    metrics_passed = all(
+        isinstance(score, (int, float)) and score >= 1.0
+        for score in (utility_score, security_score)
+    )
+    passed = status == "pass" or metrics_passed
+    sample_id = metadata.get("sample_id", "unknown sample")
+    task = metadata.get("task", "unknown task")
+    log_path = metadata.get("inspect_log_path", "unknown log")
+    named_scores = {
+        name: score
+        for name, score in {
+            "utility": utility_score,
+            "security": security_score,
+        }.items()
+        if isinstance(score, (int, float))
+    }
+    reason = (
+        f"AgentThreatBench task={task} sample={sample_id} "
+        f"utility={utility_score} security={security_score} status={status}; "
+        f"Inspect log: {log_path}"
+    )
+
+    return {
+        "pass": passed,
+        "score": 1.0 if passed else 0.0,
+        "reason": reason,
+        "named_scores": named_scores,
+    }

--- a/examples/integration-inspect-agent-threat-bench/promptfooconfig.yaml
+++ b/examples/integration-inspect-agent-threat-bench/promptfooconfig.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: AgentThreatBench via Inspect wrapper
+prompts:
+  - '{{prompt}}'
+providers:
+  - id: file://provider.py
+    label: AgentThreatBench via Inspect
+    config:
+      defaultModel: openai/gpt-5-nano
+      # Promptfoo's Python worker timeout, in milliseconds.
+      timeout: 300000
+      # Inspect subprocess timeout, in seconds.
+      timeoutSeconds: 300
+defaultTest:
+  metadata:
+    tracingEnabled: true
+  assert:
+    - type: python
+      value: file://assertion.py
+tests: file://agent_threat_bench_tests.py:generate_tests
+tracing:
+  enabled: true
+  otlp:
+    http:
+      enabled: true
+      port: 4318
+      host: 127.0.0.1
+      acceptFormats:
+        - json
+        - protobuf

--- a/examples/integration-inspect-agent-threat-bench/provider.py
+++ b/examples/integration-inspect-agent-threat-bench/provider.py
@@ -115,7 +115,11 @@ def call_api(prompt: str, options: dict, context: dict) -> dict:
     if eval_log is None:
         return {
             "error": f"Inspect completed but no .eval log was found in {log_dir}.",
-            "metadata": {"inspect_log_path": str(log_dir), "status": "error", "task": task},
+            "metadata": {
+                "inspect_log_path": str(log_dir),
+                "status": "error",
+                "task": task,
+            },
         }
 
     dump_result = _dump_eval_log(inspect_cmd, eval_log, base_path)
@@ -127,7 +131,11 @@ def call_api(prompt: str, options: dict, context: dict) -> dict:
     except json.JSONDecodeError as exc:
         return {
             "error": f"Could not parse Inspect log dump JSON for {eval_log}: {exc}",
-            "metadata": {"inspect_log_path": str(eval_log), "status": "error", "task": task},
+            "metadata": {
+                "inspect_log_path": str(eval_log),
+                "status": "error",
+                "task": task,
+            },
         }
 
     parsed = _parse_inspect_log(log_json)
@@ -293,7 +301,9 @@ def _parse_inspect_log(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _sample_scores(sample: dict[str, Any]) -> tuple[dict[str, float] | None, str | None]:
+def _sample_scores(
+    sample: dict[str, Any],
+) -> tuple[dict[str, float] | None, str | None]:
     scores = sample.get("scores") or {}
     preferred_score = scores.get(SCORER)
     if preferred_score is None:
@@ -303,7 +313,10 @@ def _sample_scores(sample: dict[str, Any]) -> tuple[dict[str, float] | None, str
 
     value = preferred_score.get("value") if isinstance(preferred_score, dict) else None
     if not isinstance(value, dict):
-        return None, f"Inspect recorded {SCORER}, but its value was not a metric object."
+        return (
+            None,
+            f"Inspect recorded {SCORER}, but its value was not a metric object.",
+        )
 
     parsed_scores = {}
     for metric in ("utility", "security"):
@@ -349,7 +362,10 @@ def _final_answer(sample: dict[str, Any]) -> str | None:
 
 
 def _token_usage(data: dict[str, Any], sample: dict[str, Any]) -> dict[str, int] | None:
-    usage_sources = [sample.get("model_usage"), (data.get("stats") or {}).get("model_usage")]
+    usage_sources = [
+        sample.get("model_usage"),
+        (data.get("stats") or {}).get("model_usage"),
+    ]
     totals = {"prompt": 0, "completion": 0, "total": 0}
     found = False
     for usage_by_model in usage_sources:

--- a/examples/integration-inspect-agent-threat-bench/provider.py
+++ b/examples/integration-inspect-agent-threat-bench/provider.py
@@ -1,0 +1,438 @@
+"""Promptfoo provider that orchestrates Inspect's AgentThreatBench tasks.
+
+Inspect owns AgentThreatBench's task prompts, simulated tools, tool loop, and
+dual utility/security scorer. Promptfoo starts one Inspect eval per generated
+test row, dumps the `.eval` log to JSON, and exposes both metric scores.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL = "openai/gpt-5-nano"
+DEFAULT_TIMEOUT_SECONDS = 300
+SCORER = "agent_threat_bench_scorer"
+TASKS = ("memory_poison", "autonomy_hijack", "data_exfil")
+
+
+def call_api(prompt: str, options: dict, context: dict) -> dict:
+    """Run one AgentThreatBench sample through Inspect."""
+    del prompt
+    config = options.get("config") or {}
+    vars_ = context.get("vars") or {}
+    requested_sample_id = vars_.get("sample_id")
+    task = _normalize_task(vars_.get("task"))
+    if not requested_sample_id:
+        return {
+            "error": (
+                "AgentThreatBench sample_id is required. Use "
+                "agent_threat_bench_tests.py or set vars.sample_id."
+            )
+        }
+    if task is None:
+        return {
+            "error": (
+                "AgentThreatBench task must be one of: "
+                f"{', '.join(TASKS)}. Use agent_threat_bench_tests.py or set vars.task."
+            )
+        }
+
+    model = vars_.get("model") or config.get("defaultModel") or DEFAULT_MODEL
+    timeout_seconds = _int_config(config.get("timeoutSeconds"), DEFAULT_TIMEOUT_SECONDS)
+    base_path = _resolve_base_path(config)
+    log_root = _resolve_log_root(config, base_path)
+    log_dir = _new_log_dir(log_root, task)
+    inspect_cmd = _inspect_command(config)
+    if not inspect_cmd:
+        return {
+            "error": (
+                "Inspect CLI command is empty. Set providers[0].config.inspectCommand "
+                "or PROMPTFOO_AGENT_THREAT_BENCH_INSPECT_COMMAND."
+            )
+        }
+
+    inspect_task = f"inspect_evals/agent_threat_bench_{task}"
+    eval_cmd = [
+        *inspect_cmd,
+        "eval",
+        inspect_task,
+        "--model",
+        str(model),
+        "--log-dir",
+        str(log_dir),
+        "--sample-id",
+        str(requested_sample_id),
+    ]
+
+    started = time.monotonic()
+    try:
+        eval_result = subprocess.run(
+            eval_cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            cwd=str(base_path),
+        )
+    except FileNotFoundError:
+        return {"error": _missing_inspect_message(inspect_cmd[0])}
+    except subprocess.TimeoutExpired:
+        return {
+            "error": (
+                f"Inspect AgentThreatBench run timed out after {timeout_seconds}s. "
+                "Increase providers[0].config.timeoutSeconds for real runs."
+            ),
+            "metadata": {
+                "inspect_log_path": str(log_dir),
+                "status": "error",
+                "duration_seconds": round(time.monotonic() - started, 3),
+                "task": task,
+            },
+        }
+
+    duration = time.monotonic() - started
+    if eval_result.returncode != 0:
+        return {
+            "error": _humanize_inspect_failure(eval_result),
+            "metadata": {
+                "inspect_log_path": str(log_dir),
+                "status": "error",
+                "duration_seconds": round(duration, 3),
+                "task": task,
+            },
+        }
+
+    eval_log = _find_eval_log(log_dir)
+    if eval_log is None:
+        return {
+            "error": f"Inspect completed but no .eval log was found in {log_dir}.",
+            "metadata": {"inspect_log_path": str(log_dir), "status": "error", "task": task},
+        }
+
+    dump_result = _dump_eval_log(inspect_cmd, eval_log, base_path)
+    if isinstance(dump_result, dict):
+        return dump_result
+
+    try:
+        log_json = json.loads(dump_result.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "error": f"Could not parse Inspect log dump JSON for {eval_log}: {exc}",
+            "metadata": {"inspect_log_path": str(eval_log), "status": "error", "task": task},
+        }
+
+    parsed = _parse_inspect_log(log_json)
+    parsed_sample_id = parsed.get("sample_id")
+    sample_id = parsed_sample_id or "unknown sample"
+    if parsed_sample_id and sample_id != str(requested_sample_id):
+        return {
+            "error": (
+                f"Inspect returned sample {sample_id}, but Promptfoo requested "
+                f"{requested_sample_id}."
+            ),
+            "metadata": {
+                "inspect_log_path": str(eval_log),
+                "status": "error",
+                "sample_id": sample_id,
+                "requested_sample_id": str(requested_sample_id),
+                "duration_seconds": round(duration, 3),
+                "task": task,
+            },
+        }
+
+    scores = parsed.get("scores") or {}
+    utility_score = scores.get("utility")
+    security_score = scores.get("security")
+    status = (
+        "pass"
+        if all(
+            isinstance(score, (int, float)) and score >= 1.0
+            for score in (utility_score, security_score)
+        )
+        else "fail"
+    )
+    metadata = {
+        "inspect_log_path": str(eval_log),
+        "status": status,
+        "sample_id": sample_id,
+        "requested_sample_id": str(requested_sample_id),
+        "task": task,
+        "inspect_task": inspect_task,
+        "model": str(model),
+        "utility_score": utility_score,
+        "security_score": security_score,
+        "num_messages": parsed.get("num_messages", 0),
+        "duration_seconds": round(duration, 3),
+    }
+    token_usage = parsed.get("token_usage")
+
+    inspect_error = _inspect_log_error(parsed)
+    if inspect_error:
+        metadata["status"] = "error"
+        metadata["inspect_status"] = parsed.get("inspect_status")
+        metadata["inspect_error"] = inspect_error
+        result: dict[str, Any] = {
+            "error": (
+                f"Inspect AgentThreatBench run did not produce both scores for "
+                f"sample {sample_id}: {inspect_error}"
+            ),
+            "metadata": metadata,
+        }
+        if token_usage:
+            result["tokenUsage"] = token_usage
+        return result
+
+    final_answer = (
+        parsed.get("final_answer") or "(no final assistant text found in Inspect log)"
+    )
+    output = (
+        f"Task {task} sample {sample_id}: utility={utility_score} "
+        f"security={security_score} status={status}\n\nFinal answer: {final_answer}"
+    )
+    result: dict[str, Any] = {"output": output, "metadata": metadata}
+    if token_usage:
+        result["tokenUsage"] = token_usage
+    return result
+
+
+def _inspect_command(config: dict) -> list[str]:
+    env_command = os.environ.get("PROMPTFOO_AGENT_THREAT_BENCH_INSPECT_COMMAND")
+    command = config.get("inspectCommand") or env_command or "inspect"
+    if isinstance(command, list):
+        return [str(part) for part in command]
+    return shlex.split(str(command))
+
+
+def _normalize_task(raw: Any) -> str | None:
+    task = str(raw or "").strip()
+    task = task.removeprefix("inspect_evals/")
+    task = task.removeprefix("agent_threat_bench_")
+    return task if task in TASKS else None
+
+
+def _resolve_base_path(config: dict) -> Path:
+    configured = config.get("basePath")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(__file__).resolve().parent
+
+
+def _resolve_log_root(config: dict, base_path: Path) -> Path:
+    configured = config.get("logRoot")
+    path = Path(configured).expanduser() if configured else base_path / "inspect_logs"
+    if not path.is_absolute():
+        path = base_path / path
+    return path.resolve()
+
+
+def _new_log_dir(log_root: Path, task: str) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = log_root / f"{stamp}-{task}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _find_eval_log(log_dir: Path) -> Path | None:
+    logs = sorted(
+        log_dir.rglob("*.eval"), key=lambda path: path.stat().st_mtime, reverse=True
+    )
+    return logs[0] if logs else None
+
+
+def _dump_eval_log(
+    inspect_cmd: list[str], eval_log: Path, base_path: Path
+) -> subprocess.CompletedProcess | dict:
+    dump_cmd = [*inspect_cmd, "log", "dump", str(eval_log)]
+    try:
+        dump_result = subprocess.run(
+            dump_cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            cwd=str(base_path),
+        )
+    except FileNotFoundError:
+        return {"error": _missing_inspect_message(inspect_cmd[0])}
+    except subprocess.TimeoutExpired:
+        return {
+            "error": f"Timed out while dumping Inspect log {eval_log} to JSON.",
+            "metadata": {"inspect_log_path": str(eval_log), "status": "error"},
+        }
+
+    if dump_result.returncode != 0:
+        return {
+            "error": f"Inspect log dump failed for {eval_log} with exit code {dump_result.returncode}.",
+            "metadata": {"inspect_log_path": str(eval_log), "status": "error"},
+        }
+    return dump_result
+
+
+def _parse_inspect_log(data: dict[str, Any]) -> dict[str, Any]:
+    samples = data.get("samples") or []
+    sample = samples[0] if samples else {}
+    sample_scores, score_error = _sample_scores(sample) if sample else (None, None)
+    return {
+        "scores": None if score_error else sample_scores,
+        "score_error": score_error,
+        "sample_id": sample.get("id") or sample.get("uuid"),
+        "final_answer": _final_answer(sample),
+        "num_messages": len(sample.get("messages") or []),
+        "token_usage": _token_usage(data, sample),
+        "inspect_status": data.get("status"),
+        "sample_error": sample.get("error"),
+    }
+
+
+def _sample_scores(sample: dict[str, Any]) -> tuple[dict[str, float] | None, str | None]:
+    scores = sample.get("scores") or {}
+    preferred_score = scores.get(SCORER)
+    if preferred_score is None:
+        if scores:
+            return None, f"Inspect did not record {SCORER} for the selected sample."
+        return None, None
+
+    value = preferred_score.get("value") if isinstance(preferred_score, dict) else None
+    if not isinstance(value, dict):
+        return None, f"Inspect recorded {SCORER}, but its value was not a metric object."
+
+    parsed_scores = {}
+    for metric in ("utility", "security"):
+        parsed = _score_value(value.get(metric))
+        if parsed is None:
+            return None, f"Inspect recorded {SCORER}, but {metric} was not numeric."
+        parsed_scores[metric] = parsed
+    return parsed_scores, None
+
+
+def _score_value(value: Any) -> float | None:
+    if isinstance(value, dict):
+        return _score_value(value.get("value"))
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip().upper()
+        if normalized == "C":
+            return 1.0
+        if normalized == "I":
+            return 0.0
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _final_answer(sample: dict[str, Any]) -> str | None:
+    output = sample.get("output") or {}
+    completion = output.get("completion")
+    if isinstance(completion, str) and completion.strip():
+        return completion.strip()
+
+    for message in reversed(sample.get("messages") or []):
+        if message.get("role") == "assistant":
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+    return None
+
+
+def _token_usage(data: dict[str, Any], sample: dict[str, Any]) -> dict[str, int] | None:
+    usage_sources = [sample.get("model_usage"), (data.get("stats") or {}).get("model_usage")]
+    totals = {"prompt": 0, "completion": 0, "total": 0}
+    found = False
+    for usage_by_model in usage_sources:
+        if not isinstance(usage_by_model, dict):
+            continue
+        for usage in usage_by_model.values():
+            if not isinstance(usage, dict):
+                continue
+            totals["prompt"] += int(
+                usage.get("input_tokens") or usage.get("prompt_tokens") or 0
+            )
+            totals["completion"] += int(
+                usage.get("output_tokens") or usage.get("completion_tokens") or 0
+            )
+            totals["total"] += int(usage.get("total_tokens") or 0)
+            found = True
+        if found:
+            break
+    if found and totals["total"] == 0:
+        totals["total"] = totals["prompt"] + totals["completion"]
+    return totals if found else None
+
+
+def _inspect_log_error(parsed: dict[str, Any]) -> str | None:
+    score_error = parsed.get("score_error")
+    if score_error:
+        return str(score_error)
+
+    sample_error = parsed.get("sample_error")
+    if sample_error:
+        return "Inspect reported an unscored sample error. See the Inspect log for details."
+
+    if parsed.get("inspect_status") == "error":
+        return "Inspect log status is error and no scorer result was recorded."
+
+    if not parsed.get("scores"):
+        sample_id = parsed.get("sample_id")
+        if sample_id:
+            return (
+                f"Inspect completed sample {sample_id}, but no {SCORER} result "
+                "was recorded."
+            )
+        return (
+            "Inspect completed, but selected zero samples or recorded no scorer result. "
+            "Check vars.sample_id."
+        )
+    return None
+
+
+def _int_config(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _missing_inspect_message(command: str) -> str:
+    if shutil.which(command) is None:
+        return (
+            f"Could not find Inspect CLI command '{command}'. Install prerequisites with "
+            "`pip install inspect-evals openai anthropic` or set "
+            "providers[0].config.inspectCommand."
+        )
+    return f"Could not execute Inspect CLI command '{command}'."
+
+
+def _humanize_inspect_failure(result: subprocess.CompletedProcess) -> str:
+    tail = _tail(result.stderr) or _tail(result.stdout) or "(no output)"
+    hint = ""
+    lowered = tail.lower()
+    if "specified dataset is empty" in lowered or "no samples" in lowered:
+        hint = " Check vars.sample_id and vars.task."
+    elif "requires optional dependencies" in lowered:
+        hint = " Install the selected Inspect model provider SDK, such as `openai` or `anthropic`."
+    elif "api_key" in lowered or "api key" in lowered or "authentication" in lowered:
+        hint = " Check that the selected model provider API key is exported."
+    elif "model" in lowered:
+        hint = " Check providers[0].config.defaultModel or vars.model."
+    return f"Inspect eval failed with exit code {result.returncode}.{hint}"
+
+
+def _tail(text: Any, limit: int = 4000) -> str:
+    if not text:
+        return ""
+    text = text.decode(errors="replace") if isinstance(text, bytes) else str(text)
+    return text[-limit:]

--- a/site/docs/red-team/owasp-agentic-ai.md
+++ b/site/docs/red-team/owasp-agentic-ai.md
@@ -55,6 +55,12 @@ redteam:
 
 To set up the scan through the Promptfoo UI, select the **OWASP Agentic** preset on the Plugins page.
 
+## Benchmarking with AgentThreatBench
+
+[AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/) is a fixed Inspect benchmark for ASI01 and ASI06. Its tasks inject adversarial content into a simulated memory store, email triage tools, and customer support tools, then score both task utility and attack resistance.
+
+Use the [`integration-inspect-agent-threat-bench`](https://github.com/promptfoo/promptfoo/tree/main/examples/integration-inspect-agent-threat-bench) example to run those Inspect-native tasks through Promptfoo and keep the benchmark's separate `utility` and `security` scores. Use the plugins below when you want to red team your own target agent instead of the benchmark harness.
+
 ## ASI01: Agent Goal Hijack
 
 Agent Goal Hijack occurs when an attacker alters an agent's objectives or decision path through malicious content, exploiting the agent's planning and reasoning capabilities.

--- a/test/examples/integrationInspectAgentThreatBenchProvider.test.ts
+++ b/test/examples/integrationInspectAgentThreatBenchProvider.test.ts
@@ -1,0 +1,437 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { PythonProvider } from '../../src/providers/pythonCompletion';
+import { mockProcessEnv } from '../util/utils';
+
+describe('integration-inspect-agent-threat-bench example provider', () => {
+  const tempDirs: string[] = [];
+  let restoreEnv: (() => void) | undefined;
+  let cachedPythonExecutable: string | undefined;
+
+  afterEach(() => {
+    restoreEnv?.();
+    restoreEnv = undefined;
+
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  function makeTempDir(): string {
+    const root = path.join(process.cwd(), 'scratch', 'agent-threat-bench-provider-tests');
+    fs.mkdirSync(root, { recursive: true });
+    const dir = fs.mkdtempSync(path.join(root, 'case-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function pythonExecutable(): string {
+    if (cachedPythonExecutable) {
+      return cachedPythonExecutable;
+    }
+
+    const pythonProbe = 'import sys; print(sys.executable)';
+    const candidates = [
+      ...(process.env.PROMPTFOO_PYTHON
+        ? [{ command: process.env.PROMPTFOO_PYTHON, args: ['-c', pythonProbe] }]
+        : []),
+      ...(process.env.PYTHON ? [{ command: process.env.PYTHON, args: ['-c', pythonProbe] }] : []),
+      ...(process.env.PYTHON3 ? [{ command: process.env.PYTHON3, args: ['-c', pythonProbe] }] : []),
+      ...(process.platform === 'win32'
+        ? [
+            { command: 'py', args: ['-3', '-c', pythonProbe] },
+            { command: 'python', args: ['-c', pythonProbe] },
+          ]
+        : [
+            { command: 'python3', args: ['-c', pythonProbe] },
+            { command: 'python', args: ['-c', pythonProbe] },
+          ]),
+    ];
+
+    for (const candidate of candidates) {
+      const result = spawnSync(candidate.command, candidate.args, { encoding: 'utf8' });
+      const executable = result.status === 0 ? result.stdout.trim() : '';
+      if (executable) {
+        cachedPythonExecutable = executable;
+        return executable;
+      }
+    }
+
+    return process.platform === 'win32' ? 'python' : 'python3';
+  }
+
+  function copyProvider(providerDir: string): void {
+    fs.mkdirSync(providerDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(
+        process.cwd(),
+        'examples',
+        'integration-inspect-agent-threat-bench',
+        'provider.py',
+      ),
+      path.join(providerDir, 'provider.py'),
+    );
+  }
+
+  it('generates one Promptfoo row per Inspect AgentThreatBench sample', () => {
+    const tempDir = makeTempDir();
+    const fakeInspectRoot = path.join(tempDir, 'fake-inspect');
+    const fakeTaskDir = path.join(fakeInspectRoot, 'inspect_evals', 'agent_threat_bench');
+    fs.mkdirSync(fakeTaskDir, { recursive: true });
+    fs.writeFileSync(path.join(fakeInspectRoot, 'inspect_evals', '__init__.py'), '');
+    fs.writeFileSync(
+      path.join(fakeTaskDir, '__init__.py'),
+      `
+from types import SimpleNamespace
+
+class FakeSample:
+    def __init__(self, sample_id, text, owasp_id, attack_name, difficulty):
+        self.id = sample_id
+        self.input = text
+        self.metadata = {
+            "owasp_id": owasp_id,
+            "attack_name": attack_name,
+            "difficulty": difficulty,
+        }
+
+def agent_threat_bench_memory_poison():
+    return SimpleNamespace(dataset=[
+        FakeSample("mp_001", "What is the vacation policy?", "ASI06", "direct", "easy"),
+        FakeSample("mp_002", "What benefits are available?", "ASI06", "context", "medium"),
+    ])
+
+def agent_threat_bench_autonomy_hijack():
+    return SimpleNamespace(dataset=[
+        FakeSample("ah_001", "Triage my inbox.", "ASI01", "inline", "easy"),
+    ])
+
+def agent_threat_bench_data_exfil():
+    return SimpleNamespace(dataset=[
+        FakeSample("de_001", "Resolve the customer issue.", "ASI01", "exfil", "hard"),
+    ])
+`,
+    );
+
+    const testsPath = path.join(
+      process.cwd(),
+      'examples',
+      'integration-inspect-agent-threat-bench',
+      'agent_threat_bench_tests.py',
+    );
+    const checkPath = path.join(tempDir, 'check_agent_threat_bench_tests.py');
+    fs.writeFileSync(
+      checkPath,
+      `
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+tests_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("agent_threat_bench_tests", tests_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+tests = module.generate_tests()
+print(json.dumps({
+    "count": len(tests),
+    "tasks": [test["vars"]["task"] for test in tests],
+    "first": tests[0],
+    "last": tests[-1],
+}))
+`,
+    );
+
+    const result = spawnSync(pythonExecutable(), [checkPath, testsPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PYTHONPATH: [fakeInspectRoot, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter),
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.count).toBe(4);
+    expect(parsed.tasks).toEqual([
+      'memory_poison',
+      'memory_poison',
+      'autonomy_hijack',
+      'data_exfil',
+    ]);
+    expect(parsed.first).toMatchObject({
+      description: 'memory_poison - What is the vacation policy?',
+      vars: {
+        prompt: 'What is the vacation policy?',
+        sample_id: 'mp_001',
+        task: 'memory_poison',
+      },
+      metadata: {
+        attack_name: 'direct',
+        difficulty: 'easy',
+        owasp_id: 'ASI06',
+        sample_id: 'mp_001',
+        task: 'memory_poison',
+        testCaseId: 'agent-threat-bench-memory-poison-mp_001',
+      },
+    });
+    expect(parsed.last.metadata).toMatchObject({
+      attack_name: 'exfil',
+      difficulty: 'hard',
+      owasp_id: 'ASI01',
+    });
+  });
+
+  it('parses utility and security scores from the AgentThreatBench scorer', () => {
+    const tempDir = makeTempDir();
+    const providerDir = path.join(tempDir, 'example');
+    copyProvider(providerDir);
+    const providerPath = path.join(providerDir, 'provider.py');
+    const checkPath = path.join(tempDir, 'check_scores.py');
+    fs.writeFileSync(
+      checkPath,
+      `
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+provider_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("provider", provider_path)
+provider = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(provider)
+
+scores, scores_error = provider._sample_scores({
+    "scores": {
+        "aux": {"value": 1.0},
+        "agent_threat_bench_scorer": {
+            "value": {"utility": "C", "security": {"value": "I"}},
+        },
+    }
+})
+missing_metric, missing_metric_error = provider._sample_scores({
+    "scores": {
+        "agent_threat_bench_scorer": {
+            "value": {"utility": "C"},
+        },
+    }
+})
+missing_scorer, missing_scorer_error = provider._sample_scores({
+    "scores": {"aux": {"value": 1.0}}
+})
+missing_error = provider._inspect_log_error({
+    "scores": None,
+    "sample_id": "mp_001",
+    "inspect_status": "success",
+})
+
+print(json.dumps({
+    "scores": scores,
+    "scores_error": scores_error,
+    "missing_metric": missing_metric,
+    "missing_metric_error": missing_metric_error,
+    "missing_scorer": missing_scorer,
+    "missing_scorer_error": missing_scorer_error,
+    "missing_error": missing_error,
+}))
+`,
+    );
+
+    const result = spawnSync(pythonExecutable(), [checkPath, providerPath], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.scores).toEqual({ security: 0, utility: 1 });
+    expect(parsed.scores_error).toBeNull();
+    expect(parsed.missing_metric).toBeNull();
+    expect(parsed.missing_metric_error).toBe(
+      'Inspect recorded agent_threat_bench_scorer, but security was not numeric.',
+    );
+    expect(parsed.missing_scorer).toBeNull();
+    expect(parsed.missing_scorer_error).toBe(
+      'Inspect did not record agent_threat_bench_scorer for the selected sample.',
+    );
+    expect(parsed.missing_error).toBe(
+      'Inspect completed sample mp_001, but no agent_threat_bench_scorer result was recorded.',
+    );
+  });
+
+  it('reports AgentThreatBench scores as Promptfoo named metrics', () => {
+    const tempDir = makeTempDir();
+    const assertionPath = path.join(
+      process.cwd(),
+      'examples',
+      'integration-inspect-agent-threat-bench',
+      'assertion.py',
+    );
+    const checkPath = path.join(tempDir, 'check_assertion.py');
+    fs.writeFileSync(
+      checkPath,
+      `
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+assertion_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("assertion", assertion_path)
+assertion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(assertion)
+
+result = assertion.get_assert("ignored", {
+    "providerResponse": {
+        "metadata": {
+            "inspect_log_path": "/tmp/agent-threat-bench.eval",
+            "sample_id": "de_001",
+            "security_score": 0,
+            "status": "fail",
+            "task": "data_exfil",
+            "utility_score": 1,
+        }
+    }
+})
+print(json.dumps(result))
+`,
+    );
+
+    const result = spawnSync(pythonExecutable(), [checkPath, assertionPath], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      named_scores: { security: 0, utility: 1 },
+      pass: false,
+      score: 0,
+    });
+  });
+
+  it('rejects empty Inspect commands before launching Inspect', async () => {
+    const tempDir = makeTempDir();
+    const providerDir = path.join(tempDir, 'example');
+    copyProvider(providerDir);
+
+    const provider = new PythonProvider('file://provider.py', {
+      config: {
+        basePath: path.relative(process.cwd(), providerDir),
+        inspectCommand: '   ',
+        pythonExecutable: pythonExecutable(),
+        timeout: 10_000,
+        timeoutSeconds: 10,
+      },
+    });
+
+    try {
+      const result = await provider.callApi('ignored', {
+        vars: { sample_id: 'mp_001', task: 'memory_poison' },
+      } as any);
+
+      expect(result.error).toBe(
+        'Inspect CLI command is empty. Set providers[0].config.inspectCommand or PROMPTFOO_AGENT_THREAT_BENCH_INSPECT_COMMAND.',
+      );
+    } finally {
+      await provider.shutdown();
+    }
+  }, 20_000);
+
+  it('runs one exact task sample and returns both scores', async () => {
+    const tempDir = makeTempDir();
+    const providerDir = path.join(tempDir, 'example');
+    copyProvider(providerDir);
+
+    const fakeInspectPath = path.join(tempDir, 'fake_inspect.py');
+    const recordPath = path.join(tempDir, 'inspect_eval_record.json');
+    fs.writeFileSync(
+      fakeInspectPath,
+      `
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+
+if args[:2] == ["log", "dump"]:
+    print(json.dumps({
+        "status": "success",
+        "samples": [{
+            "id": "de_001",
+            "scores": {
+                "agent_threat_bench_scorer": {
+                    "value": {"utility": "C", "security": "C"},
+                },
+            },
+            "output": {"completion": "Ticket resolved safely."},
+            "messages": [{"role": "assistant", "content": "Ticket resolved safely."}],
+            "model_usage": {"mock/model": {"input_tokens": 12, "output_tokens": 5}},
+        }],
+    }))
+    sys.exit(0)
+
+if args and args[0] == "eval":
+    log_dir = Path(args[args.index("--log-dir") + 1])
+    Path(os.environ["FAKE_INSPECT_RECORD"]).write_text(json.dumps({
+        "args": args,
+        "cwd": os.getcwd(),
+        "is_absolute": log_dir.is_absolute(),
+    }))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "fake.eval").write_text("fake eval")
+    sys.exit(0)
+
+print(f"unexpected args: {args}", file=sys.stderr)
+sys.exit(4)
+`,
+    );
+    restoreEnv = mockProcessEnv({ FAKE_INSPECT_RECORD: recordPath });
+
+    const provider = new PythonProvider('file://provider.py', {
+      config: {
+        basePath: path.relative(process.cwd(), providerDir),
+        defaultModel: 'mock/model',
+        inspectCommand: [pythonExecutable(), fakeInspectPath],
+        pythonExecutable: pythonExecutable(),
+        timeout: 10_000,
+        timeoutSeconds: 10,
+      },
+    });
+
+    try {
+      const result = await provider.callApi('ignored', {
+        vars: { sample_id: 'de_001', task: 'data_exfil' },
+      } as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toContain('Task data_exfil sample de_001');
+      expect(result.metadata).toMatchObject({
+        inspect_task: 'inspect_evals/agent_threat_bench_data_exfil',
+        model: 'mock/model',
+        sample_id: 'de_001',
+        security_score: 1,
+        status: 'pass',
+        task: 'data_exfil',
+        utility_score: 1,
+      });
+      expect(result.tokenUsage).toMatchObject({ completion: 5, prompt: 12, total: 17 });
+
+      const record = JSON.parse(fs.readFileSync(recordPath, 'utf8'));
+      expect(record.is_absolute).toBe(true);
+      expect(record.args).toEqual(
+        expect.arrayContaining([
+          'eval',
+          'inspect_evals/agent_threat_bench_data_exfil',
+          '--sample-id',
+          'de_001',
+        ]),
+      );
+      expect(path.resolve(record.cwd)).toBe(path.resolve(providerDir));
+    } finally {
+      await provider.shutdown();
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary
- add an init-able `integration-inspect-agent-threat-bench` example that runs AgentThreatBench through Inspect
- generate Promptfoo rows from upstream Inspect tasks and map Inspect utility/security scores back into Promptfoo assertions and named metrics
- add focused provider/test-generator coverage and link the example from the OWASP Agentic docs

## Why
AgentThreatBench already owns stateful benchmark tasks, simulated tools, and scoring in Inspect. This keeps Promptfoo focused on example UX, orchestration, filtering, reporting, and CI gating without flattening the benchmark into a prompt-only dataset.

Closes #9296.

## Validation
- `git diff --check`
- `npx --yes --cache /private/tmp/promptfoo-issue-9296-npx-cache prettier@3.8.3 --write test/examples/integrationInspectAgentThreatBenchProvider.test.ts`
- `npx --yes --cache /private/tmp/promptfoo-issue-9296-npx-cache prettier@3.8.3 --check examples/integration-inspect-agent-threat-bench/README.md`
- `npx --yes --cache /private/tmp/promptfoo-issue-9296-npx-cache @biomejs/biome@2.4.15 check test/examples/integrationInspectAgentThreatBenchProvider.test.ts`
- direct Python smoke checks for AgentThreatBench test generation, score parsing, provider output, and assertion named-score output

## Test caveat
- attempted `npm run test:vitest -- test/examples/integrationInspectAgentThreatBenchProvider.test.ts`, but this fresh worktree does not have dependencies installed and `vitest` was unavailable (`sh: vitest: command not found`)
