### PR TITLE
chore: remove inactive code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,6 @@
 
 /docs/           @alandelong-oai @mldangelo-oai        # Internal agent docs
 /examples/       @mldangelo-oai @ianw-oai              # Example configurations
-/helm/           @jbeckwith-oai                        # Kubernetes Helm charts
 
 # ============================================================================
 # SOURCE - SHARED OWNERSHIP (multiple contributors >15%)
@@ -83,7 +82,7 @@
 /site/src/pages/**/*.tsx    @ianw-oai @mldangelo-oai      # Landing page content
 /site/src/pages/**/*.md     @ianw-oai @mldangelo-oai      # Landing page markdown
 /site/blog/                 @mldangelo-oai                # Blog posts
-/SECURITY.md                @mldangelo-oai @jbeckwith-oai # Security policy
+/SECURITY.md                @mldangelo-oai                # Security policy
 /CONTRIBUTING.md            @mldangelo-oai                # Contributing guide
 /site/docs/contributing.md  @mldangelo-oai                # Contributing docs
 
@@ -91,17 +90,7 @@
 # DEVELOPER PRODUCTIVITY (VP Eng: Justin)
 # ============================================================================
 
-/.github/                      @jbeckwith-oai             # CI/CD workflows
-/scripts/                      @jbeckwith-oai             # Build & dev scripts
-/biome.json                    @jbeckwith-oai             # Linting config
-/tsconfig.json                 @jbeckwith-oai             # TypeScript config
-/tsdown.config.ts              @jbeckwith-oai             # Build config
-/vitest.config.ts              @jbeckwith-oai             # Test config
-/vitest.integration.config.ts  @jbeckwith-oai             # Integration test config
 /knip.json                     @faizan-oai                # Dead code detection
-/renovate.json                 @jbeckwith-oai             # Dependency updates
-/package.json                  @jbeckwith-oai             # Dependencies & scripts
-/release-please-config.json    @jbeckwith-oai             # Release automation
 
 # ============================================================================
 # DATABASE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 
 /docs/           @alandelong-oai @mldangelo-oai        # Internal agent docs
 /examples/       @mldangelo-oai @ianw-oai              # Example configurations
+/helm/           @mldangelo-oai                        # Kubernetes Helm charts
 
 # ============================================================================
 # SOURCE - SHARED OWNERSHIP (multiple contributors >15%)
@@ -87,10 +88,20 @@
 /site/docs/contributing.md  @mldangelo-oai                # Contributing docs
 
 # ============================================================================
-# DEVELOPER PRODUCTIVITY (VP Eng: Justin)
+# DEVELOPER PRODUCTIVITY
 # ============================================================================
 
+/.github/                      @mldangelo-oai           # CI/CD workflows
+/scripts/                      @mldangelo-oai           # Build & dev scripts
+/biome.json                    @mldangelo-oai           # Linting config
+/tsconfig.json                 @mldangelo-oai           # TypeScript config
+/tsdown.config.ts              @mldangelo-oai           # Build config
+/vitest.config.ts              @mldangelo-oai           # Test config
+/vitest.integration.config.ts  @mldangelo-oai           # Integration test config
 /knip.json                     @faizan-oai                # Dead code detection
+/renovate.json                 @mldangelo-oai           # Dependency updates
+/package.json                  @mldangelo-oai           # Dependencies & scripts
+/release-please-config.json    @mldangelo-oai           # Release automation
 
 # ============================================================================
 # DATABASE


### PR DESCRIPTION
## Summary

Promptfoo uses CODEOWNERS to automatically request reviews from the people or teams responsible for specific parts of the repository. This change removes inactive individual owner handles from that routing while keeping explicit coverage for the affected paths.

- Remove `jbeckwith-oai` from `.github/CODEOWNERS`.
- Transfer the former singleton `jbeckwith-oai` routes, including `/helm/` and developer-productivity files, to `mldangelo-oai`.
- Keep `SECURITY.md` owned by `mldangelo-oai`.
- Confirm `sklein-oai` is not present in `.github/CODEOWNERS`, so no CODEOWNERS edit was needed for that handle.
- Remove stale Justin-specific wording from the developer-productivity section header.

## Testing

- `git diff --check -- .github/CODEOWNERS`
- `rg -n "jbeckwith-oai|sklein-oai|Justin|VP Eng" .github/CODEOWNERS` returned no matches
- Repo pre-commit lint hook passed during both commits