### PR TITLE
fix(code-scan): honor minimum-severity alias when min-severity is unset

### DIFF
--- a/code-scan-action/action.yml
+++ b/code-scan-action/action.yml
@@ -12,13 +12,11 @@ inputs:
     required: false
     default: https://api.promptfoo.app
   min-severity:
-    description: 'Minimum severity level to report (low|medium|high|critical)'
+    description: 'Minimum severity level to report (low|medium|high|critical). Defaults to medium when neither min-severity nor minimum-severity is set.'
     required: false
-    default: 'medium'
   minimum-severity:
-    description: 'Alias for min-severity (low|medium|high|critical)'
+    description: 'Alias for min-severity (low|medium|high|critical). Has no default; takes effect only when min-severity is not set.'
     required: false
-    default: 'medium'
   config-path:
     description: 'Path to YAML configuration file'
     required: false

--- a/code-scan-action/src/main.ts
+++ b/code-scan-action/src/main.ts
@@ -53,10 +53,40 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+const DEFAULT_MINIMUM_SEVERITY = 'medium';
+
+/**
+ * Resolve the effective minimum severity from the two supported inputs.
+ *
+ * The two inputs do NOT carry defaults in `action.yml`. That keeps
+ * `core.getInput()` returning `''` when a workflow has not set the input,
+ * which is what lets a workflow that only sets the alias (`minimum-severity`)
+ * actually take effect. Precedence is:
+ *
+ *   1. `min-severity` if set
+ *   2. `minimum-severity` if set
+ *   3. fallback to `DEFAULT_MINIMUM_SEVERITY`
+ *
+ * If both are set to different values, `min-severity` wins and a warning is
+ * emitted so the workflow author can collapse the inputs.
+ */
+function resolveMinimumSeverityInput(): string {
+  const primary = core.getInput('min-severity').trim();
+  const alias = core.getInput('minimum-severity').trim();
+
+  if (primary && alias && primary !== alias) {
+    core.warning(
+      `Both min-severity (${primary}) and minimum-severity (${alias}) are set; using min-severity. minimum-severity is an alias and should only be set when min-severity is unset.`,
+    );
+  }
+
+  return primary || alias || DEFAULT_MINIMUM_SEVERITY;
+}
+
 function getActionInputs(): ActionInputs {
   return {
     apiHost: core.getInput('api-host'),
-    minimumSeverity: core.getInput('min-severity') || core.getInput('minimum-severity'),
+    minimumSeverity: resolveMinimumSeverityInput(),
     configPath: core.getInput('config-path'),
     guidanceText: core.getInput('guidance'),
     guidanceFile: core.getInput('guidance-file'),

--- a/site/docs/code-scanning/github-action.md
+++ b/site/docs/code-scanning/github-action.md
@@ -40,16 +40,16 @@ When using the GitHub App:
 
 Most CLI options from [`promptfoo code-scans run`](/docs/code-scanning/cli) can be used as action inputs:
 
-| Input               | Description                                                      | Default                     |
-| ------------------- | ---------------------------------------------------------------- | --------------------------- |
-| `api-host`          | Promptfoo API host URL                                           | `https://api.promptfoo.app` |
-| `min-severity`      | Minimum severity to report (`low`, `medium`, `high`, `critical`) | `medium`                    |
-| `minimum-severity`  | Alias for `min-severity`                                         | `medium`                    |
-| `config-path`       | Path to `.promptfoo-code-scan.yaml` config file                  | Auto-detected               |
-| `guidance`          | Custom guidance to tailor the scan (see [CLI docs][1])           | None                        |
-| `guidance-file`     | Path to file containing custom guidance (see [CLI docs][1])      | None                        |
-| `enable-fork-prs`   | Enable scanning PRs from forked repositories                     | `false`                     |
-| `sarif-output-path` | Optional path to write SARIF output for GitHub Code Scanning     | None                        |
+| Input               | Description                                                                                                                              | Default                     |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `api-host`          | Promptfoo API host URL                                                                                                                   | `https://api.promptfoo.app` |
+| `min-severity`      | Minimum severity to report (`low`, `medium`, `high`, `critical`)                                                                         | `medium`                    |
+| `minimum-severity`  | Alias for `min-severity`. Takes effect only when `min-severity` is unset; if both are set, `min-severity` wins and a warning is emitted. | None                        |
+| `config-path`       | Path to `.promptfoo-code-scan.yaml` config file                                                                                          | Auto-detected               |
+| `guidance`          | Custom guidance to tailor the scan (see [CLI docs][1])                                                                                   | None                        |
+| `guidance-file`     | Path to file containing custom guidance (see [CLI docs][1])                                                                              | None                        |
+| `enable-fork-prs`   | Enable scanning PRs from forked repositories                                                                                             | `false`                     |
+| `sarif-output-path` | Optional path to write SARIF output for GitHub Code Scanning                                                                             | None                        |
 
 [1]: [More on custom guidance](/docs/code-scanning/cli#custom-guidance)
 

--- a/site/docs/code-scanning/github-action.md
+++ b/site/docs/code-scanning/github-action.md
@@ -80,7 +80,7 @@ To enable scanning of fork PRs by default, add `enable-fork-prs: true` to your w
 - name: Run Promptfoo Code Scan
   uses: promptfoo/code-scan-action@v1
   with:
-    min-severity: medium # Report medium, high and critical severity issues only (if omitted, all severity levels are reported)
+    min-severity: medium # Report medium, high and critical issues (also the default when omitted)
 ```
 
 **Use custom guidance:**

--- a/test/code-scan-action/main.test.ts
+++ b/test/code-scan-action/main.test.ts
@@ -741,4 +741,79 @@ describe('code-scan-action main', () => {
       expect(mocks.core.setFailed).not.toHaveBeenCalled();
     });
   });
+
+  describe('minimum severity input resolution', () => {
+    function mockSeverityInputs(values: {
+      'min-severity'?: string;
+      'minimum-severity'?: string;
+    }): void {
+      mocks.core.getInput.mockImplementation((name: string) => {
+        if (name === 'github-token') {
+          return 'fake-token';
+        }
+        if (name === 'min-severity') {
+          return values['min-severity'] ?? '';
+        }
+        if (name === 'minimum-severity') {
+          return values['minimum-severity'] ?? '';
+        }
+        return '';
+      });
+    }
+
+    it('uses min-severity when only min-severity is set', async () => {
+      mockSeverityInputs({ 'min-severity': 'critical' });
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('critical', undefined);
+      expect(mocks.core.warning).not.toHaveBeenCalledWith(expect.stringContaining('min-severity'));
+    });
+
+    it('uses minimum-severity when only the alias is set (regression test for #9427)', async () => {
+      mockSeverityInputs({ 'minimum-severity': 'critical' });
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('critical', undefined);
+      expect(mocks.core.warning).not.toHaveBeenCalledWith(expect.stringContaining('min-severity'));
+    });
+
+    it('falls back to medium when neither input is set', async () => {
+      mockSeverityInputs({});
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('medium', undefined);
+      expect(mocks.core.warning).not.toHaveBeenCalledWith(expect.stringContaining('min-severity'));
+    });
+
+    it('prefers min-severity and warns when both inputs disagree', async () => {
+      mockSeverityInputs({ 'min-severity': 'high', 'minimum-severity': 'critical' });
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('high', undefined);
+      expect(mocks.core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Both min-severity (high) and minimum-severity (critical) are set'),
+      );
+    });
+
+    it('does not warn when both inputs are set to the same value', async () => {
+      mockSeverityInputs({ 'min-severity': 'high', 'minimum-severity': 'high' });
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('high', undefined);
+      expect(mocks.core.warning).not.toHaveBeenCalledWith(expect.stringContaining('min-severity'));
+    });
+
+    it('trims whitespace from severity inputs', async () => {
+      mockSeverityInputs({ 'minimum-severity': '  critical  ' });
+
+      await importActionAndGetPromptfooCall();
+
+      expect(mocks.config.generateConfigFile).toHaveBeenCalledWith('critical', undefined);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #9427.

Fixes the `minimum-severity` GitHub Action alias so it takes effect when `min-severity` is not specified. Previously both inputs had `medium` defaults in `action.yml`, causing the canonical input's injected default to mask an explicitly configured alias.

## Changes

- Remove YAML defaults from `min-severity` and `minimum-severity`, and resolve the effective `medium` fallback in action code.
- Give `min-severity` precedence when both inputs are provided and warn when their configured values disagree.
- Add focused action tests for canonical input, alias input, fallback, precedence, matching values, and whitespace handling.
- Document the alias precedence and correct the severity example so its omitted-input behavior matches the `medium` fallback.
- Merge the current `origin/main` before validation.

## Validation

- `npm run f` passed.
- `npm run l` passed.
- `git diff --check` passed.
- Attempted `npm --prefix code-scan-action run tsc`, but local action dependencies are incomplete (`tsc: not found`).
- Attempted `npx vitest run test/code-scan-action`, but the local root dependency installation is incomplete (`vitest/config` cannot be resolved).
- GitHub CI and PR title validation passed on head `80b614c81a063214bf1cbac2df49660ee8c1719c`.