### PR TITLE
fix: store raw SVG previews as generic blobs

### DIFF
--- a/src/blobs/extractor.ts
+++ b/src/blobs/extractor.ts
@@ -15,7 +15,7 @@ interface BlobContext {
   promptIdx?: number;
 }
 
-type BlobKind = 'audio' | 'image';
+type BlobKind = 'audio' | 'image' | 'other';
 
 function isDataUrl(value: string): boolean {
   return /^data:(audio|image)\/[^;]+;base64,/.test(value);
@@ -213,7 +213,7 @@ function createStoreOnce(blobContext: BlobContext): StoreOnce {
   };
 }
 
-function getRawSvgOutputPreview(output: string): { dataUrl: string; uri: string } | null {
+function getRawSvgOutputPreview(output: string): { base64: string; uri: string } | null {
   const trimmed = output.trim();
   if (!trimmed.startsWith('<')) {
     return null;
@@ -234,7 +234,7 @@ function getRawSvgOutputPreview(output: string): { dataUrl: string; uri: string 
 
   const buffer = Buffer.from(trimmed, 'utf8');
   return {
-    dataUrl: `data:image/svg+xml;base64,${buffer.toString('base64')}`,
+    base64: buffer.toString('base64'),
     uri: `${BLOB_SCHEME}${sha256(buffer)}`,
   };
 }
@@ -275,7 +275,13 @@ async function storeRawSvgOutputPreview(
     return { metadata, mutated: false };
   }
 
-  const stored = await storeOnce(preview.dataUrl, 'image/svg+xml', 'response.output', 'image', 0);
+  const stored = await storeOnce(
+    preview.base64,
+    'application/octet-stream',
+    'response.output',
+    'other',
+    0,
+  );
   if (!stored) {
     return { metadata, mutated: false };
   }

--- a/test/blobs/extractor.test.ts
+++ b/test/blobs/extractor.test.ts
@@ -645,7 +645,7 @@ describe('Cloud blob upload', () => {
     expect(mockStoreBlob).toHaveBeenCalledTimes(1);
   });
 
-  it('should store small raw SVG outputs for the media library without replacing text output', async () => {
+  it('should store raw SVG outputs as download-only preview blobs without replacing text output', async () => {
     mockShouldAttemptRemoteBlobUpload.mockReturnValue(false);
 
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="4"/></svg>';
@@ -658,10 +658,10 @@ describe('Cloud blob upload', () => {
     expect(mockStoreBlob).toHaveBeenCalledTimes(1);
     expect(mockStoreBlob).toHaveBeenCalledWith(
       Buffer.from(svg),
-      'image/svg+xml',
+      'application/octet-stream',
       expect.objectContaining({
         location: 'response.output',
-        kind: 'image',
+        kind: 'other',
       }),
     );
   });


### PR DESCRIPTION
## Summary
This keeps raw SVG text in `response.output`, but stores the preview blob as a generic download instead of an inline SVG image.

## Why
The raw SVG preview path was feeding a valid `image/svg+xml` blob straight into the media library path. This change keeps the narrow preview-indexing behavior, but makes that blob land as `application/octet-stream` with kind `other` so current UI flows stop treating it like an inline image.

## What changed
- store raw SVG preview bytes as a generic blob instead of `image/svg+xml`
- keep `response.output` untouched so downstream judges still see the original SVG text
- add regression coverage for the downgraded preview storage behavior

## Validation
- `npx vitest run test/blobs/extractor.test.ts test/evaluator/execution.test.ts`
- `npm run l`
- `npm run tsc`
