### PR TITLE
fix(eval): reuse configured grading provider references

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -106,7 +106,7 @@ tests:
           id: litellm:gemini-pro
           config:
             apiBaseUrl: http://localhost:4000
-            apiKey: ${LITELLM_API_KEY}
+            apiKey: '{{ env.LITELLM_API_KEY }}'
             temperature: 0
 ```
 
@@ -117,7 +117,7 @@ providers:
   - id: litellm:gemini-pro
     config:
       apiBaseUrl: http://localhost:4000
-      apiKey: ${LITELLM_API_KEY}
+      apiKey: '{{ env.LITELLM_API_KEY }}'
       temperature: 0
 
 tests:

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -89,47 +89,26 @@ See the [llm-rubric grader override docs](/docs/configuration/expected-outputs/m
 
 ### Using LiteLLM as the G-Eval grader
 
-G-Eval makes two grader calls: one to generate evaluation steps (`g-eval-steps`) and one to score the output (`g-eval`). Entries in the top-level `providers` list are evaluation targets. If LiteLLM should only grade another provider's responses, configure it directly on the assertion:
+G-Eval makes one grader call to generate evaluation steps and another to score the output. To reuse a configured LiteLLM provider for both calls, reference its ID on the assertion and restrict the test target to the provider being evaluated:
 
 ```yaml
 providers:
   - id: openai:gpt-5
-
-tests:
-  - vars:
-      topic: 'refund policy'
-    assert:
-      - type: g-eval
-        value: 'Check whether the answer is grounded in the policy and does not add unsupported details'
-        threshold: 0.7
-        provider:
-          id: litellm:gemini-pro
-          config:
-            apiBaseUrl: http://localhost:4000
-            apiKey: '{{ env.LITELLM_API_KEY }}'
-            temperature: 0
-```
-
-If the configured LiteLLM provider is intentionally also an evaluation target, an assertion can reference its provider ID instead. Promptfoo reuses the loaded provider instance, including its proxy URL, key, and model parameters, for both grader calls:
-
-```yaml
-providers:
   - id: litellm:gemini-pro
     config:
       apiBaseUrl: http://localhost:4000
-      apiKey: '{{ env.LITELLM_API_KEY }}'
       temperature: 0
 
 tests:
   - providers:
-      - litellm:gemini-pro
+      - openai:gpt-5
     assert:
       - type: g-eval
         value: 'Check whether the answer is grounded and complete'
         provider: litellm:gemini-pro
 ```
 
-If the LiteLLM grader returns an empty response, promptfoo reports which G-Eval phase and provider returned no output to make proxy or model routing issues easier to debug.
+For LiteLLM proxy credentials and environment configuration, see the [LiteLLM provider guide](/docs/providers/litellm).
 
 ## Example
 

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -87,6 +87,31 @@ assert:
 
 See the [llm-rubric grader override docs](/docs/configuration/expected-outputs/model-graded/llm-rubric#setting-grader-parameters-temperature-etc) for more detail.
 
+### Using LiteLLM as the G-Eval grader
+
+G-Eval makes two grader calls: one to generate evaluation steps (`g-eval-steps`) and one to score the output (`g-eval`). When using a LiteLLM proxy as the grader, define the LiteLLM provider once and reference the same provider ID from the assertion so the configured proxy URL, key, and model parameters are reused for both calls:
+
+```yaml
+providers:
+  - id: openai:gpt-5
+  - id: litellm:gemini-pro
+    config:
+      apiBaseUrl: http://localhost:4000
+      apiKey: ${LITELLM_API_KEY}
+      temperature: 0
+
+tests:
+  - vars:
+      topic: 'refund policy'
+    assert:
+      - type: g-eval
+        value: 'Check whether the answer is grounded in the policy and does not add unsupported details'
+        threshold: 0.7
+        provider: litellm:gemini-pro
+```
+
+If the LiteLLM grader returns an empty response, promptfoo reports which G-Eval phase and provider returned no output to make proxy or model routing issues easier to debug.
+
 ## Example
 
 Here's a complete example showing how to use G-Eval to assess multiple aspects of an LLM response:

--- a/site/docs/configuration/expected-outputs/model-graded/g-eval.md
+++ b/site/docs/configuration/expected-outputs/model-graded/g-eval.md
@@ -89,16 +89,11 @@ See the [llm-rubric grader override docs](/docs/configuration/expected-outputs/m
 
 ### Using LiteLLM as the G-Eval grader
 
-G-Eval makes two grader calls: one to generate evaluation steps (`g-eval-steps`) and one to score the output (`g-eval`). When using a LiteLLM proxy as the grader, define the LiteLLM provider once and reference the same provider ID from the assertion so the configured proxy URL, key, and model parameters are reused for both calls:
+G-Eval makes two grader calls: one to generate evaluation steps (`g-eval-steps`) and one to score the output (`g-eval`). Entries in the top-level `providers` list are evaluation targets. If LiteLLM should only grade another provider's responses, configure it directly on the assertion:
 
 ```yaml
 providers:
   - id: openai:gpt-5
-  - id: litellm:gemini-pro
-    config:
-      apiBaseUrl: http://localhost:4000
-      apiKey: ${LITELLM_API_KEY}
-      temperature: 0
 
 tests:
   - vars:
@@ -107,6 +102,30 @@ tests:
       - type: g-eval
         value: 'Check whether the answer is grounded in the policy and does not add unsupported details'
         threshold: 0.7
