### PR TITLE
fix(providers): align Gemini safety block handling

### DIFF
--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -13,6 +13,7 @@
  */
 
 import { fetchWithCache } from '../../cache';
+import cliState from '../../cliState';
 import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import { fetchWithProxy } from '../../util/fetch/index';
@@ -517,7 +518,11 @@ export class GoogleProvider extends GoogleGenericProvider {
             flaggedOutput: true,
             reason: finishReason,
           };
-          return { output: finishReason, tokenUsage, guardrails };
+          if (cliState.config?.redteam) {
+            // Refusals are successful outcomes during redteam evaluations.
+            return { output: finishReason, tokenUsage, guardrails };
+          }
+          return { error: finishReason, tokenUsage, guardrails };
         } else if (candidate.finishReason && candidate.finishReason === 'MAX_TOKENS') {
           // MAX_TOKENS is treated as a successful completion
           if (candidate.content?.parts) {

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -50,6 +50,49 @@ type GaxiosError = any;
 
 const DEFAULT_AI_STUDIO_HOST = 'generativelanguage.googleapis.com';
 
+interface SafetyRelevantAssertion {
+  type?: string;
+  assert?: SafetyRelevantAssertion[];
+}
+
+type SafetyRelevantContext = CallApiContextParams & {
+  test?: NonNullable<CallApiContextParams['test']> & {
+    assert?: SafetyRelevantAssertion[];
+  };
+};
+
+function hasScorableSafetyAssertion(assertion: SafetyRelevantAssertion): boolean {
+  if (
+    assertion.type === 'guardrails' ||
+    assertion.type === 'not-guardrails' ||
+    assertion.type?.startsWith('promptfoo:redteam:')
+  ) {
+    return true;
+  }
+
+  return (
+    assertion.type === 'assert-set' &&
+    Array.isArray(assertion.assert) &&
+    assertion.assert.some(hasScorableSafetyAssertion)
+  );
+}
+
+function shouldExposeSafetyBlockAsOutput(context?: CallApiContextParams): boolean {
+  if (cliState.config?.redteam) {
+    return true;
+  }
+
+  const test = (context as SafetyRelevantContext | undefined)?.test;
+  if (
+    typeof test?.metadata?.pluginId === 'string' &&
+    (Boolean(test.metadata.pluginConfig) || Boolean(test.metadata.goal))
+  ) {
+    return true;
+  }
+
+  return test?.assert?.some(hasScorableSafetyAssertion) ?? false;
+}
+
 /**
  * Unified Google provider for Gemini models.
  *
@@ -439,7 +482,7 @@ export class GoogleProvider extends GoogleGenericProvider {
     data: GeminiApiResponse,
     cached: boolean,
     config: CompletionOptions,
-    _context?: CallApiContextParams,
+    context?: CallApiContextParams,
   ): Promise<ProviderResponse> {
     try {
       const { toolsDisabled } = resolveGoogleToolConfig(config);
@@ -518,11 +561,17 @@ export class GoogleProvider extends GoogleGenericProvider {
             flaggedOutput: true,
             reason: finishReason,
           };
-          if (cliState.config?.redteam) {
-            // Refusals are successful outcomes during redteam evaluations.
-            return { output: finishReason, tokenUsage, guardrails };
+          const safetyResponse = {
+            tokenUsage,
+            guardrails,
+            raw: data,
+            cached,
+          };
+          if (shouldExposeSafetyBlockAsOutput(context)) {
+            // Assertions must receive safety refusals as scorable provider outputs.
+            return { output: finishReason, ...safetyResponse };
           }
-          return { error: finishReason, tokenUsage, guardrails };
+          return { error: finishReason, ...safetyResponse };
         } else if (candidate.finishReason && candidate.finishReason === 'MAX_TOKENS') {
           // MAX_TOKENS is treated as a successful completion
           if (candidate.content?.parts) {

--- a/test/evaluator/execution.test.ts
+++ b/test/evaluator/execution.test.ts
@@ -67,7 +67,6 @@ describeEvaluator('evaluator execution control', () => {
     const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
     await evaluate(testSuite, evalRecord, {});
 
-    expect(mockApiProvider.delay).toBe(0);
     expect(sleep).not.toHaveBeenCalled();
     expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
   });

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as cache from '../../../src/cache';
+import cliState from '../../../src/cliState';
 import { GoogleProvider } from '../../../src/providers/google/provider';
 import * as util from '../../../src/providers/google/util';
 import * as fetchUtil from '../../../src/util/fetch/index';
@@ -98,6 +99,7 @@ vi.mock('fs', async (importOriginal) => {
 
 describe('GoogleProvider', () => {
   beforeEach(() => {
+    cliState.config = undefined;
     vi.clearAllMocks();
     // Reset hoisted mocks to default pass-through behavior
     mockMaybeLoadToolsFromExternalFile.mockReset().mockImplementation((input) => input);
@@ -554,6 +556,51 @@ describe('GoogleProvider', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.output).toBe('truncated response');
+    });
+
+    it('should return an error for safety finish reasons outside redteam evaluations', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: {
+          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          error: 'Content was blocked due to safety settings with finish reason: SAFETY.',
+          guardrails: expect.objectContaining({
+            flagged: true,
+            flaggedOutput: true,
+          }),
+        }),
+      );
+    });
+
+    it('should return safety finish reasons as output during redteam evaluations', async () => {
+      cliState.config = { redteam: {} } as any;
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: {
+          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe(
+        'Content was blocked due to safety settings with finish reason: SAFETY.',
+      );
+      expect(result.guardrails?.flagged).toBe(true);
     });
 
     it('should handle thinking tokens in response', async () => {

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -558,13 +558,14 @@ describe('GoogleProvider', () => {
       expect(result.output).toBe('truncated response');
     });
 
-    it('should return an error for safety finish reasons outside redteam evaluations', async () => {
+    it('should return an error for safety finish reasons outside scorable evaluations', async () => {
+      const responseData = {
+        candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+      };
       vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
-        data: {
-          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
-          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
-        },
-        cached: false,
+        data: responseData,
+        cached: true,
         status: 200,
         statusText: 'OK',
       });
@@ -578,6 +579,8 @@ describe('GoogleProvider', () => {
             flagged: true,
             flaggedOutput: true,
           }),
+          cached: true,
+          raw: responseData,
         }),
       );
     });
@@ -595,6 +598,92 @@ describe('GoogleProvider', () => {
       });
 
       const result = await provider.callApi('test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe(
+        'Content was blocked due to safety settings with finish reason: SAFETY.',
+      );
+      expect(result.guardrails?.flagged).toBe(true);
+      expect(result.cached).toBe(false);
+      expect(result.raw).toEqual({
+        candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+      });
+    });
+
+    it('should expose safety finish reasons to guardrails assertions', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: {
+          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: {},
+        test: { assert: [{ type: 'not-guardrails' }] },
+      } as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe(
+        'Content was blocked due to safety settings with finish reason: SAFETY.',
+      );
+      expect(result.guardrails?.flagged).toBe(true);
+    });
+
+    it('should expose safety finish reasons for exported redteam test metadata', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: {
+          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: {},
+        test: {
+          metadata: { pluginId: 'ascii-smuggling', goal: 'exfiltrate data' },
+        },
+      } as any);
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe(
+        'Content was blocked due to safety settings with finish reason: SAFETY.',
+      );
+      expect(result.guardrails?.flagged).toBe(true);
+    });
+
+    it('should expose safety finish reasons for nested redteam assertions', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: {
+          candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: {},
+        test: {
+          assert: [
+            {
+              type: 'assert-set',
+              assert: [{ type: 'promptfoo:redteam:ascii-smuggling' }],
+            },
+          ],
+        },
+      } as any);
 
       expect(result.error).toBeUndefined();
       expect(result.output).toBe(

--- a/test/providers/http/auth.test.ts
+++ b/test/providers/http/auth.test.ts
@@ -127,7 +127,7 @@ describe('RSA signature authentication', () => {
     expect(crypto.createSign).toHaveBeenCalledTimes(1); // Should not be called again
   });
 
-  it('should regenerate signature when expired', async () => {
+  it('should regenerate signature at the default refresh buffer boundary', async () => {
     const provider = new HttpProvider('http://example.com', {
       config: {
         method: 'POST',
@@ -151,10 +151,14 @@ describe('RSA signature authentication', () => {
     await provider.callApi('test');
     expect(crypto.createSign).toHaveBeenCalledTimes(1);
 
-    // Second call after validity period should regenerate signature
-    vi.spyOn(Date, 'now').mockReturnValue(301000); // After validity period
+    // The default refresh buffer is 10%, so a five-minute signature refreshes at 4.5 minutes.
+    vi.mocked(Date.now).mockReturnValue(270999);
     await provider.callApi('test');
-    expect(crypto.createSign).toHaveBeenCalledTimes(2); // Should be called again
+    expect(crypto.createSign).toHaveBeenCalledTimes(1);
+
+    vi.mocked(Date.now).mockReturnValue(271000);
+    await provider.callApi('test');
+    expect(crypto.createSign).toHaveBeenCalledTimes(2);
   });
 
   it('should use custom signature data template', async () => {

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 
 import dedent from 'dedent';
 import { globSync } from 'glob';
@@ -109,9 +110,7 @@ vi.mock('../../src/integrations/huggingfaceDatasets', () => ({
 }));
 
 vi.mock('../../src/util/azureBlob', async () => ({
-  ...(await vi.importActual<typeof import('../../src/util/azureBlob')>(
-    '../../src/util/azureBlob',
-  )),
+  ...(await vi.importActual<typeof import('../../src/util/azureBlob')>('../../src/util/azureBlob')),
   readAzureBlobText: vi.fn(),
 }));
 
@@ -410,9 +409,7 @@ describe('readStandaloneTestsFile', () => {
 
   it('should read CSV test sets from Azure Blob Storage URIs', async () => {
     const blobUri = 'az://account/container/tests.csv';
-    vi.mocked(readAzureBlobText).mockResolvedValue(
-      'review_id,__expected\nreview-004,ready',
-    );
+    vi.mocked(readAzureBlobText).mockResolvedValue('review_id,__expected\nreview-004,ready');
 
     const result = await readStandaloneTestsFile(blobUri);
 
@@ -646,7 +643,6 @@ describe('readStandaloneTestsFile', () => {
 
   it('should read real XLSX file from examples (integration test)', async () => {
     // Integration test using the actual Excel file from examples
-    const path = require('path');
     const exampleFile = path.join(__dirname, '../../examples/simple-csv/tests.xlsx');
 
     // Only run if read-excel-file is actually installed (in dev environment)


### PR DESCRIPTION
## Summary

- return Google Gemini safety-finish blocks as errors in non-redteam evaluations while preserving successful refusal output during redteam runs
- add regression coverage for both Google provider modes and remove an invalid no-delay assertion
- make the RSA signature refresh test exercise the actual buffered boundary and use an ESM `path` import in the XLSX test

## AI findings addressed

- `src/providers/google/provider.ts`: non-redteam safety finish reasons were silently returned as output
- `test/providers/google/provider.test.ts`: safety finish-reason behavior lacked direct coverage
- `test/evaluator/execution.test.ts`: no-delay test asserted an unset mock property
- `test/providers/http/auth.test.ts`: refresh coverage did not document or assert the effective buffer boundary
- `test/util/testCaseReader.test.ts`: inline CommonJS `path` import in an ESM test file

## Validation

- `npm run l` (passes with the existing Google provider cognitive-complexity warnings)
- `npm run f` (passes with the same existing warnings; no further changes)
- `npx vitest run test/providers/google/provider.test.ts test/evaluator/execution.test.ts test/providers/http/auth.test.ts test/util/testCaseReader.test.ts --sequence.shuffle=false` (216 tests passed)
- `npm run tsc`
