### PR TITLE
feat(assertions): tolerate optional defaults in trajectory:tool-args-match

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -778,6 +778,12 @@ With the configuration above:
 
 `defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped; a nested default value is compared as a whole and is not partially stripped.
 
+:::note
+
+Stripping runs before matching in both modes, but `partial` mode already ignores extra arguments, so `defaults` is only meaningful with `mode: exact`. Keep a key in `args` _or_ `defaults`, not both: an observed value equal to its default is stripped before the `args` comparison runs, so listing the same key in both can make an otherwise-matching call fail.
+
+:::
+
 Promptfoo looks for tool arguments in span attributes such as `tool.arguments`, `tool.args`, `tool.input`, `function.arguments`, `args`, `arguments`, `input`, and Vercel AI SDK telemetry's `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. String values are parsed as JSON when possible.
 
 ### trajectory:tool-sequence {#trajectorytool-sequence}

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -768,15 +768,15 @@ tests:
 
 With the configuration above:
 
-| Observed tool arguments                  | Outcome | Reason                                                             |
-| ---------------------------------------- | ------- | ------------------------------------------------------------------ |
-| `{ status: 'Q' }`                        | pass    | matches expected exactly                                           |
-| `{ status: 'Q', page: 1 }`               | pass    | `page: 1` equals the declared default, stripped before matching    |
-| `{ status: 'Q', page: 1, page_size: 5 }` | pass    | both defaults stripped                                             |
-| `{ status: 'Q', page: 2 }`               | fail    | `page: 2` is not the declared default, kept, treated as unexpected |
-| `{ status: 'Q', delete_database: true }` | fail    | `delete_database` is not in `args` or `defaults`                   |
+| Observed tool arguments                  | Outcome | Reason                                                                                                                        |
+| ---------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `{ status: 'Q' }`                        | pass    | matches expected exactly                                                                                                      |
+| `{ status: 'Q', page: 1 }`               | pass    | `page: 1` equals the declared default, stripped before matching                                                               |
+| `{ status: 'Q', page: 1, page_size: 5 }` | pass    | both defaults stripped                                                                                                        |
+| `{ status: 'Q', page: 2 }`               | fail    | `page: 2` does not equal the declared default (1), so it stays in the payload; `exact` mode then rejects the unexpected extra |
+| `{ status: 'Q', delete_database: true }` | fail    | `delete_database` is not in `args` or `defaults`                                                                              |
 
-`defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped.
+`defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped; a nested default value is compared as a whole and is not partially stripped.
 
 Promptfoo looks for tool arguments in span attributes such as `tool.arguments`, `tool.args`, `tool.input`, `function.arguments`, `args`, `arguments`, `input`, and Vercel AI SDK telemetry's `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. String values are parsed as JSON when possible.
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -742,8 +742,41 @@ tests:
 - `name` or `pattern` to identify the traced tool call
 - `args` or `arguments` containing the expected payload
 - optional `mode`, either `partial` (default) or `exact`
+- optional `defaults`, a map of argument names to their default values
 
 In `partial` mode, object properties are matched recursively as a subset. In `exact` mode, the entire argument payload must match exactly.
