### PR TITLE
fix(eval): invalidate count cache after retry cleanup

### DIFF
--- a/src/commands/retry.ts
+++ b/src/commands/retry.ts
@@ -7,6 +7,7 @@ import { evalResultsTable } from '../database/tables';
 import { evaluate } from '../evaluator';
 import logger from '../logger';
 import Eval from '../models/eval';
+import { clearCountCache } from '../models/evalPerformance';
 import { createShareableUrl, isSharingEnabled } from '../share';
 import { ResultFailureReason } from '../types/index';
 import {
@@ -65,9 +66,18 @@ export async function deleteErrorResults(resultIds: string[]): Promise<void> {
   }
 
   const db = getDb();
+  const affectedEvals = await db
+    .selectDistinct({ evalId: evalResultsTable.evalId })
+    .from(evalResultsTable)
+    .where(inArray(evalResultsTable.id, resultIds))
+    .all();
 
   // Use batch delete with inArray for better performance
   await db.delete(evalResultsTable).where(inArray(evalResultsTable.id, resultIds));
+
+  for (const { evalId } of affectedEvals) {
+    clearCountCache(evalId);
+  }
 
   logger.debug(`Deleted ${resultIds.length} error results from database`);
 }

--- a/test/commands/retry.test.ts
+++ b/test/commands/retry.test.ts
@@ -11,6 +11,7 @@ import { getDb } from '../../src/database/index';
 import { evalResultsTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
+import { getTotalResultRowCount } from '../../src/models/evalPerformance';
 import { ResultFailureReason } from '../../src/types/index';
 import { shouldShareResults } from '../../src/util/sharing';
 
@@ -179,6 +180,46 @@ describe('retry command', () => {
 
       expect(remaining).toHaveLength(1);
       expect(remaining[0].id).toBe(`${evalRecord.id}-del-2`);
+    });
+
+    it('should invalidate the cached total row count after deleting results', async () => {
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
+      const db = getDb();
+
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-del-1`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: { raw: 'test', display: 'test', label: 'test' },
+          testCase: { vars: {} },
+          provider: { id: 'test-provider' },
+          success: false,
+          score: 0,
+          failureReason: ResultFailureReason.ERROR,
+          namedScores: {},
+        },
+        {
+          id: `${evalRecord.id}-del-2`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: { raw: 'test', display: 'test', label: 'test' },
+          testCase: { vars: {} },
+          provider: { id: 'test-provider' },
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+        },
+      ]);
+
+      expect(await getTotalResultRowCount(evalRecord.id)).toBe(2);
+
+      await deleteErrorResults([`${evalRecord.id}-del-1`]);
+
+      expect(await getTotalResultRowCount(evalRecord.id)).toBe(1);
     });
 
     it('should handle empty array gracefully', async () => {


### PR DESCRIPTION
## Summary

- clear eval result-count caches after `retry` deletes replaced error rows
- retain batched deletion while discovering only affected eval IDs for invalidation
- add regression coverage that populates the total-row cache before cleanup

## Bug

The recent result-insert invalidation fix did not cover the delete side of retry cleanup. After a successful retry inserted replacement rows, `deleteErrorResults()` removed the original error rows without clearing `getTotalResultRowCount()`'s five-minute cache. Code paths such as result sharing could therefore continue to observe a stale total row count after retry completed.

## Validation

- Regression proof before the fix: `test/commands/retry.test.ts` failed with cached count `2` after one result had been deleted, where `1` was expected.
- `./node_modules/.bin/vitest run test/commands/retry.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l`
- `npm run tsc`
- `npm run build`
- Local CLI smoke flow in isolated `PROMPTFOO_CONFIG_DIR`: produced an intentional ERROR result with a local provider, then ran `npm run local -- retry <evalId> -c <success-config> --no-share --verbose`; retry completed, deleted the original error row, and recalculated metrics.
