### PR TITLE
docs(site): clarify scripting language support

### DIFF
--- a/code-scan-action/package-lock.json
+++ b/code-scan-action/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "fastest-levenshtein": "^1.0.16",
         "gcp-metadata": "^8.1.2",
         "glob": "^13.0.6",
-        "hono": "^4.12.19",
         "http-z": "^8.1.1",
         "istextorbinary": "^9.5.0",
         "js-rouge": "^3.2.0",
@@ -18874,16 +18873,42 @@
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
-      "version": "28.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
-      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
-        "parse5": "^8.0.0",
+        "parse5": "^7.0.0",
         "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@types/jsesc": {
@@ -18945,9 +18970,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -27316,9 +27341,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -620,7 +620,7 @@ Promptfoo has several scripting extension points. They do not all support the sa
 | Custom assertion type                        | [`javascript`](/docs/configuration/expected-outputs/javascript) | [`python`](/docs/configuration/expected-outputs/python) | [`ruby`](/docs/configuration/expected-outputs/ruby) | Not supported                             |
 | `options.transform` and `transformVars` file | Supported (`.js`, `.cjs`, `.mjs`, `.ts`, `.cts`, `.mts`)        | Supported (`.py`)                                       | Not supported                                       | Not supported                             |
 
-For provider execution in any language, use an [`exec:` custom script provider](/docs/providers/custom-script) that accepts promptfoo's command-line arguments. This is separate from built-in assertion and transform support.
+For provider execution in any language, use an [`exec:` custom script provider](/docs/providers/custom-script) that reads the prompt, provider options JSON, and context JSON from positional arguments. This is separate from built-in assertion and transform support.
 
 ## Transforming outputs
 

--- a/site/docs/configuration/guide.md
+++ b/site/docs/configuration/guide.md
@@ -610,6 +610,18 @@ This is useful when you want better reasoning but don't want to expose the think
 
 For more details on extended thinking capabilities, see the [Anthropic provider docs](/docs/providers/anthropic#extended-thinking) and [AWS Bedrock provider docs](/docs/providers/aws-bedrock#claude-models).
 
+## Scripting Language Support
+
+Promptfoo has several scripting extension points. They do not all support the same languages:
+
+| Feature                                      | JavaScript / TypeScript                                         | Python                                                  | Ruby                                                | Go                                        |
+| -------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------- |
+| Custom file provider                         | [Supported](/docs/providers/custom-api)                         | [Supported](/docs/providers/python)                     | [Supported](/docs/providers/ruby)                   | [Text `CallApi` only](/docs/providers/go) |
+| Custom assertion type                        | [`javascript`](/docs/configuration/expected-outputs/javascript) | [`python`](/docs/configuration/expected-outputs/python) | [`ruby`](/docs/configuration/expected-outputs/ruby) | Not supported                             |
+| `options.transform` and `transformVars` file | Supported (`.js`, `.cjs`, `.mjs`, `.ts`, `.cts`, `.mts`)        | Supported (`.py`)                                       | Not supported                                       | Not supported                             |
+
+For provider execution in any language, use an [`exec:` custom script provider](/docs/providers/custom-script) that accepts promptfoo's command-line arguments. This is separate from built-in assertion and transform support.
+
 ## Transforming outputs
 
 Transforms can be applied at multiple levels in the evaluation pipeline:

--- a/site/docs/providers/go.md
+++ b/site/docs/providers/go.md
@@ -33,6 +33,8 @@ The function should:
 - Return a map containing an "output" key with the response
 - Return an error if the operation fails
 
+The Go file provider currently supports standard text generation through `CallApi` only. For other provider-like Go scripts, use the [`exec:` custom script provider](/docs/providers/custom-script).
+
 ## Configuration
 
 To configure the Go provider, you need to specify the path to your Go script and any additional options you want to pass to the script. Here's an example configuration in YAML format:


### PR DESCRIPTION
## Summary

- add a single configuration-guide matrix for scripting language support across custom providers, custom assertions, and test transforms
- document that the Go file provider exposes text `CallApi` only and that Ruby assertions are supported
- distinguish arbitrary-language `exec:` provider execution from built-in assertion and transform support

## Verification

- reconciled matrix with `src/providers/registry.ts`, `src/golang/wrapper.go`, `src/assertions/index.ts`, `src/util/transform.ts`, and `src/util/fileExtensions.ts`
- `npm run f`
- `SKIP_OG_GENERATION=true npm run build` from `site/`
