### PR TITLE
feat(cli): warn on deprecated Node.js 20 runtime

### DIFF
--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -40,6 +40,7 @@ const nodeEngineComparatorSets =
   typeof __PROMPTFOO_NODE_ENGINE_COMPARATOR_SETS__ === 'undefined'
     ? fallbackNodeEngineComparatorSets
     : __PROMPTFOO_NODE_ENGINE_COMPARATOR_SETS__;
+const deprecatedNodeMajorVersions = new Set([20]);
 
 function parseNodeEngineVersion(
   version: string,
@@ -117,6 +118,15 @@ function isSupportedNodeEngineVersion(currentVersion: string): boolean | null {
   );
 }
 
+function shouldWarnForDeprecatedNodeVersion(currentVersion: string): boolean {
+  const parsedCurrentVersion = parseNodeEngineVersion(currentVersion);
+  return (
+    parsedCurrentVersion !== null &&
+    isSupportedNodeEngineVersion(currentVersion) === true &&
+    deprecatedNodeMajorVersions.has(parsedCurrentVersion[0])
+  );
+}
+
 function formatUnsupportedNodeVersionMessage(currentVersion: string): string {
   return [
     '\x1b[33mpromptfoo requires a supported Node.js runtime.',
@@ -137,6 +147,17 @@ function formatMalformedNodeVersionMessage(currentVersion: string): string {
   ].join('\n');
 }
 
+function formatDeprecatedNodeVersionMessage(currentVersion: string): string {
+  return [
+    '\x1b[33mWarning: Node.js 20 has reached end-of-life and is deprecated in promptfoo.',
+    '',
+    `Detected: ${currentVersion}`,
+    'Recommended: Node.js >=22.22.0 (Node.js 24 LTS preferred)',
+    '',
+    'Upgrade your Node.js runtime to avoid disruption in a future promptfoo release.\x1b[0m',
+  ].join('\n');
+}
+
 // Skip version check for alternative runtimes (Bun, Deno) - they support modern JS features
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== 'undefined';
 const isDeno = typeof (globalThis as Record<string, unknown>).Deno !== 'undefined';
@@ -150,6 +171,9 @@ if (!isBun && !isDeno) {
   if (!isSupportedVersion) {
     console.error(formatUnsupportedNodeVersionMessage(process.version));
     process.exit(1);
+  }
+  if (shouldWarnForDeprecatedNodeVersion(process.version)) {
+    console.warn(formatDeprecatedNodeVersionMessage(process.version));
   }
 }
 

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -120,6 +120,27 @@ const nodeEngineComparatorSets: NodeEngineComparator[][] = [
   ],
   [{ operator: '>=', version: '22.22.0' }],
 ];
