### PR TITLE
fix(providers): align golang provider runtime contract

### DIFF
--- a/examples/provider-golang/README.md
+++ b/examples/provider-golang/README.md
@@ -87,7 +87,9 @@ providers:
 Both `main.go` and `evaluation/main.go` implement the same interface:
 
 ```go
-func CallApi(prompt string, options map[string]interface{}) (string, error)
+func CallApi(prompt string, options map[string]interface{}, ctx map[string]interface{}) (map[string]interface{}, error)
 ```
 
-They share the same OpenAI client code but can be configured differently through the config file.
+They return a map containing the `output` key. The `ctx` argument contains test variables and
+metadata for the current eval. Both implementations share the same OpenAI client code but can be
+configured differently through the config file.

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -20,8 +20,6 @@ import {
 import type {
   ApiProvider,
   CallApiContextParams,
-  ProviderClassificationResponse,
-  ProviderEmbeddingResponse,
   ProviderOptions,
   ProviderResponse,
 } from '../types/providers';
@@ -47,6 +45,11 @@ export class GolangProvider implements ApiProvider {
       options?.config.basePath || '',
       runPath,
     );
+    if (functionName && functionName !== 'call_api' && functionName !== 'CallApi') {
+      throw new Error(
+        `The Golang provider only supports the CallApi function; received "${functionName}"`,
+      );
+    }
     this.scriptPath = path.relative(options?.config.basePath || '', providerPath);
     this.functionName = functionName || null;
     this.id = () => options?.id ?? `golang:${this.scriptPath}:${this.functionName || 'default'}`;
@@ -72,17 +75,15 @@ export class GolangProvider implements ApiProvider {
   private async executeGolangScript(
     prompt: string,
     context: CallApiContextParams | undefined,
-    apiType: 'call_api' | 'call_embedding_api' | 'call_classification_api',
-  ): Promise<any> {
+  ): Promise<ProviderResponse> {
     const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
     const moduleRoot = await this.findModuleRoot(path.dirname(absPath));
     logger.debug(`Found module root at ${moduleRoot}`);
     logger.debug(`Computing file hash for script ${absPath}`);
     const fileHash = sha256(await fs.readFile(absPath, 'utf-8'));
-    const functionName = this.functionName || apiType;
+    const functionName = this.functionName || 'call_api';
     const sanitizedContext = sanitizeScriptContext('GolangProvider', context);
-    const args =
-      apiType === 'call_api' ? [prompt, this.options, sanitizedContext] : [prompt, this.options];
+    const args = [prompt, this.options, sanitizedContext];
     const jsonArgs = safeJsonStringify(args) || '[]';
     // Build a separate arg set for cache-key hashing that excludes per-run
     // non-deterministic fields (`evaluationId`, `traceparent`, etc.). The
@@ -90,14 +91,13 @@ export class GolangProvider implements ApiProvider {
     // Stable (sorted) JSON ensures callers that clone/reshape options or
     // context with a different key order still hit the same cache entry.
     const cacheableContext = buildCacheableScriptContext(context);
-    const cacheKeyArgs =
-      apiType === 'call_api' ? [prompt, this.options, cacheableContext] : [prompt, this.options];
+    const cacheKeyArgs = [prompt, this.options, cacheableContext];
     const cache = await getCache();
     let cachedResult;
     const containsSensitiveInput = containsSensitiveScriptInput(cacheKeyArgs);
     const cacheEnabled = isCacheEnabled() && !containsSensitiveInput;
     const cacheKey = cacheEnabled
-      ? `golang:${this.scriptPath}:${functionName}:${apiType}:${fileHash}:${sha256(
+      ? `golang:${this.scriptPath}:${functionName}:call_api:${fileHash}:${sha256(
           stableJsonStringify(cacheKeyArgs) || '[]',
         )}`
       : undefined;
@@ -110,13 +110,13 @@ export class GolangProvider implements ApiProvider {
     }
 
     if (cachedResult) {
-      logger.debug(`Returning cached ${apiType} result for script ${absPath}`);
+      logger.debug(`Returning cached call_api result for script ${absPath}`);
       return { ...JSON.parse(cachedResult), cached: true };
     } else {
       logger.debug('Running Golang script', {
         scriptPath: absPath,
         providerPath: this.scriptPath,
-        apiType,
+        apiType: 'call_api',
         argCount: args.length,
         hasContext: Boolean(sanitizedContext),
       });
@@ -199,14 +199,6 @@ export class GolangProvider implements ApiProvider {
   }
 
   async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
-    return this.executeGolangScript(prompt, context, 'call_api');
-  }
-
-  async callEmbeddingApi(prompt: string): Promise<ProviderEmbeddingResponse> {
-    return this.executeGolangScript(prompt, undefined, 'call_embedding_api');
-  }
-
-  async callClassificationApi(prompt: string): Promise<ProviderClassificationResponse> {
-    return this.executeGolangScript(prompt, undefined, 'call_classification_api');
+    return this.executeGolangScript(prompt, context);
   }
 }

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -141,9 +141,11 @@ describe('GolangProvider', () => {
           extension: 'go',
         };
       }
+      const normalizedPath = runPath.replace(/^(file:\/\/|golang:)/, '');
+      const [filePath, functionName] = normalizedPath.split(':');
       return {
-        filePath: runPath.replace(/^(file:\/\/|golang:)/, '').split(':')[0],
-        functionName: runPath.includes(':') ? runPath.split(':')[1] : undefined,
+        filePath,
+        functionName,
         isPathPattern: false,
         extension: 'go',
       };
@@ -293,12 +295,21 @@ describe('GolangProvider', () => {
       expect(provider.id()).toBe('testId');
     });
 
-    it('should initialize with file:// prefix and function name', () => {
-      const provider = new GolangProvider('file://script.go:function_name', {
+    it('should initialize with file:// prefix and CallApi function name', () => {
+      const provider = new GolangProvider('file://script.go:CallApi', {
         id: 'testId',
         config: { basePath: '/base' },
       });
       expect(provider.id()).toBe('testId');
+    });
+
+    it('should reject function names that the Go wrapper cannot invoke', () => {
+      expect(
+        () =>
+          new GolangProvider('file://script.go:function_name', {
+            config: { basePath: '/base' },
+          }),
+      ).toThrow('The Golang provider only supports the CallApi function');
     });
 
     it('should handle undefined basePath and use default id', () => {
@@ -308,8 +319,8 @@ describe('GolangProvider', () => {
     });
 
     it('should use class id() method when no id is provided in options', () => {
-      const provider = new GolangProvider('script.go:custom_function');
-      expect(provider.id()).toBe('golang:script.go:custom_function');
+      const provider = new GolangProvider('script.go:CallApi');
+      expect(provider.id()).toBe('golang:script.go:CallApi');
     });
 
     it('should allow id() override and later retrieval', () => {
@@ -525,7 +536,6 @@ describe('GolangProvider', () => {
         expect.objectContaining({
           vars: expect.objectContaining({ circular: expect.anything() }),
         }),
-        'call_api',
       );
 
       spy.mockRestore();
@@ -601,68 +611,12 @@ describe('GolangProvider', () => {
   });
 
   describe('API methods', () => {
-    it('should call callEmbeddingApi successfully', async () => {
-      const provider = new GolangProvider('script.go', {
-        config: { basePath: '/absolute/path/to' },
-      });
-      mockExecFile.mockImplementation(((
-        file: string,
-        _args: any[],
-        optionsOrCallback: any,
-        maybeCallback?: any,
-      ) => {
-        const callback =
-          typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
-        if (!callback) {
-          return {} as any;
-        }
-        setImmediate(() => {
-          callback(
-            null,
-            {
-              stdout: file.includes('golang_wrapper') ? '{"embedding":[0.1,0.2,0.3]}' : '',
-              stderr: '',
-            },
-            '',
-          );
-        });
-        return {} as any;
-      }) as any);
+    it('should expose only the implemented text completion method', () => {
+      const provider = new GolangProvider('script.go');
 
-      const result = await provider.callEmbeddingApi('test prompt');
-      expect(result).toEqual({ embedding: [0.1, 0.2, 0.3] });
-    });
-
-    it('should call callClassificationApi successfully', async () => {
-      const provider = new GolangProvider('script.go', {
-        config: { basePath: '/absolute/path/to' },
-      });
-      mockExecFile.mockImplementation(((
-        file: string,
-        _args: any[],
-        optionsOrCallback: any,
-        maybeCallback?: any,
-      ) => {
-        const callback =
-          typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
-        if (!callback) {
-          return {} as any;
-        }
-        setImmediate(() => {
-          callback(
-            null,
-            {
-              stdout: file.includes('golang_wrapper') ? '{"classification":"test_class"}' : '',
-              stderr: '',
-            },
-            '',
-          );
-        });
-        return {} as any;
-      }) as any);
-
-      const result = await provider.callClassificationApi('test prompt');
-      expect(result).toEqual({ classification: 'test_class' });
+      expect(provider.callApi).toBeTypeOf('function');
+      expect(provider).not.toHaveProperty('callEmbeddingApi');
+      expect(provider).not.toHaveProperty('callClassificationApi');
     });
 
     it('should handle stderr output without failing', async () => {
@@ -795,7 +749,7 @@ describe('GolangProvider', () => {
       await expect(provider.callApi('test prompt')).rejects.toThrow('Error running Golang script');
     });
 
-    it('should use custom function name when specified', async () => {
+    it('should reject a custom function name before executing a Go binary', async () => {
       const mockParsePathOrGlob = vi.mocked((await import('../../src/util')).parsePathOrGlob);
       mockParsePathOrGlob.mockReturnValueOnce({
         filePath: '/absolute/path/to/script.go',
@@ -804,31 +758,13 @@ describe('GolangProvider', () => {
         extension: 'go',
       });
 
-      const provider = new GolangProvider('script.go:custom_function', {
-        config: { basePath: '/absolute/path/to' },
-      });
-
-      let executedFunctionName = '';
-      mockExecFile.mockImplementation(((
-        file: string,
-        args: any[],
-        optionsOrCallback: any,
-        maybeCallback?: any,
-      ) => {
-        const callback =
-          typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
-        if (!callback) {
-          return {} as any;
-        }
-        if (file.includes('golang_wrapper')) {
-          executedFunctionName = args[1]; // args[1] is the function name
-        }
-        setImmediate(() => callback(null, { stdout: '{"output":"test"}', stderr: '' }, ''));
-        return {} as any;
-      }) as any);
-
-      await provider.callApi('test prompt');
-      expect(executedFunctionName).toBe('custom_function');
+      expect(
+        () =>
+          new GolangProvider('script.go:custom_function', {
+            config: { basePath: '/absolute/path/to' },
+          }),
+      ).toThrow('The Golang provider only supports the CallApi function');
+      expect(mockExecFile).not.toHaveBeenCalled();
     });
 
     it('should use custom go executable when specified', async () => {
@@ -892,7 +828,6 @@ describe('GolangProvider', () => {
         expect.objectContaining({
           vars: expect.objectContaining({ circular: expect.anything() }),
         }),
-        'call_api',
       );
 
       // Restore the original implementation


### PR DESCRIPTION
## Summary

- restrict the Golang provider facade to the `CallApi` runtime contract actually implemented by `src/golang/wrapper.go`
- reject unsupported named Go entrypoints before compiling or executing a temporary binary
- remove unreachable embedding/classification API methods and replace mocked-success tests with contract tests

## Stack

- Base PR: #8648 (`fix(cache): hash script provider keys`), because both changes touch `src/providers/golangCompletion.ts`

## Verification

- `npm run f`
- `npm run l` (passes with the two existing warning-level complexity findings from the base PR in `src/util/json.ts`)
- `npm run tsc`
- `./node_modules/.bin/vitest run test/providers/golangCompletion.test.ts`
- `PROMPTFOO_DISABLE_SHARING=true PROMPTFOO_DISABLE_UPDATE=true PROMPTFOO_DISABLE_TELEMETRY=1 GOCACHE=/private/tmp/promptfoo-go-cache npm run local -- eval -c /private/tmp/promptfoo-go-e2e/promptfooconfig.yaml --no-cache -o /private/tmp/promptfoo-go-e2e/results-isolated-cache.json` (`1` passed, `0` failures, `0` errors)