+
+#### Tolerating default arguments {#trajectory-tool-args-match-defaults}
+
+Use `defaults` when an agent may or may not include arguments whose values match the tool's documented defaults (for example, pagination parameters that the API would fill in anyway). Before matching, any actual argument whose value equals its declared default is stripped from the payload.
+
+This lets you pair `mode: exact` — which catches hallucinated extra arguments — with a tolerance for harmless optional defaults. An actual argument with a non-default value is still treated as an unexpected extra.
+
+```yaml
+tests:
+  - assert:
+      - type: trajectory:tool-args-match
+        value:
+          name: orders
+          mode: exact
+          args:
+            status: Q
+          defaults:
+            page: 1
+            page_size: 5
+```
+
+With the configuration above:
+
+| Observed tool arguments                  | Outcome | Reason                                                             |
+| ---------------------------------------- | ------- | ------------------------------------------------------------------ |
+| `{ status: 'Q' }`                        | pass    | matches expected exactly                                           |
+| `{ status: 'Q', page: 1 }`               | pass    | `page: 1` equals the declared default, stripped before matching    |
+| `{ status: 'Q', page: 1, page_size: 5 }` | pass    | both defaults stripped                                             |
+| `{ status: 'Q', page: 2 }`               | fail    | `page: 2` is not the declared default, kept, treated as unexpected |
+| `{ status: 'Q', delete_database: true }` | fail    | `delete_database` is not in `args` or `defaults`                   |
+
+`defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped.
 
 Promptfoo looks for tool arguments in span attributes such as `tool.arguments`, `tool.args`, `tool.input`, `function.arguments`, `args`, `arguments`, `input`, and Vercel AI SDK telemetry's `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. String values are parsed as JSON when possible.
 

--- a/src/assertions/trajectory.ts
+++ b/src/assertions/trajectory.ts
@@ -31,6 +31,7 @@ interface TrajectoryToolArgsMatchValue extends TrajectoryStepMatcher {
   args?: unknown;
   arguments?: unknown;
   mode?: 'exact' | 'partial';
+  defaults?: Record<string, unknown>;
 }
 
 function getTraceOrThrow(params: AssertionParams) {
@@ -260,16 +261,40 @@ function matchesExpectedArgsPartial(actual: unknown, expected: unknown): boolean
   return isDeepStrictEqual(actual, expected);
 }
 
