### PR TITLE
feat(providers): expose Codex transcript metadata

### DIFF
--- a/site/docs/guides/evaluate-coding-agents.md
+++ b/site/docs/guides/evaluate-coding-agents.md
@@ -43,6 +43,22 @@ Choose the provider by the runtime boundary you need to evaluate:
 
 Across the coding-agent providers, relative `working_dir` values resolve from the directory containing the config file. That keeps configs portable when you run the same eval from the example directory, the repo root, or CI.
 
+## Inspecting Codex Runs
+
+Both Codex providers record the current-turn prompt and emitted assistant responses in `metadata.messages`. In the eval results UI, open a row and select **Messages** to read the transcript.
+
+Use the additional evidence surfaces when the final answer is not enough:
+
+| Need to inspect                            | Provider/configuration                                                                  |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Prompt and assistant responses             | `metadata.messages` from either Codex provider; visible in **Messages**                 |
+| Shell, file, MCP, search, and message work | `enable_streaming: true` plus tracing for `openai:codex-sdk`                            |
+| Rich app-server item and request events    | `openai:codex-app-server`; inspect `metadata.codexAppServer.items` and `serverRequests` |
+| Raw app-server notifications               | `include_raw_events: true` and optionally `experimental_raw_events: true`               |
+| Emitted app-server reasoning summaries     | `reasoning_summary: detailed`; inspect metadata/raw events or traces                    |
+
+Reasoning summaries and reasoning trajectory spans are emitted observability data. They do not reveal hidden model chain of thought.
+
 ## Examples
 
 ### Security audit with structured output

--- a/site/docs/providers/openai-codex-app-server.md
+++ b/site/docs/providers/openai-codex-app-server.md
@@ -39,6 +39,7 @@ Use this provider when the thing being tested depends on app-server-only behavio
 | Eval surface                                    | Supported? | Notes                                                                                            |
 | ----------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------ |
 | Final assistant text                            | Yes        | Returned in `response.output` as a string.                                                       |
+| Prompt/assistant transcript                     | Yes        | Successful rows include `metadata.messages`, rendered in the eval details **Messages** tab.      |
 | Text, image, local image, skill, mention inputs | Yes        | Pass plain text or a JSON array of supported app-server input items.                             |
 | JSON schema output                              | Yes        | Pass `output_schema`; assert with `is-json` or parse `output` yourself.                          |
 | Token usage and estimated cost                  | Yes        | Token usage is read from `thread/tokenUsage/updated`; cost needs a known model id.               |
@@ -82,7 +83,7 @@ prompts:
   - 'Review this repository and summarize the highest-risk code paths.'
 ```
 
-The provider returns Codex's final assistant text as `output`. It also records thread ids, turn ids, item counts, command/file/tool metadata, approval decisions, and token usage under `metadata.codexAppServer`.
+The provider returns Codex's final assistant text as `output`. It stores the current-turn user/assistant exchange in `metadata.messages`, which appears in the eval details **Messages** tab. It also records thread ids, turn ids, item counts, command/file/tool metadata, approval decisions, and token usage under `metadata.codexAppServer`.
 
 For downstream coding-agent checks, `raw` also includes SDK-compatible `items` and `usage` fields alongside the protocol-shaped thread and turn payloads. That keeps trajectory-style assertions aligned between `openai:codex-app-server` and `openai:codex-sdk` without losing the richer app-server metadata.
 
@@ -315,6 +316,7 @@ Supported input item types are `text`, `image`, `local_image`, `localImage`, `sk
 The provider records app-server details for assertions and debugging:
 
 ```js
+providerResponse.metadata.messages;
 providerResponse.metadata.codexAppServer.threadId;
 providerResponse.metadata.codexAppServer.turnId;
 providerResponse.metadata.codexAppServer.itemCounts;
@@ -323,6 +325,29 @@ providerResponse.metadata.codexAppServer.serverRequests;
 ```
 
 Command output, tool arguments, and approval metadata are sanitized before they are placed in metadata or tracing attributes.
