### PR TITLE
chore(deps): enforce Socket age floor for npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -259,27 +259,8 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Runtime npm deps: wait 7 days before updates",
+      "description": "All npm packages: wait 7 days to match the Socket minimum release age floor",
       "matchDatasources": ["npm"],
-      "matchDepTypes": ["dependencies"],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "Dev npm deps: wait 7 days before updates",
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "Optional npm deps: wait 7 days before updates (same as devDependencies)",
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["optionalDependencies"],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "npm overrides/resolutions: wait 7 days to match .npmrc min-release-age floor",
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["overrides", "pnpm.overrides", "resolutions"],
       "minimumReleaseAge": "7 days"
     },
 


### PR DESCRIPTION
## Summary
- consolidate npm `minimumReleaseAge` configuration into one `matchDatasources: ["npm"]` Renovate rule
- retain the seven-day floor across all npm dependency classifications
- leave package-specific grouping and scheduling rules unchanged

## Validation
- `npm run l`
- `npm run f`
- `npx --yes --package renovate -- renovate-config-validator renovate.json` (`Config validated successfully`)
- `git diff --check origin/main...HEAD`

## Note
- Renovate validation reports its existing `matchPackagePatterns` migration suggestion; this PR does not modify those package matching rules.
