### PR TITLE
fix(eval): refresh history cache after inserts

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -42,6 +42,7 @@ import { convertTestResultsToTableRow } from '../util/exportToFile/index';
 import { isNonTransientHttpStatus, NON_TRANSIENT_HTTP_STATUSES } from '../util/fetch/errors';
 import invariant from '../util/invariant';
 import { sanitizeRuntimeOptions } from '../util/sanitizer';
+import { clearStandaloneEvalCache } from '../util/standaloneEvalCache';
 import { getCurrentTimestamp } from '../util/time';
 import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import {
@@ -557,6 +558,8 @@ export default class Eval {
       }
     });
 
+    clearStandaloneEvalCache();
+
     return new Eval(config, {
       id: evalId,
       author,
@@ -658,6 +661,7 @@ export default class Eval {
       updateObj.results = expr;
     }
     await db.update(evalsTable).set(updateObj).where(eq(evalsTable.id, this.id)).run();
+    clearStandaloneEvalCache();
     this.persisted = true;
   }
 

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -1261,6 +1261,7 @@ export default class Eval {
       // Notify the view server after prompt metadata changes so cached /api/prompts
       // responses and socket listeners can pick up prompts added after eval creation.
       updateSignalFile(this.id);
+      clearStandaloneEvalCache();
     }
   }
 
@@ -1272,6 +1273,7 @@ export default class Eval {
         .insert(evalResultsTable)
         .values(results.map((r) => ({ ...r, evalId: this.id })))
         .run();
+      clearStandaloneEvalCache();
     }
     this._resultsLoaded = true;
   }
@@ -1587,6 +1589,8 @@ export default class Eval {
         });
       }
     });
+
+    clearStandaloneEvalCache();
 
     logger.info('Eval copy completed successfully', {
       sourceEvalId: this.id,

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -1,5 +1,4 @@
 import { and, desc, eq, inArray } from 'drizzle-orm';
-import { LRUCache } from 'lru-cache';
 import { DEFAULT_QUERY_LIMIT } from '../constants';
 import { deleteTraceRecordsForEvals } from '../database/evalDeletion';
 import { getDb } from '../database/index';
@@ -20,7 +19,6 @@ import logger from '../logger';
 import Eval, { createEvalId } from '../models/eval';
 import { generateIdFromPrompt } from '../models/prompt';
 import {
-  type CompletedPrompt,
   type EvaluateSummaryV2,
   type EvaluateTable,
   type EvalWithMetadata,
@@ -33,6 +31,14 @@ import {
 import invariant from '../util/invariant';
 import { sha256 } from './createHash';
 import { restoreAzureBlobSasTokens } from './sanitizer';
+import {
+  type StandaloneEval as CachedStandaloneEval,
+  clearStandaloneEvalCache as clearStandaloneEvalCacheImpl,
+  getCachedStandaloneEvals,
+  setCachedStandaloneEvals,
+} from './standaloneEvalCache';
+
+export type StandaloneEval = CachedStandaloneEval;
 
 export async function writeResultsToDatabase(
   results: EvaluateSummaryV2,
@@ -151,6 +157,8 @@ export async function writeResultsToDatabase(
     }
   });
 
+  clearStandaloneEvalCacheImpl();
+
   return evalId;
 }
 
@@ -192,7 +200,7 @@ export async function updateResult(
     }
 
     await existingEval.save();
-    clearStandaloneEvalCache();
+    clearStandaloneEvalCacheImpl();
 
     logger.info(`Updated eval with ID ${id}`);
   } catch (err) {
@@ -446,7 +454,7 @@ export async function deleteEval(evalId: string) {
       throw new Error(`Eval with ID ${evalId} not found`);
     }
   });
