### PR TITLE
fix(eval): invalidate history cache after result update

### DIFF
--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -208,6 +208,7 @@ export async function updateResult(
     }
 
     await existingEval.save();
+    clearStandaloneEvalCache();
 
     logger.info(`Updated eval with ID ${id}`);
   } catch (err) {

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -461,6 +461,7 @@ export async function deleteEval(evalId: string) {
       throw new Error(`Eval with ID ${evalId} not found`);
     }
   });
+  clearStandaloneEvalCache();
 }
 
 /**
@@ -477,6 +478,7 @@ export function deleteEvals(ids: string[]) {
     db.delete(evalResultsTable).where(inArray(evalResultsTable.evalId, ids)).run();
     db.delete(evalsTable).where(inArray(evalsTable.id, ids)).run();
   });
+  clearStandaloneEvalCache();
 }
 
 /**
@@ -495,6 +497,7 @@ export async function deleteAllEvals(): Promise<void> {
     db.delete(evalsToTagsTable).run();
     db.delete(evalsTable).run();
   });
+  clearStandaloneEvalCache();
 }
 
 export type StandaloneEval = CompletedPrompt & {
@@ -518,7 +521,12 @@ const standaloneEvalCache = new LRUCache<string, StandaloneEval[]>({
   max: 2000,
 });
 
-/** Clears the standalone eval LRU cache. Intended for tests that mutate evals. */
+/**
+ * Invalidates the standalone eval LRU cache backing `getStandaloneEvals()`.
+ * Called by mutation paths in this module (update, delete) so `/api/history` reflects
+ * changes immediately instead of waiting up to the 2-hour TTL. Also re-exported for
+ * tests that need to assert behavior across cache boundaries.
+ */
 export function clearStandaloneEvalCache(): void {
   standaloneEvalCache.clear();
 }

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -81,7 +81,7 @@ describe('getStandaloneEvals', () => {
     expect(byId.get(regularEval.id)).toBe(true);
   });
 
-  it('reflects flag transitions after updateResult rewrites config', async () => {
+  it('reflects flag transitions after updateResult rewrites config without stale cached history', async () => {
     const eval_ = await createEvalWithPrompts({});
     expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
       false,
@@ -89,8 +89,6 @@ describe('getStandaloneEvals', () => {
 
     await updateResult(eval_.id, { redteam: {} as any });
 
-    // updateResult does not invalidate the LRU cache; tests clear it to observe the new value.
-    clearStandaloneEvalCache();
     expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
       true,
     );

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -7,7 +7,6 @@ import Eval from '../../src/models/eval';
 import {
   clearStandaloneEvalCache,
   deleteEval,
-  deleteEvals,
   getStandaloneEvals,
   updateResult,
 } from '../../src/util/database';
@@ -108,20 +107,6 @@ describe('getStandaloneEvals', () => {
     const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
     expect(afterIds).toContain(keep.id);
     expect(afterIds).not.toContain(drop.id);
-  });
-
-  it('drops bulk-deleted evals from cached history immediately', async () => {
-    const keep = await createEvalWithPrompts({});
-    const dropA = await createEvalWithPrompts({});
-    const dropB = await createEvalWithPrompts({});
-
-    await getStandaloneEvals();
-    deleteEvals([dropA.id, dropB.id]);
-
-    const ids = (await getStandaloneEvals()).map((row) => row.evalId);
-    expect(ids).toContain(keep.id);
-    expect(ids).not.toContain(dropA.id);
-    expect(ids).not.toContain(dropB.id);
   });
 
   it('classifies redteam: null as redteam, matching the runtime predicate', async () => {

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -6,6 +6,8 @@ import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import {
   clearStandaloneEvalCache,
+  deleteEval,
+  deleteEvals,
   getStandaloneEvals,
   updateResult,
 } from '../../src/util/database';
@@ -92,6 +94,34 @@ describe('getStandaloneEvals', () => {
     expect((await getStandaloneEvals()).find((row) => row.evalId === eval_.id)?.isRedteam).toBe(
       true,
     );
+  });
+
+  it('drops deleted evals from cached history immediately', async () => {
+    const keep = await createEvalWithPrompts({});
+    const drop = await createEvalWithPrompts({});
+
+    const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(beforeIds).toEqual(expect.arrayContaining([keep.id, drop.id]));
+
+    await deleteEval(drop.id);
+
+    const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(afterIds).toContain(keep.id);
+    expect(afterIds).not.toContain(drop.id);
+  });
+
+  it('drops bulk-deleted evals from cached history immediately', async () => {
+    const keep = await createEvalWithPrompts({});
+    const dropA = await createEvalWithPrompts({});
+    const dropB = await createEvalWithPrompts({});
+
+    await getStandaloneEvals();
+    deleteEvals([dropA.id, dropB.id]);
+
+    const ids = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(ids).toContain(keep.id);
+    expect(ids).not.toContain(dropA.id);
+    expect(ids).not.toContain(dropB.id);
   });
 
   it('classifies redteam: null as redteam, matching the runtime predicate', async () => {


### PR DESCRIPTION
## Summary

- Clear cached `/api/history` rows after `updateResult()` successfully persists an evaluation edit.
- Turn the red-team classification transition test into an immediate-read regression rather than clearing the cache in the test.

## Root Cause

The recent materialized `is_redteam` work correctly updates the stored flag when an eval config changes type, but `getStandaloneEvals()` could continue returning an already-cached row for up to two hours. The added transition test cleared the cache manually, so it did not exercise the behavior seen by an API consumer after an update.

## Validation

- Proving regression on current `main`: `npx vitest run test/util/databaseStandalone.test.ts --sequence.shuffle=false` failed with cached `isRedteam: false` after updating the eval to red-team.
- `npx vitest run test/util/databaseStandalone.test.ts test/models/eval.test.ts test/server/routes-eval.test.ts test/server/routes/eval.validation.test.ts --sequence.shuffle=false` (146 passed)
- `npm run f`
- `npm run l`
- `npm run tsc`
- `npm run build`
- `git diff --check`
