### PR TITLE
fix(eval): preserve all distinct CallApiFunction providers in combineConfigs

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -431,7 +431,7 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
   }
 
   const providers: UnifiedConfig['providers'] = [];
-  const seenProviders = new Set<string>();
+  const seenProviders = new Set<unknown>();
   configs.forEach((config) => {
     invariant(
       typeof config.providers !== 'function',
@@ -444,9 +444,12 @@ export async function combineConfigs(configPaths: string[]): Promise<UnifiedConf
       }
     } else if (Array.isArray(config.providers)) {
       config.providers.forEach((provider) => {
-        if (!seenProviders.has(JSON.stringify(provider))) {
+        // Functions are not JSON-serializable; use reference identity as the dedup key
+        // so that distinct CallApiFunction providers are all preserved.
+        const key = typeof provider === 'function' ? provider : JSON.stringify(provider);
+        if (!seenProviders.has(key)) {
           providers.push(provider);
-          seenProviders.add(JSON.stringify(provider));
+          seenProviders.add(key);
         }
       });
     }

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1182,6 +1182,48 @@ describe('combineConfigs', () => {
     // When no defaultTest is provided, combineConfigs returns undefined
     expect(result.defaultTest).toBeUndefined();
   });
+
+  it('should preserve all distinct CallApiFunction providers without deduplication', async () => {
+    const providerA = async (prompt: string) => ({ output: `a: ${prompt}` });
+    const providerB = async (prompt: string) => ({ output: `b: ${prompt}` });
+    const providerC = async (prompt: string) => ({ output: `c: ${prompt}` });
+
+    const mockConfig = {
+      prompts: ['{{prompt}}'],
+      providers: [providerA, providerB, providerC],
+      tests: [{ vars: { prompt: 'hi' } }],
+    };
+
+    vi.mocked(importModule).mockResolvedValue(mockConfig);
+
+    const result = await combineConfigs(['config.ts']);
+
+    // All three distinct function providers must be preserved.
+    // Previously JSON.stringify(fn) === undefined for all functions, so only
+    // the first survived the dedup Set check.
+    expect(result.providers).toHaveLength(3);
+    expect(result.providers).toContain(providerA);
+    expect(result.providers).toContain(providerB);
+    expect(result.providers).toContain(providerC);
+  });
+
+  it('should deduplicate the same CallApiFunction instance when it appears multiple times', async () => {
+    const sharedProvider = async (prompt: string) => ({ output: `shared: ${prompt}` });
+
+    const mockConfig = {
+      prompts: ['{{prompt}}'],
+      providers: [sharedProvider, sharedProvider],
+      tests: [{ vars: { prompt: 'hi' } }],
+    };
+
+    vi.mocked(importModule).mockResolvedValue(mockConfig);
+
+    const result = await combineConfigs(['config.ts']);
+
+    // The same function reference listed twice should be deduplicated to one entry.
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers).toContain(sharedProvider);
+  });
 });
 
 describe('dereferenceConfig', () => {


### PR DESCRIPTION
## Problem

When a TypeScript config passes multiple distinct `CallApiFunction` providers, `combineConfigs` silently drops all but the first. Reproducer from issue #9383:

```typescript
const config: TestSuiteConfig = {
  prompts: ['{{prompt}}'],
  providers: [makeProvider('a'), makeProvider('b'), makeProvider('c')],
  tests: [{ vars: { prompt: 'hi' } }],
};
```

Running `promptfoo eval` produces only one result column instead of three.

## Root cause

`combineConfigs` deduplicates providers using a `Set<string>` keyed on `JSON.stringify(provider)`. For function values, `JSON.stringify` returns `undefined` — not a unique string. So every `CallApiFunction` after the first finds `undefined` already in the Set and is discarded.

```typescript
// before — all functions stringify to undefined → only first survives
const seenProviders = new Set<string>();
config.providers.forEach((provider) => {
  if (!seenProviders.has(JSON.stringify(provider))) { // false for fn #1, true for all others
    providers.push(provider);
    seenProviders.add(JSON.stringify(provider));       // adds undefined
  }
});
```

## Fix

When the provider is a function, use the function reference itself as the dedup key (reference equality). Non-function providers continue to use `JSON.stringify` (value equality). The Set is widened to `Set<unknown>` to accommodate both.

```typescript
const seenProviders = new Set<unknown>();
config.providers.forEach((provider) => {
  const key = typeof provider === 'function' ? provider : JSON.stringify(provider);
  if (!seenProviders.has(key)) {
    providers.push(provider);
    seenProviders.add(key);
  }
});
```

This means:
- **Distinct** function providers (different references) → all preserved
- **Same** function reference listed twice → deduplicated to one
- String / object providers → behaviour unchanged

## Tests

Two new tests added to `test/util/config/load.test.ts` inside the `combineConfigs` describe block:

1. `should preserve all distinct CallApiFunction providers without deduplication` — three distinct async functions → all three survive.
2. `should deduplicate the same CallApiFunction instance when it appears multiple times` — same reference twice → collapsed to one.

All 108 tests in the file pass.

## Prior art

No prior PRs found targeting this specific issue.

Fixes #9383