### PR TITLE
fix(mcp): use cryptographic session identifiers

### DIFF
--- a/src/commands/mcp/server.ts
+++ b/src/commands/mcp/server.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import express from 'express';
 import logger from '../../logger';
 import telemetry from '../../telemetry';
@@ -27,7 +29,9 @@ function createMcpSdkDependencyError(): Error {
   );
 }
 
-async function loadMcpServerSdk(): Promise<typeof import('@modelcontextprotocol/sdk/server/mcp.js')> {
+async function loadMcpServerSdk(): Promise<
+  typeof import('@modelcontextprotocol/sdk/server/mcp.js')
+> {
   try {
     return await import('@modelcontextprotocol/sdk/server/mcp.js');
   } catch (error) {
@@ -132,7 +136,7 @@ export async function startHttpMcpServer(port: number): Promise<void> {
   // Set up HTTP transport for MCP
   const { StreamableHTTPServerTransport } = await loadMcpHttpTransport();
   const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => Math.random().toString(36).substring(2, 15),
+    sessionIdGenerator: () => randomUUID(),
   });
 
   await mcpServer.connect(transport);

--- a/test/commands/mcp/server.test.ts
+++ b/test/commands/mcp/server.test.ts
@@ -1,4 +1,36 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRandomUUID } = vi.hoisted(() => ({
+  mockRandomUUID: vi.fn(() => 'secure-mcp-session-id'),
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: mockRandomUUID,
+}));
+
+const expressMocks = vi.hoisted(() => {
+  const close = vi.fn((callback: (error?: Error) => void) => callback());
+  const listen = vi.fn((_port: number, callback: () => void) => {
+    callback();
+    return { close };
+  });
+  const app = {
+    use: vi.fn(),
+    post: vi.fn(),
+    get: vi.fn(),
+    listen,
+  };
+  const json = vi.fn();
+  const express = Object.assign(
+    vi.fn(() => app),
+    { json },
+  );
+  return { app, close, express, json, listen };
+});
+
+vi.mock('express', () => ({
+  default: expressMocks.express,
+}));
 
 // Mock dependencies before importing the module
 vi.mock('../../../src/logger', () => ({
@@ -78,6 +110,7 @@ const mcpServerMocks = vi.hoisted(() => {
   const mockMcpServerImplementation = function MockMcpServer(
     this: {
       connect: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
       tool: ReturnType<typeof vi.fn>;
       resource: ReturnType<typeof vi.fn>;
     },
@@ -85,6 +118,7 @@ const mcpServerMocks = vi.hoisted(() => {
   ) {
     mcpServerCalls.push(config);
     this.connect = vi.fn();
+    this.close = vi.fn().mockResolvedValue(undefined);
     this.tool = vi.fn();
     this.resource = vi.fn();
   };
@@ -101,20 +135,32 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: vi.fn().mockImplementation(() => ({})),
 }));
 
+const streamableHttpMocks = vi.hoisted(() => ({
+  constructor: vi.fn().mockImplementation(function MockStreamableHTTPServerTransport() {
+    return {
+      handleRequest: vi.fn(),
+    };
+  }),
+}));
+
 vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: vi.fn().mockImplementation(() => ({
-    handleRequest: vi.fn(),
-  })),
+  StreamableHTTPServerTransport: streamableHttpMocks.constructor,
 }));
 
 const { mcpServerCalls } = mcpServerMocks;
 
 describe('MCP Server', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mcpServerMocks.MockMcpServer.mockReset().mockImplementation(
       mcpServerMocks.mockMcpServerImplementation,
     );
+    streamableHttpMocks.constructor.mockClear();
+    mockRandomUUID.mockClear();
     mcpServerCalls.length = 0;
   });
 
@@ -234,6 +280,34 @@ describe('MCP Server', () => {
         feature: 'mcp_server',
         transport: expect.any(String),
       });
+    });
+  });
+
+  describe('startHttpMcpServer', () => {
+    it('creates cryptographically random session identifiers', async () => {
+      let shutdown: (() => void) | undefined;
+      vi.spyOn(process, 'once').mockImplementation(((event: string, listener: () => void) => {
+        if (event === 'SIGINT') {
+          shutdown = listener;
+        }
+        return process;
+      }) as typeof process.once);
+
+      const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
+      const serverPromise = startHttpMcpServer(3100);
+
+      await vi.waitFor(() => {
+        expect(streamableHttpMocks.constructor).toHaveBeenCalledOnce();
+      });
+
+      const transportOptions = streamableHttpMocks.constructor.mock.calls[0][0] as {
+        sessionIdGenerator: () => string;
+      };
+      expect(transportOptions.sessionIdGenerator()).toBe('secure-mcp-session-id');
+      expect(mockRandomUUID).toHaveBeenCalledOnce();
+
+      shutdown?.();
+      await serverPromise;
     });
   });
 });

--- a/test/commands/mcp/server.test.ts
+++ b/test/commands/mcp/server.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockProcessEnv } from '../../util/utils';
 
 const { mockRandomUUID } = vi.hoisted(() => ({
   mockRandomUUID: vi.fn(() => 'secure-mcp-session-id'),
@@ -285,6 +286,7 @@ describe('MCP Server', () => {
 
   describe('startHttpMcpServer', () => {
     it('creates cryptographically random session identifiers', async () => {
+      const restoreEnv = mockProcessEnv({ MCP_TRANSPORT: undefined });
       let shutdown: (() => void) | undefined;
       vi.spyOn(process, 'once').mockImplementation(((event: string, listener: () => void) => {
         if (event === 'SIGINT') {
@@ -293,21 +295,27 @@ describe('MCP Server', () => {
         return process;
       }) as typeof process.once);
 
-      const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
-      const serverPromise = startHttpMcpServer(3100);
+      let serverPromise: Promise<void> | undefined;
+      try {
+        const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
+        serverPromise = startHttpMcpServer(3100);
 
-      await vi.waitFor(() => {
-        expect(streamableHttpMocks.constructor).toHaveBeenCalledOnce();
-      });
+        await vi.waitFor(() => {
+          expect(streamableHttpMocks.constructor).toHaveBeenCalledOnce();
+        });
 
-      const transportOptions = streamableHttpMocks.constructor.mock.calls[0][0] as {
-        sessionIdGenerator: () => string;
-      };
-      expect(transportOptions.sessionIdGenerator()).toBe('secure-mcp-session-id');
-      expect(mockRandomUUID).toHaveBeenCalledOnce();
-
-      shutdown?.();
-      await serverPromise;
+        const transportOptions = streamableHttpMocks.constructor.mock.calls[0][0] as {
+          sessionIdGenerator: () => string;
+        };
+        expect(transportOptions.sessionIdGenerator()).toBe('secure-mcp-session-id');
+        expect(mockRandomUUID).toHaveBeenCalledOnce();
+      } finally {
+        if (shutdown) {
+          shutdown();
+          await serverPromise;
+        }
+        restoreEnv();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace HTTP MCP session identifiers based on `Math.random()` with `crypto.randomUUID()`
- add focused coverage for HTTP transport session ID generation without opening a real listener

## Why
MCP HTTP session identifiers should use platform cryptographic randomness rather than short pseudo-random strings. This is a targeted hardening improvement consistent with the local-interface security model.

## Validation
- `npm run l`
- `npm run f`
- `./node_modules/.bin/vitest run test/commands/mcp/server.test.ts --sequence.shuffle=false --configLoader runner`
- `./node_modules/.bin/tsc --noEmit`
