### PR TITLE
fix(eval): preserve optimized prompt routing

### DIFF
--- a/src/optimizer/promptOptimizer.ts
+++ b/src/optimizer/promptOptimizer.ts
@@ -491,6 +491,25 @@ function buildCandidateDefaultTest(
   };
 }
 
+function buildCandidateScenarios(
+  scenarios: TestSuite['scenarios'],
+  routingPrompt: Prompt,
+  seedPrompt: Prompt,
+  candidateLabels: string[],
+): TestSuite['scenarios'] {
+  return scenarios?.map((scenario) => ({
+    ...scenario,
+    config: scenario.config.map((test) => ({
+      ...test,
+      prompts: extendPromptFilter(test.prompts, routingPrompt, seedPrompt, candidateLabels),
+    })),
+    tests: scenario.tests.map((test) => ({
+      ...test,
+      prompts: extendPromptFilter(test.prompts, routingPrompt, seedPrompt, candidateLabels),
+    })),
+  }));
+}
+
 function createCandidateTestSuite(
   testSuite: TestSuite,
   routingPrompt: Prompt,
@@ -528,7 +547,12 @@ function createCandidateTestSuite(
       seedPrompt,
       candidateLabels,
     ),
-    // TODO(ian): Extend scenario prompt filters when optimizing scenario-scoped prompt routes.
+    scenarios: buildCandidateScenarios(
+      testSuite.scenarios,
+      routingPrompt,
+      seedPrompt,
+      candidateLabels,
+    ),
   };
 }
 
@@ -625,6 +649,9 @@ export async function optimizePromptTestSuite(
   }
 
   const selectedTestSuite = createSelectedOptimizationTestSuite(testSuite, options);
+  if (selectedTestSuite.prompts[0].function) {
+    throw new Error('Prompt optimization currently supports literal string prompts only.');
+  }
   const { searchTestSuite, validationTestSuite, searchTestCount, validationTestCount } =
     createValidationPartition(selectedTestSuite, options.validationSplit);
 

--- a/test/optimizer/promptOptimizer.test.ts
+++ b/test/optimizer/promptOptimizer.test.ts
@@ -522,7 +522,7 @@ describe('prompt optimizer', () => {
     });
   });
 
-  it('extends prompt filters for explicit and default tests when candidates are added', async () => {
+  it('extends prompt filters for explicit, default, and scenario tests when candidates are added', async () => {
     const provider = createMockProvider({
       id: 'optimizer-provider',
       response: optimizerResponse('Optimized Seed'),
@@ -560,6 +560,12 @@ describe('prompt optimizer', () => {
       prompts: [{ raw: 'Seed', label: 'Seed' }],
       defaultTest: { prompts: ['Seed'] },
       tests: [{ prompts: ['Seed'] }],
+      scenarios: [
+        {
+          config: [{}],
+          tests: [{ prompts: ['Seed'] }],
+        },
+      ],
     };
 
     await optimizePromptTestSuite({}, testSuite);
@@ -571,6 +577,7 @@ describe('prompt optimizer', () => {
         ? candidateSuite.defaultTest.prompts
         : undefined,
     ).toEqual(['Seed', 'Seed [optimized 1]']);
+    expect(candidateSuite.scenarios?.[0].tests[0].prompts).toEqual(['Seed', 'Seed [optimized 1]']);
   });
 
   it('rejects validation splits for scenario-based optimization instead of pretending they are held out', async () => {
@@ -661,6 +668,20 @@ describe('prompt optimizer', () => {
     await expect(optimizePromptTestSuite({}, testSuite)).rejects.toThrow(
       'Prompt optimization requires at least one configured test or scenario.',
     );
+  });
+
+  it('rejects function-backed prompts before evaluating unchanged function output', async () => {
+    vi.mocked(evaluate).mockRejectedValue(new Error('baseline evaluation should not run'));
+    const testSuite: TestSuite = {
+      providers: [createMockProvider({ id: 'target-provider' })],
+      prompts: [{ raw: 'Seed', label: 'Seed', function: async () => 'Seed' }],
+      tests: [{}],
+    };
+
+    await expect(optimizePromptTestSuite({}, testSuite)).rejects.toThrow(
+      'Prompt optimization currently supports literal string prompts only.',
+    );
+    expect(evaluate).not.toHaveBeenCalled();
   });
 
   it('uses validation score to reject search-only overfitting when split is enabled', async () => {

--- a/test/optimizer/promptOptimizer.test.ts
+++ b/test/optimizer/promptOptimizer.test.ts
@@ -562,7 +562,7 @@ describe('prompt optimizer', () => {
       tests: [{ prompts: ['Seed'] }],
       scenarios: [
         {
-          config: [{}],
+          config: [{ prompts: ['Seed'] }],
           tests: [{ prompts: ['Seed'] }],
         },
       ],
@@ -577,6 +577,7 @@ describe('prompt optimizer', () => {
         ? candidateSuite.defaultTest.prompts
         : undefined,
     ).toEqual(['Seed', 'Seed [optimized 1]']);
+    expect(candidateSuite.scenarios?.[0].config[0].prompts).toEqual(['Seed', 'Seed [optimized 1]']);
     expect(candidateSuite.scenarios?.[0].tests[0].prompts).toEqual(['Seed', 'Seed [optimized 1]']);
   });
 


### PR DESCRIPTION
## Summary

- Extend optimized prompt labels into scenario-scoped prompt filters, alongside existing top-level and default-test routing.
- Reject function-backed prompts before baseline evaluation because rewritten prompt text would otherwise be replaced by the unchanged executable function.
- Add focused regressions for both optimizer correctness failures.

## Root Cause

Candidate-suite construction extended prompt filters for `tests` and `defaultTest` but left scenario prompt filters unchanged, so scenario-routed evaluations could silently exclude generated candidates. Separately, prompt objects with a `function` retain that executable function when candidates are built; evaluation runs the function and overwrites the optimized `raw` text, making an optimization score describe unchanged prompt behavior.

## Validation

- Confirmed the scenario regression failed before the source fix: the candidate suite retained only `['Seed']` for the scenario test route.
- Confirmed the function-backed prompt regression failed before the source fix: baseline evaluation ran instead of rejecting unsupported semantics.
- `npx vitest run test/optimizer/promptOptimizer.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l`
- `npm run tsc`
- `git diff --check`

## Scope

These are correctness fixes for the prompt optimizer and do not change red-team behavior or security boundaries. They are grouped because they share the candidate-suite construction and evaluation contract.