+
+## Debugging Agent Behavior
+
+`metadata.messages` is the human-readable transcript for the current row: prompt input followed by emitted assistant messages. Reasoning, commands, file activity, MCP calls, and web searches remain available separately under `metadata.codexAppServer.items` so that a reasoning summary is not presented as an assistant answer.
+
+For maximum emitted evidence:
+
+```yaml
+providers:
+  - id: openai:codex-app-server:gpt-5.5
+    config:
+      sandbox_mode: read-only
+      approval_policy: never
+      model_reasoning_effort: high
+      reasoning_summary: detailed
+      experimental_raw_events: true
+      include_raw_events: true
+      deep_tracing: true
+```
+
+`reasoning_summary: detailed` requests richer reasoning summaries from app-server. `experimental_raw_events` asks Codex to emit raw Responses API items, while `include_raw_events` retains protocol notifications in `response.raw`. Use `deep_tracing` with Promptfoo tracing enabled when you want item-level activity in the **Traces** tab.
+
+These fields expose emitted summaries and runtime actions, not hidden model chain of thought.
 
 ## Tracing
 

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -6,7 +6,7 @@ description: 'Use OpenAI Codex SDK for evals with thread management, structured 
 
 # OpenAI Codex SDK
 
-This provider makes OpenAI's Codex SDK available for agent evals in promptfoo. It can evaluate Codex's final response text, token usage, thread/session IDs, heuristic skill usage, and traced shell/MCP/search/file steps. It accepts plain text prompts and JSON-encoded Codex input arrays with `text` and `local_image` items, but it does not expose embeddings, moderation, image generation, or realtime APIs.
+This provider makes OpenAI's Codex SDK available for agent evals in promptfoo. It can evaluate Codex's final response text, the current-turn conversation shown in the eval UI, token usage, thread/session IDs, heuristic skill usage, and traced shell/MCP/search/file steps. It accepts plain text prompts and JSON-encoded Codex input arrays with `text` and `local_image` items, but it does not expose embeddings, moderation, image generation, or realtime APIs.
 
 The provider runs Codex with an explicit working directory, sandbox policy, approval policy, network/search settings, and a controlled CLI environment. The model output returned to promptfoo is the final Codex text response; if you request JSON schema output, `output` is still a string and your assertions should parse it with `is-json` or `JSON.parse(output)`.
 
@@ -28,6 +28,7 @@ You can reference this provider using either base ID, and you can inline the mod
 | Eval surface                       | Supported? | Notes                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Final assistant text               | Yes        | Returned in `response.output` as a string.                                                                                                                                                                                                                                                                                                                        |
+| Prompt/assistant transcript        | Yes        | Successful rows include `metadata.messages`, which is rendered in the eval details **Messages** tab. With streaming enabled, emitted intermediate assistant messages are also included.                                                                                                                                                                           |
 | Text + local image prompt inputs   | Partial    | Pass plain text as usual, or pass a JSON array of `{"type":"text","text":"..."}` and `{"type":"local_image","path":"/abs/file.png"}` entries. Other JSON prompt shapes are treated as plain text.                                                                                                                                                                 |
 | JSON schema output                 | Yes        | Pass `output_schema`; use `is-json` and `JSON.parse(output)` in JS assertions because the provider does not auto-parse the final text.                                                                                                                                                                                                                            |
 | Token usage and estimated cost     | Yes        | `tokenUsage` is returned when the SDK reports usage, including `completionDetails.reasoning` when Codex reports reasoning output tokens. Cost is estimated only when `config.model` is known to promptfoo's pricing table. Codex's own instruction preamble and tool schemas are included in prompt tokens, so tiny prompts can still report high `input_tokens`. |
