### PR TITLE
fix(code-scan): suppress SARIF on skipped fork scans

### DIFF
--- a/site/docs/code-scanning/cli.md
+++ b/site/docs/code-scanning/cli.md
@@ -99,6 +99,9 @@ promptfoo code-scans run --format sarif > promptfoo-code-scan.sarif
 ```
 
 SARIF output includes location-backed findings that GitHub Code Scanning can display.
+If a `--github-pr` scan is skipped while a fork awaits maintainer approval, SARIF output is not
+generated and the command exits nonzero. Upload SARIF only after this command succeeds, since an
+empty uploaded report would incorrectly appear to be a completed clean scan.
 
 ## Configuration File
 

--- a/site/docs/code-scanning/cli.md
+++ b/site/docs/code-scanning/cli.md
@@ -99,9 +99,6 @@ promptfoo code-scans run --format sarif > promptfoo-code-scan.sarif
 ```
 
 SARIF output includes location-backed findings that GitHub Code Scanning can display.
-If a `--github-pr` scan is skipped while a fork awaits maintainer approval, SARIF output is not
-generated and the command exits nonzero. Upload SARIF only after this command succeeds, since an
-empty uploaded report would incorrectly appear to be a completed clean scan.
 
 ## Configuration File
 

--- a/src/codeScan/scanner/index.ts
+++ b/src/codeScan/scanner/index.ts
@@ -327,12 +327,12 @@ export async function executeScan(repoPath: string, options: ScanOptions): Promi
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    // Handle fork PR auth rejection as success — the server has already posted a helpful PR
-    // comment. Machine-readable modes must still emit a structured ScanResponse so consumers
-    // (e.g. the GitHub Action) don't choke on empty stdout. See issue #9424.
+    // Handle fork PR auth rejection as success for interactive and JSON consumers — the
+    // server has already posted a helpful PR comment. SARIF is different: an empty SARIF
+    // report would look like a completed clean scan if a workflow uploads it.
     if (errorMessage.includes('Fork PR scanning not authorized')) {
       const msg = 'Fork PR scanning requires maintainer approval. See PR comment for options.';
-      if (outputFormat !== CodeScanOutputFormat.TEXT) {
+      if (outputFormat === CodeScanOutputFormat.JSON) {
         // commentsPosted is intentionally omitted — the scanner has no signal that the
         // server actually posted the PR comment, only that authorization was rejected.
         // Consumers should branch on skipReason instead.
@@ -345,6 +345,15 @@ export async function executeScan(repoPath: string, options: ScanOptions): Promi
           format: outputFormat,
           githubPr: options.githubPr,
         });
+      } else if (outputFormat === CodeScanOutputFormat.SARIF) {
+        logger.error(
+          `Scan skipped: ${msg} SARIF output was not generated because the scan did not complete.`,
+        );
+        cliState.postActionCallback = async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          process.exitCode = 1;
+        };
+        return;
       } else if (showSpinner && spinner) {
         spinner.succeed(msg);
       } else {

--- a/test/codeScans/scanner/fork-pr-auth.test.ts
+++ b/test/codeScans/scanner/fork-pr-auth.test.ts
@@ -93,10 +93,7 @@ describe('Scanner fork PR auth rejection', () => {
 
   const SKIP_MESSAGE = 'Fork PR scanning requires maintainer approval. See PR comment for options.';
 
-  it.each([
-    'json',
-    'sarif',
-  ] as const)('emits a structured skip response with skipReason in %s mode', async (format) => {
+  it('emits a structured skip response with skipReason in json mode', async () => {
     mockForkPrAuthScanner();
 
     const { executeScan } = await import('../../../src/codeScan/scanner/index');
@@ -107,7 +104,7 @@ describe('Scanner fork PR auth rejection', () => {
     const { processDiff } = await import('../../../src/codeScan/git/diffProcessor');
 
     await executeScan('/test/repo', {
-      format,
+      format: 'json',
       diffsOnly: true,
       githubPr: 'test-owner/test-repo#123',
     });
@@ -123,7 +120,7 @@ describe('Scanner fork PR auth rejection', () => {
       },
       expect.any(Number),
       {
-        format,
+        format: 'json',
         githubPr: 'test-owner/test-repo#123',
       },
     );
@@ -133,6 +130,27 @@ describe('Scanner fork PR auth rejection', () => {
     await cliState.postActionCallback?.();
 
     expect(process.exitCode).toBe(0);
+  });
+
+  it('does not emit empty SARIF when fork authorization skips the scan', async () => {
+    mockForkPrAuthScanner();
+    vi.doUnmock('../../../src/codeScan/scanner/output');
+
+    const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { executeScan } = await import('../../../src/codeScan/scanner/index');
+    const cliState = (await import('../../../src/cliState')).default;
+
+    await executeScan('/test/repo', {
+      format: 'sarif',
+      diffsOnly: true,
+      githubPr: 'test-owner/test-repo#123',
+    });
+
+    await cliState.postActionCallback?.();
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it('emits stdout JSON that the action can round-trip parse', async () => {


### PR DESCRIPTION
## Summary
- prevent authorization-skipped fork PR scans from emitting an empty SARIF report that can look like a completed clean scan
- preserve structured JSON `skipReason` output for the GitHub Action path

## Root cause
PR #9426 correctly added a structured fork-authorization skip response for the action, but routed that same response through the CLI SARIF formatter. `scanResponseToSarif({ success: true, comments: [], skipReason })` produces a valid report with zero results, so a direct `--format sarif` workflow could upload an unscanned clean result.

## Validation
- Added `test/codeScans/scanner/fork-pr-auth.test.ts` coverage: it failed before the fix because a skipped scan wrote empty SARIF, then passed after the fix.
- `./node_modules/.bin/vitest run test/codeScans test/code-scan-action --sequence.shuffle=false`
- `npm run f`
- `npm run l` (passes with the existing non-blocking complexity warning in `executeScan()`)
- `npm run tsc`
- `git diff --check`