+function stripDefaults(
+  actual: unknown,
+  defaults: Record<string, unknown> | undefined,
+): unknown {
+  if (!defaults || !isRecord(actual)) {
+    return actual;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(actual)) {
+    if (
+      Object.prototype.hasOwnProperty.call(defaults, key) &&
+      isDeepStrictEqual(value, defaults[key])
+    ) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
 function matchesToolArgs(
   actual: unknown,
   expected: unknown,
   mode: NonNullable<TrajectoryToolArgsMatchValue['mode']>,
+  defaults: Record<string, unknown> | undefined,
 ): boolean {
+  const cleanedActual = stripDefaults(actual, defaults);
+
   if (mode === 'exact') {
-    return isDeepStrictEqual(actual, expected);
+    return isDeepStrictEqual(cleanedActual, expected);
   }
 
-  return matchesExpectedArgsPartial(actual, expected);
+  return matchesExpectedArgsPartial(cleanedActual, expected);
 }
 
 function resolveToolArgsMatchMode(
@@ -284,6 +309,22 @@ function resolveToolArgsMatchMode(
   }
 
   throw new Error('trajectory:tool-args-match assertion mode must be "partial" or "exact"');
+}
+
+function resolveToolArgsMatchDefaults(
+  defaults: unknown,
+): Record<string, unknown> | undefined {
+  if (defaults === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(defaults)) {
+    throw new Error(
+      'trajectory:tool-args-match assertion defaults must be an object mapping argument names to default values',
+    );
+  }
+
+  return defaults;
 }
 
 function resolveToolArgsMatchValue(value: unknown) {
@@ -308,6 +349,7 @@ function resolveToolArgsMatchValue(value: unknown) {
     matcher,
     expectedArgs,
     mode: resolveToolArgsMatchMode((value as TrajectoryToolArgsMatchValue).mode),
+    defaults: resolveToolArgsMatchDefaults((value as TrajectoryToolArgsMatchValue).defaults),
   } as const;
 }
 
@@ -385,14 +427,16 @@ export const handleTrajectoryToolSequence = (params: AssertionParams): GradingRe
 export const handleTrajectoryToolArgsMatch = (params: AssertionParams): GradingResult => {
   const trace = getTraceOrThrow(params);
   const toolSteps = extractTrajectorySteps(trace).filter((step) => step.type === 'tool');
-  const { matcher, expectedArgs, mode } = resolveToolArgsMatchValue(
+  const { matcher, expectedArgs, mode, defaults } = resolveToolArgsMatchValue(
     params.renderedValue ?? params.assertion.value,
   );
   const matcherLabel = matcher.pattern || matcher.name || '*';
   const actualTools = toolSteps.map(formatTrajectoryStep);
   const matchingSteps = toolSteps.filter((step) => matchesTrajectoryStep(step, matcher));
   const stepsWithArgs = matchingSteps.filter((step) => step.args !== undefined);
-  const matchedStep = stepsWithArgs.find((step) => matchesToolArgs(step.args, expectedArgs, mode));
+  const matchedStep = stepsWithArgs.find((step) =>
+    matchesToolArgs(step.args, expectedArgs, mode, defaults),
+  );
   const basePass = matchedStep !== undefined;
   const pass = applyInverse(basePass, params.inverse);
   const expectedArgsLabel = formatTrajectoryArgs(expectedArgs);

--- a/src/assertions/trajectory.ts
+++ b/src/assertions/trajectory.ts
@@ -263,22 +263,38 @@ function matchesExpectedArgsPartial(actual: unknown, expected: unknown): boolean
   return isDeepStrictEqual(actual, expected);
 }
 
-function stripDefaults(actual: unknown, defaults: ToolArgsDefaults | undefined): unknown {
+interface StrippedToolArgs {
+  cleaned: unknown;
+  stripped: string[];
+}
+
+function stripDefaults(actual: unknown, defaults: ToolArgsDefaults | undefined): StrippedToolArgs {
   if (!defaults || !isRecord(actual)) {
-    return actual;
+    return { cleaned: actual, stripped: [] };
   }
 
-  const result: Record<string, unknown> = {};
+  const cleaned: Record<string, unknown> = {};
+  const stripped: string[] = [];
   for (const [key, value] of Object.entries(actual)) {
     if (
       Object.prototype.hasOwnProperty.call(defaults, key) &&
       isDeepStrictEqual(value, defaults[key])
     ) {
+      stripped.push(key);
       continue;
     }
-    result[key] = value;
+    // Use defineProperty rather than `cleaned[key] = value` so reserved keys such as
+    // "__proto__" are kept as own properties instead of mutating the prototype. A plain
+    // assignment would silently drop a hallucinated `__proto__` argument and let exact
+    // mode pass when it should fail — defeating the point of stripping defaults.
+    Object.defineProperty(cleaned, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
   }
-  return result;
+  return { cleaned, stripped };
 }
 
 function matchesToolArgs(
@@ -287,13 +303,13 @@ function matchesToolArgs(
   mode: NonNullable<TrajectoryToolArgsMatchValue['mode']>,
   defaults: ToolArgsDefaults | undefined,
 ): boolean {
-  const cleanedActual = stripDefaults(actual, defaults);
+  const { cleaned } = stripDefaults(actual, defaults);
 
   if (mode === 'exact') {
-    return isDeepStrictEqual(cleanedActual, expected);
+    return isDeepStrictEqual(cleaned, expected);
   }
 
-  return matchesExpectedArgsPartial(cleanedActual, expected);
+  return matchesExpectedArgsPartial(cleaned, expected);
 }
 
 function resolveToolArgsMatchMode(
@@ -436,6 +452,11 @@ export const handleTrajectoryToolArgsMatch = (params: AssertionParams): GradingR
   );
   const basePass = matchedStep !== undefined;
   const pass = applyInverse(basePass, params.inverse);
+  const ignoredDefaults = matchedStep ? stripDefaults(matchedStep.args, defaults).stripped : [];
+  const ignoredDefaultsSuffix =
+    ignoredDefaults.length > 0
+      ? `. Ignored default argument(s): ${ignoredDefaults.join(', ')}`
+      : '';
   const expectedArgsLabel = formatTrajectoryArgs(expectedArgs);
   const observedArgsLabel =
     stepsWithArgs.length > 0
@@ -452,7 +473,7 @@ export const handleTrajectoryToolArgsMatch = (params: AssertionParams): GradingR
       reason = `Forbidden argument match for tool "${matcherLabel}" was not observed. Observed args: ${observedArgsLabel}`;
     }
   } else if (basePass) {
-    reason = `Tool "${matcherLabel}" matched expected arguments (${mode}) on ${formatTrajectoryStep(matchedStep!)}. Args: ${formatTrajectoryArgs(matchedStep!.args)}`;
+    reason = `Tool "${matcherLabel}" matched expected arguments (${mode}) on ${formatTrajectoryStep(matchedStep!)}. Args: ${formatTrajectoryArgs(matchedStep!.args)}${ignoredDefaultsSuffix}`;
   } else if (matchingSteps.length === 0) {
     reason = `No tool call matched "${matcherLabel}". Actual tools: ${formatStepList(actualTools)}`;
   } else if (stepsWithArgs.length === 0) {

--- a/src/assertions/trajectory.ts
+++ b/src/assertions/trajectory.ts
@@ -27,11 +27,13 @@ interface TrajectoryGoalSuccessValue {
   goal: string;
 }
 
+type ToolArgsDefaults = Record<string, unknown>;
+
 interface TrajectoryToolArgsMatchValue extends TrajectoryStepMatcher {
   args?: unknown;
   arguments?: unknown;
   mode?: 'exact' | 'partial';
-  defaults?: Record<string, unknown>;
+  defaults?: ToolArgsDefaults;
 }
 
 function getTraceOrThrow(params: AssertionParams) {
@@ -261,10 +263,7 @@ function matchesExpectedArgsPartial(actual: unknown, expected: unknown): boolean
   return isDeepStrictEqual(actual, expected);
 }
 
-function stripDefaults(
-  actual: unknown,
-  defaults: Record<string, unknown> | undefined,
-): unknown {
+function stripDefaults(actual: unknown, defaults: ToolArgsDefaults | undefined): unknown {
   if (!defaults || !isRecord(actual)) {
     return actual;
   }
@@ -286,7 +285,7 @@ function matchesToolArgs(
   actual: unknown,
   expected: unknown,
   mode: NonNullable<TrajectoryToolArgsMatchValue['mode']>,
-  defaults: Record<string, unknown> | undefined,
+  defaults: ToolArgsDefaults | undefined,
 ): boolean {
   const cleanedActual = stripDefaults(actual, defaults);
 
@@ -311,9 +310,7 @@ function resolveToolArgsMatchMode(
   throw new Error('trajectory:tool-args-match assertion mode must be "partial" or "exact"');
 }
 
-function resolveToolArgsMatchDefaults(
-  defaults: unknown,
-): Record<string, unknown> | undefined {
+function resolveToolArgsMatchDefaults(defaults: unknown): ToolArgsDefaults | undefined {
   if (defaults === undefined) {
     return undefined;
   }

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -1323,6 +1323,343 @@ describe('trajectory assertions', () => {
         'trajectory:tool-args-match assertion object must include a name or pattern property',
       );
     });
+
+    describe('defaults', () => {
+      it('passes in exact mode when an unexpected actual key matches a declared default', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'exact',
+              args: { order_id: '123' },
+              defaults: { include_history: false },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'exact',
+            args: { order_id: '123' },
+            defaults: { include_history: false },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result).toEqual({
+          pass: true,
+          score: 1,
+          reason:
+            'Tool "search_orders" matched expected arguments (exact) on tool:search_orders. Args: {"order_id":"123","include_history":false}',
+          assertion: params.assertion,
+        });
+      });
+
+      it('fails in exact mode when an actual key value differs from the declared default', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'exact',
+              args: { order_id: '123' },
+              defaults: { include_history: true },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'exact',
+            args: { order_id: '123' },
+            defaults: { include_history: true },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+        expect(result.score).toBe(0);
+        expect(result.reason).toContain('No call to tool "search_orders" matched expected arguments');
+      });
+
+      it('passes in exact mode when actual contains multiple keys all matching declared defaults', () => {
+        const allDefaultsTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-all-defaults',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1,"page_size":5}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: allDefaultsTrace,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1, page_size: 5 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1, page_size: 5 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('passes in exact mode when actual omits a key listed in defaults', () => {
+        const traceWithoutDefault: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-no-default',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q"}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: traceWithoutDefault,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1, page_size: 5 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1, page_size: 5 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('fails in exact mode when actual contains a hallucinated key not in args or defaults', () => {
+        const hallucinatedTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-hallucinated',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1,"delete_database":true}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: hallucinatedTrace,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+        expect(result.score).toBe(0);
+        expect(result.reason).toContain('delete_database');
+      });
+
+      it('treats empty defaults the same as no defaults', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'exact',
+              args: { order_id: '123' },
+              defaults: {},
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'exact',
+            args: { order_id: '123' },
+            defaults: {},
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+      });
+
+      it('supports defaults with structured values via deep equality', () => {
+        const structuredTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-structured',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","sort":{"field":"created","order":"desc"}}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: structuredTrace,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { sort: { field: 'created', order: 'desc' } },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { sort: { field: 'created', order: 'desc' } },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('does not change partial-mode behavior when defaults are set', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              args: { order_id: '123' },
+              defaults: { include_history: false },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            args: { order_id: '123' },
+            defaults: { include_history: false },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('rejects malformed defaults (array)', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              args: { order_id: '123' },
+              defaults: ['include_history'] as unknown as Record<string, unknown>,
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            args: { order_id: '123' },
+            defaults: ['include_history'] as unknown as Record<string, unknown>,
+          },
+        };
+
+        expect(() => handleTrajectoryToolArgsMatch(params)).toThrow(
+          'trajectory:tool-args-match assertion defaults must be an object mapping argument names to default values',
+        );
+      });
+
+      it('inverts correctly when defaults allow an otherwise-forbidden match', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          inverse: true,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'not-trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'exact',
+              args: { order_id: '123' },
+              defaults: { include_history: false },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'exact',
+            args: { order_id: '123' },
+            defaults: { include_history: false },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+        expect(result.reason).toContain('Forbidden argument match');
+      });
+    });
   });
 
   describe('trajectory:step-count', () => {

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -1351,7 +1351,7 @@ describe('trajectory assertions', () => {
           pass: true,
           score: 1,
           reason:
-            'Tool "search_orders" matched expected arguments (exact) on tool:search_orders. Args: {"order_id":"123","include_history":false}',
+            'Tool "search_orders" matched expected arguments (exact) on tool:search_orders. Args: {"order_id":"123","include_history":false}. Ignored default argument(s): include_history',
           assertion: params.assertion,
         });
       });
@@ -1380,7 +1380,9 @@ describe('trajectory assertions', () => {
         const result = handleTrajectoryToolArgsMatch(params);
         expect(result.pass).toBe(false);
         expect(result.score).toBe(0);
-        expect(result.reason).toContain('No call to tool "search_orders" matched expected arguments');
+        expect(result.reason).toContain(
+          'No call to tool "search_orders" matched expected arguments',
+        );
       });
 
       it('passes in exact mode when actual contains multiple keys all matching declared defaults', () => {
@@ -1866,6 +1868,260 @@ describe('trajectory assertions', () => {
         const result = handleTrajectoryToolArgsMatch(params);
         expect(result.pass).toBe(false);
         expect(result.reason).toContain('Forbidden argument match');
+      });
+
+      it('surfaces the stripped keys in the pass reason when multiple defaults are tolerated', () => {
+        const allDefaultsTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-reason-defaults',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1,"page_size":5}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: allDefaultsTrace,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1, page_size: 5 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1, page_size: 5 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+        expect(result.reason).toContain('Ignored default argument(s): page, page_size');
+      });
+
+      it('does not append the ignored-defaults note when nothing was stripped', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'partial',
+              args: { order_id: '123' },
+              defaults: { include_history: true },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'partial',
+            args: { order_id: '123' },
+            defaults: { include_history: true },
+          },
+        };
+
+        // The observed call has include_history:false, which does not equal the
+        // declared default (true), so nothing is stripped and no note is added.
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+        expect(result.reason).not.toContain('Ignored default');
+      });
+
+      it('does not let a hallucinated __proto__ argument escape exact matching when defaults are set', () => {
+        const protoTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-proto-default',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","__proto__":{"polluted":true}}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: protoTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1 },
+          },
+        };
+
+        // A non-default __proto__ key must be preserved through stripping so exact
+        // mode still rejects it as a hallucinated extra (matching no-defaults behavior).
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+        // The prototype must not have been mutated by the stripping rebuild.
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      });
+
+      it('fails in partial mode when a key in both args and defaults is stripped to nothing', () => {
+        const collisionTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-partial-collision',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: collisionTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              // partial (default) mode; page is listed in BOTH args and defaults
+              args: { status: 'Q', page: 1 },
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            args: { status: 'Q', page: 1 },
+            defaults: { page: 1 },
+          },
+        };
+
+        // Documented footgun: stripping removes page before the subset check, so the
+        // explicitly-asserted page:1 can no longer be satisfied.
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+      });
+
+      it('applies defaults when the expected payload uses the arguments alias', () => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              mode: 'exact',
+              arguments: { order_id: '123' },
+              defaults: { include_history: false },
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            mode: 'exact',
+            arguments: { order_id: '123' },
+            defaults: { include_history: false },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('treats defaults as a no-op when the actual payload is a top-level array', () => {
+        const arrayTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-array-args',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '[1,2,3]',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: arrayTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: [1, 2, 3],
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: [1, 2, 3],
+            defaults: { page: 1 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it.each([
+        ['null', null],
+        ['string', 'include_history'],
+        ['number', 1],
+      ])('rejects malformed defaults (%s)', (_label, malformed) => {
+        const params: AssertionParams = {
+          ...defaultParams,
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'search_orders',
+              args: { order_id: '123' },
+              defaults: malformed as unknown as Record<string, unknown>,
+            },
+          },
+          renderedValue: {
+            name: 'search_orders',
+            args: { order_id: '123' },
+            defaults: malformed as unknown as Record<string, unknown>,
+          },
+        };
+
+        expect(() => handleTrajectoryToolArgsMatch(params)).toThrow(
+          'trajectory:tool-args-match assertion defaults must be an object mapping argument names to default values',
+        );
       });
     });
   });

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -1586,7 +1586,7 @@ describe('trajectory assertions', () => {
         expect(result.pass).toBe(true);
       });
 
