### PR TITLE
fix(providers): return refreshed HTTP auth tokens safely

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -22,7 +22,7 @@ import { loadFunction, parseFileUrl } from '../util/functions/loadFunction';
 import { renderVarsInObject } from '../util/index';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
-import { TOKEN_REFRESH_BUFFER_MS, type TokenRefreshLock } from '../util/oauth';
+import { TOKEN_REFRESH_BUFFER_MS } from '../util/oauth';
 import { safeResolve } from '../util/pathUtils';
 import {
   isSecretField,
@@ -850,6 +850,10 @@ type FileAuthResult = {
 type CachedAuthToken = {
   token: string;
   expiresAt?: number;
+};
+
+type AuthTokenRefreshLock = {
+  promise: Promise<CachedAuthToken>;
 };
 
 /**
@@ -1880,7 +1884,7 @@ export class HttpProvider implements ApiProvider {
   private lastSignatureTimestamp?: number;
   private lastSignature?: string;
   private authTokenCache = new Map<string, CachedAuthToken>();
-  private tokenRefreshLocks = new Map<string, TokenRefreshLock>();
+  private tokenRefreshLocks = new Map<string, AuthTokenRefreshLock>();
   private httpsAgent?: Dispatcher;
   private httpsAgentPromise?: Promise<Dispatcher>;
   /**
@@ -2025,12 +2029,9 @@ export class HttpProvider implements ApiProvider {
     }
 
     logger.debug('[HTTP Provider Auth]: Starting or waiting for OAuth token refresh');
-    await this.refreshTokenWithLock(cacheKey, () =>
+    return this.refreshTokenWithLock(cacheKey, () =>
       this.performTokenRefresh(oauthConfig, cacheKey),
     );
-    const refreshedToken = this.authTokenCache.get(cacheKey);
-    invariant(refreshedToken, 'OAuth token should be cached after refresh');
-    return refreshedToken;
   }
 
   private async performTokenRefresh(
@@ -2044,7 +2045,7 @@ export class HttpProvider implements ApiProvider {
       password?: string;
     },
     cacheKey: string,
-  ): Promise<void> {
+  ): Promise<CachedAuthToken> {
     try {
       // Prepare the token request body
       const tokenRequestBody = new URLSearchParams();
@@ -2108,22 +2109,22 @@ export class HttpProvider implements ApiProvider {
       // expires_in is typically in seconds, default to 3600 (1 hour) if not provided
       const expiresInSeconds = tokenData.expires_in || 3600;
       const expiresAt = Date.now() + expiresInSeconds * 1000;
-      this.cacheToken(cacheKey, tokenData.access_token, expiresAt);
+      const cachedToken = this.cacheToken(cacheKey, tokenData.access_token, expiresAt);
 
       logger.debug('[HTTP Provider Auth]: Successfully refreshed OAuth token');
+      return cachedToken;
     } catch (err) {
       logger.error(`[HTTP Provider Auth]: Failed to refresh OAuth token: ${String(err)}`);
       throw new Error(`Failed to refresh OAuth token: ${String(err)}`);
     }
-
-    invariant(this.authTokenCache.has(cacheKey), 'OAuth token should be cached at this point');
   }
 
-  private cacheToken(cacheKey: string, token: string, expiresAt?: number): void {
+  private cacheToken(cacheKey: string, token: string, expiresAt?: number): CachedAuthToken {
     const cachedToken = { token, expiresAt };
     this.pruneExpiredAuthTokens();
     this.authTokenCache.set(cacheKey, cachedToken);
     this.enforceAuthTokenCacheLimit();
+    return cachedToken;
   }
 
   private getValidCachedToken(cacheKey: string, now = Date.now()): CachedAuthToken | undefined {
@@ -2169,20 +2170,18 @@ export class HttpProvider implements ApiProvider {
     }
   }
 
-  private async waitForInFlightTokenRefresh(cacheKey: string): Promise<boolean> {
+  private async waitForInFlightTokenRefresh(
+    cacheKey: string,
+  ): Promise<CachedAuthToken | undefined> {
     const refreshLock = this.tokenRefreshLocks.get(cacheKey);
     if (refreshLock == null) {
-      return false;
+      return undefined;
     }
 
     logger.debug('[HTTP Provider Auth]: Token refresh already in progress, waiting...');
 
     try {
-      await refreshLock.promise;
-      if (this.getValidCachedToken(cacheKey)) {
-        return true;
-      }
-      logger.debug('[HTTP Provider Auth]: Token expired while waiting, refreshing again...');
+      return await refreshLock.promise;
     } catch {
       if (this.tokenRefreshLocks.get(cacheKey) === refreshLock) {
         this.tokenRefreshLocks.delete(cacheKey);
@@ -2190,27 +2189,27 @@ export class HttpProvider implements ApiProvider {
       logger.debug('[HTTP Provider Auth]: Previous token refresh failed, retrying...');
     }
 
-    return false;
+    return undefined;
   }
 
   private async refreshTokenWithLock(
     cacheKey: string,
-    refreshToken: () => Promise<void>,
+    refreshToken: () => Promise<CachedAuthToken>,
     onLockAcquired?: () => void,
-  ): Promise<void> {
+  ): Promise<CachedAuthToken> {
     while (this.tokenRefreshLocks.has(cacheKey)) {
-      if (await this.waitForInFlightTokenRefresh(cacheKey)) {
-        return;
+      const refreshedToken = await this.waitForInFlightTokenRefresh(cacheKey);
+      if (refreshedToken) {
+        return refreshedToken;
       }
     }
 
-    const refreshLock = { promise: Promise.resolve() as Promise<void> };
+    const refreshLock = { promise: Promise.resolve().then(refreshToken) };
     this.tokenRefreshLocks.set(cacheKey, refreshLock);
     onLockAcquired?.();
-    refreshLock.promise = Promise.resolve().then(refreshToken);
 
     try {
-      await refreshLock.promise;
+      return await refreshLock.promise;
     } finally {
       // Only clear the lock if it's still the one we created (prevents race conditions)
       if (this.tokenRefreshLocks.get(cacheKey) === refreshLock) {
@@ -2238,22 +2237,19 @@ export class HttpProvider implements ApiProvider {
     }
 
     logger.debug('[HTTP Provider Auth]: Starting or waiting for file auth token refresh');
-    await this.refreshTokenWithLock(
+    return this.refreshTokenWithLock(
       cacheKey,
       () => this.performFileTokenRefresh(authContext, cacheKey),
       () => {
         logger.debug('[HTTP Provider Auth]: Acquired file auth refresh lock');
       },
     );
-    const refreshedToken = this.authTokenCache.get(cacheKey);
-    invariant(refreshedToken, 'File auth token should be cached after refresh');
-    return refreshedToken;
   }
 
   private async performFileTokenRefresh(
     authContext: CallApiContextParams,
     cacheKey?: string,
-  ): Promise<void> {
+  ): Promise<CachedAuthToken> {
     invariant(this.config.auth?.type === 'file', 'File auth should be configured');
     invariant(cacheKey, 'File auth cache key should be defined');
 
@@ -2272,16 +2268,15 @@ export class HttpProvider implements ApiProvider {
         defaultFunctionName,
       });
       const result = FileAuthResultSchema.parse(await authFn(authContext));
-      this.cacheToken(cacheKey, result.token, result.expiration ?? undefined);
+      const cachedToken = this.cacheToken(cacheKey, result.token, result.expiration ?? undefined);
       logger.info(
         `[HTTP Provider Auth]: Successfully refreshed file auth token (${formatFileAuthFreshness(result.expiration)})`,
       );
+      return cachedToken;
     } catch (err) {
       logger.error(`[HTTP Provider Auth]: Failed to refresh file auth token: ${String(err)}`);
       throw new Error(`Failed to refresh file auth token: ${String(err)}`);
     }
-
-    invariant(this.authTokenCache.has(cacheKey), 'File auth token should be cached at this point');
   }
 
   private async refreshSignatureIfNeeded(vars: Record<string, any>): Promise<void> {

--- a/test/providers/http/auth.test.ts
+++ b/test/providers/http/auth.test.ts
@@ -545,6 +545,70 @@ describe('HttpProvider - OAuth Token Refresh Deduplication', () => {
     expect(cacheKeys.join('\n')).not.toContain('test-client-id');
   });
 
+  it('should return refreshed OAuth tokens when concurrent keys exceed the cache limit', async () => {
+    let releaseRefreshes!: () => void;
+    const refreshesBlocked = new Promise<void>((resolve) => {
+      releaseRefreshes = resolve;
+    });
+    const provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer {{token}}',
+        },
+        auth: {
+          type: 'oauth',
+          grantType: 'client_credentials',
+          tokenUrl,
+          clientId: 'test-client-id',
+          clientSecret: '{{ clientSecret }}',
+        },
+      },
+    });
+
+    const apiAuthHeaders = new Set<string>();
+    vi.mocked(fetchWithCache).mockImplementation(async (url: RequestInfo, options: any) => {
+      const urlString =
+        typeof url === 'string' ? url : url instanceof Request ? url.url : String(url);
+      if (urlString === tokenUrl) {
+        tokenRefreshCallCount += 1;
+        await refreshesBlocked;
+        const clientSecret = new URLSearchParams(String(options.body)).get('client_secret');
+        return {
+          data: JSON.stringify({
+            access_token: `token-${clientSecret}`,
+            expires_in: 3600,
+          }),
+          status: 200,
+          statusText: 'OK',
+          cached: false,
+        };
+      }
+
+      apiAuthHeaders.add(options.headers.authorization);
+      return {
+        data: JSON.stringify({ result: 'success' }),
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      };
+    });
+
+    const requests = Array.from({ length: 257 }, (_, index) =>
+      provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: { clientSecret: `secret-${index}` },
+      }),
+    );
+
+    await vi.waitFor(() => expect(tokenRefreshCallCount).toBe(257));
+    releaseRefreshes();
+
+    await expect(Promise.all(requests)).resolves.toHaveLength(257);
+    expect(apiAuthHeaders.size).toBe(257);
+    expect((provider as any).authTokenCache.size).toBe(256);
+  });
+
   it('should not cross-use OAuth tokens across concurrent raw requests', async () => {
     let releaseFirstTransform!: () => void;
     let resolveFirstTransformStarted!: () => void;

--- a/test/providers/http/auth.test.ts
+++ b/test/providers/http/auth.test.ts
@@ -1746,6 +1746,52 @@ describe('HttpProvider - File Auth', () => {
     expect(cachedTokens).toContain('token-for-user-259');
   });
 
+  it('should return refreshed file auth tokens when concurrent keys exceed the cache limit', async () => {
+    let releaseRefreshes!: () => void;
+    const refreshesBlocked = new Promise<void>((resolve) => {
+      releaseRefreshes = resolve;
+    });
+    const authFn = vi.fn(async (authContext: any) => {
+      await refreshesBlocked;
+      return {
+        token: `token-for-${authContext.vars.userId}`,
+      };
+    });
+    vi.mocked(importModule).mockImplementation(async () => ({ default: authFn }));
+
+    const provider = new HttpProvider(mockUrl, {
+      config: {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer {{token}}',
+        },
+        auth: {
+          type: 'file',
+          path: './auth/get-token.js',
+        },
+      },
+    });
+
+    const requests = Array.from({ length: 257 }, (_, index) =>
+      provider.callApi('same prompt', {
+        prompt: { raw: 'same prompt', label: 'same prompt' },
+        vars: { userId: `user-${index}` },
+      }),
+    );
+
+    await vi.waitFor(() => expect(authFn).toHaveBeenCalledTimes(257));
+    releaseRefreshes();
+
+    await expect(Promise.all(requests)).resolves.toHaveLength(257);
+    const authHeaders = new Set(
+      vi
+        .mocked(fetchWithCache)
+        .mock.calls.map((call) => (call[1]?.headers as Record<string, string>).authorization),
+    );
+    expect(authHeaders.size).toBe(257);
+    expect((provider as any).authTokenCache.size).toBe(256);
+  });
+
   it('should refresh a file auth token when it is within the oauth refresh buffer', async () => {
     const authFn = vi
       .fn()


### PR DESCRIPTION
## Summary

- Return newly refreshed HTTP authentication tokens directly through the in-flight refresh lock.
- Keep the 256-entry token cache capped for later reuse without making it the delivery channel for active requests.
- Apply the same result handoff to OAuth and file-auth refreshes through their shared lock path.
- Add a deterministic regression covering 257 concurrent distinct OAuth refresh contexts.

## Root Cause

After a successful refresh, the HTTP provider reread the token from its bounded reuse cache before serving the active request. With more concurrent distinct refresh contexts than cache slots, later insertions evicted an earlier freshly produced token before its awaiting caller resumed, causing a successful authentication refresh to throw `OAuth token should be cached after refresh`.

The refresh result now flows through the lock promise itself. Cache eviction can still limit future reuse, but it cannot invalidate a token already created for an active request.

## Validation

- Confirmed the new concurrency regression failed before the source fix with `Invariant failed: OAuth token should be cached after refresh`.
- `npx vitest run test/providers/http/auth.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l` (passes with existing complexity warnings in the broad HTTP provider)
- `npm run tsc`
- `git diff --check`

## Scope

This is an authentication reliability/correctness fix. It does not expose credentials, alter token cache size, or change security policy.

## Follow-Up Not Included

Biome identifies existing complexity hotspots in `src/providers/http.ts` (`preprocessSignatureAuthConfig`, `generateSignature`, `createHttpsAgent`, `callApiInternal`, and `callApiWithRawRequest`). They are legitimate simplification candidates, but refactoring them here would enlarge the review surface of a focused concurrency fix.
