### PR TITLE
fix(eval): handle Google Sheets export classification

### DIFF
--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -4,7 +4,12 @@ import { isMissingPackageImportError } from './util/packageImportErrors';
 
 import type { CsvRow } from './types/index';
 
-class GoogleSheetAuthenticationRequiredError extends Error {}
+class GoogleSheetAuthenticationRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GoogleSheetAuthenticationRequiredError';
+  }
+}
 
 async function loadGoogleSheetsApi(): Promise<typeof import('@googleapis/sheets')> {
   try {

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -41,6 +41,9 @@ function isHtmlExportResponse(
   if (contentType.includes('text/html')) {
     return true;
   }
+  if (contentType.includes('text/csv') || contentType.includes('application/csv')) {
+    return false;
+  }
 
   const prefix = body.trimStart().slice(0, 32).toLowerCase();
   return prefix.startsWith('<!doctype html') || prefix.startsWith('<html');

--- a/src/googleSheets.ts
+++ b/src/googleSheets.ts
@@ -1,8 +1,10 @@
 import logger from './logger';
-import { isMissingPackageImportError } from './util/packageImportErrors';
 import { fetchWithProxy } from './util/fetch/index';
+import { isMissingPackageImportError } from './util/packageImportErrors';
 
 import type { CsvRow } from './types/index';
+
+class GoogleSheetAuthenticationRequiredError extends Error {}
 
 async function loadGoogleSheetsApi(): Promise<typeof import('@googleapis/sheets')> {
   try {
@@ -56,7 +58,9 @@ export async function fetchCsvFromGoogleSheetUnauthenticated(url: string): Promi
   }
   const csvData = await response.text();
   if (isHtmlExportResponse(response, csvData)) {
-    throw new Error(`Failed to fetch CSV from Google Sheets URL: ${url}`);
+    throw new GoogleSheetAuthenticationRequiredError(
+      `Failed to fetch CSV from Google Sheets URL: ${url}`,
+    );
   }
   return parseCsv(csvData, { columns: true });
 }
@@ -122,7 +126,14 @@ export async function fetchCsvFromGoogleSheet(url: string): Promise<CsvRow[]> {
   const { public: isPublic } = access;
   logger.debug(`Google Sheets URL: ${url}, isPublic: ${isPublic}`);
   if (isPublic) {
-    return fetchCsvFromGoogleSheetUnauthenticated(url);
+    try {
+      return await fetchCsvFromGoogleSheetUnauthenticated(url);
+    } catch (error) {
+      if (error instanceof GoogleSheetAuthenticationRequiredError) {
+        return fetchCsvFromGoogleSheetAuthenticated(url);
+      }
+      throw error;
+    }
   }
   if (!('status' in access)) {
     try {

--- a/test/googleSheets.optionalDependency.test.ts
+++ b/test/googleSheets.optionalDependency.test.ts
@@ -47,6 +47,24 @@ describe('Google Sheets optional dependency', () => {
     expect(fetchWithProxy).toHaveBeenCalledTimes(2);
   });
 
+  it('parses CSV exports whose first header looks like an HTML tag', async () => {
+    const fetchWithProxy = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      headers: {
+        get: () => 'text/csv; charset=utf-8',
+      },
+      text: async () => '<html>,label\nliteral,value',
+    });
+
+    vi.doMock('../src/util/fetch/index', () => ({ fetchWithProxy }));
+
+    const { fetchCsvFromGoogleSheetUnauthenticated } = await import('../src/googleSheets');
+
+    await expect(fetchCsvFromGoogleSheetUnauthenticated(SHEET_URL)).resolves.toEqual([
+      { '<html>': 'literal', label: 'value' },
+    ]);
+  });
+
   it('falls back to authenticated sheet access when the probe and CSV export both fail', async () => {
     const fetchWithProxy = vi
       .fn()

--- a/test/googleSheets.optionalDependency.test.ts
+++ b/test/googleSheets.optionalDependency.test.ts
@@ -71,10 +71,7 @@ describe('Google Sheets optional dependency', () => {
           values: {
             get: vi.fn().mockResolvedValue({
               data: {
-                values: [
-                  ['header'],
-                  ['value'],
-                ],
+                values: [['header'], ['value']],
               },
             }),
           },
@@ -115,10 +112,51 @@ describe('Google Sheets optional dependency', () => {
           values: {
             get: vi.fn().mockResolvedValue({
               data: {
-                values: [
-                  ['header'],
-                  ['value'],
-                ],
+                values: [['header'], ['value']],
+              },
+            }),
+          },
+        },
+      }),
+    }));
+
+    const { fetchCsvFromGoogleSheet } = await import('../src/googleSheets');
+
+    await expect(fetchCsvFromGoogleSheet(SHEET_URL)).resolves.toEqual([{ header: 'value' }]);
+    expect(fetchWithProxy).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to authenticated access when the access probe masks a login page', async () => {
+    const fetchWithProxy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {
+          get: () => 'text/html; charset=utf-8',
+        },
+        text: async () => '<!doctype html><html><body>Sign in</body></html>',
+      });
+
+    vi.doMock('../src/util/fetch/index', () => ({ fetchWithProxy }));
+    vi.doMock('@googleapis/sheets', () => ({
+      auth: {
+        GoogleAuth: class {},
+      },
+      sheets: () => ({
+        spreadsheets: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              sheets: [{ properties: { title: 'Sheet1' } }],
+            },
+          }),
+          values: {
+            get: vi.fn().mockResolvedValue({
+              data: {
+                values: [['header'], ['value']],
               },
             }),
           },

--- a/test/googleSheets.optionalDependency.test.ts
+++ b/test/googleSheets.optionalDependency.test.ts
@@ -65,6 +65,24 @@ describe('Google Sheets optional dependency', () => {
     ]);
   });
 
+  it('labels login-page export errors for authentication fallback classification', async () => {
+    const fetchWithProxy = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      headers: {
+        get: () => 'text/html; charset=utf-8',
+      },
+      text: async () => '<!doctype html><html><body>Sign in</body></html>',
+    });
+
+    vi.doMock('../src/util/fetch/index', () => ({ fetchWithProxy }));
+
+    const { fetchCsvFromGoogleSheetUnauthenticated } = await import('../src/googleSheets');
+
+    await expect(fetchCsvFromGoogleSheetUnauthenticated(SHEET_URL)).rejects.toMatchObject({
+      name: 'GoogleSheetAuthenticationRequiredError',
+    });
+  });
+
   it('falls back to authenticated sheet access when the probe and CSV export both fail', async () => {
     const fetchWithProxy = vi
       .fn()


### PR DESCRIPTION
## Summary

- Fall back to authenticated Google Sheets reads when an apparently accessible sheet exports an HTML sign-in page instead of CSV.
- Preserve valid CSV exports whose first field happens to look like HTML when the server identifies the response as CSV.
- Add focused regression coverage for both classification paths.

## Root Cause

The optional-dependency change in #9284 added HTML/login-page detection for unauthenticated CSV exports and an authenticated fallback when the initial access probe fails. It had two edge cases:

1. When a private sheet's page probe returns HTTP 200 but its CSV export resolves to a sign-in page, the public branch returned the export error instead of using configured authenticated Sheets access.
2. When a valid `text/csv` export begins with an HTML-looking field such as `<html>`, the body sniff overrode the authoritative CSV content type and treated real data as a login page.

## Validation

- Confirmed the login-export regression failed before its source fix.
- Confirmed the HTML-like CSV-header regression failed before its source fix with `Failed to fetch CSV from Google Sheets URL`.
- `npx vitest run test/googleSheets.optionalDependency.test.ts test/googleSheets.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l`
- `npm run tsc`
- `git diff --check`

## Audit Context

This came from reviewing recent `origin/main` behavior-changing merges after the prior bug-hunt run. The two issues share the same response-classification boundary and are kept in one PR to avoid duplicative changes and review noise.
