### PR TITLE
chore: add missing package.json metadata fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,5 +366,6 @@
       "sharp"
     ],
     "ignoredBuiltDependencies": []
-  }
+  },
+  "homepage": "https://promptfoo.dev"
 }


### PR DESCRIPTION
## Summary

Adds missing `homepage` field to package.json:

- `homepage`: https://promptfoo.dev

This field improves npm/package registry metadata and tool discoverability.
