### PR TITLE
perf(webui): speed up evaluation selection

### DIFF
--- a/drizzle/0024_repair_eval_redteam_flags.sql
+++ b/drizzle/0024_repair_eval_redteam_flags.sql
@@ -1,0 +1,4 @@
+UPDATE `evals` SET `is_redteam` = CASE
+  WHEN json_valid(`config`) AND json_type(`config`, '$.redteam') IS NOT NULL THEN 1
+  ELSE 0
+END;

--- a/drizzle/0024_repair_eval_redteam_flags.sql
+++ b/drizzle/0024_repair_eval_redteam_flags.sql
@@ -1,3 +1,16 @@
+-- Repair stale `is_redteam` values to match the runtime classification used by
+-- the write paths in src/models/eval.ts (`config.redteam !== undefined`).
+--
+-- `json_type` is used here (not `json_extract`) on purpose:
+--   * json_extract(config, '$.redteam') returns SQL NULL both when the key is
+--     missing and when its value is JSON null.
+--   * json_type(config, '$.redteam')    returns SQL NULL only when the key is
+--     missing; it returns 'null' (string) when the value is JSON null.
+-- Only `json_type` matches `config.redteam !== undefined` in JS.
+--
+-- The WHERE clause narrows the write to rows whose stored flag actually
+-- disagrees with the derived value, so re-runs and already-correct databases
+-- skip the bulk update.
 UPDATE `evals` SET `is_redteam` = CASE
   WHEN json_valid(`config`) AND json_type(`config`, '$.redteam') IS NOT NULL THEN 1
   ELSE 0

--- a/drizzle/0024_repair_eval_redteam_flags.sql
+++ b/drizzle/0024_repair_eval_redteam_flags.sql
@@ -1,16 +1,9 @@
--- Repair stale `is_redteam` values to match the runtime classification used by
--- the write paths in src/models/eval.ts (`config.redteam !== undefined`).
+-- Backfill `is_redteam` to match the runtime predicate `config.redteam !== undefined`
+-- used by writes in src/models/eval.ts.
 --
--- `json_type` is used here (not `json_extract`) on purpose:
---   * json_extract(config, '$.redteam') returns SQL NULL both when the key is
---     missing and when its value is JSON null.
---   * json_type(config, '$.redteam')    returns SQL NULL only when the key is
---     missing; it returns 'null' (string) when the value is JSON null.
--- Only `json_type` matches `config.redteam !== undefined` in JS.
---
--- The WHERE clause narrows the write to rows whose stored flag actually
--- disagrees with the derived value, so re-runs and already-correct databases
--- skip the bulk update.
+-- Uses `json_type` (not `json_extract`) so that `{"redteam": null}` is classified as
+-- a redteam: `json_extract` returns SQL NULL for both missing keys and JSON null,
+-- but `json_type` only returns NULL when the key is missing.
 UPDATE `evals` SET `is_redteam` = CASE
   WHEN json_valid(`config`) AND json_type(`config`, '$.redteam') IS NOT NULL THEN 1
   ELSE 0

--- a/drizzle/0024_repair_eval_redteam_flags.sql
+++ b/drizzle/0024_repair_eval_redteam_flags.sql
@@ -1,4 +1,8 @@
 UPDATE `evals` SET `is_redteam` = CASE
   WHEN json_valid(`config`) AND json_type(`config`, '$.redteam') IS NOT NULL THEN 1
   ELSE 0
+END
+WHERE `is_redteam` != CASE
+  WHEN json_valid(`config`) AND json_type(`config`, '$.redteam') IS NOT NULL THEN 1
+  ELSE 0
 END;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1496 @@
