### PR TITLE
fix: handle chart and Google response edge cases

### DIFF
--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -404,14 +404,19 @@ describe('ResultsCharts', () => {
         .mocked(Chart)
         .mock.calls.map(([, config]) => config)
         .find((config) => 'type' in config && config.type === 'scatter');
-      const scatterData = scatterConfig?.data?.datasets[0].data;
+      const scatterData = scatterConfig?.data?.datasets[0].data as
+        | Array<{ x: number; y: number; rowIndex: number }>
+        | undefined;
+      const tooltipLabel = scatterConfig?.options?.plugins?.tooltip?.callbacks?.label as
+        | ((context: { dataIndex: number; raw?: unknown }) => string)
+        | undefined;
 
       expect(scatterData).toEqual([expect.objectContaining({ x: 0.6, y: 0.8, rowIndex: 1 })]);
       expect(
-        scatterConfig?.options?.plugins?.tooltip?.callbacks?.label?.({
+        tooltipLabel?.({
           dataIndex: 0,
           raw: scatterData?.[0],
-        } as any),
+        }),
       ).toContain('right first output');
     });
 

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -360,7 +360,7 @@ describe('ResultsCharts', () => {
       const scatterConfig = vi
         .mocked(Chart)
         .mock.calls.map(([, config]) => config)
-        .find((config) => config.type === 'scatter');
+        .find((config) => 'type' in config && config.type === 'scatter');
       expect(scatterConfig?.data?.datasets[0].data).toEqual([]);
     });
 

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -356,6 +356,12 @@ describe('ResultsCharts', () => {
       expect(() => {
         render(<ResultsCharts {...defaultProps} scores={scores} />);
       }).not.toThrow();
+
+      const scatterConfig = vi
+        .mocked(Chart)
+        .mock.calls.map(([, config]) => config)
+        .find((config) => config.type === 'scatter');
+      expect(scatterConfig?.data?.datasets[0].data).toEqual([]);
     });
 
     it('handles empty recentEvals array gracefully', () => {

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -364,6 +364,57 @@ describe('ResultsCharts', () => {
       expect(scatterConfig?.data?.datasets[0].data).toEqual([]);
     });
 
+    it('uses the source row when rendering scatter tooltips after filtering points', () => {
+      const mockTableWithSkippedRow = {
+        head: {
+          prompts: [{ provider: 'test-provider-1' }, { provider: 'test-provider-2' }],
+          vars: [],
+        },
+        body: [
+          {
+            outputs: [
+              { score: Number.NaN, pass: false, text: 'wrong first output' },
+              { score: 0.1, pass: false, text: 'wrong second output' },
+            ],
+            vars: [],
+          },
+          {
+            outputs: [
+              { score: 0.6, pass: true, text: 'right first output' },
+              { score: 0.8, pass: true, text: 'right second output' },
+            ],
+            vars: [],
+          },
+        ],
+      };
+
+      const scores = calculateScores(mockTableWithSkippedRow);
+
+      vi.mocked(useTableStore).mockReturnValue({
+        table: mockTableWithSkippedRow,
+        evalId: 'test-eval',
+        config: { description: 'test config' },
+        setTable: vi.fn(),
+        fetchEvalData: vi.fn(),
+      });
+
+      render(<ResultsCharts {...defaultProps} scores={scores} />);
+
+      const scatterConfig = vi
+        .mocked(Chart)
+        .mock.calls.map(([, config]) => config)
+        .find((config) => 'type' in config && config.type === 'scatter');
+      const scatterData = scatterConfig?.data?.datasets[0].data;
+
+      expect(scatterData).toEqual([expect.objectContaining({ x: 0.6, y: 0.8, rowIndex: 1 })]);
+      expect(
+        scatterConfig?.options?.plugins?.tooltip?.callbacks?.label?.({
+          dataIndex: 0,
+          raw: scatterData?.[0],
+        } as any),
+      ).toContain('right first output');
+    });
+
     it('handles empty recentEvals array gracefully', () => {
       const mockTable = {
         head: {

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -40,6 +40,13 @@ interface ChartProps {
   datasetId?: string | null;
 }
 
+type ScatterPoint = {
+  x: number;
+  y: number;
+  backgroundColor: string;
+  rowIndex: number;
+};
+
 const COLOR_PALETTE = [
   '#fd7f6f',
   '#7eb0d5',
@@ -243,7 +250,7 @@ function ScatterChart({ table }: ChartProps) {
     const minScore = Math.min(...scores);
     const maxScore = Math.max(...scores);
 
-    const data = table.body.flatMap((row) => {
+    const data = table.body.flatMap<ScatterPoint>((row, rowIndex) => {
       const prompt1Score = row.outputs[xAxisPrompt]?.score;
       const prompt2Score = row.outputs[yAxisPrompt]?.score;
 
@@ -270,6 +277,7 @@ function ScatterChart({ table }: ChartProps) {
           x: prompt1Score,
           y: prompt2Score,
           backgroundColor,
+          rowIndex,
         },
       ];
     });
@@ -306,9 +314,16 @@ function ScatterChart({ table }: ChartProps) {
           tooltip: {
             callbacks: {
               label(tooltipItem: TooltipItem<'scatter'>) {
-                const row = table.body[tooltipItem.dataIndex];
-                let prompt1Text = row.outputs[0]?.text || 'No output';
-                let prompt2Text = row.outputs[1]?.text || 'No output';
+                const point = tooltipItem.raw as Partial<ScatterPoint> | undefined;
+                const rowIndex =
+                  typeof point?.rowIndex === 'number' ? point.rowIndex : tooltipItem.dataIndex;
+                const row = table.body[rowIndex];
+                if (!row) {
+                  return '';
+                }
+
+                let prompt1Text = row.outputs[xAxisPrompt]?.text || 'No output';
+                let prompt2Text = row.outputs[yAxisPrompt]?.text || 'No output';
                 if (prompt1Text.length > 30) {
                   prompt1Text = prompt1Text.substring(0, 30) + '...';
                 }

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -243,31 +243,36 @@ function ScatterChart({ table }: ChartProps) {
     const minScore = Math.min(...scores);
     const maxScore = Math.max(...scores);
 
-    const data = table.body
-      .map((row) => {
-        const prompt1Score = row.outputs[xAxisPrompt]?.score;
-        const prompt2Score = row.outputs[yAxisPrompt]?.score;
-        let backgroundColor;
-        if (prompt2Score > prompt1Score) {
-          backgroundColor = 'green';
-        } else if (prompt2Score < prompt1Score) {
-          backgroundColor = 'red';
-        } else {
-          backgroundColor = 'gray';
-        }
-        return {
+    const data = table.body.flatMap((row) => {
+      const prompt1Score = row.outputs[xAxisPrompt]?.score;
+      const prompt2Score = row.outputs[yAxisPrompt]?.score;
+
+      if (
+        typeof prompt1Score !== 'number' ||
+        Number.isNaN(prompt1Score) ||
+        typeof prompt2Score !== 'number' ||
+        Number.isNaN(prompt2Score)
+      ) {
+        return [];
+      }
+
+      let backgroundColor;
+      if (prompt2Score > prompt1Score) {
+        backgroundColor = 'green';
+      } else if (prompt2Score < prompt1Score) {
+        backgroundColor = 'red';
+      } else {
+        backgroundColor = 'gray';
+      }
+
+      return [
+        {
           x: prompt1Score,
           y: prompt2Score,
           backgroundColor,
-        };
-      })
-      .filter(
-        (point) =>
-          typeof point.x === 'number' &&
-          !Number.isNaN(point.x) &&
-          typeof point.y === 'number' &&
-          !Number.isNaN(point.y),
-      );
+        },
+      ];
+    });
 
     scatterChartInstance.current = new Chart(scatterCanvasRef.current, {
       type: 'scatter',
@@ -496,6 +501,11 @@ interface ProgressData {
   };
 }
 
+function getPassRate(metrics: ProgressData['metrics']): number {
+  const totalTests = metrics.testPassCount + metrics.testFailCount;
+  return totalTests === 0 ? 0 : (metrics.testPassCount / totalTests) * 100;
+}
+
 function PerformanceOverTimeChart({ evalId }: ChartProps) {
   const { config } = useTableStore();
   const lineCanvasRef = useRef(null);
@@ -510,8 +520,12 @@ function PerformanceOverTimeChart({ evalId }: ChartProps) {
 
       try {
         const res = await callApi(`/history?description=${encodeURIComponent(config.description)}`);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch progress data: ${res.status} ${res.statusText}`);
+        }
+
         const data = await res.json();
-        setProgressData(data.data);
+        setProgressData(Array.isArray(data?.data) ? data.data : []);
       } catch (error) {
         console.error('Error fetching progress data:', error);
       }
@@ -552,10 +566,7 @@ function PerformanceOverTimeChart({ evalId }: ChartProps) {
     const datasets = evaluations.reduce<
       Record<number, { x: number; y: number; evalData: ProgressData }[]>
     >((acc, eval_) => {
-      const passRate =
-        (eval_.metrics.testPassCount /
-          (eval_.metrics.testPassCount + eval_.metrics.testFailCount)) *
-        100;
+      const passRate = getPassRate(eval_.metrics);
 
       if (!acc[eval_.evaluationNumber]) {
         acc[eval_.evaluationNumber] = [];
@@ -611,10 +622,7 @@ function PerformanceOverTimeChart({ evalId }: ChartProps) {
                 evalData: ProgressData;
               };
               const { evalData } = item;
-              const passRate =
-                (evalData.metrics.testPassCount /
-                  (evalData.metrics.testPassCount + evalData.metrics.testFailCount)) *
-                100;
+              const passRate = getPassRate(evalData.metrics);
               return [
                 `Label: ${evalData.label}`,
                 `Provider: ${evalData.provider}`,

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -13,6 +13,8 @@ import {
   formatCandidateContents,
   geminiFormatAndSystemInstructions,
   getCandidate,
+  getLastPromptSafetyRatings,
+  isNonCandidateStreamChunk,
   mergeGoogleCompletionOptions,
   mergeParts,
   normalizeSafetySettings,
@@ -380,19 +382,17 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
     }
 
     const dataWithResponse = (Array.isArray(data) ? data : [data]) as GeminiResponseData[];
-    const lastData = dataWithResponse[dataWithResponse.length - 1] ?? data;
-    const lastDataWithCandidate =
-      dataWithResponse.filter((datum) => datum.candidates?.length).at(-1) ?? lastData;
+    const lastData = dataWithResponse[dataWithResponse.length - 1];
+    if (!lastData) {
+      return {
+        error: `No response data found in response: ${JSON.stringify(data)}`,
+      };
+    }
     let output: ReturnType<typeof formatCandidateContents> | undefined;
-    let candidate;
+    let candidate: ReturnType<typeof getCandidate> | undefined;
     try {
       for (const datum of dataWithResponse) {
-        if (
-          Array.isArray(data) &&
-          !datum.candidates?.length &&
-          datum.usageMetadata &&
-          !datum.promptFeedback
-        ) {
+        if (Array.isArray(data) && isNonCandidateStreamChunk(datum)) {
           continue;
         }
 
@@ -400,7 +400,7 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
         output = mergeParts(output, formatCandidateContents(candidate));
       }
 
-      if (output === undefined) {
+      if (output === undefined || candidate === undefined) {
         throw new Error(`No output found in response: ${JSON.stringify(data)}`);
       }
     } catch (err) {
@@ -408,15 +408,17 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
         error: `${String(err)}`,
       };
     }
+    const finalCandidate = candidate;
 
     try {
       let guardrails: GuardrailResponse | undefined;
+      const promptSafetyRatings = getLastPromptSafetyRatings(dataWithResponse);
 
-      if (lastDataWithCandidate.promptFeedback?.safetyRatings || candidate.safetyRatings) {
-        const flaggedInput = lastDataWithCandidate.promptFeedback?.safetyRatings?.some(
+      if (promptSafetyRatings || finalCandidate.safetyRatings) {
+        const flaggedInput = promptSafetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
+        const flaggedOutput = finalCandidate.safetyRatings?.some(
           (r) => r.probability !== 'NEGLIGIBLE',
         );
-        const flaggedOutput = candidate.safetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
         const flagged = flaggedInput || flaggedOutput;
 
         guardrails = {
@@ -477,10 +479,18 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
         cached,
         ...(guardrails && { guardrails }),
         metadata: {
-          ...(candidate.groundingChunks && { groundingChunks: candidate.groundingChunks }),
-          ...(candidate.groundingMetadata && { groundingMetadata: candidate.groundingMetadata }),
-          ...(candidate.groundingSupports && { groundingSupports: candidate.groundingSupports }),
-          ...(candidate.webSearchQueries && { webSearchQueries: candidate.webSearchQueries }),
+          ...(finalCandidate.groundingChunks && {
+            groundingChunks: finalCandidate.groundingChunks,
+          }),
+          ...(finalCandidate.groundingMetadata && {
+            groundingMetadata: finalCandidate.groundingMetadata,
+          }),
+          ...(finalCandidate.groundingSupports && {
+            groundingSupports: finalCandidate.groundingSupports,
+          }),
+          ...(finalCandidate.webSearchQueries && {
+            webSearchQueries: finalCandidate.webSearchQueries,
+          }),
         },
       };
     } catch (err) {

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -14,6 +14,7 @@ import {
   geminiFormatAndSystemInstructions,
   getCandidate,
   mergeGoogleCompletionOptions,
+  mergeParts,
   normalizeSafetySettings,
   removeGoogleFunctionDeclarations,
   resolveGoogleToolConfig,
@@ -378,10 +379,30 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
       };
     }
 
-    let output, candidate;
+    const dataWithResponse = (Array.isArray(data) ? data : [data]) as GeminiResponseData[];
+    const lastData = dataWithResponse[dataWithResponse.length - 1] ?? data;
+    const lastDataWithCandidate =
+      dataWithResponse.filter((datum) => datum.candidates?.length).at(-1) ?? lastData;
+    let output: ReturnType<typeof formatCandidateContents> | undefined;
+    let candidate;
     try {
-      candidate = getCandidate(data);
-      output = formatCandidateContents(candidate);
+      for (const datum of dataWithResponse) {
+        if (
+          Array.isArray(data) &&
+          !datum.candidates?.length &&
+          datum.usageMetadata &&
+          !datum.promptFeedback
+        ) {
+          continue;
+        }
+
+        candidate = getCandidate(datum);
+        output = mergeParts(output, formatCandidateContents(candidate));
+      }
+
+      if (output === undefined) {
+        throw new Error(`No output found in response: ${JSON.stringify(data)}`);
+      }
     } catch (err) {
       return {
         error: `${String(err)}`,
@@ -391,8 +412,8 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
     try {
       let guardrails: GuardrailResponse | undefined;
 
-      if (data.promptFeedback?.safetyRatings || candidate.safetyRatings) {
-        const flaggedInput = data.promptFeedback?.safetyRatings?.some(
+      if (lastDataWithCandidate.promptFeedback?.safetyRatings || candidate.safetyRatings) {
+        const flaggedInput = lastDataWithCandidate.promptFeedback?.safetyRatings?.some(
           (r) => r.probability !== 'NEGLIGIBLE',
         );
         const flaggedOutput = candidate.safetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
@@ -407,25 +428,25 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
 
       const tokenUsage = cached
         ? {
-            cached: data.usageMetadata?.totalTokenCount,
-            total: data.usageMetadata?.totalTokenCount,
+            cached: lastData.usageMetadata?.totalTokenCount,
+            total: lastData.usageMetadata?.totalTokenCount,
             numRequests: 0,
-            ...(data.usageMetadata?.thoughtsTokenCount !== undefined && {
+            ...(lastData.usageMetadata?.thoughtsTokenCount !== undefined && {
               completionDetails: {
-                reasoning: data.usageMetadata.thoughtsTokenCount,
+                reasoning: lastData.usageMetadata.thoughtsTokenCount,
                 acceptedPrediction: 0,
                 rejectedPrediction: 0,
               },
             }),
           }
         : {
-            prompt: data.usageMetadata?.promptTokenCount,
-            completion: data.usageMetadata?.candidatesTokenCount,
-            total: data.usageMetadata?.totalTokenCount,
+            prompt: lastData.usageMetadata?.promptTokenCount,
+            completion: lastData.usageMetadata?.candidatesTokenCount,
+            total: lastData.usageMetadata?.totalTokenCount,
             numRequests: 1,
-            ...(data.usageMetadata?.thoughtsTokenCount !== undefined && {
+            ...(lastData.usageMetadata?.thoughtsTokenCount !== undefined && {
               completionDetails: {
-                reasoning: data.usageMetadata.thoughtsTokenCount,
+                reasoning: lastData.usageMetadata.thoughtsTokenCount,
                 acceptedPrediction: 0,
                 rejectedPrediction: 0,
               },
@@ -435,15 +456,16 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
       // Calculate cost (only for non-cached responses)
       // Include thinking tokens in output cost - Google bills them as output tokens
       const completionForCost =
-        data.usageMetadata?.candidatesTokenCount == null
+        lastData.usageMetadata?.candidatesTokenCount == null
           ? undefined
-          : data.usageMetadata.candidatesTokenCount + (data.usageMetadata?.thoughtsTokenCount ?? 0);
+          : lastData.usageMetadata.candidatesTokenCount +
+            (lastData.usageMetadata?.thoughtsTokenCount ?? 0);
       const cost = cached
         ? undefined
         : calculateGoogleCost(
             this.modelName,
             config,
-            data.usageMetadata?.promptTokenCount,
+            lastData.usageMetadata?.promptTokenCount,
             completionForCost,
           );
 

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -396,7 +396,12 @@ export class AIStudioChatProvider extends GoogleGenericProvider {
           continue;
         }
 
-        candidate = getCandidate(datum);
+        const candidateForChunk = getCandidate(datum);
+        if (candidateForChunk.finishReason === 'STOP' && !candidateForChunk.content?.parts) {
+          continue;
+        }
+
+        candidate = candidateForChunk;
         output = mergeParts(output, formatCandidateContents(candidate));
       }
 

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -538,6 +538,15 @@ export class GoogleProvider extends GoogleGenericProvider {
           };
         }
 
+        if (
+          Array.isArray(data) &&
+          !datum.candidates?.length &&
+          datum.usageMetadata &&
+          !datum.promptFeedback
+        ) {
+          continue;
+        }
+
         const candidate = getCandidate(datum);
         const safetyFinishReasons = [
           'SAFETY',
@@ -583,11 +592,13 @@ export class GoogleProvider extends GoogleGenericProvider {
           };
         } else if (candidate.content?.parts) {
           output = formatCandidateContents(candidate);
-        } else {
-          return {
-            error: `No output found in response: ${JSON.stringify(data)}`,
-          };
         }
+      }
+
+      if (output === undefined) {
+        return {
+          error: `No output found in response: ${JSON.stringify(data)}`,
+        };
       }
 
       const lastData = dataWithResponse[dataWithResponse.length - 1];
@@ -619,9 +630,11 @@ export class GoogleProvider extends GoogleGenericProvider {
           };
 
       let guardrails: GuardrailResponse | undefined;
-      const candidate = getCandidate(lastData);
-      if (lastData.promptFeedback?.safetyRatings || candidate.safetyRatings) {
-        const flaggedInput = lastData.promptFeedback?.safetyRatings?.some(
+      const lastDataWithCandidate =
+        dataWithResponse.filter((datum) => datum.candidates?.length).at(-1) ?? lastData;
+      const candidate = getCandidate(lastDataWithCandidate);
+      if (lastDataWithCandidate.promptFeedback?.safetyRatings || candidate.safetyRatings) {
+        const flaggedInput = lastDataWithCandidate.promptFeedback?.safetyRatings?.some(
           (r) => r.probability !== 'NEGLIGIBLE',
         );
         const flaggedOutput = candidate.safetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
@@ -631,6 +644,7 @@ export class GoogleProvider extends GoogleGenericProvider {
 
       // Extract grounding metadata
       const candidateWithMetadata = dataWithResponse
+        .filter((datum) => datum.candidates?.length)
         .map((datum) => getCandidate(datum))
         .find(
           (c) =>

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -29,6 +29,8 @@ import {
   geminiFormatAndSystemInstructions,
   getCandidate,
   getGoogleClient,
+  getLastPromptSafetyRatings,
+  isNonCandidateStreamChunk,
   loadCredentials,
   mergeGoogleCompletionOptions,
   mergeParts,
@@ -539,12 +541,7 @@ export class GoogleProvider extends GoogleGenericProvider {
           };
         }
 
-        if (
-          Array.isArray(data) &&
-          !datum.candidates?.length &&
-          datum.usageMetadata &&
-          !datum.promptFeedback
-        ) {
+        if (Array.isArray(data) && isNonCandidateStreamChunk(datum)) {
           continue;
         }
 
@@ -634,10 +631,9 @@ export class GoogleProvider extends GoogleGenericProvider {
       const lastDataWithCandidate =
         dataWithResponse.filter((datum) => datum.candidates?.length).at(-1) ?? lastData;
       const candidate = getCandidate(lastDataWithCandidate);
-      if (lastDataWithCandidate.promptFeedback?.safetyRatings || candidate.safetyRatings) {
-        const flaggedInput = lastDataWithCandidate.promptFeedback?.safetyRatings?.some(
-          (r) => r.probability !== 'NEGLIGIBLE',
-        );
+      const promptSafetyRatings = getLastPromptSafetyRatings(dataWithResponse);
+      if (promptSafetyRatings || candidate.safetyRatings) {
+        const flaggedInput = promptSafetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
         const flaggedOutput = candidate.safetyRatings?.some((r) => r.probability !== 'NEGLIGIBLE');
         const flagged = flaggedInput || flaggedOutput;
         guardrails = { flaggedInput, flaggedOutput, flagged };

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -31,6 +31,7 @@ import {
   getGoogleClient,
   loadCredentials,
   mergeGoogleCompletionOptions,
+  mergeParts,
   normalizeSafetySettings,
   removeGoogleFunctionDeclarations,
   resolveGoogleToolConfig,
@@ -498,7 +499,7 @@ export class GoogleProvider extends GoogleGenericProvider {
       }
 
       const dataWithResponse = normalizedData as GeminiResponseData[];
-      let output;
+      let output: ReturnType<typeof formatCandidateContents> | undefined;
 
       for (const datum of dataWithResponse) {
         // Check for blockReason first
@@ -584,14 +585,14 @@ export class GoogleProvider extends GoogleGenericProvider {
         } else if (candidate.finishReason && candidate.finishReason === 'MAX_TOKENS') {
           // MAX_TOKENS is treated as a successful completion
           if (candidate.content?.parts) {
-            output = formatCandidateContents(candidate);
+            output = mergeParts(output, formatCandidateContents(candidate));
           }
         } else if (candidate.finishReason && candidate.finishReason !== 'STOP') {
           return {
             error: `Finish reason ${candidate.finishReason}: ${JSON.stringify(data)}`,
           };
         } else if (candidate.content?.parts) {
-          output = formatCandidateContents(candidate);
+          output = mergeParts(output, formatCandidateContents(candidate));
         }
       }
 

--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -595,7 +595,7 @@ export async function getGoogleAccessToken(credentials?: string): Promise<string
   }
 }
 
-export function getCandidate(data: GeminiResponseData) {
+export function getCandidate(data: GeminiResponseData): Candidate {
   if (!data || !data.candidates || data.candidates.length < 1) {
     // Check if the prompt was blocked
     let errorDetails = 'No candidates returned in API response.';
@@ -629,7 +629,34 @@ export function getCandidate(data: GeminiResponseData) {
     );
   }
   const candidate = data.candidates[0];
+  if (!candidate) {
+    throw new Error(
+      `No candidates returned in API response.\n\nGot response: ${JSON.stringify(data)}`,
+    );
+  }
   return candidate;
+}
+
+export function isNonCandidateStreamChunk(datum: GeminiResponseData): boolean {
+  return (
+    !datum.candidates?.length &&
+    ((Boolean(datum.usageMetadata) && !datum.promptFeedback) ||
+      (Boolean(datum.promptFeedback?.safetyRatings) && !datum.promptFeedback?.blockReason))
+  );
+}
+
+export function getLastPromptSafetyRatings(
+  data: GeminiResponseData[],
+): NonNullable<GeminiResponseData['promptFeedback']>['safetyRatings'] | undefined {
+  let safetyRatings: NonNullable<GeminiResponseData['promptFeedback']>['safetyRatings'] | undefined;
+
+  for (const datum of data) {
+    if (datum.promptFeedback?.safetyRatings) {
+      safetyRatings = datum.promptFeedback.safetyRatings;
+    }
+  }
+
+  return safetyRatings;
 }
 
 export function formatCandidateContents(candidate: Candidate) {

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -320,6 +320,41 @@ describe('AIStudioChatProvider', () => {
       });
     });
 
+    it('should ignore terminal STOP chunks without parts after streamed output', async () => {
+      const provider = new AIStudioChatProvider('gemini-pro', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            candidates: [{ content: { parts: [{ text: 'streamed response' }] } }],
+          },
+          {
+            candidates: [{ finishReason: 'STOP' }],
+            usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2, totalTokenCount: 6 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      });
+
+      const response = await provider.callGemini('test prompt');
+
+      expect(response.error).toBeUndefined();
+      expect(response.output).toBe('streamed response');
+      expect(response.tokenUsage).toEqual({
+        prompt: 4,
+        completion: 2,
+        total: 6,
+        numRequests: 1,
+      });
+    });
+
     it('should preserve prompt safety ratings from separate streaming chunks', async () => {
       const provider = new AIStudioChatProvider('gemini-pro', {
         config: {

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -283,6 +283,67 @@ describe('AIStudioChatProvider', () => {
       });
     });
 
+    it('should accumulate incremental chunks in array responses', async () => {
+      const provider = new AIStudioChatProvider('gemini-pro', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            candidates: [{ content: { parts: [{ text: 'Hello ' }] } }],
+          },
+          {
+            candidates: [{ content: { parts: [{ text: 'world' }] } }],
+          },
+          {
+            usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 2, totalTokenCount: 5 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      });
+
+      const response = await provider.callGemini('test prompt');
+
+      expect(response.error).toBeUndefined();
+      expect(response.output).toBe('Hello world');
+      expect(response.tokenUsage).toEqual({
+        prompt: 3,
+        completion: 2,
+        total: 5,
+        numRequests: 1,
+      });
+    });
+
+    it('should reject array responses that never provide output', async () => {
+      const provider = new AIStudioChatProvider('gemini-pro', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 0, totalTokenCount: 3 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      });
+
+      const response = await provider.callGemini('test prompt');
+
+      expect(response.error).toContain('No output found in response');
+    });
+
     it('should handle responses blocked with promptFeedback', async () => {
       const provider = new AIStudioChatProvider('gemini-pro', {
         config: {

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -320,6 +320,51 @@ describe('AIStudioChatProvider', () => {
       });
     });
 
+    it('should preserve prompt safety ratings from separate streaming chunks', async () => {
+      const provider = new AIStudioChatProvider('gemini-pro', {
+        config: {
+          apiKey: 'test-key',
+        },
+      });
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            promptFeedback: {
+              safetyRatings: [{ category: 'HARM_CATEGORY_HARASSMENT', probability: 'HIGH' }],
+            },
+          },
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: 'safe response' }] },
+                safetyRatings: [
+                  { category: 'HARM_CATEGORY_HARASSMENT', probability: 'NEGLIGIBLE' },
+                ],
+              },
+            ],
+          },
+          {
+            usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 2, totalTokenCount: 5 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      });
+
+      const response = await provider.callGemini('test prompt');
+
+      expect(response.error).toBeUndefined();
+      expect(response.output).toBe('safe response');
+      expect(response.guardrails).toEqual({
+        flaggedInput: true,
+        flaggedOutput: false,
+        flagged: true,
+      });
+    });
+
     it('should reject array responses that never provide output', async () => {
       const provider = new AIStudioChatProvider('gemini-pro', {
         config: {

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -585,6 +585,44 @@ describe('GoogleProvider', () => {
       });
     });
 
+    it('should preserve prompt safety ratings from separate streaming chunks', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            promptFeedback: {
+              safetyRatings: [{ category: 'HARM_CATEGORY_HARASSMENT', probability: 'HIGH' }],
+            },
+          },
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: 'streamed response' }] },
+                safetyRatings: [
+                  { category: 'HARM_CATEGORY_HARASSMENT', probability: 'NEGLIGIBLE' },
+                ],
+              },
+            ],
+          },
+          {
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('streamed response');
+      expect(result.guardrails).toEqual({
+        flaggedInput: true,
+        flaggedOutput: false,
+        flagged: true,
+      });
+    });
+
     it('should accumulate incremental chunks in streaming responses', async () => {
       vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
         data: [

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -558,6 +558,50 @@ describe('GoogleProvider', () => {
       expect(result.output).toBe('truncated response');
     });
 
+    it('should ignore metadata-only chunks in streaming responses', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            candidates: [{ content: { parts: [{ text: 'streamed response' }] } }],
+          },
+          {
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('streamed response');
+      expect(result.tokenUsage).toEqual({
+        prompt: 10,
+        completion: 5,
+        total: 15,
+        numRequests: 1,
+      });
+    });
+
+    it('should reject streaming responses that never provide output', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 0, totalTokenCount: 10 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No output found in response');
+    });
+
     it('should return an error for safety finish reasons outside scorable evaluations', async () => {
       const responseData = {
         candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'SAFETY' }],

--- a/test/providers/google/provider.test.ts
+++ b/test/providers/google/provider.test.ts
@@ -585,6 +585,30 @@ describe('GoogleProvider', () => {
       });
     });
 
+    it('should accumulate incremental chunks in streaming responses', async () => {
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: [
+          {
+            candidates: [{ content: { parts: [{ text: 'Hello ' }] } }],
+          },
+          {
+            candidates: [{ content: { parts: [{ text: 'world' }] } }],
+          },
+          {
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, totalTokenCount: 12 },
+          },
+        ],
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('Hello world');
+    });
+
     it('should reject streaming responses that never provide output', async () => {
       vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
         data: [

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -52,6 +52,38 @@ vi.mock('../../src/providers', () => ({
 vi.mock('../../src/util/fetch/index.ts');
 
 const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockParseXlsxFileState = vi.hoisted(() => ({
+  implementation: undefined as ((filePath: string) => Promise<any[]>) | undefined,
+}));
+const mockMaybeLoadConfigFromExternalFileImpl = vi.hoisted(() => {
+  const implementation = (config: any): any => {
+    if (Array.isArray(config)) {
+      return config.map((item) => implementation(item));
+    }
+
+    if (typeof config === 'object' && config !== null) {
+      const result = { ...config };
+      for (const [key, value] of Object.entries(config)) {
+        if (typeof value === 'string' && value.startsWith('file://')) {
+          const filePath = value.slice('file://'.length);
+          const fileContent = mockReadFileSync(filePath, 'utf-8');
+          if (typeof fileContent === 'string') {
+            try {
+              result[key] = JSON.parse(fileContent);
+            } catch {
+              result[key] = fileContent;
+            }
+          }
+        }
+      }
+      return result;
+    }
+
+    return config;
+  };
+
+  return implementation;
+});
 
 vi.mock('fs', () => ({
   readFileSync: mockReadFileSync,
@@ -61,6 +93,15 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
 }));
+
+vi.mock('../../src/util/xlsx', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/xlsx')>();
+  return {
+    ...actual,
+    parseXlsxFile: (filePath: string) =>
+      mockParseXlsxFileState.implementation?.(filePath) ?? actual.parseXlsxFile(filePath),
+  };
+});
 
 vi.mock('fs/promises', () => {
   const promisesFs = {
@@ -133,40 +174,7 @@ vi.mock('../../src/esm', () => ({
 }));
 
 vi.mock('../../src/util/file', () => ({
-  maybeLoadConfigFromExternalFile: vi.fn((config) => {
-    // Mock implementation that handles file:// references
-
-    // Handle arrays first to preserve their type
-    if (Array.isArray(config)) {
-      return config.map((item) => {
-        const mockFn = maybeLoadConfigFromExternalFile;
-        return mockFn(item);
-      });
-    }
-
-    // Handle objects (but not arrays)
-    if (typeof config === 'object' && config !== null) {
-      const result = { ...config };
-      for (const [key, value] of Object.entries(config)) {
-        if (typeof value === 'string' && value.startsWith('file://')) {
-          // Extract the file path from the file:// URL
-          const filePath = value.slice('file://'.length);
-          // Get the mocked file content using the extracted path
-          const fileContent = fs.readFileSync(filePath, 'utf-8');
-          if (typeof fileContent === 'string') {
-            try {
-              result[key] = JSON.parse(fileContent);
-            } catch {
-              result[key] = fileContent;
-            }
-          }
-        }
-      }
-      return result;
-    }
-
-    return config;
-  }),
+  maybeLoadConfigFromExternalFile: vi.fn(mockMaybeLoadConfigFromExternalFileImpl),
 }));
 
 // Helper to clear all mocks
@@ -184,6 +192,7 @@ const clearAllMocks = () => {
   vi.mocked(readAzureBlobText).mockReset();
   vi.mocked(maybeLoadConfigFromExternalFile).mockReset();
   vi.mocked(importModule).mockReset();
+  mockParseXlsxFileState.implementation = undefined;
 };
 
 describe('readStandaloneTestsFile', () => {
@@ -192,37 +201,9 @@ describe('readStandaloneTestsFile', () => {
     // Reset getEnvString to default behavior
     vi.mocked(getEnvString).mockImplementation((_key, defaultValue) => defaultValue || '');
     // Restore maybeLoadConfigFromExternalFile mock
-    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation((config) => {
-      // Handle arrays first to preserve their type
-      if (Array.isArray(config)) {
-        return config.map((item) => {
-          const mockFn = maybeLoadConfigFromExternalFile;
-          return mockFn(item);
-        });
-      }
-
-      // Mock implementation that handles file:// references
-      if (typeof config === 'object' && config !== null) {
-        const result = { ...config };
-        for (const [key, value] of Object.entries(config)) {
-          if (typeof value === 'string' && value.startsWith('file://')) {
-            // Extract the file path from the file:// URL
-            const filePath = value.slice('file://'.length);
-            // Get the mocked file content using the extracted path
-            const fileContent = fs.readFileSync(filePath, 'utf-8');
-            if (typeof fileContent === 'string') {
-              try {
-                result[key] = JSON.parse(fileContent);
-              } catch {
-                result[key] = fileContent;
-              }
-            }
-          }
-        }
-        return result;
-      }
-      return config;
-    });
+    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation(
+      mockMaybeLoadConfigFromExternalFileImpl,
+    );
   });
 
   afterEach(() => {
@@ -605,37 +586,24 @@ describe('readStandaloneTestsFile', () => {
       { var1: 'value3', var2: 'value4', __expected: 'expected2' },
     ];
 
-    vi.doMock('../../src/util/xlsx', () => ({
-      parseXlsxFile: vi.fn().mockResolvedValue(mockData),
-    }));
+    mockParseXlsxFileState.implementation = vi.fn().mockResolvedValue(mockData);
 
-    vi.resetModules();
+    const result = await readStandaloneTestsFile('test.xlsx');
 
-    try {
-      const { readStandaloneTestsFile: freshReadStandaloneTestsFile } = await import(
-        '../../src/util/testCaseReader'
-      );
-
-      const result = await freshReadStandaloneTestsFile('test.xlsx');
-
-      expect(result).toEqual([
-        {
-          assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
-          description: 'Row #1',
-          options: {},
-          vars: { var1: 'value1', var2: 'value2' },
-        },
-        {
-          assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
-          description: 'Row #2',
-          options: {},
-          vars: { var1: 'value3', var2: 'value4' },
-        },
-      ]);
-    } finally {
-      vi.doUnmock('../../src/util/xlsx');
-      vi.resetModules();
-    }
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
   });
 
   // Note: parseXlsxFile error handling tests (module not installed, empty sheets, etc.)
@@ -805,38 +773,9 @@ describe('readTest', () => {
   beforeEach(() => {
     clearAllMocks();
     // Restore maybeLoadConfigFromExternalFile mock
-    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation((config) => {
-      // Handle arrays first to preserve their type
-      if (Array.isArray(config)) {
-        return config.map((item) => {
-          const mockFn = maybeLoadConfigFromExternalFile;
-          return mockFn(item);
-        });
-      }
-
-      // Mock implementation that handles file:// references
-      if (typeof config === 'object' && config !== null) {
-        const result = { ...config };
-        for (const [key, value] of Object.entries(config)) {
-          if (typeof value === 'string' && value.startsWith('file://')) {
-            // Extract the file path from the file:// URL
-            const filePath = value.slice('file://'.length);
-            // Get the mocked file content using the extracted path
-            const fileContent = fs.readFileSync(filePath, 'utf-8');
-            if (typeof fileContent === 'string') {
-              try {
-                result[key] = JSON.parse(fileContent);
-              } catch {
-                result[key] = fileContent;
-              }
-            }
-          }
-        }
-        return result;
-      }
-
-      return config;
-    });
+    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation(
+      mockMaybeLoadConfigFromExternalFileImpl,
+    );
   });
 
   afterEach(() => {
@@ -1061,37 +1000,9 @@ describe('readTests', () => {
     clearAllMocks();
     vi.mocked(globSync).mockReturnValue([]);
     // Restore maybeLoadConfigFromExternalFile mock for readTests tests
-    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation((config) => {
-      // Handle arrays first to preserve their type
-      if (Array.isArray(config)) {
-        return config.map((item) => {
-          const mockFn = maybeLoadConfigFromExternalFile;
-          return mockFn(item);
-        });
-      }
-
-      // Mock implementation that handles file:// references
-      if (typeof config === 'object' && config !== null) {
-        const result = { ...config };
-        for (const [key, value] of Object.entries(config)) {
-          if (typeof value === 'string' && value.startsWith('file://')) {
-            // Extract the file path from the file:// URL
-            const filePath = value.slice('file://'.length);
-            // Get the mocked file content using the extracted path
-            const fileContent = fs.readFileSync(filePath, 'utf-8');
-            if (typeof fileContent === 'string') {
-              try {
-                result[key] = JSON.parse(fileContent);
-              } catch {
-                result[key] = fileContent;
-              }
-            }
-          }
-        }
-        return result;
-      }
-      return config;
-    });
+    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation(
+      mockMaybeLoadConfigFromExternalFileImpl,
+    );
   });
 
   afterEach(() => {
@@ -1651,104 +1562,60 @@ describe('readTests', () => {
       { var1: 'value3', var2: 'value4', __expected: 'expected2' },
     ];
 
-    vi.doMock('../../src/util/xlsx', () => ({
-      parseXlsxFile: vi.fn().mockResolvedValue(mockData),
-    }));
+    mockParseXlsxFileState.implementation = vi.fn().mockResolvedValue(mockData);
 
-    vi.resetModules();
+    const result = await readTests(['test.xlsx']);
 
-    try {
-      const { readTests: freshReadTests } = await import('../../src/util/testCaseReader');
-
-      const result = await freshReadTests(['test.xlsx']);
-
-      expect(result).toEqual([
-        {
-          assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
-          description: 'Row #1',
-          options: {},
-          vars: { var1: 'value1', var2: 'value2' },
-        },
-        {
-          assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
-          description: 'Row #2',
-          options: {},
-          vars: { var1: 'value3', var2: 'value4' },
-        },
-      ]);
-    } finally {
-      vi.doUnmock('../../src/util/xlsx');
-      vi.resetModules();
-    }
+    expect(result).toEqual([
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected1' }],
+        description: 'Row #1',
+        options: {},
+        vars: { var1: 'value1', var2: 'value2' },
+      },
+      {
+        assert: [{ metric: undefined, type: 'equals', value: 'expected2' }],
+        description: 'Row #2',
+        options: {},
+        vars: { var1: 'value3', var2: 'value4' },
+      },
+    ]);
   });
 
   it('should handle xlsx files with sheet specifier in array format', async () => {
     // Mock parseXlsxFile to return processed CsvRow[] data
     const mockData = [{ name: 'test1', value: 'result1' }];
 
-    vi.doMock('../../src/util/xlsx', () => ({
-      parseXlsxFile: vi.fn().mockResolvedValue(mockData),
-    }));
+    mockParseXlsxFileState.implementation = vi.fn().mockResolvedValue(mockData);
 
-    vi.resetModules();
+    const result = await readTests(['test.xlsx#DataSheet']);
 
-    try {
-      const { readTests: freshReadTests } = await import('../../src/util/testCaseReader');
-
-      const result = await freshReadTests(['test.xlsx#DataSheet']);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].vars).toEqual({ name: 'test1', value: 'result1' });
-    } finally {
-      vi.doUnmock('../../src/util/xlsx');
-      vi.resetModules();
-    }
+    expect(result).toHaveLength(1);
+    expect(result[0].vars).toEqual({ name: 'test1', value: 'result1' });
   });
 
   it('should handle xls files in array format', async () => {
     // Mock parseXlsxFile to return processed CsvRow[] data
     const mockData = [{ col1: 'data1', col2: 'data2' }];
 
-    vi.doMock('../../src/util/xlsx', () => ({
-      parseXlsxFile: vi.fn().mockResolvedValue(mockData),
-    }));
+    mockParseXlsxFileState.implementation = vi.fn().mockResolvedValue(mockData);
 
-    vi.resetModules();
+    const result = await readTests(['legacy.xls']);
 
-    try {
-      const { readTests: freshReadTests } = await import('../../src/util/testCaseReader');
-
-      const result = await freshReadTests(['legacy.xls']);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].vars).toEqual({ col1: 'data1', col2: 'data2' });
-    } finally {
-      vi.doUnmock('../../src/util/xlsx');
-      vi.resetModules();
-    }
+    expect(result).toHaveLength(1);
+    expect(result[0].vars).toEqual({ col1: 'data1', col2: 'data2' });
   });
 
   it('should handle file:// prefix with xlsx files in array format', async () => {
     // Mock parseXlsxFile to return processed CsvRow[] data
     const mockData = [{ input: 'hello', expected: 'world' }];
 
-    vi.doMock('../../src/util/xlsx', () => ({
-      parseXlsxFile: vi.fn().mockResolvedValue(mockData),
-    }));
+    mockParseXlsxFileState.implementation = vi.fn().mockResolvedValue(mockData);
 
-    vi.resetModules();
+    const result = await readTests(['file://test.xlsx']);
 
-    try {
-      const { readTests: freshReadTests } = await import('../../src/util/testCaseReader');
-
-      const result = await freshReadTests(['file://test.xlsx']);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].vars).toEqual({ input: 'hello', expected: 'world' });
-    } finally {
-      vi.doUnmock('../../src/util/xlsx');
-      vi.resetModules();
-    }
+    expect(result).toHaveLength(1);
+    expect(result[0].vars).toEqual({ input: 'hello', expected: 'world' });
   });
 });
 
@@ -1789,38 +1656,9 @@ describe('readVarsFiles', () => {
   beforeEach(() => {
     clearAllMocks();
     // Restore maybeLoadConfigFromExternalFile mock
-    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation((config) => {
-      // Handle arrays first to preserve their type
-      if (Array.isArray(config)) {
-        return config.map((item) => {
-          const mockFn = maybeLoadConfigFromExternalFile;
-          return mockFn(item);
-        });
-      }
-
-      // Handle objects (but not arrays)
-      if (typeof config === 'object' && config !== null) {
-        const result = { ...config };
-        for (const [key, value] of Object.entries(config)) {
-          if (typeof value === 'string' && value.startsWith('file://')) {
-            // Extract the file path from the file:// URL
-            const filePath = value.slice('file://'.length);
-            // Get the mocked file content using the extracted path
-            const fileContent = fs.readFileSync(filePath, 'utf-8');
-            if (typeof fileContent === 'string') {
-              try {
-                result[key] = JSON.parse(fileContent);
-              } catch {
-                result[key] = fileContent;
-              }
-            }
-          }
-        }
-        return result;
-      }
-
-      return config;
-    });
+    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation(
+      mockMaybeLoadConfigFromExternalFileImpl,
+    );
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- validate scatter chart inputs before deriving point styling, and guard performance-history responses and zero-test pass rates
- tolerate metadata-only Google streaming chunks while retaining an error for responses that never produce output
- consolidate `testCaseReader` config-loader and XLSX mocks to eliminate duplicated implementations and module-reset coupling

## Validation

- `npm run f`
- `npm run l` (passes with the existing non-blocking cognitive-complexity diagnostics in `src/providers/google/provider.ts`)
- `./node_modules/.bin/vitest run test/providers/google/provider.test.ts test/util/testCaseReader.test.ts --sequence.shuffle=false`
- `npm run test:app -- src/pages/eval/components/ResultsCharts.test.tsx --run`
- `npm run tsc`
- `npm --prefix src/app run tsc -- --noEmit`
- `git diff --check`

## Environment Note

`npm ci` could not complete because Socket Security Policy blocked the transitive `socket.io-adapter-2.5.7.tgz` download. Validation used existing local dependencies from a Promptfoo checkout at package version `0.121.12`.
