### PR TITLE
fix: invalidate count cache after EvalResult inserts (#9348)

### DIFF
--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -4,6 +4,7 @@ import { getDb } from '../database/index';
 import { evalResultsTable } from '../database/tables';
 import { getEnvBool } from '../envars';
 import logger from '../logger';
+import { clearCountCache } from './evalPerformance';
 import { hashPrompt } from '../prompts/utils';
 import { ProviderConfig } from '../providers/shared';
 import {
@@ -386,6 +387,7 @@ export default class EvalResult {
       args.gradingResult = sanitizeGradingResultForDb(args.gradingResult);
       args.metadata = sanitizeMetadataForDb(args.metadata);
       const dbResult = await db.insert(evalResultsTable).values(args).returning();
+      clearCountCache(evalId);
       return new EvalResult({ ...dbResult[0], persisted: true });
     }
     return new EvalResult(args);
@@ -429,6 +431,7 @@ export default class EvalResult {
         returnResults.push(new EvalResult({ ...dbResult, persisted: true }));
       }
     });
+    clearCountCache(evalId);
     return returnResults;
   }
 

--- a/test/models/evalPerformance.test.ts
+++ b/test/models/evalPerformance.test.ts
@@ -196,4 +196,80 @@ describe('evalPerformance', () => {
       expect(totalCount).toBe(12);
     });
   });
+
+  describe('cache invalidation on result write (issue #9348)', () => {
+    const makeResult = (evalId: string, testIdx: number) =>
+      ({
+        description: `test-${testIdx}`,
+        promptIdx: 0,
+        testIdx,
+        testCase: { vars: { input: `test${testIdx}` } },
+        promptId: 'test-prompt',
+        provider: { id: 'provider-1', label: 'Provider 1' },
+        prompt: { raw: 'Test prompt', label: 'Test prompt' },
+        vars: { input: `test${testIdx}` },
+        response: { output: `response-${testIdx}`, tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 0 } },
+        error: null,
+        failureReason: ResultFailureReason.NONE,
+        success: true,
+        score: 1,
+        latencyMs: 10,
+        gradingResult: { pass: true, score: 1, reason: 'Pass', namedScores: {}, tokensUsed: { total: 0, prompt: 0, completion: 0, cached: 0 }, componentResults: [] },
+        namedScores: {},
+        cost: 0,
+        metadata: {},
+      }) as Parameters<typeof import('../../src/models/evalResult')['default']['createFromEvaluateResult']>[1];
+
+    it('getCachedResultsCount refreshes after createFromEvaluateResult (issue #9348)', async () => {
+      const eval_ = await Eval.create(
+        { providers: [{ id: 'provider-1' }], prompts: ['Test prompt'], tests: [] },
+        [{ raw: 'Test prompt', label: 'Test prompt' }],
+      );
+
+      // Seed zero into cache before any inserts
+      const before = await getCachedResultsCount(eval_.id);
+      expect(before).toBe(0);
+
+      // Insert a result — this should bust the cache automatically
+      await eval_.addResult(makeResult(eval_.id, 0));
+
+      // Must see fresh count without any manual clearCountCache() call
+      const after = await getCachedResultsCount(eval_.id);
+      expect(after).toBe(1);
+    });
+
+    it('getTotalResultRowCount refreshes after createFromEvaluateResult (issue #9348)', async () => {
+      const eval_ = await Eval.create(
+        { providers: [{ id: 'provider-1' }], prompts: ['Test prompt'], tests: [] },
+        [{ raw: 'Test prompt', label: 'Test prompt' }],
+      );
+
+      const before = await getTotalResultRowCount(eval_.id);
+      expect(before).toBe(0);
+
+      await eval_.addResult(makeResult(eval_.id, 0));
+
+      const after = await getTotalResultRowCount(eval_.id);
+      expect(after).toBe(1);
+    });
+
+    it('getCachedResultsCount refreshes after createManyFromEvaluateResult (issue #9348)', async () => {
+      const eval_ = await Eval.create(
+        { providers: [{ id: 'provider-1' }], prompts: ['Test prompt'], tests: [] },
+        [{ raw: 'Test prompt', label: 'Test prompt' }],
+      );
+
+      const before = await getCachedResultsCount(eval_.id);
+      expect(before).toBe(0);
+
+      const EvalResult = (await import('../../src/models/evalResult')).default;
+      await EvalResult.createManyFromEvaluateResult(
+        [makeResult(eval_.id, 0), makeResult(eval_.id, 1)] as any,
+        eval_.id,
+      );
+
+      const after = await getCachedResultsCount(eval_.id);
+      expect(after).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #9348

`getCachedResultsCount()` and `getTotalResultRowCount()` cache their results with a 5-minute TTL, but neither `EvalResult.createFromEvaluateResult()` nor `EvalResult.createManyFromEvaluateResult()` ever called `clearCountCache()` after writing rows. This meant callers could see stale zero (or outdated) counts for up to 5 minutes after rows were inserted.

## Root Cause

The cache module (`evalPerformance.ts`) already exports `clearCountCache(evalId?)` but it was only used manually in tests and the `closeDb` path. The insert methods in `evalResult.ts` had no knowledge of the cache.

## Fix

- Import `clearCountCache` into `src/models/evalResult.ts`
- Call `clearCountCache(evalId)` after the `db.insert().returning()` in `createFromEvaluateResult` (persisted path only)
- Call `clearCountCache(evalId)` after the synchronous transaction in `createManyFromEvaluateResult`

## Tests

Added three regression tests to `test/models/evalPerformance.test.ts`:

1. `getCachedResultsCount` returns a fresh count after `createFromEvaluateResult` without any manual `clearCountCache()` call
2. `getTotalResultRowCount` returns a fresh count after `createFromEvaluateResult`
3. `getCachedResultsCount` returns a fresh count after `createManyFromEvaluateResult`

All existing evalPerformance tests continue to pass.