+{
+  "id": "00fa2978-039b-4dbd-8e05-d962a981755f",
+  "prevId": "516dc2b9-fcef-43c1-88dc-543e422e3f53",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "blob_assets": {
+      "name": "blob_assets",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "blob_assets_provider_idx": {
+          "name": "blob_assets_provider_idx",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "blob_assets_created_at_idx": {
+          "name": "blob_assets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "blob_assets_mime_type_idx": {
+          "name": "blob_assets_mime_type_idx",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob_references": {
+      "name": "blob_references",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "blob_references_blob_idx": {
+          "name": "blob_references_blob_idx",
+          "columns": [
+            "blob_hash"
+          ],
+          "isUnique": false
+        },
+        "blob_references_eval_idx": {
+          "name": "blob_references_eval_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "blob_references_blob_created_at_idx": {
+          "name": "blob_references_blob_created_at_idx",
+          "columns": [
+            "blob_hash",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blob_references_blob_hash_blob_assets_hash_fk": {
+          "name": "blob_references_blob_hash_blob_assets_hash_fk",
+          "tableFrom": "blob_references",
+          "columnsFrom": [
+            "blob_hash"
+          ],
+          "tableTo": "blob_assets",
+          "columnsTo": [
+            "hash"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "blob_references_eval_id_evals_id_fk": {
+          "name": "blob_references_eval_id_evals_id_fk",
+          "tableFrom": "blob_references",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "configs_created_at_idx": {
+          "name": "configs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "configs_type_idx": {
+          "name": "configs_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "datasets": {
+      "name": "datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tests": {
+          "name": "tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "datasets_created_at_idx": {
+          "name": "datasets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case": {
+          "name": "test_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grading_result": {
+          "name": "grading_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "named_scores": {
+          "name": "named_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_result_eval_id_idx": {
+          "name": "eval_result_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_idx": {
+          "name": "eval_result_test_idx",
+          "columns": [
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_idx": {
+          "name": "eval_result_eval_test_idx",
+          "columns": [
+            "eval_id",
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_success_idx": {
+          "name": "eval_result_eval_success_idx",
+          "columns": [
+            "eval_id",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_failure_idx": {
+          "name": "eval_result_eval_failure_idx",
+          "columns": [
+            "eval_id",
+            "failure_reason"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_success_idx": {
+          "name": "eval_result_eval_test_success_idx",
+          "columns": [
+            "eval_id",
+            "test_idx",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_response_idx": {
+          "name": "eval_result_response_idx",
+          "columns": [
+            "response"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_reason_idx": {
+          "name": "eval_result_grading_result_reason_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.reason')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_comment_idx": {
+          "name": "eval_result_grading_result_comment_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.comment')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_vars_idx": {
+          "name": "eval_result_test_case_vars_idx",
+          "columns": [
+            "json_extract(\"test_case\", '$.vars')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_metadata_idx": {
+          "name": "eval_result_test_case_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_named_scores_idx": {
+          "name": "eval_result_named_scores_idx",
+          "columns": [
+            "json_extract(\"named_scores\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_idx": {
+          "name": "eval_result_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_plugin_id_idx": {
+          "name": "eval_result_metadata_plugin_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.pluginId')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_strategy_id_idx": {
+          "name": "eval_result_metadata_strategy_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.strategyId')"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_eval_id_evals_id_fk": {
+          "name": "eval_results_eval_id_evals_id_fk",
+          "tableFrom": "eval_results",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "eval_results_prompt_id_prompts_id_fk": {
+          "name": "eval_results_prompt_id_prompts_id_fk",
+          "tableFrom": "eval_results",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "tableTo": "prompts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals": {
+      "name": "evals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_options": {
+          "name": "runtime_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_redteam": {
+          "name": "is_redteam",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "evals_created_at_idx": {
+          "name": "evals_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "evals_author_idx": {
+          "name": "evals_author_idx",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        },
+        "evals_is_redteam_idx": {
+          "name": "evals_is_redteam_idx",
+          "columns": [
+            "is_redteam"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_datasets": {
+      "name": "evals_to_datasets",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_datasets_eval_id_idx": {
+          "name": "evals_to_datasets_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_datasets_dataset_id_idx": {
+          "name": "evals_to_datasets_dataset_id_idx",
+          "columns": [
+            "dataset_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_datasets_eval_id_evals_id_fk": {
+          "name": "evals_to_datasets_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "evals_to_datasets_dataset_id_datasets_id_fk": {
+          "name": "evals_to_datasets_dataset_id_datasets_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "tableTo": "datasets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_datasets_eval_id_dataset_id_pk": {
+          "columns": [
+            "eval_id",
+            "dataset_id"
+          ],
+          "name": "evals_to_datasets_eval_id_dataset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_prompts": {
+      "name": "evals_to_prompts",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_prompts_eval_id_idx": {
+          "name": "evals_to_prompts_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_prompts_prompt_id_idx": {
+          "name": "evals_to_prompts_prompt_id_idx",
+          "columns": [
+            "prompt_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_prompts_eval_id_evals_id_fk": {
+          "name": "evals_to_prompts_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "evals_to_prompts_prompt_id_prompts_id_fk": {
+          "name": "evals_to_prompts_prompt_id_prompts_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "tableTo": "prompts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_prompts_eval_id_prompt_id_pk": {
+          "columns": [
+            "eval_id",
+            "prompt_id"
+          ],
+          "name": "evals_to_prompts_eval_id_prompt_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_tags": {
+      "name": "evals_to_tags",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_tags_eval_id_idx": {
+          "name": "evals_to_tags_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_tags_tag_id_idx": {
+          "name": "evals_to_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_tags_eval_id_evals_id_fk": {
+          "name": "evals_to_tags_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_tags",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "evals_to_tags_tag_id_tags_id_fk": {
+          "name": "evals_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "evals_to_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_tags_eval_id_tag_id_pk": {
+          "columns": [
+            "eval_id",
+            "tag_id"
+          ],
+          "name": "evals_to_tags_eval_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_audits": {
+      "name": "model_audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_path": {
+          "name": "model_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checks": {
+          "name": "checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_errors": {
+          "name": "has_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_checks": {
+          "name": "total_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passed_checks": {
+          "name": "passed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_checks": {
+          "name": "failed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision_sha": {
+          "name": "revision_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_last_modified": {
+          "name": "source_last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scanner_version": {
+          "name": "scanner_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_audits_created_at_idx": {
+          "name": "model_audits_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_path_idx": {
+          "name": "model_audits_model_path_idx",
+          "columns": [
+            "model_path"
+          ],
+          "isUnique": false
+        },
+        "model_audits_has_errors_idx": {
+          "name": "model_audits_has_errors_idx",
+          "columns": [
+            "has_errors"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_type_idx": {
+          "name": "model_audits_model_type_idx",
+          "columns": [
+            "model_type"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_id_idx": {
+          "name": "model_audits_model_id_idx",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "model_audits_revision_sha_idx": {
+          "name": "model_audits_revision_sha_idx",
+          "columns": [
+            "revision_sha"
+          ],
+          "isUnique": false
+        },
+        "model_audits_content_hash_idx": {
+          "name": "model_audits_content_hash_idx",
+          "columns": [
+            "content_hash"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_revision_idx": {
+          "name": "model_audits_model_revision_idx",
+          "columns": [
+            "model_id",
+            "revision_sha"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_content_idx": {
+          "name": "model_audits_model_content_idx",
+          "columns": [
+            "model_id",
+            "content_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_created_at_idx": {
+          "name": "prompts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        },
+        "spans_span_id_idx": {
+          "name": "spans_span_id_idx",
+          "columns": [
+            "span_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "spans_trace_id_traces_trace_id_fk": {
+          "name": "spans_trace_id_traces_trace_id_fk",
+          "tableFrom": "spans",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "tableTo": "traces",
+          "columnsTo": [
+            "trace_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "tags_name_value_unique": {
+          "name": "tags_name_value_unique",
+          "columns": [
+            "name",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "traces_trace_id_unique": {
+          "name": "traces_trace_id_unique",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": true
+        },
+        "traces_evaluation_idx": {
+          "name": "traces_evaluation_idx",
+          "columns": [
+            "evaluation_id"
+          ],
+          "isUnique": false
+        },
+        "traces_trace_id_idx": {
+          "name": "traces_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "traces_evaluation_id_evals_id_fk": {
+          "name": "traces_evaluation_id_evals_id_fk",
+          "tableFrom": "traces",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "tableTo": "evals",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {
+      "eval_result_grading_result_reason_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.reason')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_grading_result_comment_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.comment')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_vars_idx": {
+        "columns": {
+          "json_extract(\"test_case\", '$.vars')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_named_scores_idx": {
+        "columns": {
+          "json_extract(\"named_scores\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_plugin_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.pluginId')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_strategy_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.strategyId')": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1767985150681,
       "tag": "0023_wooden_mandrill",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1779816393227,
+      "tag": "0024_repair_eval_redteam_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/src/pages/eval/components/EvalSelectorDialog.test.tsx
+++ b/src/app/src/pages/eval/components/EvalSelectorDialog.test.tsx
@@ -59,6 +59,7 @@ describe('EvalSelectorDialog', () => {
     const mockOnClose = vi.fn();
     const mockOnEvalSelected = vi.fn();
     const focusedEvalId = 'test-eval-id';
+    const focusedDatasetId = 'test-dataset-id';
     const filterByDatasetId = true;
 
     render(
@@ -68,6 +69,7 @@ describe('EvalSelectorDialog', () => {
           onClose={mockOnClose}
           onEvalSelected={mockOnEvalSelected}
           focusedEvalId={focusedEvalId}
+          focusedDatasetId={focusedDatasetId}
           filterByDatasetId={filterByDatasetId}
         />
       </MemoryRouter>,
@@ -76,6 +78,7 @@ describe('EvalSelectorDialog', () => {
     expect(MockedEvalsTable).toHaveBeenCalledWith(
       expect.objectContaining({
         focusedEvalId: focusedEvalId,
+        focusedDatasetId: focusedDatasetId,
         filterByDatasetId: filterByDatasetId,
       }),
       undefined,

--- a/src/app/src/pages/eval/components/EvalSelectorDialog.tsx
+++ b/src/app/src/pages/eval/components/EvalSelectorDialog.tsx
@@ -13,6 +13,7 @@ type Props = {
   onEvalSelected: (evalId: string) => void;
   focusedEvalId?: string;
   filterByDatasetId?: boolean;
+  focusedDatasetId?: string | null;
   description?: string;
 };
 
@@ -22,6 +23,7 @@ const EvalSelectorDialog = ({
   onEvalSelected,
   focusedEvalId,
   filterByDatasetId,
+  focusedDatasetId,
   description = 'Choose an evaluation to view',
 }: Props) => {
   return (
@@ -36,6 +38,7 @@ const EvalSelectorDialog = ({
             onEvalSelected={onEvalSelected}
             focusedEvalId={focusedEvalId}
             filterByDatasetId={filterByDatasetId}
+            focusedDatasetId={focusedDatasetId}
             showUtilityButtons
           />
         </div>

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -122,7 +122,11 @@ vi.mock('./CompareEvalMenuItem', () => ({
 }));
 
 vi.mock('./EvalSelectorDialog', () => ({
-  default: () => <div>Eval Selector Dialog</div>,
+  default: ({ focusedDatasetId }: { focusedDatasetId?: string | null }) => (
+    <div data-testid="eval-selector-dialog" data-focused-dataset-id={focusedDatasetId ?? ''}>
+      Eval Selector Dialog
+    </div>
+  ),
 }));
 
 vi.mock('./EvalSelectorKeyboardShortcut', () => ({
@@ -384,6 +388,30 @@ describe('ResultsView Share Button', () => {
       // Use getAllByText since there may be multiple Delete elements (menu item + dialog)
       expect(screen.getAllByText('Delete').length).toBeGreaterThan(0);
     });
+  });
+
+  it('passes the current dataset to the comparison eval selector', () => {
+    renderWithRouter(
+      <ResultsView
+        recentEvals={[
+          {
+            ...mockRecentEvals[0],
+            evalId: 'test-eval-id',
+            datasetId: 'dataset-for-comparison',
+          },
+        ]}
+        onRecentEvalSelected={mockOnRecentEvalSelected}
+        defaultEvalId="test-eval-id"
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByTestId('eval-selector-dialog')
+        .some(
+          (dialog) => dialog.getAttribute('data-focused-dataset-id') === 'dataset-for-comparison',
+        ),
+    ).toBe(true);
   });
 
   it('carries the source eval id when editing and rerunning a redacted config', async () => {

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -379,6 +379,9 @@ export default function ResultsView({
 
   const currentEvalId = evalId || defaultEvalId || 'default';
   const validEvalId = evalId || defaultEvalId;
+  const currentDatasetId = recentEvals.find(
+    (recentEval) => recentEval.evalId === currentEvalId,
+  )?.datasetId;
 
   const handleShareButtonClick = async () => {
     if (IS_RUNNING_LOCALLY) {
@@ -997,6 +1000,7 @@ export default function ResultsView({
         description="Only evals with the same dataset can be compared."
         focusedEvalId={currentEvalId}
         filterByDatasetId
+        focusedDatasetId={currentDatasetId}
       />
       <DownloadDialog open={downloadDialogOpen} onClose={() => setDownloadDialogOpen(false)} />
       <SettingsModal

--- a/src/app/src/pages/evals/components/EvalsTable.search.test.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.search.test.tsx
@@ -1,0 +1,65 @@
+import { TooltipProvider } from '@app/components/ui/tooltip';
+import { callApi } from '@app/utils/api';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import EvalsTable from './EvalsTable';
+
+vi.mock('@app/utils/api');
+
+describe('EvalsTable search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('searches displayed descriptions when the first row has no description', async () => {
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [
+          {
+            evalId: 'eval-newest',
+            createdAt: 2,
+            description: null,
+            datasetId: null,
+            isRedteam: false,
+            label: 'eval-newest',
+            numTests: 1,
+            passRate: 100,
+          },
+          {
+            evalId: 'eval-target',
+            createdAt: 1,
+            description: 'Persistent Python worker smoke test',
+            datasetId: null,
+            isRedteam: false,
+            label: 'Persistent Python worker smoke test (eval-target)',
+            numTests: 1,
+            passRate: 100,
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <MemoryRouter>
+          <EvalsTable onEvalSelected={vi.fn()} showUtilityButtons />
+        </MemoryRouter>
+      </TooltipProvider>,
+    );
+
+    await screen.findByText('Persistent Python worker smoke test');
+
+    await userEvent.type(
+      screen.getByRole('searchbox', { name: 'Search evaluations' }),
+      'Persistent Python',
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Persistent Python worker smoke test')).toBeInTheDocument();
+      expect(screen.queryByText('eval-newest')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/src/pages/evals/components/EvalsTable.search.test.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.search.test.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
-import { callApi } from '@app/utils/api';
+import { mockCallApiResponse } from '@app/tests/apiMocks';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -14,33 +14,30 @@ describe('EvalsTable search', () => {
   });
 
   it('searches displayed descriptions when the first row has no description', async () => {
-    vi.mocked(callApi).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        data: [
-          {
-            evalId: 'eval-newest',
-            createdAt: 2,
-            description: null,
-            datasetId: null,
-            isRedteam: false,
-            label: 'eval-newest',
-            numTests: 1,
-            passRate: 100,
-          },
-          {
-            evalId: 'eval-target',
-            createdAt: 1,
-            description: 'Persistent Python worker smoke test',
-            datasetId: null,
-            isRedteam: false,
-            label: 'Persistent Python worker smoke test (eval-target)',
-            numTests: 1,
-            passRate: 100,
-          },
-        ],
-      }),
-    } as unknown as Response);
+    mockCallApiResponse({
+      data: [
+        {
+          evalId: 'eval-newest',
+          createdAt: 2,
+          description: null,
+          datasetId: null,
+          isRedteam: false,
+          label: 'eval-newest',
+          numTests: 1,
+          passRate: 100,
+        },
+        {
+          evalId: 'eval-target',
+          createdAt: 1,
+          description: 'Persistent Python worker smoke test',
+          datasetId: null,
+          isRedteam: false,
+          label: 'Persistent Python worker smoke test (eval-target)',
+          numTests: 1,
+          passRate: 100,
+        },
+      ],
+    });
 
     render(
       <TooltipProvider delayDuration={0}>

--- a/src/app/src/pages/evals/components/EvalsTable.test.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.test.tsx
@@ -190,6 +190,42 @@ describe('EvalsTable', () => {
       expect(screen.getByTestId('row-eval-2')).toBeInTheDocument();
       expect(screen.queryByTestId('row-eval-3')).toBeNull();
     });
+    expect(callApi).toHaveBeenCalledWith(
+      '/results',
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('should request only the focused dataset for comparison when its datasetId is known', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: mockEvals }),
+    };
+    vi.mocked(callApi).mockResolvedValue(mockResponse as any);
+
+    render(
+      <MemoryRouter>
+        <EvalsTable
+          onEvalSelected={vi.fn()}
+          focusedEvalId="eval-1"
+          focusedDatasetId="dataset-1"
+          filterByDatasetId={true}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        '/results?datasetId=dataset-1',
+        expect.objectContaining({
+          cache: 'no-store',
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
   });
 
   it('should call onEvalSelected when a row is clicked', async () => {

--- a/src/app/src/pages/evals/components/EvalsTable.test.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.test.tsx
@@ -228,6 +228,71 @@ describe('EvalsTable', () => {
     });
   });
 
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ] as const)('should request all evals and let the client narrow when focusedDatasetId is %s', async (_label, focusedDatasetId) => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: mockEvalsWithMultipleDatasets }),
+    };
+    vi.mocked(callApi).mockResolvedValue(mockResponse as any);
+
+    render(
+      <MemoryRouter>
+        <EvalsTable
+          onEvalSelected={vi.fn()}
+          focusedEvalId="eval-1"
+          focusedDatasetId={focusedDatasetId}
+          filterByDatasetId={true}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        '/results',
+        expect.objectContaining({
+          cache: 'no-store',
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      // Client-side filter still narrows to focusedEval.datasetId.
+      expect(screen.getByTestId('row-eval-1')).toBeInTheDocument();
+      expect(screen.getByTestId('row-eval-2')).toBeInTheDocument();
+      expect(screen.queryByTestId('row-eval-3')).toBeNull();
+    });
+  });
+
+  it('should encode focusedDatasetId so dataset ids with special characters are safe', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: mockEvals }),
+    };
+    vi.mocked(callApi).mockResolvedValue(mockResponse as any);
+
+    render(
+      <MemoryRouter>
+        <EvalsTable
+          onEvalSelected={vi.fn()}
+          focusedEvalId="eval-1"
+          focusedDatasetId="dataset id with spaces & symbols"
+          filterByDatasetId={true}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        '/results?datasetId=dataset%20id%20with%20spaces%20%26%20symbols',
+        expect.objectContaining({
+          cache: 'no-store',
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+  });
+
   it('should call onEvalSelected when a row is clicked', async () => {
     const user = userEvent.setup();
     const mockResponse = {

--- a/src/app/src/pages/evals/components/EvalsTable.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.tsx
@@ -27,6 +27,7 @@ interface EvalsTableProps {
   focusedEvalId?: string;
   showUtilityButtons?: boolean;
   filterByDatasetId?: boolean;
+  focusedDatasetId?: string | null;
   deletionEnabled?: boolean;
 }
 
@@ -35,6 +36,7 @@ export default function EvalsTable({
   focusedEvalId,
   showUtilityButtons = false,
   filterByDatasetId = false,
+  focusedDatasetId,
   deletionEnabled = false,
 }: EvalsTableProps) {
   if (filterByDatasetId) {
@@ -50,26 +52,33 @@ export default function EvalsTable({
   const location = useLocation();
 
   // Fetch evals from the API
-  const fetchEvals = useCallback(async (signal: AbortSignal) => {
-    try {
-      setIsLoading(true);
-      const response = await callApi('/results', { cache: 'no-store', signal });
-      if (!response.ok) {
-        throw new Error('Failed to fetch evals');
+  const fetchEvals = useCallback(
+    async (signal: AbortSignal) => {
+      try {
+        setIsLoading(true);
+        const query =
+          filterByDatasetId && focusedDatasetId
+            ? `?datasetId=${encodeURIComponent(focusedDatasetId)}`
+            : '';
+        const response = await callApi(`/results${query}`, { cache: 'no-store', signal });
+        if (!response.ok) {
+          throw new Error('Failed to fetch evals');
+        }
+        const body = (await response.json()) as { data: EvalSummary[] };
+        setEvals(body.data);
+        setError(null);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!signal.aborted) {
+          setIsLoading(false);
+        }
       }
-      const body = (await response.json()) as { data: EvalSummary[] };
-      setEvals(body.data);
-      setError(null);
-    } catch (err) {
-      if ((err as Error).name !== 'AbortError') {
-        setError((err as Error).message);
-      }
-    } finally {
-      if (!signal.aborted) {
-        setIsLoading(false);
-      }
-    }
-  }, []);
+    },
+    [filterByDatasetId, focusedDatasetId],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   useEffect(() => {
@@ -237,7 +246,8 @@ export default function EvalsTable({
           ]
         : []),
       {
-        accessorKey: 'description',
+        id: 'description',
+        accessorFn: (row) => row.description || row.label,
         header: 'Description',
         cell: ({ row }) => {
           const text = row.original.description || row.original.label;

--- a/src/app/src/pages/evals/components/EvalsTable.tsx
+++ b/src/app/src/pages/evals/components/EvalsTable.tsx
@@ -247,6 +247,9 @@ export default function EvalsTable({
         : []),
       {
         id: 'description',
+        // accessorFn (not accessorKey) ensures every row is searched. TanStack Table
+        // infers column types from the first row, so a leading row with description:
+        // null would silently drop this column from global search.
         accessorFn: (row) => row.description || row.label,
         header: 'Description',
         cell: ({ row }) => {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -370,6 +370,7 @@ function createImportedV2Eval(evalData: any, context: ImportedEvalContext): stri
       description: evalData.description || evalData.config?.description,
       results: evalData.results,
       config: evalData.config,
+      isRedteam: evalData.config?.redteam !== undefined,
     })
     .run();
   return evalId;

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -464,7 +464,7 @@ export default class Eval {
           vars: opts?.vars || [],
           runtimeOptions: sanitizeRuntimeOptions(opts?.runtimeOptions),
           prompts: opts?.completedPrompts || [],
-          isRedteam: Boolean(config.redteam),
+          isRedteam: config.redteam !== undefined,
         })
         .run();
 
@@ -611,6 +611,7 @@ export default class Eval {
     const db = getDb();
     const updateObj: Record<string, unknown> = {
       config: this.config,
+      isRedteam: this.config.redteam !== undefined,
       prompts: this.prompts,
       description: this.config.description,
       author: this.author,
@@ -1399,7 +1400,7 @@ export default class Eval {
           prompts: newPrompts,
           vars: newVars,
           runtimeOptions: sanitizeRuntimeOptions(this.runtimeOptions),
-          isRedteam: Boolean(newConfig.redteam),
+          isRedteam: newConfig.redteam !== undefined,
         })
         .run();
 
@@ -1553,9 +1554,9 @@ export async function getEvalSummaries(
 
   if (type) {
     if (type === 'redteam') {
-      whereClauses.push(sql<boolean>`json_type(${evalsTable.config}, '$.redteam') IS NOT NULL`);
+      whereClauses.push(eq(evalsTable.isRedteam, true));
     } else {
-      whereClauses.push(sql<boolean>`json_type(${evalsTable.config}, '$.redteam') IS NULL`);
+      whereClauses.push(eq(evalsTable.isRedteam, false));
     }
   }
 
@@ -1565,14 +1566,16 @@ export async function getEvalSummaries(
       createdAt: evalsTable.createdAt,
       description: evalsTable.description,
       datasetId: evalsToDatasetsTable.datasetId,
-      isRedteam: sql<boolean>`json_type(${evalsTable.config}, '$.redteam') IS NOT NULL`,
+      isRedteam: evalsTable.isRedteam,
       prompts: evalsTable.prompts,
-      config: evalsTable.config,
+      // Configs can contain very large embedded test definitions. Only materialize them
+      // for the report surface that requests provider labels.
+      config: includeProviders ? evalsTable.config : sql<Partial<UnifiedConfig> | null>`NULL`,
     })
     .from(evalsTable)
     .leftJoin(evalsToDatasetsTable, eq(evalsTable.id, evalsToDatasetsTable.evalId))
     .where(and(...whereClauses))
-    .orderBy(desc(evalsTable.createdAt))
+    .orderBy(desc(evalsTable.createdAt), desc(evalsTable.id))
     .all();
 
   /**
@@ -1609,7 +1612,7 @@ export async function getEvalSummaries(
 
     // Construct an array of providers
     const deserializedProviders = [];
-    const providers = result.config.providers;
+    const providers = result.config?.providers;
 
     if (includeProviders) {
       if (typeof providers === 'string') {

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { LRUCache } from 'lru-cache';
 import { DEFAULT_QUERY_LIMIT } from '../constants';
 import { deleteTraceRecordsForEvals } from '../database/evalDeletion';
@@ -517,6 +517,11 @@ const standaloneEvalCache = new LRUCache<string, StandaloneEval[]>({
   max: 2000,
 });
 
+/** Clears the standalone eval LRU cache. Intended for tests that mutate evals. */
+export function clearStandaloneEvalCache(): void {
+  standaloneEvalCache.clear();
+}
+
 export async function getStandaloneEvals({
   limit = DEFAULT_QUERY_LIMIT,
   tag,
@@ -544,7 +549,7 @@ export async function getStandaloneEvals({
       datasetId: evalsToDatasetsTable.datasetId,
       tagName: tagsTable.name,
       tagValue: tagsTable.value,
-      isRedteam: sql`json_extract(evals.config, '$.redteam') IS NOT NULL`.as('isRedteam'),
+      isRedteam: evalsTable.isRedteam,
     })
     .from(evalsTable)
     .leftJoin(evalsToPromptsTable, eq(evalsTable.id, evalsToPromptsTable.evalId))
@@ -576,15 +581,7 @@ export async function getStandaloneEvals({
   const evalMap = new Map(evalData.map(({ evalId, eval_, table }) => [evalId, { eval_, table }]));
 
   const standaloneEvals = results.flatMap((result) => {
-    const {
-      description,
-      createdAt,
-      evalId,
-      promptId,
-      datasetId,
-      // @ts-ignore
-      isRedteam,
-    } = result;
+    const { description, createdAt, evalId, promptId, datasetId, isRedteam } = result;
 
     const evalInfo = evalMap.get(evalId);
     invariant(evalInfo, `Eval with ID ${evalId} not found in map`);
@@ -616,7 +613,7 @@ export async function getStandaloneEvals({
         promptId,
         datasetId,
         createdAt,
-        isRedteam: isRedteam as boolean,
+        isRedteam,
         ...pluginCounts,
         ...col,
       };

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -54,6 +54,7 @@ export async function writeResultsToDatabase(
         description: config.description,
         config,
         results,
+        isRedteam: config.redteam !== undefined,
       })
       .onConflictDoNothing()
       .run(),

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -9,7 +9,7 @@ import * as blobRefs from '../../src/blobs/blobRefs';
 import { FilesystemBlobStorageProvider } from '../../src/blobs/filesystemProvider';
 import { importCommand } from '../../src/commands/import';
 import { getDb } from '../../src/database/index';
-import { evalsToPromptsTable } from '../../src/database/tables';
+import { evalsTable, evalsToPromptsTable } from '../../src/database/tables';
 import logger from '../../src/logger';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
@@ -658,7 +658,7 @@ describe('importCommand', () => {
           id: evalId,
           createdAt: '2024-01-02T03:04:05.000Z',
           author: 'legacy-author',
-          config: { description: 'legacy import' },
+          config: { description: 'legacy import', redteam: {} },
           results: {
             version: 2,
             timestamp: '2024-01-02T03:04:05.000Z',
@@ -676,6 +676,12 @@ describe('importCommand', () => {
       const importedEval = await Eval.findById(evalId);
       expect(importedEval).toBeDefined();
       expect(importedEval!.author).toBe('legacy-author');
+      const storedEval = getDb()
+        .select({ isRedteam: evalsTable.isRedteam })
+        .from(evalsTable)
+        .where(sql`${evalsTable.id} = ${evalId}`)
+        .get();
+      expect(storedEval?.isRedteam).toBe(true);
       expect(await importedEval!.toEvaluateSummary()).toMatchObject({
         version: 2,
         results: [{ success: true, vars: { topic: 'legacy' } }],

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1,8 +1,8 @@
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../src/database/index';
 import { updateSignalFile } from '../../src/database/signal';
-import { evalResultsTable, spansTable, tracesTable } from '../../src/database/tables';
+import { evalResultsTable, evalsTable, spansTable, tracesTable } from '../../src/database/tables';
 import { getAuthor } from '../../src/globalConfig/accounts';
 import { runDbMigrations } from '../../src/migrate';
 import Eval, {
@@ -13,6 +13,7 @@ import Eval, {
   getEvalSummaries,
 } from '../../src/models/eval';
 import { TraceStore } from '../../src/tracing/store';
+import { updateResult, writeResultsToDatabase } from '../../src/util/database';
 import EvalFactory from '../factories/evalFactory';
 
 import type { Prompt } from '../../src/types/index';
@@ -141,6 +142,9 @@ describe('evaluator', () => {
       const eval1 = await EvalFactory.create();
       const eval2 = await EvalFactory.create();
       const eval3 = await EvalFactory.create();
+      getDb().update(evalsTable).set({ createdAt: 1 }).where(eq(evalsTable.id, eval1.id)).run();
+      getDb().update(evalsTable).set({ createdAt: 2 }).where(eq(evalsTable.id, eval2.id)).run();
+      getDb().update(evalsTable).set({ createdAt: 3 }).where(eq(evalsTable.id, eval3.id)).run();
 
       const evaluations = await getEvalSummaries();
 
@@ -148,6 +152,73 @@ describe('evaluator', () => {
       expect(evaluations[0].evalId).toBe(eval3.id);
       expect(evaluations[1].evalId).toBe(eval2.id);
       expect(evaluations[2].evalId).toBe(eval1.id);
+    });
+
+    it('should sort timestamp ties consistently in full and filtered summaries', async () => {
+      const eval1 = await Eval.create({}, []);
+      const eval2 = await Eval.create({}, []);
+      const createdAt = Date.now();
+
+      getDb().update(evalsTable).set({ createdAt }).where(eq(evalsTable.id, eval1.id)).run();
+      getDb().update(evalsTable).set({ createdAt }).where(eq(evalsTable.id, eval2.id)).run();
+
+      const expectedIds = [eval1.id, eval2.id].sort().reverse();
+      const allIds = (await getEvalSummaries()).map(({ evalId }) => evalId);
+      const filteredIds = (await getEvalSummaries(undefined, 'eval')).map(({ evalId }) => evalId);
+
+      expect(allIds).toEqual(expectedIds);
+      expect(filteredIds).toEqual(expectedIds);
+    });
+
+    it('should update redteam classification when a persisted config changes type', async () => {
+      const redteamEvaluation = await Eval.create({ redteam: {} as any }, []);
+      const regularEvaluation = await Eval.create({}, []);
+
+      await updateResult(redteamEvaluation.id, {});
+      await updateResult(regularEvaluation.id, { redteam: {} as any });
+
+      const stored = getDb()
+        .select({ id: evalsTable.id, isRedteam: evalsTable.isRedteam })
+        .from(evalsTable)
+        .all();
+      const redteamSummaries = await getEvalSummaries(undefined, 'redteam');
+      const evalSummaries = await getEvalSummaries(undefined, 'eval');
+
+      expect(stored).toContainEqual({ id: redteamEvaluation.id, isRedteam: false });
+      expect(stored).toContainEqual({ id: regularEvaluation.id, isRedteam: true });
+      expect(redteamSummaries).not.toContainEqual(
+        expect.objectContaining({ evalId: redteamEvaluation.id }),
+      );
+      expect(redteamSummaries).toContainEqual(
+        expect.objectContaining({ evalId: regularEvaluation.id, isRedteam: true }),
+      );
+      expect(evalSummaries).toContainEqual(
+        expect.objectContaining({ evalId: redteamEvaluation.id, isRedteam: false }),
+      );
+      expect(evalSummaries).not.toContainEqual(
+        expect.objectContaining({ evalId: regularEvaluation.id }),
+      );
+    });
+
+    it('should persist the redteam flag for legacy result writes', async () => {
+      const evalId = await writeResultsToDatabase(
+        {
+          version: 2,
+          timestamp: new Date().toISOString(),
+          results: [],
+          table: { head: { prompts: [], vars: [] }, body: [] },
+          stats: { successes: 0, failures: 0 },
+        } as any,
+        { redteam: {} as any },
+      );
+
+      const stored = getDb()
+        .select({ isRedteam: evalsTable.isRedteam })
+        .from(evalsTable)
+        .where(eq(evalsTable.id, evalId))
+        .get();
+
+      expect(stored?.isRedteam).toBe(true);
     });
 
     it('should correctly deserialize all provider types', async () => {

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -221,6 +221,27 @@ describe('evaluator', () => {
       expect(stored?.isRedteam).toBe(true);
     });
 
+    it.each([
+      { label: 'redteam: {}', config: { redteam: {} as any }, expected: true },
+      { label: 'redteam: null', config: { redteam: null as any }, expected: true },
+      { label: 'no redteam key', config: {}, expected: false },
+    ])('classifies $label as isRedteam=$expected on create', async ({ config, expected }) => {
+      const eval_ = await Eval.create(config, []);
+      const stored = getDb()
+        .select({ isRedteam: evalsTable.isRedteam })
+        .from(evalsTable)
+        .where(eq(evalsTable.id, eval_.id))
+        .get();
+      expect(stored?.isRedteam).toBe(expected);
+
+      const redteamSummaries = await getEvalSummaries(undefined, 'redteam');
+      const evalSummaries = await getEvalSummaries(undefined, 'eval');
+      const presentInRedteam = redteamSummaries.some((s) => s.evalId === eval_.id);
+      const presentInEval = evalSummaries.some((s) => s.evalId === eval_.id);
+      expect(presentInRedteam).toBe(expected);
+      expect(presentInEval).toBe(!expected);
+    });
+
     it('should correctly deserialize all provider types', async () => {
       // Test different provider formats
       const testCases = [

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -1,0 +1,206 @@
+import { eq, sql } from 'drizzle-orm';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getDb } from '../../src/database/index';
+import { evalsTable } from '../../src/database/tables';
+import { runDbMigrations } from '../../src/migrate';
+import Eval from '../../src/models/eval';
+import {
+  clearStandaloneEvalCache,
+  getStandaloneEvals,
+  updateResult,
+} from '../../src/util/database';
+
+import type { CompletedPrompt, Prompt } from '../../src/types/index';
+
+const completedPrompt: CompletedPrompt = {
+  raw: 'hello',
+  label: 'hello',
+  provider: 'test-provider',
+  metrics: {
+    score: 1,
+    testPassCount: 1,
+    testFailCount: 0,
+    testErrorCount: 0,
+    assertPassCount: 1,
+    assertFailCount: 0,
+    totalLatencyMs: 0,
+    tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 0 },
+    namedScores: {},
+    namedScoresCount: {},
+    cost: 0,
+  },
+};
+
+const renderedPrompts: Prompt[] = [{ raw: 'hello', label: 'hello' }];
+
+async function createEvalWithPrompts(config: Partial<Parameters<typeof Eval.create>[0]>) {
+  return Eval.create(config as Parameters<typeof Eval.create>[0], renderedPrompts, {
+    completedPrompts: [completedPrompt],
+  });
+}
+
+describe('getStandaloneEvals', () => {
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    await db.run('DELETE FROM eval_results');
+    await db.run('DELETE FROM evals_to_datasets');
+    await db.run('DELETE FROM evals_to_prompts');
+    await db.run('DELETE FROM evals_to_tags');
+    await db.run('DELETE FROM evals');
+    clearStandaloneEvalCache();
+  });
+
+  it('returns isRedteam from the materialized column, not raw JSON inspection', async () => {
+    const redteamEval = await createEvalWithPrompts({ redteam: {} as any });
+    const regularEval = await createEvalWithPrompts({});
+
+    // Simulate a legacy row whose materialized flag is stale relative to the JSON config.
+    // The old query would have read the JSON; the new query must trust the column.
+    getDb()
+      .update(evalsTable)
+      .set({ isRedteam: false })
+      .where(eq(evalsTable.id, redteamEval.id))
+      .run();
+    getDb()
+      .update(evalsTable)
+      .set({ isRedteam: true })
+      .where(eq(evalsTable.id, regularEval.id))
+      .run();
+
+    const rows = await getStandaloneEvals();
+    const byId = new Map(rows.map((row) => [row.evalId, row.isRedteam] as const));
+
+    expect(byId.get(redteamEval.id)).toBe(false);
+    expect(byId.get(regularEval.id)).toBe(true);
+  });
+
+  it('reflects flag transitions after updateResult rewrites config', async () => {
+    const eval_ = await createEvalWithPrompts({});
+    expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
+      false,
+    );
+
+    await updateResult(eval_.id, { redteam: {} as any });
+
+    // The /api/history LRU cache is not invalidated on writes; tests must clear it
+    // explicitly to observe the new value.
+    clearStandaloneEvalCache();
+    expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
+      true,
+    );
+  });
+
+  it('classifies redteam: null as redteam, matching the runtime predicate', async () => {
+    // `config.redteam !== undefined` is true for null, so the write paths store
+    // isRedteam = true. Confirm getStandaloneEvals surfaces that consistently.
+    const eval_ = await createEvalWithPrompts({ redteam: null as any });
+
+    const stored = getDb()
+      .select({ isRedteam: evalsTable.isRedteam })
+      .from(evalsTable)
+      .where(eq(evalsTable.id, eval_.id))
+      .get();
+    expect(stored?.isRedteam).toBe(true);
+
+    const row = (await getStandaloneEvals()).find((r) => r.evalId === eval_.id);
+    expect(row?.isRedteam).toBe(true);
+  });
+});
+
+describe('migration 0024 repair semantics', () => {
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    await db.run('DELETE FROM eval_results');
+    await db.run('DELETE FROM evals_to_datasets');
+    await db.run('DELETE FROM evals_to_prompts');
+    await db.run('DELETE FROM evals_to_tags');
+    await db.run('DELETE FROM evals');
+    clearStandaloneEvalCache();
+  });
+
+  it('classifies {redteam: null} as redteam via json_type (not json_extract)', async () => {
+    // This is the exact CASE expression from 0024. Verify it matches the runtime
+    // predicate (config.redteam !== undefined) for both `null` and missing keys.
+    const db = getDb();
+    const evalNullRedteam = await Eval.create({ redteam: null as any }, []);
+    const evalNoRedteam = await Eval.create({}, []);
+    const evalWithRedteam = await Eval.create({ redteam: {} as any }, []);
+
+    const classify = (id: string) =>
+      db
+        .select({
+          fromMigration: sql<number>`CASE
+            WHEN json_valid(${evalsTable.config}) AND json_type(${evalsTable.config}, '$.redteam') IS NOT NULL THEN 1
+            ELSE 0
+          END`,
+          fromLegacyExtract: sql<number>`CASE
+            WHEN json_valid(${evalsTable.config}) AND json_extract(${evalsTable.config}, '$.redteam') IS NOT NULL THEN 1
+            ELSE 0
+          END`,
+        })
+        .from(evalsTable)
+        .where(eq(evalsTable.id, id))
+        .get();
+
+    const nullRow = classify(evalNullRedteam.id);
+    const missingRow = classify(evalNoRedteam.id);
+    const presentRow = classify(evalWithRedteam.id);
+
+    // json_type-based predicate (used by 0024) matches !== undefined semantics.
+    expect(nullRow?.fromMigration).toBe(1);
+    expect(missingRow?.fromMigration).toBe(0);
+    expect(presentRow?.fromMigration).toBe(1);
+
+    // Legacy json_extract predicate would classify {redteam: null} as non-redteam,
+    // which is exactly the divergence the new migration repairs.
+    expect(nullRow?.fromLegacyExtract).toBe(0);
+    expect(missingRow?.fromLegacyExtract).toBe(0);
+    expect(presentRow?.fromLegacyExtract).toBe(1);
+  });
+
+  it('idempotently repairs only stale rows', async () => {
+    const db = getDb();
+    const evalWithRedteam = await Eval.create({ redteam: {} as any }, []);
+    const evalRegular = await Eval.create({}, []);
+
+    // Manually flip both flags to stale values, simulating drift from older code paths.
+    db.update(evalsTable)
+      .set({ isRedteam: false })
+      .where(eq(evalsTable.id, evalWithRedteam.id))
+      .run();
+    db.update(evalsTable).set({ isRedteam: true }).where(eq(evalsTable.id, evalRegular.id)).run();
+
+    const repairSql = sql`UPDATE evals SET is_redteam = CASE
+      WHEN json_valid(config) AND json_type(config, '$.redteam') IS NOT NULL THEN 1
+      ELSE 0
+    END
+    WHERE is_redteam != CASE
+      WHEN json_valid(config) AND json_type(config, '$.redteam') IS NOT NULL THEN 1
+      ELSE 0
+    END`;
+
+    // First run: should repair both stale rows.
+    const firstRun = db.run(repairSql);
+    expect(firstRun.changes).toBe(2);
+
+    // Second run: idempotent, nothing changes.
+    const secondRun = db.run(repairSql);
+    expect(secondRun.changes).toBe(0);
+
+    const rows = db
+      .select({ id: evalsTable.id, isRedteam: evalsTable.isRedteam })
+      .from(evalsTable)
+      .all();
+    const byId = new Map(rows.map((row) => [row.id, row.isRedteam] as const));
+    expect(byId.get(evalWithRedteam.id)).toBe(true);
+    expect(byId.get(evalRegular.id)).toBe(false);
+  });
+});

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -33,10 +33,30 @@ const completedPrompt: CompletedPrompt = {
 
 const renderedPrompts: Prompt[] = [{ raw: 'hello', label: 'hello' }];
 
+// Mirrors the CASE expression in drizzle/0024_repair_eval_redteam_flags.sql.
+const isRedteamCase = sql`CASE
+  WHEN json_valid(${evalsTable.config}) AND json_type(${evalsTable.config}, '$.redteam') IS NOT NULL THEN 1
+  ELSE 0
+END`;
+
 async function createEvalWithPrompts(config: Partial<Parameters<typeof Eval.create>[0]>) {
   return Eval.create(config as Parameters<typeof Eval.create>[0], renderedPrompts, {
     completedPrompts: [completedPrompt],
   });
+}
+
+async function resetEvalTables() {
+  const db = getDb();
+  await db.run('DELETE FROM eval_results');
+  await db.run('DELETE FROM evals_to_datasets');
+  await db.run('DELETE FROM evals_to_prompts');
+  await db.run('DELETE FROM evals_to_tags');
+  await db.run('DELETE FROM evals');
+  clearStandaloneEvalCache();
+}
+
+function setIsRedteam(evalId: string, value: boolean) {
+  getDb().update(evalsTable).set({ isRedteam: value }).where(eq(evalsTable.id, evalId)).run();
 }
 
 describe('getStandaloneEvals', () => {
@@ -44,32 +64,15 @@ describe('getStandaloneEvals', () => {
     await runDbMigrations();
   });
 
-  beforeEach(async () => {
-    const db = getDb();
-    await db.run('DELETE FROM eval_results');
-    await db.run('DELETE FROM evals_to_datasets');
-    await db.run('DELETE FROM evals_to_prompts');
-    await db.run('DELETE FROM evals_to_tags');
-    await db.run('DELETE FROM evals');
-    clearStandaloneEvalCache();
-  });
+  beforeEach(resetEvalTables);
 
   it('returns isRedteam from the materialized column, not raw JSON inspection', async () => {
     const redteamEval = await createEvalWithPrompts({ redteam: {} as any });
     const regularEval = await createEvalWithPrompts({});
 
-    // Simulate a legacy row whose materialized flag is stale relative to the JSON config.
-    // The old query would have read the JSON; the new query must trust the column.
-    getDb()
-      .update(evalsTable)
-      .set({ isRedteam: false })
-      .where(eq(evalsTable.id, redteamEval.id))
-      .run();
-    getDb()
-      .update(evalsTable)
-      .set({ isRedteam: true })
-      .where(eq(evalsTable.id, regularEval.id))
-      .run();
+    // Flip the column away from what the JSON config would imply; the query must trust the column.
+    setIsRedteam(redteamEval.id, false);
+    setIsRedteam(regularEval.id, true);
 
     const rows = await getStandaloneEvals();
     const byId = new Map(rows.map((row) => [row.evalId, row.isRedteam] as const));
@@ -86,8 +89,7 @@ describe('getStandaloneEvals', () => {
 
     await updateResult(eval_.id, { redteam: {} as any });
 
-    // The /api/history LRU cache is not invalidated on writes; tests must clear it
-    // explicitly to observe the new value.
+    // updateResult does not invalidate the LRU cache; tests clear it to observe the new value.
     clearStandaloneEvalCache();
     expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
       true,
@@ -95,8 +97,6 @@ describe('getStandaloneEvals', () => {
   });
 
   it('classifies redteam: null as redteam, matching the runtime predicate', async () => {
-    // `config.redteam !== undefined` is true for null, so the write paths store
-    // isRedteam = true. Confirm getStandaloneEvals surfaces that consistently.
     const eval_ = await createEvalWithPrompts({ redteam: null as any });
 
     const stored = getDb()
@@ -116,19 +116,9 @@ describe('migration 0024 repair semantics', () => {
     await runDbMigrations();
   });
 
-  beforeEach(async () => {
-    const db = getDb();
-    await db.run('DELETE FROM eval_results');
-    await db.run('DELETE FROM evals_to_datasets');
-    await db.run('DELETE FROM evals_to_prompts');
-    await db.run('DELETE FROM evals_to_tags');
-    await db.run('DELETE FROM evals');
-    clearStandaloneEvalCache();
-  });
+  beforeEach(resetEvalTables);
 
   it('classifies {redteam: null} as redteam via json_type (not json_extract)', async () => {
-    // This is the exact CASE expression from 0024. Verify it matches the runtime
-    // predicate (config.redteam !== undefined) for both `null` and missing keys.
     const db = getDb();
     const evalNullRedteam = await Eval.create({ redteam: null as any }, []);
     const evalNoRedteam = await Eval.create({}, []);
@@ -137,10 +127,7 @@ describe('migration 0024 repair semantics', () => {
     const classify = (id: string) =>
       db
         .select({
-          fromMigration: sql<number>`CASE
-            WHEN json_valid(${evalsTable.config}) AND json_type(${evalsTable.config}, '$.redteam') IS NOT NULL THEN 1
-            ELSE 0
-          END`,
+          fromMigration: sql<number>`${isRedteamCase}`,
           fromLegacyExtract: sql<number>`CASE
             WHEN json_valid(${evalsTable.config}) AND json_extract(${evalsTable.config}, '$.redteam') IS NOT NULL THEN 1
             ELSE 0
@@ -154,13 +141,11 @@ describe('migration 0024 repair semantics', () => {
     const missingRow = classify(evalNoRedteam.id);
     const presentRow = classify(evalWithRedteam.id);
 
-    // json_type-based predicate (used by 0024) matches !== undefined semantics.
     expect(nullRow?.fromMigration).toBe(1);
     expect(missingRow?.fromMigration).toBe(0);
     expect(presentRow?.fromMigration).toBe(1);
 
-    // Legacy json_extract predicate would classify {redteam: null} as non-redteam,
-    // which is exactly the divergence the new migration repairs.
+    // Legacy json_extract collapses {redteam: null} to non-redteam — the divergence this migration repairs.
     expect(nullRow?.fromLegacyExtract).toBe(0);
     expect(missingRow?.fromLegacyExtract).toBe(0);
     expect(presentRow?.fromLegacyExtract).toBe(1);
@@ -171,29 +156,13 @@ describe('migration 0024 repair semantics', () => {
     const evalWithRedteam = await Eval.create({ redteam: {} as any }, []);
     const evalRegular = await Eval.create({}, []);
 
-    // Manually flip both flags to stale values, simulating drift from older code paths.
-    db.update(evalsTable)
-      .set({ isRedteam: false })
-      .where(eq(evalsTable.id, evalWithRedteam.id))
-      .run();
-    db.update(evalsTable).set({ isRedteam: true }).where(eq(evalsTable.id, evalRegular.id)).run();
+    setIsRedteam(evalWithRedteam.id, false);
+    setIsRedteam(evalRegular.id, true);
 
-    const repairSql = sql`UPDATE evals SET is_redteam = CASE
-      WHEN json_valid(config) AND json_type(config, '$.redteam') IS NOT NULL THEN 1
-      ELSE 0
-    END
-    WHERE is_redteam != CASE
-      WHEN json_valid(config) AND json_type(config, '$.redteam') IS NOT NULL THEN 1
-      ELSE 0
-    END`;
+    const repairSql = sql`UPDATE evals SET is_redteam = ${isRedteamCase} WHERE is_redteam != ${isRedteamCase}`;
 
-    // First run: should repair both stale rows.
-    const firstRun = db.run(repairSql);
-    expect(firstRun.changes).toBe(2);
-
-    // Second run: idempotent, nothing changes.
-    const secondRun = db.run(repairSql);
-    expect(secondRun.changes).toBe(0);
+    expect(db.run(repairSql).changes).toBe(2);
+    expect(db.run(repairSql).changes).toBe(0);
 
     const rows = db
       .select({ id: evalsTable.id, isRedteam: evalsTable.isRedteam })


### PR DESCRIPTION
## Summary

- Avoid loading and deserializing large eval `config` JSON in the ordinary `/api/results` summary path, and use the indexed `is_redteam` field for type filtering.
- Repair existing `is_redteam` values in a migration and keep that materialized field accurate across create, save/update, copy, legacy write, and import paths.
- Scope the compare selector request to its known dataset, add deterministic tie ordering, and fix description search when the newest row has no description.

## Trace And Rationale

The **Select Evaluation / Choose an evaluation to view** dialog is populated by `GET /api/results`, which resolves through `getEvalSummaries()`. On a large local database snapshot, the ordinary selector query was selecting/deserializing embedded config JSON even though it only needs summary columns. It also used JSON inspection for redteam filtering despite an existing indexed `is_redteam` column.

The UI uses client virtualization rather than pagination, and its search/export/delete behavior expects the complete supplied row set. This change preserves that behavior for the normal selector while reducing the response query cost. The comparison selector already has an exact dataset constraint, so it now sends that existing filter to the API instead of downloading unrelated histories.

## Historical Context

- `is_redteam` and its original backfill migration landed in [#5230](https://github.com/promptfoo/promptfoo/pull/5230) on September 7, 2025 as part of open-source red team limits.
- [#5527](https://github.com/promptfoo/promptfoo/pull/5527) reverted that limits feature on September 9, 2025 while intentionally retaining the database column and migration; the original backfill in `0019_new_clint_barton.sql` used `json_extract(config, '$.redteam') IS NOT NULL`.
- The runtime summary predicate that the column was later compared against used `json_type(config, '$.redteam') IS NOT NULL`. These two predicates diverge for `{"redteam": null}`: `json_extract` returns SQL NULL for both missing keys and JSON null values, while `json_type` returns the string `'null'` for JSON null and SQL NULL only when the key is missing. Only `json_type` matches JS `config.redteam !== undefined`.
- [#7966](https://github.com/promptfoo/promptfoo/pull/7966) began writing `isRedteam` again for `Eval.create()` on March 5, 2026, but config updates, legacy imports, and legacy writes could still leave stored values stale.
- This PR makes the materialized flag authoritative for `/api/results` summary filtering, so `0024_repair_eval_redteam_flags` repairs pre-upgrade discrepancies before indexed reads are used. The repair migration uses `json_type` (and a comment explains why) so it aligns with the runtime write predicate.

## Redteam Classification Semantics

The runtime write predicate (`Eval.create`, `Eval.save`, `Eval.copy`, `writeResultsToDatabase`, and the V2 import path) is now uniformly `config.redteam !== undefined`. This is intentionally broader than the previous `Boolean(config.redteam)` coercion:

- `{redteam: <object>}` → classified as redteam (no change).
- `{redteam: null}` → classified as redteam (previously stored `false`). This matches the `json_type` predicate the runtime summary filter has used since the column was introduced, and is also what the repair migration enforces.
- `{redteam: false | 0 | ""}` → also classified as redteam under the new predicate. These are edge cases that the typed `RedteamFileConfig | undefined` schema does not produce in practice, but they fall out of the `!== undefined` definition.
- Missing key / `redteam: undefined` → classified as not redteam.

`getStandaloneEvals` (the `/api/history` query) is also moved off raw `json_extract` and onto the indexed `is_redteam` column so every read path uses the same classification.

## Correctness Found During QA

- Persisted config updates could leave `is_redteam` stale when an eval changed between regular and redteam configuration; `Eval.save()` now updates the flag.
- Existing data may predate reliable flag writes; migration `0024_repair_eval_redteam_flags` backfills the materialized field using the same redteam-key semantics as the summary API and updates only mismatched rows. An SQL comment now documents why `json_type` and not `json_extract` is used so future repair migrations don't regress the semantics.
- Indexed filtering exposed nondeterministic ordering for equal timestamps; summaries now sort by `createdAt DESC, id DESC`.
- The dialog's global description search could silently exclude the Description column when the first row had a null description; its accessor now searches the visible description-or-label value. A code comment near the `accessorFn` explains the TanStack first-row-sampling footgun.
- `getStandaloneEvals` (powering `/api/history`) was the last query path still inspecting raw config JSON for redteam classification. Switched to the indexed column for consistency with the rest of the codebase.

## Benchmark

Measured against current `origin/main` on the same migrated copy of a local database snapshot:

- 27,495 evaluations
- 343.4 MB of stored config JSON
- five preexisting redteam-flag mismatches repaired (`430` flagged rows before, `435` after)
- five alternating timed reads per endpoint after warmup; normalized response content matched and patched ordering was stable

| Endpoint | Rows | `main` median | Patched median | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `/api/results` | 27,495 | 1350.2 ms | 232.8 ms | 5.80x |
| `/api/results?type=eval` | 27,060 | 1292.8 ms | 194.2 ms | 6.66x |
| `/api/results?type=redteam` | 435 | 543.9 ms | 13.1 ms | 41.68x |
| `/api/results?type=redteam&includeProviders=true` | 435 | 540.6 ms | 175.3 ms | 3.08x |
| `/api/results?datasetId=...` | 1 | 3.2 ms | 7.0 ms | Near-zero either way |

The initial unconditional one-time backfill migration took 10.10 seconds on the 2.6 GB snapshot; the source database was not modified. After review, the migration was narrowed to update only rows whose stored flag differs from the JSON-derived classification, retaining the full correctness scan while avoiding unnecessary writes.

In a disposable WAL-mode synthetic replay at the measured row/config scale (27,495 rows, approximately 343 MB of config JSON, five stale flags), the narrowed statement reduced affected rows from 27,495 to 5 and median update time from 306.5 ms to 270.5 ms. The migration must still parse each row's config to locate stale flags; this optimization reduces writes and index churn rather than eliminating scan time.

The one-row dataset-filtered request is included for correctness and comparison-dialog scoping coverage, not as a meaningful latency benchmark.

## Follow-Up Improvements (post initial review)

- `getStandaloneEvals` (`/api/history`) now reads `is_redteam` from the indexed column instead of computing `json_extract(config, '$.redteam') IS NOT NULL` at query time. This brings the last read path into alignment with the rest of the codebase and removes the predicate divergence on `{redteam: null}`.
- `clearStandaloneEvalCache()` is exported from `src/util/database.ts` so tests that mutate eval state can observe writes without waiting on the 2-hour LRU TTL. The cache itself was not invalidating on writes before; that is preserved as existing behavior.
- Migration `0024_repair_eval_redteam_flags.sql` now has an SQL comment explaining the deliberate use of `json_type` (and why `json_extract` would diverge from the JS runtime predicate).
- `EvalsTable` Description column has an explanatory code comment about why `accessorFn` is required rather than `accessorKey` (TanStack Table infers column type from the first row).
- New regression tests:
  - `test/util/databaseStandalone.test.ts`: covers `getStandaloneEvals` reading from the materialized column, transitions across `updateResult`, and the `{redteam: null}` edge case. Also locks down the json_type vs json_extract divergence and the migration's WHERE-clause idempotency directly in SQL.
  - `test/models/eval.test.ts`: parameterized classification test for `{redteam: {}}`, `{redteam: null}`, and missing-key configs across both the stored flag and `getEvalSummaries` filtering.
  - `src/app/src/pages/evals/components/EvalsTable.test.tsx`: covers the `focusedDatasetId={null,undefined}` fallback to `/results` (and client-side narrowing), plus `encodeURIComponent` for dataset ids containing spaces and ampersands.

## QA

- `npm run f` and `npm run l` (pass; reports one preexisting nonblocking cognitive-complexity warning in `src/models/eval.ts:833`)
- `npm run tsc`
- `npm --prefix src/app run tsc -- --noEmit`
- `npm run build`
- Backend regression matrix: 103 files / 2,584 tests passed across `test/models`, `test/util`, `test/commands/import.test.ts`, and `test/server`, covering model writes, import, migration, server eval routes and schemas, redteam probe accounting, and the new `getStandaloneEvals` and migration semantics tests.
- Frontend regression matrix: 75 files / 1,559 tests passed under `src/pages/evals` and `src/pages/eval`, covering the selector, results view, report consumers, search/filter behavior, sorting, virtualized table support, and the new dataset-fallback / URL-encoding tests.
- `npm --prefix src/app run test -- --run` (full app suite): 274 files / 4,549 frontend tests passed.
- Migrated a copy of the large local database and confirmed redteam mismatches went from `5` to `0`.
- Follow-up migration optimization validation: the final SQL updated stale regular/redteam/JSON-null/malformed-config fixtures while leaving correctly materialized fixtures unchanged.
- Live local UI QA confirmed selector load, description search, Created sorting, and same-dataset comparison requests (`/api/results?datasetId=...`).
