### PR TITLE
fix(providers): avoid subagent suffix on main Claude SDK errors

### DIFF
--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -1084,7 +1084,7 @@ When the SDK reports a model-call failure, the provider surfaces it in two place
 - `metadata.assistantErrors` — array of `{ error, uuid, parentToolUseId, request_id?, subagent_type?, task_description? }` entries collected from `SDKAssistantMessage.error`. The `error` field uses the SDK's discriminated codes (`'model_not_found'`, `'rate_limit'`, `'authentication_failed'`, `'billing_error'`, `'oauth_org_not_allowed'`, `'server_error'`, `'invalid_request'`, `'max_output_tokens'`, `'unknown'`). Requires `@anthropic-ai/claude-agent-sdk` 0.3.144 or newer for `model_not_found`; older SDKs collapse it into `'invalid_request'`.
 - `metadata.apiErrorStatus` — HTTP status code reported on successful result messages when an upstream API call hit a transient error (e.g., `529` during overload). Only present when the SDK populates it.
 
-When a run ends in a non-success subtype and the stream included an assistant error, the provider appends the code to the error string: `Claude Agent SDK call failed: error_during_execution (model_not_found)`. Example assertion:
+When a main-agent run ends in a non-success subtype and its assistant messages included an error, the provider appends the code to the error string: `Claude Agent SDK call failed: error_during_execution (model_not_found)`. Background subagent errors remain in `metadata.assistantErrors` but do not label the main-agent error string. Example assertion:
 
 ```yaml
 assert:

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1592,16 +1592,15 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
             return response;
           }
 
-          // Surface the last assistant error code (`model_not_found`,
-          // `rate_limit`, etc.) alongside the subtype so callers can tell
-          // apart "ran out of turns" from "model doesn't exist" without
-          // digging into metadata.
-          const lastAssistantError =
-            assistantErrors.length > 0
-              ? assistantErrors[assistantErrors.length - 1].error
-              : undefined;
-          const errorMessage = lastAssistantError
-            ? `Claude Agent SDK call failed: ${finalMsg.subtype} (${lastAssistantError})`
+          // Only a main-agent assistant error can explain the selected main
+          // result. Background subagent messages are interleaved in the same
+          // stream and remain available in metadata for callers that need them.
+          const lastMainAssistantError = assistantErrors
+            .slice()
+            .reverse()
+            .find(({ parentToolUseId }) => parentToolUseId === null)?.error;
+          const errorMessage = lastMainAssistantError
+            ? `Claude Agent SDK call failed: ${finalMsg.subtype} (${lastMainAssistantError})`
             : `Claude Agent SDK call failed: ${finalMsg.subtype}`;
           return {
             error: errorMessage,

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1595,10 +1595,13 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
           // Only a main-agent assistant error can explain the selected main
           // result. Background subagent messages are interleaved in the same
           // stream and remain available in metadata for callers that need them.
-          const lastMainAssistantError = assistantErrors
-            .slice()
-            .reverse()
-            .find(({ parentToolUseId }) => parentToolUseId === null)?.error;
+          let lastMainAssistantError: SDKAssistantMessageError | undefined;
+          for (let i = assistantErrors.length - 1; i >= 0; i--) {
+            if (assistantErrors[i].parentToolUseId === null) {
+              lastMainAssistantError = assistantErrors[i].error;
+              break;
+            }
+          }
           const errorMessage = lastMainAssistantError
             ? `Claude Agent SDK call failed: ${finalMsg.subtype} (${lastMainAssistantError})`
             : `Claude Agent SDK call failed: ${finalMsg.subtype}`;

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -1300,6 +1300,59 @@ describe('ClaudeCodeSDKProvider', () => {
           },
         ]);
       });
+
+      it('annotates with the last main-agent error even when a subagent error is more recent', async () => {
+        mockQuery.mockReturnValue(
+          createMockQuery([
+            buildAssistantMessage('rate_limit', {
+              uuid: '55555555-5555-5555-5555-555555555555',
+            }),
+            buildAssistantMessage('model_not_found', {
+              uuid: '66666666-6666-6666-6666-666666666666',
+              parent_tool_use_id: 'task-tool-1',
+              subagent_type: 'Explore',
+            }),
+            {
+              type: 'result',
+              subtype: 'error_during_execution',
+              session_id: 'main-error-session',
+              uuid: '77777777-7777-7777-7777-777777777777' as `${string}-${string}-${string}-${string}-${string}`,
+              usage: createMockUsage(10, 0),
+              total_cost_usd: 0,
+              duration_ms: 500,
+              duration_api_ms: 400,
+              is_error: true,
+              num_turns: 2,
+              permission_denials: [],
+              modelUsage: {},
+              errors: [],
+              origin: { kind: 'human' },
+            },
+          ]),
+        );
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('Test prompt');
+
+        expect(result.error).toBe(
+          'Claude Agent SDK call failed: error_during_execution (rate_limit)',
+        );
+        expect(result.metadata?.assistantErrors).toEqual([
+          {
+            error: 'rate_limit',
+            uuid: '55555555-5555-5555-5555-555555555555',
+            parentToolUseId: null,
+          },
+          {
+            error: 'model_not_found',
+            uuid: '66666666-6666-6666-6666-666666666666',
+            parentToolUseId: 'task-tool-1',
+            subagent_type: 'Explore',
+          },
+        ]);
+      });
     });
 
     describe('checkProviderApiKeys pre-check', () => {

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -1084,11 +1084,16 @@ describe('ClaudeCodeSDKProvider', () => {
     describe('assistant errors and api_error_status (SDK >= 0.3.144)', () => {
       const buildAssistantMessage = (
         error: SDKAssistantMessageError | undefined,
-        opts: { uuid?: string; request_id?: string; subagent_type?: string } = {},
+        opts: {
+          uuid?: string;
+          request_id?: string;
+          subagent_type?: string;
+          parent_tool_use_id?: string;
+        } = {},
       ): Partial<SDKMessage> => ({
         type: 'assistant',
         message: createMockBetaMessage([{ type: 'text', text: 'hello' }]) as any,
-        parent_tool_use_id: null,
+        parent_tool_use_id: opts.parent_tool_use_id ?? null,
         uuid: (opts.uuid ??
           '11111111-1111-1111-1111-111111111111') as `${string}-${string}-${string}-${string}-${string}`,
         session_id: 'test-session-123',
@@ -1249,6 +1254,49 @@ describe('ClaudeCodeSDKProvider', () => {
             error: 'model_not_found',
             uuid: '33333333-3333-3333-3333-333333333333',
             parentToolUseId: null,
+          },
+        ]);
+      });
+
+      it('does not annotate a main terminal error with a background subagent error', async () => {
+        mockQuery.mockReturnValue(
+          createMockQuery([
+            buildAssistantMessage('model_not_found', {
+              uuid: '44444444-4444-4444-4444-444444444444',
+              parent_tool_use_id: 'task-tool-1',
+              subagent_type: 'Explore',
+            }),
+            {
+              type: 'result',
+              subtype: 'error_max_turns',
+              session_id: 'main-error-session',
+              uuid: '99999999-9999-9999-9999-999999999999' as `${string}-${string}-${string}-${string}-${string}`,
+              usage: createMockUsage(10, 0),
+              total_cost_usd: 0,
+              duration_ms: 500,
+              duration_api_ms: 400,
+              is_error: true,
+              num_turns: 2,
+              permission_denials: [],
+              modelUsage: {},
+              errors: [],
+              origin: { kind: 'human' },
+            },
+          ]),
+        );
+
+        const provider = new ClaudeCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+        const result = await provider.callApi('Test prompt');
+
+        expect(result.error).toBe('Claude Agent SDK call failed: error_max_turns');
+        expect(result.metadata?.assistantErrors).toEqual([
+          {
+            error: 'model_not_found',
+            uuid: '44444444-4444-4444-4444-444444444444',
+            parentToolUseId: 'task-tool-1',
+            subagent_type: 'Explore',
           },
         ]);
       });


### PR DESCRIPTION
## Summary

- Prevent background Claude Agent SDK assistant failures from suffixing the selected main-agent terminal error.
- Retain nested assistant failures in `metadata.assistantErrors` and clarify the documented top-level error contract.
- Add a regression for a background `model_not_found` followed by a human-origin `error_max_turns`.

## Bug

After #9452, an interleaved background subagent error could relabel an unrelated main-agent failure. A stream containing a background `model_not_found` and a human-origin `error_max_turns` returned:

```text
Claude Agent SDK call failed: error_max_turns (model_not_found)
```

Consumers branching on the suffix could therefore handle a main-agent turn limit as if the main model were unavailable.

## Validation

- Failing before fix: `./node_modules/.bin/vitest run test/providers/claude-agent-sdk.test.ts --sequence.shuffle=false` failed at the new regression, receiving `error_max_turns (model_not_found)`.
- Passing after fix: `./node_modules/.bin/vitest run test/providers/claude-agent-sdk.test.ts --sequence.shuffle=false` (`158` tests passed).
- `npm run tsc`
- `npm run l && npm run f` (passes; reports existing non-blocking cognitive-complexity warnings in `src/providers/claude-agent-sdk.ts`).
