### PR TITLE
chore: resolve AI quality findings

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -329,7 +329,7 @@ type AssertionValueFunctionContext = {
   providerResponse: ProviderResponse | undefined;
 };
 type AssertionResponse = string | boolean | number | GradingResult;
-type AssertFunction = (output: string, context: AssertionValueFunctionContext) => AssertResponse;
+type AssertFunction = (output: string, context: AssertionValueFunctionContext) => AssertionResponse;
 ```
 
 See [GradingResult definition](/docs/configuration/reference#gradingresult).
@@ -441,7 +441,7 @@ prompts:
   - file://prompt1.txt
   - file://prompt2.txt
 providers:
-  - openai:gpt-5-mini
+  - openai:gpt-5.5
   - localai:chat:vicuna
 tests:
   - vars:

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -613,19 +613,7 @@ describe('readStandaloneTestsFile', () => {
     // Integration test using the actual Excel file from examples
     const exampleFile = path.join(__dirname, '../../examples/simple-csv/tests.xlsx');
 
-    // Only run if read-excel-file is actually installed (in dev environment)
-    try {
-      await import('read-excel-file/node');
-    } catch {
-      // Skip test if read-excel-file is not installed
-      return;
-    }
-
     const actualFs = await vi.importActual<typeof import('fs')>('fs');
-    if (!actualFs.existsSync(exampleFile)) {
-      return;
-    }
-
     vi.mocked(fs.existsSync).mockImplementation((filePath) => actualFs.existsSync(filePath));
 
     const result = await readStandaloneTestsFile(exampleFile);
@@ -697,13 +685,10 @@ describe('readStandaloneTestsFile', () => {
     vi.mocked(runPython).mockResolvedValue(pythonResult);
 
     // Mock maybeLoadConfigFromExternalFile to transform file:// references
-    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation((config) => {
+    const transformExternalFileConfig = (config: any): any => {
       // Handle arrays first to preserve their type
       if (Array.isArray(config)) {
-        return config.map((item) => {
-          const mockFn = maybeLoadConfigFromExternalFile;
-          return mockFn(item);
-        });
+        return config.map((item) => transformExternalFileConfig(item));
       }
 
       if (typeof config === 'object' && config !== null) {
@@ -716,7 +701,8 @@ describe('readStandaloneTestsFile', () => {
         return result;
       }
       return config;
-    });
+    };
+    vi.mocked(maybeLoadConfigFromExternalFile).mockImplementation(transformExternalFileConfig);
 
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockImplementation((path) => {


### PR DESCRIPTION
## Summary

- Correct the assertion-template return type in the expected outputs docs and update its OpenAI provider example to `openai:gpt-5.5`, the current latest model documented by OpenAI.
- Make the real XLSX integration test fail visibly when its required fixture/dependency is unavailable instead of silently returning.
- Keep the external-file mock recursion inside its local implementation rather than recursively invoking the mocked export.

## AI finding disposition

- `test/providers/anthropic/completion.test.ts`: no change required. Recomputing the four pinned digests with the production hashing functions reproduced the existing values, and each literal is already 64 hexadecimal characters. The finding's proposed extra trailing `0` would make the fixtures incorrect.

Official model reference: https://developers.openai.com/api/docs/guides/latest-model

## Validation

- `npm run l`
- `npm run f`
- `npx vitest run test/providers/anthropic/completion.test.ts test/util/testCaseReader.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `SKIP_OG_GENERATION=true npm run build` from `site/`
