### PR TITLE
fix: classify script stderr by severity

### DIFF
--- a/src/python/pythonUtils.ts
+++ b/src/python/pythonUtils.ts
@@ -13,6 +13,7 @@ import {
   removeSecureTempDirectory,
   writeSecureTempFile,
 } from '../util/secureTempFiles';
+import { PythonStderrLogger } from './stderr';
 
 const execFileAsync = promisify(execFile);
 
@@ -334,16 +335,18 @@ export async function runPython<T = unknown>(
     await new Promise<void>((resolve, reject) => {
       try {
         const pyshell = new PythonShell('wrapper.py', pythonOptions);
+        const stderrLogger = new PythonStderrLogger();
 
         pyshell.stdout?.on('data', (chunk: Buffer) => {
           logger.debug(chunk.toString('utf-8').trim());
         });
 
         pyshell.stderr?.on('data', (chunk: Buffer) => {
-          logger.error(chunk.toString('utf-8').trim());
+          stderrLogger.handleData(chunk);
         });
 
         pyshell.end((err) => {
+          stderrLogger.flush();
           if (err) {
             reject(err);
           } else {
@@ -374,18 +377,12 @@ export async function runPython<T = unknown>(
 
     return result.data;
   } catch (error) {
-    logger.error(
-      `Error running Python script: ${(error as Error).message}\nStack Trace: ${
-        (error as Error).stack?.replace('--- Python Traceback ---', 'Python Traceback: ') ||
-        'No Python traceback available'
-      }`,
-    );
-    throw new Error(
-      `Error running Python script: ${(error as Error).message}\nStack Trace: ${
-        (error as Error).stack?.replace('--- Python Traceback ---', 'Python Traceback: ') ||
-        'No Python traceback available'
-      }`,
-    );
+    const message = `Error running Python script: ${(error as Error).message}\nStack Trace: ${
+      (error as Error).stack?.replace('--- Python Traceback ---', 'Python Traceback: ') ||
+      'No Python traceback available'
+    }`;
+    logger.error(message);
+    throw new Error(message);
   } finally {
     if (tempDirectory) {
       try {

--- a/src/python/stderr.ts
+++ b/src/python/stderr.ts
@@ -1,0 +1,115 @@
+import { StringDecoder } from 'string_decoder';
+
+import logger from '../logger';
+
+export const MAX_STDERR_BUFFER_LENGTH = 16_384;
+
+type StderrLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export class PythonStderrLogger {
+  private buffer = '';
+  private decoder = new StringDecoder('utf8');
+  private inTraceback = false;
+
+  constructor(private readonly prefix = '') {}
+
+  handleData(data: Buffer | string): void {
+    const text = typeof data === 'string' ? data : this.decoder.write(data);
+    this.buffer += text;
+
+    const carry = this.buffer.endsWith('\r') ? '\r' : '';
+    const normalized = (carry ? this.buffer.slice(0, -1) : this.buffer).replace(/\r\n?/g, '\n');
+    const lines = normalized.split('\n');
+    this.buffer = (lines.pop() ?? '') + carry;
+
+    for (const line of lines) {
+      this.logLine(line);
+    }
+
+    if (this.buffer.length >= MAX_STDERR_BUFFER_LENGTH) {
+      this.logLine(this.buffer);
+      this.buffer = '';
+    }
+  }
+
+  flush(): void {
+    const remaining = this.buffer + this.decoder.end();
+    this.buffer = '';
+
+    if (remaining) {
+      for (const line of remaining.split(/\r\n|[\r\n]/)) {
+        this.logLine(line);
+      }
+    }
+
+    this.inTraceback = false;
+    this.decoder = new StringDecoder('utf8');
+  }
+
+  private logLine(line: string): void {
+    if (!line.trim()) {
+      this.inTraceback = false;
+      return;
+    }
+
+    if (this.inTraceback && /^\s/.test(line)) {
+      this.writeLog('error', line);
+      return;
+    }
+
+    const trimmedStart = line.trimStart();
+    if (/^Traceback \(most recent call last\):/i.test(trimmedStart)) {
+      this.inTraceback = true;
+      this.writeLog('error', line);
+      return;
+    }
+
+    const prefixMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)\b[: ]?/i.exec(
+      trimmedStart,
+    );
+    if (prefixMatch) {
+      this.inTraceback = false;
+      this.writeLog(this.normalizeLevel(prefixMatch[1]), line);
+      return;
+    }
+
+    if (this.inTraceback) {
+      this.inTraceback = false;
+      this.writeLog('error', line);
+      return;
+    }
+
+    if (
+      /^(During handling of the above exception|The above exception was the direct cause)/i.test(
+        trimmedStart,
+      )
+    ) {
+      this.writeLog('error', line);
+      return;
+    }
+
+    this.writeLog('warn', line);
+  }
+
+  private normalizeLevel(level: string): StderrLevel {
+    switch (level.toUpperCase()) {
+      case 'DEBUG':
+        return 'debug';
+      case 'INFO':
+        return 'info';
+      case 'WARN':
+      case 'WARNING':
+        return 'warn';
+      case 'ERROR':
+      case 'CRITICAL':
+      case 'FATAL':
+        return 'error';
+      default:
+        return 'warn';
+    }
+  }
+
+  private writeLog(level: StderrLevel, line: string): void {
+    logger[level](`${this.prefix}${line}`);
+  }
+}

--- a/src/python/worker.ts
+++ b/src/python/worker.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { StringDecoder } from 'string_decoder';
 
 import { PythonShell } from 'python-shell';
 import { getWrapperDir } from '../esm';
@@ -13,8 +12,9 @@ import {
   writeSecureTempFile,
 } from '../util/secureTempFiles';
 import { validatePythonPath } from './pythonUtils';
+import { PythonStderrLogger } from './stderr';
 
-export const MAX_STDERR_BUFFER_LENGTH = 16_384;
+export { MAX_STDERR_BUFFER_LENGTH } from './stderr';
 
 export class PythonWorker {
   private process: PythonShell | null = null;
@@ -22,9 +22,7 @@ export class PythonWorker {
   private busy: boolean = false;
   private shuttingDown: boolean = false;
   private crashCount: number = 0;
-  private stderrBuffer: string = '';
-  private stderrDecoder = new StringDecoder('utf8');
-  private inTraceback: boolean = false;
+  private stderrLogger = new PythonStderrLogger('Python worker stderr: ');
   private readonly maxCrashes: number = 3;
   private pendingRequest: {
     responseFile: string;
@@ -108,128 +106,11 @@ export class PythonWorker {
   }
 
   private handleStderr(data: Buffer | string): void {
-    const text = typeof data === 'string' ? data : this.stderrDecoder.write(data);
-    this.stderrBuffer += text;
-
-    // A trailing bare `\r` may be the first half of a `\r\n` pair split across
-    // chunks, so hold it back until the next chunk (or flush) disambiguates it.
-    const carry = this.stderrBuffer.endsWith('\r') ? '\r' : '';
-    const normalized = (carry ? this.stderrBuffer.slice(0, -1) : this.stderrBuffer).replace(
-      /\r\n?/g,
-      '\n',
-    );
-
-    const lines = normalized.split('\n');
-    this.stderrBuffer = (lines.pop() ?? '') + carry;
-
-    for (const line of lines) {
-      this.logStderrLine(line);
-    }
-
-    // Bound an unterminated line so a misbehaving provider cannot grow the
-    // buffer without limit. The flushed fragment is best-effort: it may be the
-    // middle of a longer line and is classified on its own.
-    if (this.stderrBuffer.length >= MAX_STDERR_BUFFER_LENGTH) {
-      this.logStderrLine(this.stderrBuffer);
-      this.stderrBuffer = '';
-    }
+    this.stderrLogger.handleData(data);
   }
 
   private flushStderr(): void {
-    const remaining = this.stderrBuffer + this.stderrDecoder.end();
-    this.stderrBuffer = '';
-
-    if (remaining) {
-      for (const line of remaining.split(/\r\n|[\r\n]/)) {
-        this.logStderrLine(line);
-      }
-    }
-
-    // Reset traceback state only after the buffered lines are logged, so a
-    // buffered final traceback line is still classified as an error. Refresh
-    // the decoder in case the worker restarts and reuses this instance.
-    this.inTraceback = false;
-    this.stderrDecoder = new StringDecoder('utf8');
-  }
-
-  private logStderrLine(line: string): void {
-    // Blank lines terminate any in-progress traceback.
-    if (!line.trim()) {
-      this.inTraceback = false;
-      return;
-    }
-
-    // Inside a traceback, indented lines are always continuation frames.
-    // Classify them before prefix detection so a source line such as
-    // `    info = get_info()` is not mistaken for an INFO log record.
-    if (this.inTraceback && /^\s/.test(line)) {
-      this.writeStderrLog('error', line);
-      return;
-    }
-
-    const trimmedStart = line.trimStart();
-
-    // The traceback header opens a new traceback block.
-    if (/^Traceback \(most recent call last\):/i.test(trimmedStart)) {
-      this.inTraceback = true;
-      this.writeStderrLog('error', line);
-      return;
-    }
-
-    // An explicit Python log-level prefix wins over everything else.
-    const prefixMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL|FATAL)\b[: ]?/i.exec(
-      trimmedStart,
-    );
-    if (prefixMatch) {
-      this.inTraceback = false;
-      this.writeStderrLog(this.normalizeStderrLevel(prefixMatch[1]), line);
-      return;
-    }
-
-    // A non-indented line while inside a traceback is the exception summary
-    // (e.g. `ValueError: boom`) that ends the traceback.
-    if (this.inTraceback) {
-      this.inTraceback = false;
-      this.writeStderrLog('error', line);
-      return;
-    }
-
-    // Connector lines bridge chained exceptions; keep them at error level so a
-    // multi-exception report reads coherently in the logs.
-    if (
-      /^(During handling of the above exception|The above exception was the direct cause)/i.test(
-        trimmedStart,
-      )
-    ) {
-      this.writeStderrLog('error', line);
-      return;
-    }
-
-    // Unclassified stderr stays visible without being treated as a failure.
-    this.writeStderrLog('warn', line);
-  }
-
-  private normalizeStderrLevel(level: string): 'debug' | 'info' | 'warn' | 'error' {
-    switch (level.toUpperCase()) {
-      case 'DEBUG':
-        return 'debug';
-      case 'INFO':
-        return 'info';
-      case 'WARN':
-      case 'WARNING':
-        return 'warn';
-      case 'ERROR':
-      case 'CRITICAL':
-      case 'FATAL':
-        return 'error';
-      default:
-        return 'warn';
-    }
-  }
-
-  private writeStderrLog(level: 'debug' | 'info' | 'warn' | 'error', line: string): void {
-    const message = `Python worker stderr: ${line}`;
-    logger[level](message);
+    this.stderrLogger.flush();
   }
 
   async call(functionName: string, args: unknown[]): Promise<unknown> {

--- a/src/ruby/rubyUtils.ts
+++ b/src/ruby/rubyUtils.ts
@@ -15,6 +15,44 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+function logStderr(stderr: string): void {
+  for (const line of stderr.split(/\r?\n/)) {
+    const message = line.trim();
+    if (!message) {
+      continue;
+    }
+
+    const levelMatch = /^(DEBUG|INFO|WARN|WARNING|ERROR|FATAL)\b[: ]?/i.exec(message);
+    if (levelMatch) {
+      switch (levelMatch[1].toUpperCase()) {
+        case 'DEBUG':
+          logger.debug(message);
+          continue;
+        case 'INFO':
+          logger.info(message);
+          continue;
+        case 'WARN':
+        case 'WARNING':
+          logger.warn(message);
+          continue;
+        default:
+          logger.error(message);
+          continue;
+      }
+    }
+
+    if (
+      /\b(error|exception|fatal|failed|failure)\b/i.test(message) ||
+      /(?:Error|Exception)\b/.test(message) ||
+      /^from\s.+:\d+/.test(message)
+    ) {
+      logger.error(message);
+    } else {
+      logger.warn(message);
+    }
+  }
+}
+
 /**
  * Global state for Ruby executable path caching.
  * Ensures consistent Ruby executable usage across multiple provider instances.
@@ -316,7 +354,7 @@ export async function runRuby<T = unknown>(
     }
 
     if (stderr) {
-      logger.error(stderr.trim());
+      logStderr(stderr);
     }
 
     const output = await fs.readFile(outputPath, 'utf-8');

--- a/src/ruby/rubyUtils.ts
+++ b/src/ruby/rubyUtils.ts
@@ -26,17 +26,17 @@ function logStderr(stderr: string): void {
     if (levelMatch) {
       switch (levelMatch[1].toUpperCase()) {
         case 'DEBUG':
-          logger.debug(message);
+          logger.debug(line);
           continue;
         case 'INFO':
-          logger.info(message);
+          logger.info(line);
           continue;
         case 'WARN':
         case 'WARNING':
-          logger.warn(message);
+          logger.warn(line);
           continue;
         default:
-          logger.error(message);
+          logger.error(line);
           continue;
       }
     }
@@ -46,9 +46,9 @@ function logStderr(stderr: string): void {
       /(?:Error|Exception)\b/.test(message) ||
       /^from\s.+:\d+/.test(message)
     ) {
-      logger.error(message);
+      logger.error(line);
     } else {
-      logger.warn(message);
+      logger.warn(line);
     }
   }
 }

--- a/test/googleSheets.optionalDependency.test.ts
+++ b/test/googleSheets.optionalDependency.test.ts
@@ -22,9 +22,8 @@ describe('Google Sheets optional dependency', () => {
     const fetchPromise = fetchCsvFromGoogleSheetAuthenticated(SHEET_URL);
 
     await expect(fetchPromise).rejects.toThrow(
-      'The @googleapis/sheets package is required for authenticated Google Sheets access.',
+      /The @googleapis\/sheets package is required for authenticated Google Sheets access\.[\s\S]*npm install @googleapis\/sheets/,
     );
-    await expect(fetchPromise).rejects.toThrow('npm install @googleapis/sheets');
   });
 
   it('keeps public-sheet CSV reads working when the access probe fails', async () => {
@@ -37,9 +36,6 @@ describe('Google Sheets optional dependency', () => {
       });
 
     vi.doMock('../src/util/fetch/index', () => ({ fetchWithProxy }));
-    vi.doMock('@googleapis/sheets', () => {
-      throw new Error('Cannot find package @googleapis/sheets');
-    });
 
     const { fetchCsvFromGoogleSheet } = await import('../src/googleSheets');
 

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -2209,24 +2209,5 @@ describe('evaluator', () => {
       const safePath = buildSafeJsonPath(attackField);
       expect(safePath).toBe('$."field\'; DROP TABLE evals; --"');
     });
-
-    it('should safely handle search queries with SQL metacharacters', async () => {
-      // Search queries are handled via Drizzle's parameterized sql template strings:
-      // sql`response LIKE ${searchPattern}`
-      //
-      // The searchPattern is never interpolated into the SQL string.
-      // A malicious search like "'; SELECT * FROM evals; --" would be:
-      // 1. Wrapped in % for LIKE: "%'; SELECT * FROM evals; --%"
-      // 2. Passed as a parameterized value
-      // 3. Treated as a literal string to search for
-      //
-      // This is verified by inspection of buildFilterWhereSql:
-      // const searchPattern = `%${opts.searchQuery}%`;
-      // sql`response LIKE ${searchPattern}` - parameterized, not interpolated
-
-      // The existing "should sanitize SQL inputs properly" test at line 711
-      // exercises this with actual database queries and verifies no SQL error occurs.
-      expect(true).toBe(true);
-    });
   });
 });

--- a/test/python/pythonUtils.test.ts
+++ b/test/python/pythonUtils.test.ts
@@ -62,6 +62,7 @@ vi.mock('../../src/logger', () => ({
   default: {
     debug: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
     warn: vi.fn(),
   },
 }));
@@ -97,6 +98,9 @@ describe('Python Utils', () => {
     mockExecFileAsync.mockReset();
     pythonUtils.state.cachedPythonPath = null;
     pythonUtils.state.validationPromise = null;
+    mockPythonShellInstance.stdout.on.mockReset();
+    mockPythonShellInstance.stderr.on.mockReset();
+    mockPythonShellInstance.end.mockReset();
     // Set default mock return values
     vi.mocked(getEnvString).mockReturnValue('');
     vi.mocked(getEnvBool).mockReturnValue(false);
@@ -609,6 +613,27 @@ describe('Python Utils', () => {
       const debugMessages = vi.mocked(logger.debug).mock.calls.flat().map(String).join('\n');
       expect(debugMessages).not.toContain('secret-input');
       expect(debugMessages).not.toContain('secret-result');
+    });
+
+    it('classifies routine stderr without reporting Python logging as errors', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ type: 'final_result', data: 'result' }),
+      );
+      mockExecFileAsync.mockResolvedValue({ stdout: 'Python 3.8.10\n', stderr: '' });
+      mockPythonShellInstance.stderr.on.mockImplementation((event: string, callback: any) => {
+        if (event === 'data') {
+          callback(Buffer.from('INFO:root:loaded config\nWARNING:root:slow response\n'));
+        }
+      });
+      mockPythonShellInstance.end.mockImplementation((callback: any) => {
+        callback(null);
+      });
+
+      await pythonUtils.runPython('/path/to/script.py', 'test_method', []);
+
+      expect(logger.info).toHaveBeenCalledWith('INFO:root:loaded config');
+      expect(logger.warn).toHaveBeenCalledWith('WARNING:root:slow response');
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should throw an error if Python script does not return final_result', async () => {

--- a/test/ruby/rubyUtils.test.ts
+++ b/test/ruby/rubyUtils.test.ts
@@ -102,7 +102,8 @@ describe('Ruby utilities', () => {
       .mockResolvedValueOnce({ stdout: 'ruby 3.3.0\n', stderr: '' })
       .mockResolvedValueOnce({
         stdout: '',
-        stderr: 'INFO: loaded\nplain progress\nRuntimeError: boom\n',
+        stderr:
+          "INFO: loaded\nplain progress\nRuntimeError: boom\n\tfrom /path/script.rb:12:in `call_api'\n",
       });
 
     await rubyUtils.runRuby('/path/to/script.rb', 'call_api', []);
@@ -110,6 +111,7 @@ describe('Ruby utilities', () => {
     expect(logger.info).toHaveBeenCalledWith('INFO: loaded');
     expect(logger.warn).toHaveBeenCalledWith('plain progress');
     expect(logger.error).toHaveBeenCalledWith('RuntimeError: boom');
+    expect(logger.error).toHaveBeenCalledWith("\tfrom /path/script.rb:12:in `call_api'");
     expect(logger.error).not.toHaveBeenCalledWith(expect.stringContaining('plain progress'));
   });
 });

--- a/test/ruby/rubyUtils.test.ts
+++ b/test/ruby/rubyUtils.test.ts
@@ -40,6 +40,8 @@ vi.mock('../../src/logger', () => ({
   default: {
     debug: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -92,5 +94,22 @@ describe('Ruby utilities', () => {
     const debugMessages = vi.mocked(logger.debug).mock.calls.flat().map(String).join('\n');
     expect(debugMessages).not.toContain('secret-input');
     expect(debugMessages).not.toContain('secret-result');
+  });
+
+  it('classifies routine stderr without reporting it as an error', async () => {
+    mockExecFileAsync
+      .mockReset()
+      .mockResolvedValueOnce({ stdout: 'ruby 3.3.0\n', stderr: '' })
+      .mockResolvedValueOnce({
+        stdout: '',
+        stderr: 'INFO: loaded\nplain progress\nRuntimeError: boom\n',
+      });
+
+    await rubyUtils.runRuby('/path/to/script.rb', 'call_api', []);
+
+    expect(logger.info).toHaveBeenCalledWith('INFO: loaded');
+    expect(logger.warn).toHaveBeenCalledWith('plain progress');
+    expect(logger.error).toHaveBeenCalledWith('RuntimeError: boom');
+    expect(logger.error).not.toHaveBeenCalledWith(expect.stringContaining('plain progress'));
   });
 });

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -110,7 +110,7 @@ describe('sanitizeObject', () => {
   });
 
   describe('function handling', () => {
-    it('should convert named functions to string representation', () => {
+    it('should lose named functions during JSON serialization', () => {
       function namedFunction() {
         return 'test';
       }
@@ -119,7 +119,7 @@ describe('sanitizeObject', () => {
       expect(result.func).toBeUndefined();
     });
 
-    it('should convert anonymous functions to string representation', () => {
+    it('should lose anonymous functions during JSON serialization', () => {
       const anonymousFunc = function () {
         return 'test';
       };
@@ -128,7 +128,7 @@ describe('sanitizeObject', () => {
       expect(result.func).toBeUndefined();
     });
 
-    it('should convert arrow functions to string representation', () => {
+    it('should lose arrow functions during JSON serialization', () => {
       const arrowFunc = () => 'test';
       const result = sanitizeObject({ func: arrowFunc });
       // Functions get lost during JSON.parse/stringify cycle
@@ -774,8 +774,10 @@ describe('sanitizeObject', () => {
     it('should handle BigInt values', () => {
       const input = { bigNum: BigInt(9007199254740991), password: 'secret' };
       const result = sanitizeObject(input);
-      // BigInt is not JSON serializable, safe-stringify returns a string
-      expect(result).toBe('[unable to serialize, circular reference is too complex to analyze]');
+      // BigInt is not JSON serializable; sanitizer should not expose original data.
+      expect(typeof result).toBe('string');
+      expect(result).not.toContain('9007199254740991');
+      expect(result).not.toContain('secret');
     });
   });
 


### PR DESCRIPTION
## Summary
- share the existing Python stderr parser between persistent workers and one-shot script execution so routine `INFO`/`WARNING` output is not logged as an error
- classify Ruby script stderr by explicit severity, retaining error reporting for exception-shaped output
- remove or tighten AI-flagged test assertions whose wording or implementation did not provide meaningful coverage

## AI Findings Triage
- Addressed the actionable findings visible on the GitHub AI findings page across `src/python/pythonUtils.ts`, `src/ruby/rubyUtils.ts`, `test/googleSheets.optionalDependency.test.ts`, `test/models/eval.test.ts`, and `test/util/sanitizer.test.ts`.
- Preserved `falls back to authenticated sheet access when the probe and CSV export both fail`: `fetchCsvFromGoogleSheet()` intentionally falls back to authenticated access for any unauthenticated export failure after a probe with no status. Replacing this success assertion with a rejection would assert behavior contrary to the implementation.

## Validation
- `npx vitest run test/python/pythonUtils.test.ts test/python/worker.test.ts test/ruby/rubyUtils.test.ts test/googleSheets.optionalDependency.test.ts test/models/eval.test.ts test/util/sanitizer.test.ts --sequence.shuffle=false` (350 tests passed)
- `npm run l`
- `npm run f`
- `npm run tsc`
- `npm run local -- eval -c /private/tmp/promptfoo-ai-findings-stderr-eval.yaml --no-cache -o /private/tmp/promptfoo-ai-findings-stderr-results.json` (1 result passed, score 1, 0 errors; exercises routine Python and Ruby stderr)

## Local Environment Note
- A clean `npm ci` in this fresh worktree did not finish within an extended retry window. Focused local checks ran using the existing local dependency tree; CI provides clean-install validation for the PR.