-  clearStandaloneEvalCache();
+  clearStandaloneEvalCacheImpl();
 }
 
 /**
@@ -463,7 +471,7 @@ export async function deleteEvals(ids: string[]): Promise<void> {
     await tx.delete(evalResultsTable).where(inArray(evalResultsTable.evalId, ids)).run();
     await tx.delete(evalsTable).where(inArray(evalsTable.id, ids)).run();
   });
-  clearStandaloneEvalCache();
+  clearStandaloneEvalCacheImpl();
 }
 
 /**
@@ -482,38 +490,17 @@ export async function deleteAllEvals(): Promise<void> {
     await tx.delete(evalsToTagsTable).run();
     await tx.delete(evalsTable).run();
   });
-  clearStandaloneEvalCache();
+  clearStandaloneEvalCacheImpl();
 }
-
-export type StandaloneEval = CompletedPrompt & {
-  evalId: string;
-  description: string | null;
-  datasetId: string | null;
-  promptId: string | null;
-  isRedteam: boolean;
-  createdAt: number;
-
-  pluginFailCount: Record<string, number>;
-  pluginPassCount: Record<string, number>;
-  uuid: string;
-};
-
-const standaloneEvalCache = new LRUCache<string, StandaloneEval[]>({
-  ttl: 60 * 60 * 2 * 1000, // 2 hours in milliseconds
-  // Cache entries are keyed by (limit, tag, description) filter combinations.
-  // 2000 handles heavy automation scenarios while keeping memory bounded (~few MB).
-  // On eviction, the next request simply re-queries the DB with minimal latency impact.
-  max: 2000,
-});
 
 /**
  * Invalidates the standalone eval LRU cache backing `getStandaloneEvals()`.
- * Called by mutation paths in this module (update, delete) so `/api/history` reflects
+ * Called by mutation paths in this module (write, update, delete) so `/api/history` reflects
  * changes immediately instead of waiting up to the 2-hour TTL. Also re-exported for
  * tests that need to assert behavior across cache boundaries.
  */
 export function clearStandaloneEvalCache(): void {
-  standaloneEvalCache.clear();
+  clearStandaloneEvalCacheImpl();
 }
 
 export async function getStandaloneEvals({
@@ -526,7 +513,7 @@ export async function getStandaloneEvals({
   description?: string;
 } = {}): Promise<StandaloneEval[]> {
   const cacheKey = `standalone_evals_${limit}_${tag?.key}_${tag?.value}_${description}`;
-  const cachedResult = standaloneEvalCache.get(cacheKey);
+  const cachedResult = getCachedStandaloneEvals(cacheKey);
 
   if (cachedResult) {
     return cachedResult;
@@ -620,6 +607,6 @@ export async function getStandaloneEvals({
     uuid: crypto.randomUUID(),
   }));
 
-  standaloneEvalCache.set(cacheKey, withUUIDs);
+  setCachedStandaloneEvals(cacheKey, withUUIDs);
   return withUUIDs;
 }

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -32,13 +32,16 @@ import invariant from '../util/invariant';
 import { sha256 } from './createHash';
 import { restoreAzureBlobSasTokens } from './sanitizer';
 import {
-  type StandaloneEval as CachedStandaloneEval,
-  clearStandaloneEvalCache as clearStandaloneEvalCacheImpl,
+  clearStandaloneEvalCache,
   getCachedStandaloneEvals,
+  getStandaloneEvalCacheKey,
   setCachedStandaloneEvals,
 } from './standaloneEvalCache';
 
-export type StandaloneEval = CachedStandaloneEval;
+import type { StandaloneEval } from './standaloneEvalCache';
+
+export type { StandaloneEval };
+export { clearStandaloneEvalCache };
 
 export async function writeResultsToDatabase(
   results: EvaluateSummaryV2,
@@ -157,7 +160,7 @@ export async function writeResultsToDatabase(
     }
   });
 
-  clearStandaloneEvalCacheImpl();
+  clearStandaloneEvalCache();
 
   return evalId;
 }
@@ -453,7 +456,7 @@ export async function deleteEval(evalId: string) {
       throw new Error(`Eval with ID ${evalId} not found`);
     }
   });