-      it('does not change partial-mode behavior when defaults are set', () => {
+      it('still passes in partial mode when defaults are set', () => {
         const params: AssertionParams = {
           ...defaultParams,
           baseType: 'trajectory:tool-args-match',
@@ -1631,6 +1631,214 @@ describe('trajectory assertions', () => {
         expect(() => handleTrajectoryToolArgsMatch(params)).toThrow(
           'trajectory:tool-args-match assertion defaults must be an object mapping argument names to default values',
         );
+      });
+
+      it('matches the documented outcome table row "status:Q, page:1" using the example config', () => {
+        const docsTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-docs-row-2',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: docsTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1, page_size: 5 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1, page_size: 5 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('matches the documented outcome table row "status:Q, page:2" using the example config', () => {
+        const docsTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-docs-row-4',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":2}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: docsTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1, page_size: 5 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1, page_size: 5 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+      });
+
+      it('strips a null default value when actual emits null for that key', () => {
+        const nullTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-null-default',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","cursor":null}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: nullTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { cursor: null },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { cursor: null },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(true);
+      });
+
+      it('strips a key listed in defaults even when args also declares it (defaults applied first)', () => {
+        const collisionTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-collision',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","page":1}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: {
+            ...defaultParams.assertionValueContext,
+            trace: collisionTrace,
+          },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q', page: 2 },
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q', page: 2 },
+            defaults: { page: 1 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
+      });
+
+      it('does not recurse into nested objects when stripping defaults (top-level only)', () => {
+        const nestedTrace: TraceData = {
+          ...mockTraceData,
+          spans: [
+            {
+              spanId: 'span-nested-default',
+              name: 'tool.call',
+              startTime: 1000,
+              endTime: 1100,
+              attributes: {
+                'tool.name': 'orders',
+                'tool.arguments': '{"status":"Q","pagination":{"page":1}}',
+              },
+            },
+          ],
+        };
+        const params: AssertionParams = {
+          ...defaultParams,
+          assertionValueContext: { ...defaultParams.assertionValueContext, trace: nestedTrace },
+          baseType: 'trajectory:tool-args-match',
+          assertion: {
+            type: 'trajectory:tool-args-match',
+            value: {
+              name: 'orders',
+              mode: 'exact',
+              args: { status: 'Q' },
+              defaults: { page: 1 },
+            },
+          },
+          renderedValue: {
+            name: 'orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { page: 1 },
+          },
+        };
+
+        const result = handleTrajectoryToolArgsMatch(params);
+        expect(result.pass).toBe(false);
       });
 
       it('inverts correctly when defaults allow an otherwise-forbidden match', () => {


### PR DESCRIPTION
## Summary

Adds a `defaults` field to `trajectory:tool-args-match` so `mode: exact` can catch hallucinated extra arguments without failing when an agent includes (or omits) the tool's documented optional defaults.

Before matching, any actual tool-call argument whose value deep-equals its declared default is stripped from the payload. This closes the gap between the existing modes:

- `partial` silently tolerates hallucinated extras (e.g. `delete_database: true`)
- `exact` is too brittle for tools with optional defaults (e.g. pagination)

```yaml
- type: trajectory:tool-args-match
  value:
    name: orders
    mode: exact
    args: { status: Q }
    defaults: { page: 1, page_size: 5 }
```

| Observed | Outcome |
| --- | --- |
| `{status:'Q'}` | pass |
| `{status:'Q', page:1, page_size:5}` | pass (defaults stripped) |
| `{status:'Q', page:2}` | fail (value ≠ declared default) |
| `{status:'Q', delete_database:true}` | fail (hallucinated extra) |

Closes #9458.

## Test plan

- [x] 15 new unit tests in `test/assertions/trajectory.test.ts` covering: every row of the docs outcome table (using the docs example config verbatim), structured/nested default values via deep equality, empty defaults no-op, partial-mode interaction, malformed defaults rejection, inverse (`not-`) assertion, null default value, args/defaults key collision, and top-level-only stripping (no recursion).
- [x] All 1094 assertion tests pass (`npx vitest run test/assertions/`).
- [x] `npm run tsc` clean.
- [x] Docs site builds with `SKIP_OG_GENERATION=true npm run build`.
- [x] No changes to existing public API; `defaults` is optional and `partial` remains the default mode for backward compatibility.

## Follow-up hardening

Post-review changes (commit `e6e5d56`):

- **Reserved-key safety (correctness):** `stripDefaults` rebuilt the payload with `result[key] = value`, which for `key === "__proto__"` hits the prototype setter and silently drops the key. With `defaults` configured, a hallucinated `{ status: 'Q', __proto__: {…} }` therefore *passed* `mode: exact` (the no-`defaults` path correctly fails) — defeating the feature's purpose of catching hallucinated extras. Now rebuilt via `Object.defineProperty` so reserved keys are preserved as own properties (and the prototype is never mutated).
- **Transparent reason:** when default-valued extras are stripped, the pass reason now appends `Ignored default argument(s): page, page_size`, so an `(exact)` match that still shows extra keys is self-explanatory.
- **Docs:** added a note that stripping runs in both modes (so `defaults` is meaningful only with `mode: exact`) and a caveat against listing the same key in both `args` and `defaults`.
- **Tests:** added regression coverage for the `__proto__` bypass, the ignored-defaults reason, partial-mode key collision, the `arguments` alias, non-record actual payloads, and `null`/string/number malformed defaults. Trajectory suite now at 77 tests, all passing; `npm run tsc` clean.
