### PR TITLE
fix(eval): redact Azure Blob SAS tokens in outputs

### DIFF
--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.test.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.test.tsx
@@ -17,9 +17,11 @@ const renderWithProvider = (ui: React.ReactElement) => {
 };
 
 const mockShowToast = vi.fn();
+let sourceEvalId: string | undefined;
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
+  useLocation: () => ({ state: sourceEvalId ? { sourceEvalId } : null }),
 }));
 
 vi.mock('@app/utils/api', () => ({
@@ -39,6 +41,7 @@ describe('RunTestSuiteButton', () => {
     useStore.getState().reset();
     resetCallApiMock();
     mockShowToast.mockReset();
+    sourceEvalId = undefined;
     timers = useTestTimers();
   });
 
@@ -132,6 +135,30 @@ describe('RunTestSuiteButton', () => {
       prompts: [{ raw: 'file://prompt.txt', label: 'Prompt label' }],
       providers: 'openai:gpt-4',
       tests: 'file://tests.csv',
+    });
+  });
+
+  it('should include the source eval id when rerunning a loaded evaluation', async () => {
+    sourceEvalId = 'source-eval-id';
+    mockCallApiRoutes([{ method: 'POST', path: '/eval/job', response: { id: '123' } }]);
+    useStore.getState().updateConfig({
+      prompts: ['prompt 1'],
+      providers: ['echo'],
+      tests: 'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+    });
+
+    renderWithProvider(<RunTestSuiteButton />);
+    await act(async () => {
+      screen
+        .getByRole('button', { name: 'Run Eval' })
+        .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    const [, requestInit] = getCallApiMock().mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(requestInit.body as string)).toMatchObject({
+      sourceEvalId: 'source-eval-id',
+      tests: 'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
     });
   });
 

--- a/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
+++ b/src/app/src/pages/eval-creator/components/RunTestSuiteButton.tsx
@@ -8,7 +8,7 @@ import { useEvalHistoryRefresh } from '@app/hooks/useEvalHistoryRefresh';
 import { useToast } from '@app/hooks/useToast';
 import { useStore } from '@app/stores/evalConfig';
 import { callApi } from '@app/utils/api';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   countTests,
   normalizePrompts,
@@ -19,6 +19,7 @@ import type { CreateJobResponse, GetJobResponse } from '@promptfoo/types/api/eva
 
 const RunTestSuiteButton = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { config } = useStore();
   const { signalEvalCompleted } = useEvalHistoryRefresh();
   const { showToast } = useToast();
@@ -72,6 +73,13 @@ const RunTestSuiteButton = () => {
     setRunError(null);
     setProgressPercent(0);
 
+    const sourceEvalId =
+      location.state &&
+      typeof location.state === 'object' &&
+      'sourceEvalId' in location.state &&
+      typeof location.state.sourceEvalId === 'string'
+        ? location.state.sourceEvalId
+        : undefined;
     const testSuite = {
       defaultTest,
       derivedMetrics,
@@ -83,6 +91,7 @@ const RunTestSuiteButton = () => {
       scenarios,
       tests, // Note: This is 'tests' in the API, not 'testCases'
       extensions,
+      ...(sourceEvalId && { sourceEvalId }),
     };
 
     const handleRunError = (error: unknown) => {

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -10,9 +10,10 @@ import { useResultsViewSettingsStore, useTableStore } from './store';
 import type { ResultLightweightWithLabel } from '@promptfoo/types';
 
 // Mock all the required modules - use vi.hoisted to ensure these are available in vi.mock factories
-const { mockShowToast, mockNavigate } = vi.hoisted(() => ({
+const { mockShowToast, mockNavigate, mockUpdateConfig } = vi.hoisted(() => ({
   mockShowToast: vi.fn(),
   mockNavigate: vi.fn(),
+  mockUpdateConfig: vi.fn(),
 }));
 
 vi.mock('@app/hooks/useToast', () => ({
@@ -23,7 +24,7 @@ vi.mock('@app/hooks/useToast', () => ({
 
 vi.mock('@app/stores/evalConfig', () => ({
   useStore: () => ({
-    updateConfig: vi.fn(),
+    updateConfig: mockUpdateConfig,
   }),
 }));
 
@@ -234,6 +235,8 @@ function createCopyEvalResponse(): Response {
 }
 
 beforeEach(() => {
+  mockNavigate.mockReset();
+  mockUpdateConfig.mockReset();
   mockUseFilterMode.mockReturnValue({
     filterMode: 'all',
     setFilterMode: vi.fn(),
@@ -380,6 +383,26 @@ describe('ResultsView Share Button', () => {
       expect(screen.getByText('View YAML')).toBeInTheDocument();
       // Use getAllByText since there may be multiple Delete elements (menu item + dialog)
       expect(screen.getAllByText('Delete').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('carries the source eval id when editing and rerunning a redacted config', async () => {
+    renderWithRouter(
+      <ResultsView
+        recentEvals={mockRecentEvals}
+        onRecentEvalSelected={mockOnRecentEvalSelected}
+        defaultEvalId="test-eval-id"
+      />,
+    );
+
+    await userEvent.click(screen.getByText('Eval actions'));
+    await userEvent.click(screen.getByText('Edit and re-run'));
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Test Evaluation' }),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/setup', {
+      state: { sourceEvalId: 'test-eval-id' },
     });
   });
 

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -780,7 +780,7 @@ export default function ResultsView({
             return;
           }
           updateConfig(config);
-          navigate(ROUTES.SETUP);
+          navigate(ROUTES.SETUP, { state: { sourceEvalId: evalId } });
         }}
       >
         <Play className="size-4 mr-2" />

--- a/src/commands/mcp/tools/getEvaluationDetails.ts
+++ b/src/commands/mcp/tools/getEvaluationDetails.ts
@@ -1,6 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 import { readResult } from '../../../util/database';
+import { redactAzureBlobSasTokens } from '../../../util/sanitizer';
 import { createToolResponse } from '../lib/utils';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -49,7 +50,10 @@ export function registerGetEvaluationDetailsTool(server: McpServer) {
         }
 
         // Extract key metrics for easier consumption
-        const evalData = result.result;
+        const evalData = {
+          ...result.result,
+          config: redactAzureBlobSasTokens(result.result.config),
+        };
         const summary = {
           id,
         } as EvaluationDetailsSummary;

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -9,7 +9,11 @@ import { evaluateWithSource } from '../../node';
 import { EvalSchemas } from '../../types/api/eval';
 import { deleteEval, deleteEvals, updateResult, writeResultsToDatabase } from '../../util/database';
 import invariant from '../../util/invariant';
-import { redactAzureBlobSasTokens, sanitizeObject } from '../../util/sanitizer';
+import {
+  redactAzureBlobSasTokens,
+  restoreAzureBlobSasTokens,
+  sanitizeObject,
+} from '../../util/sanitizer';
 import { shouldShareResults } from '../../util/sharing';
 import { setDownloadHeaders } from '../utils/downloadHelpers';
 import { replyValidationError, sendError } from '../utils/errors';
@@ -128,7 +132,7 @@ function sendEvalTableResponse(res: Response, evalId: string, responsePayload: E
   }
 }
 
-evalRouter.post('/job', (req: Request, res: Response): void => {
+evalRouter.post('/job', async (req: Request, res: Response): Promise<void> => {
   const result = EvalSchemas.CreateJob.Request.safeParse(req.body);
   if (!result.success) {
     res.status(400).json({ error: z.prettifyError(result.error) });
@@ -139,12 +143,30 @@ evalRouter.post('/job', (req: Request, res: Response): void => {
   // Provider configs can have arbitrary keys (e.g., custom headers, API options) that
   // nested provider schemas may strip. This keeps Zod transforms/coercions while
   // preserving provider flexibility.
-  const { evaluateOptions, providers: _validatedProviders, ...restData } = result.data;
-  const testSuite = {
+  const {
+    evaluateOptions,
+    sourceEvalId,
+    providers: _validatedProviders,
+    ...restData
+  } = result.data;
+  let testSuite = {
     ...restData,
     // Preserve raw providers from req.body to keep nested config fields
     providers: (req.body as { providers?: unknown }).providers,
   };
+
+  if (sourceEvalId) {
+    try {
+      const sourceEval = await Eval.findById(sourceEvalId);
+      if (sourceEval) {
+        testSuite = restoreAzureBlobSasTokens(testSuite, sourceEval.config);
+      }
+    } catch (error) {
+      sendError(res, 500, 'Failed to prepare eval job', error);
+      return;
+    }
+  }
+
   const id = crypto.randomUUID();
   evalJobs.set(id, {
     evalId: null,

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -9,7 +9,7 @@ import { evaluateWithSource } from '../../node';
 import { EvalSchemas } from '../../types/api/eval';
 import { deleteEval, deleteEvals, updateResult, writeResultsToDatabase } from '../../util/database';
 import invariant from '../../util/invariant';
-import { sanitizeObject } from '../../util/sanitizer';
+import { redactAzureBlobSasTokens, sanitizeObject } from '../../util/sanitizer';
 import { shouldShareResults } from '../../util/sharing';
 import { setDownloadHeaders } from '../utils/downloadHelpers';
 import { replyValidationError, sendError } from '../utils/errors';
@@ -468,7 +468,7 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
     totalCount: table.totalCount,
     filteredCount: table.filteredCount,
     filteredMetrics,
-    config: eval_.config,
+    config: redactAzureBlobSasTokens(eval_.config),
     author: eval_.author || null,
     version: eval_.version(),
     id,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,6 +30,7 @@ import {
   getTestCases,
   readResult,
 } from '../util/database';
+import { redactAzureBlobSasTokens } from '../util/sanitizer';
 import { BrowserBehavior, BrowserBehaviorNames, openBrowser } from '../util/server';
 import { csrfProtection } from './middleware/csrfProtection';
 import { blobsRouter } from './routes/blobs';
@@ -185,7 +186,14 @@ export function createApp() {
       res.status(404).json({ error: 'Result not found' });
       return;
     }
-    res.json(ServerSchemas.Result.Response.parse({ data: file.result }));
+    res.json(
+      ServerSchemas.Result.Response.parse({
+        data: {
+          ...file.result,
+          config: redactAzureBlobSasTokens(file.result.config),
+        },
+      }),
+    );
   });
 
   app.get('/api/prompts', async (_req: Request, res: Response): Promise<void> => {
@@ -222,7 +230,11 @@ export function createApp() {
   });
 
   app.get('/api/datasets', async (_req: Request, res: Response): Promise<void> => {
-    res.json(ServerSchemas.Datasets.Response.parse({ data: await getTestCases() }));
+    res.json(
+      ServerSchemas.Datasets.Response.parse({
+        data: redactAzureBlobSasTokens(await getTestCases()),
+      }),
+    );
   });
 
   app.get('/api/results/share/check-domain', async (req: Request, res: Response): Promise<void> => {

--- a/src/share.ts
+++ b/src/share.ts
@@ -16,6 +16,7 @@ import {
 } from './util/cloud';
 import { fetchWithProxy } from './util/fetch/index';
 import { createBlobInlineCache, inlineBlobRefsForShare } from './util/inlineBlobsForShare';
+import { redactAzureBlobSasTokens } from './util/sanitizer';
 
 import type Eval from './models/eval';
 import type EvalResult from './models/evalResult';
@@ -127,10 +128,16 @@ async function sendEvalRecord(
 ): Promise<string> {
   // Fetch traces for the eval
   const traces = await evalRecord.getTraces();
+  const redactedConfig = redactAzureBlobSasTokens(evalRecord.config);
 
   // Inject current team ID into config metadata if cloud is enabled
   // This ensures the eval is created in the correct team (not the default team)
-  let evalData: Record<string, unknown> = { ...evalRecord, results: [], traces };
+  let evalData: Record<string, unknown> = {
+    ...evalRecord,
+    config: redactedConfig,
+    results: [],
+    traces,
+  };
   if (cloudConfig.isEnabled()) {
     const currentOrgId = cloudConfig.getCurrentOrganizationId();
     const currentTeamId = cloudConfig.getCurrentTeamId(currentOrgId);
@@ -138,9 +145,9 @@ async function sendEvalRecord(
       evalData = {
         ...evalData,
         config: {
-          ...(evalRecord.config || {}),
+          ...(redactedConfig || {}),
           metadata: {
-            ...(evalRecord.config?.metadata || {}),
+            ...(redactedConfig?.metadata || {}),
             teamId: currentTeamId,
           },
         },

--- a/src/types/api/eval.ts
+++ b/src/types/api/eval.ts
@@ -146,6 +146,7 @@ export const CreateJobRequestSchema = TestSuiteConfigSchema.extend({
   // Override prompts to require array - evaluate() calls .map() on prompts
   prompts: z.array(z.union([z.string(), z.record(z.string(), z.unknown())])),
   evaluateOptions: EvaluateOptionsSchema.optional(),
+  sourceEvalId: z.string().min(1).optional(),
 }).passthrough();
 
 export const CreateJobResponseSchema = z.object({

--- a/src/util/azureBlob.ts
+++ b/src/util/azureBlob.ts
@@ -34,10 +34,21 @@ function createAzureBlobUriError(uri: string, detail: string): Error {
   );
 }
 
+function sanitizeAzureBlobErrorDetail(uri: string, detail: string): string {
+  const queryStart = uri.indexOf('?');
+  if (queryStart < 0) {
+    return detail;
+  }
+
+  const fragmentStart = uri.indexOf('#', queryStart);
+  const query = uri.slice(queryStart, fragmentStart >= 0 ? fragmentStart : undefined);
+  return detail.replaceAll(query, '?<redacted>');
+}
+
 function formatAzureBlobReadError(uri: string, error: unknown): Error {
   const detail = error instanceof Error ? error.message : String(error);
   return new Error(
-    `Failed to read Azure Blob Storage URI "${sanitizeAzureBlobUriForError(uri)}": ${detail}`,
+    `Failed to read Azure Blob Storage URI "${sanitizeAzureBlobUriForError(uri)}": ${sanitizeAzureBlobErrorDetail(uri, detail)}`,
   );
 }
 
@@ -92,7 +103,9 @@ export function parseAzureBlobUri(uri: string): AzureBlobUriParts {
 }
 
 function isAzureBlobSasToken(queryString: string): boolean {
-  const searchParams = new URLSearchParams(queryString.startsWith('?') ? queryString.slice(1) : queryString);
+  const searchParams = new URLSearchParams(
+    queryString.startsWith('?') ? queryString.slice(1) : queryString,
+  );
   return searchParams.has('sig');
 }
 

--- a/src/util/azureBlob.ts
+++ b/src/util/azureBlob.ts
@@ -42,7 +42,7 @@ function sanitizeAzureBlobErrorDetail(uri: string, detail: string): string {
 
   const fragmentStart = uri.indexOf('#', queryStart);
   const query = uri.slice(queryStart, fragmentStart >= 0 ? fragmentStart : undefined);
-  return detail.replaceAll(query, '?<redacted>');
+  return detail.split(query).join('?<redacted>');
 }
 
 function formatAzureBlobReadError(uri: string, error: unknown): Error {

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -32,6 +32,7 @@ import {
 } from '../types/index';
 import invariant from '../util/invariant';
 import { sha256 } from './createHash';
+import { restoreAzureBlobSasTokens } from './sanitizer';
 
 export async function writeResultsToDatabase(
   results: EvaluateSummaryV2,
@@ -199,7 +200,7 @@ export async function updateResult(
     }
 
     if (newConfig) {
-      existingEval.config = newConfig;
+      existingEval.config = restoreAzureBlobSasTokens(newConfig, existingEval.config);
     }
     if (newTable) {
       existingEval.setTable(newTable);

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -190,10 +190,56 @@ function isClassInstance(obj: any): boolean {
   return hasMethods;
 }
 
+function redactAzureBlobSasToken(value: string): string {
+  if (!value.startsWith('az://')) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'az:' || !parsed.searchParams.has('sig')) {
+      return value;
+    }
+  } catch {
+    return value;
+  }
+
+  return sanitizeUrl(value);
+}
+
+/**
+ * Redact SAS credentials embedded in Azure Blob config references without
+ * applying broader output sanitization to configuration consumed by clients.
+ */
+export function redactAzureBlobSasTokens<T>(value: T): T {
+  if (typeof value === 'string') {
+    return redactAzureBlobSasToken(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAzureBlobSasTokens(item)) as T;
+  }
+
+  if (!value || typeof value !== 'object' || isClassInstance(value)) {
+    return value;
+  }
+
+  const redactedEntries = Object.entries(value).map(([key, item]) => [
+    key,
+    redactAzureBlobSasTokens(item),
+  ]);
+  return Object.fromEntries(redactedEntries) as T;
+}
+
 /**
  * Parse and sanitize JSON strings, also check if the string looks like a secret
  */
 function sanitizeJsonString(str: string, depth: number, maxDepth: number): string {
+  const redactedAzureBlobUri = redactAzureBlobSasToken(str);
+  if (redactedAzureBlobUri !== str) {
+    return redactedAzureBlobUri;
+  }
+
   try {
     const parsed = JSON.parse(str);
     if (parsed && typeof parsed === 'object') {

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -191,20 +191,43 @@ function isClassInstance(obj: any): boolean {
 }
 
 function redactAzureBlobSasToken(value: string): string {
-  if (!value.startsWith('az://')) {
+  if (!/^az:\/\//i.test(value)) {
     return value;
   }
 
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== 'az:' || !parsed.searchParams.has('sig')) {
-      return value;
-    }
-  } catch {
+  const queryStart = value.indexOf('?');
+  if (queryStart === -1) {
     return value;
   }
 
-  return sanitizeUrl(value);
+  const fragmentStart = value.indexOf('#', queryStart);
+  const queryEnd = fragmentStart === -1 ? value.length : fragmentStart;
+  let redacted = false;
+  const sanitizedQuery = value
+    .slice(queryStart + 1, queryEnd)
+    .split('&')
+    .map((parameter) => {
+      const equalsIndex = parameter.indexOf('=');
+      const encodedName = equalsIndex === -1 ? parameter : parameter.slice(0, equalsIndex);
+      let name: string;
+      try {
+        name = decodeURIComponent(encodedName.replace(/\+/g, ' '));
+      } catch {
+        return parameter;
+      }
+
+      if (name.toLowerCase() !== 'sig') {
+        return parameter;
+      }
+
+      redacted = true;
+      return `${encodedName}=${encodeURIComponent(REDACTED)}`;
+    })
+    .join('&');
+
+  return redacted
+    ? `${value.slice(0, queryStart + 1)}${sanitizedQuery}${value.slice(queryEnd)}`
+    : value;
 }
 
 /**
@@ -229,6 +252,38 @@ export function redactAzureBlobSasTokens<T>(value: T): T {
     redactAzureBlobSasTokens(item),
   ]);
   return Object.fromEntries(redactedEntries) as T;
+}
+
+/**
+ * Preserve stored SAS credentials when a sanitized config is written back unchanged.
+ * If the caller edits the resource or supplies a replacement token, retain its value.
+ */
+export function restoreAzureBlobSasTokens<T>(value: T, storedValue: unknown): T {
+  if (typeof value === 'string') {
+    if (typeof storedValue === 'string' && value === redactAzureBlobSasToken(storedValue)) {
+      return storedValue as T;
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const storedItems = Array.isArray(storedValue) ? storedValue : [];
+    return value.map((item, index) => restoreAzureBlobSasTokens(item, storedItems[index])) as T;
+  }
+
+  if (!value || typeof value !== 'object' || isClassInstance(value)) {
+    return value;
+  }
+
+  const storedObject =
+    storedValue && typeof storedValue === 'object' && !Array.isArray(storedValue)
+      ? (storedValue as Record<string, unknown>)
+      : {};
+  const restoredEntries = Object.entries(value).map(([key, item]) => [
+    key,
+    restoreAzureBlobSasTokens(item, storedObject[key]),
+  ]);
+  return Object.fromEntries(restoredEntries) as T;
 }
 
 /**

--- a/test/commands/mcp/tools/getEvaluationDetailsFilter.test.ts
+++ b/test/commands/mcp/tools/getEvaluationDetailsFilter.test.ts
@@ -105,4 +105,20 @@ describe('get_evaluation_details filtering', () => {
     expect(response.success).toBe(true);
     expect(response.data.evaluation.results).toHaveLength(4);
   });
+
+  it('redacts Azure Blob SAS tokens from returned evaluation config', async () => {
+    const sasUri = 'az://account/container/tests.yaml?sp=r&sig=azure-secret';
+    const storedEvaluation = getMockEvalData() as any;
+    storedEvaluation.result.config = { tests: sasUri };
+    registerGetEvaluationDetailsTool(mockMcpServer);
+    const toolHandler = mockMcpServer.tool.mock.calls[0][2];
+    vi.mocked(readResult).mockResolvedValue(storedEvaluation);
+
+    const response = await toolHandler({ id: 'test-eval', filter: 'all' });
+
+    expect(response.data.evaluation.config.tests).toBe(
+      'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+    );
+    expect(storedEvaluation.result.config.tests).toBe(sasUri);
+  });
 });

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -361,6 +361,25 @@ describe('eval routes', () => {
       expect(updatedEval.config.tests).toHaveLength(2);
     });
 
+    it('redacts Azure Blob SAS tokens from table config without mutating stored config', async () => {
+      const sasUri = 'az://account/container/tests.yaml?sp=r&sig=azure-secret';
+      const eval_ = await EvalFactory.create();
+      testEvalIds.add(eval_.id);
+      eval_.config.tests = sasUri;
+      await eval_.save();
+
+      const res = await api.get(`/api/eval/${eval_.id}/table`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.config.tests).toBe(
+        'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+      );
+
+      const storedEval = await Eval.findById(eval_.id);
+      invariant(storedEval, 'Eval is required');
+      expect(storedEval.config.tests).toBe(sasUri);
+    });
+
     it('returns table data with only the largest per-cell prompt stripped when possible', async () => {
       const eval_ = await EvalFactory.create({ numResults: 3 });
       testEvalIds.add(eval_.id);

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -361,8 +361,9 @@ describe('eval routes', () => {
       expect(updatedEval.config.tests).toHaveLength(2);
     });
 
-    it('redacts Azure Blob SAS tokens from table config without mutating stored config', async () => {
-      const sasUri = 'az://account/container/tests.yaml?sp=r&sig=azure-secret';
+    it('preserves Azure Blob SAS tokens when a redacted table config is saved back', async () => {
+      const sasUri =
+        'az://{{ account }}/container/{{ suite }}.yaml?sp=r&sig=azure-secret&sv={{ version }}';
       const eval_ = await EvalFactory.create();
       testEvalIds.add(eval_.id);
       eval_.config.tests = sasUri;
@@ -372,12 +373,19 @@ describe('eval routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.config.tests).toBe(
-        'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+        'az://{{ account }}/container/{{ suite }}.yaml?sp=r&sig=%5BREDACTED%5D&sv={{ version }}',
       );
 
-      const storedEval = await Eval.findById(eval_.id);
-      invariant(storedEval, 'Eval is required');
-      expect(storedEval.config.tests).toBe(sasUri);
+      const patchRes = await api
+        .patch(`/api/eval/${eval_.id}`)
+        .send({ config: { ...res.body.config, description: 'renamed eval' } });
+
+      expect(patchRes.status).toBe(200);
+
+      const updatedEval = await Eval.findById(eval_.id);
+      invariant(updatedEval, 'Eval is required');
+      expect(updatedEval.config.tests).toBe(sasUri);
+      expect(updatedEval.config.description).toBe('renamed eval');
     });
 
     it('returns table data with only the largest per-cell prompt stripped when possible', async () => {

--- a/test/server/routes/eval.sharing.test.ts
+++ b/test/server/routes/eval.sharing.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../../src/util/sharing', () => ({
 vi.mock('../../../src/models/eval', () => ({
   default: {
     create: vi.fn(),
+    findById: vi.fn(),
   },
 }));
 vi.mock('../../../src/globalConfig/accounts');
@@ -29,6 +30,7 @@ import { shouldShareResults } from '../../../src/util/sharing';
 
 const errorSpy = vi.spyOn(logger, 'error');
 const mockedEvalCreate = vi.mocked(Eval.create);
+const mockedEvalFindById = vi.mocked(Eval.findById);
 const mockedEvaluateWithSource = vi.mocked(evaluateWithSource);
 const mockedShouldShareResults = vi.mocked(shouldShareResults);
 
@@ -146,6 +148,24 @@ describe('Eval Routes - Sharing behavior', () => {
       }),
     );
     expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('sk-test-12345678901234567890');
+  });
+
+  it('restores redacted Azure SAS tokens before rerunning a stored eval', async () => {
+    const sasUri = 'az://account/container/tests.yaml?sp=r&sig=azure-secret';
+    mockedEvalFindById.mockResolvedValueOnce({ config: { tests: sasUri } } as never);
+
+    await postJob({
+      ...minimalTestSuite,
+      tests: 'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+      sourceEvalId: 'source-eval-id',
+    });
+
+    await vi.waitFor(() => {
+      expect(mockedEvaluateWithSource).toHaveBeenCalled();
+    });
+
+    const evaluateArg = mockedEvaluateWithSource.mock.calls[0][0] as any;
+    expect(evaluateArg.tests).toBe(sasUri);
   });
 
   it('should not log the raw save body on database failure', async () => {

--- a/test/server/routes/serverApiSchemas.test.ts
+++ b/test/server/routes/serverApiSchemas.test.ts
@@ -189,6 +189,28 @@ describe('inline server API DTO validation', () => {
     expect(response.body).toEqual({ error: 'Result not found' });
   });
 
+  it('redacts Azure Blob SAS tokens from result and dataset response DTOs', async () => {
+    const sasUri = 'az://account/container/tests.yaml?sp=r&sig=azure-secret';
+    mockedReadResult.mockResolvedValue({
+      id: 'eval-1',
+      createdAt: new Date(),
+      result: { config: { tests: sasUri } },
+    } as never);
+    mockedGetTestCases.mockResolvedValue([{ testCases: sasUri }] as never);
+
+    const resultResponse = await api.get('/api/results/eval-1');
+    const datasetsResponse = await api.get('/api/datasets');
+
+    expect(resultResponse.status).toBe(200);
+    expect(resultResponse.body.data.config.tests).toBe(
+      'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+    );
+    expect(datasetsResponse.status).toBe(200);
+    expect(datasetsResponse.body.data[0].testCases).toBe(
+      'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+    );
+  });
+
   it('validates prompt hash params and returns prompt DTOs', async () => {
     const hash = 'a'.repeat(64);
     mockedGetPromptsForTestCasesHash.mockResolvedValue([{ raw: 'hello', label: 'hello' }] as never);

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -634,6 +634,31 @@ describe('createShareableUrl', () => {
       expect(result).toBe(`https://promptfoo.app/eval/${mockEval.id}`);
     });
 
+    it('redacts Azure Blob SAS tokens from the shared eval config', async () => {
+      vi.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+      mockEval.config = {
+        tests: 'az://account/container/tests.yaml?sp=r&sig=azure-secret',
+      };
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: mockEval.id }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+
+      await createShareableUrl(mockEval as Eval);
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody.config.tests).toBe(
+        'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D',
+      );
+      expect(mockFetch.mock.calls[0][1].body).not.toContain('azure-secret');
+    });
+
     it('sends eval with trace data when traces are available', async () => {
       vi.mocked(cloudConfig.isEnabled).mockReturnValue(true);
       vi.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');

--- a/test/util/azureBlob.test.ts
+++ b/test/util/azureBlob.test.ts
@@ -123,9 +123,7 @@ describe('Azure Blob test-set loading', () => {
       'DefaultEndpointsProtocol=https;AccountName=otheraccount;AccountKey=secret',
     );
 
-    await expect(
-      readAzureBlobText('az://account/container/path/tests.json'),
-    ).rejects.toThrow(
+    await expect(readAzureBlobText('az://account/container/path/tests.json')).rejects.toThrow(
       'AZURE_STORAGE_CONNECTION_STRING targets storage account "otheraccount", but the az:// URI targets "account".',
     );
     expect(mocks.fromConnectionString).not.toHaveBeenCalled();
@@ -160,6 +158,20 @@ describe('Azure Blob test-set loading', () => {
       readAzureBlobText('az://account/container/path/tests.json?sp=r&sig=secret'),
     ).rejects.toThrow(
       'Failed to read Azure Blob Storage URI "az://account/container/path/tests.json?<redacted>": boom',
+    );
+  });
+
+  it('redacts SAS query strings repeated in SDK error details', async () => {
+    mocks.downloadToBuffer.mockRejectedValueOnce(
+      new Error(
+        'Request failed for https://account.blob.core.windows.net/container/path/tests.json?sp=r&sig=secret',
+      ),
+    );
+
+    await expect(
+      readAzureBlobText('az://account/container/path/tests.json?sp=r&sig=secret'),
+    ).rejects.toThrow(
+      'Request failed for https://account.blob.core.windows.net/container/path/tests.json?<redacted>',
     );
   });
 });

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -150,6 +150,7 @@ describe('writeOutput', () => {
     const outputPath = 'output.json';
     const eval_ = new Eval({
       description: 'Test config',
+      tests: 'az://account/container/tests.yaml?sp=r&sig=azure-secret',
       env: {
         AWS_BEARER_TOKEN_BEDROCK: 'bedrock-secret-token',
         ANTHROPIC_API_KEY: 'anthropic-secret-token',
@@ -177,6 +178,7 @@ describe('writeOutput', () => {
     expect(parsed.config.providers[0].config.apiKey).toBe('[REDACTED]');
     expect(parsed.config.providers[0].config.max_turns).toBe(2);
     expect(parsed.config.description).toBe('Test config');
+    expect(parsed.config.tests).toBe('az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D');
   });
 
   it.each([

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -61,6 +61,14 @@ describe('sanitizeObject', () => {
       const invalidJson = '{invalid json}';
       expect(sanitizeObject(invalidJson)).toBe(invalidJson);
     });
+
+    it('should redact SAS tokens embedded in Azure Blob test URIs', () => {
+      const result = sanitizeObject({
+        tests: 'az://account/container/tests.yaml?sp=r&sig=azure-secret',
+      });
+
+      expect(result.tests).toBe('az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D');
+    });
   });
 
   describe('function handling', () => {

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
-import { sanitizeBody, sanitizeObject, sanitizeUrl } from '../../src/util/sanitizer';
+import {
+  redactAzureBlobSasTokens,
+  restoreAzureBlobSasTokens,
+  sanitizeBody,
+  sanitizeObject,
+  sanitizeUrl,
+} from '../../src/util/sanitizer';
 
 // Mock console methods to prevent test noise
 const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -68,6 +74,38 @@ describe('sanitizeObject', () => {
       });
 
       expect(result.tests).toBe('az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D');
+    });
+
+    it('should redact SAS tokens without encoding Azure Blob URI templates', () => {
+      const result = redactAzureBlobSasTokens({
+        tests:
+          'az://{{ account }}/container/{{ suite }}.yaml?sp=r&sig=azure-secret&sv={{ version }}',
+      });
+
+      expect(result.tests).toBe(
+        'az://{{ account }}/container/{{ suite }}.yaml?sp=r&sig=%5BREDACTED%5D&sv={{ version }}',
+      );
+    });
+
+    it('should restore only an unchanged redacted Azure Blob SAS URI', () => {
+      const stored = {
+        tests: 'az://account/container/tests.yaml?sp=r&sig=azure-secret',
+      };
+
+      expect(
+        restoreAzureBlobSasTokens(
+          { tests: 'az://account/container/tests.yaml?sp=r&sig=%5BREDACTED%5D' },
+          stored,
+        ),
+      ).toEqual(stored);
+      expect(
+        restoreAzureBlobSasTokens(
+          { tests: 'az://account/container/edited.yaml?sp=r&sig=%5BREDACTED%5D' },
+          stored,
+        ),
+      ).toEqual({
+        tests: 'az://account/container/edited.yaml?sp=r&sig=%5BREDACTED%5D',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Redact credentials embedded in Azure Blob test-set references before eval data leaves the process.
- Redact a configured SAS query when a downstream Azure SDK error repeats the authenticated blob URL.
- Cover exported output, share uploads, server table/result/dataset responses, MCP evaluation detail responses, and blob-read error details.
- Keep persisted runnable configuration intact so authenticated Azure Blob test-set reads continue to work.

## Root Cause

Azure Blob test-set references retain their authentication query in evaluation configuration. Existing output sanitization did not recognize that credential when embedded in a config string, and several outward response paths serialized stored configuration directly. In addition, the blob reader redacted the outer `az://` reference but forwarded nested SDK error text verbatim, allowing the same configured SAS query to reappear when the SDK included its request URL in an error message.

## Validation

- Confirmed the nested SDK-error regression failed before its source fix with the raw `sig` query still present in the outward error.
- `npx vitest run test/util/azureBlob.test.ts test/util/sanitizer.test.ts test/util/output.test.ts test/share.test.ts test/server/eval.test.ts test/server/routes/serverApiSchemas.test.ts test/commands/mcp/tools/getEvaluationDetailsFilter.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l`
- `npm run tsc`
- `git diff --check`

## Security Handling

This update completes the SAS-output redaction class already disclosed by this open public PR and does not introduce a second public issue or branch for the same exposure.
