### PR TITLE
docs(site): correct script provider handler contracts

### DIFF
--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -76,7 +76,7 @@ Python providers use persistent worker processes. Your script is loaded once whe
 When Promptfoo evaluates a test case with a Python provider:
 
 1. **Promptfoo** prepares the prompt based on your configuration
-2. **Python Script** calls `call_api` with three parameters:
+2. **Promptfoo** invokes `call_api` in your Python script with three parameters:
    - `prompt`: The final prompt string
    - `options`: Provider configuration from your YAML
    - `context`: Variables and metadata for the current test

--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -76,7 +76,7 @@ Python providers use persistent worker processes. Your script is loaded once whe
 When Promptfoo evaluates a test case with a Python provider:
 
 1. **Promptfoo** prepares the prompt based on your configuration
-2. **Python Script** is called with three parameters:
+2. **Python Script** calls `call_api` with three parameters:
    - `prompt`: The final prompt string
    - `options`: Provider configuration from your YAML
    - `context`: Variables and metadata for the current test
@@ -108,11 +108,11 @@ def call_api(prompt: str, options: dict, context: dict) -> dict:
     """Main function for text generation tasks."""
     pass
 
-def call_embedding_api(prompt: str, options: dict, context: dict) -> dict:
+def call_embedding_api(prompt: str, options: dict) -> dict:
     """For embedding generation tasks."""
     pass
 
-def call_classification_api(prompt: str, options: dict, context: dict) -> dict:
+def call_classification_api(prompt: str, options: dict) -> dict:
     """For classification tasks."""
     pass
 ```
@@ -124,14 +124,17 @@ async def call_api(prompt: str, options: dict, context: dict) -> dict:
     """Async main function for text generation tasks."""
     pass
 
-async def call_embedding_api(prompt: str, options: dict, context: dict) -> dict:
+async def call_embedding_api(prompt: str, options: dict) -> dict:
     """Async function for embedding generation tasks."""
     pass
 
-async def call_classification_api(prompt: str, options: dict, context: dict) -> dict:
+async def call_classification_api(prompt: str, options: dict) -> dict:
     """Async function for classification tasks."""
     pass
 ```
+
+`context` is passed to `call_api` only. Embedding and classification handlers receive `prompt` and
+`options`.
 
 ### Understanding Parameters
 
@@ -176,7 +179,7 @@ Contains your provider configuration and metadata:
 
 #### The `context` Parameter
 
-Provides information about the current test case:
+For `call_api`, this provides information about the current test case:
 
 ```python
 {

--- a/site/docs/providers/ruby.md
+++ b/site/docs/providers/ruby.md
@@ -67,7 +67,7 @@ That's it! You've created your first custom Ruby provider.
 When Promptfoo evaluates a test case with a Ruby provider:
 
 1. **Promptfoo** prepares the prompt based on your configuration
-2. **Ruby Script** calls `call_api` with three parameters:
+2. **Promptfoo** invokes `call_api` in your Ruby script with three parameters:
    - `prompt`: The final prompt string
    - `options`: Provider configuration from your YAML
    - `context`: Variables and metadata for the current test

--- a/site/docs/providers/ruby.md
+++ b/site/docs/providers/ruby.md
@@ -67,7 +67,7 @@ That's it! You've created your first custom Ruby provider.
 When Promptfoo evaluates a test case with a Ruby provider:
 
 1. **Promptfoo** prepares the prompt based on your configuration
-2. **Ruby Script** is called with three parameters:
+2. **Ruby Script** calls `call_api` with three parameters:
    - `prompt`: The final prompt string
    - `options`: Provider configuration from your YAML
    - `context`: Variables and metadata for the current test
@@ -97,14 +97,17 @@ def call_api(prompt, options, context)
   # Main function for text generation tasks
 end
 
-def call_embedding_api(prompt, options, context)
+def call_embedding_api(prompt, options)
   # For embedding generation tasks
 end
 
-def call_classification_api(prompt, options, context)
+def call_classification_api(prompt, options)
   # For classification tasks
 end
 ```
+
+`context` is passed to `call_api` only. Embedding and classification handlers receive `prompt` and
+`options`.
 
 ### Understanding Parameters
 
@@ -154,7 +157,7 @@ Contains your provider configuration and metadata:
 
 #### The `context` Parameter
 
-Provides information about the current test case:
+For `call_api`, this provides information about the current test case:
 
 ```ruby
 {
@@ -470,8 +473,8 @@ npx promptfoo@latest eval
 
 Promptfoo automatically detects your Ruby installation in this priority order:
 
-1. **Environment variable**: `PROMPTFOO_RUBY` (if set)
-2. **Provider config**: `rubyExecutable` in your config
+1. **Provider config**: `rubyExecutable` in your config
+2. **Environment variable**: `PROMPTFOO_RUBY` (if set)
 3. **Windows detection**: Uses `where ruby` (Windows only)
 4. **Smart detection**: Uses `ruby -e "puts RbConfig.ruby"` to find the actual Ruby path
 5. **Fallback commands**:


### PR DESCRIPTION
## Summary

- document that Python and Ruby `call_embedding_api` and `call_classification_api` handlers receive only `prompt` and `options`
- clarify that test `context` is supplied to `call_api`
- correct Ruby executable detection precedence so per-provider `rubyExecutable` is listed ahead of `PROMPTFOO_RUBY`

## Verification

- reconciled signatures with `src/providers/pythonCompletion.ts`, `src/providers/rubyCompletion.ts`, and `src/ruby/rubyUtils.ts`
- `npm run f`
- `SKIP_OG_GENERATION=true npm run build` from `site/`
