### PR TITLE
test(server): parameterize filtered metrics cleanup query

### DIFF
--- a/test/server/routes/eval.filteredMetrics.test.ts
+++ b/test/server/routes/eval.filteredMetrics.test.ts
@@ -10,6 +10,7 @@
 
 import type { Server } from 'node:http';
 
+import { sql } from 'drizzle-orm';
 import request from 'supertest';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../../src/database/index';
@@ -262,7 +263,7 @@ describe('GET /api/eval/:id/table - Filtered Metrics Integration', () => {
 
       // Delete all results to test empty dataset handling
       const db = await getDb();
-      await db.run(`DELETE FROM eval_results WHERE eval_id = '${eval_.id}'`);
+      await db.run(sql`DELETE FROM eval_results WHERE eval_id = ${eval_.id}`);
 
       const response = await api.get(`/api/eval/${eval_.id}/table`).query({ filterMode: 'errors' });
 


### PR DESCRIPTION
## Summary
- replace the interpolated `eval_results` cleanup statement in the filtered metrics route test with a Drizzle parameterized SQL template
- address the currently visible GitHub AI code-quality finding for `test/server/routes/eval.filteredMetrics.test.ts`

## Why
The test inserted `eval_.id` into a raw SQL string. Although it is generated internally in the test, using the same parameterized query pattern as application database code avoids reinforcing an unsafe SQL construction pattern.

## Validation
- `npm ci`
- `npm run f`
- `npm run l`
- `PROMPTFOO_DISABLE_TELEMETRY=1 npx vitest run test/server/routes/eval.filteredMetrics.test.ts`
- `npm run tsc`
- `git diff --check`