+const deprecatedNodeMajorVersions = new Set([20]);
+
+function shouldWarnForDeprecatedNodeVersion(currentVersion: string): boolean {
+  const parsedCurrentVersion = parseNodeEngineVersion(currentVersion);
+  return (
+    parsedCurrentVersion !== null &&
+    isSupportedNodeEngineVersion(currentVersion, nodeEngineComparatorSets) === true &&
+    deprecatedNodeMajorVersions.has(parsedCurrentVersion[0])
+  );
+}
+
+function formatDeprecatedNodeVersionMessage(currentVersion: string): string {
+  return [
+    '\x1b[33mWarning: Node.js 20 has reached end-of-life and is deprecated in promptfoo.',
+    '',
+    `Detected: ${currentVersion}`,
+    'Recommended: Node.js >=22.22.0 (Node.js 24 LTS preferred)',
+    '',
+    'Upgrade your Node.js runtime to avoid disruption in a future promptfoo release.\x1b[0m',
+  ].join('\n');
+}
 
 describe('entrypoint version check logic', () => {
   describe('Node.js version parsing', () => {
@@ -265,6 +286,30 @@ describe('entrypoint version check logic', () => {
       expect(errorMessage).toContain('Unable to parse the current Node.js version');
       expect(errorMessage).toContain('node-20.9.0');
       expect(errorMessage).toContain(`Required: ${nodeEngineRange}`);
+    });
+  });
+
+  describe('deprecation warning', () => {
+    it('warns for supported Node.js 20 versions', () => {
+      expect(shouldWarnForDeprecatedNodeVersion('v20.20.0')).toBe(true);
+      expect(shouldWarnForDeprecatedNodeVersion('v20.20.2')).toBe(true);
+    });
+
+    it('does not warn for recommended or unparsable runtimes', () => {
+      expect(shouldWarnForDeprecatedNodeVersion('v20.19.0')).toBe(false);
+      expect(shouldWarnForDeprecatedNodeVersion('v22.22.0')).toBe(false);
+      expect(shouldWarnForDeprecatedNodeVersion('v24.16.0')).toBe(false);
+      expect(shouldWarnForDeprecatedNodeVersion('invalid')).toBe(false);
+    });
+
+    it('formats an actionable warning for Node.js 20', () => {
+      const warningMessage = formatDeprecatedNodeVersionMessage('v20.20.2');
+
+      expect(warningMessage).toContain('Node.js 20 has reached end-of-life');
+      expect(warningMessage).toContain('deprecated in promptfoo');
+      expect(warningMessage).toContain('Detected: v20.20.2');
+      expect(warningMessage).toContain('Recommended: Node.js >=22.22.0');
+      expect(warningMessage).toContain('Upgrade your Node.js runtime');
     });
   });
 

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -291,15 +291,35 @@ describe('entrypoint version check logic', () => {
 
   describe('deprecation warning', () => {
     it('warns for supported Node.js 20 versions', () => {
-      expect(shouldWarnForDeprecatedNodeVersion('v20.20.0')).toBe(true);
-      expect(shouldWarnForDeprecatedNodeVersion('v20.20.2')).toBe(true);
+      const deprecatedVersions = ['v20.20.0', 'v20.20.2', 'v20.21.1'];
+
+      for (const version of deprecatedVersions) {
+        expect(shouldWarnForDeprecatedNodeVersion(version)).toBe(true);
+      }
     });
 
-    it('does not warn for recommended or unparsable runtimes', () => {
-      expect(shouldWarnForDeprecatedNodeVersion('v20.19.0')).toBe(false);
-      expect(shouldWarnForDeprecatedNodeVersion('v22.22.0')).toBe(false);
-      expect(shouldWarnForDeprecatedNodeVersion('v24.16.0')).toBe(false);
-      expect(shouldWarnForDeprecatedNodeVersion('invalid')).toBe(false);
+    it('does not warn for unsupported Node.js versions', () => {
+      const unsupportedVersions = ['v20.19.0', 'v21.0.0', 'v22.13.0'];
+
+      for (const version of unsupportedVersions) {
+        expect(shouldWarnForDeprecatedNodeVersion(version)).toBe(false);
+      }
+    });
+
+    it('does not warn for supported Node.js versions outside the deprecated majors', () => {
+      const recommendedVersions = ['v22.22.0', 'v24.16.0'];
+
+      for (const version of recommendedVersions) {
+        expect(shouldWarnForDeprecatedNodeVersion(version)).toBe(false);
+      }
+    });
+
+    it('does not warn for prerelease or unparsable Node.js versions', () => {
+      const unparsableVersions = ['v20.20.0-rc.1', 'node-20.20.0', 'invalid'];
+
+      for (const version of unparsableVersions) {
+        expect(shouldWarnForDeprecatedNodeVersion(version)).toBe(false);
+      }
     });
 
     it('formats an actionable warning for Node.js 20', () => {
@@ -310,6 +330,8 @@ describe('entrypoint version check logic', () => {
       expect(warningMessage).toContain('Detected: v20.20.2');
       expect(warningMessage).toContain('Recommended: Node.js >=22.22.0');
       expect(warningMessage).toContain('Upgrade your Node.js runtime');
+      expect(warningMessage).toContain('\x1b[33m');
+      expect(warningMessage).toContain('\x1b[0m');
     });
   });
 


### PR DESCRIPTION
## Summary

- warn users running supported Node.js 20 releases that the runtime is end-of-life and deprecated in promptfoo
- recommend upgrading to Node.js >=22.22.0 while preserving current Node 20 compatibility
- cover warning and no-warning behavior in entrypoint version-check tests

## Motivation

Node.js 20 is end-of-life, but supported promptfoo users and CI workloads may still run it. This adds a non-blocking migration notice before changing the supported engine range.

## Testing

- `npm run l`
- `npm run f`
- `npx vitest run test/entrypoint.test.ts --sequence.shuffle=false`
- `npx biome check src/entrypoint.ts test/entrypoint.test.ts`
- `npm run build`
- built CLI: Node `v20.20.2` warns and succeeds; Node `v24.16.0` succeeds without warning; Node `v20.9.0` retains the existing unsupported-runtime failure