-  clearStandaloneEvalCacheImpl();
+  clearStandaloneEvalCache();
 }
 
 /**
@@ -470,7 +473,7 @@ export async function deleteEvals(ids: string[]): Promise<void> {
     await tx.delete(evalResultsTable).where(inArray(evalResultsTable.evalId, ids)).run();
     await tx.delete(evalsTable).where(inArray(evalsTable.id, ids)).run();
   });
-  clearStandaloneEvalCacheImpl();
+  clearStandaloneEvalCache();
 }
 
 /**
@@ -489,17 +492,7 @@ export async function deleteAllEvals(): Promise<void> {
     await tx.delete(evalsToTagsTable).run();
     await tx.delete(evalsTable).run();
   });
-  clearStandaloneEvalCacheImpl();
-}
-
-/**
- * Invalidates the standalone eval LRU cache backing `getStandaloneEvals()`.
- * Called by mutation paths in this module (write, update, delete) so `/api/history` reflects
- * changes immediately instead of waiting up to the 2-hour TTL. Also re-exported for
- * tests that need to assert behavior across cache boundaries.
- */
-export function clearStandaloneEvalCache(): void {
-  clearStandaloneEvalCacheImpl();
+  clearStandaloneEvalCache();
 }
 
 export async function getStandaloneEvals({
@@ -511,7 +504,7 @@ export async function getStandaloneEvals({
   tag?: { key: string; value: string };
   description?: string;
 } = {}): Promise<StandaloneEval[]> {
-  const cacheKey = `standalone_evals_${limit}_${tag?.key}_${tag?.value}_${description}`;
+  const cacheKey = getStandaloneEvalCacheKey({ limit, tag, description });
   const cachedResult = getCachedStandaloneEvals(cacheKey);
 
   if (cachedResult) {

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -200,7 +200,6 @@ export async function updateResult(
     }
 
     await existingEval.save();
-    clearStandaloneEvalCacheImpl();
 
     logger.info(`Updated eval with ID ${id}`);
   } catch (err) {

--- a/src/util/standaloneEvalCache.ts
+++ b/src/util/standaloneEvalCache.ts
@@ -1,0 +1,36 @@
+import { LRUCache } from 'lru-cache';
+
+import type { CompletedPrompt } from '../types/index';
+
+export type StandaloneEval = CompletedPrompt & {
+  evalId: string;
+  description: string | null;
+  datasetId: string | null;
+  promptId: string | null;
+  isRedteam: boolean;
+  createdAt: number;
+
+  pluginFailCount: Record<string, number>;
+  pluginPassCount: Record<string, number>;
+  uuid: string;
+};
+
+const standaloneEvalCache = new LRUCache<string, StandaloneEval[]>({
+  ttl: 60 * 60 * 2 * 1000, // 2 hours in milliseconds
+  // Cache entries are keyed by (limit, tag, description) filter combinations.
+  // 2000 handles heavy automation scenarios while keeping memory bounded (~few MB).
+  // On eviction, the next request simply re-queries the DB with minimal latency impact.
+  max: 2000,
+});
+
+export function getCachedStandaloneEvals(cacheKey: string): StandaloneEval[] | undefined {
+  return standaloneEvalCache.get(cacheKey);
+}
+
+export function setCachedStandaloneEvals(cacheKey: string, evals: StandaloneEval[]): void {
+  standaloneEvalCache.set(cacheKey, evals);
+}
+
+export function clearStandaloneEvalCache(): void {
+  standaloneEvalCache.clear();
+}

--- a/src/util/standaloneEvalCache.ts
+++ b/src/util/standaloneEvalCache.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache';
+import { DEFAULT_QUERY_LIMIT } from '../constants';
 
 import type { CompletedPrompt } from '../types/index';
 
@@ -15,13 +16,29 @@ export type StandaloneEval = CompletedPrompt & {
   uuid: string;
 };
 
+export type StandaloneEvalCacheKeyOptions = {
+  limit?: number;
+  tag?: { key: string; value: string };
+  description?: string;
+};
+
 const standaloneEvalCache = new LRUCache<string, StandaloneEval[]>({
   ttl: 60 * 60 * 2 * 1000, // 2 hours in milliseconds
   // Cache entries are keyed by (limit, tag, description) filter combinations.
+  // Mutation paths clear the cache; this TTL is a backstop for quiet servers
+  // and future missed invalidations.
   // 2000 handles heavy automation scenarios while keeping memory bounded (~few MB).
   // On eviction, the next request simply re-queries the DB with minimal latency impact.
   max: 2000,
 });
+
+export function getStandaloneEvalCacheKey({
+  limit = DEFAULT_QUERY_LIMIT,
+  tag,
+  description,
+}: StandaloneEvalCacheKeyOptions = {}): string {
+  return `standalone_evals_${limit}_${tag?.key}_${tag?.value}_${description}`;
+}
 
 export function getCachedStandaloneEvals(cacheKey: string): StandaloneEval[] | undefined {
   return standaloneEvalCache.get(cacheKey);

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -110,6 +110,18 @@ describe('getStandaloneEvals', () => {
     expect(afterIds).not.toContain(drop.id);
   });
 
+  it('includes newly created evals after history has been cached', async () => {
+    const first = await createEvalWithPrompts({});
+    const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(beforeIds).toContain(first.id);
+
+    const second = await createEvalWithPrompts({});
+
+    const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(afterIds).toContain(first.id);
+    expect(afterIds).toContain(second.id);
+  });
+
   it('classifies redteam: null as redteam, matching the runtime predicate', async () => {
     const eval_ = await createEvalWithPrompts({ redteam: null as any });
 

--- a/test/util/databaseStandalone.test.ts
+++ b/test/util/databaseStandalone.test.ts
@@ -4,14 +4,18 @@ import { getDb } from '../../src/database/index';
 import { evalsTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
+import EvalResult from '../../src/models/evalResult';
+import { type CompletedPrompt, type Prompt, ResultFailureReason } from '../../src/types/index';
 import {
   clearStandaloneEvalCache,
   deleteEval,
   getStandaloneEvals,
   updateResult,
 } from '../../src/util/database';
-
-import type { CompletedPrompt, Prompt } from '../../src/types/index';
+import {
+  getCachedStandaloneEvals,
+  getStandaloneEvalCacheKey,
+} from '../../src/util/standaloneEvalCache';
 
 const completedPrompt: CompletedPrompt = {
   raw: 'hello',
@@ -59,6 +63,10 @@ async function resetEvalTables() {
 async function setIsRedteam(evalId: string, value: boolean) {
   const db = await getDb();
   await db.update(evalsTable).set({ isRedteam: value }).where(eq(evalsTable.id, evalId)).run();
+}
+
+function expectStandaloneHistoryCached(options?: Parameters<typeof getStandaloneEvalCacheKey>[0]) {
+  expect(getCachedStandaloneEvals(getStandaloneEvalCacheKey(options))).toBeDefined();
 }
 
 describe('getStandaloneEvals', () => {
@@ -113,13 +121,99 @@ describe('getStandaloneEvals', () => {
   it('includes newly created evals after history has been cached', async () => {
     const first = await createEvalWithPrompts({});
     const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    const limitedBeforeIds = (await getStandaloneEvals({ limit: 5 })).map((row) => row.evalId);
     expect(beforeIds).toContain(first.id);
+    expect(limitedBeforeIds).toContain(first.id);
+    expectStandaloneHistoryCached();
+    expectStandaloneHistoryCached({ limit: 5 });
 
     const second = await createEvalWithPrompts({});
 
     const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    const limitedAfterIds = (await getStandaloneEvals({ limit: 5 })).map((row) => row.evalId);
     expect(afterIds).toContain(first.id);
     expect(afterIds).toContain(second.id);
+    expect(limitedAfterIds).toContain(first.id);
+    expect(limitedAfterIds).toContain(second.id);
+  });
+
+  it('includes copied evals after history has been cached', async () => {
+    const source = await createEvalWithPrompts({});
+    const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(beforeIds).toContain(source.id);
+    expectStandaloneHistoryCached();
+
+    const persistedSource = await Eval.findById(source.id);
+    expect(persistedSource).toBeDefined();
+    const copy = await persistedSource!.copy('copy of source');
+
+    const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(afterIds).toContain(source.id);
+    expect(afterIds).toContain(copy.id);
+  });
+
+  it('includes direct eval saves after history has been cached', async () => {
+    const eval_ = await createEvalWithPrompts({});
+    const beforeRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(beforeRow?.description).toBeNull();
+    expectStandaloneHistoryCached();
+
+    const persistedEval = await Eval.findById(eval_.id);
+    expect(persistedEval).toBeDefined();
+    persistedEval!.config.description = 'updated description';
+    await persistedEval!.save();
+
+    const afterRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(afterRow?.description).toBe('updated description');
+  });
+
+  it('includes prompt changes after history has been cached', async () => {
+    const eval_ = await createEvalWithPrompts({});
+    const beforeRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(beforeRow?.raw).toBe('hello');
+    expectStandaloneHistoryCached();
+
+    await eval_.addPrompts([
+      {
+        ...completedPrompt,
+        raw: 'goodbye',
+        label: 'goodbye',
+      },
+    ]);
+
+    const afterRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(afterRow?.raw).toBe('goodbye');
+  });
+
+  it('includes result changes after history has been cached', async () => {
+    const eval_ = await createEvalWithPrompts({});
+    const beforeRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(beforeRow?.pluginFailCount['plugin-a']).toBeUndefined();
+    expectStandaloneHistoryCached();
+
+    await eval_.setResults([
+      new EvalResult({
+        id: 'set-results-history-row',
+        evalId: eval_.id,
+        promptIdx: 0,
+        testIdx: 0,
+        testCase: { vars: {}, metadata: { pluginId: 'plugin-a' } },
+        prompt: renderedPrompts[0],
+        provider: { id: 'test-provider' },
+        response: { output: 'bad' },
+        gradingResult: null,
+        namedScores: {},
+        metadata: {},
+        success: false,
+        score: 0,
+        latencyMs: 1,
+        cost: 0,
+        failureReason: ResultFailureReason.ASSERT,
+      }),
+    ]);
+
+    const afterRow = (await getStandaloneEvals()).find((row) => row.evalId === eval_.id);
+    expect(afterRow?.pluginFailCount['plugin-a']).toBe(1);
   });
 
   it('classifies redteam: null as redteam, matching the runtime predicate', async () => {

--- a/test/util/databaseWrite.test.ts
+++ b/test/util/databaseWrite.test.ts
@@ -7,7 +7,15 @@ import {
   getStandaloneEvals,
   writeResultsToDatabase,
 } from '../../src/util/database';
+import {
+  getCachedStandaloneEvals,
+  getStandaloneEvalCacheKey,
+} from '../../src/util/standaloneEvalCache';
 import { createEvaluateSummaryV2 } from '../factories/eval';
+
+function expectWrittenHistoryCached() {
+  expect(getCachedStandaloneEvals(getStandaloneEvalCacheKey())).toBeDefined();
+}
 
 describe('writeResultsToDatabase', () => {
   beforeAll(async () => {
@@ -54,19 +62,50 @@ describe('writeResultsToDatabase', () => {
     await expect(db.select().from(tagsTable).all()).resolves.toHaveLength(0);
   });
 
-  it('includes imported evals after history has been cached', async () => {
-    const firstEvalId = await writeResultsToDatabase(
-      createEvaluateSummaryV2(),
-      {},
-      new Date('2024-01-01T00:00:00.000Z'),
-    );
+  it('keeps cached history when a later write rolls back', async () => {
+    const firstEvalId = await writeResultsToDatabase(createEvaluateSummaryV2(), {}, new Date());
     const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
     expect(beforeIds).toContain(firstEvalId);
+    expectWrittenHistoryCached();
+    const secondDate = new Date(Date.now() + 1000);
+
+    const db = await getDb();
+    await db.run(`
+      CREATE TRIGGER fail_evals_to_tags_insert
+      BEFORE INSERT ON evals_to_tags
+      BEGIN
+        SELECT RAISE(ABORT, 'forced tag failure');
+      END;
+    `);
+
+    await expect(
+      writeResultsToDatabase(
+        createEvaluateSummaryV2(),
+        {
+          tags: { suite: 'regression' },
+          tests: [],
+        },
+        secondDate,
+      ),
+    ).rejects.toThrow();
+
+    const cachedIds = getCachedStandaloneEvals(getStandaloneEvalCacheKey())?.map(
+      (row) => row.evalId,
+    );
+    expect(cachedIds).toContain(firstEvalId);
+  });
+
+  it('includes newly persisted evals after history has been cached', async () => {
+    const firstDate = new Date();
+    const firstEvalId = await writeResultsToDatabase(createEvaluateSummaryV2(), {}, firstDate);
+    const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(beforeIds).toContain(firstEvalId);
+    expectWrittenHistoryCached();
 
     const secondEvalId = await writeResultsToDatabase(
       createEvaluateSummaryV2(),
       {},
-      new Date('2024-01-01T00:00:01.000Z'),
+      new Date(firstDate.getTime() + 1000),
     );
 
     const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);

--- a/test/util/databaseWrite.test.ts
+++ b/test/util/databaseWrite.test.ts
@@ -2,7 +2,11 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { getDb } from '../../src/database/index';
 import { datasetsTable, evalsTable, promptsTable, tagsTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
-import { writeResultsToDatabase } from '../../src/util/database';
+import {
+  clearStandaloneEvalCache,
+  getStandaloneEvals,
+  writeResultsToDatabase,
+} from '../../src/util/database';
 import { createEvaluateSummaryV2 } from '../factories/eval';
 
 describe('writeResultsToDatabase', () => {
@@ -20,6 +24,7 @@ describe('writeResultsToDatabase', () => {
     await db.run('DELETE FROM datasets');
     await db.run('DELETE FROM prompts');
     await db.run('DELETE FROM tags');
+    clearStandaloneEvalCache();
   });
 
   it('rolls back related rows when a dependent insert fails', async () => {
@@ -47,5 +52,25 @@ describe('writeResultsToDatabase', () => {
     await expect(db.select().from(promptsTable).all()).resolves.toHaveLength(0);
     await expect(db.select().from(datasetsTable).all()).resolves.toHaveLength(0);
     await expect(db.select().from(tagsTable).all()).resolves.toHaveLength(0);
+  });
+
+  it('includes imported evals after history has been cached', async () => {
+    const firstEvalId = await writeResultsToDatabase(
+      createEvaluateSummaryV2(),
+      {},
+      new Date('2024-01-01T00:00:00.000Z'),
+    );
+    const beforeIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(beforeIds).toContain(firstEvalId);
+
+    const secondEvalId = await writeResultsToDatabase(
+      createEvaluateSummaryV2(),
+      {},
+      new Date('2024-01-01T00:00:01.000Z'),
+    );
+
+    const afterIds = (await getStandaloneEvals()).map((row) => row.evalId);
+    expect(afterIds).toContain(firstEvalId);
+    expect(afterIds).toContain(secondEvalId);
   });
 });


### PR DESCRIPTION
## Summary

The Web UI history endpoint caches standalone eval rows for up to two hours. Recent cache invalidation work handled eval updates and deletes, but eval inserts could still leave `/api/history` stale after the first history read.

This fixes the insert side of that behavior:

- Move the standalone history cache into a small shared helper module.
- Clear that cache after successful `Eval.create()` inserts.
- Clear that cache after successful `writeResultsToDatabase()` imports/writes.
- Keep `clearStandaloneEvalCache()` exported from `src/util/database.ts` for existing tests/callers.

## Why

Users expect a newly created or imported eval to appear in history immediately. Before this change, if history was read first, a later eval insert could be hidden until the cache expired or another mutation happened to clear the cache.

## Tests

- `IS_TESTING=true node_modules/.bin/vitest run test/util/databaseStandalone.test.ts test/util/databaseWrite.test.ts test/models/eval.test.ts`
- `/Users/wholley/.nvm/versions/node/v24.16.0/bin/npm run tsc`
- `/Users/wholley/.nvm/versions/node/v24.16.0/bin/npm run f`
- `/Users/wholley/.nvm/versions/node/v24.16.0/bin/npm run l`

`npm run f` and `npm run l` report the existing `src/models/eval.ts` cognitive-complexity warning at line 851, with exit 0.