@@ -114,6 +115,31 @@ prompts:
 ```
 
 The provider creates an ephemeral thread for each eval test case.
+
+## Inspecting the Transcript and Trajectory
+
+Every successful Codex SDK row includes the current prompt and final assistant response in `metadata.messages`. Open a row in the web UI and select **Messages** to inspect that exchange.
+
+For emitted intermediate assistant messages, command/file/tool activity, and any emitted reasoning events, enable streaming and tracing:
+
+```yaml
+tracing:
+  enabled: true
+  otlp:
+    http:
+      enabled: true
+
+providers:
+  - id: openai:codex-sdk
+    config:
+      model: gpt-5.5
+      enable_streaming: true
+      deep_tracing: true
+```
+
+`response.raw` includes Codex items and, when streaming is enabled, the accumulated `conversationMessages` and `reasoningTexts`. The **Traces** tab exposes the captured item spans when tracing is configured.
+
+Reasoning items are summaries/events emitted by Codex. They do not expose hidden model chain of thought, and they are intentionally kept in raw/tracing evidence instead of being displayed as assistant messages.
 
 ### With Custom Model
 

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.test.tsx
@@ -152,6 +152,44 @@ describe('EvalOutputPromptDialog', () => {
     expect(screen.getByText('testValue')).toBeInTheDocument();
   });
 
+  it('displays structured provider messages in the Messages tab', async () => {
+    renderWithProviders(
+      <EvalOutputPromptDialog
+        {...defaultProps}
+        metadata={{
+          messages: [
+            { role: 'user', content: 'Inspect this file' },
+            { role: 'assistant', content: 'I inspected it.' },
+          ],
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Messages' }));
+
+    expect(screen.getByText('Inspect this file')).toBeInTheDocument();
+    expect(screen.getByText('I inspected it.')).toBeInTheDocument();
+  });
+
+  it('continues to display JSON-encoded provider messages in the Messages tab', async () => {
+    renderWithProviders(
+      <EvalOutputPromptDialog
+        {...defaultProps}
+        metadata={{
+          messages: JSON.stringify([
+            { role: 'user', content: 'Serialized prompt' },
+            { role: 'assistant', content: 'Serialized response' },
+          ]),
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Messages' }));
+
+    expect(screen.getByText('Serialized prompt')).toBeInTheDocument();
+    expect(screen.getByText('Serialized response')).toBeInTheDocument();
+  });
+
   it('calls onClose when close button is clicked', async () => {
     renderWithProviders(<EvalOutputPromptDialog {...defaultProps} />);
     await userEvent.click(screen.getByLabelText('close'));

--- a/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputPromptDialog.tsx
@@ -327,7 +327,8 @@ export default function EvalOutputPromptDialog({
   let parsedMessages: Message[] = [];
   try {
     const messagesValue = metadata?.messages;
-    parsedMessages = JSON.parse(typeof messagesValue === 'string' ? messagesValue : '[]');
+    const messages = typeof messagesValue === 'string' ? JSON.parse(messagesValue) : messagesValue;
+    parsedMessages = Array.isArray(messages) ? (messages as Message[]) : [];
   } catch {}
 
   const citationsData = metadata?.citations as Citation | Citation[] | undefined;

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -155,6 +155,11 @@ type CodexAppServerUserInput =
       path: string;
     };
 
+type CodexConversationMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
 type CodexAppServerThreadCleanup = 'unsubscribe' | 'archive' | 'none';
 type CodexAppServerUserInputPolicy = 'empty' | 'first-option' | Record<string, string | string[]>;
 
@@ -2733,7 +2738,13 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
         ? { notifications: this.sanitizeForMetadata(state.notifications) }
         : {}),
     };
-    const metadata = this.buildResponseMetadata(state, threadHandle, config, normalizedItems);
+    const metadata = this.buildResponseMetadata(
+      state,
+      threadHandle,
+      config,
+      output,
+      normalizedItems,
+    );
 
     return {
       output,
@@ -2766,6 +2777,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     state: CodexAppServerTurnState,
     threadHandle: ThreadHandle,
     config: CodexAppServerConfig,
+    output: string,
     normalizedItems: Record<string, unknown>[],
   ): ProviderResponse['metadata'] {
     const skillMetadata = this.buildSkillMetadata(
@@ -2773,6 +2785,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       this.getSkillRootPrefixes(config, state.appServerEnv),
     );
     return {
+      messages: this.buildConversationMessages(state, output),
       codexAppServer: {
         threadId: threadHandle.threadId,
         turnId: state.turnId,
@@ -2792,6 +2805,25 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
         ? { attemptedSkillCalls: skillMetadata.attemptedSkillCalls }
         : {}),
     };
+  }
+
+  private buildConversationMessages(
+    state: CodexAppServerTurnState,
+    output: string,
+  ): CodexConversationMessage[] {
+    const messages: CodexConversationMessage[] = [
+      { role: 'user', content: this.formatPromptInputForTrace(state.promptInput) },
+    ];
+    const assistantTexts = state.items
+      .filter((item) => item?.type === 'agentMessage' && typeof item.text === 'string')
+      .map((item) => item.text as string);
+
+    messages.push(...assistantTexts.map((content) => ({ role: 'assistant' as const, content })));
+    if (output && assistantTexts[assistantTexts.length - 1] !== output) {
+      messages.push({ role: 'assistant', content: output });
+    }
+
+    return messages;
   }
 
   private normalizeItemForMetadata(item: any): Record<string, unknown> {

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -2823,7 +2823,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       messages.push({ role: 'assistant', content: output });
     }
 
-    return messages;
+    return this.sanitizeForMetadata(messages) as CodexConversationMessage[];
   }
 
   private normalizeItemForMetadata(item: any): Record<string, unknown> {

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -109,6 +109,11 @@ type CodexPromptInputItem =
 
 type CodexPromptInput = string | CodexPromptInputItem[];
 
+type CodexConversationMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
 interface CodexStreamingState {
   items: any[];
   usage: any;
@@ -116,7 +121,7 @@ interface CodexStreamingState {
   itemStartTimes: Map<string, number>;
   lastEventTime: number;
   reasoningTexts: string[];
-  conversationMessages: Array<{ role: string; content: string }>;
+  conversationMessages: CodexConversationMessage[];
 }
 
 const MINIMAL_CLI_ENV_KEYS = [
@@ -1997,7 +2002,13 @@ export class OpenAICodexSDKProvider implements ApiProvider {
         skillRootPrefixes,
       );
 
-      return this.buildCodexProviderResponse(turn, sessionId, skillRootPrefixes, resolvedConfig);
+      return this.buildCodexProviderResponse(
+        turn,
+        sessionId,
+        promptInput,
+        skillRootPrefixes,
+        resolvedConfig,
+      );
     } catch (error: unknown) {
       const isAbort =
         (error instanceof Error && error.name === 'AbortError') ||
@@ -2125,6 +2136,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
   private buildCodexProviderResponse(
     turn: any,
     sessionId: string,
+    promptInput: CodexPromptInput,
     skillRootPrefixes: readonly string[],
     resolvedConfig: OpenAICodexSDKConfig,
   ): ProviderResponse {
@@ -2136,27 +2148,50 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       output,
       tokenUsage,
       cost: this.calculateCodexResponseCost(tokenUsage, resolvedConfig.model),
-      metadata: this.buildCodexResponseMetadata(turn.items, skillRootPrefixes),
+      metadata: this.buildCodexResponseMetadata(promptInput, turn, skillRootPrefixes),
       raw: JSON.stringify(turn),
       sessionId,
     };
   }
 
   private buildCodexResponseMetadata(
-    items: any[],
+    promptInput: CodexPromptInput,
+    turn: any,
     skillRootPrefixes: readonly string[],
   ): ProviderResponse['metadata'] {
-    const skillMetadata = this.buildSkillMetadata(items, skillRootPrefixes);
-    if (!skillMetadata) {
-      return undefined;
-    }
+    const skillMetadata = this.buildSkillMetadata(turn.items, skillRootPrefixes);
 
     return {
-      ...(skillMetadata.skillCalls.length > 0 ? { skillCalls: skillMetadata.skillCalls } : {}),
-      ...(skillMetadata.attemptedSkillCalls.length > skillMetadata.skillCalls.length
+      messages: this.buildConversationMessages(promptInput, turn),
+      ...(skillMetadata?.skillCalls.length ? { skillCalls: skillMetadata.skillCalls } : {}),
+      ...(skillMetadata &&
+      skillMetadata.attemptedSkillCalls.length > skillMetadata.skillCalls.length
         ? { attemptedSkillCalls: skillMetadata.attemptedSkillCalls }
         : {}),
     };
+  }
+
+  private buildConversationMessages(
+    promptInput: CodexPromptInput,
+    turn: any,
+  ): CodexConversationMessage[] {
+    const messages: CodexConversationMessage[] = [
+      { role: 'user', content: this.formatPromptInputForTrace(promptInput) },
+    ];
+    const assistantTexts: string[] = Array.isArray(turn.items)
+      ? turn.items
+          .filter((item: any) => item?.type === 'agent_message' && typeof item.text === 'string')
+          .map((item: any) => item.text as string)
+      : [];
+
+    messages.push(...assistantTexts.map((content) => ({ role: 'assistant' as const, content })));
+
+    const finalResponse = typeof turn.finalResponse === 'string' ? turn.finalResponse : '';
+    if (finalResponse && assistantTexts[assistantTexts.length - 1] !== finalResponse) {
+      messages.push({ role: 'assistant', content: finalResponse });
+    }
+
+    return messages;
   }
 
   private buildCodexTokenUsage(turnUsage: any): ProviderResponse['tokenUsage'] {

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -4068,7 +4068,7 @@ describe('OpenAICodexAppServerProvider', () => {
     expect(result.output).toBe('Done');
   });
 
-  it('sanitizes sensitive command metadata', async () => {
+  it('sanitizes sensitive command and conversation metadata', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);
 
@@ -4113,12 +4113,27 @@ describe('OpenAICodexAppServerProvider', () => {
       },
     });
     server.send({
-      method: 'item/agentMessage/delta',
+      method: 'item/completed',
       params: {
         threadId: 'thr_sanitize',
         turnId: 'turn_sanitize',
-        itemId: 'msg_secret',
-        delta: 'Done',
+        item: {
+          type: 'agentMessage',
+          id: 'msg_secret',
+          text: 'Observed api_key=sk-proj-abcdefghijklmnopqrstuvwxyz123456',
+        },
+      },
+    });
+    server.send({
+      method: 'item/completed',
+      params: {
+        threadId: 'thr_sanitize',
+        turnId: 'turn_sanitize',
+        item: {
+          type: 'agentMessage',
+          id: 'msg_final',
+          text: 'Done',
+        },
       },
     });
     server.send({
@@ -4130,6 +4145,12 @@ describe('OpenAICodexAppServerProvider', () => {
     });
 
     const result = await resultPromise;
+    expect(result.output).toBe('Done');
+    expect(result.metadata?.messages).toEqual([
+      { role: 'user', content: 'Inspect command output' },
+      { role: 'assistant', content: 'Observed api_key=[REDACTED]' },
+      { role: 'assistant', content: 'Done' },
+    ]);
     const metadataJson = JSON.stringify(result.metadata);
     expect(metadataJson).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz123456');
     expect(metadataJson).toContain('[REDACTED]');

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -360,6 +360,10 @@ describe('OpenAICodexAppServerProvider', () => {
       itemCounts: { agentMessage: 1 },
       notificationCount: 5,
     });
+    expect(result.metadata?.messages).toEqual([
+      { role: 'user', content: 'Summarize this repo' },
+      { role: 'assistant', content: 'Final response' },
+    ]);
     expect(JSON.parse(result.raw as string)).toMatchObject({
       output: 'Final response',
       tokenUsage: {
@@ -4000,6 +4004,10 @@ describe('OpenAICodexAppServerProvider', () => {
       output_tokens: 50,
       reasoning_output_tokens: 12,
     });
+    expect(result.metadata?.messages).toEqual([
+      { role: 'user', content: 'Inspect raw evidence' },
+      { role: 'assistant', content: 'Done' },
+    ]);
   });
 
   it('counts notifications without retaining raw notification payloads by default', async () => {

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -256,6 +256,12 @@ describe('OpenAICodexSDKProvider', () => {
             cached: 5,
           },
           cost: undefined,
+          metadata: {
+            messages: [
+              { role: 'user', content: 'Test prompt' },
+              { role: 'assistant', content: 'Test response' },
+            ],
+          },
           raw: expect.any(String),
           sessionId: 'test-thread-123',
         });
@@ -307,6 +313,10 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi(prompt);
 
         expect(result.output).toBe('Image-aware response');
+        expect(result.metadata?.messages).toEqual([
+          { role: 'user', content: 'Describe this screenshot\n[local_image: /tmp/screenshot.png]' },
+          { role: 'assistant', content: 'Image-aware response' },
+        ]);
         expect(mockRun).toHaveBeenCalledWith(
           [
             { type: 'text', text: 'Describe this screenshot' },
@@ -516,6 +526,7 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi('Use the token-skill skill');
 
         expect(result.metadata).toEqual({
+          messages: expect.any(Array),
           skillCalls: [
             {
               name: 'token-skill',
@@ -546,6 +557,7 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi('Use the token-skill skill');
 
         expect(result.metadata).toEqual({
+          messages: expect.any(Array),
           skillCalls: [
             {
               name: 'token-skill',
@@ -584,6 +596,7 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi('Use the token-skill skill');
 
         expect(result.metadata).toEqual({
+          messages: expect.any(Array),
           skillCalls: [
             {
               name: 'token-skill',
@@ -613,7 +626,11 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('Read all skills');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata?.messages).toEqual([
+          { role: 'user', content: 'Read all skills' },
+          { role: 'assistant', content: 'WILDCARD' },
+        ]);
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
 
       it('should ignore absolute .agents skill paths outside the current repo root', async () => {
@@ -635,7 +652,7 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('Read another repo skill');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
 
       it('should not infer skillCalls from directory listings without a direct SKILL.md command read', async () => {
@@ -658,7 +675,7 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('List the available files');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
 
       it('should omit skillCalls when no skill files are read', async () => {
@@ -685,7 +702,11 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('What is 2 + 2?');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata?.messages).toEqual([
+          { role: 'user', content: 'What is 2 + 2?' },
+          { role: 'assistant', content: '4' },
+        ]);
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
 
       it('should infer skillCalls from custom CODEX_HOME skill directories', async () => {
@@ -713,6 +734,7 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi('Use the home skill');
 
         expect(result.metadata).toEqual({
+          messages: expect.any(Array),
           skillCalls: [
             {
               name: 'home-skill',
@@ -749,6 +771,7 @@ describe('OpenAICodexSDKProvider', () => {
           const result = await provider.callApi('Use the profile skill');
 
           expect(result.metadata).toEqual({
+            messages: expect.any(Array),
             skillCalls: [
               {
                 name: 'profile-skill',
@@ -797,6 +820,7 @@ describe('OpenAICodexSDKProvider', () => {
         const result = await provider.callApi('Use the token-skill skill');
 
         expect(result.metadata).toEqual({
+          messages: expect.any(Array),
           attemptedSkillCalls: [
             {
               name: 'token-skill',
@@ -827,7 +851,7 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('Read the unrelated SKILL file');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
 
       it('should ignore arbitrary hidden .codex skill paths outside the configured home root', async () => {
@@ -850,7 +874,7 @@ describe('OpenAICodexSDKProvider', () => {
         });
         const result = await provider.callApi('Read the unrelated hidden Codex skill file');
 
-        expect(result.metadata).toBeUndefined();
+        expect(result.metadata).not.toHaveProperty('skillCalls');
       });
     });
 
@@ -1676,6 +1700,11 @@ describe('OpenAICodexSDKProvider', () => {
             reasoning: 3,
           },
         });
+        expect(result.metadata?.messages).toEqual([
+          { role: 'user', content: 'Test prompt' },
+          { role: 'assistant', content: 'Part 1' },
+          { role: 'assistant', content: 'Part 2' },
+        ]);
       });
 
       it('should abort streaming on signal', async () => {


### PR DESCRIPTION
Expose each Codex provider's current-turn transcript through `metadata.messages` for the eval UI, preserve app-server metadata redaction for sensitive transcript content, and document the separate emitted reasoning and trajectory evidence surfaces.
