### PR TITLE
test(providers): drop flaky cross-process Anthropic cache hash spawn

### DIFF
--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -1,5 +1,3 @@
-import { spawnSync } from 'node:child_process';
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearCache, disableCache, enableCache, getCache } from '../../../src/cache';
 import logger from '../../../src/logger';
@@ -167,44 +165,10 @@ describe('AnthropicCompletionProvider', () => {
       expect(firstLoad.namespace).not.toContain('sk-ant-reload-secret');
     });
 
-    it('should keep cache key hashes stable across fresh processes', () => {
-      const importProbe = `
-        const { getAnthropicAuthCacheNamespace, hashAnthropicCacheValue } =
-          await import('./src/providers/anthropic/generic.ts');
-        process.stdout.write(JSON.stringify({
-          authNamespace: getAnthropicAuthCacheNamespace('sk-ant-restart-secret'),
-          requestHash: hashAnthropicCacheValue({ prompt: 'same prompt' }),
-        }));
-      `;
-
-      const spawnOptions = {
-        cwd: process.cwd(),
-        encoding: 'utf8' as const,
-        timeout: 10_000,
-      };
-      const firstRun = spawnSync(
-        process.execPath,
-        ['--import', 'tsx', '-e', importProbe],
-        spawnOptions,
-      );
-      const secondRun = spawnSync(
-        process.execPath,
-        ['--import', 'tsx', '-e', importProbe],
-        spawnOptions,
-      );
-
-      expect(firstRun.error, firstRun.error?.message).toBeUndefined();
-      expect(secondRun.error, secondRun.error?.message).toBeUndefined();
-      expect(firstRun.status, firstRun.stderr || firstRun.stdout).toBe(0);
-      expect(secondRun.status, secondRun.stderr || secondRun.stdout).toBe(0);
-      expect(firstRun.stdout).toBe(secondRun.stdout);
-      expect(JSON.parse(firstRun.stdout)).toMatchObject({
-        authNamespace: expect.stringMatching(/^[a-f0-9]{64}$/),
-        requestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
-      });
-      expect(firstRun.stdout).not.toContain('sk-ant-restart-secret');
-    });
-
+    // Pinning fixed digests here is the cross-process stability check: if a
+    // future change accidentally introduces non-determinism (e.g. randomness or
+    // env-derived state baked in at module load), these literal values will
+    // diverge in every process that runs the suite.
     it('should produce known hex digests for fixed inputs', async () => {
       const { getAnthropicAuthCacheNamespace, hashAnthropicCacheValue } = await import(
         '../../../src/providers/anthropic/generic'


### PR DESCRIPTION
## Summary

- Removes the flaky `should keep cache key hashes stable across fresh processes` test from `test/providers/anthropic/completion.test.ts` that was timing out on Windows + Node 24 CI runners (e.g. failed run in #9421).
- The test spawned two `node --import tsx -e ...` subprocesses with a 10s/spawn budget; tsx startup plus the transitive import graph of `src/providers/anthropic/generic.ts` (Anthropic SDK, Claude Code auth helpers, etc.) routinely exceeds that on Windows and the spawn fails with `ETIMEDOUT`. Per `test/AGENTS.md` we never bump test timeouts — we fix the slow test, and here the right fix is removal because the coverage is redundant.
- Drops the now-unused `spawnSync` import and adds a short comment on the existing `should produce known hex digests for fixed inputs` test explaining that it serves as the cross-process stability check.

## Why is this safe?

Cross-process determinism is already enforced by two existing tests added in the same PR (#9124) that introduced the spawn test:

1. **`should produce known hex digests for fixed inputs`** (line ~168) pins specific SHA-256 digests for the same inputs the spawn test used (`'sk-ant-restart-secret'`, `{ prompt: 'same prompt' }`). Because those expected digests are baked into the test file as string literals, **any process that diverges from determinism must fail this assertion**. By transitivity, two fresh processes that both pass it produce identical output.
2. **`should keep auth cache namespace stable across module reloads`** uses `vi.resetModules()` to catch module-load-time randomness (the original bug class #9124 was guarding against).

The spawn test only added unique value against a very narrow failure mode — non-determinism that depends on environment state present only inside Vitest's process — which neither matches the original bug nor is realistic given the functions are pure (`createHash` / `createHmac` over a fixed string context).

## Test plan

- [x] `npx vitest run test/providers/anthropic/completion.test.ts` — 13/13 pass in ~400ms
- [x] `npm run l && npm run f` — clean
- [ ] CI: confirm the Windows / Node 24.x shard 3/3 job that was previously flaking now goes green