+        provider:
+          id: litellm:gemini-pro
+          config:
+            apiBaseUrl: http://localhost:4000
+            apiKey: ${LITELLM_API_KEY}
+            temperature: 0
+```
+
+If the configured LiteLLM provider is intentionally also an evaluation target, an assertion can reference its provider ID instead. Promptfoo reuses the loaded provider instance, including its proxy URL, key, and model parameters, for both grader calls:
+
+```yaml
+providers:
+  - id: litellm:gemini-pro
+    config:
+      apiBaseUrl: http://localhost:4000
+      apiKey: ${LITELLM_API_KEY}
+      temperature: 0
+
+tests:
+  - providers:
+      - litellm:gemini-pro
+    assert:
+      - type: g-eval
+        value: 'Check whether the answer is grounded and complete'
         provider: litellm:gemini-pro
 ```
 

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -14,8 +14,8 @@ import { isTransformFunction } from './types/transform';
 import { maybeLoadFromExternalFile } from './util/file';
 import {
   buildConfiguredProviderMap,
-  GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
+  resolveConfiguredProviderReference,
 } from './util/gradingProvider';
 import { readFilters, writeMultipleOutputs, writeOutput } from './util/index';
 import { readTests } from './util/testCaseReader';
@@ -208,17 +208,10 @@ async function resolveGradingProvider(
     return isApiProvider(provider) ? provider : resolveProvider(provider, providerMap, context);
   }
 
-  const resolvedProvider = { ...provider };
-  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
-    const nestedProvider = provider[providerType];
-    if (!nestedProvider) {
-      continue;
-    }
-    resolvedProvider[providerType] = isApiProvider(nestedProvider)
-      ? nestedProvider
-      : await resolveProvider(nestedProvider, providerMap, context);
-  }
-  return resolvedProvider;
+  // A typed map can carry alternatives for assertion types that never run.
+  // Reuse configured provider instances, but leave all other entries for
+  // getGradingProvider() to instantiate only when its type is selected.
+  return resolveConfiguredProviderReference(provider, providerMap);
 }
 
 async function createRuntimeTestSuite(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -14,6 +14,7 @@ import { isTransformFunction } from './types/transform';
 import { maybeLoadFromExternalFile } from './util/file';
 import {
   buildConfiguredProviderMap,
+  GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
   resolveConfiguredProviderReference,
 } from './util/gradingProvider';
@@ -22,6 +23,7 @@ import { readTests } from './util/testCaseReader';
 import { INLINE_FUNCTION_LABEL, TRANSFORM_KEYS } from './util/transform';
 
 import type {
+  EnvOverrides,
   EvaluateTestSuite,
   GradingConfig,
   Scenario,
@@ -30,7 +32,7 @@ import type {
   UnifiedConfig,
 } from './types/index';
 import type { InternalEvaluateOptions } from './types/internal';
-import type { ApiProvider } from './types/providers';
+import type { ApiProvider, ProviderTypeMap } from './types/providers';
 
 /**
  * Shallow-clone a test case so the caller can swap in resolved ApiProvider
@@ -199,10 +201,33 @@ function createSerializableUnifiedConfig(
   return config;
 }
 
+function addSuiteEnvToDeferredTypedProviders(
+  provider: ProviderTypeMap,
+  env: EnvOverrides | undefined,
+): ProviderTypeMap {
+  if (!env) {
+    return provider;
+  }
+
+  const providerWithEnv = { ...provider };
+  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
+    const nestedProvider = provider[providerType];
+    if (!nestedProvider || isApiProvider(nestedProvider)) {
+      continue;
+    }
+
+    providerWithEnv[providerType] =
+      typeof nestedProvider === 'string'
+        ? { id: nestedProvider, env }
+        : { ...nestedProvider, env: { ...env, ...nestedProvider.env } };
+  }
+  return providerWithEnv;
+}
+
 async function resolveGradingProvider(
   provider: GradingConfig['provider'],
   providerMap: Record<string, ApiProvider>,
-  context: { env?: unknown; basePath?: string },
+  context: { env?: EnvOverrides; basePath?: string },
 ): Promise<GradingConfig['provider']> {
   if (!isProviderTypeMap(provider)) {
     return isApiProvider(provider) ? provider : resolveProvider(provider, providerMap, context);
@@ -211,7 +236,10 @@ async function resolveGradingProvider(
   // A typed map can carry alternatives for assertion types that never run.
   // Reuse configured provider instances, but leave all other entries for
   // getGradingProvider() to instantiate only when its type is selected.
-  return resolveConfiguredProviderReference(provider, providerMap);
+  const resolvedProvider = resolveConfiguredProviderReference(provider, providerMap);
+  return isProviderTypeMap(resolvedProvider)
+    ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, context.env)
+    : resolvedProvider;
 }
 
 async function createRuntimeTestSuite(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -18,13 +18,14 @@ import { INLINE_FUNCTION_LABEL, TRANSFORM_KEYS } from './util/transform';
 
 import type {
   EvaluateTestSuite,
+  GradingConfig,
   Scenario,
   TestCase,
   TestSuite,
   UnifiedConfig,
 } from './types/index';
 import type { InternalEvaluateOptions } from './types/internal';
-import type { ApiProvider } from './types/providers';
+import type { ApiProvider, ProviderTypeMap } from './types/providers';
 
 /**
  * Shallow-clone a test case so the caller can swap in resolved ApiProvider
@@ -194,7 +195,7 @@ function createSerializableUnifiedConfig(
 }
 
 function buildProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
-  const providerMap: Record<string, ApiProvider> = {};
+  const providerMap: Record<string, ApiProvider> = Object.create(null);
   for (const provider of providers) {
     providerMap[provider.id()] = provider;
     if (provider.label) {
@@ -202,6 +203,41 @@ function buildProviderMap(providers: ApiProvider[]): Record<string, ApiProvider>
     }
   }
   return providerMap;
+}
+
+const GRADING_PROVIDER_TYPE_KEYS = ['text', 'embedding', 'classification', 'moderation'] as const;
+
+function isProviderTypeMap(provider: unknown): provider is ProviderTypeMap {
+  return Boolean(
+    provider &&
+      typeof provider === 'object' &&
+      !Array.isArray(provider) &&
+      !isApiProvider(provider) &&
+      !('id' in provider) &&
+      GRADING_PROVIDER_TYPE_KEYS.some((providerType) => Object.hasOwn(provider, providerType)),
+  );
+}
+
+async function resolveGradingProvider(
+  provider: GradingConfig['provider'],
+  providerMap: Record<string, ApiProvider>,
+  context: { env?: unknown; basePath?: string },
+): Promise<GradingConfig['provider']> {
+  if (!isProviderTypeMap(provider)) {
+    return isApiProvider(provider) ? provider : resolveProvider(provider, providerMap, context);
+  }
+
+  const resolvedProvider = { ...provider };
+  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
+    const nestedProvider = provider[providerType];
+    if (!nestedProvider) {
+      continue;
+    }
+    resolvedProvider[providerType] = isApiProvider(nestedProvider)
+      ? nestedProvider
+      : await resolveProvider(nestedProvider, providerMap, context);
+  }
+  return resolvedProvider;
 }
 
 async function createRuntimeTestSuite(
@@ -247,7 +283,7 @@ async function resolveNestedProviders(
       constructedTestSuite.defaultTest.options?.provider &&
       !isApiProvider(constructedTestSuite.defaultTest.options.provider)
     ) {
-      constructedTestSuite.defaultTest.options.provider = await resolveProvider(
+      constructedTestSuite.defaultTest.options.provider = await resolveGradingProvider(
         constructedTestSuite.defaultTest.options.provider,
         providerMap,
         { env: testSuiteConfig.env, basePath: cliState.basePath },
@@ -259,7 +295,7 @@ async function resolveNestedProviders(
 
   for (const test of constructedTestSuite.tests) {
     if (test.options?.provider && !isApiProvider(test.options.provider)) {
-      test.options.provider = await resolveProvider(test.options.provider, providerMap, {
+      test.options.provider = await resolveGradingProvider(test.options.provider, providerMap, {
         env: testSuiteConfig.env,
         basePath: cliState.basePath,
       });
@@ -269,7 +305,7 @@ async function resolveNestedProviders(
         continue;
       }
       if (assertion.provider && !isApiProvider(assertion.provider)) {
-        assertion.provider = await resolveProvider(assertion.provider, providerMap, {
+        assertion.provider = await resolveGradingProvider(assertion.provider, providerMap, {
           env: testSuiteConfig.env,
           basePath: cliState.basePath,
         });

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -13,8 +13,8 @@ import { isApiProvider } from './types/providers';
 import { isTransformFunction } from './types/transform';
 import { maybeLoadFromExternalFile } from './util/file';
 import {
+  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
-  GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
   resolveConfiguredProviderReference,
 } from './util/gradingProvider';
@@ -32,7 +32,7 @@ import type {
   UnifiedConfig,
 } from './types/index';
 import type { InternalEvaluateOptions } from './types/internal';
-import type { ApiProvider, ProviderTypeMap } from './types/providers';
+import type { ApiProvider } from './types/providers';
 
 /**
  * Shallow-clone a test case so the caller can swap in resolved ApiProvider
@@ -199,29 +199,6 @@ function createSerializableUnifiedConfig(
   }
 
   return config;
-}
-
-function addSuiteEnvToDeferredTypedProviders(
-  provider: ProviderTypeMap,
-  env: EnvOverrides | undefined,
-): ProviderTypeMap {
-  if (!env) {
-    return provider;
-  }
-
-  const providerWithEnv = { ...provider };
-  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
-    const nestedProvider = provider[providerType];
-    if (!nestedProvider || isApiProvider(nestedProvider)) {
-      continue;
-    }
-
-    providerWithEnv[providerType] =
-      typeof nestedProvider === 'string'
-        ? { id: nestedProvider, env }
-        : { ...nestedProvider, env: { ...env, ...nestedProvider.env } };
-  }
-  return providerWithEnv;
 }
 
 async function resolveGradingProvider(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -13,7 +13,6 @@ import { isApiProvider } from './types/providers';
 import { isTransformFunction } from './types/transform';
 import { maybeLoadFromExternalFile } from './util/file';
 import {
-  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
   isProviderTypeMap,
   resolveConfiguredProviderReference,
@@ -213,10 +212,7 @@ async function resolveGradingProvider(
   // A typed map can carry alternatives for assertion types that never run.
   // Reuse configured provider instances, but leave all other entries for
   // getGradingProvider() to instantiate only when its type is selected.
-  const resolvedProvider = resolveConfiguredProviderReference(provider, providerMap);
-  return isProviderTypeMap(resolvedProvider)
-    ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, context.env)
-    : resolvedProvider;
+  return resolveConfiguredProviderReference(provider, providerMap, context.env);
 }
 
 async function createRuntimeTestSuite(

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -12,6 +12,11 @@ import { createShareableUrl, isSharingEnabled } from './share';
 import { isApiProvider } from './types/providers';
 import { isTransformFunction } from './types/transform';
 import { maybeLoadFromExternalFile } from './util/file';
+import {
+  buildConfiguredProviderMap,
+  GRADING_PROVIDER_TYPE_KEYS,
+  isProviderTypeMap,
+} from './util/gradingProvider';
 import { readFilters, writeMultipleOutputs, writeOutput } from './util/index';
 import { readTests } from './util/testCaseReader';
 import { INLINE_FUNCTION_LABEL, TRANSFORM_KEYS } from './util/transform';
@@ -25,7 +30,7 @@ import type {
   UnifiedConfig,
 } from './types/index';
 import type { InternalEvaluateOptions } from './types/internal';
-import type { ApiProvider, ProviderTypeMap } from './types/providers';
+import type { ApiProvider } from './types/providers';
 
 /**
  * Shallow-clone a test case so the caller can swap in resolved ApiProvider
@@ -194,30 +199,6 @@ function createSerializableUnifiedConfig(
   return config;
 }
 
-function buildProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
-  const providerMap: Record<string, ApiProvider> = Object.create(null);
-  for (const provider of providers) {
-    providerMap[provider.id()] = provider;
-    if (provider.label) {
-      providerMap[provider.label] = provider;
-    }
-  }
-  return providerMap;
-}
-
-const GRADING_PROVIDER_TYPE_KEYS = ['text', 'embedding', 'classification', 'moderation'] as const;
-
-function isProviderTypeMap(provider: unknown): provider is ProviderTypeMap {
-  return Boolean(
-    provider &&
-      typeof provider === 'object' &&
-      !Array.isArray(provider) &&
-      !isApiProvider(provider) &&
-      !('id' in provider) &&
-      GRADING_PROVIDER_TYPE_KEYS.some((providerType) => Object.hasOwn(provider, providerType)),
-  );
-}
-
 async function resolveGradingProvider(
   provider: GradingConfig['provider'],
   providerMap: Record<string, ApiProvider>,
@@ -352,7 +333,7 @@ export async function evaluateWithSource(
   const loadedProviders = await loadApiProviders(testSuiteConfig.providers, {
     env: testSuiteConfig.env,
   });
-  const providerMap = buildProviderMap(loadedProviders);
+  const providerMap = buildConfiguredProviderMap(loadedProviders);
   const constructedTestSuite = await createRuntimeTestSuite(testSuiteConfig, loadedProviders);
   await resolveNestedProviders(testSuiteConfig, constructedTestSuite, providerMap);
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -54,6 +54,7 @@ import {
   type AssertionType,
   type AtomicTestCase,
   type CompletedPrompt,
+  type EnvOverrides,
   type EvaluateResult,
   type EvaluateStats,
   type GradingResult,
@@ -71,7 +72,9 @@ import { filterByRange } from './util/filterRange';
 import { warnEmptyFilterRange } from './util/filterRangeWarn';
 import { loadFunction, parseFileUrl } from './util/functions/loadFunction';
 import {
+  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
+  isProviderTypeMap,
   resolveConfiguredProviderReference,
 } from './util/gradingProvider';
 import invariant from './util/invariant';
@@ -1997,10 +2000,11 @@ function buildPromptIndexMap(prompts: CompletedPrompt[]) {
 function resolveAssertionProviderReferences(
   assertion: AssertionOrSet,
   providerMap: Record<string, ApiProvider>,
+  env?: EnvOverrides,
 ): AssertionOrSet {
   if (assertion.type === 'assert-set') {
     const resolvedAssertions = assertion.assert.map(
-      (child) => resolveAssertionProviderReferences(child, providerMap) as Assertion,
+      (child) => resolveAssertionProviderReferences(child, providerMap, env) as Assertion,
     );
     if (resolvedAssertions.every((child, index) => child === assertion.assert[index])) {
       return assertion;
@@ -2008,16 +2012,26 @@ function resolveAssertionProviderReferences(
     return { ...assertion, assert: resolvedAssertions };
   }
 
-  const provider = resolveConfiguredProviderReference(assertion.provider, providerMap);
+  const resolvedProvider = resolveConfiguredProviderReference(assertion.provider, providerMap);
+  const provider = isProviderTypeMap(resolvedProvider)
+    ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, env)
+    : resolvedProvider;
   return provider === assertion.provider ? assertion : { ...assertion, provider };
 }
 
 function resolveRuntimeGradingProviderReferences(
   testCase: AtomicTestCase,
   providerMap: Record<string, ApiProvider>,
+  env?: EnvOverrides,
 ): void {
   if (testCase.options?.provider) {
-    const provider = resolveConfiguredProviderReference(testCase.options.provider, providerMap);
+    const resolvedProvider = resolveConfiguredProviderReference(
+      testCase.options.provider,
+      providerMap,
+    );
+    const provider = isProviderTypeMap(resolvedProvider)
+      ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, env)
+      : resolvedProvider;
     if (provider !== testCase.options.provider) {
       testCase.options = { ...testCase.options, provider };
     }
@@ -2025,7 +2039,7 @@ function resolveRuntimeGradingProviderReferences(
 
   if (testCase.assert) {
     const assertions = testCase.assert.map((assertion) =>
-      resolveAssertionProviderReferences(assertion, providerMap),
+      resolveAssertionProviderReferences(assertion, providerMap, env),
     );
     if (assertions.some((assertion, index) => assertion !== testCase.assert?.[index])) {
       testCase.assert = assertions;
@@ -2188,7 +2202,7 @@ async function buildRunEvalOptions({
   for (let index = 0; index < tests.length; index++) {
     const testCase = tests[index];
     await prepareTestCaseForEval(testSuite, testCase, index);
-    resolveRuntimeGradingProviderReferences(testCase, configuredProviderMap);
+    resolveRuntimeGradingProviderReferences(testCase, configuredProviderMap, testSuite.env);
     testIdx = appendRunEvalOptionsForTestCase({
       concurrency,
       conversations,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -64,13 +64,16 @@ import {
   type RunEvalOptions,
   type TestSuite,
 } from './types/index';
-import { type ApiProvider, isApiProvider, type ProviderTypeMap } from './types/providers';
+import { type ApiProvider, isApiProvider } from './types/providers';
 import { JsonlFileWriter } from './util/exportToFile/writeToFile';
 import { isNonTransientHttpStatus } from './util/fetch/errors';
 import { filterByRange } from './util/filterRange';
 import { warnEmptyFilterRange } from './util/filterRangeWarn';
 import { loadFunction, parseFileUrl } from './util/functions/loadFunction';
-import { buildConfiguredProviderMap, GRADING_PROVIDER_TYPE_KEYS } from './util/gradingProvider';
+import {
+  buildConfiguredProviderMap,
+  resolveConfiguredProviderReference,
+} from './util/gradingProvider';
 import invariant from './util/invariant';
 import { safeJsonStringify, summarizeEvaluateResultForLogging } from './util/json';
 import { accumulateNamedMetric, backfillNamedScoreWeights } from './util/namedMetrics';
@@ -1989,40 +1992,6 @@ function buildPromptIndexMap(prompts: CompletedPrompt[]) {
     promptIndexMap.set(`${prompts[i].provider}:${prompts[i].id}`, i);
   }
   return promptIndexMap;
-}
-
-function resolveConfiguredProviderReference<T>(
-  provider: T,
-  providerMap: Record<string, ApiProvider>,
-): T | ApiProvider {
-  if (typeof provider === 'string') {
-    return Object.hasOwn(providerMap, provider) ? providerMap[provider] : provider;
-  }
-  if (
-    !provider ||
-    typeof provider !== 'object' ||
-    Array.isArray(provider) ||
-    isApiProvider(provider) ||
-    Object.hasOwn(provider, 'id')
-  ) {
-    return provider;
-  }
-
-  let resolvedTypeMap: ProviderTypeMap | undefined;
-  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
-    const nestedProvider = (provider as ProviderTypeMap)[providerType];
-    if (!nestedProvider) {
-      continue;
-    }
-
-    const resolvedProvider = resolveConfiguredProviderReference(nestedProvider, providerMap);
-    if (resolvedProvider !== nestedProvider) {
-      resolvedTypeMap ??= { ...(provider as ProviderTypeMap) };
-      resolvedTypeMap[providerType] = resolvedProvider;
-    }
-  }
-
-  return (resolvedTypeMap ?? provider) as T | ApiProvider;
 }
 
 function resolveAssertionProviderReferences(

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -72,9 +72,7 @@ import { filterByRange } from './util/filterRange';
 import { warnEmptyFilterRange } from './util/filterRangeWarn';
 import { loadFunction, parseFileUrl } from './util/functions/loadFunction';
 import {
-  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
-  isProviderTypeMap,
   resolveConfiguredProviderReference,
 } from './util/gradingProvider';
 import invariant from './util/invariant';
@@ -2012,10 +2010,7 @@ function resolveAssertionProviderReferences(
     return { ...assertion, assert: resolvedAssertions };
   }
 
-  const resolvedProvider = resolveConfiguredProviderReference(assertion.provider, providerMap);
-  const provider = isProviderTypeMap(resolvedProvider)
-    ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, env)
-    : resolvedProvider;
+  const provider = resolveConfiguredProviderReference(assertion.provider, providerMap, env);
   return provider === assertion.provider ? assertion : { ...assertion, provider };
 }
 
@@ -2025,13 +2020,11 @@ function resolveRuntimeGradingProviderReferences(
   env?: EnvOverrides,
 ): void {
   if (testCase.options?.provider) {
-    const resolvedProvider = resolveConfiguredProviderReference(
+    const provider = resolveConfiguredProviderReference(
       testCase.options.provider,
       providerMap,
+      env,
     );
-    const provider = isProviderTypeMap(resolvedProvider)
-      ? addSuiteEnvToDeferredTypedProviders(resolvedProvider, env)
-      : resolvedProvider;
     if (provider !== testCase.options.provider) {
       testCase.options = { ...testCase.options, provider };
     }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -70,6 +70,7 @@ import { isNonTransientHttpStatus } from './util/fetch/errors';
 import { filterByRange } from './util/filterRange';
 import { warnEmptyFilterRange } from './util/filterRangeWarn';
 import { loadFunction, parseFileUrl } from './util/functions/loadFunction';
+import { buildConfiguredProviderMap, GRADING_PROVIDER_TYPE_KEYS } from './util/gradingProvider';
 import invariant from './util/invariant';
 import { safeJsonStringify, summarizeEvaluateResultForLogging } from './util/json';
 import { accumulateNamedMetric, backfillNamedScoreWeights } from './util/namedMetrics';
@@ -1990,19 +1991,6 @@ function buildPromptIndexMap(prompts: CompletedPrompt[]) {
   return promptIndexMap;
 }
 
-function buildConfiguredProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
-  const providerMap: Record<string, ApiProvider> = Object.create(null);
-  for (const provider of providers) {
-    providerMap[provider.id()] = provider;
-    if (provider.label) {
-      providerMap[provider.label] = provider;
-    }
-  }
-  return providerMap;
-}
-
-const GRADING_PROVIDER_TYPE_KEYS = ['text', 'embedding', 'classification', 'moderation'] as const;
-
 function resolveConfiguredProviderReference<T>(
   provider: T,
   providerMap: Record<string, ApiProvider>,
@@ -2015,7 +2003,7 @@ function resolveConfiguredProviderReference<T>(
     typeof provider !== 'object' ||
     Array.isArray(provider) ||
     isApiProvider(provider) ||
-    'id' in provider
+    Object.hasOwn(provider, 'id')
   ) {
     return provider;
   }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -64,7 +64,7 @@ import {
   type RunEvalOptions,
   type TestSuite,
 } from './types/index';
-import { type ApiProvider, isApiProvider } from './types/providers';
+import { type ApiProvider, isApiProvider, type ProviderTypeMap } from './types/providers';
 import { JsonlFileWriter } from './util/exportToFile/writeToFile';
 import { isNonTransientHttpStatus } from './util/fetch/errors';
 import { filterByRange } from './util/filterRange';
@@ -1991,7 +1991,7 @@ function buildPromptIndexMap(prompts: CompletedPrompt[]) {
 }
 
 function buildConfiguredProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
-  const providerMap: Record<string, ApiProvider> = {};
+  const providerMap: Record<string, ApiProvider> = Object.create(null);
   for (const provider of providers) {
     providerMap[provider.id()] = provider;
     if (provider.label) {
@@ -2001,14 +2001,40 @@ function buildConfiguredProviderMap(providers: ApiProvider[]): Record<string, Ap
   return providerMap;
 }
 
+const GRADING_PROVIDER_TYPE_KEYS = ['text', 'embedding', 'classification', 'moderation'] as const;
+
 function resolveConfiguredProviderReference<T>(
   provider: T,
   providerMap: Record<string, ApiProvider>,
 ): T | ApiProvider {
-  if (typeof provider === 'string' && providerMap[provider]) {
-    return providerMap[provider];
+  if (typeof provider === 'string') {
+    return Object.hasOwn(providerMap, provider) ? providerMap[provider] : provider;
   }
-  return provider;
+  if (
+    !provider ||
+    typeof provider !== 'object' ||
+    Array.isArray(provider) ||
+    isApiProvider(provider) ||
+    'id' in provider
+  ) {
+    return provider;
+  }
+
+  let resolvedTypeMap: ProviderTypeMap | undefined;
+  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
+    const nestedProvider = (provider as ProviderTypeMap)[providerType];
+    if (!nestedProvider) {
+      continue;
+    }
+
+    const resolvedProvider = resolveConfiguredProviderReference(nestedProvider, providerMap);
+    if (resolvedProvider !== nestedProvider) {
+      resolvedTypeMap ??= { ...(provider as ProviderTypeMap) };
+      resolvedTypeMap[providerType] = resolvedProvider;
+    }
+  }
+
+  return (resolvedTypeMap ?? provider) as T | ApiProvider;
 }
 
 function resolveAssertionProviderReferences(

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1990,6 +1990,66 @@ function buildPromptIndexMap(prompts: CompletedPrompt[]) {
   return promptIndexMap;
 }
 
+function buildConfiguredProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
+  const providerMap: Record<string, ApiProvider> = {};
+  for (const provider of providers) {
+    providerMap[provider.id()] = provider;
+    if (provider.label) {
+      providerMap[provider.label] = provider;
+    }
+  }
+  return providerMap;
+}
+
+function resolveConfiguredProviderReference<T>(
+  provider: T,
+  providerMap: Record<string, ApiProvider>,
+): T | ApiProvider {
+  if (typeof provider === 'string' && providerMap[provider]) {
+    return providerMap[provider];
+  }
+  return provider;
+}
+
+function resolveAssertionProviderReferences(
+  assertion: AssertionOrSet,
+  providerMap: Record<string, ApiProvider>,
+): AssertionOrSet {
+  if (assertion.type === 'assert-set') {
+    const resolvedAssertions = assertion.assert.map(
+      (child) => resolveAssertionProviderReferences(child, providerMap) as Assertion,
+    );
+    if (resolvedAssertions.every((child, index) => child === assertion.assert[index])) {
+      return assertion;
+    }
+    return { ...assertion, assert: resolvedAssertions };
+  }
+
+  const provider = resolveConfiguredProviderReference(assertion.provider, providerMap);
+  return provider === assertion.provider ? assertion : { ...assertion, provider };
+}
+
+function resolveRuntimeGradingProviderReferences(
+  testCase: AtomicTestCase,
+  providerMap: Record<string, ApiProvider>,
+): void {
+  if (testCase.options?.provider) {
+    const provider = resolveConfiguredProviderReference(testCase.options.provider, providerMap);
+    if (provider !== testCase.options.provider) {
+      testCase.options = { ...testCase.options, provider };
+    }
+  }
+
+  if (testCase.assert) {
+    const assertions = testCase.assert.map((assertion) =>
+      resolveAssertionProviderReferences(assertion, providerMap),
+    );
+    if (assertions.some((assertion, index) => assertion !== testCase.assert?.[index])) {
+      testCase.assert = assertions;
+    }
+  }
+}
+
 function getDefaultTest(testSuite: TestSuite) {
   return typeof testSuite.defaultTest === 'object' ? testSuite.defaultTest : undefined;
 }
@@ -2136,6 +2196,7 @@ async function buildRunEvalOptions({
 }): Promise<RunEvalOptions[]> {
   const runEvalOptions: RunEvalOptions[] = [];
   const promptIdCache = new Map<Prompt, string>();
+  const configuredProviderMap = buildConfiguredProviderMap(testSuite.providers);
   for (const prompt of testSuite.prompts) {
     promptIdCache.set(prompt, generateIdFromPrompt(prompt));
   }
@@ -2144,6 +2205,7 @@ async function buildRunEvalOptions({
   for (let index = 0; index < tests.length; index++) {
     const testCase = tests[index];
     await prepareTestCaseForEval(testSuite, testCase, index);
+    resolveRuntimeGradingProviderReferences(testCase, configuredProviderMap);
     testIdx = appendRunEvalOptionsForTestCase({
       concurrency,
       conversations,

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -402,6 +402,8 @@ export async function matchesGEval(
   const tokensUsed = normalizeMatcherTokenUsage(undefined);
 
   const failWithTokens = (reason: string) => graderFail(reason, tokensUsed);
+  const failNoOutput = (phase: 'step-generation' | 'evaluation') =>
+    failWithTokens(`G-Eval ${phase} call to ${textProvider.id()} returned no output`);
 
   // Step 1: Get evaluation steps using renderLlmRubricPrompt
   const stepsRubricPrompt =
@@ -425,7 +427,7 @@ export async function matchesGEval(
     return failWithTokens(respSteps.error);
   }
   if (!respSteps.output) {
-    return failWithTokens('No output');
+    return failNoOutput('step-generation');
   }
   if (typeof respSteps.output !== 'string') {
     return failWithTokens('LLM-proposed evaluation steps response is not a string');
@@ -488,7 +490,7 @@ export async function matchesGEval(
     return failWithTokens(resp.error);
   }
   if (!resp.output) {
-    return failWithTokens('No output');
+    return failNoOutput('evaluation');
   }
   if (typeof resp.output !== 'string') {
     return failWithTokens('LLM-proposed evaluation result response is not a string');

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -3,6 +3,8 @@ import { isApiProvider } from '../types/providers';
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderTypeMap } from '../types/providers';
 
+type ProviderTypeValue = NonNullable<ProviderTypeMap[keyof ProviderTypeMap]>;
+
 export const GRADING_PROVIDER_TYPE_KEYS = [
   'text',
   'embedding',
@@ -39,30 +41,6 @@ export function isProviderTypeMap(provider: unknown): provider is ProviderTypeMa
   );
 }
 
-export function addSuiteEnvToDeferredTypedProviders(
-  provider: ProviderTypeMap,
-  env: EnvOverrides | undefined,
-): ProviderTypeMap {
-  if (!env) {
-    return provider;
-  }
-
-  let providerWithEnv: ProviderTypeMap | undefined;
-  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
-    const nestedProvider = provider[providerType];
-    if (!nestedProvider || isApiProvider(nestedProvider)) {
-      continue;
-    }
-
-    providerWithEnv ??= { ...provider };
-    providerWithEnv[providerType] =
-      typeof nestedProvider === 'string'
-        ? { id: nestedProvider, env }
-        : { ...nestedProvider, env: { ...env, ...nestedProvider.env } };
-  }
-  return providerWithEnv ?? provider;
-}
-
 // Build a lookup of configured providers by both id() and label, with a
 // null prototype so '__proto__'/'constructor' keys cannot pollute lookups.
 // IDs are added first; labels only fill keys an ID has not already claimed,
@@ -80,52 +58,61 @@ export function buildConfiguredProviderMap(providers: ApiProvider[]): Record<str
   return providerMap;
 }
 
-function resolveConfiguredTypedProviderReference(
-  provider: ProviderTypeMap[keyof ProviderTypeMap],
+function getConfiguredProvider(
+  id: string,
   providerMap: Record<string, ApiProvider>,
-): ProviderTypeMap[keyof ProviderTypeMap] {
-  // An id-only typed entry is a reference; entries with options stay inline.
-  if (
-    provider &&
-    typeof provider === 'object' &&
-    !isApiProvider(provider) &&
-    Object.keys(provider).length === 1 &&
-    typeof provider.id === 'string' &&
-    Object.hasOwn(providerMap, provider.id)
-  ) {
-    return providerMap[provider.id];
-  }
-
-  return resolveConfiguredProviderReference(provider, providerMap);
+): ApiProvider | undefined {
+  return Object.hasOwn(providerMap, id) ? providerMap[id] : undefined;
 }
 
+function resolveTypedProviderValue(
+  provider: ProviderTypeValue,
+  providerMap: Record<string, ApiProvider>,
+  env: EnvOverrides | undefined,
+): ProviderTypeValue {
+  if (typeof provider === 'string') {
+    return getConfiguredProvider(provider, providerMap) ?? (env ? { id: provider, env } : provider);
+  }
+  if (isApiProvider(provider)) {
+    return provider;
+  }
+
+  // An id-only typed entry is a reference; entries with options stay inline.
+  const configuredProvider =
+    Object.keys(provider).length === 1 && typeof provider.id === 'string'
+      ? getConfiguredProvider(provider.id, providerMap)
+      : undefined;
+  if (configuredProvider) {
+    return configuredProvider;
+  }
+
+  return env ? { ...provider, env: { ...env, ...provider.env } } : provider;
+}
+
+// Resolve configured grader references while carrying suite env into typed
+// provider values that must stay lazy until their assertion type is selected.
 export function resolveConfiguredProviderReference<T>(
   provider: T,
   providerMap: Record<string, ApiProvider>,
+  env?: EnvOverrides,
 ): T | ApiProvider {
   if (typeof provider === 'string') {
-    return Object.hasOwn(providerMap, provider) ? providerMap[provider] : provider;
+    return getConfiguredProvider(provider, providerMap) ?? provider;
   }
-  if (
-    !provider ||
-    typeof provider !== 'object' ||
-    Array.isArray(provider) ||
-    isApiProvider(provider) ||
-    Object.hasOwn(provider, 'id')
-  ) {
+  if (!isProviderTypeMap(provider)) {
     return provider;
   }
 
   let resolvedTypeMap: ProviderTypeMap | undefined;
   for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
-    const nestedProvider = (provider as ProviderTypeMap)[providerType];
+    const nestedProvider = provider[providerType];
     if (!nestedProvider) {
       continue;
     }
 
-    const resolvedProvider = resolveConfiguredTypedProviderReference(nestedProvider, providerMap);
+    const resolvedProvider = resolveTypedProviderValue(nestedProvider, providerMap, env);
     if (resolvedProvider !== nestedProvider) {
-      resolvedTypeMap ??= { ...(provider as ProviderTypeMap) };
+      resolvedTypeMap ??= { ...provider };
       resolvedTypeMap[providerType] = resolvedProvider;
     }
   }

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -9,6 +9,17 @@ export const GRADING_PROVIDER_TYPE_KEYS = [
   'moderation',
 ] as const;
 
+function isTypedProviderValue(value: unknown): boolean {
+  if (typeof value === 'string' || isApiProvider(value)) {
+    return true;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const id = (value as { id?: unknown }).id;
+  return typeof id === 'string' && id.length > 0;
+}
+
 export function isProviderTypeMap(provider: unknown): provider is ProviderTypeMap {
   return Boolean(
     provider &&
@@ -16,7 +27,11 @@ export function isProviderTypeMap(provider: unknown): provider is ProviderTypeMa
       !Array.isArray(provider) &&
       !isApiProvider(provider) &&
       !Object.hasOwn(provider, 'id') &&
-      GRADING_PROVIDER_TYPE_KEYS.some((providerType) => Object.hasOwn(provider, providerType)),
+      GRADING_PROVIDER_TYPE_KEYS.some(
+        (providerType) =>
+          Object.hasOwn(provider, providerType) &&
+          isTypedProviderValue((provider as Record<string, unknown>)[providerType]),
+      ),
   );
 }
 

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -1,0 +1,38 @@
+import { isApiProvider } from '../types/providers';
+
+import type { ApiProvider, ProviderTypeMap } from '../types/providers';
+
+export const GRADING_PROVIDER_TYPE_KEYS = [
+  'text',
+  'embedding',
+  'classification',
+  'moderation',
+] as const;
+
+export function isProviderTypeMap(provider: unknown): provider is ProviderTypeMap {
+  return Boolean(
+    provider &&
+      typeof provider === 'object' &&
+      !Array.isArray(provider) &&
+      !isApiProvider(provider) &&
+      !Object.hasOwn(provider, 'id') &&
+      GRADING_PROVIDER_TYPE_KEYS.some((providerType) => Object.hasOwn(provider, providerType)),
+  );
+}
+
+// Build a lookup of configured providers by both id() and label, with a
+// null prototype so '__proto__'/'constructor' keys cannot pollute lookups.
+// IDs are added first; labels only fill keys an ID has not already claimed,
+// so a label collision can never silently shadow another provider's ID.
+export function buildConfiguredProviderMap(providers: ApiProvider[]): Record<string, ApiProvider> {
+  const providerMap: Record<string, ApiProvider> = Object.create(null);
+  for (const provider of providers) {
+    providerMap[provider.id()] = provider;
+  }
+  for (const provider of providers) {
+    if (provider.label && !Object.hasOwn(providerMap, provider.label)) {
+      providerMap[provider.label] = provider;
+    }
+  }
+  return providerMap;
+}

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -47,19 +47,20 @@ export function addSuiteEnvToDeferredTypedProviders(
     return provider;
   }
 
-  const providerWithEnv = { ...provider };
+  let providerWithEnv: ProviderTypeMap | undefined;
   for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
     const nestedProvider = provider[providerType];
     if (!nestedProvider || isApiProvider(nestedProvider)) {
       continue;
     }
 
+    providerWithEnv ??= { ...provider };
     providerWithEnv[providerType] =
       typeof nestedProvider === 'string'
         ? { id: nestedProvider, env }
         : { ...nestedProvider, env: { ...env, ...nestedProvider.env } };
   }
-  return providerWithEnv;
+  return providerWithEnv ?? provider;
 }
 
 // Build a lookup of configured providers by both id() and label, with a

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -1,5 +1,6 @@
 import { isApiProvider } from '../types/providers';
 
+import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderTypeMap } from '../types/providers';
 
 export const GRADING_PROVIDER_TYPE_KEYS = [
@@ -10,7 +11,10 @@ export const GRADING_PROVIDER_TYPE_KEYS = [
 ] as const;
 
 function isTypedProviderValue(value: unknown): boolean {
-  if (typeof value === 'string' || isApiProvider(value)) {
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+  if (isApiProvider(value)) {
     return true;
   }
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -33,6 +37,29 @@ export function isProviderTypeMap(provider: unknown): provider is ProviderTypeMa
           isTypedProviderValue((provider as Record<string, unknown>)[providerType]),
       ),
   );
+}
+
+export function addSuiteEnvToDeferredTypedProviders(
+  provider: ProviderTypeMap,
+  env: EnvOverrides | undefined,
+): ProviderTypeMap {
+  if (!env) {
+    return provider;
+  }
+
+  const providerWithEnv = { ...provider };
+  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
+    const nestedProvider = provider[providerType];
+    if (!nestedProvider || isApiProvider(nestedProvider)) {
+      continue;
+    }
+
+    providerWithEnv[providerType] =
+      typeof nestedProvider === 'string'
+        ? { id: nestedProvider, env }
+        : { ...nestedProvider, env: { ...env, ...nestedProvider.env } };
+  }
+  return providerWithEnv;
 }
 
 // Build a lookup of configured providers by both id() and label, with a

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -80,6 +80,25 @@ export function buildConfiguredProviderMap(providers: ApiProvider[]): Record<str
   return providerMap;
 }
 
+function resolveConfiguredTypedProviderReference(
+  provider: ProviderTypeMap[keyof ProviderTypeMap],
+  providerMap: Record<string, ApiProvider>,
+): ProviderTypeMap[keyof ProviderTypeMap] {
+  // An id-only typed entry is a reference; entries with options stay inline.
+  if (
+    provider &&
+    typeof provider === 'object' &&
+    !isApiProvider(provider) &&
+    Object.keys(provider).length === 1 &&
+    typeof provider.id === 'string' &&
+    Object.hasOwn(providerMap, provider.id)
+  ) {
+    return providerMap[provider.id];
+  }
+
+  return resolveConfiguredProviderReference(provider, providerMap);
+}
+
 export function resolveConfiguredProviderReference<T>(
   provider: T,
   providerMap: Record<string, ApiProvider>,
@@ -104,7 +123,7 @@ export function resolveConfiguredProviderReference<T>(
       continue;
     }
 
-    const resolvedProvider = resolveConfiguredProviderReference(nestedProvider, providerMap);
+    const resolvedProvider = resolveConfiguredTypedProviderReference(nestedProvider, providerMap);
     if (resolvedProvider !== nestedProvider) {
       resolvedTypeMap ??= { ...(provider as ProviderTypeMap) };
       resolvedTypeMap[providerType] = resolvedProvider;

--- a/src/util/gradingProvider.ts
+++ b/src/util/gradingProvider.ts
@@ -36,3 +36,37 @@ export function buildConfiguredProviderMap(providers: ApiProvider[]): Record<str
   }
   return providerMap;
 }
+
+export function resolveConfiguredProviderReference<T>(
+  provider: T,
+  providerMap: Record<string, ApiProvider>,
+): T | ApiProvider {
+  if (typeof provider === 'string') {
+    return Object.hasOwn(providerMap, provider) ? providerMap[provider] : provider;
+  }
+  if (
+    !provider ||
+    typeof provider !== 'object' ||
+    Array.isArray(provider) ||
+    isApiProvider(provider) ||
+    Object.hasOwn(provider, 'id')
+  ) {
+    return provider;
+  }
+
+  let resolvedTypeMap: ProviderTypeMap | undefined;
+  for (const providerType of GRADING_PROVIDER_TYPE_KEYS) {
+    const nestedProvider = (provider as ProviderTypeMap)[providerType];
+    if (!nestedProvider) {
+      continue;
+    }
+
+    const resolvedProvider = resolveConfiguredProviderReference(nestedProvider, providerMap);
+    if (resolvedProvider !== nestedProvider) {
+      resolvedTypeMap ??= { ...(provider as ProviderTypeMap) };
+      resolvedTypeMap[providerType] = resolvedProvider;
+    }
+  }
+
+  return (resolvedTypeMap ?? provider) as T | ApiProvider;
+}

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -240,6 +240,42 @@ describeEvaluator('evaluator assertions', () => {
     expect(summary.stats.successes).toBe(1);
   });
 
+  it('routes an assertion provider id to the id-matching provider when a sibling label collides', async () => {
+    const judgeById: ApiProvider = {
+      id: vi.fn().mockReturnValue('judge'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Passes via id-matched judge.' }),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+    const judgeByLabel: ApiProvider = {
+      id: vi.fn().mockReturnValue('litellm:judge'),
+      label: 'judge',
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: false, score: 0, reason: 'Should never be called.' }),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider, judgeById, judgeByLabel],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          providers: ['test-provider'],
+          assert: [{ type: 'llm-rubric', value: 'Use the id-matched judge', provider: 'judge' }],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(judgeById.callApi).toHaveBeenCalledTimes(1);
+    expect(judgeByLabel.callApi).not.toHaveBeenCalled();
+    expect(summary.stats.successes).toBe(1);
+  });
+
   it('evaluate with grading expected value does not pass', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -2,10 +2,10 @@ import './setup';
 
 import { randomUUID } from 'crypto';
 
-import { expect, it } from 'vitest';
+import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import Eval from '../../src/models/eval';
-import { type TestSuite } from '../../src/types/index';
+import { type ApiProvider, type TestSuite } from '../../src/types/index';
 import {
   mockApiProvider,
   mockGradingApiProviderFails,
@@ -148,6 +148,96 @@ describeEvaluator('evaluator assertions', () => {
     expect(summary.stats.failures).toBe(0);
     expect(summary.results[0].success).toBe(true);
     expect(summary.results[0].response?.output).toBe('Test output');
+  });
+
+  it('reuses a configured LiteLLM provider ID for both G-Eval calls', async () => {
+    const configuredLiteLLM: ApiProvider = {
+      id: vi.fn().mockReturnValue('litellm:gemini-pro'),
+      config: { apiBaseUrl: 'http://localhost:4000', temperature: 0 },
+      callApi: vi.fn().mockImplementation(async (_prompt, context) => ({
+        output:
+          context?.prompt?.label === 'g-eval-steps'
+            ? JSON.stringify({ steps: ['Check factual accuracy'] })
+            : JSON.stringify({ score: 10, reason: 'The answer is accurate' }),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      })),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider, configuredLiteLLM],
+      prompts: [toPrompt('What is the capital of France?')],
+      tests: [
+        {
+          providers: ['test-provider'],
+          assert: [
+            {
+              type: 'g-eval',
+              value: 'The answer identifies the capital correctly',
+              provider: 'litellm:gemini-pro',
+            },
+          ],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(configuredLiteLLM.callApi).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(configuredLiteLLM.callApi).mock.calls.map(([, context]) => context?.prompt?.label),
+    ).toEqual(['g-eval-steps', 'g-eval']);
+    expect(summary.stats.successes).toBe(1);
+  });
+
+  it('reuses configured graders referenced from defaults and scenario assertion sets', async () => {
+    const configuredGrader: ApiProvider = {
+      id: vi.fn().mockReturnValue('litellm:judge'),
+      label: 'Configured grader',
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'The output passes' }),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider, configuredGrader],
+      prompts: [toPrompt('Test prompt')],
+      defaultTest: {
+        options: { provider: 'Configured grader' },
+      },
+      scenarios: [
+        {
+          config: [{}],
+          tests: [
+            {
+              providers: ['test-provider'],
+              assert: [
+                {
+                  type: 'assert-set',
+                  assert: [
+                    { type: 'llm-rubric', value: 'Use the default grader option' },
+                    {
+                      type: 'llm-rubric',
+                      value: 'Use the explicit configured grader ID',
+                      provider: 'litellm:judge',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(configuredGrader.callApi).toHaveBeenCalledTimes(2);
+    expect(summary.stats.successes).toBe(1);
   });
 
   it('evaluate with grading expected value does not pass', async () => {

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -191,7 +191,7 @@ describeEvaluator('evaluator assertions', () => {
     expect(summary.stats.successes).toBe(1);
   });
 
-  it('reuses configured graders referenced from defaults and scenario assertion sets', async () => {
+  it('reuses configured graders in typed defaults and scenario assertion sets', async () => {
     const configuredGrader: ApiProvider = {
       id: vi.fn().mockReturnValue('litellm:judge'),
       label: 'Configured grader',
@@ -204,7 +204,7 @@ describeEvaluator('evaluator assertions', () => {
       providers: [mockApiProvider, configuredGrader],
       prompts: [toPrompt('Test prompt')],
       defaultTest: {
-        options: { provider: 'Configured grader' },
+        options: { provider: { text: 'Configured grader' } },
       },
       scenarios: [
         {
@@ -220,7 +220,7 @@ describeEvaluator('evaluator assertions', () => {
                     {
                       type: 'llm-rubric',
                       value: 'Use the explicit configured grader ID',
-                      provider: 'litellm:judge',
+                      provider: { text: 'litellm:judge' },
                     },
                   ],
                 },

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -219,8 +219,8 @@ describeEvaluator('evaluator assertions', () => {
                     { type: 'llm-rubric', value: 'Use the default grader option' },
                     {
                       type: 'llm-rubric',
-                      value: 'Use the explicit configured grader ID',
-                      provider: { text: 'litellm:judge' },
+                      value: 'Use the explicit configured grader ID option',
+                      provider: { text: { id: 'litellm:judge' } },
                     },
                   ],
                 },

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -306,6 +306,45 @@ describeEvaluator('evaluator assertions', () => {
     expect(summary.results[0].success).toBe(true);
   });
 
+  it('reuses configured text and embedding graders for answer relevance', async () => {
+    const textJudge: ApiProvider = {
+      id: vi.fn().mockReturnValue('litellm:text-judge'),
+      callApi: vi.fn().mockResolvedValue({ output: 'Test prompt' }),
+    };
+    const embeddingJudge: ApiProvider = {
+      id: vi.fn().mockReturnValue('litellm:embedding:judge'),
+      callApi: vi.fn().mockResolvedValue({ output: '' }),
+      callEmbeddingApi: vi.fn().mockResolvedValue({ embedding: [1, 0] }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider, textJudge, embeddingJudge],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          providers: ['test-provider'],
+          assert: [
+            {
+              type: 'answer-relevance',
+              threshold: 0.8,
+              provider: {
+                text: 'litellm:text-judge',
+                embedding: 'litellm:embedding:judge',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(textJudge.callApi).toHaveBeenCalledTimes(3);
+    expect(embeddingJudge.callEmbeddingApi).toHaveBeenCalledTimes(4);
+    expect(summary.stats.successes).toBe(1);
+  });
+
   it('evaluate with grading expected value does not pass', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -276,6 +276,36 @@ describeEvaluator('evaluator assertions', () => {
     expect(summary.stats.successes).toBe(1);
   });
 
+  it('preserves suite env for typed graders inherited from defaultTest assertions', async () => {
+    const testSuite: TestSuite = {
+      env: { LITELLM_API_BASE: 'echo' },
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ providers: ['test-provider'] }],
+      defaultTest: {
+        assert: [
+          {
+            type: 'llm-rubric',
+            value: 'Grade the test output',
+            rubricPrompt: '{"pass":true,"score":1,"reason":"Resolved suite env"}',
+            provider: {
+              text: {
+                id: '{{ env.LITELLM_API_BASE }}',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(summary.stats.successes).toBe(1);
+    expect(summary.results[0].success).toBe(true);
+  });
+
   it('evaluate with grading expected value does not pass', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1024,6 +1024,52 @@ describe('evaluate function', () => {
         );
       });
 
+      it('does not eagerly load unused provider types from grading provider maps', async () => {
+        const mockLiteLLMProvider = createMockProvider({ id: 'litellm:judge' });
+
+        loadApiProvidersSpy.mockResolvedValueOnce([mockLiteLLMProvider]);
+
+        const testSuite = {
+          prompts: ['Test prompt'],
+          providers: ['litellm:judge'],
+          defaultTest: {
+            options: {
+              provider: {
+                text: 'litellm:judge',
+                embedding: 'unsupported-provider:unused-embedding',
+              },
+            },
+          },
+          tests: [
+            {
+              assert: [
+                {
+                  type: 'g-eval' as const,
+                  value: 'Evaluate response',
+                },
+              ],
+            },
+          ],
+        };
+
+        await evaluate(testSuite);
+
+        expect(doEvaluate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultTest: expect.objectContaining({
+              options: expect.objectContaining({
+                provider: {
+                  text: mockLiteLLMProvider,
+                  embedding: 'unsupported-provider:unused-embedding',
+                },
+              }),
+            }),
+          }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
       it('should fall back to loadApiProvider for model-graded assertions when provider not in main array', async () => {
         const mockMainProvider = createMockProvider({ id: 'litellm:gpt-4' });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -692,7 +692,7 @@ describe('evaluate function', () => {
               {
                 type: 'equals' as const,
                 value: 'expected',
-                provider: 'existing-provider', // Should resolve by ID
+                provider: 'echo',
               },
             ],
           },
@@ -701,14 +701,13 @@ describe('evaluate function', () => {
 
       await evaluate(testSuite);
 
-      // Verify the evaluation completed successfully using the fallback provider
       expect(doEvaluate).toHaveBeenCalledWith(
         expect.objectContaining({
           tests: expect.arrayContaining([
             expect.objectContaining({
               assert: expect.arrayContaining([
                 expect.objectContaining({
-                  provider: mockExistingProvider,
+                  provider: expect.not.objectContaining({ id: mockExistingProvider.id }),
                 }),
               ]),
             }),
@@ -717,6 +716,12 @@ describe('evaluate function', () => {
         expect.anything(),
         expect.anything(),
       );
+      const runtimeSuite = vi.mocked(doEvaluate).mock.calls.at(-1)?.[0];
+      const runtimeAssertion = runtimeSuite?.tests?.[0].assert?.[0];
+      if (!runtimeAssertion || runtimeAssertion.type === 'assert-set') {
+        throw new Error('Expected a regular assertion with a fallback provider');
+      }
+      expect(runtimeAssertion.provider.id()).toBe('echo');
     });
 
     it('should handle providers without labels in providerMap', async () => {
@@ -935,7 +940,7 @@ describe('evaluate function', () => {
                 {
                   type: 'g-eval' as const,
                   value: 'Evaluate response',
-                  provider: 'litellm:gpt-4', // Use existing provider from main array
+                  provider: 'echo',
                 },
               ],
             },
@@ -944,7 +949,6 @@ describe('evaluate function', () => {
 
         await evaluate(testSuite);
 
-        // Verify the evaluation completed successfully using the fallback provider
         expect(doEvaluate).toHaveBeenCalledWith(
           expect.objectContaining({
             tests: expect.arrayContaining([
@@ -952,7 +956,7 @@ describe('evaluate function', () => {
                 assert: expect.arrayContaining([
                   expect.objectContaining({
                     type: 'g-eval',
-                    provider: mockMainProvider,
+                    provider: expect.not.objectContaining({ id: mockMainProvider.id }),
                   }),
                 ]),
               }),
@@ -961,6 +965,12 @@ describe('evaluate function', () => {
           expect.anything(),
           expect.anything(),
         );
+        const runtimeSuite = vi.mocked(doEvaluate).mock.calls.at(-1)?.[0];
+        const runtimeAssertion = runtimeSuite?.tests?.[0].assert?.[0];
+        if (!runtimeAssertion || runtimeAssertion.type === 'assert-set') {
+          throw new Error('Expected a regular assertion with a fallback provider');
+        }
+        expect(runtimeAssertion.provider.id()).toBe('echo');
       });
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -764,6 +764,49 @@ describe('evaluate function', () => {
       );
     });
 
+    it('does not let a provider label silently shadow another provider id', async () => {
+      const providerById = createMockProvider({ id: 'judge' });
+      const providerWithCollidingLabel = createMockProvider({
+        id: 'litellm:judge',
+        label: 'judge',
+      });
+      loadApiProvidersSpy.mockResolvedValueOnce([providerById, providerWithCollidingLabel]);
+
+      const testSuite = {
+        prompts: ['test'],
+        providers: ['judge', 'litellm:judge'],
+        tests: [
+          {
+            assert: [
+              {
+                type: 'equals' as const,
+                value: 'expected',
+                provider: 'judge',
+              },
+            ],
+          },
+        ],
+      };
+
+      await evaluate(testSuite);
+
+      expect(doEvaluate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tests: expect.arrayContaining([
+            expect.objectContaining({
+              assert: expect.arrayContaining([
+                expect.objectContaining({
+                  provider: providerById,
+                }),
+              ]),
+            }),
+          ]),
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
     // Regression for GitHub issue #4111: model-graded assertions that specified
     // `provider` as a string ID were not resolved from the main providers
     // array/providerMap, causing those assertions to fail.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -925,6 +925,62 @@ describe('evaluate function', () => {
         );
       });
 
+      it('should resolve configured providers within grading provider type maps', async () => {
+        const mockLiteLLMProvider = createMockProvider({ id: 'litellm:judge' });
+
+        loadApiProvidersSpy.mockResolvedValueOnce([mockLiteLLMProvider]);
+
+        const testSuite = {
+          prompts: ['Test prompt'],
+          providers: ['litellm:judge'],
+          defaultTest: {
+            options: {
+              provider: { text: 'litellm:judge' },
+            },
+          },
+          tests: [
+            {
+              options: {
+                provider: { text: 'litellm:judge' },
+              },
+              assert: [
+                {
+                  type: 'g-eval' as const,
+                  value: 'Evaluate response',
+                  provider: { text: 'litellm:judge' },
+                },
+              ],
+            },
+          ],
+        };
+
+        await evaluate(testSuite);
+
+        expect(doEvaluate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultTest: expect.objectContaining({
+              options: expect.objectContaining({
+                provider: { text: mockLiteLLMProvider },
+              }),
+            }),
+            tests: expect.arrayContaining([
+              expect.objectContaining({
+                options: expect.objectContaining({
+                  provider: { text: mockLiteLLMProvider },
+                }),
+                assert: expect.arrayContaining([
+                  expect.objectContaining({
+                    provider: { text: mockLiteLLMProvider },
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
       it('should fall back to loadApiProvider for model-graded assertions when provider not in main array', async () => {
         const mockMainProvider = createMockProvider({ id: 'litellm:gpt-4' });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1070,6 +1070,63 @@ describe('evaluate function', () => {
         );
       });
 
+      it('preserves suite env for deferred grading provider map entries', async () => {
+        const mockTargetProvider = createMockProvider({ id: 'echo' });
+
+        loadApiProvidersSpy.mockResolvedValueOnce([mockTargetProvider]);
+
+        const testSuite = {
+          env: { GRADER_API_KEY: 'suite-key' },
+          prompts: ['Test prompt'],
+          providers: ['echo'],
+          defaultTest: {
+            options: {
+              provider: {
+                text: {
+                  id: 'litellm:inline-judge',
+                  config: { apiKey: '{{ env.GRADER_API_KEY }}' },
+                },
+                embedding: 'unsupported-provider:unused-embedding',
+              },
+            },
+          },
+          tests: [
+            {
+              assert: [
+                {
+                  type: 'g-eval' as const,
+                  value: 'Evaluate response',
+                },
+              ],
+            },
+          ],
+        };
+
+        await evaluate(testSuite);
+
+        expect(doEvaluate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultTest: expect.objectContaining({
+              options: expect.objectContaining({
+                provider: {
+                  text: {
+                    id: 'litellm:inline-judge',
+                    config: { apiKey: '{{ env.GRADER_API_KEY }}' },
+                    env: { GRADER_API_KEY: 'suite-key' },
+                  },
+                  embedding: {
+                    id: 'unsupported-provider:unused-embedding',
+                    env: { GRADER_API_KEY: 'suite-key' },
+                  },
+                },
+              }),
+            }),
+          }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
       it('should fall back to loadApiProvider for model-graded assertions when provider not in main array', async () => {
         const mockMainProvider = createMockProvider({ id: 'litellm:gpt-4' });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -978,7 +978,7 @@ describe('evaluate function', () => {
           providers: ['litellm:judge'],
           defaultTest: {
             options: {
-              provider: { text: 'litellm:judge' },
+              provider: { text: { id: 'litellm:judge' } },
             },
           },
           tests: [

--- a/test/matchers/g-eval.test.ts
+++ b/test/matchers/g-eval.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { matchesGEval } from '../../src/matchers/llmGrading';
+import { resolveProvider } from '../../src/providers';
+import { createLiteLLMProvider } from '../../src/providers/litellm';
 import { DefaultGradingProvider } from '../../src/providers/openai/defaults';
 
 describe('matchesGEval', () => {
@@ -123,6 +125,76 @@ describe('matchesGEval', () => {
     DefaultGradingProvider.callApi = originalCallApi;
   });
 
+  it('uses a configured LiteLLM grader for both G-Eval phases', async () => {
+    const criteria = 'Reward factual grounding and completeness';
+    const configuredLiteLLM = createLiteLLMProvider('litellm:gemini-pro', {
+      config: {
+        config: {
+          apiBaseUrl: 'http://litellm-regression.local:4000',
+          apiKey: 'test-litellm-key',
+          temperature: 0,
+        },
+      },
+    });
+
+    const resolvedProvider = await resolveProvider('litellm:gemini-pro', {
+      [configuredLiteLLM.id()]: configuredLiteLLM,
+    });
+    expect(resolvedProvider).toBe(configuredLiteLLM);
+    expect(configuredLiteLLM.config.apiBaseUrl).toBe('http://litellm-regression.local:4000');
+
+    const litellmCallApi = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        output: '{"steps": ["Check factual alignment", "Check completeness"]}',
+        tokenUsage: { total: 11, prompt: 6, completion: 5 },
+      }))
+      .mockImplementationOnce(async () => ({
+        output: '{"score": 8, "reason": "The answer is grounded and complete"}',
+        tokenUsage: { total: 13, prompt: 7, completion: 6 },
+      }));
+    resolvedProvider.callApi = litellmCallApi;
+
+    const result = await matchesGEval(
+      criteria,
+      'Question: what is the capital of France?',
+      'Paris is the capital of France.',
+      0.7,
+      { provider: resolvedProvider },
+    );
+
+    expect(result).toEqual({
+      pass: true,
+      score: 0.8,
+      reason: 'The answer is grounded and complete',
+      tokensUsed: expect.objectContaining({ total: 24, prompt: 13, completion: 11 }),
+    });
+    expect(DefaultGradingProvider.callApi).not.toHaveBeenCalled();
+    expect(litellmCallApi).toHaveBeenCalledTimes(2);
+    expect(litellmCallApi).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('generate 3-4 concise evaluation steps'),
+      expect.objectContaining({
+        prompt: expect.objectContaining({ label: 'g-eval-steps' }),
+        vars: { criteria },
+      }),
+    );
+    expect(litellmCallApi).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('Check factual alignment'),
+      expect.objectContaining({
+        prompt: expect.objectContaining({ label: 'g-eval' }),
+        vars: expect.objectContaining({
+          criteria,
+          input: 'Question: what is the capital of France?',
+          maxScore: '10',
+          output: 'Paris is the capital of France.',
+        }),
+      }),
+    );
+    expect(litellmCallApi.mock.calls[1][1].vars.steps).toContain('Check completeness');
+  });
+
   it('should fail when score is below threshold', async () => {
     vi.spyOn(DefaultGradingProvider, 'callApi')
       .mockImplementationOnce(async () => {
@@ -175,6 +247,28 @@ describe('matchesGEval', () => {
     expect(DefaultGradingProvider.callApi).toHaveBeenCalledTimes(1);
   });
 
+  it('reports the LiteLLM grader and phase when step generation returns no output', async () => {
+    const provider = createLiteLLMProvider('litellm:gemini-pro', {});
+    provider.callApi = vi.fn().mockResolvedValueOnce({
+      output: '',
+      tokenUsage: { total: 3, prompt: 1, completion: 2 },
+    });
+
+    const result = await matchesGEval('Evaluate coherence', 'Test input', 'Test output', 0.7, {
+      provider,
+    });
+
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'G-Eval step-generation call to litellm:gemini-pro returned no output',
+      tokensUsed: expect.objectContaining({ total: 3, prompt: 1, completion: 2 }),
+      metadata: { graderError: true },
+    });
+    expect(DefaultGradingProvider.callApi).not.toHaveBeenCalled();
+    expect(provider.callApi).toHaveBeenCalledTimes(1);
+  });
+
   it('should fail clearly when the evaluation steps shape is invalid', async () => {
     vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
       output: '{"steps":"Check clarity"}',
@@ -221,6 +315,33 @@ describe('matchesGEval', () => {
       }),
       metadata: { graderError: true },
     });
+  });
+
+  it('reports the LiteLLM grader and phase when evaluation returns no output', async () => {
+    const provider = createLiteLLMProvider('litellm:gemini-pro', {});
+    provider.callApi = vi
+      .fn()
+      .mockResolvedValueOnce({
+        output: '{"steps": ["Check clarity"]}',
+        tokenUsage: { total: 3, prompt: 1, completion: 2 },
+      })
+      .mockResolvedValueOnce({
+        tokenUsage: { total: 4, prompt: 2, completion: 2 },
+      });
+
+    const result = await matchesGEval('Evaluate coherence', 'Test input', 'Test output', 0.7, {
+      provider,
+    });
+
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'G-Eval evaluation call to litellm:gemini-pro returned no output',
+      tokensUsed: expect.objectContaining({ total: 7, prompt: 3, completion: 4 }),
+      metadata: { graderError: true },
+    });
+    expect(DefaultGradingProvider.callApi).not.toHaveBeenCalled();
+    expect(provider.callApi).toHaveBeenCalledTimes(2);
   });
 
   it('should fail clearly when the evaluation result is not a string', async () => {

--- a/test/matchers/g-eval.test.ts
+++ b/test/matchers/g-eval.test.ts
@@ -125,7 +125,7 @@ describe('matchesGEval', () => {
     DefaultGradingProvider.callApi = originalCallApi;
   });
 
-  it('uses a configured LiteLLM grader for both G-Eval phases', async () => {
+  it('passes LiteLLM provider context through both G-Eval phases', async () => {
     const criteria = 'Reward factual grounding and completeness';
     const configuredLiteLLM = createLiteLLMProvider('litellm:gemini-pro', {
       config: {

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
   GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
@@ -61,25 +60,6 @@ describe('isProviderTypeMap', () => {
   });
 });
 
-describe('addSuiteEnvToDeferredTypedProviders', () => {
-  it('preserves a fully resolved provider map when no entry needs env injection', () => {
-    const provider = makeProvider('litellm:judge');
-    const typeMap = { text: provider };
-
-    expect(addSuiteEnvToDeferredTypedProviders(typeMap, { API_KEY: 'suite-key' })).toBe(typeMap);
-  });
-
-  it('adds env only when a deferred typed provider must still be loaded', () => {
-    const embeddingProvider = makeProvider('litellm:embedding:judge');
-    const typeMap = { text: 'litellm:judge', embedding: embeddingProvider };
-
-    expect(addSuiteEnvToDeferredTypedProviders(typeMap, { API_KEY: 'suite-key' })).toEqual({
-      text: { id: 'litellm:judge', env: { API_KEY: 'suite-key' } },
-      embedding: embeddingProvider,
-    });
-  });
-});
-
 describe('buildConfiguredProviderMap', () => {
   it('returns a null-prototype map', () => {
     const map = buildConfiguredProviderMap([makeProvider('a')]);
@@ -131,6 +111,31 @@ describe('buildConfiguredProviderMap', () => {
 });
 
 describe('resolveConfiguredProviderReference', () => {
+  it('preserves a fully resolved provider map when no entry needs env injection', () => {
+    const provider = makeProvider('litellm:judge');
+    const typeMap = { text: provider };
+
+    expect(
+      resolveConfiguredProviderReference(typeMap, buildConfiguredProviderMap([]), {
+        API_KEY: 'suite-key',
+      }),
+    ).toBe(typeMap);
+  });
+
+  it('adds env only when a deferred typed provider must still be loaded', () => {
+    const embeddingProvider = makeProvider('litellm:embedding:judge');
+    const typeMap = { text: 'litellm:judge', embedding: embeddingProvider };
+
+    expect(
+      resolveConfiguredProviderReference(typeMap, buildConfiguredProviderMap([]), {
+        API_KEY: 'suite-key',
+      }),
+    ).toEqual({
+      text: { id: 'litellm:judge', env: { API_KEY: 'suite-key' } },
+      embedding: embeddingProvider,
+    });
+  });
+
   it('resolves configured typed entries while leaving unconfigured alternatives lazy', () => {
     const textProvider = makeProvider('litellm:judge');
     const providerMap = buildConfiguredProviderMap([textProvider]);

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildConfiguredProviderMap,
+  GRADING_PROVIDER_TYPE_KEYS,
+  isProviderTypeMap,
+} from '../../src/util/gradingProvider';
+
+import type { ApiProvider } from '../../src/types/providers';
+
+function makeProvider(id: string, label?: string): ApiProvider {
+  return {
+    id: vi.fn().mockReturnValue(id),
+    label,
+    callApi: vi.fn().mockResolvedValue({ output: '' }),
+  };
+}
+
+describe('GRADING_PROVIDER_TYPE_KEYS', () => {
+  it('lists the four supported grading-provider types', () => {
+    expect([...GRADING_PROVIDER_TYPE_KEYS]).toEqual([
+      'text',
+      'embedding',
+      'classification',
+      'moderation',
+    ]);
+  });
+});
+
+describe('isProviderTypeMap', () => {
+  it.each([
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['string', 'litellm:judge', false],
+    ['array', ['litellm:judge'], false],
+    ['empty object', {}, false],
+    ['ProviderOptions (has id)', { id: 'litellm:judge', config: {} }, false],
+    [
+      'ApiProvider instance',
+      { id: () => 'x', callApi: () => Promise.resolve({ output: '' }) },
+      false,
+    ],
+    ['ProviderOptionsMap (unknown key)', { 'litellm:judge': { config: {} } }, false],
+  ])('returns false for %s', (_label, value, expected) => {
+    expect(isProviderTypeMap(value)).toBe(expected);
+  });
+
+  it.each([
+    ['text', { text: 'litellm:judge' }],
+    ['embedding', { embedding: 'litellm:embed' }],
+    ['classification', { classification: 'classifier' }],
+    ['moderation', { moderation: 'moderator' }],
+    ['multiple', { text: 'litellm:judge', embedding: 'litellm:embed' }],
+  ])('returns true for typed map (%s)', (_label, value) => {
+    expect(isProviderTypeMap(value)).toBe(true);
+  });
+});
+
+describe('buildConfiguredProviderMap', () => {
+  it('returns a null-prototype map', () => {
+    const map = buildConfiguredProviderMap([makeProvider('a')]);
+    expect(Object.getPrototypeOf(map)).toBeNull();
+  });
+
+  it('indexes providers by id and label', () => {
+    const provider = makeProvider('openai:gpt-4', 'gpt');
+    const map = buildConfiguredProviderMap([provider]);
+    expect(map['openai:gpt-4']).toBe(provider);
+    expect(map.gpt).toBe(provider);
+  });
+
+  it('does not let a later provider label shadow an earlier provider id', () => {
+    const byId = makeProvider('judge');
+    const byLabel = makeProvider('litellm:judge', 'judge');
+    const map = buildConfiguredProviderMap([byId, byLabel]);
+    expect(map.judge).toBe(byId);
+    expect(map['litellm:judge']).toBe(byLabel);
+  });
+
+  it('is independent of provider iteration order for id/label collisions', () => {
+    const byId = makeProvider('judge');
+    const byLabel = makeProvider('litellm:judge', 'judge');
+    const reverse = buildConfiguredProviderMap([byLabel, byId]);
+    expect(reverse.judge).toBe(byId);
+    expect(reverse['litellm:judge']).toBe(byLabel);
+  });
+
+  it('still applies a label alias when no id collides', () => {
+    const provider = makeProvider('litellm:judge', 'judge');
+    const map = buildConfiguredProviderMap([provider]);
+    expect(map.judge).toBe(provider);
+    expect(map['litellm:judge']).toBe(provider);
+  });
+
+  it('does not surface prototype properties through hasOwn lookups', () => {
+    const map = buildConfiguredProviderMap([makeProvider('a')]);
+    expect(Object.hasOwn(map, '__proto__')).toBe(false);
+    expect(Object.hasOwn(map, 'constructor')).toBe(false);
+    expect(Object.hasOwn(map, 'toString')).toBe(false);
+  });
+
+  it('returns an empty null-prototype map for an empty input', () => {
+    const map = buildConfiguredProviderMap([]);
+    expect(Object.getPrototypeOf(map)).toBeNull();
+    expect(Object.keys(map)).toEqual([]);
+  });
+});

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -145,4 +145,21 @@ describe('resolveConfiguredProviderReference', () => {
       embedding: 'unsupported-provider:unused-embedding',
     });
   });
+
+  it('resolves an id-only typed provider option to a configured provider instance', () => {
+    const textProvider = makeProvider('litellm:judge');
+    const providerMap = buildConfiguredProviderMap([textProvider]);
+
+    expect(
+      resolveConfiguredProviderReference({ text: { id: 'litellm:judge' } }, providerMap),
+    ).toEqual({ text: textProvider });
+  });
+
+  it('keeps a typed provider option with overrides inline', () => {
+    const textProvider = makeProvider('litellm:judge');
+    const providerMap = buildConfiguredProviderMap([textProvider]);
+    const inlineProvider = { text: { id: 'litellm:judge', config: { temperature: 0 } } };
+
+    expect(resolveConfiguredProviderReference(inlineProvider, providerMap)).toBe(inlineProvider);
+  });
 });

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -42,6 +42,7 @@ describe('isProviderTypeMap', () => {
     ],
     ['ProviderOptionsMap (unknown key)', { 'litellm:judge': { config: {} } }, false],
     ['ProviderOptionsMap (type-named key)', { text: { config: {} } }, false],
+    ['type key with empty string value', { text: '' }, false],
     ['type key with undefined value', { text: undefined }, false],
   ])('returns false for %s', (_label, value, expected) => {
     expect(isProviderTypeMap(value)).toBe(expected);

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -41,12 +41,15 @@ describe('isProviderTypeMap', () => {
       false,
     ],
     ['ProviderOptionsMap (unknown key)', { 'litellm:judge': { config: {} } }, false],
+    ['ProviderOptionsMap (type-named key)', { text: { config: {} } }, false],
+    ['type key with undefined value', { text: undefined }, false],
   ])('returns false for %s', (_label, value, expected) => {
     expect(isProviderTypeMap(value)).toBe(expected);
   });
 
   it.each([
     ['text', { text: 'litellm:judge' }],
+    ['text ProviderOptions', { text: { id: 'litellm:judge', config: {} } }],
     ['embedding', { embedding: 'litellm:embed' }],
     ['classification', { classification: 'classifier' }],
     ['moderation', { moderation: 'moderator' }],

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  addSuiteEnvToDeferredTypedProviders,
   buildConfiguredProviderMap,
   GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
@@ -57,6 +58,25 @@ describe('isProviderTypeMap', () => {
     ['multiple', { text: 'litellm:judge', embedding: 'litellm:embed' }],
   ])('returns true for typed map (%s)', (_label, value) => {
     expect(isProviderTypeMap(value)).toBe(true);
+  });
+});
+
+describe('addSuiteEnvToDeferredTypedProviders', () => {
+  it('preserves a fully resolved provider map when no entry needs env injection', () => {
+    const provider = makeProvider('litellm:judge');
+    const typeMap = { text: provider };
+
+    expect(addSuiteEnvToDeferredTypedProviders(typeMap, { API_KEY: 'suite-key' })).toBe(typeMap);
+  });
+
+  it('adds env only when a deferred typed provider must still be loaded', () => {
+    const embeddingProvider = makeProvider('litellm:embedding:judge');
+    const typeMap = { text: 'litellm:judge', embedding: embeddingProvider };
+
+    expect(addSuiteEnvToDeferredTypedProviders(typeMap, { API_KEY: 'suite-key' })).toEqual({
+      text: { id: 'litellm:judge', env: { API_KEY: 'suite-key' } },
+      embedding: embeddingProvider,
+    });
   });
 });
 

--- a/test/util/gradingProvider.test.ts
+++ b/test/util/gradingProvider.test.ts
@@ -3,6 +3,7 @@ import {
   buildConfiguredProviderMap,
   GRADING_PROVIDER_TYPE_KEYS,
   isProviderTypeMap,
+  resolveConfiguredProviderReference,
 } from '../../src/util/gradingProvider';
 
 import type { ApiProvider } from '../../src/types/providers';
@@ -102,5 +103,22 @@ describe('buildConfiguredProviderMap', () => {
     const map = buildConfiguredProviderMap([]);
     expect(Object.getPrototypeOf(map)).toBeNull();
     expect(Object.keys(map)).toEqual([]);
+  });
+});
+
+describe('resolveConfiguredProviderReference', () => {
+  it('resolves configured typed entries while leaving unconfigured alternatives lazy', () => {
+    const textProvider = makeProvider('litellm:judge');
+    const providerMap = buildConfiguredProviderMap([textProvider]);
+
+    expect(
+      resolveConfiguredProviderReference(
+        { text: 'litellm:judge', embedding: 'unsupported-provider:unused-embedding' },
+        providerMap,
+      ),
+    ).toEqual({
+      text: textProvider,
+      embedding: 'unsupported-provider:unused-embedding',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Reuse already-loaded providers referenced by ID or label for runtime model-grader options and assertions after defaults and scenarios are assembled.
- Resolve provider references nested inside grading type maps such as `provider: { text: litellm:grader }`, including package-API preprocessing and lower-level evaluator execution.
- Share provider-map/type-map handling across both paths and ensure a provider label can never shadow another configured provider's ID.
- Preserve lazy selection in typed grading-provider maps so unused provider alternatives are not constructed or allowed to fail an unrelated assertion type.
- Preserve object identity for fully resolved typed grader maps; suite env augmentation now clones only when a deferred entry needs it.
- Reuse configured graders for id-only typed options such as `{ text: { id: 'litellm:judge' } }` while retaining option-bearing inline providers.
- Resolve typed configured references and deferred suite env in one shared pass, removing duplicate caller-side orchestration.
- Preserve suite-level environment overrides for deferred inline typed graders, including inherited assertions, and distinguish typed maps from invalid or type-named `ProviderOptionsMap` entries.
- Keep the G-Eval LiteLLM request-context and phase-aware empty-output diagnostics from the original patch.
- Keep the LiteLLM docs focused on the repaired behavior: a configured LiteLLM judge can be referenced by ID while the test restricts execution to the target provider being evaluated.

## Why this is needed

The original regression test proved that G-Eval can call a LiteLLM grader, but it did not prove that a configured grader instance was reused. Before this fix, CLI configuration could load a top-level `litellm:grader` with its proxy settings and then silently construct a different fallback LiteLLM provider when a model-graded assertion referenced that ID.

The red-team follow-up found a second bypass: the supported typed form `provider: { text: litellm:grader }` was not dereferenced. The eval could still pass while both grading calls went to the fallback endpoint instead of the configured proxy endpoint.

A review follow-up found a third correctness edge case: when one configured provider's label matched a different provider's ID, resolving that ID could silently choose the labelled provider. Provider IDs now take precedence over label aliases in both evaluation paths.

A final adversarial pass found a fourth regression in the typed-map repair: package-API evaluation eagerly constructed every typed provider alternative. A text-only G-Eval could therefore fail on an unused invalid or unconfigured `embedding` provider. Typed maps now eagerly substitute only already-loaded configured references and defer all other entries until their assertion type is actually selected.

A subsequent Codex review found that the deferred path dropped suite-level `env` for an inline selected typed grader, which could leave credentials or endpoint templates unresolved. Deferred entries now carry merged suite environment overrides without instantiating unused alternatives.

A subsequent Copilot review found that the type-map discriminator mistook a type-named `ProviderOptionsMap` entry such as `{ text: { config: ... } }` for a typed grader, even though typed provider options require an `id`. Typed maps are now recognized only when at least one type key contains a loadable typed provider value.

A final Codex documentation review found that the initial LiteLLM guidance included an incorrect shell-style API-key placeholder. The documentation is now reduced to one provider-ID reuse example and delegates proxy credentials and environment configuration to the canonical LiteLLM provider guide.

A final-head Codex review then found that inline typed graders inherited through `defaultTest.assert` bypassed suite-env augmentation after default assertions were merged at runtime. The shared deferred-provider helper is now applied after that merge as well, including within assertion sets.

A final-head Copilot review found that `{ text: '' }` was accepted as a typed provider map even though it cannot select a provider. Empty string entries are now rejected by the discriminator, consistent with typed provider options requiring a non-empty `id`.

A follow-up Copilot review found that suite-env augmentation shallow-cloned typed grader maps even when every nested provider was already resolved and no env injection was possible. The helper now lazily clones only if it modifies a deferred entry, with regressions covering both paths.

A final Copilot review found that the supported id-only typed option form `{ text: { id: 'litellm:judge' } }` still constructed a fresh provider instead of reusing a configured provider with that ID. Id-only typed entries now resolve through the configured map, while entries with `config`, `env`, labels, or other options stay inline.

A simplification pass then collapsed configured typed-reference lookup and deferred suite-env augmentation into one non-recursive typed-map pass in the shared helper. This removes the exported env-only helper and duplicate composition in both evaluation entry points without changing the tested routing behavior.

## Root cause

Package-API preprocessing and lower evaluator execution did not consistently resolve configured grading-provider references in all supported shapes. String references were repaired first, but references nested under `text`, `embedding`, `classification`, or `moderation` still bypassed configured provider reuse.

This patch resolves both direct references and typed-map references through a shared loaded-provider map while leaving inline provider configuration intact. The shared map uses ID-first insertion, non-overwriting label aliases, and own-key lookup semantics. A single typed-map substitution pass is shared by both evaluation paths, preserves suite environment overrides for deferred inline entries before and after default assertion merging, does not instantiate unused alternatives, and does not claim option-map or empty-string entries that lack a usable typed provider ID.

## Validation

- `npm run f`
- `npm run l`
- `npm run tsc -- --pretty false`
- `SKIP_OG_GENERATION=true npm --prefix site run build`
- `npm run build`
- `PROMPTFOO_DISABLE_TELEMETRY=true npm test -- test/index.test.ts test/evaluator/assertions.test.ts test/util/gradingProvider.test.ts test/matchers/g-eval.test.ts test/matchers/getGradingProvider.test.ts test/matchers/utils.test.ts test/evaluator/defaultTest.test.ts test/evaluator/gradingConcurrency.test.ts` (215 passed)
- `PROMPTFOO_DISABLE_TELEMETRY=true npm test -- test/index.test.ts test/evaluator/assertions.test.ts test/util/gradingProvider.test.ts test/matchers/g-eval.test.ts test/matchers/llm-rubric.test.ts test/matchers/closed-qa.test.ts test/matchers/factuality.test.ts test/matchers/answer-relevance.test.ts test/matchers/context-recall.test.ts test/matchers/context-relevance.test.ts test/matchers/context-faithfulness.test.ts test/matchers/comparison.test.ts test/matchers/search-rubric.test.ts test/matchers/similarity.test.ts test/matchers/classification.test.ts test/matchers/moderation.test.ts test/assertions/llmRubric.test.ts test/assertions/searchRubric.test.ts test/assertions/contextFaithfulness.test.ts test/assertions/contextRecall.test.ts test/assertions/contextRelevance.test.ts test/assertions/moderation.test.ts` (339 passed)
- Regression coverage validates ID-over-label precedence, lazy unused typed-map alternatives, suite-env preservation for deferred inline and inherited graders, resolved-map identity preservation, id-only typed option reuse without swallowing inline overrides, single-pass typed-map resolution, typed-map/options-map discrimination, and rejection of empty typed provider IDs.
- The shared judge audit now includes an `answer-relevance` evaluator regression proving configured `text` and `embedding` judge references are both reused; the other text-judge paths pass together in the expanded matcher/assertion run.
- Built package-API probe with an inline typed LiteLLM grader whose endpoint is rendered from suite `env`, plus an invalid unused `embedding` alternative: G-Eval passed and both grading requests hit only the suite-configured endpoint while a supplied fallback endpoint received none.
- Built package-API probe with configured `provider: { text: litellm:judge, embedding: unsupported-provider:unused-embedding }`: G-Eval passed and both grading requests hit only the configured LiteLLM endpoint.
- Built package-API probe with an inline typed LiteLLM grader inherited from `defaultTest.assert`, endpoint rendered from suite `env`, and an invalid unused `embedding` alternative: G-Eval passed and both grading requests hit only the suite-configured endpoint.
- Live CLI dual-endpoint probe for an inline typed LiteLLM grader inherited from `defaultTest.assert`: exported result passed with two grading requests, and both requests hit only the suite-configured endpoint rather than the forced fallback endpoint.
- Live CLI dual-endpoint probe for `defaultTest.options.provider: { text: litellm:judge }`: exported result passed with two grading requests, and both requests hit only the configured endpoint.
- Live CLI dual-endpoint probe for assertion `provider: { text: litellm:judge }`: exported result passed with two grading requests, and both requests hit only the configured endpoint.
- Live CLI dual-endpoint probe for `defaultTest.options.provider: { text: { id: litellm:judge } }`: exported result passed with two grading requests, and both requests hit only the configured endpoint while the forced fallback endpoint received none.
- After simplification, live CLI and built package-API dual-endpoint probes for `defaultTest.options.provider: { text: { id: litellm:judge } }` both passed; each made two grading requests only to the configured endpoint while the forced fallback endpoint received none.
- After merging current `origin/main` at `3abc9d010`, `npm run f`, `npm run l`, `npm run tsc -- --pretty false`, `npm run build`, and `SKIP_OG_GENERATION=true npm --prefix site run build` passed.
- On the merged head, the expanded model-graded and persisted-secret regression set passed (`374 passed`), including `test/models/evalResult.test.ts` to confirm nested grader credentials remain redacted in stored results.
- On the merged head, live CLI and built package-API dual-endpoint probes for `defaultTest.options.provider: { text: { id: litellm:judge } }` both passed again; each made two grader requests only to the configured endpoint while the forced fallback endpoint received none.
- Live CLI through a local LiteLLM proxy: configured direct-reference G-Eval passed with one target proxy call plus two grader proxy calls; exported result reports `gradingResult.tokensUsed.numRequests: 2`.
- Live CLI through the same LiteLLM proxy: configured `litellm:grader` `llm-rubric` passed with one grading request.
- Live CLI using inline LiteLLM G-Eval grader configuration passed with two grading requests and no extra target column.
- Live CLI using a direct OpenAI G-Eval grader passed with two grading requests as a comparison path.

## Full-suite note

`npm test` was attempted twice locally. Under the full parallel run, unrelated localhost server/fetch tests failed with timeouts and `EADDRNOTAVAIL` port-exhaustion errors. The affected files pass together when rerun directly: `test/server/routes/version.route.test.ts`, `test/server/routes/redteam.test.ts`, `test/server/routes/media.test.ts`, and `test/fetch.compression.test.ts` (83 passed).
